### PR TITLE
feat(db,infra): Phase 1 trust-plane plumbing — Admin PG, zero-trust roles, partitioning, all-modes compose (#890 Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,21 @@
 # Database Configuration
 DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
 
+# Admin Postgres (trust plane)
+# Dedicated database (pagespace-db-admin) for the tamper-evident security audit
+# chain and related admin/audit tables — isolated from the app DB in EVERY
+# deployment mode (cloud: separate Fly instance; tenant/onprem: postgres-admin
+# container). Real credentials are secrets (cloud: `fly secrets set`); never
+# commit real values.
+ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
+# ADMIN_DATABASE_SSL=true
+# ADMIN_DB_POOL_MAX=10
+# Break-glass rollback ONLY: setting ADMIN_DB_BREAK_GLASS=true permits audit
+# writes to fall back to the main DB and alerts loudly. It is not a supported
+# steady state — leave unset. Without it, an unset ADMIN_DATABASE_URL fails
+# fast at adminDb init.
+# ADMIN_DB_BREAK_GLASS=true
+
 # Authentication & Security
 PROCESSOR_AUTH_REQUIRED=true
 PROCESSOR_UPLOAD_RATE_LIMIT=100

--- a/.env.onprem.example
+++ b/.env.onprem.example
@@ -16,6 +16,21 @@ NEXT_PUBLIC_DEPLOYMENT_MODE=onprem
 DATABASE_URL=postgresql://pagespace:your_strong_password@localhost:5432/pagespace
 
 # ---------------------------------------------------------------------------
+# Admin Database — trust plane (REQUIRED)
+# ---------------------------------------------------------------------------
+# Dedicated Admin Postgres (the postgres-admin container in the on-prem compose
+# stack) holding the tamper-evident security audit chain and related admin/audit
+# tables, isolated from the app database above. Use a unique strong password;
+# never commit real credentials.
+ADMIN_DATABASE_URL=postgresql://pagespace:another_strong_password@localhost:5433/pagespace_admin
+# ADMIN_DATABASE_SSL=false
+# ADMIN_DB_POOL_MAX=10
+# Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to
+# fall back to the main DB and alerts loudly. Not a supported steady state —
+# leave unset. Without it, an unset ADMIN_DATABASE_URL fails fast at startup.
+# ADMIN_DB_BREAK_GLASS=true
+
+# ---------------------------------------------------------------------------
 # Security Secrets (REQUIRED - generate unique values for each)
 # ---------------------------------------------------------------------------
 # Generate with: openssl rand -hex 32

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -227,6 +227,84 @@ jobs:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_NO_UPDATE_CHECK: "true"
 
+      # Admin PG (trust plane, #890): mirrors the main migration machine but runs
+      # db:migrate:admin. The machine runs in the pagespace-web app, so it inherits
+      # ADMIN_DATABASE_URL from that app's Fly secrets — no GitHub-side copy of the URL.
+      # GATED on the ADMIN_DB_MIGRATIONS_ENABLED repo variable: deploys must not break
+      # before the Fly pagespace-db-admin instance is provisioned. Ops flips the
+      # variable to 'true' after provisioning — see the Phase 6 runbook (issue #890).
+      - name: Run admin migrations
+        if: ${{ vars.ADMIN_DB_MIGRATIONS_ENABLED == 'true' }}
+        run: |
+          docker pull ghcr.io/2witstudios/pagespace-migrate:latest
+          docker tag ghcr.io/2witstudios/pagespace-migrate:latest registry.fly.io/pagespace-web:migrate-admin
+          docker push registry.fly.io/pagespace-web:migrate-admin
+
+          # Same expected "desired start state" error as the main migration machine
+          # (one-shot machines exit before reaching "started"); verify via state below.
+          flyctl machine run registry.fly.io/pagespace-web:migrate-admin \
+            --app pagespace-web \
+            --region iad \
+            --restart no \
+            bun run db:migrate:admin \
+            2>&1 | tee /tmp/admin_machine_output.txt || true
+
+          MACHINE_ID=$(grep -oP 'Machine ID: \K[0-9a-f]+' /tmp/admin_machine_output.txt | head -1)
+          if [ -z "$MACHINE_ID" ]; then
+            echo "ERROR: could not parse machine ID from flyctl output"
+            cat /tmp/admin_machine_output.txt
+            exit 1
+          fi
+          echo "Admin migration machine: $MACHINE_ID"
+
+          if grep -q "Error:" /tmp/admin_machine_output.txt && ! grep -q "desired start state" /tmp/admin_machine_output.txt; then
+            echo "ERROR: unexpected flyctl error:"
+            grep "Error:" /tmp/admin_machine_output.txt
+            flyctl machine destroy "$MACHINE_ID" --app pagespace-web --force 2>/dev/null || true
+            exit 1
+          fi
+
+          # Poll for terminal state (stopped = success, failed/destroyed = failure) —
+          # same REST-API polling as the main migration step.
+          TIMEOUT=900
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            HTTP_CODE=$(curl -s -o /tmp/fly_admin_machine.json -w "%{http_code}" \
+              -H "Authorization: Bearer $FLY_API_TOKEN" \
+              "https://api.machines.dev/v1/apps/pagespace-web/machines/$MACHINE_ID")
+            if [ "$HTTP_CODE" = "200" ]; then
+              STATE=$(jq -r '.state // "unknown"' /tmp/fly_admin_machine.json 2>/dev/null || echo "unknown")
+            elif [ "$HTTP_CODE" = "404" ]; then
+              echo "ERROR: admin migration machine $MACHINE_ID not found (unexpectedly destroyed)"
+              exit 1
+            else
+              STATE="unknown"
+            fi
+            echo "  [${ELAPSED}s] state: $STATE"
+            if [ "$STATE" = "stopped" ]; then
+              break
+            elif [ "$STATE" = "failed" ] || [ "$STATE" = "destroyed" ]; then
+              echo "ERROR: admin migration machine reached $STATE state (migrations failed)"
+              flyctl machine logs "$MACHINE_ID" --app pagespace-web 2>/dev/null || true
+              flyctl machine destroy "$MACHINE_ID" --app pagespace-web --force 2>/dev/null || true
+              exit 1
+            fi
+            sleep 10
+            ELAPSED=$((ELAPSED + 10))
+          done
+
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "ERROR: timed out after ${TIMEOUT}s waiting for admin migration machine"
+            flyctl machine destroy "$MACHINE_ID" --app pagespace-web --force 2>/dev/null || true
+            exit 1
+          fi
+
+          flyctl machine destroy "$MACHINE_ID" --app pagespace-web --force
+          echo "Admin migrations complete"
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_NO_UPDATE_CHECK: "true"
+
       - name: Deploy web
         run: |
           docker pull ghcr.io/2witstudios/pagespace-web:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,30 @@ services:
         limits:
           memory: 200M
 
+  # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
+  # chain, isolated from the app database in every deployment mode (#890).
+  postgres-admin:
+    image: postgres:17.5-alpine
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_admin_data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=pagespace_admin
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user -d pagespace_admin"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - internal
+    deploy:
+      resources:
+        limits:
+          memory: 200M
+
   migrate:
     build:
       context: .
@@ -28,13 +52,18 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      postgres-admin:
+        condition: service_healthy
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
         bun run db:migrate &&
+        echo 'Starting admin database migrations...' &&
+        bun run db:migrate:admin &&
         echo 'Migrations complete, starting services...'
       "
     healthcheck:
@@ -75,6 +104,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - NEXT_PUBLIC_REALTIME_URL=${NEXT_PUBLIC_REALTIME_URL}
       - PROCESSOR_URL=http://processor:3003
       - PORT=3000
@@ -99,6 +129,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - ADMIN_URL=${ADMIN_URL:-http://localhost:3005}
       - NEXT_PUBLIC_WEB_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - WEB_APP_INTERNAL_URL=http://web:3000
@@ -134,6 +165,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - PORT=3003
       - NODE_OPTIONS=--max-old-space-size=1024
       - ENABLE_OCR=${ENABLE_OCR:-false}
@@ -179,6 +211,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - PORT=${REALTIME_PORT}
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3000}
     deploy:
@@ -272,4 +305,5 @@ networks:
 
 volumes:
   postgres_data:
+  postgres_admin_data:
   cron_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,10 @@ services:
 
   # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
   # chain, isolated from the app database in every deployment mode (#890).
+  # CREDENTIAL MODEL (Phase 1): the owner/bootstrap role goes ONLY to this
+  # container and the migrate one-shot — runtime services hold no admin
+  # credentials (the owner would bypass the drizzle-admin/0001 zero-trust
+  # grants). Phase 2 wires per-service LOGIN roles with the audit cutover.
   postgres-admin:
     image: postgres:17.5-alpine
     ports:
@@ -104,7 +108,6 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
-      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - NEXT_PUBLIC_REALTIME_URL=${NEXT_PUBLIC_REALTIME_URL}
       - PROCESSOR_URL=http://processor:3003
       - PORT=3000
@@ -129,7 +132,6 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
-      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - ADMIN_URL=${ADMIN_URL:-http://localhost:3005}
       - NEXT_PUBLIC_WEB_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - WEB_APP_INTERNAL_URL=http://web:3000
@@ -165,7 +167,6 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
-      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - PORT=3003
       - NODE_OPTIONS=--max-old-space-size=1024
       - ENABLE_OCR=${ENABLE_OCR:-false}
@@ -211,7 +212,6 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
-      - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
       - PORT=${REALTIME_PORT}
       - CORS_ORIGIN=${CORS_ORIGIN:-http://localhost:3000}
     deploy:

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -17,8 +17,9 @@ emits everything below.
 
 The stack now runs a second PostgreSQL container, `postgres-admin` (the
 "trust plane"), holding the tamper-evident security audit chain in isolation
-from the app database. The compose file requires three new variables and
-**refuses to start** without them:
+from the app database. The compose file introduces three new variables and
+**refuses to start** without `ADMIN_POSTGRES_PASSWORD` (the other two have
+compose-level defaults — see Notes):
 
 ```
 required variable ADMIN_POSTGRES_PASSWORD is missing a value:

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -46,7 +46,13 @@ ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admi
    ADMIN_POSTGRES_PASSWORD=<paste the generated password>
    ```
 
-3. Pull and restart the stack as usual:
+3. Pull and restart the stack as usual — via the wrapper if you deploy with it:
+
+   ```bash
+   ./scripts/tenant-stack.sh upgrade <slug>
+   ```
+
+   or with docker compose directly:
 
    ```bash
    docker compose -p ps-<slug> -f docker-compose.tenant.yml --env-file /data/tenants/<slug>/.env up -d

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -69,6 +69,10 @@ ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admi
   strictly required. Set all three anyway so the `.env` matches the template.
 - The admin database gets its own volume (`postgres_admin_data`); no existing
   data is touched.
+- `ADMIN_POSTGRES_*` is the owner/bootstrap role and is handed only to the
+  `postgres-admin` container and the `migrate` one-shot. Runtime services
+  (web/processor/realtime) hold no admin credentials in Phase 1 — per-service
+  least-privilege LOGIN roles arrive with the Phase 2 audit-write cutover.
 - `ADMIN_DB_BREAK_GLASS=true` is a break-glass rollback flag only (audit
   writes fall back to the main DB and alert loudly). It is not a supported
   steady state — do not set it during a normal upgrade.

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -1,0 +1,68 @@
+# Infrastructure Upgrade Notes
+
+Operator-facing notes for upgrading **existing** tenant/self-host deployments.
+Each section lists the manual steps a live deployment needs before pulling the
+new compose stack. Fresh deployments provisioned with
+`scripts/generate-tenant-env.sh` need none of this — the generator already
+emits everything below.
+
+> ⚠️ **NEVER re-run `generate-tenant-env.sh` on a live deployment.** It
+> regenerates ALL secrets — including `ENCRYPTION_KEY`, which makes every
+> field-level-encrypted row in your existing database permanently unreadable,
+> and `POSTGRES_PASSWORD`, which locks the stack out of its own data volume.
+> It is a provisioning tool for new tenants only. Upgrades are always
+> append-only edits to the existing `.env`.
+
+## 2026-07 — Phase 1 admin database (issue #890)
+
+The stack now runs a second PostgreSQL container, `postgres-admin` (the
+"trust plane"), holding the tamper-evident security audit chain in isolation
+from the app database. The compose file requires three new variables and
+**refuses to start** without them:
+
+```
+required variable ADMIN_POSTGRES_PASSWORD is missing a value:
+ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)
+```
+
+### Steps
+
+1. Generate a password for the admin database (32 alphanumeric characters,
+   same shape `generate-tenant-env.sh` uses):
+
+   ```bash
+   openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32; echo
+   ```
+
+2. **Append** the following lines to the **existing** `.env`
+   (e.g. `/data/tenants/<slug>/.env`) — do not remove or change any existing
+   line. These mirror the `--- Admin Database (trust plane) ---` section of
+   `env.tenant.template`:
+
+   ```dotenv
+   # --- Admin Database (trust plane) ---
+   ADMIN_POSTGRES_DB=pagespace_admin
+   ADMIN_POSTGRES_USER=pagespace
+   ADMIN_POSTGRES_PASSWORD=<paste the generated password>
+   ```
+
+3. Pull and restart the stack as usual:
+
+   ```bash
+   docker compose -p ps-<slug> -f docker-compose.tenant.yml --env-file /data/tenants/<slug>/.env up -d
+   ```
+
+   The `migrate` one-shot now waits for both databases to be healthy and runs
+   `db:migrate` followed by `db:migrate:admin`; the admin database reaches
+   full schema (partitioned chain tables, zero-trust roles) on first boot.
+
+### Notes
+
+- `ADMIN_POSTGRES_DB` / `ADMIN_POSTGRES_USER` have compose-level defaults
+  (`pagespace_admin` / `pagespace`); only `ADMIN_POSTGRES_PASSWORD` is
+  strictly required. Set all three anyway so the `.env` matches the template.
+- The admin database gets its own volume (`postgres_admin_data`); no existing
+  data is touched.
+- `ADMIN_DB_BREAK_GLASS=true` is a break-glass rollback flag only (audit
+  writes fall back to the main DB and alert loudly). It is not a supported
+  steady state — do not set it during a normal upgrade.

--- a/infrastructure/__tests__/ci-admin-migrate.test.ts
+++ b/infrastructure/__tests__/ci-admin-migrate.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+const WORKFLOW_PATH = resolve(__dirname, '../../.github/workflows/docker-images.yml');
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+}
+
+interface WorkflowFile {
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+function loadWorkflow(): WorkflowFile {
+  const raw = readFileSync(WORKFLOW_PATH, 'utf-8');
+  return parse(raw) as WorkflowFile;
+}
+
+describe('docker-images.yml admin-DB migrate step', () => {
+  const workflow = loadWorkflow();
+  const steps = workflow.jobs['deploy-fly'].steps ?? [];
+  const mainIdx = steps.findIndex(s => s.name === 'Run migrations');
+  const adminIdx = steps.findIndex(s => s.name === 'Run admin migrations');
+  const adminStep = steps[adminIdx];
+
+  it('given the deploy-fly job, should define a "Run admin migrations" step', () => {
+    expect(adminStep).toBeDefined();
+  });
+
+  it('given the admin migrations step, should run directly after the main "Run migrations" step', () => {
+    expect(mainIdx).toBeGreaterThanOrEqual(0);
+    expect(adminIdx).toBe(mainIdx + 1);
+  });
+
+  it('given the admin migrations step, should be conditional on the admin DB being provisioned', () => {
+    expect(adminStep.if).toBeDefined();
+    expect(adminStep.if).toContain('ADMIN_DB_MIGRATIONS_ENABLED');
+  });
+
+  it('given the admin migrations step, should run db:migrate:admin on a one-shot machine', () => {
+    expect(adminStep.run).toContain('flyctl machine run');
+    expect(adminStep.run).toContain('db:migrate:admin');
+  });
+
+  it('given the admin migrations step, should use the same migrate image as the main step', () => {
+    expect(adminStep.run).toContain('pagespace-migrate:latest');
+  });
+
+  it('given the admin migrations step, should fail on failed/destroyed machine states like the main step', () => {
+    expect(adminStep.run).toContain('failed');
+    expect(adminStep.run).toContain('destroyed');
+  });
+
+  it('given the main migrations step, should NOT be conditional (main DB always migrates)', () => {
+    expect(steps[mainIdx].if).toBeUndefined();
+  });
+});

--- a/infrastructure/__tests__/env-template.test.ts
+++ b/infrastructure/__tests__/env-template.test.ts
@@ -49,6 +49,7 @@ describe('Tenant env template', () => {
     'ENCRYPTION_KEY',
     'CSRF_SECRET',
     'POSTGRES_PASSWORD',
+    'ADMIN_POSTGRES_PASSWORD',
     'CRON_SECRET',
     'REALTIME_BROADCAST_SECRET',
   ];

--- a/infrastructure/__tests__/generate-tenant-env.test.ts
+++ b/infrastructure/__tests__/generate-tenant-env.test.ts
@@ -87,6 +87,14 @@ describe('generate-tenant-env.sh', () => {
     it('given the output, DEPLOYMENT_MODE should be tenant', () => {
       expect(env.get('DEPLOYMENT_MODE')).toBe('tenant');
     });
+
+    it('given the output, ADMIN_POSTGRES_DB should be pagespace_admin', () => {
+      expect(env.get('ADMIN_POSTGRES_DB')).toBe('pagespace_admin');
+    });
+
+    it('given the output, ADMIN_POSTGRES_USER should be pagespace', () => {
+      expect(env.get('ADMIN_POSTGRES_USER')).toBe('pagespace');
+    });
   });
 
   describe('secret generation', () => {
@@ -107,11 +115,18 @@ describe('generate-tenant-env.sh', () => {
       expect(val).toMatch(/^[a-zA-Z0-9]+$/);
     });
 
+    it('given ADMIN_POSTGRES_PASSWORD, should be at least 24 alphanumeric characters', () => {
+      const val = env.get('ADMIN_POSTGRES_PASSWORD') ?? '';
+      expect(val.length).toBeGreaterThanOrEqual(24);
+      expect(val).toMatch(/^[a-zA-Z0-9]+$/);
+    });
+
     it('given all secrets, should all be unique (no reuse)', () => {
       const secrets = [
         env.get('ENCRYPTION_KEY'),
         env.get('CSRF_SECRET'),
         env.get('POSTGRES_PASSWORD'),
+        env.get('ADMIN_POSTGRES_PASSWORD'),
         env.get('CRON_SECRET'),
         env.get('REALTIME_BROADCAST_SECRET'),
       ];

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+const COMPOSE_PATH = resolve(__dirname, '../../docker-compose.yml');
+
+interface ComposeService {
+  image?: string;
+  ports?: string[];
+  volumes?: string[];
+  networks?: string[] | Record<string, unknown>;
+  environment?: Record<string, string> | string[];
+  command?: string | string[];
+  deploy?: { resources?: { limits?: { memory?: string } } };
+  depends_on?: Record<string, { condition: string }>;
+  healthcheck?: { test: string[] | string; interval?: string; timeout?: string; retries?: number };
+}
+
+interface ComposeFile {
+  services: Record<string, ComposeService>;
+  networks?: Record<string, { external?: boolean; driver?: string; internal?: boolean }>;
+  volumes?: Record<string, { driver?: string } | null>;
+}
+
+function loadCompose(): ComposeFile {
+  const raw = readFileSync(COMPOSE_PATH, 'utf-8');
+  return parse(raw) as ComposeFile;
+}
+
+function getEnv(compose: ComposeFile, svc: string): Record<string, string> {
+  const env = compose.services[svc].environment;
+  if (!env) return {};
+  if (Array.isArray(env)) {
+    const result: Record<string, string> = {};
+    for (const e of env) {
+      const [k, ...v] = e.split('=');
+      result[k] = v.join('=');
+    }
+    return result;
+  }
+  return env;
+}
+
+describe('Root (dev/self-host) docker-compose configuration', () => {
+  const compose = loadCompose();
+
+  describe('postgres-admin service (trust plane)', () => {
+    it('given the root compose, should define the postgres-admin service', () => {
+      expect(compose.services['postgres-admin']).toBeDefined();
+    });
+
+    it('given the postgres-admin service, should pin the SAME postgres image as the main postgres service', () => {
+      expect(compose.services['postgres-admin'].image).toBe(compose.services.postgres.image);
+    });
+
+    it('given the postgres-admin service, should mount its own postgres_admin_data volume', () => {
+      const vols = compose.services['postgres-admin'].volumes ?? [];
+      expect(vols.some(v => v.startsWith('postgres_admin_data:'))).toBe(true);
+    });
+
+    it('given the compose file, should define the postgres_admin_data volume', () => {
+      expect(compose.volumes).toHaveProperty('postgres_admin_data');
+    });
+
+    it('given the postgres-admin service, should use the pagespace_admin database name', () => {
+      expect(getEnv(compose, 'postgres-admin').POSTGRES_DB).toBe('pagespace_admin');
+    });
+
+    it('given the postgres-admin service, should have a pg_isready healthcheck against pagespace_admin', () => {
+      const test = compose.services['postgres-admin'].healthcheck?.test;
+      const testStr = Array.isArray(test) ? test.join(' ') : test;
+      expect(testStr).toContain('pg_isready');
+      expect(testStr).toContain('pagespace_admin');
+    });
+
+    it('given the postgres-admin service, should join only the internal network', () => {
+      const nets = compose.services['postgres-admin'].networks;
+      if (Array.isArray(nets)) {
+        expect(nets).toEqual(['internal']);
+      } else {
+        expect(Object.keys(nets ?? {})).toEqual(['internal']);
+      }
+    });
+
+    it('given the postgres-admin service, should expose host port 5433 (documented in .env.onprem.example)', () => {
+      const ports = compose.services['postgres-admin'].ports ?? [];
+      expect(ports.some(p => String(p).startsWith('5433:'))).toBe(true);
+    });
+
+    it('given the postgres-admin service, should have the same memory limit as the main postgres service', () => {
+      expect(compose.services['postgres-admin'].deploy?.resources?.limits?.memory)
+        .toBe(compose.services.postgres.deploy?.resources?.limits?.memory);
+    });
+  });
+
+  describe('migrate one-shot', () => {
+    it('given the migrate service, should depend on both postgres and postgres-admin being healthy', () => {
+      const deps = compose.services.migrate.depends_on;
+      expect(deps?.postgres?.condition).toBe('service_healthy');
+      expect(deps?.['postgres-admin']?.condition).toBe('service_healthy');
+    });
+
+    it('given the migrate service, should run db:migrate:admin after db:migrate', () => {
+      const command = String(compose.services.migrate.command);
+      expect(command).toContain('db:migrate:admin');
+      expect(command.indexOf('db:migrate')).toBeLessThan(command.indexOf('db:migrate:admin'));
+    });
+
+    it('given the migrate service, should receive ADMIN_DATABASE_URL pointing at postgres-admin', () => {
+      const url = getEnv(compose, 'migrate').ADMIN_DATABASE_URL;
+      expect(url).toContain('@postgres-admin:5432/pagespace_admin');
+    });
+  });
+
+  describe('ADMIN_DATABASE_URL wiring', () => {
+    const appServices = ['web', 'admin', 'processor', 'realtime'];
+
+    it.each(appServices)(
+      'given the %s service, should receive ADMIN_DATABASE_URL pointing at postgres-admin',
+      (svc) => {
+        const url = getEnv(compose, svc).ADMIN_DATABASE_URL;
+        expect(url).toContain('@postgres-admin:5432/pagespace_admin');
+      },
+    );
+
+    it.each(appServices)(
+      'given the %s service, should still receive DATABASE_URL pointing at the main postgres',
+      (svc) => {
+        const url = getEnv(compose, svc).DATABASE_URL;
+        expect(url).toContain('@postgres:5432/pagespace');
+      },
+    );
+  });
+});

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -116,11 +116,16 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
   describe('ADMIN_DATABASE_URL wiring', () => {
     const appServices = ['web', 'admin', 'processor', 'realtime'];
 
+    // Owner/bootstrap credentials bypass the drizzle-admin/0001 zero-trust
+    // grants, so only the migrate one-shot may hold them. Runtime services
+    // get per-service LOGIN roles with the Phase 2 audit-write cutover.
+    // (This pins the compose environment map; the dev stack's `env_file: .env`
+    // may still carry the var — the hard guarantee is the tenant stack, which
+    // uses explicit environment maps only.)
     it.each(appServices)(
-      'given the %s service, should receive ADMIN_DATABASE_URL pointing at postgres-admin',
+      'given the %s runtime service, should NOT wire ADMIN_DATABASE_URL in the environment map (owner creds are migrate-only in Phase 1)',
       (svc) => {
-        const url = getEnv(compose, svc).ADMIN_DATABASE_URL;
-        expect(url).toContain('@postgres-admin:5432/pagespace_admin');
+        expect(getEnv(compose, svc)).not.toHaveProperty('ADMIN_DATABASE_URL');
       },
     );
 

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -371,14 +371,23 @@ describe('Tenant docker-compose configuration', () => {
       expect(dbUrl).toContain('${POSTGRES_PASSWORD');
     });
 
-    const adminDbServices = ['web', 'processor', 'realtime', 'migrate'];
+    it('given the migrate service, ADMIN_DATABASE_URL should reference internal postgres-admin with interpolated credentials', () => {
+      const url = getEnv('migrate').ADMIN_DATABASE_URL;
+      expect(url).toContain('@postgres-admin:');
+      expect(url).toContain('${ADMIN_POSTGRES_PASSWORD');
+    });
 
-    it.each(adminDbServices)(
-      'given the %s service, ADMIN_DATABASE_URL should reference internal postgres-admin with interpolated credentials',
+    // Owner/bootstrap credentials would bypass the drizzle-admin/0001
+    // zero-trust grants (the owner can DELETE/TRUNCATE its own tables), so
+    // runtime services must not receive them. Per-service LOGIN roles
+    // (admin_app / admin_chainer / admin_siem members) arrive with the
+    // Phase 2 audit-write cutover.
+    const runtimeServices = ['web', 'processor', 'realtime'];
+
+    it.each(runtimeServices)(
+      'given the %s runtime service, should NOT receive ADMIN_DATABASE_URL (owner creds are migrate-only in Phase 1)',
       (svc) => {
-        const url = getEnv(svc).ADMIN_DATABASE_URL;
-        expect(url).toContain('@postgres-admin:');
-        expect(url).toContain('${ADMIN_POSTGRES_PASSWORD');
+        expect(getEnv(svc)).not.toHaveProperty('ADMIN_DATABASE_URL');
       },
     );
 
@@ -421,7 +430,7 @@ describe('Tenant docker-compose configuration', () => {
       const lines = getRawYaml()
         .split('\n')
         .filter((l) => !l.trim().startsWith('#') && l.includes('ADMIN_DATABASE_URL:'));
-      expect(lines.length).toBeGreaterThanOrEqual(4); // web, processor, realtime, migrate
+      expect(lines.length).toBe(1); // migrate only — runtime services hold no admin creds in Phase 1
       for (const line of lines) {
         expect(line).toMatch(/\$\{ADMIN_POSTGRES_PASSWORD:\?/);
       }

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -403,6 +403,45 @@ describe('Tenant docker-compose configuration', () => {
     );
   });
 
+  describe('upgrade fail-fast for pre-Phase-1 .env files (admin DB credentials)', () => {
+    // A tenant .env generated before Phase 1 has no ADMIN_POSTGRES_* vars.
+    // Plain ${ADMIN_POSTGRES_PASSWORD} renders as "" (only a soft compose
+    // warning) and postgres-admin never becomes healthy, silently wedging the
+    // whole stack behind depends_on. The ${VAR:?message} required-var syntax
+    // makes `docker compose` abort immediately with a message naming the
+    // cause and the upgrade note instead.
+    it('given the postgres-admin service, POSTGRES_PASSWORD should use required-var syntax pointing at infrastructure/UPGRADE.md', () => {
+      const raw = getRawYaml();
+      expect(raw).toMatch(
+        /POSTGRES_PASSWORD: \$\{ADMIN_POSTGRES_PASSWORD:\?[^}]*infrastructure\/UPGRADE\.md[^}]*\}/,
+      );
+    });
+
+    it('given every ADMIN_DATABASE_URL derivation, should use required-var syntax on the admin password', () => {
+      const lines = getRawYaml()
+        .split('\n')
+        .filter((l) => !l.trim().startsWith('#') && l.includes('ADMIN_DATABASE_URL:'));
+      expect(lines.length).toBeGreaterThanOrEqual(4); // web, processor, realtime, migrate
+      for (const line of lines) {
+        expect(line).toMatch(/\$\{ADMIN_POSTGRES_PASSWORD:\?/);
+      }
+    });
+
+    it('given the comment block above the postgres-admin service, should link infrastructure/UPGRADE.md', () => {
+      const lines = getRawYaml().split('\n');
+      const svcIdx = lines.findIndex((l) => l.startsWith('  postgres-admin:'));
+      expect(svcIdx).toBeGreaterThan(-1);
+      const commentBlock: string[] = [];
+      for (let i = svcIdx - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (line.startsWith('#')) commentBlock.push(line);
+        else if (line === '') continue;
+        else break;
+      }
+      expect(commentBlock.join('\n')).toContain('infrastructure/UPGRADE.md');
+    });
+  });
+
   describe('healthchecks', () => {
     it('given the postgres service, should use pg_isready', () => {
       const test = compose.services.postgres.healthcheck?.test;

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -44,7 +44,7 @@ describe('Tenant docker-compose configuration', () => {
 
   describe('services', () => {
     const requiredServices = [
-      'postgres', 'migrate',
+      'postgres', 'postgres-admin', 'migrate',
       'web', 'processor', 'realtime', 'cron',
     ];
 
@@ -95,6 +95,10 @@ describe('Tenant docker-compose configuration', () => {
       expect(compose.services.postgres.image).toBe('postgres:17.5-alpine');
     });
 
+    it('given the postgres-admin service, should pin the SAME image as the main postgres service', () => {
+      expect(compose.services['postgres-admin'].image).toBe(compose.services.postgres.image);
+    });
+
     it('given the raw YAML, should not contain any redis image references', () => {
       expect(getRawYaml()).not.toMatch(/redis:/i);
     });
@@ -103,6 +107,7 @@ describe('Tenant docker-compose configuration', () => {
   describe('resource limits', () => {
     const limits: [string, string][] = [
       ['postgres', '200M'],
+      ['postgres-admin', '200M'],
       ['web', '768M'],
       ['processor', '1280M'],
       ['realtime', '256M'],
@@ -122,6 +127,17 @@ describe('Tenant docker-compose configuration', () => {
     it('given the migrate service, should depend on postgres being healthy', () => {
       const deps = compose.services.migrate.depends_on;
       expect(deps?.postgres?.condition).toBe('service_healthy');
+    });
+
+    it('given the migrate service, should depend on postgres-admin being healthy', () => {
+      const deps = compose.services.migrate.depends_on;
+      expect(deps?.['postgres-admin']?.condition).toBe('service_healthy');
+    });
+
+    it('given the migrate service, should run db:migrate:admin after db:migrate', () => {
+      const command = String(compose.services.migrate.command);
+      expect(command).toContain('db:migrate:admin');
+      expect(command.indexOf('db:migrate')).toBeLessThan(command.indexOf('db:migrate:admin'));
     });
 
     it('given the web service, should depend on migrate completed and processor healthy only', () => {
@@ -231,7 +247,7 @@ describe('Tenant docker-compose configuration', () => {
       }
     });
 
-    const internalOnly = ['postgres', 'migrate', 'processor', 'cron'];
+    const internalOnly = ['postgres', 'postgres-admin', 'migrate', 'processor', 'cron'];
 
     it.each(internalOnly)(
       'given the %s service, should only join the internal network',
@@ -301,7 +317,7 @@ describe('Tenant docker-compose configuration', () => {
 
     it('given the raw YAML, all secret references should use variable interpolation', () => {
       const raw = getRawYaml();
-      const secretVars = ['ENCRYPTION_KEY', 'CSRF_SECRET', 'POSTGRES_PASSWORD'];
+      const secretVars = ['ENCRYPTION_KEY', 'CSRF_SECRET', 'POSTGRES_PASSWORD', 'ADMIN_POSTGRES_PASSWORD'];
       for (const v of secretVars) {
         const lines = raw.split('\n').filter(l => !l.trim().startsWith('#'));
         for (const line of lines) {
@@ -355,6 +371,17 @@ describe('Tenant docker-compose configuration', () => {
       expect(dbUrl).toContain('${POSTGRES_PASSWORD');
     });
 
+    const adminDbServices = ['web', 'processor', 'realtime', 'migrate'];
+
+    it.each(adminDbServices)(
+      'given the %s service, ADMIN_DATABASE_URL should reference internal postgres-admin with interpolated credentials',
+      (svc) => {
+        const url = getEnv(svc).ADMIN_DATABASE_URL;
+        expect(url).toContain('@postgres-admin:');
+        expect(url).toContain('${ADMIN_POSTGRES_PASSWORD');
+      },
+    );
+
     const redisEnvVars = ['REDIS_URL', 'REDIS_SESSION_URL', 'REDIS_RATE_LIMIT_URL', 'REDIS_PASSWORD'];
     const jwtEnvVars = ['JWT_SECRET', 'JWT_ISSUER', 'JWT_AUDIENCE'];
     const servicesWithEnv = Object.keys(compose.services).filter(
@@ -383,6 +410,12 @@ describe('Tenant docker-compose configuration', () => {
       expect(testStr).toContain('pg_isready');
     });
 
+    it('given the postgres-admin service, should use pg_isready', () => {
+      const test = compose.services['postgres-admin'].healthcheck?.test;
+      const testStr = Array.isArray(test) ? test.join(' ') : test;
+      expect(testStr).toContain('pg_isready');
+    });
+
     it('given the processor service, should check HTTP health on port 3003', () => {
       const test = compose.services.processor.healthcheck?.test;
       const testStr = Array.isArray(test) ? test.join(' ') : test;
@@ -393,6 +426,7 @@ describe('Tenant docker-compose configuration', () => {
   describe('volumes', () => {
     const requiredVolumes = [
       'postgres_data',
+      'postgres_admin_data',
       'file_storage',
       'cache_storage',
     ];

--- a/infrastructure/__tests__/upgrade-doc.test.ts
+++ b/infrastructure/__tests__/upgrade-doc.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const UPGRADE_PATH = resolve(__dirname, '../UPGRADE.md');
+const TEMPLATE_PATH = resolve(__dirname, '../env.tenant.template');
+
+/**
+ * infrastructure/UPGRADE.md is the operator-facing upgrade note for existing
+ * tenant/self-host deployments. The tenant compose's required-var errors
+ * (${ADMIN_POSTGRES_PASSWORD:?...}) point operators here, so the doc MUST
+ * exist and MUST carry the exact remediation: append the ADMIN_POSTGRES_*
+ * vars to the EXISTING .env — never regenerate it.
+ */
+describe('infrastructure/UPGRADE.md (operator upgrade note)', () => {
+  it('given the infrastructure directory, should contain UPGRADE.md', () => {
+    expect(existsSync(UPGRADE_PATH)).toBe(true);
+  });
+
+  const doc = existsSync(UPGRADE_PATH) ? readFileSync(UPGRADE_PATH, 'utf-8') : '';
+
+  it('given the Phase 1 section, should be dated', () => {
+    expect(doc).toMatch(/## .*2026-07/);
+  });
+
+  it('given the Phase 1 section, should show the exact ADMIN_POSTGRES_* lines to append', () => {
+    expect(doc).toContain('ADMIN_POSTGRES_DB=pagespace_admin');
+    expect(doc).toContain('ADMIN_POSTGRES_USER=pagespace');
+    expect(doc).toMatch(/ADMIN_POSTGRES_PASSWORD=/);
+  });
+
+  it('given the ADMIN_POSTGRES_DB/USER lines, should mirror env.tenant.template exactly', () => {
+    const template = readFileSync(TEMPLATE_PATH, 'utf-8');
+    for (const key of ['ADMIN_POSTGRES_DB', 'ADMIN_POSTGRES_USER'] as const) {
+      const templateLine = template.split('\n').find((l) => l.startsWith(`${key}=`));
+      expect(templateLine).toBeDefined();
+      expect(doc).toContain(templateLine as string);
+    }
+  });
+
+  it('given the remediation steps, should warn NEVER to re-run generate-tenant-env.sh on a live deployment', () => {
+    expect(doc).toContain('generate-tenant-env.sh');
+    expect(doc).toMatch(/never/i);
+    // The reason must be spelled out: regenerating rotates ALL secrets
+    // including ENCRYPTION_KEY, which makes existing encrypted data unreadable.
+    expect(doc).toContain('ENCRYPTION_KEY');
+  });
+
+  it('given the remediation steps, should instruct appending to the EXISTING .env', () => {
+    expect(doc).toMatch(/append/i);
+    expect(doc).toMatch(/existing/i);
+  });
+});

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -33,6 +33,11 @@ services:
 
   # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
   # chain, isolated from the app database in every deployment mode (#890).
+  #
+  # UPGRADING an existing deployment: a pre-Phase-1 .env has no ADMIN_POSTGRES_*
+  # vars, so this stack refuses to start (required-var errors below) until they
+  # are APPENDED to the existing .env — see infrastructure/UPGRADE.md. Never
+  # re-run generate-tenant-env.sh on a live deployment.
   postgres-admin:
     image: postgres:17.5-alpine
     restart: unless-stopped
@@ -41,7 +46,7 @@ services:
     environment:
       POSTGRES_DB: ${ADMIN_POSTGRES_DB:-pagespace_admin}
       POSTGRES_USER: ${ADMIN_POSTGRES_USER:-pagespace}
-      POSTGRES_PASSWORD: ${ADMIN_POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD: ${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${ADMIN_POSTGRES_USER:-pagespace} -d ${ADMIN_POSTGRES_DB:-pagespace_admin}"]
       interval: 10s
@@ -68,7 +73,7 @@ services:
         condition: service_healthy
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
@@ -113,7 +118,7 @@ services:
       - cache_storage:/data/cache
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /data/files
       CACHE_PATH: /data/cache
       PORT: "3003"
@@ -169,7 +174,7 @@ services:
       DEPLOYMENT_MODE: tenant
       NEXT_PUBLIC_DEPLOYMENT_MODE: tenant
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /app/storage
       PROCESSOR_URL: http://processor:3003
       CRON_SECRET: ${CRON_SECRET}
@@ -218,7 +223,7 @@ services:
         condition: service_completed_successfully
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       PORT: "3001"
       CORS_ORIGIN: ${CORS_ORIGIN}
       REALTIME_BROADCAST_SECRET: ${REALTIME_BROADCAST_SECRET}

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -34,6 +34,13 @@ services:
   # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
   # chain, isolated from the app database in every deployment mode (#890).
   #
+  # CREDENTIAL MODEL (Phase 1): ADMIN_POSTGRES_* is the OWNER/bootstrap role and
+  # is handed ONLY to this container and the migrate one-shot. Runtime services
+  # (web/processor/realtime) get no admin credentials — the owner would bypass
+  # the zero-trust grants in drizzle-admin/0001. Phase 2 wires per-service LOGIN
+  # roles (admin_app / admin_chainer / admin_siem members) when the audit write
+  # path actually moves here.
+  #
   # UPGRADING an existing deployment: a pre-Phase-1 .env has no ADMIN_POSTGRES_*
   # vars, so this stack refuses to start (required-var errors below) until they
   # are APPENDED to the existing .env — see infrastructure/UPGRADE.md. Never
@@ -118,7 +125,6 @@ services:
       - cache_storage:/data/cache
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /data/files
       CACHE_PATH: /data/cache
       PORT: "3003"
@@ -174,7 +180,6 @@ services:
       DEPLOYMENT_MODE: tenant
       NEXT_PUBLIC_DEPLOYMENT_MODE: tenant
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /app/storage
       PROCESSOR_URL: http://processor:3003
       CRON_SECRET: ${CRON_SECRET}
@@ -223,7 +228,6 @@ services:
         condition: service_completed_successfully
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
-      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       PORT: "3001"
       CORS_ORIGIN: ${CORS_ORIGIN}
       REALTIME_BROADCAST_SECRET: ${REALTIME_BROADCAST_SECRET}

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -31,17 +31,50 @@ services:
     networks:
       - internal
 
+  # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
+  # chain, isolated from the app database in every deployment mode (#890).
+  postgres-admin:
+    image: postgres:17.5-alpine
+    restart: unless-stopped
+    volumes:
+      - postgres_admin_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: ${ADMIN_POSTGRES_DB:-pagespace_admin}
+      POSTGRES_USER: ${ADMIN_POSTGRES_USER:-pagespace}
+      POSTGRES_PASSWORD: ${ADMIN_POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${ADMIN_POSTGRES_USER:-pagespace} -d ${ADMIN_POSTGRES_DB:-pagespace_admin}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 200M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - internal
+
   migrate:
     image: ghcr.io/2witstudios/pagespace-migrate:${IMAGE_TAG:-latest}
     depends_on:
       postgres:
         condition: service_healthy
+      postgres-admin:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
         bun run db:migrate &&
+        echo 'Starting admin database migrations...' &&
+        bun run db:migrate:admin &&
         echo 'Migrations complete'
       "
     networks:
@@ -80,6 +113,7 @@ services:
       - cache_storage:/data/cache
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /data/files
       CACHE_PATH: /data/cache
       PORT: "3003"
@@ -135,6 +169,7 @@ services:
       DEPLOYMENT_MODE: tenant
       NEXT_PUBLIC_DEPLOYMENT_MODE: tenant
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /app/storage
       PROCESSOR_URL: http://processor:3003
       CRON_SECRET: ${CRON_SECRET}
@@ -183,6 +218,7 @@ services:
         condition: service_completed_successfully
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       PORT: "3001"
       CORS_ORIGIN: ${CORS_ORIGIN}
       REALTIME_BROADCAST_SECRET: ${REALTIME_BROADCAST_SECRET}
@@ -236,5 +272,6 @@ networks:
 
 volumes:
   postgres_data:
+  postgres_admin_data:
   file_storage:
   cache_storage:

--- a/infrastructure/env.tenant.template
+++ b/infrastructure/env.tenant.template
@@ -15,6 +15,20 @@ POSTGRES_DB=pagespace
 POSTGRES_USER=pagespace
 POSTGRES_PASSWORD=__GENERATE__
 
+# --- Admin Database (trust plane) ---
+# Dedicated Admin Postgres (postgres-admin container) for the tamper-evident
+# security audit chain, isolated from the app database in every deployment
+# mode. The compose stack derives ADMIN_DATABASE_URL from these values.
+# Real credentials are secrets — never commit them.
+ADMIN_POSTGRES_DB=pagespace_admin
+ADMIN_POSTGRES_USER=pagespace
+ADMIN_POSTGRES_PASSWORD=__GENERATE__
+# ADMIN_DATABASE_SSL=false
+# ADMIN_DB_POOL_MAX=10
+# Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to
+# fall back to the main DB and alerts loudly. Not a supported steady state.
+# ADMIN_DB_BREAK_GLASS=
+
 # --- Security Secrets ---
 ENCRYPTION_KEY=__GENERATE__
 CSRF_SECRET=__GENERATE__

--- a/infrastructure/scripts/generate-tenant-env.sh
+++ b/infrastructure/scripts/generate-tenant-env.sh
@@ -63,6 +63,11 @@ POSTGRES_DB=pagespace
 POSTGRES_USER=pagespace
 POSTGRES_PASSWORD=$(alnum_secret 32)
 
+# --- Admin Database (trust plane) ---
+ADMIN_POSTGRES_DB=pagespace_admin
+ADMIN_POSTGRES_USER=pagespace
+ADMIN_POSTGRES_PASSWORD=$(alnum_secret 32)
+
 # --- Security Secrets ---
 ENCRYPTION_KEY=$(hex_secret 32)
 CSRF_SECRET=$(hex_secret 32)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "typecheck": "turbo typecheck",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "bun run --filter '@pagespace/db' db:migrate",
+    "db:generate:admin": "bun run --filter '@pagespace/db' db:generate:admin",
+    "db:migrate:admin": "bun run --filter '@pagespace/db' db:migrate:admin",
     "test": "./scripts/test-with-db.sh",
     "test:turbo": "turbo run test",
     "test:unit": "turbo run test --filter=@pagespace/lib && bun run --filter 'web' test",

--- a/packages/db/drizzle-admin.config.ts
+++ b/packages/db/drizzle-admin.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'drizzle-kit';
+import { config } from 'dotenv';
+import path from 'path';
+
+// Load environment variables from the root .env file
+config({ path: path.resolve(__dirname, '../../.env') });
+
+/**
+ * Drizzle config for the Admin PG (trust plane) — #890 Phase 1.
+ *
+ * Separate schema barrel, separate journal (./drizzle-admin), separate
+ * database (ADMIN_DATABASE_URL) — the main-DB pipeline (root drizzle.config.ts
+ * → ./drizzle) is never touched by admin generate/migrate and vice versa.
+ * Pattern: apps/control-plane/drizzle.config.ts.
+ */
+export default defineConfig({
+  schema: './src/admin-schema.ts',
+  out: './drizzle-admin',
+  dialect: 'postgresql',
+  dbCredentials: {
+    url: process.env.ADMIN_DATABASE_URL || 'postgresql://localhost:5432/pagespace_admin',
+  },
+});

--- a/packages/db/drizzle-admin/0000_concerned_praxagora.sql
+++ b/packages/db/drizzle-admin/0000_concerned_praxagora.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS "security_audit_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"user_id" text,
+	"session_id" text,
+	"service_id" text,
+	"resource_type" text,
+	"resource_id" text,
+	"ip_address" text,
+	"ip_bidx" text,
+	"user_agent" text,
+	"geo_location" text,
+	"details" jsonb,
+	"risk_score" real,
+	"anomaly_flags" text[],
+	"timestamp" timestamp DEFAULT now() NOT NULL,
+	"chain_seq" bigserial NOT NULL,
+	"previous_hash" text NOT NULL,
+	"event_hash" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "siem_delivery_cursors" (
+	"id" text PRIMARY KEY NOT NULL,
+	"lastDeliveredId" text,
+	"lastDeliveredAt" timestamp,
+	"lastError" text,
+	"lastErrorAt" timestamp,
+	"deliveryCount" integer DEFAULT 0 NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "siem_delivery_receipts" (
+	"receiptId" text PRIMARY KEY NOT NULL,
+	"deliveryId" text NOT NULL,
+	"source" text NOT NULL,
+	"firstEntryId" text NOT NULL,
+	"lastEntryId" text NOT NULL,
+	"firstEntryTimestamp" timestamp NOT NULL,
+	"lastEntryTimestamp" timestamp NOT NULL,
+	"entryCount" integer NOT NULL,
+	"deliveredAt" timestamp NOT NULL,
+	"webhookStatus" integer,
+	"webhookResponseHash" text,
+	"ackReceivedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_timestamp" ON "security_audit_log" USING btree ("timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_user_timestamp" ON "security_audit_log" USING btree ("user_id","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_event_type" ON "security_audit_log" USING btree ("event_type","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_resource" ON "security_audit_log" USING btree ("resource_type","resource_id","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_ip" ON "security_audit_log" USING btree ("ip_address","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_ip_bidx" ON "security_audit_log" USING btree ("ip_bidx","timestamp");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_event_hash" ON "security_audit_log" USING btree ("event_hash");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_chain_seq" ON "security_audit_log" USING btree ("chain_seq");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_risk_score" ON "security_audit_log" USING btree ("risk_score");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_session" ON "security_audit_log" USING btree ("session_id","timestamp");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "siem_delivery_receipts_delivery_source_unique" ON "siem_delivery_receipts" USING btree ("deliveryId","source");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_siem_receipts_delivery_id" ON "siem_delivery_receipts" USING btree ("deliveryId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_siem_receipts_first_entry" ON "siem_delivery_receipts" USING btree ("firstEntryId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_siem_receipts_last_entry" ON "siem_delivery_receipts" USING btree ("lastEntryId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_siem_receipts_delivered_at" ON "siem_delivery_receipts" USING btree ("deliveredAt");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_siem_receipts_source_range" ON "siem_delivery_receipts" USING btree ("source","firstEntryTimestamp","lastEntryTimestamp");

--- a/packages/db/drizzle-admin/0001_zero_trust_roles.sql
+++ b/packages/db/drizzle-admin/0001_zero_trust_roles.sql
@@ -1,0 +1,86 @@
+-- Zero-trust role templates for the Admin PG trust plane (#890 Phase 1, leaf 4).
+--
+-- These are NOLOGIN role TEMPLATES. Actual login users are created per-deploy
+-- by ops and attached with `GRANT <role> TO <login_user>`; no role defined
+-- here can authenticate. Role creation is guarded (roles are cluster-scoped
+-- and may pre-exist, e.g. from a sibling database or a re-provisioned DB in
+-- the same cluster), and GRANT/REVOKE are natively idempotent, so this
+-- migration is safe to re-run.
+--
+-- Grant matrix — DELETE and TRUNCATE are granted to NOBODY on any trust-plane
+-- table. Append-only is enforced by the database itself; retention is a
+-- future SECURITY DEFINER partition-drop function (leaf 6), never a DELETE.
+--
+--   role              security_audit_log            siem_delivery_cursors  siem_delivery_receipts
+--   admin_app         SELECT, INSERT                —                      —
+--   admin_chainer     SELECT, INSERT                —                      —
+--   admin_gdpr_eraser SELECT, UPDATE(PII cols only) —                      —
+--   admin_reader      SELECT                        SELECT                 SELECT
+--   admin_siem        SELECT                        SELECT, INSERT, UPDATE SELECT, INSERT
+--
+-- admin_app: the web app's identity. INSERT for the current direct-write path
+--   and SELECT because the pre-chainer cutover (Phase 2) still reads the chain
+--   head. When the ingest table lands in Phase 2, ITS migration grants
+--   admin_app INSERT-only on it.
+-- admin_chainer: the processor's single-writer chain identity, staged here for
+--   Phase 2. Its future ingest-drain DELETE grant applies ONLY to the Phase 2
+--   ingest table — never to security_audit_log or any other chain table.
+-- admin_gdpr_eraser: Art 17 erasure. Column-scoped UPDATE on exactly the PII
+--   columns, which are hash-excluded by design, so erasure never breaks the
+--   chain. No INSERT, no UPDATE on chain/content columns.
+-- admin_reader: the admin app / chain verification. Read-only everywhere.
+-- admin_siem: SIEM delivery worker. Reads all three tables; upserts cursors
+--   (INSERT … ON CONFLICT DO UPDATE — see siem-delivery-worker.ts); receipts
+--   are write-once (INSERT only, no UPDATE — ackReceivedAt is set at insert).
+--
+-- LEAF 6 / PHASE 2 NOTE: table-level grants do NOT survive DROP/re-CREATE.
+-- The monthly-partitioning migration (leaf 6) re-creates security_audit_log
+-- and MUST re-apply this file's security_audit_log grants on the new
+-- partitioned parent (grants on the parent cascade to partitions, so one
+-- re-apply suffices). Any future table added to the trust plane gets its
+-- grants in its own migration.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_app') THEN
+    CREATE ROLE admin_app NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_chainer') THEN
+    CREATE ROLE admin_chainer NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_gdpr_eraser') THEN
+    CREATE ROLE admin_gdpr_eraser NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_reader') THEN
+    CREATE ROLE admin_reader NOLOGIN;
+  END IF;
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_siem') THEN
+    CREATE ROLE admin_siem NOLOGIN;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+GRANT USAGE ON SCHEMA public TO admin_app, admin_chainer, admin_gdpr_eraser, admin_reader, admin_siem;
+--> statement-breakpoint
+-- Defense in depth: no ambient PUBLIC privilege on any trust-plane table.
+REVOKE ALL ON security_audit_log, siem_delivery_cursors, siem_delivery_receipts FROM PUBLIC;
+--> statement-breakpoint
+GRANT SELECT, INSERT ON security_audit_log TO admin_app;
+--> statement-breakpoint
+GRANT SELECT, INSERT ON security_audit_log TO admin_chainer;
+--> statement-breakpoint
+-- chain_seq is bigserial: INSERT with the column defaulted calls nextval(),
+-- which requires USAGE on the backing sequence.
+GRANT USAGE ON SEQUENCE security_audit_log_chain_seq_seq TO admin_app, admin_chainer;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log TO admin_gdpr_eraser;
+--> statement-breakpoint
+GRANT UPDATE (user_id, session_id, ip_address, ip_bidx, user_agent, geo_location) ON security_audit_log TO admin_gdpr_eraser;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log, siem_delivery_cursors, siem_delivery_receipts TO admin_reader;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log, siem_delivery_cursors, siem_delivery_receipts TO admin_siem;
+--> statement-breakpoint
+GRANT INSERT, UPDATE ON siem_delivery_cursors TO admin_siem;
+--> statement-breakpoint
+GRANT INSERT ON siem_delivery_receipts TO admin_siem;

--- a/packages/db/drizzle-admin/0002_partition_chain_tables.sql
+++ b/packages/db/drizzle-admin/0002_partition_chain_tables.sql
@@ -1,0 +1,279 @@
+-- Monthly RANGE partitioning for the Admin PG chain tables (#890 Phase 1, leaf 6).
+--
+-- security_audit_log receives a write on every authenticated request, forever,
+-- with legally mandated infinite retention (Art 17(3)(b)); unpartitioned, its
+-- indexes and vacuum costs grow without bound. siem_delivery_receipts is
+-- likewise append-only and unbounded. Monthly partitions bound per-partition
+-- index size and vacuum work. siem_delivery_cursors (tiny, upserted) stays
+-- plain and is untouched here.
+--
+-- drizzle-kit cannot express partitioning declaratively, so this is a custom
+-- migration (generate --custom); the Drizzle schema factory is unchanged and
+-- byte-compatible column-wise, so db:generate:admin still reports no changes.
+--
+-- PK REWORK (documented tradeoff): PostgreSQL requires the partition key in
+-- every PK/unique constraint on a partitioned table.
+--   security_audit_log:      PRIMARY KEY (id)        -> (id, timestamp)
+--   siem_delivery_receipts:  PRIMARY KEY (receiptId) -> (receiptId, deliveredAt)
+--   siem_delivery_receipts:  UNIQUE (deliveryId, source) -> (deliveryId, source, deliveredAt)
+-- Consequences accepted: global id-uniqueness is no longer DB-enforced across
+-- partitions (ids are cuid2, collision odds negligible, and nothing does
+-- ON CONFLICT on either table -- verified against siem-receipt-writer.ts,
+-- which uses plain multi-row INSERT); point lookups by bare id scan one index
+-- per partition (bounded, and forensic queries are time-scoped anyway). The
+-- Drizzle schema still declares the single-column PK -- a type-level fiction
+-- that affects no runtime query; adjusting it would make drizzle-kit diff.
+--
+-- chain_seq: the bigserial's backing sequence security_audit_log_chain_seq_seq
+-- SURVIVES the re-create -- detached (OWNED BY NONE) before the old table is
+-- dropped, reused as the new column's DEFAULT, then re-owned. Values continue
+-- without reset and leaf 4's sequence USAGE grants carry over (re-asserted
+-- below anyway). The chain-head query (ORDER BY chain_seq DESC LIMIT 1) stays
+-- index-fast via the partitioned idx_security_audit_chain_seq.
+--
+-- NO DROP PATH: chain tables have infinite retention. admin_ensure_partitions
+-- is create-ahead ONLY -- it contains no drop code path at all, and EXECUTE is
+-- granted solely to admin_maintenance (which holds no table privileges and
+-- owns nothing, so it cannot drop partitions either). Partition-DROP retention
+-- for analytics lives in ClickHouse TTLs (Phase 3), never here. The two DROP
+-- TABLE statements below remove only the emptied pre-partitioning tables after
+-- their rows are copied -- they are the swap, not a retention path.
+--
+-- OPERATIONAL CADENCE: the migration seeds partitions covering any existing
+-- data range plus current + 3 months ahead + DEFAULT safety nets. A cron
+-- (Phase 6 runbook) calls SELECT admin_ensure_partitions(3) monthly as
+-- admin_maintenance to keep the horizon. If the cron dies, inserts fall into
+-- the DEFAULT partition and are never lost; note that creating a monthly
+-- partition later FAILS while DEFAULT holds rows for that month -- ops must
+-- then move those rows out of DEFAULT first (Postgres semantics, deliberately
+-- not automated here).
+--
+-- GRANTS: table grants die with DROP TABLE, so leaf 4's full grant matrix for
+-- the two re-created parents is re-applied verbatim at the end (grants on a
+-- partitioned parent cascade to partitions -- access via the parent checks
+-- only parent ACLs, so future partitions need nothing).
+
+ALTER SEQUENCE "security_audit_log_chain_seq_seq" OWNED BY NONE;
+--> statement-breakpoint
+ALTER TABLE "security_audit_log" RENAME TO "security_audit_log_unpartitioned";
+--> statement-breakpoint
+ALTER TABLE "siem_delivery_receipts" RENAME TO "siem_delivery_receipts_unpartitioned";
+--> statement-breakpoint
+-- Renaming a table does NOT rename its constraints; free the pkey names for
+-- the partitioned parents (the old tables are dropped after the copy anyway).
+ALTER TABLE "security_audit_log_unpartitioned" RENAME CONSTRAINT "security_audit_log_pkey" TO "security_audit_log_unpartitioned_pkey";
+--> statement-breakpoint
+ALTER TABLE "siem_delivery_receipts_unpartitioned" RENAME CONSTRAINT "siem_delivery_receipts_pkey" TO "siem_delivery_receipts_unpartitioned_pkey";
+--> statement-breakpoint
+CREATE TABLE "security_audit_log" (
+	"id" text NOT NULL,
+	"event_type" text NOT NULL,
+	"user_id" text,
+	"session_id" text,
+	"service_id" text,
+	"resource_type" text,
+	"resource_id" text,
+	"ip_address" text,
+	"ip_bidx" text,
+	"user_agent" text,
+	"geo_location" text,
+	"details" jsonb,
+	"risk_score" real,
+	"anomaly_flags" text[],
+	"timestamp" timestamp DEFAULT now() NOT NULL,
+	"chain_seq" bigint DEFAULT nextval('security_audit_log_chain_seq_seq') NOT NULL,
+	"previous_hash" text NOT NULL,
+	"event_hash" text NOT NULL,
+	CONSTRAINT "security_audit_log_pkey" PRIMARY KEY ("id", "timestamp")
+) PARTITION BY RANGE ("timestamp");
+--> statement-breakpoint
+ALTER SEQUENCE "security_audit_log_chain_seq_seq" OWNED BY "security_audit_log"."chain_seq";
+--> statement-breakpoint
+CREATE TABLE "siem_delivery_receipts" (
+	"receiptId" text NOT NULL,
+	"deliveryId" text NOT NULL,
+	"source" text NOT NULL,
+	"firstEntryId" text NOT NULL,
+	"lastEntryId" text NOT NULL,
+	"firstEntryTimestamp" timestamp NOT NULL,
+	"lastEntryTimestamp" timestamp NOT NULL,
+	"entryCount" integer NOT NULL,
+	"deliveredAt" timestamp NOT NULL,
+	"webhookStatus" integer,
+	"webhookResponseHash" text,
+	"ackReceivedAt" timestamp,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "siem_delivery_receipts_pkey" PRIMARY KEY ("receiptId", "deliveredAt")
+) PARTITION BY RANGE ("deliveredAt");
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_maintenance') THEN
+    CREATE ROLE admin_maintenance NOLOGIN;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION admin_ensure_partitions(months_ahead integer DEFAULT 3)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  parent text;
+  month_start date;
+  part_name text;
+  created integer := 0;
+BEGIN
+  IF months_ahead < 0 OR months_ahead > 120 THEN
+    RAISE EXCEPTION 'admin_ensure_partitions: months_ahead must be between 0 and 120, got %', months_ahead;
+  END IF;
+  FOREACH parent IN ARRAY ARRAY['security_audit_log', 'siem_delivery_receipts'] LOOP
+    part_name := parent || '_default';
+    IF to_regclass(part_name) IS NULL THEN
+      EXECUTE format('CREATE TABLE %I PARTITION OF %I DEFAULT', part_name, parent);
+      created := created + 1;
+    END IF;
+    FOR i IN 0..months_ahead LOOP
+      month_start := (date_trunc('month', now()) + make_interval(months => i))::date;
+      part_name := parent || '_p' || to_char(month_start, 'YYYY_MM');
+      IF to_regclass(part_name) IS NULL THEN
+        EXECUTE format(
+          'CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+          part_name, parent, month_start, (month_start + interval '1 month')::date
+        );
+        created := created + 1;
+      END IF;
+    END LOOP;
+  END LOOP;
+  RETURN created;
+END
+$fn$;
+--> statement-breakpoint
+REVOKE ALL ON FUNCTION admin_ensure_partitions(integer) FROM PUBLIC;
+--> statement-breakpoint
+-- Schema USAGE is required just to RESOLVE the function name (0001 granted it
+-- to the five leaf-4 roles; admin_maintenance is new here). It confers no
+-- table access.
+GRANT USAGE ON SCHEMA public TO admin_maintenance;
+--> statement-breakpoint
+GRANT EXECUTE ON FUNCTION admin_ensure_partitions(integer) TO admin_maintenance;
+--> statement-breakpoint
+SELECT admin_ensure_partitions(3);
+--> statement-breakpoint
+DO $$
+DECLARE
+  month_start date;
+  current_month date;
+BEGIN
+  SELECT date_trunc('month', min("timestamp"))::date INTO month_start
+    FROM "security_audit_log_unpartitioned";
+  IF month_start IS NOT NULL THEN
+    current_month := date_trunc('month', now())::date;
+    WHILE month_start < current_month LOOP
+      IF to_regclass('security_audit_log_p' || to_char(month_start, 'YYYY_MM')) IS NULL THEN
+        EXECUTE format(
+          'CREATE TABLE %I PARTITION OF security_audit_log FOR VALUES FROM (%L) TO (%L)',
+          'security_audit_log_p' || to_char(month_start, 'YYYY_MM'),
+          month_start, (month_start + interval '1 month')::date
+        );
+      END IF;
+      month_start := (month_start + interval '1 month')::date;
+    END LOOP;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+DO $$
+DECLARE
+  month_start date;
+  current_month date;
+BEGIN
+  SELECT date_trunc('month', min("deliveredAt"))::date INTO month_start
+    FROM "siem_delivery_receipts_unpartitioned";
+  IF month_start IS NOT NULL THEN
+    current_month := date_trunc('month', now())::date;
+    WHILE month_start < current_month LOOP
+      IF to_regclass('siem_delivery_receipts_p' || to_char(month_start, 'YYYY_MM')) IS NULL THEN
+        EXECUTE format(
+          'CREATE TABLE %I PARTITION OF siem_delivery_receipts FOR VALUES FROM (%L) TO (%L)',
+          'siem_delivery_receipts_p' || to_char(month_start, 'YYYY_MM'),
+          month_start, (month_start + interval '1 month')::date
+        );
+      END IF;
+      month_start := (month_start + interval '1 month')::date;
+    END LOOP;
+  END IF;
+END
+$$;
+--> statement-breakpoint
+INSERT INTO "security_audit_log" ("id", "event_type", "user_id", "session_id", "service_id",
+	"resource_type", "resource_id", "ip_address", "ip_bidx", "user_agent", "geo_location",
+	"details", "risk_score", "anomaly_flags", "timestamp", "chain_seq", "previous_hash", "event_hash")
+SELECT "id", "event_type", "user_id", "session_id", "service_id",
+	"resource_type", "resource_id", "ip_address", "ip_bidx", "user_agent", "geo_location",
+	"details", "risk_score", "anomaly_flags", "timestamp", "chain_seq", "previous_hash", "event_hash"
+FROM "security_audit_log_unpartitioned";
+--> statement-breakpoint
+INSERT INTO "siem_delivery_receipts" ("receiptId", "deliveryId", "source", "firstEntryId", "lastEntryId",
+	"firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt",
+	"webhookStatus", "webhookResponseHash", "ackReceivedAt", "createdAt")
+SELECT "receiptId", "deliveryId", "source", "firstEntryId", "lastEntryId",
+	"firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt",
+	"webhookStatus", "webhookResponseHash", "ackReceivedAt", "createdAt"
+FROM "siem_delivery_receipts_unpartitioned";
+--> statement-breakpoint
+DROP TABLE "security_audit_log_unpartitioned";
+--> statement-breakpoint
+DROP TABLE "siem_delivery_receipts_unpartitioned";
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_timestamp" ON "security_audit_log" USING btree ("timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_user_timestamp" ON "security_audit_log" USING btree ("user_id","timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_event_type" ON "security_audit_log" USING btree ("event_type","timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_resource" ON "security_audit_log" USING btree ("resource_type","resource_id","timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_ip" ON "security_audit_log" USING btree ("ip_address","timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_ip_bidx" ON "security_audit_log" USING btree ("ip_bidx","timestamp");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_event_hash" ON "security_audit_log" USING btree ("event_hash");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_chain_seq" ON "security_audit_log" USING btree ("chain_seq");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_risk_score" ON "security_audit_log" USING btree ("risk_score");
+--> statement-breakpoint
+CREATE INDEX "idx_security_audit_session" ON "security_audit_log" USING btree ("session_id","timestamp");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "siem_delivery_receipts_delivery_source_unique" ON "siem_delivery_receipts" USING btree ("deliveryId","source","deliveredAt");
+--> statement-breakpoint
+CREATE INDEX "idx_siem_receipts_delivery_id" ON "siem_delivery_receipts" USING btree ("deliveryId");
+--> statement-breakpoint
+CREATE INDEX "idx_siem_receipts_first_entry" ON "siem_delivery_receipts" USING btree ("firstEntryId");
+--> statement-breakpoint
+CREATE INDEX "idx_siem_receipts_last_entry" ON "siem_delivery_receipts" USING btree ("lastEntryId");
+--> statement-breakpoint
+CREATE INDEX "idx_siem_receipts_delivered_at" ON "siem_delivery_receipts" USING btree ("deliveredAt");
+--> statement-breakpoint
+CREATE INDEX "idx_siem_receipts_source_range" ON "siem_delivery_receipts" USING btree ("source","firstEntryTimestamp","lastEntryTimestamp");
+--> statement-breakpoint
+REVOKE ALL ON security_audit_log, siem_delivery_receipts FROM PUBLIC;
+--> statement-breakpoint
+GRANT SELECT, INSERT ON security_audit_log TO admin_app;
+--> statement-breakpoint
+GRANT SELECT, INSERT ON security_audit_log TO admin_chainer;
+--> statement-breakpoint
+GRANT USAGE ON SEQUENCE security_audit_log_chain_seq_seq TO admin_app, admin_chainer;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log TO admin_gdpr_eraser;
+--> statement-breakpoint
+GRANT UPDATE (user_id, session_id, ip_address, ip_bidx, user_agent, geo_location) ON security_audit_log TO admin_gdpr_eraser;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log, siem_delivery_receipts TO admin_reader;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_log, siem_delivery_receipts TO admin_siem;
+--> statement-breakpoint
+GRANT INSERT ON siem_delivery_receipts TO admin_siem;

--- a/packages/db/drizzle-admin/0003_harden_ensure_partitions.sql
+++ b/packages/db/drizzle-admin/0003_harden_ensure_partitions.sql
@@ -1,0 +1,78 @@
+-- Per-month exception hardening of admin_ensure_partitions (#890 Phase 1 FIX,
+-- REVIEW 2026-07-10 MINOR finding).
+--
+-- THE FAILURE THIS FIXES: rows for month M stranded in the DEFAULT partition
+-- (e.g. after a >horizon cron outage) make CREATE TABLE ... FOR VALUES for
+-- month M fail with "updated partition constraint for default partition would
+-- be violated". In the 0002 version that single failure aborted the ENTIRE
+-- call, rolling back every other month's creation — and because each NEW
+-- month's rows then also land in DEFAULT, the poisoning self-perpetuates
+-- until ops intervene.
+--
+-- HARDENING: each partition CREATE now runs in its own plpgsql exception
+-- scope (a subtransaction), so a poisoned month M fails ALONE — every other
+-- month is still created and committed. Failures are reported per partition
+-- via RAISE WARNING (visible in the cron/postgres log) plus one summary
+-- WARNING naming all failed partitions and the repair procedure. The function
+-- still returns the created count; signature, SECURITY DEFINER, pinned
+-- search_path, the 0..120 horizon guard, and the no-drop-path guarantee are
+-- unchanged. CREATE OR REPLACE preserves the 0002 ACL (EXECUTE only to
+-- admin_maintenance, PUBLIC revoked) — no grant statements here.
+--
+-- Alerting on DEFAULT-partition row count and the ops runbook are the Phase 6
+-- half of this finding (task yz07brexk0hww6tuv20zhxbh on the Phase 6 page).
+--
+-- REPAIR (unchanged Postgres semantics, deliberately not automated): move the
+-- stranded rows out of DEFAULT, rerun admin_ensure_partitions, re-insert.
+
+CREATE OR REPLACE FUNCTION admin_ensure_partitions(months_ahead integer DEFAULT 3)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $fn$
+DECLARE
+  parent text;
+  month_start date;
+  part_name text;
+  created integer := 0;
+  failed text[] := '{}';
+BEGIN
+  IF months_ahead < 0 OR months_ahead > 120 THEN
+    RAISE EXCEPTION 'admin_ensure_partitions: months_ahead must be between 0 and 120, got %', months_ahead;
+  END IF;
+  FOREACH parent IN ARRAY ARRAY['security_audit_log', 'siem_delivery_receipts'] LOOP
+    part_name := parent || '_default';
+    IF to_regclass(part_name) IS NULL THEN
+      BEGIN
+        EXECUTE format('CREATE TABLE %I PARTITION OF %I DEFAULT', part_name, parent);
+        created := created + 1;
+      EXCEPTION WHEN OTHERS THEN
+        failed := failed || part_name;
+        RAISE WARNING 'admin_ensure_partitions: failed to create %: %', part_name, SQLERRM;
+      END;
+    END IF;
+    FOR i IN 0..months_ahead LOOP
+      month_start := (date_trunc('month', now()) + make_interval(months => i))::date;
+      part_name := parent || '_p' || to_char(month_start, 'YYYY_MM');
+      IF to_regclass(part_name) IS NULL THEN
+        BEGIN
+          EXECUTE format(
+            'CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+            part_name, parent, month_start, (month_start + interval '1 month')::date
+          );
+          created := created + 1;
+        EXCEPTION WHEN OTHERS THEN
+          failed := failed || part_name;
+          RAISE WARNING 'admin_ensure_partitions: failed to create %: %', part_name, SQLERRM;
+        END;
+      END IF;
+    END LOOP;
+  END LOOP;
+  IF array_length(failed, 1) > 0 THEN
+    RAISE WARNING 'admin_ensure_partitions: % partition(s) not created (%), % created. Likely DEFAULT-partition rows for those months — move them out of the DEFAULT partition, rerun, then re-insert.',
+      array_length(failed, 1), array_to_string(failed, ', '), created;
+  END IF;
+  RETURN created;
+END
+$fn$;

--- a/packages/db/drizzle-admin/meta/0000_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0000_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "id": "a7153148-49b5-4c58-9bfa-9e678687f881",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0001_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0001_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "id": "bac8ee8e-987e-4e16-b553-e82976720a43",
+  "prevId": "a7153148-49b5-4c58-9bfa-9e678687f881",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0002_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0002_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "id": "7515a01a-528d-4f05-8df2-9530d4de289c",
+  "prevId": "bac8ee8e-987e-4e16-b553-e82976720a43",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0003_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0003_snapshot.json
@@ -1,0 +1,580 @@
+{
+  "id": "58909d1a-a390-491b-a8ed-d58e41a440bc",
+  "prevId": "7515a01a-528d-4f05-8df2-9530d4de289c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1783654416415,
       "tag": "0001_zero_trust_roles",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1783657358022,
+      "tag": "0002_partition_chain_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1783657358022,
       "tag": "0002_partition_chain_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1783659177987,
+      "tag": "0003_harden_ensure_partitions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1783653517540,
+      "tag": "0000_concerned_praxagora",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1783653517540,
       "tag": "0000_concerned_praxagora",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1783654416415,
+      "tag": "0001_zero_trust_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,10 @@
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
     },
+    "./admin-db": {
+      "types": "./dist/admin-db.d.ts",
+      "default": "./dist/admin-db.js"
+    },
     "./operators": {
       "types": "./dist/operators.d.ts",
       "default": "./dist/operators.js"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,10 @@
       "types": "./dist/admin-db.d.ts",
       "default": "./dist/admin-db.js"
     },
+    "./admin-schema": {
+      "types": "./dist/admin-schema.d.ts",
+      "default": "./dist/admin-schema.js"
+    },
     "./operators": {
       "types": "./dist/operators.d.ts",
       "default": "./dist/operators.js"
@@ -263,6 +267,8 @@
     "test:coverage": "vitest run --coverage",
     "db:migrate": "tsx src/migrate.ts",
     "db:migrate:local": "DATABASE_URL=postgresql://user:password@localhost:5432/pagespace tsx src/migrate.ts",
+    "db:generate:admin": "drizzle-kit generate --config=drizzle-admin.config.ts",
+    "db:migrate:admin": "tsx src/migrate-admin.ts",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx src/seed.ts",
     "lint": "eslint src",

--- a/packages/db/src/__tests__/admin-db-mode.test.ts
+++ b/packages/db/src/__tests__/admin-db-mode.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Pure-core tests for the Admin PG (trust plane) connection registry decision
+ * logic (#890 Phase 1). The three-state contract:
+ *
+ *   ADMIN_DATABASE_URL set               → 'dedicated'  (connect to Admin PG)
+ *   URL unset + ADMIN_DB_BREAK_GLASS
+ *     exactly 'true'                     → 'break-glass' (degrade to main DB, alert)
+ *   URL unset + no armed flag            → 'fail'        (fail-fast at init)
+ *
+ * Break-glass arming is fail-closed: any value other than the exact string
+ * 'true' ('TRUE', '1', ' true ', '') does NOT arm the fallback.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAdminDbMode,
+  resolveAdminPoolConfig,
+} from '../admin-db-mode';
+
+describe('resolveAdminDbMode', () => {
+  describe('dedicated mode', () => {
+    it('given ADMIN_DATABASE_URL set (postgresql://), should resolve dedicated', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
+      });
+      expect(decision.mode).toBe('dedicated');
+    });
+
+    it('given ADMIN_DATABASE_URL set (postgres://), should resolve dedicated', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'postgres://admin:pw@host:5432/pagespace_admin',
+      });
+      expect(decision.mode).toBe('dedicated');
+    });
+
+    it('given ADMIN_DATABASE_URL set AND break-glass armed, should still resolve dedicated (URL wins)', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
+        ADMIN_DB_BREAK_GLASS: 'true',
+      });
+      expect(decision.mode).toBe('dedicated');
+    });
+  });
+
+  describe('URL validation (validate-on-init)', () => {
+    it('given a non-postgres scheme, should fail with a reason naming ADMIN_DATABASE_URL', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'mysql://admin:pw@host:3306/admin',
+      });
+      expect(decision.mode).toBe('fail');
+      expect(decision.reason).toContain('ADMIN_DATABASE_URL');
+    });
+
+    it('given an http:// URL, should fail even when break-glass is armed (invalid config is never silently degraded)', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'http://host/db',
+        ADMIN_DB_BREAK_GLASS: 'true',
+      });
+      expect(decision.mode).toBe('fail');
+    });
+
+    it('given an empty-string URL and no flag, should fail (empty is treated as unset)', () => {
+      const decision = resolveAdminDbMode({ ADMIN_DATABASE_URL: '' });
+      expect(decision.mode).toBe('fail');
+    });
+
+    it('given an empty-string URL and armed break-glass, should resolve break-glass (empty is treated as unset)', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: '',
+        ADMIN_DB_BREAK_GLASS: 'true',
+      });
+      expect(decision.mode).toBe('break-glass');
+    });
+  });
+
+  describe('break-glass arming (fail-closed)', () => {
+    it("given URL unset and flag exactly 'true', should resolve break-glass", () => {
+      const decision = resolveAdminDbMode({ ADMIN_DB_BREAK_GLASS: 'true' });
+      expect(decision.mode).toBe('break-glass');
+    });
+
+    it.each(['TRUE', 'True', '1', ' true ', 'yes', 'false', ''])(
+      "given URL unset and flag %j, should NOT arm break-glass (fail-closed)",
+      (flag) => {
+        const decision = resolveAdminDbMode({ ADMIN_DB_BREAK_GLASS: flag });
+        expect(decision.mode).toBe('fail');
+      },
+    );
+  });
+
+  describe('fail-fast mode', () => {
+    it('given URL unset and no flag, should fail', () => {
+      const decision = resolveAdminDbMode({});
+      expect(decision.mode).toBe('fail');
+    });
+
+    it('given fail, reason should name both ADMIN_DATABASE_URL and ADMIN_DB_BREAK_GLASS so the operator knows both exits', () => {
+      const decision = resolveAdminDbMode({});
+      expect(decision.mode).toBe('fail');
+      expect(decision.reason).toContain('ADMIN_DATABASE_URL');
+      expect(decision.reason).toContain('ADMIN_DB_BREAK_GLASS');
+    });
+  });
+});
+
+describe('resolveAdminPoolConfig', () => {
+  const URL = 'postgresql://admin:pw@host:5432/pagespace_admin';
+
+  it('given the env URL, should use it as the connection string', () => {
+    const config = resolveAdminPoolConfig({ ADMIN_DATABASE_URL: URL });
+    expect(config.connectionString).toBe(URL);
+  });
+
+  describe('ssl (mirrors db.ts DATABASE_SSL semantics)', () => {
+    it("given ADMIN_DATABASE_SSL 'true', should disable certificate verification like the main pool", () => {
+      const config = resolveAdminPoolConfig({
+        ADMIN_DATABASE_URL: URL,
+        ADMIN_DATABASE_SSL: 'true',
+      });
+      expect(config.ssl).toEqual({ rejectUnauthorized: false });
+    });
+
+    it.each(['false', 'TRUE', undefined])(
+      'given ADMIN_DATABASE_SSL %j, should disable ssl',
+      (ssl) => {
+        const config = resolveAdminPoolConfig({
+          ADMIN_DATABASE_URL: URL,
+          ADMIN_DATABASE_SSL: ssl,
+        });
+        expect(config.ssl).toBe(false);
+      },
+    );
+  });
+
+  describe('max (ADMIN_DB_POOL_MAX)', () => {
+    it('given a positive integer string, should use it', () => {
+      const config = resolveAdminPoolConfig({
+        ADMIN_DATABASE_URL: URL,
+        ADMIN_DB_POOL_MAX: '7',
+      });
+      expect(config.max).toBe(7);
+    });
+
+    it.each([undefined, '', '0', '-3', 'abc'])(
+      'given ADMIN_DB_POOL_MAX %j, should fall back to the default of 10',
+      (max) => {
+        const config = resolveAdminPoolConfig({
+          ADMIN_DATABASE_URL: URL,
+          ADMIN_DB_POOL_MAX: max,
+        });
+        expect(config.max).toBe(10);
+      },
+    );
+  });
+
+  it('should mirror the remaining db.ts pool settings (keepAlive + timeouts)', () => {
+    const config = resolveAdminPoolConfig({ ADMIN_DATABASE_URL: URL });
+    expect(config.keepAlive).toBe(true);
+    expect(config.keepAliveInitialDelayMillis).toBe(10000);
+    expect(config.idleTimeoutMillis).toBe(600000);
+    expect(config.connectionTimeoutMillis).toBe(10000);
+  });
+});

--- a/packages/db/src/__tests__/admin-db.test.ts
+++ b/packages/db/src/__tests__/admin-db.test.ts
@@ -69,6 +69,14 @@ describe('createAdminDbRegistry', () => {
       expect(typeof adminDb.execute).toBe('function');
     });
 
+    it('should bind the admin schema barrel — query API exposes the trust-plane tables', () => {
+      const { deps } = makeDeps();
+      const adminDb = createAdminDbRegistry(deps).getAdminDb();
+      expect(adminDb.query.securityAuditLog).toBeDefined();
+      expect(adminDb.query.siemDeliveryCursors).toBeDefined();
+      expect(adminDb.query.siemDeliveryReceipts).toBeDefined();
+    });
+
     it('should never touch the ambient main db or alert in the dedicated path', () => {
       const { deps } = makeDeps();
       createAdminDbRegistry(deps).getAdminDb();

--- a/packages/db/src/__tests__/admin-db.test.ts
+++ b/packages/db/src/__tests__/admin-db.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Shell tests for the adminDb connection registry (#890 Phase 1).
+ *
+ * createAdminDbRegistry is a factory with explicit deps — tests inject fakes
+ * for pool construction, the main db, pool-stats registration, and alerting,
+ * so no test ever touches process.env or opens a connection.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool } from 'pg';
+import {
+  createAdminDbRegistry,
+  ADMIN_POOL_NAME,
+  type AdminDatabase,
+  type AdminDbDeps,
+} from '../admin-db';
+
+const DEDICATED_ENV = {
+  ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
+};
+const BREAK_GLASS_ENV = { ADMIN_DB_BREAK_GLASS: 'true' };
+
+const makeFakePool = () => ({ on: vi.fn() }) as unknown as Pool;
+
+const makeDeps = (overrides: Partial<AdminDbDeps> = {}) => {
+  const fakePool = makeFakePool();
+  const fakeMainDb = { fake: 'main-db' } as unknown as AdminDatabase;
+  const deps: AdminDbDeps = {
+    getEnv: () => DEDICATED_ENV,
+    getMainDb: vi.fn(() => fakeMainDb),
+    createPool: vi.fn(() => fakePool),
+    registerPool: vi.fn(),
+    alert: vi.fn(),
+    ...overrides,
+  };
+  return { deps, fakePool, fakeMainDb };
+};
+
+describe('createAdminDbRegistry', () => {
+  describe('dedicated mode (ADMIN_DATABASE_URL set)', () => {
+    it('should construct the pool from the resolved config', () => {
+      const { deps } = makeDeps();
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(deps.createPool).toHaveBeenCalledTimes(1);
+      expect(deps.createPool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          connectionString: DEDICATED_ENV.ADMIN_DATABASE_URL,
+          max: 10,
+          keepAlive: true,
+        }),
+      );
+    });
+
+    it('should register the pool with pool-stats under the admin name', () => {
+      const { deps, fakePool } = makeDeps();
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(deps.registerPool).toHaveBeenCalledTimes(1);
+      expect(deps.registerPool).toHaveBeenCalledWith(fakePool, ADMIN_POOL_NAME);
+    });
+
+    it('should attach the error-swallow handler like the main pool', () => {
+      const { deps, fakePool } = makeDeps();
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(fakePool.on).toHaveBeenCalledWith('error', expect.any(Function));
+    });
+
+    it('should return a drizzle client bound to the dedicated pool', () => {
+      const { deps } = makeDeps();
+      const adminDb = createAdminDbRegistry(deps).getAdminDb();
+      expect(typeof adminDb.execute).toBe('function');
+    });
+
+    it('should never touch the ambient main db or alert in the dedicated path', () => {
+      const { deps } = makeDeps();
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(deps.getMainDb).not.toHaveBeenCalled();
+      expect(deps.alert).not.toHaveBeenCalled();
+    });
+
+    it('should be a single instance per registry (lazy init, one pool)', () => {
+      const { deps } = makeDeps();
+      const registry = createAdminDbRegistry(deps);
+      const first = registry.getAdminDb();
+      const second = registry.getAdminDb();
+      expect(second).toBe(first);
+      expect(deps.createPool).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not construct any pool at registry-creation time (no connection at import time)', () => {
+      const { deps } = makeDeps();
+      createAdminDbRegistry(deps);
+      expect(deps.createPool).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('break-glass mode (URL unset, flag exactly true)', () => {
+    it('should return the main db itself (adminDb === db)', () => {
+      const { deps, fakeMainDb } = makeDeps({ getEnv: () => BREAK_GLASS_ENV });
+      const adminDb = createAdminDbRegistry(deps).getAdminDb();
+      expect(adminDb).toBe(fakeMainDb);
+    });
+
+    it('should fire a loud alert naming break-glass and the missing ADMIN_DATABASE_URL', () => {
+      const { deps } = makeDeps({ getEnv: () => BREAK_GLASS_ENV });
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(deps.alert).toHaveBeenCalledTimes(1);
+      const message = vi.mocked(deps.alert).mock.calls[0][0];
+      expect(message).toContain('BREAK-GLASS');
+      expect(message).toContain('ADMIN_DATABASE_URL');
+    });
+
+    it('should not construct a dedicated pool', () => {
+      const { deps } = makeDeps({ getEnv: () => BREAK_GLASS_ENV });
+      createAdminDbRegistry(deps).getAdminDb();
+      expect(deps.createPool).not.toHaveBeenCalled();
+      expect(deps.registerPool).not.toHaveBeenCalled();
+    });
+
+    it('should alert on every init — a fresh registry (new process) alerts again', () => {
+      const { deps } = makeDeps({ getEnv: () => BREAK_GLASS_ENV });
+      const registry = createAdminDbRegistry(deps);
+      registry.getAdminDb();
+      registry.getAdminDb(); // cached — same init, no second alert
+      expect(deps.alert).toHaveBeenCalledTimes(1);
+
+      createAdminDbRegistry(deps).getAdminDb(); // new init — alerts again
+      expect(deps.alert).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('fail-fast mode (URL unset, no armed flag)', () => {
+    it('should throw an actionable error naming ADMIN_DATABASE_URL and the break-glass flag', () => {
+      const { deps } = makeDeps({ getEnv: () => ({}) });
+      const registry = createAdminDbRegistry(deps);
+      expect(() => registry.getAdminDb()).toThrowError(/ADMIN_DATABASE_URL/);
+      expect(() => registry.getAdminDb()).toThrowError(/ADMIN_DB_BREAK_GLASS/);
+    });
+
+    it('should throw on every call, not just the first', () => {
+      const { deps } = makeDeps({ getEnv: () => ({}) });
+      const registry = createAdminDbRegistry(deps);
+      expect(() => registry.getAdminDb()).toThrow();
+      expect(() => registry.getAdminDb()).toThrow();
+    });
+
+    it('should not touch the main db or any pool before throwing', () => {
+      const { deps } = makeDeps({ getEnv: () => ({}) });
+      expect(() => createAdminDbRegistry(deps).getAdminDb()).toThrow();
+      expect(deps.getMainDb).not.toHaveBeenCalled();
+      expect(deps.createPool).not.toHaveBeenCalled();
+    });
+
+    it("given a non-'true' break-glass value, should still fail fast (fail-closed arming)", () => {
+      const { deps } = makeDeps({
+        getEnv: () => ({ ADMIN_DB_BREAK_GLASS: 'TRUE' }),
+      });
+      expect(() => createAdminDbRegistry(deps).getAdminDb()).toThrow();
+      expect(deps.alert).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/db/src/__tests__/admin-grants-migration.test.ts
+++ b/packages/db/src/__tests__/admin-grants-migration.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Static invariants of the zero-trust grants migration (#890 Phase 1, leaf 4).
+ *
+ * The live behavior (actual 42501 denials per role) is proven by
+ * admin-grants.integration.test.ts against a scratch Postgres. These tests
+ * pin the migration SQL itself so CI catches a regressed grant matrix
+ * (someone adding a DELETE grant, widening the eraser's column list, …)
+ * without needing a database.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0001_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+const ROLES = ['admin_app', 'admin_chainer', 'admin_gdpr_eraser', 'admin_reader', 'admin_siem'];
+
+describe('drizzle-admin/0001 zero-trust grants migration', () => {
+  it('should exist in the admin journal as migration 0001', () => {
+    expect(migrationFile).toBe('0001_zero_trust_roles.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 1)?.tag).toBe('0001_zero_trust_roles');
+  });
+
+  it('should create every role guarded (pre-existing roles survive a re-run) and NOLOGIN', () => {
+    for (const role of ROLES) {
+      expect(code).toContain(`IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}')`);
+      expect(code).toContain(`CREATE ROLE ${role} NOLOGIN`);
+    }
+  });
+
+  it('should grant DELETE and TRUNCATE to nobody, and never GRANT ALL', () => {
+    const grants = code.match(/GRANT[^;]+;/g) ?? [];
+    expect(grants.length).toBeGreaterThan(0);
+    for (const grant of grants) {
+      expect(grant).not.toMatch(/\bDELETE\b/);
+      expect(grant).not.toMatch(/\bTRUNCATE\b/);
+      expect(grant).not.toMatch(/\bGRANT\s+ALL\b/);
+    }
+  });
+
+  it('should scope the eraser UPDATE to exactly the six hash-excluded PII columns', () => {
+    const eraserUpdate = code.match(/GRANT UPDATE \(([^)]*)\) ON security_audit_log TO admin_gdpr_eraser/);
+    expect(eraserUpdate).not.toBeNull();
+    expect(eraserUpdate![1].split(',').map((c) => c.trim()).sort()).toEqual(
+      ['geo_location', 'ip_address', 'ip_bidx', 'session_id', 'user_agent', 'user_id'].sort(),
+    );
+    // ...and the eraser holds nothing beyond schema USAGE, SELECT, and that
+    // column-scoped UPDATE.
+    const eraserGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) =>
+      g.includes('admin_gdpr_eraser'),
+    );
+    expect(eraserGrants).toHaveLength(3);
+    expect(eraserGrants.some((g) => g.includes('USAGE ON SCHEMA public'))).toBe(true);
+    expect(eraserGrants.some((g) => /^GRANT SELECT ON security_audit_log TO admin_gdpr_eraser/.test(g))).toBe(true);
+  });
+
+  it('should revoke every ambient PUBLIC privilege on the trust-plane tables', () => {
+    expect(code).toContain(
+      'REVOKE ALL ON security_audit_log, siem_delivery_cursors, siem_delivery_receipts FROM PUBLIC',
+    );
+  });
+
+  it('should grant the chain_seq sequence only to the two inserting identities', () => {
+    expect(code).toContain(
+      'GRANT USAGE ON SEQUENCE security_audit_log_chain_seq_seq TO admin_app, admin_chainer',
+    );
+    const sequenceGrants = code.match(/GRANT[^;]+ON SEQUENCE[^;]+;/g) ?? [];
+    expect(sequenceGrants).toHaveLength(1);
+  });
+});

--- a/packages/db/src/__tests__/admin-grants.integration.test.ts
+++ b/packages/db/src/__tests__/admin-grants.integration.test.ts
@@ -24,6 +24,9 @@ const ROLES = [
   'admin_gdpr_eraser',
   'admin_reader',
   'admin_siem',
+  // Leaf 6: partition create-ahead maintenance — EXECUTE on
+  // admin_ensure_partitions and nothing else.
+  'admin_maintenance',
 ] as const;
 
 const TABLES = [
@@ -94,7 +97,7 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
     await pool.end();
   });
 
-  it('should create all five role templates as NOLOGIN', async () => {
+  it('should create all six role templates as NOLOGIN', async () => {
     const { rows } = await pool.query(
       `SELECT rolname, rolcanlogin FROM pg_roles WHERE rolname = ANY($1) ORDER BY rolname`,
       [[...ROLES]],
@@ -275,6 +278,19 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
         await expectDenied(client, `TRUNCATE security_audit_log`);
       });
     });
+
+    it.each([...ROLES])(
+      'partition immutability: %s cannot DROP a chain-table partition (incl. the DEFAULT safety net)',
+      async (role) => {
+        // Partitions are owned by the migration identity; no template role —
+        // not even admin_maintenance, which CREATES partitions via the
+        // SECURITY DEFINER function — may drop one. There is no drop path.
+        await asRole(role, async (client) => {
+          await expectDenied(client, `DROP TABLE security_audit_log_default`);
+          await expectDenied(client, `DROP TABLE siem_delivery_receipts_default`);
+        });
+      },
+    );
 
     it('PUBLIC holds no privilege at all on trust-plane tables', async () => {
       for (const table of TABLES) {

--- a/packages/db/src/__tests__/admin-grants.integration.test.ts
+++ b/packages/db/src/__tests__/admin-grants.integration.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Zero-trust role grant-denial tests for the Admin PG (#890 Phase 1, leaf 4).
+ *
+ * Acceptance: the five NOLOGIN role templates exist after `db:migrate:admin`,
+ * every allowed operation succeeds, every denied operation fails with a REAL
+ * Postgres permission error (42501) — and DELETE/TRUNCATE are granted to
+ * NOBODY on any trust-plane table.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run --config vitest.integration.config.ts src/__tests__/admin-grants.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool, type PoolClient } from 'pg';
+import { migrateAdminDb } from '../migrate-admin';
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+const ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+] as const;
+
+const TABLES = [
+  'security_audit_log',
+  'siem_delivery_cursors',
+  'siem_delivery_receipts',
+] as const;
+
+const PII_COLUMNS = [
+  'user_id',
+  'session_id',
+  'ip_address',
+  'ip_bidx',
+  'user_agent',
+  'geo_location',
+] as const;
+
+const CHAIN_COLUMNS = ['event_hash', 'previous_hash', 'chain_seq', 'event_type', 'details'] as const;
+
+describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
+  let pool: Pool;
+
+  /** Run fn on a connection assumed into `role`, always resetting after. */
+  async function asRole<T>(role: string, fn: (client: PoolClient) => Promise<T>): Promise<T> {
+    const client = await pool.connect();
+    try {
+      await client.query(`SET ROLE ${role}`);
+      return await fn(client);
+    } finally {
+      await client.query('RESET ROLE');
+      client.release();
+    }
+  }
+
+  /** Assert sql fails with insufficient_privilege (42501) — a real DB-level denial. */
+  async function expectDenied(client: PoolClient, sql: string, params?: unknown[]): Promise<void> {
+    await expect(client.query(sql, params)).rejects.toMatchObject({ code: '42501' });
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: url, max: 3 });
+    // Fresh-DB guarantee on the SCRATCH db: drop schemas AND the cluster-level
+    // roles so the migration's role creation is genuinely exercised.
+    await pool.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await pool.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await pool.query('CREATE SCHEMA public');
+    for (const role of ROLES) {
+      await pool.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+
+    // Seed one chain row as superuser for UPDATE/DELETE-denial probes.
+    await pool.query(
+      `INSERT INTO security_audit_log (id, event_type, user_id, ip_address, previous_hash, event_hash)
+       VALUES ('seed-row-1', 'auth.login', 'user-1', '203.0.113.7', 'GENESIS', 'hash-1')`,
+    );
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should create all five role templates as NOLOGIN', async () => {
+    const { rows } = await pool.query(
+      `SELECT rolname, rolcanlogin FROM pg_roles WHERE rolname = ANY($1) ORDER BY rolname`,
+      [[...ROLES]],
+    );
+    expect(rows.map((r: { rolname: string }) => r.rolname)).toEqual([...ROLES].sort());
+    expect(rows.every((r: { rolcanlogin: boolean }) => r.rolcanlogin === false)).toBe(true);
+  });
+
+  describe('admin_app (web identity)', () => {
+    it('should INSERT into security_audit_log (incl. chain_seq sequence default)', async () => {
+      await asRole('admin_app', async (client) => {
+        const { rowCount } = await client.query(
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('app-row-1', 'auth.login', 'hash-1', 'hash-2')`,
+        );
+        expect(rowCount).toBe(1);
+      });
+    });
+
+    it('should SELECT the chain head (Phase 2 pre-chainer cutover)', async () => {
+      await asRole('admin_app', async (client) => {
+        const { rows } = await client.query(
+          `SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1`,
+        );
+        expect(rows).toHaveLength(1);
+      });
+    });
+
+    it('should be DENIED UPDATE on security_audit_log', async () => {
+      await asRole('admin_app', (client) =>
+        expectDenied(client, `UPDATE security_audit_log SET event_type = 'tampered' WHERE id = 'seed-row-1'`),
+      );
+    });
+
+    it('should be DENIED any access to the SIEM tables', async () => {
+      await asRole('admin_app', async (client) => {
+        await expectDenied(client, `SELECT 1 FROM siem_delivery_cursors`);
+        await expectDenied(client, `SELECT 1 FROM siem_delivery_receipts`);
+      });
+    });
+  });
+
+  describe('admin_chainer (processor chain writer, staged for Phase 2)', () => {
+    it('should SELECT and INSERT on security_audit_log', async () => {
+      await asRole('admin_chainer', async (client) => {
+        const head = await client.query(
+          `SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1`,
+        );
+        expect(head.rows).toHaveLength(1);
+        const { rowCount } = await client.query(
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('chainer-row-1', 'auth.login', 'hash-2', 'hash-3')`,
+        );
+        expect(rowCount).toBe(1);
+      });
+    });
+
+    it('should be DENIED UPDATE on security_audit_log (chain history is immutable)', async () => {
+      await asRole('admin_chainer', (client) =>
+        expectDenied(client, `UPDATE security_audit_log SET previous_hash = 'rewritten' WHERE id = 'seed-row-1'`),
+      );
+    });
+  });
+
+  describe('admin_gdpr_eraser (Art 17, PII columns only)', () => {
+    it('should UPDATE exactly the PII columns', async () => {
+      await asRole('admin_gdpr_eraser', async (client) => {
+        const { rowCount } = await client.query(
+          `UPDATE security_audit_log
+           SET user_id = NULL, session_id = NULL, ip_address = NULL,
+               ip_bidx = NULL, user_agent = NULL, geo_location = NULL
+           WHERE id = 'seed-row-1'`,
+        );
+        expect(rowCount).toBe(1);
+      });
+      // Erasure must not have touched the chain columns.
+      const { rows } = await pool.query(
+        `SELECT event_hash, previous_hash FROM security_audit_log WHERE id = 'seed-row-1'`,
+      );
+      expect(rows[0]).toEqual({ event_hash: 'hash-1', previous_hash: 'GENESIS' });
+    });
+
+    it.each([...CHAIN_COLUMNS])('should be DENIED UPDATE on chain/content column %s', async (column) => {
+      const literal = column === 'chain_seq' ? '999999' : column === 'details' ? `'{}'::jsonb` : `'tampered'`;
+      await asRole('admin_gdpr_eraser', (client) =>
+        expectDenied(client, `UPDATE security_audit_log SET ${column} = ${literal} WHERE id = 'seed-row-1'`),
+      );
+    });
+
+    it('should be DENIED INSERT on security_audit_log', async () => {
+      await asRole('admin_gdpr_eraser', (client) =>
+        expectDenied(
+          client,
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('eraser-row-1', 'auth.login', 'x', 'y')`,
+        ),
+      );
+    });
+  });
+
+  describe('admin_reader (admin app / verification)', () => {
+    it('should SELECT on all three tables and nothing more', async () => {
+      await asRole('admin_reader', async (client) => {
+        for (const table of TABLES) {
+          await client.query(`SELECT 1 FROM ${table} LIMIT 1`);
+        }
+        await expectDenied(
+          client,
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('reader-row-1', 'auth.login', 'x', 'y')`,
+        );
+        await expectDenied(client, `UPDATE security_audit_log SET user_id = NULL WHERE id = 'seed-row-1'`);
+      });
+    });
+  });
+
+  describe('admin_siem (processor SIEM delivery)', () => {
+    it('should upsert siem_delivery_cursors (worker uses INSERT … ON CONFLICT DO UPDATE)', async () => {
+      await asRole('admin_siem', async (client) => {
+        for (let i = 0; i < 2; i++) {
+          await client.query(
+            `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "updatedAt")
+             VALUES ('security_audit', 'seed-row-1', NOW(), 1, NOW())
+             ON CONFLICT (id) DO UPDATE SET
+               "lastDeliveredId" = EXCLUDED."lastDeliveredId",
+               "deliveryCount" = siem_delivery_cursors."deliveryCount" + 1,
+               "updatedAt" = NOW()`,
+          );
+        }
+        const { rows } = await client.query(
+          `SELECT "deliveryCount" FROM siem_delivery_cursors WHERE id = 'security_audit'`,
+        );
+        expect(rows[0].deliveryCount).toBe(2);
+      });
+    });
+
+    it('should INSERT receipts but be DENIED UPDATE on them (receipts are write-once)', async () => {
+      await asRole('admin_siem', async (client) => {
+        const { rowCount } = await client.query(
+          `INSERT INTO siem_delivery_receipts
+             ("receiptId", "deliveryId", "source", "firstEntryId", "lastEntryId",
+              "firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt")
+           VALUES ('rcpt-1', 'dlv-1', 'security_audit', 'seed-row-1', 'seed-row-1', NOW(), NOW(), 1, NOW())`,
+        );
+        expect(rowCount).toBe(1);
+        await expectDenied(client, `UPDATE siem_delivery_receipts SET "entryCount" = 0 WHERE "receiptId" = 'rcpt-1'`);
+      });
+    });
+
+    it('should SELECT security_audit_log but never write it', async () => {
+      await asRole('admin_siem', async (client) => {
+        await client.query(`SELECT id FROM security_audit_log LIMIT 1`);
+        await expectDenied(
+          client,
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('siem-row-1', 'auth.login', 'x', 'y')`,
+        );
+        await expectDenied(client, `UPDATE security_audit_log SET user_id = NULL WHERE id = 'seed-row-1'`);
+      });
+    });
+  });
+
+  describe('append-only invariant — DELETE/TRUNCATE granted to NOBODY', () => {
+    it.each([...ROLES])('grant catalog: %s holds no DELETE or TRUNCATE on any trust-plane table', async (role) => {
+      for (const table of TABLES) {
+        const { rows } = await pool.query(
+          `SELECT has_table_privilege($1, $2, 'DELETE') AS del,
+                  has_table_privilege($1, $2, 'TRUNCATE') AS trunc`,
+          [role, table],
+        );
+        expect({ role, table, ...rows[0] }).toEqual({ role, table, del: false, trunc: false });
+      }
+    });
+
+    it.each([...ROLES])('live denial: %s cannot DELETE or TRUNCATE security_audit_log', async (role) => {
+      await asRole(role, async (client) => {
+        await expectDenied(client, `DELETE FROM security_audit_log WHERE id = 'seed-row-1'`);
+        await expectDenied(client, `TRUNCATE security_audit_log`);
+      });
+    });
+
+    it('PUBLIC holds no privilege at all on trust-plane tables', async () => {
+      for (const table of TABLES) {
+        const { rows } = await pool.query(
+          `SELECT bool_or(has_table_privilege('public', $1::regclass::oid, priv)) AS any_priv
+           FROM unnest(ARRAY['SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER']) AS priv`,
+          [table],
+        );
+        expect({ table, any_priv: rows[0].any_priv }).toEqual({ table, any_priv: false });
+      }
+    });
+  });
+
+  describe('re-runnability', () => {
+    it('should apply cleanly on a fresh DB where the roles ALREADY exist at cluster level', async () => {
+      // Roles are cluster-scoped: a re-provisioned database in the same
+      // cluster re-runs the migration while the roles survive. Simulate that.
+      await pool.query('DROP SCHEMA IF EXISTS public CASCADE');
+      await pool.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+      await pool.query('CREATE SCHEMA public');
+
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+
+      // Grants are back on the fresh tables.
+      const { rows } = await pool.query(
+        `SELECT has_table_privilege('admin_app', 'security_audit_log', 'INSERT') AS ins,
+                has_table_privilege('admin_app', 'security_audit_log', 'DELETE') AS del`,
+      );
+      expect(rows[0]).toEqual({ ins: true, del: false });
+    });
+  });
+});

--- a/packages/db/src/__tests__/admin-migrate-decision.test.ts
+++ b/packages/db/src/__tests__/admin-migrate-decision.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Pure decision tests for db:migrate:admin (#890 Phase 1, leaf 3).
+ *
+ * Migrations target ONLY a dedicated Admin PG. Break-glass is a runtime
+ * degradation for audit WRITES — running admin migrations against the main
+ * DB would plant the drizzle_admin journal in the app plane, so the migrate
+ * decision refuses everything except 'dedicated'.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveAdminMigrateDecision } from '../admin-db-mode';
+
+describe('resolveAdminMigrateDecision', () => {
+  it('given ADMIN_DATABASE_URL set, should permit migration with the resolved pool config', () => {
+    const decision = resolveAdminMigrateDecision({
+      ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
+    });
+    expect(decision.ok).toBe(true);
+    if (decision.ok) {
+      expect(decision.poolConfig.connectionString).toBe(
+        'postgresql://admin:pw@host:5432/pagespace_admin',
+      );
+    }
+  });
+
+  it('given break-glass armed but no URL, should refuse — migrations never run under break-glass', () => {
+    const decision = resolveAdminMigrateDecision({ ADMIN_DB_BREAK_GLASS: 'true' });
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toMatch(/break-glass/i);
+      expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);
+    }
+  });
+
+  it('given no URL and no flag, should refuse with the fail-fast reason', () => {
+    const decision = resolveAdminMigrateDecision({});
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);
+    }
+  });
+
+  it('given an invalid URL scheme, should refuse even with break-glass armed', () => {
+    const decision = resolveAdminMigrateDecision({
+      ADMIN_DATABASE_URL: 'mysql://root@host:3306/nope',
+      ADMIN_DB_BREAK_GLASS: 'true',
+    });
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toMatch(/postgres/);
+    }
+  });
+});

--- a/packages/db/src/__tests__/admin-migrate.integration.test.ts
+++ b/packages/db/src/__tests__/admin-migrate.integration.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Migration smoke test for the Admin PG pipeline (#890 Phase 1, leaf 3).
+ *
+ * Acceptance: given a fresh empty Postgres and ADMIN_DATABASE_URL pointing at
+ * it, `db:migrate:admin` ALONE reaches the full admin schema, with a journal
+ * fully separate from the main DB's.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run --config vitest.integration.config.ts src/__tests__/admin-migrate.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { migrateAdminDb } from '../migrate-admin';
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+describe.skipIf(!url)('db:migrate:admin against a scratch Admin PG', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: url, max: 2 });
+    // Fresh-DB guarantee: reset public + journal schemas on the SCRATCH db.
+    await pool.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await pool.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await pool.query('CREATE SCHEMA public');
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should reach the full admin schema from a fresh empty database in one run', async () => {
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+
+    const { rows } = await pool.query(
+      `SELECT table_name FROM information_schema.tables
+       WHERE table_schema = 'public' ORDER BY table_name`,
+    );
+    expect(rows.map((r: { table_name: string }) => r.table_name)).toEqual([
+      'security_audit_log',
+      'siem_delivery_cursors',
+      'siem_delivery_receipts',
+    ]);
+  });
+
+  it('should create security_audit_log with NO foreign keys (no users table in the trust plane)', async () => {
+    const { rows } = await pool.query(
+      `SELECT constraint_name FROM information_schema.table_constraints
+       WHERE table_schema = 'public' AND table_name = 'security_audit_log'
+         AND constraint_type = 'FOREIGN KEY'`,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('should not create any app-plane table (users stays in the main DB)', async () => {
+    const { rows } = await pool.query(
+      `SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'public' AND table_name = 'users'`,
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it('should keep its journal in drizzle_admin, never in the main drizzle schema', async () => {
+    const journal = await pool.query(
+      `SELECT count(*)::int AS applied FROM drizzle_admin.__drizzle_migrations`,
+    );
+    expect(journal.rows[0].applied).toBeGreaterThanOrEqual(1);
+
+    const mainJournal = await pool.query(
+      `SELECT 1 FROM information_schema.schemata WHERE schema_name = 'drizzle'`,
+    );
+    expect(mainJournal.rows).toHaveLength(0);
+  });
+
+  it('should create the securityAuditLog indexes', async () => {
+    const { rows } = await pool.query(
+      `SELECT indexname FROM pg_indexes
+       WHERE schemaname = 'public' AND tablename = 'security_audit_log'`,
+    );
+    const names = rows.map((r: { indexname: string }) => r.indexname);
+    expect(names).toContain('idx_security_audit_chain_seq');
+    expect(names).toContain('idx_security_audit_event_hash');
+  });
+
+  it('should be idempotent — a second run applies nothing new', async () => {
+    const before = await pool.query(
+      `SELECT count(*)::int AS applied FROM drizzle_admin.__drizzle_migrations`,
+    );
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    const after = await pool.query(
+      `SELECT count(*)::int AS applied FROM drizzle_admin.__drizzle_migrations`,
+    );
+    expect(after.rows[0].applied).toBe(before.rows[0].applied);
+  });
+});

--- a/packages/db/src/__tests__/admin-migrate.integration.test.ts
+++ b/packages/db/src/__tests__/admin-migrate.integration.test.ts
@@ -35,9 +35,14 @@ describe.skipIf(!url)('db:migrate:admin against a scratch Admin PG', () => {
   it('should reach the full admin schema from a fresh empty database in one run', async () => {
     await migrateAdminDb({ ADMIN_DATABASE_URL: url });
 
+    // Logical tables only — since leaf 6 the chain tables are partitioned
+    // parents whose monthly partitions would also show up in
+    // information_schema.tables, so filter on relispartition.
     const { rows } = await pool.query(
-      `SELECT table_name FROM information_schema.tables
-       WHERE table_schema = 'public' ORDER BY table_name`,
+      `SELECT c.relname AS table_name FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public' AND c.relkind IN ('r', 'p') AND NOT c.relispartition
+       ORDER BY c.relname`,
     );
     expect(rows.map((r: { table_name: string }) => r.table_name)).toEqual([
       'security_audit_log',

--- a/packages/db/src/__tests__/admin-partition-migration.test.ts
+++ b/packages/db/src/__tests__/admin-partition-migration.test.ts
@@ -21,10 +21,13 @@ const sql = migrationFile
   ? readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile), 'utf8')
   : '';
 /** SQL with line comments stripped, so assertions never match prose. */
-const code = sql
-  .split('\n')
-  .filter((line) => !line.trimStart().startsWith('--'))
-  .join('\n');
+function stripComments(raw: string): string {
+  return raw
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('--'))
+    .join('\n');
+}
+const code = stripComments(sql);
 
 describe('drizzle-admin/0002 monthly-partitioning migration', () => {
   it('should exist in the admin journal as migration 0002', () => {
@@ -189,5 +192,60 @@ describe('drizzle-admin/0002 monthly-partitioning migration', () => {
       expect(grant).not.toMatch(/\bTRUNCATE\b/);
       expect(grant).not.toMatch(/\bGRANT\s+ALL\b/);
     }
+  });
+});
+
+describe('drizzle-admin/0003 per-month exception hardening of admin_ensure_partitions', () => {
+  // REVIEW 2026-07-10 MINOR: one poisoned month (rows for month M sitting in
+  // the DEFAULT partition) aborted the ENTIRE create-ahead call, rolling back
+  // every other month — after a long cron outage this self-perpetuates. 0003
+  // replaces the function so each partition CREATE is its own plpgsql
+  // exception scope: a poisoned month fails ALONE and is reported via
+  // WARNING; every other month is still created.
+  const hardeningFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+    /^0003_.*\.sql$/.test(f),
+  );
+  const hardeningCode = stripComments(
+    hardeningFile ? readFileSync(path.join(ADMIN_MIGRATIONS_DIR, hardeningFile), 'utf8') : '',
+  );
+
+  it('should exist in the admin journal as migration 0003 (never edit an applied migration)', () => {
+    expect(hardeningFile).toBeDefined();
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(`${journal.entries.find((e) => e.idx === 3)?.tag}.sql`).toBe(hardeningFile);
+  });
+
+  it('should CREATE OR REPLACE the function with the same signature, SECURITY DEFINER, and pinned search_path', () => {
+    expect(hardeningCode).toContain(
+      'CREATE OR REPLACE FUNCTION admin_ensure_partitions(months_ahead integer DEFAULT 3)',
+    );
+    expect(hardeningCode).toContain('RETURNS integer');
+    expect(hardeningCode).toContain('SECURITY DEFINER');
+    expect(hardeningCode).toContain('SET search_path = public, pg_temp');
+  });
+
+  it('should wrap each partition CREATE in its own exception scope so one poisoned month fails alone', () => {
+    // One handler for the DEFAULT safety net, one inside the month loop.
+    const handlers = hardeningCode.match(/EXCEPTION WHEN OTHERS THEN/g) ?? [];
+    expect(handlers.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should report every failed partition by name via WARNING (visible to the cron log)', () => {
+    const warnings = hardeningCode.match(/RAISE WARNING[^;]+;/g) ?? [];
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings.some((w) => w.includes('part_name') || w.includes('failed'))).toBe(true);
+  });
+
+  it('should keep the horizon guard and still return the created count', () => {
+    expect(hardeningCode).toContain('months_ahead < 0 OR months_ahead > 120');
+    expect(hardeningCode).toContain('RETURN created');
+  });
+
+  it('should contain NO drop path and NO grant changes (CREATE OR REPLACE preserves the 0002 ACL)', () => {
+    expect(hardeningCode).not.toMatch(/\bDROP\b/);
+    expect(hardeningCode).not.toMatch(/\bGRANT\b/);
+    expect(hardeningCode).not.toMatch(/\bREVOKE\b/);
   });
 });

--- a/packages/db/src/__tests__/admin-partition-migration.test.ts
+++ b/packages/db/src/__tests__/admin-partition-migration.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Static invariants of the monthly-partitioning migration (#890 Phase 1, leaf 6).
+ *
+ * The live behavior (routing, EXPLAIN plans, real 42501 denials) is proven by
+ * admin-partition.integration.test.ts and admin-grants.integration.test.ts
+ * against a scratch Postgres. These tests pin the migration SQL itself so CI
+ * catches a regressed invariant (a drop path sneaking into the maintenance
+ * function, a lost grant, a partition key dropped from a PK, …) without
+ * needing a database.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0002_.*\.sql$/.test(f),
+);
+const sql = migrationFile
+  ? readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile), 'utf8')
+  : '';
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0002 monthly-partitioning migration', () => {
+  it('should exist in the admin journal as migration 0002', () => {
+    expect(migrationFile).toBe('0002_partition_chain_tables.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 2)?.tag).toBe('0002_partition_chain_tables');
+  });
+
+  it('should re-create security_audit_log as monthly RANGE-partitioned on timestamp with a composite PK', () => {
+    expect(code).toMatch(
+      /CREATE TABLE "security_audit_log" \([\s\S]+?\) PARTITION BY RANGE \("timestamp"\)/,
+    );
+    expect(code).toContain(
+      'CONSTRAINT "security_audit_log_pkey" PRIMARY KEY ("id", "timestamp")',
+    );
+  });
+
+  it('should re-create siem_delivery_receipts as monthly RANGE-partitioned on deliveredAt with a composite PK', () => {
+    expect(code).toMatch(
+      /CREATE TABLE "siem_delivery_receipts" \([\s\S]+?\) PARTITION BY RANGE \("deliveredAt"\)/,
+    );
+    expect(code).toContain(
+      'CONSTRAINT "siem_delivery_receipts_pkey" PRIMARY KEY ("receiptId", "deliveredAt")',
+    );
+  });
+
+  it('should never touch siem_delivery_cursors (tiny, upserted — stays plain)', () => {
+    const statements = code.split(';');
+    for (const stmt of statements) {
+      if (/^\s*(CREATE|ALTER|DROP)\b/.test(stmt)) {
+        expect(stmt).not.toContain('siem_delivery_cursors');
+      }
+    }
+  });
+
+  it('should preserve the chain_seq sequence across the re-create (values continue, grants survive)', () => {
+    // Detached before the old table is dropped, reused as the new default,
+    // re-owned by the new column — the sequence OBJECT survives.
+    expect(code).toContain('ALTER SEQUENCE "security_audit_log_chain_seq_seq" OWNED BY NONE');
+    expect(code).toContain(`DEFAULT nextval('security_audit_log_chain_seq_seq')`);
+    expect(code).toContain(
+      'ALTER SEQUENCE "security_audit_log_chain_seq_seq" OWNED BY "security_audit_log"."chain_seq"',
+    );
+  });
+
+  it('should copy existing rows into the partitioned tables before dropping the old ones', () => {
+    expect(code).toMatch(
+      /INSERT INTO "security_audit_log" \([\s\S]+?\)\s*SELECT[\s\S]+?FROM "security_audit_log_unpartitioned"/,
+    );
+    expect(code).toMatch(
+      /INSERT INTO "siem_delivery_receipts" \([\s\S]+?\)\s*SELECT[\s\S]+?FROM "siem_delivery_receipts_unpartitioned"/,
+    );
+  });
+
+  it('should contain NO drop statement except swapping out the two copied unpartitioned tables', () => {
+    const drops = code.match(/\bDROP\s+\w+[^;]*/g) ?? [];
+    expect(drops).toHaveLength(2);
+    for (const drop of drops) {
+      expect(drop).toMatch(/^DROP TABLE "(security_audit_log|siem_delivery_receipts)_unpartitioned"/);
+    }
+  });
+
+  it('should re-create every security_audit_log index on the partitioned parent', () => {
+    const indexes = [
+      'idx_security_audit_timestamp',
+      'idx_security_audit_user_timestamp',
+      'idx_security_audit_event_type',
+      'idx_security_audit_resource',
+      'idx_security_audit_ip',
+      'idx_security_audit_ip_bidx',
+      'idx_security_audit_event_hash',
+      'idx_security_audit_chain_seq',
+      'idx_security_audit_risk_score',
+      'idx_security_audit_session',
+    ];
+    for (const name of indexes) {
+      expect(code).toContain(`CREATE INDEX "${name}" ON "security_audit_log"`);
+    }
+  });
+
+  it('should re-create every siem_delivery_receipts index, widening the unique key by the partition key', () => {
+    // Partitioned unique indexes MUST include the partition key; the dup guard
+    // weakens from (deliveryId, source) to (deliveryId, source, deliveredAt) —
+    // acceptable: the writer (siem-receipt-writer.ts) never relies on
+    // ON CONFLICT, deliveryIds are minted per delivery attempt.
+    expect(code).toContain(
+      'CREATE UNIQUE INDEX "siem_delivery_receipts_delivery_source_unique" ON "siem_delivery_receipts" USING btree ("deliveryId","source","deliveredAt")',
+    );
+    for (const name of [
+      'idx_siem_receipts_delivery_id',
+      'idx_siem_receipts_first_entry',
+      'idx_siem_receipts_last_entry',
+      'idx_siem_receipts_delivered_at',
+      'idx_siem_receipts_source_range',
+    ]) {
+      expect(code).toContain(`CREATE INDEX "${name}" ON "siem_delivery_receipts"`);
+    }
+  });
+
+  it('should create the admin_maintenance role guarded and NOLOGIN', () => {
+    expect(code).toContain(
+      `IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_maintenance')`,
+    );
+    expect(code).toContain('CREATE ROLE admin_maintenance NOLOGIN');
+  });
+
+  it('should define the create-ahead function as SECURITY DEFINER with a pinned search_path', () => {
+    expect(code).toContain('CREATE OR REPLACE FUNCTION admin_ensure_partitions(months_ahead integer DEFAULT 3)');
+    expect(code).toContain('SECURITY DEFINER');
+    expect(code).toContain('SET search_path = public, pg_temp');
+    // Safety net: a DEFAULT partition catches anything outside created ranges.
+    expect(code).toContain('PARTITION OF %I DEFAULT');
+  });
+
+  it('should grant EXECUTE on the maintenance function to admin_maintenance ONLY', () => {
+    expect(code).toContain(
+      'REVOKE ALL ON FUNCTION admin_ensure_partitions(integer) FROM PUBLIC',
+    );
+    expect(code).toContain(
+      'GRANT EXECUTE ON FUNCTION admin_ensure_partitions(integer) TO admin_maintenance',
+    );
+    // admin_maintenance holds schema USAGE (name resolution only) plus the
+    // function, and NOTHING else — it must never gain table privileges.
+    const maintenanceGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) =>
+      g.includes('admin_maintenance'),
+    );
+    expect(maintenanceGrants).toHaveLength(2);
+    expect(maintenanceGrants.some((g) => g.includes('USAGE ON SCHEMA public'))).toBe(true);
+    expect(maintenanceGrants.some((g) => g.includes('EXECUTE ON FUNCTION'))).toBe(true);
+  });
+
+  it('should seed initial partitions from the migration itself (current + 3 months ahead)', () => {
+    expect(code).toContain('SELECT admin_ensure_partitions(3)');
+  });
+
+  it('should re-apply the full leaf-4 grant matrix on the re-created parents', () => {
+    // Table grants die with DROP TABLE; grants on the partitioned parent
+    // cascade to partitions, so one re-apply per parent suffices.
+    const expected = [
+      'REVOKE ALL ON security_audit_log, siem_delivery_receipts FROM PUBLIC;',
+      'GRANT SELECT, INSERT ON security_audit_log TO admin_app;',
+      'GRANT SELECT, INSERT ON security_audit_log TO admin_chainer;',
+      'GRANT USAGE ON SEQUENCE security_audit_log_chain_seq_seq TO admin_app, admin_chainer;',
+      'GRANT SELECT ON security_audit_log TO admin_gdpr_eraser;',
+      'GRANT UPDATE (user_id, session_id, ip_address, ip_bidx, user_agent, geo_location) ON security_audit_log TO admin_gdpr_eraser;',
+      'GRANT SELECT ON security_audit_log, siem_delivery_receipts TO admin_reader;',
+      'GRANT SELECT ON security_audit_log, siem_delivery_receipts TO admin_siem;',
+      'GRANT INSERT ON siem_delivery_receipts TO admin_siem;',
+    ];
+    for (const grant of expected) {
+      expect(code).toContain(grant);
+    }
+  });
+
+  it('should grant DELETE and TRUNCATE to nobody, and never GRANT ALL on a table', () => {
+    const grants = code.match(/GRANT[^;]+;/g) ?? [];
+    expect(grants.length).toBeGreaterThan(0);
+    for (const grant of grants) {
+      expect(grant).not.toMatch(/\bDELETE\b/);
+      expect(grant).not.toMatch(/\bTRUNCATE\b/);
+      expect(grant).not.toMatch(/\bGRANT\s+ALL\b/);
+    }
+  });
+});

--- a/packages/db/src/__tests__/admin-partition.integration.test.ts
+++ b/packages/db/src/__tests__/admin-partition.integration.test.ts
@@ -360,3 +360,98 @@ describe.skipIf(!url)('upgrade path — partitioning a DB that already holds cha
     expect(rows[0]).toEqual({ app_ins: true, app_del: false, siem_ins: true, siem_upd: false });
   });
 });
+
+describe.skipIf(!url)('DEFAULT-partition poisoning containment (0003 hardening)', () => {
+  // Reproduces the REVIEW 2026-07-10 MINOR finding: a row for month M sitting
+  // in the DEFAULT partition makes CREATE TABLE ... FOR VALUES for month M
+  // fail ("updated partition constraint for default partition would be
+  // violated"). Pre-0003 that single failure rolled back EVERY month in the
+  // call; hardened, month M fails alone, the others are created, and the
+  // failure is reported via WARNING.
+  let pool: Pool;
+  const POISONED_OFFSET = 4; // first month beyond the migration-seeded horizon (0..3)
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: url, max: 3 });
+    await resetScratchDb(pool);
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+
+    // Poison: a security_audit_log row for month +4 has no monthly partition
+    // yet, so it lands in DEFAULT — exactly what a >horizon cron outage causes.
+    await pool.query(
+      `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+       VALUES ('poison-row', 'auth.login.success', $1, 'GENESIS', 'poison-hash')`,
+      [midMonthUtc(POISONED_OFFSET)],
+    );
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should have the poison row sitting in the DEFAULT partition', async () => {
+    const { rows } = await pool.query(
+      `SELECT tableoid::regclass::text AS partition FROM security_audit_log WHERE id = 'poison-row'`,
+    );
+    expect(rows[0].partition).toBe('security_audit_log_default');
+  });
+
+  it('should create every unpoisoned month, skip ONLY the poisoned one, and WARN with its name', async () => {
+    const client = await pool.connect();
+    const warnings: string[] = [];
+    client.on('notice', (msg) => {
+      if (msg.message) warnings.push(msg.message);
+    });
+    try {
+      // Horizon 6: for security_audit_log months +4 (poisoned), +5, +6;
+      // for siem_delivery_receipts (unpoisoned) months +4, +5, +6.
+      const { rows } = await client.query('SELECT admin_ensure_partitions(6) AS created');
+      expect(rows[0].created).toBe(5); // 2 + 3 — everything except the poisoned month
+    } finally {
+      client.release();
+    }
+
+    const auditPartitions = await listPartitions(pool, 'security_audit_log');
+    expect(auditPartitions).not.toContain(partitionName('security_audit_log', POISONED_OFFSET));
+    expect(auditPartitions).toContain(partitionName('security_audit_log', 5));
+    expect(auditPartitions).toContain(partitionName('security_audit_log', 6));
+
+    const receiptPartitions = await listPartitions(pool, 'siem_delivery_receipts');
+    for (const offset of [4, 5, 6]) {
+      expect(receiptPartitions).toContain(partitionName('siem_delivery_receipts', offset));
+    }
+
+    expect(
+      warnings.some((w) => w.includes(partitionName('security_audit_log', POISONED_OFFSET))),
+    ).toBe(true);
+  });
+
+  it('should create the poisoned month after ops repair (move rows out of DEFAULT, rerun)', async () => {
+    // The documented repair: move the stranded rows out of DEFAULT, create the
+    // month, put them back. Runs as the migrate identity (table owner) — no
+    // zero-trust role holds DELETE, by design.
+    const { rows: moved } = await pool.query(
+      `DELETE FROM security_audit_log WHERE id = 'poison-row'
+       RETURNING id, event_type, "timestamp", previous_hash, event_hash`,
+    );
+    expect(moved).toHaveLength(1);
+
+    const { rows } = await pool.query('SELECT admin_ensure_partitions(6) AS created');
+    expect(rows[0].created).toBe(1); // exactly the previously poisoned month
+
+    const row = moved[0];
+    await pool.query(
+      `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [row.id, row.event_type, row.timestamp, row.previous_hash, row.event_hash],
+    );
+    const { rows: routed } = await pool.query(
+      `SELECT tableoid::regclass::text AS partition FROM security_audit_log WHERE id = 'poison-row'`,
+    );
+    expect(routed[0].partition).toBe(partitionName('security_audit_log', POISONED_OFFSET));
+
+    // Fully healed: a rerun has nothing left to create.
+    const rerun = await pool.query('SELECT admin_ensure_partitions(6) AS created');
+    expect(rerun.rows[0].created).toBe(0);
+  });
+});

--- a/packages/db/src/__tests__/admin-partition.integration.test.ts
+++ b/packages/db/src/__tests__/admin-partition.integration.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Partition-behavior integration tests for the Admin PG (#890 Phase 1, leaf 6).
+ *
+ * Acceptance: a fresh `db:migrate:admin` yields monthly RANGE-partitioned
+ * chain tables with seeded partitions (current + 3 ahead + a DEFAULT safety
+ * net); inserts route to the correct partition; the chain-head query stays
+ * index-fast (EXPLAIN-asserted); `admin_ensure_partitions` is idempotent and
+ * executable by admin_maintenance only; a DB that already holds rows from the
+ * pre-partitioning migrations upgrades losslessly with a continuing
+ * chain_seq sequence.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run --config vitest.integration.config.ts src/__tests__/admin-partition.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import {
+  migrateAdminDb,
+  ADMIN_MIGRATIONS_FOLDER,
+  ADMIN_MIGRATIONS_SCHEMA,
+  ADMIN_MIGRATIONS_TABLE,
+} from '../migrate-admin';
+import { runMigrations } from '../migration-runner';
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+const ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+] as const;
+
+const PARTITIONED_PARENTS = ['security_audit_log', 'siem_delivery_receipts'] as const;
+
+/** First day of the month `offset` months from now, in UTC (matches the scratch container's TZ). */
+function monthStartUtc(offset: number): Date {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + offset, 1));
+}
+
+/** Mid-month timestamp `offset` months from now — safely inside one partition. */
+function midMonthUtc(offset: number): Date {
+  const start = monthStartUtc(offset);
+  return new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 15, 12));
+}
+
+/** Partition name for the month `offset` months from now, e.g. security_audit_log_p2026_07. */
+function partitionName(parent: string, offset: number): string {
+  const start = monthStartUtc(offset);
+  const y = start.getUTCFullYear();
+  const m = String(start.getUTCMonth() + 1).padStart(2, '0');
+  return `${parent}_p${y}_${m}`;
+}
+
+async function resetScratchDb(pool: Pool): Promise<void> {
+  await pool.query('DROP SCHEMA IF EXISTS public CASCADE');
+  await pool.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+  await pool.query('CREATE SCHEMA public');
+  for (const role of ROLES) {
+    await pool.query(`
+      DO $$ BEGIN
+        IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+          DROP OWNED BY ${role};
+          DROP ROLE ${role};
+        END IF;
+      END $$;
+    `);
+  }
+}
+
+async function listPartitions(pool: Pool, parent: string): Promise<string[]> {
+  const { rows } = await pool.query(
+    `SELECT c.relname FROM pg_inherits i
+     JOIN pg_class c ON c.oid = i.inhrelid
+     JOIN pg_class pc ON pc.oid = i.inhparent
+     WHERE pc.relname = $1 ORDER BY c.relname`,
+    [parent],
+  );
+  return rows.map((r: { relname: string }) => r.relname);
+}
+
+describe.skipIf(!url)('monthly partitioning on a fresh Admin PG', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: url, max: 3 });
+    await resetScratchDb(pool);
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should create both chain tables as RANGE-partitioned parents; cursors stay plain', async () => {
+    const { rows } = await pool.query(
+      `SELECT c.relname, c.relkind, p.partstrat
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       LEFT JOIN pg_partitioned_table p ON p.partrelid = c.oid
+       WHERE n.nspname = 'public'
+         AND c.relname IN ('security_audit_log', 'siem_delivery_receipts', 'siem_delivery_cursors')
+       ORDER BY c.relname`,
+    );
+    expect(rows).toEqual([
+      { relname: 'security_audit_log', relkind: 'p', partstrat: 'r' },
+      { relname: 'siem_delivery_cursors', relkind: 'r', partstrat: null },
+      { relname: 'siem_delivery_receipts', relkind: 'p', partstrat: 'r' },
+    ]);
+  });
+
+  it('should seed current + 3 future monthly partitions and a DEFAULT for both parents', async () => {
+    for (const parent of PARTITIONED_PARENTS) {
+      const partitions = await listPartitions(pool, parent);
+      const expected = [
+        `${parent}_default`,
+        partitionName(parent, 0),
+        partitionName(parent, 1),
+        partitionName(parent, 2),
+        partitionName(parent, 3),
+      ].sort();
+      expect(partitions).toEqual(expected);
+    }
+  });
+
+  it('should include the partition key in each primary key (partitioned-PK requirement)', async () => {
+    const pk = async (table: string) => {
+      const { rows } = await pool.query(
+        `SELECT a.attname FROM pg_index i
+         JOIN pg_class c ON c.oid = i.indrelid
+         JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY (i.indkey)
+         WHERE c.relname = $1 AND i.indisprimary
+         ORDER BY array_position(i.indkey, a.attnum)`,
+        [table],
+      );
+      return rows.map((r: { attname: string }) => r.attname);
+    };
+    expect(await pk('security_audit_log')).toEqual(['id', 'timestamp']);
+    expect(await pk('siem_delivery_receipts')).toEqual(['receiptId', 'deliveredAt']);
+  });
+
+  it('should route audit inserts spanning three months into their monthly partitions', async () => {
+    for (const [i, offset] of [0, 1, 2].entries()) {
+      await pool.query(
+        `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+         VALUES ($1, 'auth.login.success', $2, $3, $4)`,
+        [`span-row-${i}`, midMonthUtc(offset), i === 0 ? 'GENESIS' : `hash-${i}`, `hash-${i + 1}`],
+      );
+    }
+    const { rows } = await pool.query(
+      `SELECT id, tableoid::regclass::text AS partition FROM security_audit_log
+       WHERE id LIKE 'span-row-%' ORDER BY id`,
+    );
+    expect(rows).toEqual([
+      { id: 'span-row-0', partition: partitionName('security_audit_log', 0) },
+      { id: 'span-row-1', partition: partitionName('security_audit_log', 1) },
+      { id: 'span-row-2', partition: partitionName('security_audit_log', 2) },
+    ]);
+  });
+
+  it('should land a far-future insert in the DEFAULT partition (safety net)', async () => {
+    await pool.query(
+      `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+       VALUES ('far-future-row', 'auth.login.success', $1, 'hash-x', 'hash-y')`,
+      [midMonthUtc(24)],
+    );
+    const { rows } = await pool.query(
+      `SELECT tableoid::regclass::text AS partition FROM security_audit_log WHERE id = 'far-future-row'`,
+    );
+    expect(rows[0].partition).toBe('security_audit_log_default');
+  });
+
+  it('should route receipts by deliveredAt and keep the (deliveryId, source, deliveredAt) dup guard', async () => {
+    const deliveredAt = midMonthUtc(0);
+    const insertReceipt = (receiptId: string) =>
+      pool.query(
+        `INSERT INTO siem_delivery_receipts
+           ("receiptId", "deliveryId", "source", "firstEntryId", "lastEntryId",
+            "firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt")
+         VALUES ($1, 'dlv-1', 'security_audit', 'e-1', 'e-2', $2, $2, 2, $2)`,
+        [receiptId, deliveredAt],
+      );
+
+    await insertReceipt('rcpt-part-1');
+    const { rows } = await pool.query(
+      `SELECT tableoid::regclass::text AS partition FROM siem_delivery_receipts WHERE "receiptId" = 'rcpt-part-1'`,
+    );
+    expect(rows[0].partition).toBe(partitionName('siem_delivery_receipts', 0));
+
+    // Same (deliveryId, source, deliveredAt) under a fresh PK → unique_violation.
+    await expect(insertReceipt('rcpt-part-2')).rejects.toMatchObject({ code: '23505' });
+  });
+
+  it('should answer the chain-head query with an index scan — no seq scan on any partition', async () => {
+    // Give every partition realistic volume — on near-empty partitions the
+    // planner legitimately prefers seq scans, which would make this assertion
+    // meaningless rather than strict.
+    for (const offset of [0, 1, 2, 3, 24]) {
+      await pool.query(
+        `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+         SELECT 'bulk-' || $2 || '-' || g, 'auth.login.success',
+                $1::timestamp + make_interval(mins => g), 'bulk-prev', 'bulk-hash'
+         FROM generate_series(1, 300) g`,
+        [midMonthUtc(offset), offset],
+      );
+    }
+    await pool.query('ANALYZE security_audit_log');
+
+    const { rows } = await pool.query(
+      `EXPLAIN SELECT event_hash, chain_seq FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1`,
+    );
+    const plan = rows.map((r: { 'QUERY PLAN': string }) => r['QUERY PLAN']).join('\n');
+    expect(plan).toMatch(/Index Scan Backward using \S*chain_seq\S*/);
+    expect(plan).not.toContain('Seq Scan');
+  });
+
+  it('should make admin_ensure_partitions idempotent (rerun creates nothing) and extendable', async () => {
+    const first = await pool.query('SELECT admin_ensure_partitions(3) AS created');
+    expect(first.rows[0].created).toBe(0); // migration already seeded these
+
+    const before = await listPartitions(pool, 'security_audit_log');
+    const rerun = await pool.query('SELECT admin_ensure_partitions(3) AS created');
+    expect(rerun.rows[0].created).toBe(0);
+    expect(await listPartitions(pool, 'security_audit_log')).toEqual(before);
+
+    // Create-ahead: extending the horizon creates exactly month +4 and +5 per parent.
+    const extended = await pool.query('SELECT admin_ensure_partitions(5) AS created');
+    expect(extended.rows[0].created).toBe(4);
+    expect(await listPartitions(pool, 'security_audit_log')).toContain(
+      partitionName('security_audit_log', 5),
+    );
+  });
+
+  it('should reject a nonsensical horizon instead of looping forever', async () => {
+    await expect(pool.query('SELECT admin_ensure_partitions(-1)')).rejects.toMatchObject({
+      code: 'P0001',
+    });
+    await expect(pool.query('SELECT admin_ensure_partitions(1000)')).rejects.toMatchObject({
+      code: 'P0001',
+    });
+  });
+
+  it('should let admin_maintenance execute the function but hold no table access', async () => {
+    const client = await pool.connect();
+    try {
+      await client.query('SET ROLE admin_maintenance');
+      const { rows } = await client.query('SELECT admin_ensure_partitions(3) AS created');
+      expect(rows[0].created).toBe(0);
+      await expect(client.query('SELECT 1 FROM security_audit_log')).rejects.toMatchObject({
+        code: '42501',
+      });
+    } finally {
+      await client.query('RESET ROLE');
+      client.release();
+    }
+  });
+
+  it('should deny EXECUTE on the function to every other role', async () => {
+    for (const role of ROLES.filter((r) => r !== 'admin_maintenance')) {
+      const client = await pool.connect();
+      try {
+        await client.query(`SET ROLE ${role}`);
+        await expect(client.query('SELECT admin_ensure_partitions(3)')).rejects.toMatchObject({
+          code: '42501',
+        });
+      } finally {
+        await client.query('RESET ROLE');
+        client.release();
+      }
+    }
+  });
+});
+
+describe.skipIf(!url)('upgrade path — partitioning a DB that already holds chain rows', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: url, max: 3 });
+    await resetScratchDb(pool);
+
+    // Replay history: apply ONLY the pre-partitioning migrations (0000 + 0001),
+    // then write rows the way the pre-leaf-6 schema did.
+    const migrations = readMigrationFiles({ migrationsFolder: ADMIN_MIGRATIONS_FOLDER });
+    await runMigrations(drizzle(pool), migrations.slice(0, 2), {
+      migrationsSchema: ADMIN_MIGRATIONS_SCHEMA,
+      migrationsTable: ADMIN_MIGRATIONS_TABLE,
+    });
+
+    for (const [i, offset] of [-2, -1, 0].entries()) {
+      await pool.query(
+        `INSERT INTO security_audit_log (id, event_type, "timestamp", previous_hash, event_hash)
+         VALUES ($1, 'auth.login.success', $2, $3, $4)`,
+        [`legacy-row-${i}`, midMonthUtc(offset), i === 0 ? 'GENESIS' : `legacy-hash-${i}`, `legacy-hash-${i + 1}`],
+      );
+    }
+    await pool.query(
+      `INSERT INTO siem_delivery_receipts
+         ("receiptId", "deliveryId", "source", "firstEntryId", "lastEntryId",
+          "firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt")
+       VALUES ('legacy-rcpt', 'dlv-legacy', 'security_audit', 'e-1', 'e-2', $1, $1, 2, $1)`,
+      [midMonthUtc(-1)],
+    );
+
+    // Now the partitioning migration (0002) runs against a table WITH data.
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('should preserve every legacy row and route it to its historical monthly partition', async () => {
+    const { rows } = await pool.query(
+      `SELECT id, tableoid::regclass::text AS partition FROM security_audit_log
+       WHERE id LIKE 'legacy-row-%' ORDER BY id`,
+    );
+    expect(rows).toEqual([
+      { id: 'legacy-row-0', partition: partitionName('security_audit_log', -2) },
+      { id: 'legacy-row-1', partition: partitionName('security_audit_log', -1) },
+      { id: 'legacy-row-2', partition: partitionName('security_audit_log', 0) },
+    ]);
+
+    const receipt = await pool.query(
+      `SELECT tableoid::regclass::text AS partition FROM siem_delivery_receipts WHERE "receiptId" = 'legacy-rcpt'`,
+    );
+    expect(receipt.rows[0].partition).toBe(partitionName('siem_delivery_receipts', -1));
+  });
+
+  it('should keep chain_seq values and continue the surviving sequence without a gap reset', async () => {
+    const legacy = await pool.query(
+      `SELECT chain_seq FROM security_audit_log WHERE id LIKE 'legacy-row-%' ORDER BY chain_seq`,
+    );
+    expect(legacy.rows.map((r: { chain_seq: string }) => Number(r.chain_seq))).toEqual([1, 2, 3]);
+
+    await pool.query(
+      `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+       VALUES ('post-upgrade-row', 'auth.login.success', 'legacy-hash-3', 'legacy-hash-4')`,
+    );
+    const next = await pool.query(
+      `SELECT chain_seq FROM security_audit_log WHERE id = 'post-upgrade-row'`,
+    );
+    expect(Number(next.rows[0].chain_seq)).toBe(4);
+  });
+
+  it('should hold the leaf-4 grant matrix on the re-created parents', async () => {
+    const { rows } = await pool.query(
+      `SELECT has_table_privilege('admin_app', 'security_audit_log', 'INSERT') AS app_ins,
+              has_table_privilege('admin_app', 'security_audit_log', 'DELETE') AS app_del,
+              has_table_privilege('admin_siem', 'siem_delivery_receipts', 'INSERT') AS siem_ins,
+              has_table_privilege('admin_siem', 'siem_delivery_receipts', 'UPDATE') AS siem_upd`,
+    );
+    expect(rows[0]).toEqual({ app_ins: true, app_del: false, siem_ins: true, siem_upd: false });
+  });
+});

--- a/packages/db/src/__tests__/admin-schema.test.ts
+++ b/packages/db/src/__tests__/admin-schema.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Admin PG schema barrel tests (#890 Phase 1, leaf 3).
+ *
+ * The barrel selects which tables belong to the trust plane. Contract:
+ *   - EXACTLY securityAuditLog + siemDeliveryCursors + siemDeliveryReceipts
+ *     (analytics tables go to ClickHouse in Phase 3, activityLogs in Phase 5).
+ *   - Single source of truth: the SIEM tables are the same objects as the
+ *     main schema's; securityAuditLog shares one column/index definition via
+ *     the defineSecurityAuditLogTable factory.
+ *   - The admin instance carries NO cross-plane FK — `users` lives in the app
+ *     plane only, and a cross-database FK is impossible. The main instance
+ *     keeps its FK (dropping it there is Phase 2+).
+ */
+import { describe, it, expect } from 'vitest';
+import { is } from 'drizzle-orm';
+import { PgTable, getTableConfig } from 'drizzle-orm/pg-core';
+import { getTableColumns, getTableName } from 'drizzle-orm';
+import * as adminSchema from '../admin-schema';
+import { securityAuditLog as mainSecurityAuditLog } from '../schema/security-audit';
+import {
+  siemDeliveryCursors as mainSiemDeliveryCursors,
+  siemDeliveryReceipts as mainSiemDeliveryReceipts,
+} from '../schema/monitoring';
+import type { AdminDatabase } from '../admin-db';
+
+const exportedTables = Object.entries(adminSchema).filter(([, value]) =>
+  is(value, PgTable),
+);
+
+describe('admin-schema barrel', () => {
+  it('should export exactly the three trust-plane tables', () => {
+    expect(exportedTables.map(([key]) => key).sort()).toEqual([
+      'securityAuditLog',
+      'siemDeliveryCursors',
+      'siemDeliveryReceipts',
+    ]);
+  });
+
+  it('should re-export the SIEM tables as the same objects as the main schema (no fork)', () => {
+    expect(adminSchema.siemDeliveryCursors).toBe(mainSiemDeliveryCursors);
+    expect(adminSchema.siemDeliveryReceipts).toBe(mainSiemDeliveryReceipts);
+  });
+
+  describe('securityAuditLog admin instance', () => {
+    it('should target the same table name as the main instance', () => {
+      expect(getTableName(adminSchema.securityAuditLog)).toBe(
+        getTableName(mainSecurityAuditLog),
+      );
+      expect(getTableName(adminSchema.securityAuditLog)).toBe('security_audit_log');
+    });
+
+    it('should have the identical column set as the main instance (single source of truth)', () => {
+      const adminColumns = getTableColumns(adminSchema.securityAuditLog);
+      const mainColumns = getTableColumns(mainSecurityAuditLog);
+      expect(Object.keys(adminColumns)).toEqual(Object.keys(mainColumns));
+      for (const key of Object.keys(mainColumns)) {
+        expect(adminColumns[key as keyof typeof adminColumns].name).toBe(
+          mainColumns[key as keyof typeof mainColumns].name,
+        );
+        expect(adminColumns[key as keyof typeof adminColumns].columnType).toBe(
+          mainColumns[key as keyof typeof mainColumns].columnType,
+        );
+      }
+    });
+
+    it('should have the identical index set as the main instance', () => {
+      const indexNames = (table: typeof mainSecurityAuditLog) =>
+        getTableConfig(table)
+          .indexes.map((index) => index.config.name)
+          .sort();
+      expect(indexNames(adminSchema.securityAuditLog)).toEqual(
+        indexNames(mainSecurityAuditLog),
+      );
+    });
+
+    it('should carry NO foreign keys — the trust plane has no users table to reference', () => {
+      expect(getTableConfig(adminSchema.securityAuditLog).foreignKeys).toHaveLength(0);
+    });
+
+    it('main instance keeps its users FK (dropping it from the app plane is Phase 2+)', () => {
+      expect(getTableConfig(mainSecurityAuditLog).foreignKeys).toHaveLength(1);
+    });
+  });
+
+  describe('SIEM tables carry no cross-plane FKs', () => {
+    it('siemDeliveryCursors has no foreign keys', () => {
+      expect(getTableConfig(adminSchema.siemDeliveryCursors).foreignKeys).toHaveLength(0);
+    });
+
+    it('siemDeliveryReceipts has no foreign keys', () => {
+      expect(getTableConfig(adminSchema.siemDeliveryReceipts).foreignKeys).toHaveLength(0);
+    });
+  });
+
+  describe('AdminDatabase type binding (compile-time)', () => {
+    it('adminDb.query surface is exactly the admin barrel tables', () => {
+      // Fails `bun run typecheck` if AdminDatabase is not bound to the barrel
+      // (Record<string, never> ⇒ keyof query is never ⇒ excess properties) or
+      // if the barrel gains/loses a table without this contract being updated.
+      const querySurface: Record<keyof AdminDatabase['query'], true> = {
+        securityAuditLog: true,
+        siemDeliveryCursors: true,
+        siemDeliveryReceipts: true,
+      };
+      expect(Object.keys(querySurface)).toHaveLength(3);
+    });
+  });
+});

--- a/packages/db/src/__tests__/migration-runner.test.ts
+++ b/packages/db/src/__tests__/migration-runner.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Migration-runner core tests (#890 Phase 1, leaf 3).
+ *
+ * The per-migration-transaction runner (extracted from migrate.ts) is
+ * parameterized over the journal location so the main DB ('drizzle' schema)
+ * and the Admin PG ('drizzle_admin' schema) never collide. Tests inject a
+ * fake executor — no test opens a connection.
+ */
+import { describe, it, expect } from 'vitest';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type { SQL } from 'drizzle-orm';
+import {
+  runMigrations,
+  type MigrationExecutor,
+  type RunnableMigration,
+} from '../migration-runner';
+
+const dialect = new PgDialect();
+
+interface FakeDb {
+  executor: MigrationExecutor;
+  executed: string[];
+  transactionCount: () => number;
+}
+
+const makeFakeDb = (appliedHashes: string[] = []): FakeDb => {
+  const executed: string[] = [];
+  let transactions = 0;
+  const executor: MigrationExecutor = {
+    async execute(query: SQL) {
+      const text = dialect.sqlToQuery(query).sql;
+      executed.push(text);
+      if (/select/i.test(text) && text.includes('hash')) {
+        return { rows: appliedHashes.map((hash) => ({ hash })) };
+      }
+      return { rows: [] };
+    },
+    async transaction<T>(cb: (tx: MigrationExecutor) => Promise<T>): Promise<T> {
+      transactions += 1;
+      return cb(executor);
+    },
+  };
+  return { executor, executed, transactionCount: () => transactions };
+};
+
+const migration = (hash: string, statements: string[]): RunnableMigration => ({
+  hash,
+  folderMillis: 1720000000000,
+  sql: statements,
+});
+
+const ADMIN_JOURNAL = {
+  migrationsSchema: 'drizzle_admin',
+  migrationsTable: '__drizzle_migrations',
+};
+
+describe('runMigrations', () => {
+  it('should create the journal schema and table under the given identifiers', async () => {
+    const { executor, executed } = makeFakeDb();
+    await runMigrations(executor, [], ADMIN_JOURNAL);
+
+    expect(executed.some((s) => /CREATE SCHEMA IF NOT EXISTS "drizzle_admin"/.test(s))).toBe(true);
+    expect(
+      executed.some((s) =>
+        /CREATE TABLE IF NOT EXISTS "drizzle_admin"\."__drizzle_migrations"/.test(s),
+      ),
+    ).toBe(true);
+  });
+
+  it('should never touch the main journal schema when given the admin journal', async () => {
+    const { executor, executed } = makeFakeDb();
+    await runMigrations(executor, [migration('abc', ['SELECT 1'])], ADMIN_JOURNAL);
+
+    expect(executed.some((s) => s.includes('"drizzle".'))).toBe(false);
+  });
+
+  it('should apply a pending migration and record its hash in the journal', async () => {
+    const { executor, executed } = makeFakeDb();
+    await runMigrations(
+      executor,
+      [migration('abc', ['CREATE TABLE "t" ("id" text)'])],
+      ADMIN_JOURNAL,
+    );
+
+    expect(executed).toContain('CREATE TABLE "t" ("id" text)');
+    expect(
+      executed.some((s) =>
+        /INSERT INTO "drizzle_admin"\."__drizzle_migrations"/.test(s),
+      ),
+    ).toBe(true);
+  });
+
+  it('should skip migrations whose hash is already applied', async () => {
+    const { executor, executed, transactionCount } = makeFakeDb(['abc']);
+    await runMigrations(
+      executor,
+      [migration('abc', ['CREATE TABLE "t" ("id" text)'])],
+      ADMIN_JOURNAL,
+    );
+
+    expect(executed).not.toContain('CREATE TABLE "t" ("id" text)');
+    expect(transactionCount()).toBe(0);
+  });
+
+  it('should run each pending migration in its own transaction', async () => {
+    const { executor, transactionCount } = makeFakeDb(['already-applied']);
+    await runMigrations(
+      executor,
+      [
+        migration('already-applied', ['SELECT 0']),
+        migration('one', ['SELECT 1']),
+        migration('two', ['SELECT 2', 'SELECT 3']),
+      ],
+      ADMIN_JOURNAL,
+    );
+
+    expect(transactionCount()).toBe(2);
+  });
+
+  it('should support the main journal identifiers unchanged (drizzle schema)', async () => {
+    const { executor, executed } = makeFakeDb();
+    await runMigrations(executor, [], {
+      migrationsSchema: 'drizzle',
+      migrationsTable: '__drizzle_migrations',
+    });
+
+    expect(
+      executed.some((s) =>
+        /CREATE TABLE IF NOT EXISTS "drizzle"\."__drizzle_migrations"/.test(s),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/db/src/admin-db-mode.ts
+++ b/packages/db/src/admin-db-mode.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure decision logic for the Admin PG (trust plane) connection registry
+ * (#890 Phase 1). No I/O, no process.env reads — callers pass env values in.
+ *
+ * Three-state contract:
+ *   ADMIN_DATABASE_URL set (valid postgres URL)      → 'dedicated'
+ *   URL unset + ADMIN_DB_BREAK_GLASS exactly 'true'  → 'break-glass'
+ *   URL unset + flag not armed                       → 'fail'
+ *
+ * A set-but-invalid URL is 'fail' even when break-glass is armed: a
+ * misconfigured deploy must stop, never silently degrade to the main DB.
+ */
+
+export interface AdminDbEnv {
+  ADMIN_DATABASE_URL?: string | undefined;
+  ADMIN_DATABASE_SSL?: string | undefined;
+  ADMIN_DB_POOL_MAX?: string | undefined;
+  ADMIN_DB_BREAK_GLASS?: string | undefined;
+}
+
+export type AdminDbModeName = 'dedicated' | 'break-glass' | 'fail';
+
+export interface AdminDbModeDecision {
+  mode: AdminDbModeName;
+  reason: string;
+}
+
+const isPostgresUrl = (url: string): boolean =>
+  url.startsWith('postgresql://') || url.startsWith('postgres://');
+
+// Fail-closed: only the exact string 'true' arms the fallback. 'TRUE', '1',
+// ' true ', '' etc. do not — mirrors the serverEnvSchema contract from leaf 1.
+const isBreakGlassArmed = (flag: string | undefined): boolean => flag === 'true';
+
+export const resolveAdminDbMode = (env: AdminDbEnv): AdminDbModeDecision => {
+  const url = env.ADMIN_DATABASE_URL;
+
+  // Empty string is treated as unset (falls through to break-glass/fail).
+  if (url !== undefined && url !== '') {
+    if (!isPostgresUrl(url)) {
+      return {
+        mode: 'fail',
+        reason:
+          'ADMIN_DATABASE_URL is set but is not a postgres:// or postgresql:// connection string. ' +
+          'Fix the URL — an invalid trust-plane target is never degraded to the main DB.',
+      };
+    }
+    return { mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' };
+  }
+
+  if (isBreakGlassArmed(env.ADMIN_DB_BREAK_GLASS)) {
+    return {
+      mode: 'break-glass',
+      reason:
+        "ADMIN_DATABASE_URL is unset and ADMIN_DB_BREAK_GLASS='true' — degrading audit writes to the main DB",
+    };
+  }
+
+  return {
+    mode: 'fail',
+    reason:
+      'ADMIN_DATABASE_URL is not set. The Admin PG (trust plane) is required in every deployment mode. ' +
+      "Set ADMIN_DATABASE_URL to the dedicated admin Postgres, or — as an emergency rollback only — set ADMIN_DB_BREAK_GLASS='true' to permit audit writes to the main DB.",
+  };
+};
+
+export interface AdminPoolConfig {
+  connectionString: string;
+  ssl: false | { rejectUnauthorized: false };
+  max: number;
+  keepAlive: true;
+  keepAliveInitialDelayMillis: number;
+  idleTimeoutMillis: number;
+  connectionTimeoutMillis: number;
+}
+
+const DEFAULT_POOL_MAX = 10;
+
+const resolvePoolMax = (raw: string | undefined): number => {
+  if (!raw) return DEFAULT_POOL_MAX;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_POOL_MAX;
+};
+
+// Mirrors the main pool settings in db.ts (ssl semantics, keepAlive, timeouts).
+export const resolveAdminPoolConfig = (env: AdminDbEnv): AdminPoolConfig => ({
+  connectionString: env.ADMIN_DATABASE_URL ?? '',
+  ssl: env.ADMIN_DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
+  max: resolvePoolMax(env.ADMIN_DB_POOL_MAX),
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+  idleTimeoutMillis: 600000,
+  connectionTimeoutMillis: 10000,
+});

--- a/packages/db/src/admin-db-mode.ts
+++ b/packages/db/src/admin-db-mode.ts
@@ -92,3 +92,28 @@ export const resolveAdminPoolConfig = (env: AdminDbEnv): AdminPoolConfig => ({
   idleTimeoutMillis: 600000,
   connectionTimeoutMillis: 10000,
 });
+
+export type AdminMigrateDecision =
+  | { ok: true; poolConfig: AdminPoolConfig }
+  | { ok: false; reason: string };
+
+/**
+ * db:migrate:admin gate — only 'dedicated' may migrate. Break-glass degrades
+ * audit WRITES to the main DB at runtime, but running admin migrations there
+ * would plant the drizzle_admin journal inside the app plane, so it refuses.
+ */
+export const resolveAdminMigrateDecision = (env: AdminDbEnv): AdminMigrateDecision => {
+  const decision = resolveAdminDbMode(env);
+  if (decision.mode === 'break-glass') {
+    return {
+      ok: false,
+      reason:
+        'admin migrations never run under break-glass — they target only a dedicated Admin PG. ' +
+        'Set ADMIN_DATABASE_URL to the trust-plane database.',
+    };
+  }
+  if (decision.mode === 'fail') {
+    return { ok: false, reason: decision.reason };
+  }
+  return { ok: true, poolConfig: resolveAdminPoolConfig(env) };
+};

--- a/packages/db/src/admin-db.ts
+++ b/packages/db/src/admin-db.ts
@@ -1,0 +1,111 @@
+/**
+ * adminDb — the Admin PG (trust plane) client (#890 Phase 1).
+ *
+ * Composition root for the dedicated admin Postgres that will hold the
+ * tamper-evident security audit chain and related trust-plane tables. Mode
+ * selection is pure (admin-db-mode.ts); this shell only constructs the pool
+ * and wires deps. Init is lazy — importing this module opens no connection.
+ *
+ * Schema binding: leaf 3 builds the admin schema barrel; until then the
+ * client is drizzle-bound without a schema.
+ */
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { db } from './db';
+import { registerPool } from './pool-stats';
+import {
+  resolveAdminDbMode,
+  resolveAdminPoolConfig,
+  type AdminDbEnv,
+  type AdminPoolConfig,
+} from './admin-db-mode';
+
+export {
+  resolveAdminDbMode,
+  resolveAdminPoolConfig,
+  type AdminDbEnv,
+  type AdminDbModeDecision,
+  type AdminDbModeName,
+  type AdminPoolConfig,
+} from './admin-db-mode';
+
+export type AdminDatabase = NodePgDatabase<Record<string, never>>;
+
+export const ADMIN_POOL_NAME = 'admin';
+
+export interface AdminDbDeps {
+  getEnv: () => AdminDbEnv;
+  getMainDb: () => AdminDatabase;
+  createPool: (config: AdminPoolConfig) => Pool;
+  registerPool: (pool: Pool, name: string) => void;
+  alert: (message: string) => void;
+}
+
+export interface AdminDbRegistry {
+  getAdminDb: () => AdminDatabase;
+}
+
+const breakGlassAlert = (reason: string): string =>
+  [
+    '████████████████████████████████████████████████████████████████████',
+    '██ SECURITY ALERT — ADMIN DB BREAK-GLASS ACTIVE                    ██',
+    '████████████████████████████████████████████████████████████████████',
+    `Audit/trust-plane writes are going to the MAIN application database: ${reason}.`,
+    'This is an emergency rollback state, never a supported steady state.',
+    'Provision the Admin PG, set ADMIN_DATABASE_URL, and remove ADMIN_DB_BREAK_GLASS.',
+  ].join('\n');
+
+export function createAdminDbRegistry(deps: AdminDbDeps): AdminDbRegistry {
+  let instance: AdminDatabase | null = null;
+
+  const init = (): AdminDatabase => {
+    const env = deps.getEnv();
+    const decision = resolveAdminDbMode(env);
+
+    switch (decision.mode) {
+      case 'dedicated': {
+        const pool = deps.createPool(resolveAdminPoolConfig(env));
+        // Prevent uncaughtException spam when the network drops idle
+        // connections — same guard as the main pool in db.ts.
+        pool.on('error', () => {});
+        deps.registerPool(pool, ADMIN_POOL_NAME);
+        return drizzle(pool);
+      }
+      case 'break-glass': {
+        deps.alert(breakGlassAlert(decision.reason));
+        return deps.getMainDb();
+      }
+      case 'fail':
+        throw new Error(`adminDb init failed: ${decision.reason}`);
+    }
+  };
+
+  return {
+    getAdminDb() {
+      if (!instance) instance = init();
+      return instance;
+    },
+  };
+}
+
+const registry = createAdminDbRegistry({
+  // Env is read at init time, not import time, so late-loaded dotenv wins.
+  getEnv: () => ({
+    ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+    ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
+    ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
+    ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+  }),
+  // Break-glass only. Cast is transitional: leaf 3 binds the admin schema
+  // barrel and narrows AdminDatabase to it.
+  getMainDb: () => db as unknown as AdminDatabase,
+  createPool: (config) => new Pool(config),
+  registerPool,
+  alert: (message) => console.error(message),
+});
+
+/**
+ * Per-process adminDb accessor. Lazy: connects (or throws, or degrades with a
+ * loud alert) on first call, then returns the same instance for the process.
+ */
+export const getAdminDb = (): AdminDatabase => registry.getAdminDb();

--- a/packages/db/src/admin-db.ts
+++ b/packages/db/src/admin-db.ts
@@ -6,12 +6,13 @@
  * selection is pure (admin-db-mode.ts); this shell only constructs the pool
  * and wires deps. Init is lazy — importing this module opens no connection.
  *
- * Schema binding: leaf 3 builds the admin schema barrel; until then the
- * client is drizzle-bound without a schema.
+ * Schema binding: the admin schema barrel (admin-schema.ts) — EXACTLY the
+ * trust-plane tables; the query API (adminDb.query.*) is typed against it.
  */
 import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import { db } from './db';
+import { pool as mainPool } from './db';
+import * as adminSchema from './admin-schema';
 import { registerPool } from './pool-stats';
 import {
   resolveAdminDbMode,
@@ -29,7 +30,7 @@ export {
   type AdminPoolConfig,
 } from './admin-db-mode';
 
-export type AdminDatabase = NodePgDatabase<Record<string, never>>;
+export type AdminDatabase = NodePgDatabase<typeof adminSchema>;
 
 export const ADMIN_POOL_NAME = 'admin';
 
@@ -69,7 +70,7 @@ export function createAdminDbRegistry(deps: AdminDbDeps): AdminDbRegistry {
         // connections — same guard as the main pool in db.ts.
         pool.on('error', () => {});
         deps.registerPool(pool, ADMIN_POOL_NAME);
-        return drizzle(pool);
+        return drizzle(pool, { schema: adminSchema });
       }
       case 'break-glass': {
         deps.alert(breakGlassAlert(decision.reason));
@@ -96,9 +97,9 @@ const registry = createAdminDbRegistry({
     ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
     ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
   }),
-  // Break-glass only. Cast is transitional: leaf 3 binds the admin schema
-  // barrel and narrows AdminDatabase to it.
-  getMainDb: () => db as unknown as AdminDatabase,
+  // Break-glass only: an admin-schema-typed client over the MAIN pool — same
+  // database and connections as `db`, narrow trust-plane type, no cast.
+  getMainDb: () => drizzle(mainPool, { schema: adminSchema }),
   createPool: (config) => new Pool(config),
   registerPool,
   alert: (message) => console.error(message),

--- a/packages/db/src/admin-schema.ts
+++ b/packages/db/src/admin-schema.ts
@@ -1,0 +1,33 @@
+/**
+ * Admin PG (trust plane) schema barrel (#890 Phase 1).
+ *
+ * Selects WHICH tables belong to the dedicated admin database. Per the
+ * 2026-07-09 reconciliation this is EXACTLY:
+ *   - securityAuditLog (tamper-evident chained table)
+ *   - siemDeliveryCursors
+ *   - siemDeliveryReceipts
+ * The 4 analytics tables (systemLogs, apiMetrics, userActivities, errorLogs)
+ * go to ClickHouse in Phase 3 — NOT into Admin PG. The ingest table is a
+ * Phase 2 migration; activityLogs joins in Phase 5.
+ *
+ * Source of truth stays in ./schema/* — the SIEM tables are plain re-exports,
+ * and securityAuditLog is instantiated from the shared factory WITHOUT the
+ * cross-plane FK to `users` (a cross-database FK is impossible; the admin DB
+ * holds no app tables). Columns/indexes are defined once, so the planes
+ * cannot drift. The relations from ./schema/security-audit are deliberately
+ * not included: they join to `users`, which exists in the app plane only.
+ *
+ * This module is both the drizzle-kit schema entry (drizzle-admin.config.ts)
+ * and the runtime schema bound to the adminDb client (admin-db.ts).
+ */
+import { defineSecurityAuditLogTable } from './schema/security-audit';
+
+/** Trust-plane instance of security_audit_log — identical shape, no users FK. */
+export const securityAuditLog = defineSecurityAuditLogTable({ crossPlaneUserFk: false });
+
+export type {
+  SecurityEventType,
+  InsertSecurityAuditLog,
+  SelectSecurityAuditLog,
+} from './schema/security-audit';
+export { siemDeliveryCursors, siemDeliveryReceipts } from './schema/monitoring';

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,7 +4,9 @@ import { schema } from './schema';
 import { registerPool, getPoolStats } from './pool-stats';
 import 'dotenv/config';
 
-const pool = new Pool({
+// Exported for the adminDb break-glass path (admin-db.ts), which binds an
+// admin-schema client over this same pool — no second connection pool.
+export const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
   max: process.env.DB_POOL_MAX ? parseInt(process.env.DB_POOL_MAX, 10) : 10,

--- a/packages/db/src/migrate-admin.ts
+++ b/packages/db/src/migrate-admin.ts
@@ -1,0 +1,72 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { runMigrations } from './migration-runner';
+import { resolveAdminMigrateDecision, type AdminDbEnv } from './admin-db-mode';
+
+/**
+ * Admin PG (trust plane) migration entrypoint — db:migrate:admin (#890
+ * Phase 1). Separate journal end to end: ./drizzle-admin on disk, the
+ * 'drizzle_admin' schema in the database — the main pipeline (migrate.ts →
+ * ./drizzle → 'drizzle') is never touched.
+ *
+ * Migrations run ONLY against a dedicated Admin PG: break-glass is a runtime
+ * degradation for audit writes, and honoring it here would plant the admin
+ * journal (and future admin DDL) in the main application database.
+ */
+
+export const ADMIN_MIGRATIONS_FOLDER = 'drizzle-admin';
+export const ADMIN_MIGRATIONS_SCHEMA = 'drizzle_admin';
+export const ADMIN_MIGRATIONS_TABLE = '__drizzle_migrations';
+
+export async function migrateAdminDb(
+  env: AdminDbEnv,
+  log: (message: string) => void = () => {},
+): Promise<void> {
+  const decision = resolveAdminMigrateDecision(env);
+  if (!decision.ok) {
+    throw new Error(`db:migrate:admin refused: ${decision.reason}`);
+  }
+
+  const migrations = readMigrationFiles({ migrationsFolder: ADMIN_MIGRATIONS_FOLDER });
+
+  const pool = new Pool(decision.poolConfig);
+  try {
+    await runMigrations(
+      drizzle(pool),
+      migrations,
+      { migrationsSchema: ADMIN_MIGRATIONS_SCHEMA, migrationsTable: ADMIN_MIGRATIONS_TABLE },
+      log,
+    );
+  } finally {
+    await pool.end();
+  }
+}
+
+async function main() {
+  console.log('Running admin (trust plane) migrations...');
+  console.log('ADMIN_DATABASE_URL:', process.env.ADMIN_DATABASE_URL ? 'Set' : 'Not set');
+
+  await migrateAdminDb(
+    {
+      ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+      ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
+      ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
+      ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+    },
+    console.log,
+  );
+
+  console.log('Admin migrations finished.');
+  process.exit(0);
+}
+
+// Run only as a script (tsx src/migrate-admin.ts) — importing this module
+// (e.g. from the integration smoke test) must not trigger a migration.
+if (process.argv[1]?.includes('migrate-admin')) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,17 +1,12 @@
 
 import { readMigrationFiles } from "drizzle-orm/migrator";
-import { sql } from "drizzle-orm";
 import { db } from "./db";
+import { runMigrations } from "./migration-runner";
 
 /**
- * Custom migration runner that executes each migration in its own transaction.
- *
- * Drizzle's built-in migrate() runs ALL pending migrations in a single transaction,
- * which breaks when a migration adds an enum value (ALTER TYPE ADD VALUE) and a
- * later migration uses that value — PostgreSQL error 55P04:
- * "New enum values must be committed before they can be used."
- *
- * This runner commits each migration individually, fixing the enum issue.
+ * Main-DB migration entrypoint. The per-migration-transaction logic lives in
+ * migration-runner.ts (shared with the Admin PG runner, migrate-admin.ts);
+ * this shell only binds the main journal: ./drizzle + the 'drizzle' schema.
  */
 async function main() {
   console.log("Running migrations...");
@@ -19,42 +14,12 @@ async function main() {
 
   const migrations = readMigrationFiles({ migrationsFolder: "drizzle" });
 
-  const migrationsSchema = "drizzle";
-  const migrationsTable = "__drizzle_migrations";
-
-  // Ensure schema and table exist
-  await db.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
-  await db.execute(
-    sql`CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)} (
-      id SERIAL PRIMARY KEY,
-      hash text NOT NULL,
-      created_at bigint
-    )`
+  await runMigrations(
+    db,
+    migrations,
+    { migrationsSchema: "drizzle", migrationsTable: "__drizzle_migrations" },
+    console.log,
   );
-
-  // Load all applied migration hashes — checking by hash (not by max timestamp) is
-  // required because migrations regenerated after a collision can receive timestamps
-  // older than already-applied migrations, causing the simpler "last timestamp" check
-  // to silently skip them.
-  const dbMigrations = await db.execute(
-    sql`SELECT hash FROM ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)}`
-  );
-  const appliedHashes = new Set((dbMigrations.rows as { hash: string }[]).map((r) => r.hash));
-
-  for (const migration of migrations) {
-    if (!appliedHashes.has(migration.hash)) {
-      console.log(`  Applying: ${migration.hash.substring(0, 8)}... (${migration.folderMillis})`);
-
-      await db.transaction(async (tx) => {
-        for (const stmt of migration.sql) {
-          await tx.execute(sql.raw(stmt));
-        }
-        await tx.execute(
-          sql`INSERT INTO ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)} ("hash", "created_at") VALUES (${migration.hash}, ${migration.folderMillis})`
-        );
-      });
-    }
-  }
 
   console.log("Migrations finished.");
   process.exit(0);

--- a/packages/db/src/migration-runner.ts
+++ b/packages/db/src/migration-runner.ts
@@ -1,0 +1,75 @@
+import { sql, type SQL } from 'drizzle-orm';
+
+/**
+ * Per-migration-transaction runner core (extracted from migrate.ts, #890
+ * Phase 1) — parameterized over the journal location so the main DB
+ * ('drizzle' schema) and the Admin PG ('drizzle_admin' schema) keep fully
+ * independent journals.
+ *
+ * Drizzle's built-in migrate() runs ALL pending migrations in a single
+ * transaction, which breaks when a migration adds an enum value (ALTER TYPE
+ * ADD VALUE) and a later migration uses that value — PostgreSQL error 55P04:
+ * "New enum values must be committed before they can be used."
+ * This runner commits each migration individually, fixing the enum issue.
+ */
+
+/** Structural subset of drizzle's MigrationMeta (readMigrationFiles output). */
+export interface RunnableMigration {
+  hash: string;
+  folderMillis: number;
+  sql: string[];
+}
+
+export interface MigrationJournal {
+  migrationsSchema: string;
+  migrationsTable: string;
+}
+
+/** Minimal executor surface — satisfied by NodePgDatabase and PgTransaction. */
+export interface MigrationExecutor {
+  execute(query: SQL): Promise<{ rows: unknown[] }>;
+  transaction<T>(cb: (tx: MigrationExecutor) => Promise<T>): Promise<T>;
+}
+
+export async function runMigrations(
+  db: MigrationExecutor,
+  migrations: readonly RunnableMigration[],
+  journal: MigrationJournal,
+  log: (message: string) => void = () => {},
+): Promise<void> {
+  const { migrationsSchema, migrationsTable } = journal;
+
+  // Ensure schema and table exist
+  await db.execute(sql`CREATE SCHEMA IF NOT EXISTS ${sql.identifier(migrationsSchema)}`);
+  await db.execute(
+    sql`CREATE TABLE IF NOT EXISTS ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)} (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at bigint
+    )`
+  );
+
+  // Load all applied migration hashes — checking by hash (not by max timestamp) is
+  // required because migrations regenerated after a collision can receive timestamps
+  // older than already-applied migrations, causing the simpler "last timestamp" check
+  // to silently skip them.
+  const dbMigrations = await db.execute(
+    sql`SELECT hash FROM ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)}`
+  );
+  const appliedHashes = new Set((dbMigrations.rows as { hash: string }[]).map((r) => r.hash));
+
+  for (const migration of migrations) {
+    if (!appliedHashes.has(migration.hash)) {
+      log(`  Applying: ${migration.hash.substring(0, 8)}... (${migration.folderMillis})`);
+
+      await db.transaction(async (tx) => {
+        for (const stmt of migration.sql) {
+          await tx.execute(sql.raw(stmt));
+        }
+        await tx.execute(
+          sql`INSERT INTO ${sql.identifier(migrationsSchema)}.${sql.identifier(migrationsTable)} ("hash", "created_at") VALUES (${migration.hash}, ${migration.folderMillis})`
+        );
+      });
+    }
+  }
+}

--- a/packages/db/src/pool-stats.test.ts
+++ b/packages/db/src/pool-stats.test.ts
@@ -21,6 +21,19 @@ describe('pool-stats', () => {
     });
   });
 
+  describe('named pools', () => {
+    it('given an admin pool registered under its own name, should not clobber the default pool stats', () => {
+      registerPool(makePool(5, 3, 1));
+      registerPool(makePool(2, 2, 0), 'admin');
+      expect(getPoolStats()).toEqual({ total: 5, idle: 3, waiting: 1 });
+      expect(getPoolStats('admin')).toEqual({ total: 2, idle: 2, waiting: 0 });
+    });
+
+    it('given an unknown pool name, should return zeros', () => {
+      expect(getPoolStats('nonexistent')).toEqual({ total: 0, idle: 0, waiting: 0 });
+    });
+  });
+
   describe('registerPool', () => {
     it('returns total from pool.totalCount', () => {
       registerPool(makePool(7, 3, 2));

--- a/packages/db/src/pool-stats.ts
+++ b/packages/db/src/pool-stats.ts
@@ -1,16 +1,25 @@
 import type { Pool } from 'pg';
 
-let _pool: Pool | null = null;
+export const MAIN_POOL_NAME = 'main';
 
-export function registerPool(pool: Pool): void {
-  _pool = pool;
+const pools = new Map<string, Pool>();
+
+export interface PoolStats {
+  total: number;
+  idle: number;
+  waiting: number;
 }
 
-export function getPoolStats(): { total: number; idle: number; waiting: number } {
-  if (!_pool) return { total: 0, idle: 0, waiting: 0 };
+export function registerPool(pool: Pool, name: string = MAIN_POOL_NAME): void {
+  pools.set(name, pool);
+}
+
+export function getPoolStats(name: string = MAIN_POOL_NAME): PoolStats {
+  const pool = pools.get(name);
+  if (!pool) return { total: 0, idle: 0, waiting: 0 };
   return {
-    total: _pool.totalCount,
-    idle: _pool.idleCount,
-    waiting: _pool.waitingCount,
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
   };
 }

--- a/packages/db/src/schema/security-audit.ts
+++ b/packages/db/src/schema/security-audit.ts
@@ -74,21 +74,29 @@ export type SecurityEventType =
   | 'security.incident.created';
 
 /**
- * Security Audit Log table - tamper-evident security event tracking.
+ * Single source of truth for the security_audit_log table shape (#890 Phase 1).
  *
- * Uses a hash chain to ensure audit trail integrity:
- * - Each entry includes the hash of the previous entry
- * - Any modification breaks the chain and is detectable
- * - First entry in chain uses 'genesis' as previousHash
+ * The table exists in two planes during the trust-plane migration: the main
+ * app DB (current writer, FK to users intact) and the Admin PG trust plane
+ * (src/admin-schema.ts), where a FK to `users` is impossible — cross-database
+ * foreign keys don't exist, and the admin DB deliberately holds no app tables.
+ * drizzle-kit serializes inline FKs unconditionally, so the admin variant
+ * cannot be a plain re-export; this factory keeps columns and indexes defined
+ * exactly once so the two instances can never drift. Only `crossPlaneUserFk`
+ * differs between them.
  */
-export const securityAuditLog = pgTable('security_audit_log', {
+export const defineSecurityAuditLogTable = (opts: { crossPlaneUserFk: boolean }) =>
+  pgTable('security_audit_log', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
 
   // Event classification
   eventType: text('event_type').notNull().$type<SecurityEventType>(),
 
-  // Actor (who triggered the event)
-  userId: text('user_id').references(() => users.id, { onDelete: 'set null' }),
+  // Actor (who triggered the event). The FK exists only in the app plane —
+  // the Admin PG has no users table to reference.
+  userId: opts.crossPlaneUserFk
+    ? text('user_id').references(() => users.id, { onDelete: 'set null' })
+    : text('user_id'),
   sessionId: text('session_id'),
   serviceId: text('service_id'),
 
@@ -146,6 +154,19 @@ export const securityAuditLog = pgTable('security_audit_log', {
   // Session tracking
   sessionIdx: index('idx_security_audit_session').on(table.sessionId, table.timestamp),
 }));
+
+/**
+ * Security Audit Log table - tamper-evident security event tracking.
+ *
+ * Uses a hash chain to ensure audit trail integrity:
+ * - Each entry includes the hash of the previous entry
+ * - Any modification breaks the chain and is detectable
+ * - First entry in chain uses 'genesis' as previousHash
+ *
+ * This is the APP-PLANE instance (main DB, FK to users). The trust-plane
+ * instance lives in src/admin-schema.ts. Dropping the FK here is Phase 2+.
+ */
+export const securityAuditLog = defineSecurityAuditLogTable({ crossPlaneUserFk: true });
 
 /**
  * Relations for security audit log

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -8,9 +8,9 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.{js,ts}'],
     exclude: [
       // Integration tests that require a running PostgreSQL database.
-      // Run via ./scripts/test-with-db.sh, or:
-      //   bun run --filter '@pagespace/db' test -- src/__tests__/accessible-page-ids.integration.test.ts
-      'src/__tests__/accessible-page-ids.integration.test.ts',
+      // Run via ./scripts/test-with-db.sh or vitest.integration.config.ts
+      // (admin-migrate additionally needs ADMIN_DATABASE_URL → scratch DB).
+      'src/**/*.integration.test.ts',
     ],
     setupFiles: ['./src/test/setup.ts'],
     // Run test files sequentially to avoid database race conditions

--- a/packages/lib/src/audit/__tests__/phase0-regression.test.ts
+++ b/packages/lib/src/audit/__tests__/phase0-regression.test.ts
@@ -346,19 +346,20 @@ describe('3. DI completeness sweep (no singleton fallthrough)', () => {
     expect(result.isValid).toBe(true);
   });
 
-  it('given no AUDIT_DATABASE_URL seam exists yet, its presence in the environment has no effect on any reader (forward-compat guard for Phase 1)', async () => {
-    const prev = process.env.AUDIT_DATABASE_URL;
-    process.env.AUDIT_DATABASE_URL = 'postgres://not-yet-wired-up/audit';
+  it('given ADMIN_DATABASE_URL is set, its presence has no effect on any audit reader (readers stay on the injected/default db until Phase 2 wires the adminDb registry)', async () => {
+    const prev = process.env.ADMIN_DATABASE_URL;
+    process.env.ADMIN_DATABASE_URL = 'postgres://not-yet-wired-up/pagespace_admin';
     try {
       // No deps injected -> falls back to the (mocked) default db, exactly as
-      // it would with the env var absent. Phase 0 has no code path that reads
-      // this variable, so its presence must be a complete no-op.
+      // it would with the env var absent. Only the adminDb registry
+      // (@pagespace/db/admin-db) reads this variable, and no audit reader
+      // consults that registry yet, so its presence must be a complete no-op.
       const result = await verifySecurityAuditChain();
       expect(result.isValid).toBe(true);
       expect(result.totalEntries).toBe(0);
     } finally {
-      if (prev === undefined) delete process.env.AUDIT_DATABASE_URL;
-      else process.env.AUDIT_DATABASE_URL = prev;
+      if (prev === undefined) delete process.env.ADMIN_DATABASE_URL;
+      else process.env.ADMIN_DATABASE_URL = prev;
     }
   });
 });

--- a/packages/lib/src/config/__tests__/env-validation.test.ts
+++ b/packages/lib/src/config/__tests__/env-validation.test.ts
@@ -148,6 +148,173 @@ describe('env-validation', () => {
     });
   });
 
+  describe('Admin Postgres (trust plane) config', () => {
+    const baseEnv = {
+      NODE_ENV: 'test',
+      DATABASE_URL: 'postgresql://user:pass@localhost:5432/db',
+    };
+
+    it('given a valid postgresql:// ADMIN_DATABASE_URL, should parse and expose it (connect path)', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DATABASE_URL: 'postgresql://user:pass@postgres-admin:5432/pagespace_admin',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DATABASE_URL).toBe(
+          'postgresql://user:pass@postgres-admin:5432/pagespace_admin',
+        );
+      }
+    });
+
+    it('given a valid postgres:// ADMIN_DATABASE_URL, should parse successfully', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DATABASE_URL: 'postgres://user:pass@postgres-admin:5432/pagespace_admin',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('given a non-postgres ADMIN_DATABASE_URL (http://), should fail with a clear message', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DATABASE_URL: 'http://postgres-admin:5432/pagespace_admin',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path.includes('ADMIN_DATABASE_URL'));
+        expect(issue).toBeDefined();
+        expect(issue?.message).toMatch(/PostgreSQL connection string/);
+      }
+    });
+
+    it('given an empty-string ADMIN_DATABASE_URL, should fail validation', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DATABASE_URL: '',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes('ADMIN_DATABASE_URL')),
+        ).toBe(true);
+      }
+    });
+
+    it('given ADMIN_DATABASE_URL unset with ADMIN_DB_BREAK_GLASS=true, should parse and expose the flag (degrade-loudly path)', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DB_BREAK_GLASS: 'true',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DATABASE_URL).toBeUndefined();
+        expect(result.data.ADMIN_DB_BREAK_GLASS).toBe('true');
+      }
+    });
+
+    it('given ADMIN_DATABASE_URL unset and no break-glass flag, should parse at the schema level with both undefined (fail-fast lives in adminDb init)', () => {
+      const result = serverEnvSchema.safeParse(baseEnv);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DATABASE_URL).toBeUndefined();
+        expect(result.data.ADMIN_DB_BREAK_GLASS).toBeUndefined();
+      }
+    });
+
+    it('given a stray ADMIN_DB_BREAK_GLASS value (e.g. "1"), should still parse — only the exact value "true" arms break-glass downstream', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_DB_BREAK_GLASS: '1',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DB_BREAK_GLASS).toBe('1');
+      }
+    });
+
+    it('given ADMIN_DATABASE_SSL=true or false, should parse successfully', () => {
+      for (const value of ['true', 'false']) {
+        const result = serverEnvSchema.safeParse({
+          ...baseEnv,
+          ADMIN_DATABASE_SSL: value,
+        });
+
+        expect(result.success).toBe(true);
+      }
+    });
+
+    it('given an invalid ADMIN_DATABASE_SSL value, should fail validation', () => {
+      const result = serverEnvSchema.safeParse({
+        ...baseEnv,
+        ADMIN_DATABASE_SSL: 'maybe',
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes('ADMIN_DATABASE_SSL')),
+        ).toBe(true);
+      }
+    });
+
+    it('given a numeric ADMIN_DB_POOL_MAX, should coerce it to a positive integer', () => {
+      const result = serverEnvSchema.safeParse({
+        ...baseEnv,
+        ADMIN_DB_POOL_MAX: '10',
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DB_POOL_MAX).toBe(10);
+      }
+    });
+
+    it('given a non-numeric or non-positive ADMIN_DB_POOL_MAX, should fail validation', () => {
+      for (const value of ['abc', '0', '-5', '2.5']) {
+        const result = serverEnvSchema.safeParse({
+          ...baseEnv,
+          ADMIN_DB_POOL_MAX: value,
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(
+            result.error.issues.some((i) => i.path.includes('ADMIN_DB_POOL_MAX')),
+          ).toBe(true);
+        }
+      }
+    });
+
+    it('given ADMIN_DB_POOL_MAX unset, should parse with it undefined', () => {
+      const result = serverEnvSchema.safeParse(baseEnv);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DB_POOL_MAX).toBeUndefined();
+      }
+    });
+  });
+
   describe('validateEnv', () => {
     it('given valid environment, should return parsed env object', () => {
       process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -16,6 +16,29 @@ export const serverEnvSchema = z
         'DATABASE_URL must be a valid PostgreSQL connection string'
       ),
 
+    // Admin Postgres (trust plane) — dedicated database for the tamper-evident
+    // security audit chain and related admin/audit tables, isolated from the app
+    // DB in every deployment mode. Optional at the schema level: the hard
+    // fail-fast when unset (and no break-glass flag) is enforced by the adminDb
+    // client at init, not here, so non-audit code paths can still validate env.
+    ADMIN_DATABASE_URL: z
+      .string()
+      .min(1, 'ADMIN_DATABASE_URL must not be empty when set')
+      .refine(
+        (url) => url.startsWith('postgresql://') || url.startsWith('postgres://'),
+        'ADMIN_DATABASE_URL must be a valid PostgreSQL connection string'
+      )
+      .optional(),
+    ADMIN_DATABASE_SSL: z.enum(['true', 'false']).optional(),
+    ADMIN_DB_POOL_MAX: z.coerce.number().int().positive().optional(),
+
+    // Break-glass rollback ONLY: arms the fallback that permits audit writes to
+    // the main DB (which must alert loudly) when the Admin PG is unavailable.
+    // Never a supported steady state. Accept any string so a stray value (e.g.
+    // ADMIN_DB_BREAK_GLASS=1) never fails app-wide env validation; consumers
+    // arm break-glass only on the exact value 'true' (fail-closed otherwise).
+    ADMIN_DB_BREAK_GLASS: z.string().optional(),
+
     // CSRF Protection (required in production/development, optional in test)
     CSRF_SECRET: z.string().optional(),
 


### PR DESCRIPTION
Phase 1 of the DB decomposition / zero-trust logging epic (#890 — references, does not close). Builds on the Phase 0 repository seam (#1976).

## Why

Today the tamper-evident `security_audit_log` chain lives in the same Postgres it protects — its head proves nothing to anyone who doesn't already trust that DB — and every authenticated request serializes on a global advisory lock. The end state is a **trust plane** beside the app plane: a dedicated Admin Postgres holding the chain tables, written through a lock-free ingest + single-writer chainer, anchored to an external witness.

This PR is the plumbing for that plane, with **zero behavior change**: no audit write path moves yet (that's Phase 2). Naming follows the reconciled architecture from the merged "DB Service Decomposition" program: **Admin PG** — `pagespace-db-admin`, `adminDb`, `ADMIN_DATABASE_URL`. Per the same reconciliation, the Admin PG holds ONLY the chain/SIEM tables (`security_audit_log`, `siem_delivery_cursors`, `siem_delivery_receipts`); the four analytics tables go to ClickHouse in Phase 3 and `ai_usage_logs` stays in main PG permanently.

## ⚠️ Operators: upgrade note for existing tenant/self-host deployments

**Pulling this compose with a pre-Phase-1 `.env` will refuse to start, by design.** The tenant stack now requires `ADMIN_POSTGRES_DB/USER/PASSWORD`; every interpolation uses `${ADMIN_POSTGRES_PASSWORD:?...}` so the failure names its cause and points at the fix. Follow **`infrastructure/UPGRADE.md`** (new in this PR): append the three `ADMIN_POSTGRES_*` lines to your **existing** `.env`. **Never re-run `generate-tenant-env.sh` on an existing deployment** — it regenerates ALL secrets including `ENCRYPTION_KEY`, which is unrecoverable data loss. This was the one MAJOR review finding; fixed in-branch (see below).

## What's in it (six leaves + review tail)

1. **Env contract** (`packages/lib`): `ADMIN_DATABASE_URL` (must be `postgres://`/`postgresql://` when set), `ADMIN_DATABASE_SSL`, `ADMIN_DB_POOL_MAX`, `ADMIN_DB_BREAK_GLASS` (arms only on exact `'true'`, fail-closed). Documented in `.env.example` / `.env.onprem.example` / `env.tenant.template`.
2. **`adminDb` connection registry** (`packages/db/src/admin-db.ts` + pure core `admin-db-mode.ts`, subpath export `@pagespace/db/admin-db`): composition-root factory with three-state init — URL set → connect; unset + break-glass armed → degrade to main DB with a loud banner; unset + no flag → throw fail-fast. No silent fallback. `pool-stats` became a named-pool map so the admin pool doesn't clobber main stats.
3. **Admin schema barrel + separate migration pipeline**: `@pagespace/db/admin-schema` (exactly the 3 tables), journal `packages/db/drizzle-admin/` + in-DB `drizzle_admin.__drizzle_migrations`, scripts `db:generate:admin` / `db:migrate:admin`. A fresh empty Postgres reaches full schema via `db:migrate:admin` alone. Main pipeline untouched — root `db:generate` reports "No schema changes". The admin `security_audit_log` instance drops the cross-plane `users` FK via a shared `defineSecurityAuditLogTable` factory (cross-database FKs are impossible; columns defined once, parity pinned by tests — ratified in review).
4. **Zero-trust roles** (`drizzle-admin/0001`, custom migration): NOLOGIN role templates — `admin_app` (SELECT+INSERT on the chain table, interim until the Phase 2 ingest table), `admin_chainer`, `admin_reader`, `admin_siem` (cursor upserts + write-once receipts), `admin_gdpr_eraser` (UPDATE on exactly the 6 hash-excluded PII columns — Art 17 without breaking the chain). **DELETE/TRUNCATE granted to nobody; PUBLIC fully revoked** — proven live per role×table via `has_table_privilege` + 42501 probes.
5. **Compose + CI, all modes**: `postgres-admin` container in the root dev stack and the tenant stack (same pinned `postgres:17.5-alpine`, own volume, internal-only); `ADMIN_DATABASE_URL` goes to the **migrate one-shot only** — runtime services hold no admin credentials in Phase 1 (see review-driven hardening below); migrate runs both migrate steps and gates on both DBs healthy; `generate-tenant-env.sh` emits the Admin section for fresh installs. CI gets a 'Run admin migrations' step mirroring the main migrate machine, gated behind repo var `ADMIN_DB_MIGRATIONS_ENABLED` (default off — cloud rollout is a Phase 6 runbook step).
6. **Monthly range partitioning** (`drizzle-admin/0002`): both chain tables partitioned from day one (PKs widened to include the partition key), existing-data months seeded + current+3 created ahead + DEFAULT safety nets; `admin_ensure_partitions()` SECURITY DEFINER create-ahead function, EXECUTE only to new `admin_maintenance`; **zero drop code — infinite chain retention (Art 17(3)(b)) is enforced structurally**, and no role can drop partitions.

**Review outcome** (dedicated REVIEW → FIX sessions, findings on the epic board): 1 MAJOR — the bricked-upgrade path above — fixed with the compose `:?` fail-fast + `infrastructure/UPGRADE.md`. 2 MINOR: DEFAULT-partition poisoning of create-ahead → fixed in `drizzle-admin/0003` (per-month exception scope: a poisoned month fails alone with a WARNING naming it + repair steps, other months still created; alerting/runbook half deferred to Phase 6); break-glass alerting beyond the console banner deferred to Phase 2 (no runtime caller exists yet). Plus 3 design ratifications (no-users-FK factory, receipts partition key, interim `admin_app` SELECT+INSERT).

## Verification (re-run after rebase onto current master)

- `packages/db` unit: **308 passed** (8 fails = pre-existing environmental `activity-logs-compliance`, needs a provisioned test DB; untouched by this branch)
- `packages/lib` `src/audit` + `src/config`: **200/200**
- `test:infra` (compose/CI suites): **291 passed** / 4 failed — all 4 pre-existing on master (CI service-matrix pin at 5 vs 7 services; 3 arm64 GHCR image-runtime tests), board items filed
- Admin integration on a **fresh docker PG16**: **61/61** across the 3 suites — `db:migrate:admin` fresh-DB smoke (0000–0003, idempotent rerun), full grant-denial matrix, partitioning (EXPLAIN pruning, upgrade-path-with-rows, sequence continuity)
- `bun run typecheck`: 16/16 green · root `db:generate` AND `db:generate:admin`: "No schema changes"

Note for reviewers: CI does not run the docker integration suites — they were run locally as above; unit/lint/typecheck are the CI signal.

## Convergence pass (post-open review sweep)

A targeted re-review of the two FIX commits + the Phase 0 (#1976) rebase interaction found no blockers/majors; two small items landed as `2c686c305`:

- Master's `phase0-regression.test.ts` forward-compat guard tested `AUDIT_DATABASE_URL` — a name that never shipped (Phase 1's var is `ADMIN_DATABASE_URL` per the reconciliation), making the guard vacuous. It now pins the real invariant: audit readers ignore `ADMIN_DATABASE_URL` until Phase 2 wires the adminDb registry.
- `infrastructure/UPGRADE.md` now names `./scripts/tenant-stack.sh upgrade <slug>` as the canonical restart path alongside the raw compose command.

**Phase 2 heads-up (board finding filed, no Phase 1 impact):** the Phase 0 seam type `SecurityAuditRepositoryDeps.db: typeof defaultDb` is not assignable from `AdminDatabase` (3-table schema) — Phase 2's `createSecurityAuditRepository({ db: getAdminDb() })` wiring needs a deliberate widening of the seam deps type.

**CodeRabbit round (`1fa973447`):** UPGRADE.md intro now says only `ADMIN_POSTGRES_PASSWORD` is strictly required (DB/USER have compose defaults), matching the Notes. Its second suggestion — renaming SIEM columns to snake_case — was declined with reasoning on the thread: the SIEM tables are deliberate plain re-exports of the main-plane definitions (parity-by-construction for the Phase 2 cutover); renaming one plane forks them, renaming both is a main-DB migration out of scope for a phase whose invariant is `db:generate` = "No schema changes".

**Review-driven hardening (`a5483937e`, Codex P2 finding):** the compose stacks originally handed runtime services (web/processor/realtime) an `ADMIN_DATABASE_URL` built from the **owner/bootstrap** credentials — which bypass every zero-trust grant in `drizzle-admin/0001`. Owner creds are now **migrate-only**: runtime services hold no admin credentials at all in Phase 1 (nothing reads the var at runtime — no `getAdminDb()` caller exists), and the Phase 2 cutover wires **per-service** LOGIN roles (web→`admin_app`, chainer→`admin_chainer`, SIEM→`admin_siem`; board task filed, including the Fly-secrets analogue for cloud). Pinned by updated compose tests; credential model documented in both compose files and `UPGRADE.md`.

## Pre-existing discoveries (non-blocking, board tasks filed)

- `check()` constraints in `schema/monitoring.ts` are silently ignored by drizzle-kit 0.23 — the `siem_delivery_cursors` delivered-pair invariant is unenforced at DB level in **both** planes (needs drizzle-kit ≥0.28 or a hand-rolled migration).
- Root-compose host port mappings on internal-only networks are silently not published — affects the existing main `postgres` `5432:5432` as much as the mirrored `postgres-admin` `5433:5432`; `.env.onprem.example`'s `localhost` guidance doesn't work against the stack as-is. Needs a ruling (extra non-internal network vs doc fix).
- `validate-ci-config.test.ts` pins the build matrix at 5 services but `docker-images.yml` has had 7 since admin+marketing were added (1 test red on master); `image-runtime.test.ts` fails on Apple Silicon (no arm64 GHCR manifests).

Refs #890 · Phase 0: #1976 · Epic board: `zv9shvbt2icd2voxwb5fr3rb` / phase page `qi267ytm9kl8cmyw0kpvqb5c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAaBUmCfzatwBwv23tNs91
