### PR TITLE
feat(audit): Phase 2 — audit write path cutover to Admin PG (lock-free emission + single-writer chainer + external anchoring) (#890 Phase 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admi
 # ADMIN_APP_PASSWORD=admin-app-password
 # ADMIN_PROCESSOR_PASSWORD=admin-processor-password
 # ADMIN_READER_PASSWORD=admin-reader-password
+# ADMIN_ERASER_PASSWORD=admin-eraser-password
 # ADMIN_DATABASE_SSL=true
 # ADMIN_DB_POOL_MAX=10
 # Break-glass rollback ONLY: setting ADMIN_DB_BREAK_GLASS=true permits audit
@@ -24,6 +25,12 @@ ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admi
 # steady state — leave unset. Without it, an unset ADMIN_DATABASE_URL fails
 # fast at adminDb init.
 # ADMIN_DB_BREAK_GLASS=true
+# Fresh installs ONLY: lets the audit chainer start the admin chain from
+# genesis (empty head). Correct when copying this template for a NEW stack —
+# there is no legacy history. NEVER add it to an upgraded deployment's .env
+# while legacy security_audit_log rows exist: run the backfill first
+# (infrastructure/UPGRADE.md, #890 Phase 2 era-fork guard).
+AUDIT_CHAINER_ALLOW_GENESIS=true
 
 # Authentication & Security
 PROCESSOR_AUTH_REQUIRED=true

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,16 @@ DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
 # deployment mode (cloud: separate Fly instance; tenant/onprem: postgres-admin
 # container). Real credentials are secrets (cloud: `fly secrets set`); never
 # commit real values.
+# Runtime services connect as per-service least-privilege LOGIN users (web →
+# admin_app_user, processor → admin_processor_user, admin → admin_reader_user);
+# the OWNER URL below is migrate/provisioning-only. The compose stacks set the
+# per-service URLs explicitly; docker-compose.yml's migrate one-shot provisions
+# the login users from ADMIN_APP/PROCESSOR/READER_PASSWORD via
+# `bun run db:provision:admin-users`. Passwords must be URL-safe (alphanumeric).
 ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
+# ADMIN_APP_PASSWORD=admin-app-password
+# ADMIN_PROCESSOR_PASSWORD=admin-processor-password
+# ADMIN_READER_PASSWORD=admin-reader-password
 # ADMIN_DATABASE_SSL=true
 # ADMIN_DB_POOL_MAX=10
 # Break-glass rollback ONLY: setting ADMIN_DB_BREAK_GLASS=true permits audit

--- a/.env.onprem.example
+++ b/.env.onprem.example
@@ -22,7 +22,16 @@ DATABASE_URL=postgresql://pagespace:your_strong_password@localhost:5432/pagespac
 # stack) holding the tamper-evident security audit chain and related admin/audit
 # tables, isolated from the app database above. Use a unique strong password;
 # never commit real credentials.
+# NOTE: this URL is the OWNER role — migrations/provisioning only. Runtime
+# services connect as least-privilege LOGIN users (admin_app_user /
+# admin_processor_user / admin_reader_user) provisioned by
+# `bun run db:provision:admin-users` from the ADMIN_*_PASSWORD values below.
+# Passwords must be URL-safe (alphanumeric) — they are embedded in
+# ADMIN_DATABASE_URL connection strings without URL-encoding.
 ADMIN_DATABASE_URL=postgresql://pagespace:another_strong_password@localhost:5433/pagespace_admin
+# ADMIN_APP_PASSWORD=unique_strong_password_1
+# ADMIN_PROCESSOR_PASSWORD=unique_strong_password_2
+# ADMIN_READER_PASSWORD=unique_strong_password_3
 # ADMIN_DATABASE_SSL=false
 # ADMIN_DB_POOL_MAX=10
 # Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -228,14 +228,30 @@ jobs:
           FLY_NO_UPDATE_CHECK: "true"
 
       # Admin PG (trust plane, #890): mirrors the main migration machine but runs
-      # db:migrate:admin. The machine runs in the pagespace-web app, so it inherits
-      # ADMIN_DATABASE_URL from that app's Fly secrets — no GitHub-side copy of the URL.
+      # db:migrate:admin. The machine runs in the pagespace-web app, BUT it must
+      # not use that app's runtime ADMIN_DATABASE_URL secret — that is the
+      # least-privilege admin_app LOGIN (Phase 2), which cannot run DDL. The
+      # OWNER connection string lives ONLY in the ADMIN_DATABASE_URL_MIGRATE
+      # GitHub secret and is passed to the one-shot machine via --env, so owner
+      # credentials never sit in any Fly app's runtime secrets (migrate-admin.ts
+      # prefers ADMIN_DATABASE_URL_MIGRATE over the inherited runtime URL).
       # GATED on the ADMIN_DB_MIGRATIONS_ENABLED repo variable: deploys must not break
       # before the Fly pagespace-db-admin instance is provisioned. Ops flips the
-      # variable to 'true' after provisioning — see the Phase 6 runbook (issue #890).
+      # variable to 'true' after provisioning — see the Phase 6 runbook (issue #890)
+      # and the Fly secret matrix in infrastructure/UPGRADE.md (Phase 2).
       - name: Run admin migrations
         if: ${{ vars.ADMIN_DB_MIGRATIONS_ENABLED == 'true' }}
         run: |
+          # Fail fast: without the dedicated migrate URL the machine would fall
+          # back to the app's runtime login and fail with permission errors deep
+          # inside the migration — surface the misconfiguration by name instead.
+          if [ -z "$ADMIN_DATABASE_URL_MIGRATE" ]; then
+            echo "ERROR: ADMIN_DATABASE_URL_MIGRATE secret is not set."
+            echo "ADMIN_DB_MIGRATIONS_ENABLED=true requires the dedicated owner migrate URL"
+            echo "(see infrastructure/UPGRADE.md, Phase 2 Fly secret matrix)."
+            exit 1
+          fi
+
           docker pull ghcr.io/2witstudios/pagespace-migrate:latest
           docker tag ghcr.io/2witstudios/pagespace-migrate:latest registry.fly.io/pagespace-web:migrate-admin
           docker push registry.fly.io/pagespace-web:migrate-admin
@@ -246,6 +262,7 @@ jobs:
             --app pagespace-web \
             --region iad \
             --restart no \
+            --env ADMIN_DATABASE_URL_MIGRATE="$ADMIN_DATABASE_URL_MIGRATE" \
             bun run db:migrate:admin \
             2>&1 | tee /tmp/admin_machine_output.txt || true
 
@@ -304,6 +321,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           FLY_NO_UPDATE_CHECK: "true"
+          ADMIN_DATABASE_URL_MIGRATE: ${{ secrets.ADMIN_DATABASE_URL_MIGRATE }}
 
       - name: Deploy web
         run: |

--- a/apps/processor/src/__tests__/admin-pg-types.test.ts
+++ b/apps/processor/src/__tests__/admin-pg-types.test.ts
@@ -1,0 +1,137 @@
+/**
+ * UTC type-parsing on the Admin PG pools (#890 Phase 2 FIX).
+ *
+ * drizzle stores `timestamp` (WITHOUT time zone) columns as UTC wall clock
+ * (mapToDriverValue = toISOString) and parses them back as UTC — but pg's
+ * default text parser for OID 1114 interprets the wall clock in the
+ * process's LOCAL zone. Every raw-pg read on the trust plane feeds hash
+ * recomputation (SIEM preflight, chainer verify-on-append), so a processor
+ * running with TZ ≠ UTC would recompute shifted hashes and halt delivery on
+ * a false chain_tamper. The admin pools therefore override the OID 1114
+ * parser to read the wall clock as UTC, matching the write side exactly.
+ *
+ * The TZ simulation mutates process.env.TZ for this file only (restored in
+ * afterAll); assertions that REQUIRE an effective non-UTC zone are guarded
+ * by tzShiftEffective so a runtime that ignores runtime TZ changes cannot
+ * produce spurious failures — the parser's UTC contract is asserted
+ * unconditionally either way.
+ */
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+const capturedPoolConfigs = vi.hoisted(
+  () => [] as Array<{ connectionString: string; types?: { getTypeParser(oid: number, format?: string): unknown } }>,
+);
+
+vi.mock('pg', async (importOriginal) => {
+  const actual = (await importOriginal()) as { default: Record<string, unknown> };
+  class CapturingPool {
+    constructor(config: (typeof capturedPoolConfigs)[number]) {
+      capturedPoolConfigs.push(config);
+    }
+    connect() {
+      return Promise.resolve({ query: vi.fn(), release: vi.fn() });
+    }
+    end() {
+      return Promise.resolve();
+    }
+  }
+  return { default: { ...actual.default, Pool: CapturingPool }, Pool: CapturingPool };
+});
+
+import {
+  buildAdminPgTypes,
+  parsePgTimestampAsUtc,
+  TIMESTAMP_WITHOUT_TZ_OID,
+} from '../admin-pg-types';
+import { getAdminPoolForWorker } from '../db';
+import { recomputeSecurityAuditHash } from '../services/siem-chain-hashers';
+
+const ORIGINAL_TZ = process.env.TZ;
+
+// The UTC instant the write side stored: drizzle serializes it as
+// toISOString and pg's wire text for the column drops the T/Z.
+const STORED_ISO = '2026-07-10T03:04:05.678Z';
+const WIRE_TEXT = '2026-07-10 03:04:05.678';
+
+let tzShiftEffective = false;
+
+beforeAll(() => {
+  process.env.TZ = 'Pacific/Auckland'; // UTC+12/+13 — never 0
+  tzShiftEffective = new Date('2026-01-01 00:00:00').getTimezoneOffset() !== 0;
+});
+
+afterAll(() => {
+  if (ORIGINAL_TZ === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = ORIGINAL_TZ;
+  }
+});
+
+describe('parsePgTimestampAsUtc', () => {
+  it('parses the wire wall clock as UTC regardless of process TZ', () => {
+    expect(parsePgTimestampAsUtc(WIRE_TEXT).toISOString()).toBe(STORED_ISO);
+    expect(parsePgTimestampAsUtc('2026-07-10 03:04:05').toISOString()).toBe(
+      '2026-07-10T03:04:05.000Z',
+    );
+    // Microsecond precision (pg default for timestamp) truncates to ms.
+    expect(parsePgTimestampAsUtc('2026-07-10 03:04:05.678901').toISOString()).toBe(STORED_ISO);
+  });
+
+  it("under a simulated non-UTC TZ, pg's default local parse WOULD shift the instant (the bug being fixed)", () => {
+    if (!tzShiftEffective) return; // runtime ignores runtime TZ changes — contract assertions above still hold
+    expect(new Date(WIRE_TEXT).toISOString()).not.toBe(STORED_ISO);
+  });
+
+  it('under a simulated non-UTC TZ, hash recomputation over a parser-read timestamp matches the write-side hash', () => {
+    const fields = {
+      eventType: 'auth.login.success',
+      serviceId: 'web',
+      resourceType: null,
+      resourceId: null,
+      details: { attempt: 1 },
+      riskScore: null,
+      anomalyFlags: null,
+      timestamp: parsePgTimestampAsUtc(WIRE_TEXT),
+    };
+    const writeSide = recomputeSecurityAuditHash(
+      { ...fields, timestamp: new Date(STORED_ISO) },
+      'genesis',
+    );
+    expect(recomputeSecurityAuditHash(fields, 'genesis')).toBe(writeSide);
+    if (tzShiftEffective) {
+      // The default local parse recomputes a DIFFERENT hash — false tamper.
+      expect(
+        recomputeSecurityAuditHash({ ...fields, timestamp: new Date(WIRE_TEXT) }, 'genesis'),
+      ).not.toBe(writeSide);
+    }
+  });
+});
+
+describe('buildAdminPgTypes', () => {
+  it('returns the UTC parser for OID 1114 text reads and delegates everything else to pg defaults', () => {
+    const types = buildAdminPgTypes();
+    expect(types.getTypeParser(TIMESTAMP_WITHOUT_TZ_OID, 'text')).toBe(parsePgTimestampAsUtc);
+    expect(types.getTypeParser(TIMESTAMP_WITHOUT_TZ_OID)).toBe(parsePgTimestampAsUtc);
+    // Binary format is not ours to reinterpret.
+    expect(types.getTypeParser(TIMESTAMP_WITHOUT_TZ_OID, 'binary')).not.toBe(
+      parsePgTimestampAsUtc,
+    );
+    // int4 falls through to pg's own parser.
+    const int4 = types.getTypeParser(23, 'text') as (v: string) => number;
+    expect(int4('42')).toBe(42);
+  });
+});
+
+describe('getAdminPoolForWorker', () => {
+  it('constructs the admin pool with the UTC type parsers wired in', () => {
+    process.env.ADMIN_DATABASE_URL = 'postgresql://admin_processor_user:pw@localhost:5432/scratch';
+    getAdminPoolForWorker();
+    const adminConfig = capturedPoolConfigs.find((c) =>
+      c.connectionString.includes('admin_processor_user'),
+    );
+    expect(adminConfig).toBeDefined();
+    const parser = adminConfig!.types?.getTypeParser(TIMESTAMP_WITHOUT_TZ_OID, 'text');
+    expect(parser).toBe(parsePgTimestampAsUtc);
+  });
+});

--- a/apps/processor/src/__tests__/server.test.ts
+++ b/apps/processor/src/__tests__/server.test.ts
@@ -217,6 +217,9 @@ vi.mock('../db', () => ({
   setPageFailed: vi.fn(),
   setPageVisual: vi.fn(),
   getPoolForWorker: vi.fn(),
+  // Unreached in this suite: no ADMIN_DATABASE_URL in the test env, so the
+  // SIEM pool routing resolves every read to the main pool.
+  getAdminPoolForWorker: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/processor/src/admin-pg-types.ts
+++ b/apps/processor/src/admin-pg-types.ts
@@ -1,0 +1,52 @@
+/**
+ * UTC type parsing for the Admin PG (trust plane) pools — #890 Phase 2 FIX.
+ *
+ * drizzle stores `timestamp` (WITHOUT time zone) columns as UTC wall clock
+ * (write: toISOString; read: appends Z) — but pg's default text parser for
+ * OID 1114 interprets the wall clock in the process's LOCAL zone. Raw-pg
+ * reads on the trust plane feed hash recomputation (SIEM delivery preflight,
+ * chainer verify-on-append), so a processor running with TZ ≠ UTC would
+ * recompute shifted hashes → false chain_tamper → delivery halt + tamper
+ * pages. Parsing OID 1114 as UTC on the admin pools makes the read side
+ * match the write side regardless of process TZ.
+ */
+
+// @ts-expect-error -- pg has no bundled types; runtime cast below handles type safety
+import pg from 'pg';
+
+const pgTypes = (
+  pg as unknown as { types: { getTypeParser(oid: number, format?: string): unknown } }
+).types;
+
+/** OID of `timestamp without time zone`. */
+export const TIMESTAMP_WITHOUT_TZ_OID = 1114;
+
+/**
+ * Parse a timestamp-without-tz wire string ('2026-07-10 03:04:05.678') as
+ * UTC wall clock — the zone drizzle wrote it in.
+ */
+export function parsePgTimestampAsUtc(value: string): Date {
+  return new Date(`${value}+0000`);
+}
+
+export interface PgTypesConfig {
+  getTypeParser(oid: number, format?: string): unknown;
+}
+
+/**
+ * Pool-scoped `types` config for Admin PG pools: OID 1114 text reads parse
+ * as UTC, everything else (including binary reads) falls through to pg's
+ * defaults. Pool-scoped on purpose — the main-DB pool keeps stock behavior
+ * (its columns are not raw-pg hash inputs on this plane; the process-wide
+ * TZ=UTC entrypoint pin is a Phase 6 task).
+ */
+export function buildAdminPgTypes(): PgTypesConfig {
+  return {
+    getTypeParser(oid: number, format?: string): unknown {
+      if (oid === TIMESTAMP_WITHOUT_TZ_OID && format !== 'binary') {
+        return parsePgTimestampAsUtc;
+      }
+      return pgTypes.getTypeParser(oid, format);
+    },
+  };
+}

--- a/apps/processor/src/admin-pg-types.ts
+++ b/apps/processor/src/admin-pg-types.ts
@@ -21,12 +21,27 @@ const pgTypes = (
 /** OID of `timestamp without time zone`. */
 export const TIMESTAMP_WITHOUT_TZ_OID = 1114;
 
+// pg's text wire format for OID 1114: 'YYYY-MM-DD HH:MM:SS[.ffffff]'.
+const PG_TIMESTAMP_TEXT = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?$/;
+
 /**
  * Parse a timestamp-without-tz wire string ('2026-07-10 03:04:05.678') as
- * UTC wall clock — the zone drizzle wrote it in.
+ * UTC wall clock — the zone drizzle wrote it in. Parsed field-by-field:
+ * space-separated date strings are implementation-defined for `new Date()`
+ * (V8 accepts them, JavaScriptCore often does not), and hash recomputation
+ * cannot tolerate an engine-dependent Invalid Date.
  */
 export function parsePgTimestampAsUtc(value: string): Date {
-  return new Date(`${value}+0000`);
+  const m = PG_TIMESTAMP_TEXT.exec(value);
+  if (!m) {
+    // Non-timestamp wire text ('infinity', BC dates): defer to the engine
+    // rather than guess — these never feed hash recomputation.
+    return new Date(`${value}+0000`);
+  }
+  const ms = m[7] ? Number(m[7].padEnd(3, '0').slice(0, 3)) : 0;
+  return new Date(
+    Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3]), Number(m[4]), Number(m[5]), Number(m[6]), ms),
+  );
 }
 
 export interface PgTypesConfig {

--- a/apps/processor/src/db.ts
+++ b/apps/processor/src/db.ts
@@ -30,6 +30,23 @@ export function getPoolForWorker(): PgPool {
   return getPool();
 }
 
+// Admin PG (trust plane) pool — separate server, separate identity: the
+// processor connects as admin_processor_user (admin_chainer + admin_siem)
+// via its service-scoped ADMIN_DATABASE_URL (#890 Phase 2). Small max: the
+// only consumer is the single-writer audit chainer.
+let adminPool: PgPool | null = null;
+
+export function getAdminPoolForWorker(): PgPool {
+  if (!adminPool) {
+    const connectionString = process.env.ADMIN_DATABASE_URL;
+    if (!connectionString) {
+      throw new Error('ADMIN_DATABASE_URL is not configured');
+    }
+    adminPool = new Pool({ connectionString, max: 2 });
+  }
+  return adminPool;
+}
+
 export async function setPageProcessing(pageId: string): Promise<void> {
   const client = await getPool().connect();
   try {

--- a/apps/processor/src/db.ts
+++ b/apps/processor/src/db.ts
@@ -11,7 +11,10 @@ interface PgPool {
 
 // @ts-expect-error -- pg has no bundled types; runtime cast below handles type safety
 import pg from 'pg';
-const { Pool } = pg as unknown as { Pool: new (config: { connectionString: string; max: number }) => PgPool };
+import { buildAdminPgTypes, type PgTypesConfig } from './admin-pg-types';
+const { Pool } = pg as unknown as {
+  Pool: new (config: { connectionString: string; max: number; types?: PgTypesConfig }) => PgPool;
+};
 
 let pool: PgPool | null = null;
 
@@ -34,6 +37,9 @@ export function getPoolForWorker(): PgPool {
 // processor connects as admin_processor_user (admin_chainer + admin_siem)
 // via its service-scoped ADMIN_DATABASE_URL (#890 Phase 2). Small max: the
 // only consumer is the single-writer audit chainer.
+// timestamp-without-tz columns parse as UTC (buildAdminPgTypes): raw-pg
+// reads on this pool feed hash recomputation, which must match drizzle's
+// UTC wall-clock storage regardless of process TZ.
 let adminPool: PgPool | null = null;
 
 export function getAdminPoolForWorker(): PgPool {
@@ -42,7 +48,7 @@ export function getAdminPoolForWorker(): PgPool {
     if (!connectionString) {
       throw new Error('ADMIN_DATABASE_URL is not configured');
     }
-    adminPool = new Pool({ connectionString, max: 2 });
+    adminPool = new Pool({ connectionString, max: 2, types: buildAdminPgTypes() });
   }
   return adminPool;
 }

--- a/apps/processor/src/server.ts
+++ b/apps/processor/src/server.ts
@@ -21,7 +21,25 @@ import { SIEM_SOURCES, CURSOR_INIT_SENTINEL } from './services/siem-sources';
 import { buildSiemHealth, type SiemHealthResponse } from './services/siem-health-builder';
 import { readCursorSnapshots } from './workers/siem-cursor-reader';
 import { readRecentReceipts } from './workers/siem-receipt-reader';
-import { getPoolForWorker } from './db';
+import { resolveSiemPoolRouting, type SiemStorePlane } from './services/siem-pool-routing';
+import { getPoolForWorker, getAdminPoolForWorker } from './db';
+
+// SIEM state (cursors/receipts) moved to the Admin PG at the #890 Phase 2
+// cutover; per-source data reads follow the same pool-per-operation matrix
+// the delivery worker uses (services/siem-pool-routing.ts). In break-glass
+// everything reverts to main. In 'fail' mode we still serve the main-db
+// (legacy) state rather than erroring: /health is a liveness surface and the
+// worker itself already logs the misconfiguration loudly.
+function siemPoolFor(plane: SiemStorePlane | undefined) {
+  return plane === 'admin' ? getAdminPoolForWorker() : getPoolForWorker();
+}
+
+function siemRouting() {
+  return resolveSiemPoolRouting({
+    ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+    ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+  }).routing;
+}
 
 // Whitelist for the /siem/receipts endpoint, derived from the canonical
 // SIEM_SOURCES list so a third source added there cannot silently bypass
@@ -84,7 +102,9 @@ async function doRefreshSiemCursorCache(): Promise<void> {
   }
 
   try {
-    const pool = getPoolForWorker();
+    // Cursors and receipts share the SIEM state plane, so one client covers
+    // both reads.
+    const pool = siemPoolFor(siemRouting()?.cursors);
     const client = await pool.connect();
     try {
       // allSettled so a transient failure in the optional receipts read does
@@ -227,8 +247,18 @@ app.get('/siem/receipts', authenticateService, requireScope('siem:read'), async 
   const sourceKey = source as AuditLogSource;
 
   try {
-    const pool = getPoolForWorker();
-    const client = await pool.connect();
+    // The entry's timestamp lives in its SOURCE table (per-source plane:
+    // security_audit_log is in the Admin PG post-cutover, activity_logs on
+    // main until Phase 5); the receipts live in the SIEM state plane. Reuse
+    // one client when both resolve to the same pool (break-glass, or a
+    // security-source lookup in dedicated mode).
+    const routing = siemRouting();
+    const dataPlane: SiemStorePlane = routing?.data[sourceKey] ?? 'main';
+    const receiptsPlane: SiemStorePlane = routing?.receipts ?? 'main';
+    const dataPool = siemPoolFor(dataPlane);
+    const client = await dataPool.connect();
+    const receiptsClient =
+      receiptsPlane === dataPlane ? client : await siemPoolFor(receiptsPlane).connect();
     try {
       // Two-stage lookup: resolve the entry's timestamp from its own source
       // table (literal-switch SQL — no template interpolation), then find
@@ -239,7 +269,7 @@ app.get('/siem/receipts', authenticateService, requireScope('siem:read'), async 
         return res.status(200).json({ entryId, source: sourceKey, receipts: [] });
       }
 
-      const receiptsResult = await client.query(
+      const receiptsResult = await receiptsClient.query(
         `SELECT "deliveryId", "source", "deliveredAt", "webhookStatus", "ackReceivedAt", "entryCount"
          FROM siem_delivery_receipts
          WHERE "source" = $1
@@ -268,6 +298,9 @@ app.get('/siem/receipts', authenticateService, requireScope('siem:read'), async 
 
       return res.status(200).json({ entryId, source: sourceKey, receipts });
     } finally {
+      if (receiptsClient !== client) {
+        receiptsClient.release();
+      }
       client.release();
     }
   } catch (err) {

--- a/apps/processor/src/services/__tests__/anchor-publishers.test.ts
+++ b/apps/processor/src/services/__tests__/anchor-publishers.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Unit tests for the anchor publisher shells (#890 Phase 2, leaf 3).
+ *
+ * Anchor SEMANTICS (payload bytes, signature) are pure and pinned in
+ * @pagespace/lib anchor.test.ts — these tests exercise ONLY the shells:
+ * env config parsing, the S3 PutObject wiring (Object-Lock params gated by
+ * the capability flag), and the receipt INSERT. Publishers propagate their
+ * errors to the caller — swallowing/loud-logging is the chainer hook's job.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { buildAnchorPayload, serializeSignedAnchor } from '@pagespace/lib/audit/anchor';
+
+import {
+  loadAnchorConfig,
+  validateAnchorConfig,
+  buildAnchorObjectKey,
+  computeRetainUntilDate,
+  createS3AnchorPublisher,
+  createAnchorReceiptPublisher,
+} from '../anchor-publishers';
+
+const anchor = buildAnchorPayload({
+  head: 'a'.repeat(64),
+  chainSeq: 42,
+  anchoredAt: new Date('2026-02-01T00:00:00.000Z'),
+  secret: 'test-secret',
+});
+
+describe('loadAnchorConfig', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    for (const key of [
+      'AUDIT_ANCHOR_ENABLED',
+      'AUDIT_ANCHOR_SECRET',
+      'AUDIT_ANCHOR_EVERY_RUNS',
+      'AUDIT_ANCHOR_MIN_INTERVAL_S',
+      'ANCHOR_S3_BUCKET',
+      'ANCHOR_S3_RETENTION_DAYS',
+      'ANCHOR_S3_OBJECT_LOCK',
+    ]) {
+      vi.stubEnv(key, '');
+    }
+  });
+
+  it('given no env at all, should be disabled (anchoring is OFF unless configured)', () => {
+    const config = loadAnchorConfig();
+
+    expect(config.enabled).toBe(false);
+  });
+
+  it('given AUDIT_ANCHOR_ENABLED=true with a secret, should enable with defaults everyRuns=1, minIntervalS=0, no S3', () => {
+    vi.stubEnv('AUDIT_ANCHOR_ENABLED', 'true');
+    vi.stubEnv('AUDIT_ANCHOR_SECRET', 'hmac-secret');
+
+    const config = loadAnchorConfig();
+
+    expect(config).toEqual({
+      enabled: true,
+      secret: 'hmac-secret',
+      everyRuns: 1,
+      minIntervalS: 0,
+      s3: undefined,
+    });
+  });
+
+  it('given the full env matrix, should parse every field including the S3 capability flag', () => {
+    vi.stubEnv('AUDIT_ANCHOR_ENABLED', 'true');
+    vi.stubEnv('AUDIT_ANCHOR_SECRET', 'hmac-secret');
+    vi.stubEnv('AUDIT_ANCHOR_EVERY_RUNS', '5');
+    vi.stubEnv('AUDIT_ANCHOR_MIN_INTERVAL_S', '600');
+    vi.stubEnv('ANCHOR_S3_BUCKET', 'audit-anchors');
+    vi.stubEnv('ANCHOR_S3_RETENTION_DAYS', '30');
+    vi.stubEnv('ANCHOR_S3_OBJECT_LOCK', 'true');
+
+    const config = loadAnchorConfig();
+
+    expect(config).toEqual({
+      enabled: true,
+      secret: 'hmac-secret',
+      everyRuns: 5,
+      minIntervalS: 600,
+      s3: { bucket: 'audit-anchors', retentionDays: 30, objectLock: true },
+    });
+  });
+
+  it('given garbage numerics, should fall back to defaults (everyRuns 1, minIntervalS 0, retentionDays 365)', () => {
+    vi.stubEnv('AUDIT_ANCHOR_ENABLED', 'true');
+    vi.stubEnv('AUDIT_ANCHOR_SECRET', 's');
+    vi.stubEnv('AUDIT_ANCHOR_EVERY_RUNS', 'lots');
+    vi.stubEnv('AUDIT_ANCHOR_MIN_INTERVAL_S', '-3');
+    vi.stubEnv('ANCHOR_S3_BUCKET', 'b');
+    vi.stubEnv('ANCHOR_S3_RETENTION_DAYS', 'forever');
+
+    const config = loadAnchorConfig();
+
+    expect(config.everyRuns).toBe(1);
+    expect(config.minIntervalS).toBe(0);
+    expect(config.s3).toEqual({ bucket: 'b', retentionDays: 365, objectLock: false });
+  });
+});
+
+describe('validateAnchorConfig', () => {
+  it('given a disabled config, should be valid (off is always a legal state)', () => {
+    expect(validateAnchorConfig({ enabled: false, secret: '', everyRuns: 1, minIntervalS: 0, s3: undefined }))
+      .toEqual({ valid: true, errors: [] });
+  });
+
+  it('given enabled without a secret, should name AUDIT_ANCHOR_SECRET', () => {
+    const result = validateAnchorConfig({ enabled: true, secret: '', everyRuns: 1, minIntervalS: 0, s3: undefined });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('AUDIT_ANCHOR_SECRET');
+  });
+});
+
+describe('buildAnchorObjectKey', () => {
+  it('given an anchor, should lay out anchors/<chain_seq>-<epoch-ms>.json', () => {
+    expect(buildAnchorObjectKey(anchor)).toBe(
+      `anchors/42-${new Date('2026-02-01T00:00:00.000Z').getTime()}.json`,
+    );
+  });
+});
+
+describe('computeRetainUntilDate', () => {
+  it('given retentionDays, should add exactly that many days to the anchor time', () => {
+    const retainUntil = computeRetainUntilDate(new Date('2026-02-01T00:00:00.000Z'), 30);
+
+    expect(retainUntil.toISOString()).toBe('2026-03-03T00:00:00.000Z');
+  });
+});
+
+describe('createS3AnchorPublisher', () => {
+  it('given Object-Lock capability ON, should PutObject the serialized anchor with COMPLIANCE retention', async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const publisher = createS3AnchorPublisher({
+      s3Client: { send },
+      bucket: 'audit-anchors',
+      retentionDays: 30,
+      objectLock: true,
+    });
+
+    await publisher.publish(anchor);
+
+    expect(publisher.name).toBe('s3');
+    expect(send).toHaveBeenCalledTimes(1);
+    const command = send.mock.calls[0][0] as PutObjectCommand;
+    expect(command).toBeInstanceOf(PutObjectCommand);
+    expect(command.input).toEqual({
+      Bucket: 'audit-anchors',
+      Key: buildAnchorObjectKey(anchor),
+      Body: serializeSignedAnchor(anchor),
+      ContentType: 'application/json',
+      ObjectLockMode: 'COMPLIANCE',
+      ObjectLockRetainUntilDate: computeRetainUntilDate(new Date(anchor.anchoredAt), 30),
+    });
+  });
+
+  it('given Object-Lock capability OFF (provider may not support it), should PutObject WITHOUT lock params', async () => {
+    const send = vi.fn().mockResolvedValue({});
+    const publisher = createS3AnchorPublisher({
+      s3Client: { send },
+      bucket: 'audit-anchors',
+      retentionDays: 30,
+      objectLock: false,
+    });
+
+    await publisher.publish(anchor);
+
+    const command = send.mock.calls[0][0] as PutObjectCommand;
+    expect(command.input).toEqual({
+      Bucket: 'audit-anchors',
+      Key: buildAnchorObjectKey(anchor),
+      Body: serializeSignedAnchor(anchor),
+      ContentType: 'application/json',
+    });
+  });
+
+  it('given the S3 client rejects, should propagate the error (the chainer hook owns swallowing)', async () => {
+    const publisher = createS3AnchorPublisher({
+      s3Client: { send: vi.fn().mockRejectedValue(new Error('bucket gone')) },
+      bucket: 'b',
+      retentionDays: 1,
+      objectLock: false,
+    });
+
+    await expect(publisher.publish(anchor)).rejects.toThrow('bucket gone');
+  });
+});
+
+describe('createAnchorReceiptPublisher', () => {
+  const makePool = (query = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 })) => {
+    const release = vi.fn();
+    const client = { query, release };
+    return { pool: { connect: vi.fn().mockResolvedValue(client) }, query, release };
+  };
+
+  it('given an anchor, should INSERT one receipt row with the signed fields (no RETURNING — the role has no SELECT)', async () => {
+    const { pool, query, release } = makePool();
+    const publisher = createAnchorReceiptPublisher({ pool });
+
+    await publisher.publish(anchor);
+
+    expect(publisher.name).toBe('receipt');
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO security_audit_anchors');
+    expect(sql).not.toContain('RETURNING');
+    expect(sql).toContain('version');
+    expect(sql).toContain('chain_seq');
+    expect(sql).toContain('head_hash');
+    expect(sql).toContain('anchored_at');
+    expect(sql).toContain('signature');
+    // id (cuid2, publisher-minted) + the five signed fields.
+    expect(params).toHaveLength(6);
+    expect(params.slice(1)).toEqual([
+      anchor.version,
+      anchor.chainSeq,
+      anchor.head,
+      new Date(anchor.anchoredAt),
+      anchor.signature,
+    ]);
+    expect(typeof params[0]).toBe('string');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('given the INSERT rejects, should propagate the error AND still release the client', async () => {
+    const { pool, release } = makePool(vi.fn().mockRejectedValue(new Error('42501')));
+    const publisher = createAnchorReceiptPublisher({ pool });
+
+    await expect(publisher.publish(anchor)).rejects.toThrow('42501');
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
+++ b/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
@@ -1,12 +1,16 @@
 import { describe, it } from 'vitest';
 import { computeLogHash } from '@pagespace/lib/monitoring/activity-logger';
 import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeChainHash } from '@pagespace/lib/audit/chain-step';
 import { assert } from '../../__tests__/riteway';
 import {
   recomputeActivityLogHash,
   recomputeSecurityAuditHash,
+  recomputeSecurityAuditHashEraAware,
   type ActivityLogHashableFields,
   type SecurityAuditHashableFields,
+  type SecurityAuditEraFields,
 } from '../siem-chain-hashers';
 
 // Round-trip tests prove the preflight hasher byte-exactly matches the
@@ -195,6 +199,90 @@ describe('recomputeSecurityAuditHash', () => {
       should: 'recompute to the write-side hash (null → undefined in hash input)',
       actual: preflightHash,
       expected: writeSideHash,
+    });
+  });
+});
+
+describe('recomputeSecurityAuditHashEraAware', () => {
+  // Post-cutover (#890 Phase 2) the admin store holds TWO hash eras in one
+  // chain: legacy rows (emission_hash NULL, event_hash = computeSecurityEventHash)
+  // and chainer rows (emission_hash set, event_hash = H(emission, prev)).
+  // The era-aware recompute mirrors verifyStoredEntryHash in packages/lib —
+  // presence of emission_hash selects the formula.
+
+  const timestamp = new Date('2026-04-10T09:15:00.000Z');
+  const event: AuditEvent = {
+    eventType: 'auth.login.success',
+    serviceId: 'auth',
+    resourceType: 'user',
+    resourceId: 'u1',
+    details: { method: 'password', mfa: true },
+    riskScore: 0.3,
+    anomalyFlags: ['new_device'],
+  };
+  const fields = (emissionHash: string | null): SecurityAuditEraFields => ({
+    eventType: event.eventType,
+    serviceId: event.serviceId ?? null,
+    resourceType: event.resourceType ?? null,
+    resourceId: event.resourceId ?? null,
+    details: event.details ?? null,
+    riskScore: event.riskScore ?? null,
+    anomalyFlags: event.anomalyFlags ?? null,
+    timestamp,
+    emissionHash,
+  });
+
+  it('given a chainer-era row (emission_hash present), should recompute event_hash as H(emission(data), prev) — byte-exact against the lib pure core', () => {
+    const emission = computeEmissionHash(event, timestamp);
+    const writeSideEventHash = computeChainHash(emission, 'PREV_CHAIN');
+
+    assert({
+      given: 'a chainer-era row',
+      should: 'match the chainer write-side chain hash',
+      actual: recomputeSecurityAuditHashEraAware(fields(emission), 'PREV_CHAIN'),
+      expected: writeSideEventHash,
+    });
+  });
+
+  it('given a legacy-era row (emission_hash NULL), should fall back to the legacy computeSecurityEventHash formula', () => {
+    assert({
+      given: 'a legacy row in the admin store',
+      should: 'recompute with the pre-cutover formula',
+      actual: recomputeSecurityAuditHashEraAware(fields(null), 'PREV_SEC'),
+      expected: recomputeSecurityAuditHash(fields(null), 'PREV_SEC'),
+    });
+  });
+
+  it('given tampered row data on a chainer-era row, should produce a hash that no longer matches the stored event_hash', () => {
+    const emission = computeEmissionHash(event, timestamp);
+    const storedEventHash = computeChainHash(emission, 'PREV_CHAIN');
+    const tampered: SecurityAuditEraFields = {
+      ...fields(emission),
+      details: { method: 'password', mfa: false },
+    };
+
+    assert({
+      given: 'a chainer-era row whose details were modified after chaining',
+      should: 'recompute to a different hash (tamper detectable)',
+      actual: recomputeSecurityAuditHashEraAware(tampered, 'PREV_CHAIN') === storedEventHash,
+      expected: false,
+    });
+  });
+
+  it('given a chainer-era row with a corrupted STORED emission value, should still recompute the true chain hash from row data', () => {
+    // The stored emission_hash is only the ERA discriminator here — the
+    // recompute derives the emission from row data, so an emission-column-only
+    // tamper does not corrupt delivery-time chain verification. Stored-emission
+    // equality is enforced by the cron verifier (verifyStoredEntryHash), not
+    // by the delivery preflight.
+    const emission = computeEmissionHash(event, timestamp);
+    const trueEventHash = computeChainHash(emission, 'PREV_CHAIN');
+
+    assert({
+      given: 'a chainer-era row whose emission_hash column was overwritten',
+      should: 'recompute the data-derived chain hash regardless',
+      actual: recomputeSecurityAuditHashEraAware(fields('f'.repeat(64)), 'PREV_CHAIN'),
+      expected: trueEventHash,
     });
   });
 });

--- a/apps/processor/src/services/__tests__/siem-pipeline.e2e.test.ts
+++ b/apps/processor/src/services/__tests__/siem-pipeline.e2e.test.ts
@@ -197,6 +197,11 @@ vi.mock('../../db', () => {
     getPoolForWorker: () => ({
       connect: async () => client,
     }),
+    // Unreached: this e2e pins the LEGACY single-store pipeline, which
+    // post-cutover is the break-glass routing (env stubbed in beforeEach).
+    getAdminPoolForWorker: () => {
+      throw new Error('getAdminPoolForWorker must not be called in the break-glass e2e');
+    },
   };
 });
 
@@ -314,6 +319,10 @@ describe('SIEM pipeline e2e', () => {
     setEnv('AUDIT_WEBHOOK_SECRET', WEBHOOK_SECRET);
     setEnv('AUDIT_WEBHOOK_BATCH_SIZE', '100');
     setEnv('AUDIT_WEBHOOK_RETRY_ATTEMPTS', '0');
+    // This e2e pins the LEGACY single-store pipeline — post-cutover that is
+    // exactly the break-glass routing (#890 Phase 2 leaf 7).
+    setEnv('ADMIN_DATABASE_URL', '');
+    setEnv('ADMIN_DB_BREAK_GLASS', 'true');
   });
 
   afterEach(async () => {

--- a/apps/processor/src/services/__tests__/siem-pool-routing.test.ts
+++ b/apps/processor/src/services/__tests__/siem-pool-routing.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import { resolveSiemPoolRouting } from '../siem-pool-routing';
+
+const ADMIN_URL = 'postgresql://admin_processor_user:pw@admin-host:5432/pagespace_admin';
+
+describe('resolveSiemPoolRouting', () => {
+  it('given a dedicated Admin PG (ADMIN_DATABASE_URL set), should pin the full pool-per-operation matrix', () => {
+    const { decision, routing } = resolveSiemPoolRouting({ ADMIN_DATABASE_URL: ADMIN_URL });
+
+    assert({
+      given: 'ADMIN_DATABASE_URL set',
+      should: 'resolve mode dedicated',
+      actual: decision.mode,
+      expected: 'dedicated',
+    });
+
+    // THE pool-per-operation matrix (#890 Phase 2 leaf 7). Changing any cell
+    // is a cutover-semantics change — cursors/receipts live in the Admin PG,
+    // security_audit_log data moved there, activity_logs data has NOT moved
+    // (Phase 5), and the advisory lock stays on main so old and new workers
+    // keep serializing against each other across a rolling deploy.
+    assert({
+      given: 'dedicated mode',
+      should: 'route each operation to its store plane',
+      actual: routing,
+      expected: {
+        mode: 'dedicated',
+        advisoryLock: 'main',
+        cursors: 'admin',
+        receipts: 'admin',
+        data: {
+          activity_logs: 'main',
+          security_audit_log: 'admin',
+        },
+        seedCursorFromLegacy: true,
+        awaitingBackfillProbe: true,
+      },
+    });
+  });
+
+  it('given break-glass (URL unset, flag armed), should route every operation to main — the exact legacy worker', () => {
+    const { decision, routing } = resolveSiemPoolRouting({
+      ADMIN_DATABASE_URL: undefined,
+      ADMIN_DB_BREAK_GLASS: 'true',
+    });
+
+    assert({
+      given: 'break-glass env',
+      should: 'resolve mode break-glass',
+      actual: decision.mode,
+      expected: 'break-glass',
+    });
+    assert({
+      given: 'break-glass mode',
+      should: 'route everything to the main pool with no seed/probe behavior',
+      actual: routing,
+      expected: {
+        mode: 'break-glass',
+        advisoryLock: 'main',
+        cursors: 'main',
+        receipts: 'main',
+        data: {
+          activity_logs: 'main',
+          security_audit_log: 'main',
+        },
+        seedCursorFromLegacy: false,
+        awaitingBackfillProbe: false,
+      },
+    });
+  });
+
+  it('given no admin URL and no break-glass flag, should return no routing (worker halts loudly)', () => {
+    const { decision, routing } = resolveSiemPoolRouting({});
+
+    assert({
+      given: 'unconfigured trust plane',
+      should: 'resolve mode fail',
+      actual: decision.mode,
+      expected: 'fail',
+    });
+    assert({
+      given: 'fail mode',
+      should: 'provide no routing',
+      actual: routing,
+      expected: null,
+    });
+  });
+
+  it('given a malformed ADMIN_DATABASE_URL even with break-glass armed, should fail (never silently degrade a typo)', () => {
+    const { decision, routing } = resolveSiemPoolRouting({
+      ADMIN_DATABASE_URL: 'not-a-url',
+      ADMIN_DB_BREAK_GLASS: 'true',
+    });
+
+    assert({
+      given: 'invalid admin URL',
+      should: 'resolve mode fail',
+      actual: decision.mode,
+      expected: 'fail',
+    });
+    assert({
+      given: 'invalid admin URL',
+      should: 'provide no routing',
+      actual: routing,
+      expected: null,
+    });
+  });
+});

--- a/apps/processor/src/services/anchor-publishers.ts
+++ b/apps/processor/src/services/anchor-publishers.ts
@@ -1,0 +1,184 @@
+/**
+ * Anchor publisher shells (#890 Phase 2, leaf 3).
+ *
+ * The chainer's externally-witnessed head: after an anchor interval, the
+ * signed head statement (pure core: @pagespace/lib/audit/anchor) is published
+ * to surfaces the Admin PG credentials cannot rewrite:
+ *
+ *   - S3 Object-Lock WORM (`anchors/<chain_seq>-<ts>.json`) — the true
+ *     external witness. Object-Lock params are gated by ANCHOR_S3_OBJECT_LOCK
+ *     because the current provider (Tigris) may not support them; bucket
+ *     provisioning and lock-mode verification belong to the Phase 6 runbook.
+ *   - security_audit_anchors receipt rows (writeReceipts precedent) — the
+ *     second, already-shipped witness surface; append-only for every role.
+ *
+ * Everything here is a thin factory shell with explicit deps — no logic
+ * beyond wiring. Publishers PROPAGATE errors; the chainer hook owns
+ *  fire-and-forget semantics (publish failure never blocks chaining).
+ *
+ * Env matrix (anchoring is OFF unless configured — AUDIT_SIEM_ENABLED
+ * precedent):
+ *   AUDIT_ANCHOR_ENABLED        'true' to enable
+ *   AUDIT_ANCHOR_SECRET         HMAC-SHA256 signing key (required if enabled)
+ *   AUDIT_ANCHOR_EVERY_RUNS     publish every Nth 'chained' run (default 1)
+ *   AUDIT_ANCHOR_MIN_INTERVAL_S minimum seconds between anchors (default 0)
+ *   ANCHOR_S3_BUCKET            enables the S3 publisher when set
+ *   ANCHOR_S3_RETENTION_DAYS    Object-Lock retention (default 365)
+ *   ANCHOR_S3_OBJECT_LOCK       'true' to send Object-Lock params
+ */
+
+import { createId } from '@paralleldrive/cuid2';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { serializeSignedAnchor, type SignedAnchor } from '@pagespace/lib/audit/anchor';
+
+/** A witness surface the chainer hook publishes each signed anchor to. */
+export interface AnchorPublisher {
+  name: string;
+  publish(anchor: SignedAnchor): Promise<void>;
+}
+
+export interface AnchorS3Config {
+  bucket: string;
+  retentionDays: number;
+  /** Capability flag: send Object-Lock params (provider must support them). */
+  objectLock: boolean;
+}
+
+export interface AnchorConfig {
+  enabled: boolean;
+  secret: string;
+  everyRuns: number;
+  minIntervalS: number;
+  s3: AnchorS3Config | undefined;
+}
+
+function positiveIntOr(fallback: number, raw: string | undefined, minimum = 1): number {
+  const parsed = Number.parseInt(raw ?? '', 10);
+  return Number.isInteger(parsed) && parsed >= minimum ? parsed : fallback;
+}
+
+/** Load anchoring configuration from environment variables. */
+export function loadAnchorConfig(): AnchorConfig {
+  const bucket = process.env.ANCHOR_S3_BUCKET || '';
+
+  return {
+    enabled: process.env.AUDIT_ANCHOR_ENABLED === 'true',
+    secret: process.env.AUDIT_ANCHOR_SECRET || '',
+    everyRuns: positiveIntOr(1, process.env.AUDIT_ANCHOR_EVERY_RUNS),
+    minIntervalS: positiveIntOr(0, process.env.AUDIT_ANCHOR_MIN_INTERVAL_S, 0),
+    s3: bucket
+      ? {
+          bucket,
+          retentionDays: positiveIntOr(365, process.env.ANCHOR_S3_RETENTION_DAYS),
+          objectLock: process.env.ANCHOR_S3_OBJECT_LOCK === 'true',
+        }
+      : undefined,
+  };
+}
+
+/** Validate anchoring configuration (loadSiemConfig/validateSiemConfig precedent). */
+export function validateAnchorConfig(config: AnchorConfig): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  if (!config.enabled) {
+    return { valid: true, errors: [] };
+  }
+
+  if (!config.secret) {
+    errors.push('AUDIT_ANCHOR_SECRET is required when AUDIT_ANCHOR_ENABLED=true');
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/** WORM key layout: anchors/<chain_seq>-<epoch-ms>.json (sortable, collision-free per run). */
+export function buildAnchorObjectKey(anchor: SignedAnchor): string {
+  return `anchors/${anchor.chainSeq}-${new Date(anchor.anchoredAt).getTime()}.json`;
+}
+
+/** Object-Lock retention horizon: anchoredAt + retentionDays. */
+export function computeRetainUntilDate(anchoredAt: Date, retentionDays: number): Date {
+  return new Date(anchoredAt.getTime() + retentionDays * 24 * 60 * 60 * 1000);
+}
+
+// Minimal structural S3 surface so tests inject a plain double and the
+// factory stays decoupled from the concrete client (createS3Client wiring
+// happens at the chainer hook).
+export interface S3ClientLike {
+  send(command: PutObjectCommand): Promise<unknown>;
+}
+
+export interface CreateS3AnchorPublisherDeps extends AnchorS3Config {
+  s3Client: S3ClientLike;
+}
+
+/**
+ * S3 Object-Lock publisher — one PutObject per anchor, body = the canonical
+ * serialized anchor (byte-comparable against a recomputation on fetch).
+ */
+export function createS3AnchorPublisher(deps: CreateS3AnchorPublisherDeps): AnchorPublisher {
+  return {
+    name: 's3',
+    async publish(anchor: SignedAnchor): Promise<void> {
+      await deps.s3Client.send(
+        new PutObjectCommand({
+          Bucket: deps.bucket,
+          Key: buildAnchorObjectKey(anchor),
+          Body: serializeSignedAnchor(anchor),
+          ContentType: 'application/json',
+          ...(deps.objectLock
+            ? {
+                ObjectLockMode: 'COMPLIANCE',
+                ObjectLockRetainUntilDate: computeRetainUntilDate(
+                  new Date(anchor.anchoredAt),
+                  deps.retentionDays,
+                ),
+              }
+            : {}),
+        }),
+      );
+    },
+  };
+}
+
+// Minimal pg surface (this workspace ships no @types/pg — see ../db.ts).
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+
+export interface PgPoolLike {
+  connect(): Promise<PgClient>;
+}
+
+/**
+ * Receipt publisher — one INSERT into security_audit_anchors per anchor, as
+ * the chainer's own identity (admin_chainer holds INSERT and nothing else on
+ * this table, so no RETURNING). The cuid2 id is minted here because raw SQL
+ * bypasses Drizzle's $defaultFn (writeReceipts precedent).
+ */
+export function createAnchorReceiptPublisher(deps: { pool: PgPoolLike }): AnchorPublisher {
+  return {
+    name: 'receipt',
+    async publish(anchor: SignedAnchor): Promise<void> {
+      const client = await deps.pool.connect();
+      try {
+        await client.query(
+          `INSERT INTO security_audit_anchors
+             (id, version, chain_seq, head_hash, anchored_at, signature)
+           VALUES ($1, $2, $3, $4, $5, $6)`,
+          [
+            createId(),
+            anchor.version,
+            anchor.chainSeq,
+            anchor.head,
+            new Date(anchor.anchoredAt),
+            anchor.signature,
+          ],
+        );
+      } finally {
+        client.release();
+      }
+    },
+  };
+}

--- a/apps/processor/src/services/siem-chain-hashers.ts
+++ b/apps/processor/src/services/siem-chain-hashers.ts
@@ -1,5 +1,8 @@
 import { createHash } from 'crypto';
 import { stableStringify } from '@pagespace/lib/utils/stable-stringify';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeChainHash } from '@pagespace/lib/audit/chain-step';
+import type { AuditEvent } from '@pagespace/lib/audit/security-audit';
 
 /**
  * Per-source hash recomputation strategies for the SIEM delivery preflight.
@@ -118,4 +121,53 @@ export function recomputeSecurityAuditHash(
   });
 
   return createHash('sha256').update(serialized).digest('hex');
+}
+
+/**
+ * SecurityAuditHashableFields plus the admin-plane era discriminator.
+ *
+ * Post-cutover (#890 Phase 2) the admin store's security_audit_log chain
+ * holds two hash eras: legacy rows carried over by the backfill keep
+ * emission_hash NULL and were hashed with computeSecurityEventHash; rows
+ * appended by the audit chainer carry emission_hash and satisfy
+ * event_hash = H(emission_hash, previous_hash). Loads from the legacy main
+ * table (break-glass) always set emissionHash to null — that table has no
+ * such column and only ever held the legacy formula.
+ */
+export interface SecurityAuditEraFields extends SecurityAuditHashableFields {
+  emissionHash: string | null;
+}
+
+/**
+ * Era-aware recompute of the expected `eventHash` for a security_audit_log
+ * entry — the read-side mirror of verifyStoredEntryHash in
+ * packages/lib/src/audit/security-audit-chain-verifier.ts.
+ *
+ * The stored emission_hash selects the formula by PRESENCE only; the hash
+ * itself is derived from row data (computeEmissionHash), so a tamper that
+ * only rewrites the stored emission_hash column cannot smuggle modified data
+ * past delivery. Stored-emission equality itself is the cron verifier's
+ * check, not the preflight's.
+ */
+export function recomputeSecurityAuditHashEraAware(
+  data: SecurityAuditEraFields,
+  previousHash: string
+): string {
+  if (data.emissionHash === null) {
+    return recomputeSecurityAuditHash(data, previousHash);
+  }
+
+  // Reconstruct the hashed event exactly as verifyStoredEntryHash does —
+  // nullable DB columns become undefined; PII never participates (#541).
+  const event: AuditEvent = {
+    eventType: data.eventType as AuditEvent['eventType'],
+    serviceId: data.serviceId ?? undefined,
+    resourceType: data.resourceType ?? undefined,
+    resourceId: data.resourceId ?? undefined,
+    details: data.details ?? undefined,
+    riskScore: data.riskScore ?? undefined,
+    anomalyFlags: data.anomalyFlags ?? undefined,
+  };
+
+  return computeChainHash(computeEmissionHash(event, data.timestamp), previousHash);
 }

--- a/apps/processor/src/services/siem-pool-routing.ts
+++ b/apps/processor/src/services/siem-pool-routing.ts
@@ -1,0 +1,101 @@
+import {
+  resolveAdminDbMode,
+  type AdminDbEnv,
+  type AdminDbModeDecision,
+} from '@pagespace/db/admin-db';
+import type { AuditLogSource } from './siem-adapter';
+
+/**
+ * Pool-per-operation matrix for the SIEM delivery worker (#890 Phase 2 leaf 7).
+ *
+ * Post-cutover the worker straddles two stores: security_audit_log rows land
+ * in the dedicated Admin PG (written by the lock-free ingest + chainer path),
+ * while activity_logs stays in the main DB until Phase 5. The worker's own
+ * state — siem_delivery_cursors and siem_delivery_receipts — lives in the
+ * Admin PG (Phase 1 barrel), for BOTH sources: the cursor for a main-db data
+ * source is still an admin-plane row.
+ *
+ * Mode follows the write path's resolver (resolveAdminDbMode) so the worker
+ * always reads the store that audit writes actually target:
+ *   - 'dedicated'   → the matrix below (admin state + split data planes).
+ *   - 'break-glass' → everything on main: writes degraded to the legacy
+ *                     table, so delivery, cursors, and receipts all revert
+ *                     to the exact pre-cutover worker behavior.
+ *   - 'fail'        → no routing. Writes are being rejected; delivering from
+ *                     either store would be guessing. The worker halts loudly.
+ */
+
+export type SiemStorePlane = 'main' | 'admin';
+
+export interface SiemPoolRouting {
+  mode: 'dedicated' | 'break-glass';
+  /**
+   * Always 'main' until Phase 5: the lock key ('activity_logs', hashed) and
+   * its host DB must stay stable across a rolling deploy so old-code and
+   * new-code workers keep serializing their cursor upserts against each
+   * other. Moving the lock to the admin pool before the last main-db source
+   * moves would let the two versions run concurrently.
+   */
+  advisoryLock: SiemStorePlane;
+  /** siem_delivery_cursors reads/writes — both sources. */
+  cursors: SiemStorePlane;
+  /** siem_delivery_receipts writes — both sources. */
+  receipts: SiemStorePlane;
+  /** Source-table data reads (delivery batch, preflight anchor + hashables). */
+  data: Record<AuditLogSource, SiemStorePlane>;
+  /**
+   * First dedicated run: copy an initialized legacy cursor tuple from the
+   * main DB into the admin cursors table so the watermark survives the flip
+   * (no replay of already-shipped rows, no NOW()-plant gap).
+   */
+  seedCursorFromLegacy: boolean;
+  /**
+   * When the security cursor's anchor row is missing from the admin store
+   * but still present in the main store, the legacy rows simply haven't been
+   * backfilled yet — defer that source instead of failing closed.
+   */
+  awaitingBackfillProbe: boolean;
+}
+
+export interface SiemPoolRoutingResolution {
+  decision: AdminDbModeDecision;
+  routing: SiemPoolRouting | null;
+}
+
+const DEDICATED_ROUTING: SiemPoolRouting = {
+  mode: 'dedicated',
+  advisoryLock: 'main',
+  cursors: 'admin',
+  receipts: 'admin',
+  data: {
+    activity_logs: 'main',
+    security_audit_log: 'admin',
+  },
+  seedCursorFromLegacy: true,
+  awaitingBackfillProbe: true,
+};
+
+const BREAK_GLASS_ROUTING: SiemPoolRouting = {
+  mode: 'break-glass',
+  advisoryLock: 'main',
+  cursors: 'main',
+  receipts: 'main',
+  data: {
+    activity_logs: 'main',
+    security_audit_log: 'main',
+  },
+  seedCursorFromLegacy: false,
+  awaitingBackfillProbe: false,
+};
+
+export function resolveSiemPoolRouting(env: AdminDbEnv): SiemPoolRoutingResolution {
+  const decision = resolveAdminDbMode(env);
+  switch (decision.mode) {
+    case 'dedicated':
+      return { decision, routing: DEDICATED_ROUTING };
+    case 'break-glass':
+      return { decision, routing: BREAK_GLASS_ROUTING };
+    case 'fail':
+      return { decision, routing: null };
+  }
+}

--- a/apps/processor/src/types/index.ts
+++ b/apps/processor/src/types/index.ts
@@ -103,6 +103,7 @@ export type JobDataMap = {
   'pull-verify': PullVerifyJobData;
   'siem-delivery': Record<string, never>;
   'account-erasure': AccountErasureJobData;
+  'audit-chainer': Record<string, never>;
 };
 
 export type QueueName = keyof JobDataMap;

--- a/apps/processor/src/workers/__tests__/audit-backfill-flip.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-backfill-flip.integration.test.ts
@@ -604,8 +604,20 @@ describe.skipIf(!url)('leaf-8 backfill flip with real chainer + SIEM workers (wi
           emittedAt: T(60),
         },
       ]);
-      const chained = await processAuditChainer({ pool: procPool });
-      expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+      // The era-fork guard (#890 Phase 2 FIX) REFUSES this exact scenario —
+      // an upgrade deployment must never chain from genesis. Rows stay
+      // buffered in ingest.
+      const refused = await processAuditChainer({ pool: procPool });
+      expect(refused).toMatchObject({ outcome: 'genesis_refused', drained: 0 });
+      // Forcing the fork (a fresh-install flag wrongly set on an upgrade) is
+      // what the backfill script's precondition abort below defends against.
+      process.env.AUDIT_CHAINER_ALLOW_GENESIS = 'true';
+      try {
+        const chained = await processAuditChainer({ pool: procPool });
+        expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+      } finally {
+        delete process.env.AUDIT_CHAINER_ALLOW_GENESIS;
+      }
     });
 
     it('the script ABORTS unlinked_emission_era and plants nothing', async () => {

--- a/apps/processor/src/workers/__tests__/audit-backfill-flip.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-backfill-flip.integration.test.ts
@@ -1,0 +1,628 @@
+/**
+ * Cross-actor rehearsal of the #890 Phase 2 leaf-8 backfill against the REAL
+ * chainer and SIEM delivery workers, wire-connected on scratch Postgres.
+ *
+ * The scripts-side rehearsal (scripts/__tests__/backfill-audit-db.integration.test.ts)
+ * proves the script alone: plant/parity/verify/freeze. THIS suite proves the
+ * choreography the runbook prescribes, with every actor real:
+ *
+ *   1. Chainer exclusion is real: while the backfill's advisory lock is held,
+ *      processAuditChainer() no-ops 'lock_busy' (behavioral pin that the
+ *      script's CHAINER_ADVISORY_LOCK_KEY is the chainer's own key).
+ *   2. Runbook order — processor stopped, web still emitting: events buffer
+ *      in security_audit_ingest, SIEM seeds cursors from the legacy watermark
+ *      and defers the security source (awaiting_backfill, no error).
+ *   3. The REAL script plants the legacy rows (anchor-committed-last); the
+ *      chainer's next run drains the buffered ingest rows and links the
+ *      emission era onto the BACKFILLED legacy head with chain_seq continuing
+ *      after the legacy range (setval proof — no collision), and the full
+ *      genesis→head era-aware verification passes.
+ *   4. SIEM's deferral releases: exactly the undelivered legacy rows then the
+ *      chainer rows deliver, exactly once, cursor continuity intact.
+ *   5. Violated order (chainer ran first): the script ABORTS
+ *      unlinked_emission_era and plants nothing — the leaf-7 flagged case.
+ *
+ * TZ is pinned to UTC (before any Date is created): production containers run
+ * UTC, and the SIEM preflight's raw-pg timestamp parsing is only aligned with
+ * drizzle's UTC-wall-clock storage convention when local time IS UTC.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run src/workers/__tests__/audit-backfill-flip.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import path from 'path';
+import { migrateAdminDb } from '@pagespace/db/migrate-admin';
+import { provisionAdminLoginUsers } from '@pagespace/db/provision-admin-users';
+import { createAdminAuditDbClient, type AdminAuditDbClient } from '@pagespace/db/admin-eraser-db';
+import { verifySecurityAuditChain } from '@pagespace/lib/audit/security-audit-chain-verifier';
+import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeLogHash } from '@pagespace/lib/monitoring/activity-logger';
+
+const { deliveredBatches, mockDeliver } = vi.hoisted(() => {
+  // Before anything else in this module touches a Date: see header.
+  process.env.TZ = 'UTC';
+  const deliveredBatches: { id: string; source: string }[][] = [];
+  const mockDeliver = vi.fn(
+    async (_config: unknown, entries: { id: string; source: string }[]) => {
+      deliveredBatches.push(entries.map((e) => ({ id: e.id, source: e.source })));
+      return {
+        success: true,
+        entriesDelivered: entries.length,
+        webhookStatus: 200,
+        responseHash: 'a'.repeat(64),
+        ackReceivedAt: new Date(),
+      };
+    }
+  );
+  return { deliveredBatches, mockDeliver };
+});
+
+vi.mock('../../services/siem-adapter', async () => {
+  const actual = await vi.importActual<typeof import('../../services/siem-adapter')>(
+    '../../services/siem-adapter'
+  );
+  return {
+    ...actual,
+    loadSiemConfig: () => ({
+      enabled: true,
+      type: 'webhook' as const,
+      webhook: {
+        url: 'https://siem.example.com/ingest',
+        secret: 'integration-secret',
+        batchSize: 100,
+        retryAttempts: 0,
+      },
+    }),
+    validateSiemConfig: () => ({ valid: true, errors: [] }),
+    deliverToSiemWithRetry: mockDeliver,
+  };
+});
+
+import { processSiemDelivery, resetSiemModeBannerForTests } from '../siem-delivery-worker';
+import { processAuditChainer } from '../audit-chainer-worker';
+import { CURSOR_INIT_SENTINEL } from '../../services/siem-sources';
+import {
+  runAuditBackfill,
+  CHAINER_ADVISORY_LOCK_KEY,
+  SIEM_CURSOR_INIT_SENTINEL,
+  type PoolLike,
+} from '../../../../../scripts/backfill-audit-db';
+
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+interface PgPool extends PoolLike {
+  connect(): Promise<PgClient>;
+  end(): Promise<void>;
+}
+// @ts-expect-error -- pg has no bundled types; runtime cast below handles type safety
+import pg from 'pg';
+const { Pool } = pg as unknown as { Pool: new (config: Record<string, unknown>) => PgPool };
+
+const url = process.env.ADMIN_DATABASE_URL;
+const MAIN_DB_NAME = 'pagespace_main_bf_flip_it';
+
+const PASSWORDS = {
+  ADMIN_APP_PASSWORD: 'appsecretbfflip1',
+  ADMIN_PROCESSOR_PASSWORD: 'procsecretbfflip1',
+} as const;
+
+const ALL_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+  'admin_app_user',
+  'admin_processor_user',
+  'admin_reader_user',
+] as const;
+
+function loginConfig(user: string, password: string) {
+  const parsed = new URL(url as string);
+  return {
+    host: parsed.hostname,
+    port: Number(parsed.port || 5432),
+    database: parsed.pathname.slice(1),
+    user,
+    password,
+    max: 2,
+  };
+}
+
+function mainDbUrl(): string {
+  const parsed = new URL(url as string);
+  parsed.pathname = `/${MAIN_DB_NAME}`;
+  return parsed.toString();
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+const T = (s: number) => new Date(Date.UTC(2026, 1, 1, 0, 0, s));
+
+interface LegacyRow {
+  id: string;
+  event: AuditEvent;
+  timestamp: Date;
+  previousHash: string;
+  eventHash: string;
+}
+
+function buildLegacyChain(count: number): LegacyRow[] {
+  const rows: LegacyRow[] = [];
+  let prev = 'genesis';
+  for (let i = 1; i <= count; i++) {
+    const event: AuditEvent = {
+      eventType: 'auth.login.success',
+      userId: `user-${i}`,
+      sessionId: `sess-${i}`,
+      serviceId: 'web',
+      resourceType: 'user',
+      resourceId: `u-${i}`,
+      ipAddress: '10.0.0.9',
+      userAgent: 'it-agent',
+      geoLocation: 'EU/Berlin',
+      details: { legacy: i },
+      riskScore: 0.5, // exactly representable in float4
+    };
+    const timestamp = T(i);
+    const eventHash = computeSecurityEventHash(event, prev, timestamp);
+    rows.push({ id: `r${i}`, event, timestamp, previousHash: prev, eventHash });
+    prev = eventHash;
+  }
+  return rows;
+}
+
+async function insertLegacySecurityRows(pool: PgPool, rows: LegacyRow[]): Promise<void> {
+  for (const [idx, r] of rows.entries()) {
+    await pool.query(
+      `INSERT INTO security_audit_log
+         (id, timestamp, event_type, user_id, session_id, service_id, resource_type,
+          resource_id, ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+          anomaly_flags, chain_seq, previous_hash, event_hash)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::jsonb, $14, $15, $16, $17, $18)`,
+      [
+        r.id,
+        r.timestamp,
+        r.event.eventType,
+        r.event.userId ?? null,
+        r.event.sessionId ?? null,
+        r.event.serviceId ?? null,
+        r.event.resourceType ?? null,
+        r.event.resourceId ?? null,
+        r.event.ipAddress ?? null,
+        `bidx-${r.id}`,
+        r.event.userAgent ?? null,
+        r.event.geoLocation ?? null,
+        r.event.details ? JSON.stringify(r.event.details) : null,
+        r.event.riskScore ?? null,
+        r.event.anomalyFlags ?? null,
+        idx + 1,
+        r.previousHash,
+        r.eventHash,
+      ]
+    );
+  }
+}
+
+interface ActivityRow {
+  id: string;
+  timestamp: Date;
+  previousLogHash: string;
+  logHash: string;
+}
+
+function buildActivityChain(count: number): ActivityRow[] {
+  const rows: ActivityRow[] = [];
+  let prev = 'act-seed';
+  for (let i = 0; i < count; i++) {
+    const timestamp = T(i);
+    const logHash = computeLogHash(
+      {
+        id: `a${i}`,
+        timestamp,
+        operation: 'page.update',
+        resourceType: 'page',
+        resourceId: `p-${i}`,
+        driveId: 'd1',
+        pageId: `p-${i}`,
+      },
+      prev
+    );
+    rows.push({ id: `a${i}`, timestamp, previousLogHash: prev, logHash });
+    prev = logHash;
+  }
+  return rows;
+}
+
+async function insertActivityRows(pool: PgPool, rows: ActivityRow[]): Promise<void> {
+  for (const r of rows) {
+    await pool.query(
+      `INSERT INTO activity_logs (id, timestamp, "userId", "actorEmail", "actorDisplayName",
+         operation, "resourceType", "resourceId", "driveId", "pageId", "previousLogHash", "logHash")
+       VALUES ($1, $2, 'u1', 'user@example.com', NULL, 'page.update', 'page', $3, 'd1', $3, $4, $5)`,
+      [r.id, r.timestamp, `p-${r.id.slice(1)}`, r.previousLogHash, r.logHash]
+    );
+  }
+}
+
+async function setCursor(
+  pool: PgPool,
+  source: string,
+  lastDeliveredId: string,
+  lastDeliveredAt: Date,
+  deliveryCount: number
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "updatedAt")
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastDeliveredId" = $2, "lastDeliveredAt" = $3, "deliveryCount" = $4, "updatedAt" = NOW()`,
+    [source, lastDeliveredId, lastDeliveredAt, deliveryCount]
+  );
+}
+
+async function readCursor(pool: PgPool, source: string) {
+  const r = await pool.query(
+    'SELECT "lastDeliveredId", "deliveryCount", "lastError" FROM siem_delivery_cursors WHERE id = $1',
+    [source]
+  );
+  const row = r.rows[0];
+  if (!row) return undefined;
+  return {
+    lastDeliveredId: row.lastDeliveredId as string,
+    deliveryCount: Number(row.deliveryCount),
+    lastError: (row.lastError as string | null) ?? null,
+  };
+}
+
+async function seedIngestRows(
+  appPool: PgPool,
+  rows: Array<{ id: string; event: AuditEvent; timestamp: Date; emittedAt: Date }>
+): Promise<void> {
+  for (const { id, event, timestamp, emittedAt } of rows) {
+    await appPool.query(
+      `INSERT INTO security_audit_ingest
+         (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+          ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+          anomaly_flags, timestamp, emission_hash, emitted_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17)`,
+      [
+        id,
+        event.eventType,
+        event.userId ?? null,
+        event.sessionId ?? null,
+        event.serviceId ?? null,
+        event.resourceType ?? null,
+        event.resourceId ?? null,
+        event.ipAddress ?? null,
+        null,
+        event.userAgent ?? null,
+        event.geoLocation ?? null,
+        event.details ? JSON.stringify(event.details) : null,
+        event.riskScore ?? null,
+        event.anomalyFlags ?? null,
+        timestamp,
+        computeEmissionHash(event, timestamp),
+        emittedAt,
+      ]
+    );
+  }
+}
+
+// --- harness ------------------------------------------------------------
+
+// Real main-plane shapes where it matters to the backfill: security_audit_log
+// carries chain_seq and ip_bidx, timestamps are `timestamp` WITHOUT time zone
+// (drizzle stores UTC wall clock; TZ=UTC keeps every reader aligned).
+const MAIN_TABLES_DDL = `
+  CREATE TABLE activity_logs (
+    id text PRIMARY KEY,
+    timestamp timestamp NOT NULL,
+    "userId" text,
+    "actorEmail" text NOT NULL,
+    "actorDisplayName" text,
+    "isAiGenerated" boolean NOT NULL DEFAULT false,
+    "aiProvider" text,
+    "aiModel" text,
+    "aiConversationId" text,
+    operation text NOT NULL,
+    "resourceType" text NOT NULL,
+    "resourceId" text NOT NULL,
+    "resourceTitle" text,
+    "driveId" text,
+    "pageId" text,
+    metadata jsonb,
+    "contentSnapshot" text,
+    "previousValues" jsonb,
+    "newValues" jsonb,
+    "previousLogHash" text,
+    "logHash" text
+  );
+  CREATE TABLE security_audit_log (
+    id text PRIMARY KEY,
+    event_type text NOT NULL,
+    user_id text,
+    session_id text,
+    service_id text,
+    resource_type text,
+    resource_id text,
+    ip_address text,
+    ip_bidx text,
+    user_agent text,
+    geo_location text,
+    details jsonb,
+    risk_score real,
+    anomaly_flags text[],
+    timestamp timestamp DEFAULT now() NOT NULL,
+    chain_seq bigserial NOT NULL,
+    previous_hash text NOT NULL,
+    event_hash text NOT NULL
+  );
+  CREATE TABLE siem_delivery_cursors (
+    id text PRIMARY KEY,
+    "lastDeliveredId" text,
+    "lastDeliveredAt" timestamp,
+    "deliveryCount" integer NOT NULL DEFAULT 0,
+    "lastError" text,
+    "lastErrorAt" timestamp,
+    "updatedAt" timestamp NOT NULL DEFAULT now(),
+    CONSTRAINT cursor_pair_check CHECK (("lastDeliveredId" IS NULL) = ("lastDeliveredAt" IS NULL))
+  );
+`;
+// siem_delivery_receipts deliberately ABSENT on main: misroutes must explode.
+
+describe.skipIf(!url)('leaf-8 backfill flip with real chainer + SIEM workers (wire-connected)', () => {
+  let adminOwner: PgPool;
+  let mainOwner: PgPool;
+  let appPool: PgPool;
+  let procPool: PgPool;
+  let adminClient: AdminAuditDbClient;
+
+  const workerDeps = () => ({
+    mainPool: mainOwner,
+    adminPool: procPool,
+    env: { ADMIN_DATABASE_URL: url },
+  });
+
+  const backfillDeps = () => ({
+    main: mainOwner,
+    adminPool: adminOwner,
+    adminDb: adminClient.db,
+    batchSize: 2,
+    log: () => {},
+  });
+
+  async function resetBothStores(): Promise<void> {
+    await Promise.all([appPool?.end(), procPool?.end(), adminClient?.end()]);
+    await adminOwner.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await adminOwner.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await adminOwner.query('CREATE SCHEMA public');
+    for (const role of ALL_ROLES) {
+      await adminOwner.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+    const previousCwd = process.cwd();
+    process.chdir(path.resolve(__dirname, '../../../../../packages/db'));
+    try {
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    } finally {
+      process.chdir(previousCwd);
+    }
+    const result = await provisionAdminLoginUsers({ ADMIN_DATABASE_URL: url, ...PASSWORDS });
+    expect(result.provisioned).toEqual(['admin_app_user', 'admin_processor_user']);
+
+    // Fresh pools/clients per reset — cached schema OIDs go stale otherwise.
+    appPool = new Pool(loginConfig('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD));
+    procPool = new Pool(loginConfig('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD));
+    adminClient = createAdminAuditDbClient({ connectionString: url as string });
+
+    await mainOwner.query(
+      'DROP TABLE IF EXISTS activity_logs, security_audit_log, siem_delivery_cursors, siem_delivery_receipts'
+    );
+    await mainOwner.query(MAIN_TABLES_DDL);
+  }
+
+  beforeAll(async () => {
+    adminOwner = new Pool({ connectionString: url, max: 4 });
+    await adminOwner.query(`CREATE DATABASE ${MAIN_DB_NAME}`).catch((err: unknown) => {
+      if ((err as { code?: string }).code !== '42P04') throw err;
+    });
+    mainOwner = new Pool({ connectionString: mainDbUrl(), max: 4 });
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      adminClient?.end(),
+      adminOwner?.end(),
+      mainOwner?.end(),
+      appPool?.end(),
+      procPool?.end(),
+    ]);
+  });
+
+  beforeEach(() => {
+    deliveredBatches.length = 0;
+    mockDeliver.mockClear();
+    resetSiemModeBannerForTests();
+  });
+
+  it('pins the SIEM cursor sentinel the script duplicates (cross-package drift guard)', () => {
+    expect(SIEM_CURSOR_INIT_SENTINEL).toBe(CURSOR_INIT_SENTINEL);
+  });
+
+  describe('runbook order: processor stopped → backfill → chainer starts → SIEM releases', () => {
+    const legacy = buildLegacyChain(5); // r1..r5; r1..r3 shipped pre-flip
+    const activity = buildActivityChain(2); // a0 shipped, a1 pending
+
+    beforeAll(async () => {
+      await resetBothStores();
+      await insertLegacySecurityRows(mainOwner, legacy);
+      await insertActivityRows(mainOwner, activity);
+      await setCursor(mainOwner, 'security_audit_log', 'r3', legacy[2].timestamp, 3);
+      await setCursor(mainOwner, 'activity_logs', 'a0', activity[0].timestamp, 1);
+
+      // "Web still up while the processor is stopped": e6/e7 buffer in ingest.
+      await seedIngestRows(appPool, [
+        {
+          id: 'e6',
+          event: { eventType: 'data.read', userId: 'user-6', serviceId: 'web', resourceType: 'page', resourceId: 'p-6', details: { era: 'chainer', n: 6 } },
+          timestamp: T(6),
+          emittedAt: T(6),
+        },
+        {
+          id: 'e7',
+          event: { eventType: 'data.read', userId: 'user-7', serviceId: 'web', resourceType: 'page', resourceId: 'p-7', details: { era: 'chainer', n: 7 } },
+          timestamp: T(7),
+          emittedAt: T(7),
+        },
+      ]);
+    });
+
+    it("holds the chainer's own advisory lock: a concurrent chainer run no-ops 'lock_busy'", async () => {
+      const holder = await adminOwner.connect();
+      try {
+        await holder.query('SELECT pg_advisory_lock(hashtext($1))', [CHAINER_ADVISORY_LOCK_KEY]);
+        const run = await processAuditChainer({ pool: procPool });
+        expect(run).toMatchObject({ outcome: 'lock_busy', drained: 0 });
+      } finally {
+        await holder
+          .query('SELECT pg_advisory_unlock(hashtext($1))', [CHAINER_ADVISORY_LOCK_KEY])
+          .catch(() => undefined);
+        holder.release();
+      }
+    });
+
+    it('pre-backfill: SIEM seeds cursors, defers security (no error), activity keeps flowing', async () => {
+      await processSiemDelivery(workerDeps()); // run 1: seeding only
+      expect(mockDeliver).not.toHaveBeenCalled();
+
+      await processSiemDelivery(workerDeps()); // run 2: activity ships, security deferred
+      expect(deliveredBatches).toHaveLength(1);
+      expect(deliveredBatches[0].map((e) => `${e.source}:${e.id}`)).toEqual(['activity_logs:a1']);
+
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'r3', deliveryCount: 3, lastError: null });
+    });
+
+    it('the REAL script backfills; the chainer then links the eras with no seq collision', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('backfilled');
+      expect(summary.planted).toBe(5);
+      expect(summary.anchorRowId).toBe('r3'); // read from the SEEDED admin cursor
+      expect(summary.anchorPlanted).toBe(true);
+      expect(summary.journal[summary.journal.length - 1]).toBe('anchor:r3');
+      expect(summary.parity).toEqual({ ok: true, failures: [] });
+      expect(summary.verification?.isValid).toBe(true);
+      expect(summary.verification?.totalEntries).toBe(5);
+
+      // Processor starts: the chainer drains the buffered ingest rows…
+      const chained = await processAuditChainer({ pool: procPool });
+      expect(chained).toMatchObject({ outcome: 'chained', drained: 2 });
+      expect(chained.verification?.valid).toBe(true);
+
+      // …links the emission era onto the BACKFILLED legacy head…
+      const boundary = await adminOwner.query(
+        `SELECT previous_hash, chain_seq::int AS seq FROM security_audit_log WHERE id = 'e6'`
+      );
+      expect(boundary.rows[0].previous_hash).toBe(legacy[4].eventHash);
+
+      // …with chain_seq continuing AFTER the legacy range (setval proof).
+      expect(boundary.rows[0].seq).toBe(6);
+      const e7 = await adminOwner.query(
+        `SELECT chain_seq::int AS seq FROM security_audit_log WHERE id = 'e7'`
+      );
+      expect(e7.rows[0].seq).toBe(7);
+
+      // Full dual-era genesis→head verification over the whole store.
+      const verification = await verifySecurityAuditChain(
+        { stopOnFirstBreak: true },
+        { db: adminClient.db }
+      );
+      console.log('[flip rehearsal] dual-era genesis→head:', JSON.stringify(verification));
+      expect(verification.isValid).toBe(true);
+      expect(verification.totalEntries).toBe(7);
+      expect(verification.invalidEntries).toBe(0);
+    });
+
+    it('SIEM releases the deferral: undelivered legacy then chainer rows, exactly once', async () => {
+      await processSiemDelivery(workerDeps());
+
+      expect(deliveredBatches).toHaveLength(1);
+      expect(deliveredBatches[0].map((e) => `${e.source}:${e.id}`)).toEqual([
+        'security_audit_log:r4',
+        'security_audit_log:r5',
+        'security_audit_log:e6',
+        'security_audit_log:e7',
+      ]);
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'e7', deliveryCount: 7, lastError: null });
+    });
+
+    it('an idle rerun delivers nothing — no replays after the flip settles', async () => {
+      await processSiemDelivery(workerDeps());
+      expect(mockDeliver).not.toHaveBeenCalled();
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'e7', deliveryCount: 7 });
+    });
+
+    it('a script rerun after the flip is idempotent (boundary already linked)', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('backfilled');
+      expect(summary.precondition).toEqual({ ok: true, state: 'boundary_linked' });
+      expect(summary.planted).toBe(0);
+      expect(summary.parity?.ok).toBe(true);
+      expect(summary.verification?.isValid).toBe(true);
+      expect(summary.verification?.totalEntries).toBe(7);
+    });
+  });
+
+  describe('violated order: the chainer ran before the backfill', () => {
+    beforeAll(async () => {
+      await resetBothStores();
+      const legacy = buildLegacyChain(2);
+      await insertLegacySecurityRows(mainOwner, legacy);
+      await setCursor(mainOwner, 'security_audit_log', 'r1', legacy[0].timestamp, 1);
+
+      await seedIngestRows(appPool, [
+        {
+          id: 'g1',
+          event: { eventType: 'data.read', userId: 'user-g', resourceType: 'page', resourceId: 'p-g1' },
+          timestamp: T(60),
+          emittedAt: T(60),
+        },
+      ]);
+      const chained = await processAuditChainer({ pool: procPool });
+      expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+    });
+
+    it('the script ABORTS unlinked_emission_era and plants nothing', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('aborted');
+      expect(summary.precondition).toMatchObject({ ok: false, reason: 'unlinked_emission_era' });
+      expect(summary.planted).toBe(0);
+
+      const legacyPlanted = await adminOwner.query(
+        'SELECT count(*)::int AS n FROM security_audit_log WHERE emission_hash IS NULL'
+      );
+      expect(legacyPlanted.rows[0].n).toBe(0);
+      // The genesis-era chainer row is untouched — remediation is a human call.
+      const emissionRows = await adminOwner.query(
+        'SELECT count(*)::int AS n FROM security_audit_log WHERE emission_hash IS NOT NULL'
+      );
+      expect(emissionRows.rows[0].n).toBe(1);
+    });
+  });
+});

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
@@ -25,7 +25,14 @@ import {
   GENESIS_PREVIOUS_HASH,
 } from '@pagespace/lib/audit/chain-step';
 import type { AuditEvent } from '@pagespace/lib/audit/security-audit';
-import { processAuditChainer } from '../audit-chainer-worker';
+import { verifyAnchorSignature, serializeSignedAnchor, type SignedAnchor } from '@pagespace/lib/audit/anchor';
+import type { PutObjectCommand } from '@aws-sdk/client-s3';
+import { processAuditChainer, resetAnchorPublishStateForTests } from '../audit-chainer-worker';
+import {
+  createS3AnchorPublisher,
+  createAnchorReceiptPublisher,
+  type AnchorConfig,
+} from '../../services/anchor-publishers';
 
 // Minimal pg surface (this workspace ships no @types/pg — see ../../db.ts).
 interface PgClient {
@@ -275,6 +282,159 @@ describe.skipIf(!url)('audit chainer drain cycle as admin_processor_user (wire-c
     const afterUnlock = await processAuditChainer({ pool: procPool });
     expect(afterUnlock).toMatchObject({ outcome: 'chained', drained: 1 });
     expect(afterUnlock.verification?.valid).toBe(true);
+  });
+
+  const anchorConfig: AnchorConfig = {
+    enabled: true,
+    secret: 'integration-anchor-secret',
+    everyRuns: 1,
+    minIntervalS: 0,
+    s3: undefined,
+  };
+
+  it('given anchoring enabled with the DEFAULT publishers, should write a verifiable receipt row AS admin_processor_user (wire-connected grant)', async () => {
+    resetAnchorPublishStateForTests();
+    await seedIngestRows(appPool, [
+      {
+        id: 'anchor-a-0',
+        event: { eventType: 'data.read', userId: 'user-anchor', resourceType: 'page', resourceId: 'p-a' } as AuditEvent,
+        timestamp: t(30),
+        emittedAt: t(30),
+      },
+    ]);
+
+    const result = await processAuditChainer({ pool: procPool, anchorConfig });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.verification?.valid).toBe(true);
+    expect(result.anchor).toEqual({
+      attempted: true,
+      chainSeq: result.newHeadSeq,
+      published: ['receipt'],
+      failed: [],
+    });
+
+    const receipts = await owner.query(
+      'SELECT version, chain_seq, head_hash, anchored_at, signature FROM security_audit_anchors ORDER BY created_at DESC LIMIT 1',
+    );
+    expect(receipts.rows).toHaveLength(1);
+    const row = receipts.rows[0] as {
+      version: number;
+      chain_seq: string;
+      head_hash: string;
+      anchored_at: Date | string;
+      signature: string;
+    };
+    expect(row.head_hash).toBe(result.newHead);
+    expect(Number(row.chain_seq)).toBe(result.newHeadSeq);
+    // The stored row reconstitutes into a SignedAnchor that verifies — the
+    // receipt surface is a real witness, not just a log line.
+    const reconstituted: SignedAnchor = {
+      version: row.version,
+      source: 'pagespace-audit-chain',
+      chainSeq: Number(row.chain_seq),
+      head: row.head_hash,
+      anchoredAt: new Date(row.anchored_at).toISOString(),
+      signature: row.signature,
+    };
+    expect(verifyAnchorSignature(reconstituted, anchorConfig.secret)).toBe(true);
+  });
+
+  it('given an S3 double beside the receipt publisher, should PutObject the exact serialized anchor with Object-Lock params', async () => {
+    resetAnchorPublishStateForTests();
+    const sent: PutObjectCommand[] = [];
+    const s3Double = {
+      send: async (command: PutObjectCommand) => {
+        sent.push(command);
+        return {};
+      },
+    };
+
+    await seedIngestRows(appPool, [
+      {
+        id: 'anchor-b-0',
+        event: { eventType: 'data.read', userId: 'user-anchor', resourceType: 'page', resourceId: 'p-b' } as AuditEvent,
+        timestamp: t(31),
+        emittedAt: t(31),
+      },
+    ]);
+
+    const result = await processAuditChainer({
+      pool: procPool,
+      anchorConfig,
+      anchorPublishers: [
+        createAnchorReceiptPublisher({ pool: procPool }),
+        createS3AnchorPublisher({ s3Client: s3Double, bucket: 'anchors-it', retentionDays: 7, objectLock: true }),
+      ],
+    });
+
+    expect(result.anchor).toMatchObject({ attempted: true, published: ['receipt', 's3'], failed: [] });
+    expect(sent).toHaveLength(1);
+    const input = sent[0].input;
+    expect(input.Bucket).toBe('anchors-it');
+    expect(input.Key).toMatch(new RegExp(`^anchors/${result.newHeadSeq}-\\d+\\.json$`));
+    expect(input.ObjectLockMode).toBe('COMPLIANCE');
+    expect(input.ObjectLockRetainUntilDate).toBeInstanceOf(Date);
+    // Body round-trips: the WORM object verifies byte-for-byte.
+    const stored = JSON.parse(String(input.Body)) as SignedAnchor;
+    expect(stored.head).toBe(result.newHead);
+    expect(verifyAnchorSignature(stored, anchorConfig.secret)).toBe(true);
+    expect(serializeSignedAnchor(stored)).toBe(String(input.Body));
+  });
+
+  it('given a publisher that throws, should still chain and drain on the REAL database (failure never blocks chaining)', async () => {
+    resetAnchorPublishStateForTests();
+    await seedIngestRows(appPool, [
+      {
+        id: 'anchor-c-0',
+        event: { eventType: 'auth.logout', userId: 'user-anchor' } as AuditEvent,
+        timestamp: t(32),
+        emittedAt: t(32),
+      },
+    ]);
+
+    const result = await processAuditChainer({
+      pool: procPool,
+      anchorConfig,
+      anchorPublishers: [
+        {
+          name: 'receipt',
+          publish: async () => {
+            throw new Error('witness down');
+          },
+        },
+      ],
+    });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.verification?.valid).toBe(true);
+    expect(result.anchor).toMatchObject({ attempted: true, published: [], failed: ['receipt'] });
+    const queued = await owner.query('SELECT count(*)::int AS n FROM security_audit_ingest');
+    expect(queued.rows[0].n).toBe(0);
+    const chainedRow = await owner.query(
+      `SELECT id FROM security_audit_log WHERE id = 'anchor-c-0'`,
+    );
+    expect(chainedRow.rows).toHaveLength(1);
+  });
+
+  it('given the anchors grant matrix, the witness surface is append-only over the wire (42501 for every mutation)', async () => {
+    // admin_processor_user (chainer): INSERT only — no SELECT, UPDATE, DELETE.
+    await expect(
+      procPool.query('SELECT * FROM security_audit_anchors'),
+    ).rejects.toMatchObject({ code: '42501' });
+    await expect(
+      procPool.query(`UPDATE security_audit_anchors SET head_hash = 'forged'`),
+    ).rejects.toMatchObject({ code: '42501' });
+    await expect(
+      procPool.query('DELETE FROM security_audit_anchors'),
+    ).rejects.toMatchObject({ code: '42501' });
+    // admin_app_user: nothing at all on the witness surface.
+    await expect(
+      appPool.query(
+        `INSERT INTO security_audit_anchors (id, version, chain_seq, head_hash, anchored_at, signature)
+         VALUES ('forged', 1, 1, 'h', now(), 's')`,
+      ),
+    ).rejects.toMatchObject({ code: '42501' });
   });
 
   it('given the drain grant matrix, admin_processor_user still cannot UPDATE/DELETE the chain or INSERT into the queue (42501)', async () => {

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
@@ -122,6 +122,10 @@ describe.skipIf(!url)('audit chainer drain cycle as admin_processor_user (wire-c
   let procPool: PgPool;
 
   beforeAll(async () => {
+    // This suite IS the fresh-install scenario: an empty admin chain with no
+    // legacy rows to backfill, so the genesis link is legitimate (#890
+    // Phase 2 FIX era-fork guard).
+    process.env.AUDIT_CHAINER_ALLOW_GENESIS = 'true';
     owner = new Pool({ connectionString: url, max: 3 });
     // Fresh-DB guarantee on the SCRATCH db — same reset as the db package's
     // admin integration suites, including LOGIN users so provisioning runs.
@@ -157,6 +161,7 @@ describe.skipIf(!url)('audit chainer drain cycle as admin_processor_user (wire-c
   });
 
   afterAll(async () => {
+    delete process.env.AUDIT_CHAINER_ALLOW_GENESIS;
     await Promise.all([owner?.end(), appPool?.end(), procPool?.end()]);
   });
 

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.integration.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Full drain-cycle integration for the audit chainer (#890 Phase 2, leaf 2).
+ *
+ * Runs the REAL worker (processAuditChainer, no mocks) connected AS the
+ * processor's provisioned LOGIN user (admin_processor_user → admin_chainer +
+ * admin_siem templates), proving least-privilege sufficiency of the grant
+ * matrix end to end: emission rows enter as admin_app_user (INSERT-only),
+ * the chainer drains (SELECT+DELETE on the queue — the only trust-plane
+ * DELETE), appends (INSERT + chain_seq sequence USAGE), and verify-on-append
+ * re-reads (SELECT) — all over the wire, no SET ROLE, no owner shortcuts.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run src/workers/__tests__/audit-chainer-worker.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import { migrateAdminDb } from '@pagespace/db/migrate-admin';
+import { provisionAdminLoginUsers } from '@pagespace/db/provision-admin-users';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import {
+  computeChainHash,
+  GENESIS_PREVIOUS_HASH,
+} from '@pagespace/lib/audit/chain-step';
+import type { AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { processAuditChainer } from '../audit-chainer-worker';
+
+// Minimal pg surface (this workspace ships no @types/pg — see ../../db.ts).
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+interface PgPool {
+  connect(): Promise<PgClient>;
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  end(): Promise<void>;
+}
+// @ts-expect-error -- pg has no bundled types; runtime cast below handles type safety
+import pg from 'pg';
+const { Pool } = pg as unknown as {
+  Pool: new (config: Record<string, unknown>) => PgPool;
+};
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+const PASSWORDS = {
+  ADMIN_APP_PASSWORD: 'appsecretchainer1',
+  ADMIN_PROCESSOR_PASSWORD: 'procsecretchainer1',
+} as const;
+
+const ALL_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+  'admin_app_user',
+  'admin_processor_user',
+  'admin_reader_user',
+] as const;
+
+function loginConfig(user: string, password: string) {
+  const parsed = new URL(url as string);
+  return {
+    host: parsed.hostname,
+    port: Number(parsed.port || 5432),
+    database: parsed.pathname.slice(1),
+    user,
+    password,
+    max: 2,
+  };
+}
+
+/** Seed one emission-shaped ingest row AS admin_app_user (the real write identity). */
+async function seedIngestRows(
+  appPool: PgPool,
+  rows: Array<{ id: string; event: AuditEvent; timestamp: Date; emittedAt: Date }>,
+): Promise<void> {
+  for (const { id, event, timestamp, emittedAt } of rows) {
+    await appPool.query(
+      `INSERT INTO security_audit_ingest
+         (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+          ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+          anomaly_flags, timestamp, emission_hash, emitted_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17)`,
+      [
+        id,
+        event.eventType,
+        event.userId ?? null,
+        event.sessionId ?? null,
+        event.serviceId ?? null,
+        event.resourceType ?? null,
+        event.resourceId ?? null,
+        event.ipAddress ?? null,
+        null,
+        event.userAgent ?? null,
+        event.geoLocation ?? null,
+        event.details ? JSON.stringify(event.details) : null,
+        event.riskScore ?? null,
+        event.anomalyFlags ?? null,
+        timestamp,
+        computeEmissionHash(event, timestamp),
+        emittedAt,
+      ],
+    );
+  }
+}
+
+describe.skipIf(!url)('audit chainer drain cycle as admin_processor_user (wire-connected)', () => {
+  let owner: PgPool;
+  let appPool: PgPool;
+  let procPool: PgPool;
+
+  beforeAll(async () => {
+    owner = new Pool({ connectionString: url, max: 3 });
+    // Fresh-DB guarantee on the SCRATCH db — same reset as the db package's
+    // admin integration suites, including LOGIN users so provisioning runs.
+    await owner.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await owner.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await owner.query('CREATE SCHEMA public');
+    for (const role of ALL_ROLES) {
+      await owner.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+
+    // migrateAdminDb resolves its migrations folder relative to CWD
+    // (packages/db convention) — hop there for the migration call only.
+    const previousCwd = process.cwd();
+    process.chdir(path.resolve(__dirname, '../../../../../packages/db'));
+    try {
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const result = await provisionAdminLoginUsers({ ADMIN_DATABASE_URL: url, ...PASSWORDS });
+    expect(result.provisioned).toEqual(['admin_app_user', 'admin_processor_user']);
+
+    appPool = new Pool(loginConfig('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD));
+    procPool = new Pool(loginConfig('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD));
+  });
+
+  afterAll(async () => {
+    await Promise.all([owner?.end(), appPool?.end(), procPool?.end()]);
+  });
+
+  const t = (i: number) => new Date(Date.UTC(2026, 1, 1, 0, 0, i));
+
+  it('given seeded emission rows, should chain from genesis, empty the queue, and verify on append', async () => {
+    await seedIngestRows(
+      appPool,
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `drain-a-${i}`,
+        event: {
+          eventType: 'auth.login.success',
+          userId: `user-${i}`,
+          serviceId: 'web',
+          details: { probe: 'chainer-integration', i },
+        } as AuditEvent,
+        timestamp: t(i),
+        emittedAt: t(i),
+      })),
+    );
+
+    const result = await processAuditChainer({ pool: procPool });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.drained).toBe(5);
+    expect(result.verification).toEqual({ valid: true, verified: 5 });
+
+    const chained = await owner.query(
+      `SELECT id, previous_hash, event_hash, emission_hash, chain_seq
+       FROM security_audit_log ORDER BY chain_seq ASC`,
+    );
+    expect(chained.rows).toHaveLength(5);
+    expect(chained.rows.map((r) => r.id)).toEqual([0, 1, 2, 3, 4].map((i) => `drain-a-${i}`));
+    expect(chained.rows[0].previous_hash).toBe(GENESIS_PREVIOUS_HASH);
+    for (let i = 0; i < chained.rows.length; i++) {
+      const row = chained.rows[i];
+      if (i > 0) {
+        expect(row.previous_hash).toBe(chained.rows[i - 1].event_hash);
+      }
+      // Recompute from STORAGE — the chain must be verifiable without any
+      // in-memory state from the run that wrote it.
+      expect(row.event_hash).toBe(
+        computeChainHash(row.emission_hash as string, row.previous_hash as string),
+      );
+    }
+    expect(result.newHead).toBe(chained.rows[4].event_hash);
+
+    const remaining = await owner.query('SELECT count(*)::int AS n FROM security_audit_ingest');
+    expect(remaining.rows[0].n).toBe(0);
+  });
+
+  it('given an empty queue, a rerun should be idle and leave the head untouched', async () => {
+    const headBefore = await owner.query(
+      'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
+    );
+
+    const result = await processAuditChainer({ pool: procPool });
+
+    expect(result).toEqual({ outcome: 'idle', drained: 0 });
+    const headAfter = await owner.query(
+      'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
+    );
+    expect(headAfter.rows[0].event_hash).toBe(headBefore.rows[0].event_hash);
+  });
+
+  it('given later rows drained across TWO batches (batchSize=1), should link every batch to the live head', async () => {
+    const headBefore = (
+      await owner.query('SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1')
+    ).rows[0].event_hash as string;
+
+    await seedIngestRows(
+      appPool,
+      [10, 11].map((i) => ({
+        id: `drain-b-${i}`,
+        event: { eventType: 'data.read', userId: 'user-b', resourceType: 'page', resourceId: `p-${i}` } as AuditEvent,
+        timestamp: t(i),
+        emittedAt: t(i),
+      })),
+    );
+
+    const first = await processAuditChainer({ pool: procPool, batchSize: 1 });
+    const second = await processAuditChainer({ pool: procPool, batchSize: 1 });
+    expect(first).toMatchObject({ outcome: 'chained', drained: 1 });
+    expect(second).toMatchObject({ outcome: 'chained', drained: 1 });
+    expect(first.verification?.valid).toBe(true);
+    expect(second.verification?.valid).toBe(true);
+
+    const tail = await owner.query(
+      `SELECT id, previous_hash, event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 2`,
+    );
+    // Newest first: drain-b-11 links to drain-b-10, which links to the old head.
+    expect(tail.rows[0].id).toBe('drain-b-11');
+    expect(tail.rows[0].previous_hash).toBe(tail.rows[1].event_hash);
+    expect(tail.rows[1].id).toBe('drain-b-10');
+    expect(tail.rows[1].previous_hash).toBe(headBefore);
+  });
+
+  it('given the advisory lock held by another session, should no-op and leave the queue intact', async () => {
+    const blocker = await owner.connect();
+    try {
+      await blocker.query("SELECT pg_advisory_lock(hashtext('audit-chainer'))");
+
+      await seedIngestRows(appPool, [
+        {
+          id: 'drain-c-0',
+          event: { eventType: 'auth.logout', userId: 'user-c' } as AuditEvent,
+          timestamp: t(20),
+          emittedAt: t(20),
+        },
+      ]);
+
+      const blocked = await processAuditChainer({ pool: procPool });
+      expect(blocked).toEqual({ outcome: 'lock_busy', drained: 0 });
+
+      const queued = await owner.query('SELECT count(*)::int AS n FROM security_audit_ingest');
+      expect(queued.rows[0].n).toBe(1);
+
+      await blocker.query("SELECT pg_advisory_unlock(hashtext('audit-chainer'))");
+    } finally {
+      blocker.release();
+    }
+
+    const afterUnlock = await processAuditChainer({ pool: procPool });
+    expect(afterUnlock).toMatchObject({ outcome: 'chained', drained: 1 });
+    expect(afterUnlock.verification?.valid).toBe(true);
+  });
+
+  it('given the drain grant matrix, admin_processor_user still cannot UPDATE/DELETE the chain or INSERT into the queue (42501)', async () => {
+    // Least-privilege boundary: the chainer identity's DELETE exists ONLY on
+    // the queue; the chain stays append-only even for its single writer.
+    await expect(
+      procPool.query(`UPDATE security_audit_log SET event_hash = 'tampered' WHERE id = 'drain-a-0'`),
+    ).rejects.toMatchObject({ code: '42501' });
+    await expect(
+      procPool.query(`DELETE FROM security_audit_log WHERE id = 'drain-a-0'`),
+    ).rejects.toMatchObject({ code: '42501' });
+    await expect(
+      procPool.query(
+        `INSERT INTO security_audit_ingest (id, event_type, emission_hash) VALUES ('x', 'auth.logout', 'h')`,
+      ),
+    ).rejects.toMatchObject({ code: '42501' });
+  });
+});

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Unit tests for the audit chainer worker shell (#890 Phase 2, leaf 2).
+ *
+ * All chain math is pure and pinned in @pagespace/lib chain-step.test.ts —
+ * these tests exercise ONLY the wiring: advisory-lock gating, drain order,
+ * the single INSERT+DELETE transaction, post-commit verify-on-append, and
+ * the loud failure path. The pure functions run unmocked (determinism lets
+ * the test recompute expected payloads).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  assignChainBatch,
+  GENESIS_PREVIOUS_HASH,
+  type ChainableIngestRow,
+} from '@pagespace/lib/audit/chain-step';
+
+const { mockQuery, mockRelease, mockNotifyAppendFailure } = vi.hoisted(() => ({
+  mockQuery: vi.fn(),
+  mockRelease: vi.fn(),
+  mockNotifyAppendFailure: vi.fn(),
+}));
+
+vi.mock('../../db', () => ({
+  getAdminPoolForWorker: vi.fn(() => ({
+    connect: vi.fn().mockResolvedValue({ query: mockQuery, release: mockRelease }),
+  })),
+}));
+
+vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
+  notifyChainAppendVerificationFailure: mockNotifyAppendFailure,
+}));
+
+import { processAuditChainer } from '../audit-chainer-worker';
+
+const mockPool = {
+  connect: vi.fn(async () => ({ query: mockQuery, release: mockRelease })),
+};
+
+function makeIngestRows(count: number): ChainableIngestRow[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `ingest-${i}`,
+    eventType: 'auth.login.success' as const,
+    userId: `user-${i}`,
+    sessionId: null,
+    serviceId: 'web',
+    resourceType: null,
+    resourceId: null,
+    ipAddress: `ciphertext-${i}`,
+    ipBidx: `bidx-${i}`,
+    userAgent: null,
+    geoLocation: null,
+    details: { attempt: i },
+    riskScore: null,
+    anomalyFlags: null,
+    timestamp: new Date(Date.UTC(2026, 0, 25, 10, 0, i)),
+    emissionHash: `${'0'.repeat(60)}${i.toString(16).padStart(4, '0')}`,
+  }));
+}
+
+const stub = (rows: unknown[] = [], rowCount = rows.length) =>
+  mockQuery.mockResolvedValueOnce({ rows, rowCount });
+
+const stubLock = (acquired: boolean) => stub([{ acquired }]);
+
+describe('processAuditChainer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('given no ADMIN_DATABASE_URL and no injected pool, should no-op as disabled (trust plane unconfigured)', async () => {
+    vi.stubEnv('ADMIN_DATABASE_URL', '');
+
+    const result = await processAuditChainer();
+
+    expect(result).toEqual({ outcome: 'disabled', drained: 0 });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('given the advisory lock is held elsewhere, should no-op WITHOUT unlocking (never release a lock it does not own)', async () => {
+    stubLock(false);
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result).toEqual({ outcome: 'lock_busy', drained: 0 });
+    // Only the try-lock query ran — no unlock, no reads.
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery.mock.calls[0][0]).toContain('pg_try_advisory_lock');
+    expect(mockQuery.mock.calls[0][1]).toEqual(['audit-chainer']);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('given an empty ingest queue, should return idle, skip the head read, and release the lock', async () => {
+    stubLock(true);
+    stub([]); // ingest SELECT — empty
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result).toEqual({ outcome: 'idle', drained: 0 });
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+    expect(mockQuery.mock.calls[1][0]).toContain('FROM security_audit_ingest');
+    expect(mockQuery.mock.calls[1][0]).toContain('ORDER BY emitted_at, id');
+    expect(mockQuery.mock.calls[2][0]).toContain('pg_advisory_unlock');
+  });
+
+  it('given ingest rows and an empty chain, should chain from genesis, insert+delete in ONE transaction, and verify green', async () => {
+    const rows = makeIngestRows(3);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    stubLock(true);
+    stub(rows); // ingest SELECT
+    stub([]); // head SELECT — empty chain → genesis
+    stub(); // BEGIN
+    stub([], 3); // INSERT
+    stub([], 3); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+      })),
+    ); // verify re-read
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.drained).toBe(3);
+    expect(result.verification).toEqual({ valid: true, verified: 3 });
+
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls[3]).toBe('BEGIN');
+    expect(calls[4]).toContain('INSERT INTO security_audit_log');
+    expect(calls[5]).toContain('DELETE FROM security_audit_ingest');
+    expect(calls[6]).toBe('COMMIT');
+    // The INSERT carries the pure-core chain values in row order.
+    const insertValues = mockQuery.mock.calls[4][1] as unknown[];
+    expect(insertValues).toContain(expected.chainedRowPayloads[0].eventHash);
+    expect(insertValues).toContain(GENESIS_PREVIOUS_HASH);
+    expect(insertValues).toContain(expected.chainedRowPayloads[2].eventHash);
+    // The DELETE drains exactly the chained ids.
+    expect(mockQuery.mock.calls[5][1]).toEqual([rows.map((r) => r.id)]);
+    // Verify re-read walks chain_seq order.
+    expect(calls[7]).toContain('ORDER BY chain_seq');
+    expect(mockNotifyAppendFailure).not.toHaveBeenCalled();
+  });
+
+  it('given an existing chain head, should link the first payload to it (not genesis)', async () => {
+    const rows = makeIngestRows(2);
+    const priorHead = 'existing-head-hash';
+    const expected = assignChainBatch(rows, { prevHash: priorHead });
+
+    stubLock(true);
+    stub(rows);
+    stub([{ event_hash: priorHead }]); // head SELECT
+    stub(); // BEGIN
+    stub([], 2); // INSERT
+    stub([], 2); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+      })),
+    );
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.verification).toEqual({ valid: true, verified: 2 });
+    const headSql = String(mockQuery.mock.calls[2][0]);
+    expect(headSql).toContain('FROM security_audit_log');
+    expect(headSql).toContain('ORDER BY chain_seq DESC');
+    const insertValues = mockQuery.mock.calls[3 + 1][1] as unknown[];
+    expect(insertValues).toContain(priorHead);
+  });
+
+  it('given a batchSize override, should pass it to the drain LIMIT', async () => {
+    stubLock(true);
+    stub([]); // ingest — empty
+    stub([]); // unlock
+
+    await processAuditChainer({ pool: mockPool, batchSize: 42 });
+
+    expect(mockQuery.mock.calls[1][1]).toEqual([42]);
+  });
+
+  it('given the transaction fails, should ROLLBACK, rethrow, and still unlock + release', async () => {
+    const rows = makeIngestRows(1);
+    stubLock(true);
+    stub(rows);
+    stub([]); // head
+    stub(); // BEGIN
+    mockQuery.mockRejectedValueOnce(new Error('insert exploded')); // INSERT
+    stub(); // ROLLBACK
+    stub([]); // unlock
+
+    await expect(processAuditChainer({ pool: mockPool })).rejects.toThrow('insert exploded');
+
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls).toContain('ROLLBACK');
+    expect(calls[calls.length - 1]).toContain('pg_advisory_unlock');
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('given verify-on-append detects a break, should alert loudly and report the failed verification', async () => {
+    const rows = makeIngestRows(2);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    stubLock(true);
+    stub(rows);
+    stub([]); // head — genesis
+    stub(); // BEGIN
+    stub([], 2); // INSERT
+    stub([], 2); // DELETE
+    stub(); // COMMIT
+    // Re-read returns a TAMPERED second row.
+    stub([
+      {
+        id: expected.chainedRowPayloads[0].id,
+        emissionHash: expected.chainedRowPayloads[0].emissionHash,
+        previousHash: expected.chainedRowPayloads[0].previousHash,
+        eventHash: expected.chainedRowPayloads[0].eventHash,
+      },
+      {
+        id: expected.chainedRowPayloads[1].id,
+        emissionHash: expected.chainedRowPayloads[1].emissionHash,
+        previousHash: expected.chainedRowPayloads[1].previousHash,
+        eventHash: 'tampered-hash',
+      },
+    ]);
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.verification?.valid).toBe(false);
+    expect(mockNotifyAppendFailure).toHaveBeenCalledTimes(1);
+    expect(mockNotifyAppendFailure.mock.calls[0][0]).toMatchObject({
+      entryId: expected.chainedRowPayloads[1].id,
+      breakAtIndex: 1,
+      breakReason: 'hash_mismatch',
+      segmentTotalRows: 2,
+      priorHead: GENESIS_PREVIOUS_HASH,
+    });
+    expect(consoleError).toHaveBeenCalled();
+    expect(String(consoleError.mock.calls[0][0])).toContain('VERIFY-ON-APPEND');
+
+    consoleError.mockRestore();
+  });
+
+  it('given a broken alert surface, should never mask the detection (alert error swallowed)', async () => {
+    const rows = makeIngestRows(1);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mockNotifyAppendFailure.mockRejectedValueOnce(new Error('alert transport down'));
+
+    stubLock(true);
+    stub(rows);
+    stub([]);
+    stub(); // BEGIN
+    stub([], 1); // INSERT
+    stub([], 1); // DELETE
+    stub(); // COMMIT
+    stub([
+      {
+        id: expected.chainedRowPayloads[0].id,
+        emissionHash: null, // forces missing_emission_hash
+        previousHash: expected.chainedRowPayloads[0].previousHash,
+        eventHash: expected.chainedRowPayloads[0].eventHash,
+      },
+    ]);
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.verification?.valid).toBe(false);
+    consoleError.mockRestore();
+  });
+});

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
@@ -15,10 +15,11 @@ import {
   type ChainableIngestRow,
 } from '@pagespace/lib/audit/chain-step';
 
-const { mockQuery, mockRelease, mockNotifyAppendFailure } = vi.hoisted(() => ({
+const { mockQuery, mockRelease, mockNotifyAppendFailure, mockNotifyAnchorFailure } = vi.hoisted(() => ({
   mockQuery: vi.fn(),
   mockRelease: vi.fn(),
   mockNotifyAppendFailure: vi.fn(),
+  mockNotifyAnchorFailure: vi.fn(),
 }));
 
 vi.mock('../../db', () => ({
@@ -29,9 +30,12 @@ vi.mock('../../db', () => ({
 
 vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
   notifyChainAppendVerificationFailure: mockNotifyAppendFailure,
+  notifyAnchorPublishFailure: mockNotifyAnchorFailure,
 }));
 
-import { processAuditChainer } from '../audit-chainer-worker';
+import { verifyAnchorSignature, ANCHOR_SOURCE, ANCHOR_VERSION, type SignedAnchor } from '@pagespace/lib/audit/anchor';
+import type { AnchorConfig, AnchorPublisher } from '../../services/anchor-publishers';
+import { processAuditChainer, resetAnchorPublishStateForTests } from '../audit-chainer-worker';
 
 const mockPool = {
   connect: vi.fn(async () => ({ query: mockQuery, release: mockRelease })),
@@ -282,6 +286,269 @@ describe('processAuditChainer', () => {
     const result = await processAuditChainer({ pool: mockPool });
 
     expect(result.verification?.valid).toBe(false);
+    consoleError.mockRestore();
+  });
+});
+
+describe('processAuditChainer anchoring hook (#890 Phase 2 leaf 3)', () => {
+  const SECRET = 'unit-anchor-secret';
+  const enabledConfig: AnchorConfig = {
+    enabled: true,
+    secret: SECRET,
+    everyRuns: 1,
+    minIntervalS: 0,
+    s3: undefined,
+  };
+
+  const makePublisher = (
+    name: string,
+    impl?: () => Promise<void>,
+  ): AnchorPublisher & { publish: ReturnType<typeof vi.fn> } => ({
+    name,
+    publish: vi.fn(impl ?? (async () => undefined)),
+  });
+
+  /** Stub one full successful chained run; returns the expected head + seq. */
+  function stubChainedRun(count: number, priorHead: string | null, startSeq: number) {
+    const rows = makeIngestRows(count);
+    const expected = assignChainBatch(rows, { prevHash: priorHead ?? GENESIS_PREVIOUS_HASH });
+    stubLock(true);
+    stub(rows); // ingest SELECT
+    stub(priorHead === null ? [] : [{ event_hash: priorHead }]); // head SELECT
+    stub(); // BEGIN
+    stub([], count); // INSERT
+    stub([], count); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p, i) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+        chainSeq: String(startSeq + i), // pg returns bigint as string
+      })),
+    ); // verify re-read
+    stub([]); // unlock
+    return {
+      head: expected.newHead.prevHash,
+      headSeq: startSeq + count - 1,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetAnchorPublishStateForTests();
+  });
+
+  it('given anchoring unconfigured (env unset), should chain WITHOUT attempting any publish', async () => {
+    vi.stubEnv('AUDIT_ANCHOR_ENABLED', '');
+    const publisher = makePublisher('s3');
+    stubChainedRun(2, null, 1);
+
+    const result = await processAuditChainer({ pool: mockPool, anchorPublishers: [publisher] });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.anchor).toBeUndefined();
+    expect(publisher.publish).not.toHaveBeenCalled();
+  });
+
+  it('given an enabled config, should publish the signed head to every publisher after a chained run', async () => {
+    const s3 = makePublisher('s3');
+    const receipt = makePublisher('receipt');
+    const { head, headSeq } = stubChainedRun(3, null, 1);
+
+    const result = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: enabledConfig,
+      anchorPublishers: [s3, receipt],
+    });
+
+    expect(result.newHead).toBe(head);
+    expect(result.newHeadSeq).toBe(headSeq);
+    expect(result.anchor).toEqual({
+      attempted: true,
+      chainSeq: headSeq,
+      published: ['s3', 'receipt'],
+      failed: [],
+    });
+    expect(s3.publish).toHaveBeenCalledTimes(1);
+    expect(receipt.publish).toHaveBeenCalledTimes(1);
+    const anchor = s3.publish.mock.calls[0][0] as SignedAnchor;
+    expect(anchor).toMatchObject({
+      version: ANCHOR_VERSION,
+      source: ANCHOR_SOURCE,
+      chainSeq: headSeq,
+      head,
+    });
+    // The shell signs with the configured secret — the pure core verifies it.
+    expect(verifyAnchorSignature(anchor, SECRET)).toBe(true);
+    // Both publishers receive the SAME anchor object (one statement, two witnesses).
+    expect(receipt.publish.mock.calls[0][0]).toBe(anchor);
+  });
+
+  it('given a publisher that throws, should NEVER block or corrupt chaining: run stays chained, other witness still published, loud log', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const s3 = makePublisher('s3', async () => {
+      throw new Error('bucket gone');
+    });
+    const receipt = makePublisher('receipt');
+    stubChainedRun(2, null, 1);
+
+    const result = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: enabledConfig,
+      anchorPublishers: [s3, receipt],
+    });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.drained).toBe(2);
+    expect(result.verification).toEqual({ valid: true, verified: 2 });
+    expect(result.anchor).toEqual({
+      attempted: true,
+      chainSeq: 2,
+      published: ['receipt'],
+      failed: ['s3'],
+    });
+    // The queue drain committed before any publish — verify the transaction ran.
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls).toContain('COMMIT');
+    expect(receipt.publish).toHaveBeenCalledTimes(1);
+    expect(
+      consoleError.mock.calls.some((c) => String(c[0]).includes('ANCHOR PUBLISH FAILED')),
+    ).toBe(true);
+    consoleError.mockRestore();
+  });
+
+  it('given EVERY publisher throws on EVERY run, should keep chaining and alert on the 3rd consecutive failure', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const failing = makePublisher('receipt', async () => {
+      throw new Error('receipt table gone');
+    });
+
+    let priorHead: string | null = null;
+    let seq = 1;
+    for (let run = 0; run < 3; run++) {
+      const { head, headSeq } = stubChainedRun(1, priorHead, seq);
+      const result = await processAuditChainer({
+        pool: mockPool,
+        anchorConfig: enabledConfig,
+        anchorPublishers: [failing],
+      });
+      expect(result.outcome).toBe('chained');
+      expect(result.anchor).toMatchObject({ attempted: true, failed: ['receipt'] });
+      priorHead = head;
+      seq = headSeq + 1;
+    }
+
+    expect(failing.publish).toHaveBeenCalledTimes(3);
+    expect(mockNotifyAnchorFailure).toHaveBeenCalledTimes(1);
+    expect(mockNotifyAnchorFailure.mock.calls[0][0]).toMatchObject({
+      publisherName: 'receipt',
+      consecutiveFailures: 3,
+      errorMessage: 'receipt table gone',
+    });
+    consoleError.mockRestore();
+  });
+
+  it('given everyRuns=2, should skip the first chained run and publish on the second (interval policy)', async () => {
+    const publisher = makePublisher('receipt');
+    const config: AnchorConfig = { ...enabledConfig, everyRuns: 2 };
+
+    const first = stubChainedRun(1, null, 1);
+    const resultA = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: config,
+      anchorPublishers: [publisher],
+    });
+    const second = stubChainedRun(1, first.head, 2);
+    const resultB = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: config,
+      anchorPublishers: [publisher],
+    });
+
+    expect(resultA.anchor).toEqual({ attempted: false, skippedReason: 'every_runs' });
+    expect(resultB.anchor).toMatchObject({ attempted: true, published: ['receipt'] });
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+    expect((publisher.publish.mock.calls[0][0] as SignedAnchor).head).toBe(second.head);
+  });
+
+  it('given minIntervalS not yet elapsed since the last anchor, should skip publishing (time policy)', async () => {
+    const publisher = makePublisher('receipt');
+    const config: AnchorConfig = { ...enabledConfig, minIntervalS: 3600 };
+
+    const first = stubChainedRun(1, null, 1);
+    const resultA = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: config,
+      anchorPublishers: [publisher],
+    });
+    stubChainedRun(1, first.head, 2);
+    const resultB = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: config,
+      anchorPublishers: [publisher],
+    });
+
+    expect(resultA.anchor).toMatchObject({ attempted: true, published: ['receipt'] });
+    expect(resultB.anchor).toEqual({ attempted: false, skippedReason: 'min_interval' });
+    expect(publisher.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('given verify-on-append failed, should NOT anchor the head (never witness-sign an unverified head)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const publisher = makePublisher('receipt');
+    const rows = makeIngestRows(1);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    stubLock(true);
+    stub(rows);
+    stub([]); // head — genesis
+    stub(); // BEGIN
+    stub([], 1); // INSERT
+    stub([], 1); // DELETE
+    stub(); // COMMIT
+    stub([
+      {
+        id: expected.chainedRowPayloads[0].id,
+        emissionHash: expected.chainedRowPayloads[0].emissionHash,
+        previousHash: expected.chainedRowPayloads[0].previousHash,
+        eventHash: 'tampered-hash',
+        chainSeq: '1',
+      },
+    ]);
+    stub([]); // unlock
+
+    const result = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: enabledConfig,
+      anchorPublishers: [publisher],
+    });
+
+    expect(result.verification?.valid).toBe(false);
+    expect(result.anchor).toBeUndefined();
+    expect(publisher.publish).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('given an enabled config missing its secret, should skip with invalid_config and a loud log (misconfiguration is visible, not fatal)', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const publisher = makePublisher('receipt');
+    stubChainedRun(1, null, 1);
+
+    const result = await processAuditChainer({
+      pool: mockPool,
+      anchorConfig: { ...enabledConfig, secret: '' },
+      anchorPublishers: [publisher],
+    });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.anchor).toEqual({ attempted: false, skippedReason: 'invalid_config' });
+    expect(publisher.publish).not.toHaveBeenCalled();
+    expect(
+      consoleError.mock.calls.some((c) => String(c[0]).includes('AUDIT_ANCHOR_SECRET')),
+    ).toBe(true);
     consoleError.mockRestore();
   });
 });

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
@@ -71,6 +71,9 @@ describe('processAuditChainer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    // These wiring tests exercise fresh-install (genesis) chains — the
+    // era-fork guard is pinned by its own describe block below.
+    vi.stubEnv('AUDIT_CHAINER_ALLOW_GENESIS', 'true');
   });
 
   it('given no ADMIN_DATABASE_URL and no injected pool, should no-op as disabled (trust plane unconfigured)', async () => {
@@ -193,6 +196,33 @@ describe('processAuditChainer', () => {
     await processAuditChainer({ pool: mockPool, batchSize: 42 });
 
     expect(mockQuery.mock.calls[1][1]).toEqual([42]);
+  });
+
+  it('given pg_advisory_unlock fails, should DESTROY the connection (release with the error) so a poisoned session cannot leak the session lock into the pool', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stubLock(true);
+    stub([]); // ingest — empty → idle
+    mockQuery.mockRejectedValueOnce(new Error('unlock exploded')); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result).toEqual({ outcome: 'idle', drained: 0 });
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+    // pg destroys the connection when release() receives an error — the
+    // still-locked session must never return to the pool alive.
+    expect(mockRelease.mock.calls[0][0]).toBeInstanceOf(Error);
+    consoleError.mockRestore();
+  });
+
+  it('given a clean unlock, should release the connection back to the pool ALIVE (no destroy)', async () => {
+    stubLock(true);
+    stub([]); // ingest — empty → idle
+    stub([]); // unlock — ok
+
+    await processAuditChainer({ pool: mockPool });
+
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+    expect(mockRelease.mock.calls[0][0]).toBeUndefined();
   });
 
   it('given the transaction fails, should ROLLBACK, rethrow, and still unlock + release', async () => {
@@ -338,6 +368,7 @@ describe('processAuditChainer anchoring hook (#890 Phase 2 leaf 3)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
+    vi.stubEnv('AUDIT_CHAINER_ALLOW_GENESIS', 'true');
     resetAnchorPublishStateForTests();
   });
 
@@ -550,5 +581,96 @@ describe('processAuditChainer anchoring hook (#890 Phase 2 leaf 3)', () => {
       consoleError.mock.calls.some((c) => String(c[0]).includes('AUDIT_ANCHOR_SECRET')),
     ).toBe(true);
     consoleError.mockRestore();
+  });
+});
+
+describe('processAuditChainer genesis-era guard (#890 Phase 2 FIX)', () => {
+  // On an UPGRADE deployment the admin head is empty until the backfill
+  // plants the legacy rows: a chainer run in that window would chain new
+  // events from 'genesis', forking the eras irrecoverably (chain columns are
+  // append-only — nobody holds UPDATE). Chaining from a genesis head is
+  // therefore refused unless AUDIT_CHAINER_ALLOW_GENESIS=true, which ONLY a
+  // fresh install (no legacy rows to backfill) may set.
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    resetAnchorPublishStateForTests();
+  });
+
+  it('given ingest rows and a GENESIS head without the flag, should REFUSE to chain: loud log, nothing written, lock released', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stubLock(true);
+    stub(makeIngestRows(2)); // ingest SELECT
+    stub([]); // head SELECT — empty chain → genesis
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result).toEqual({ outcome: 'genesis_refused', drained: 0 });
+    const calls = mockQuery.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes('BEGIN'))).toBe(false);
+    expect(calls.some((c) => c.includes('INSERT INTO security_audit_log'))).toBe(false);
+    expect(calls.some((c) => c.includes('DELETE FROM security_audit_ingest'))).toBe(false);
+    // The queue is a lossless buffer — the rows stay put for after backfill.
+    expect(calls[calls.length - 1]).toContain('pg_advisory_unlock');
+    expect(
+      consoleError.mock.calls.some((c) => String(c[0]).includes('AUDIT_CHAINER_ALLOW_GENESIS')),
+    ).toBe(true);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it('given AUDIT_CHAINER_ALLOW_GENESIS=true (fresh install), should chain from genesis normally', async () => {
+    vi.stubEnv('AUDIT_CHAINER_ALLOW_GENESIS', 'true');
+    const rows = makeIngestRows(1);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+    stubLock(true);
+    stub(rows);
+    stub([]); // head — genesis
+    stub(); // BEGIN
+    stub([], 1); // INSERT
+    stub([], 1); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+      })),
+    );
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.verification).toEqual({ valid: true, verified: 1 });
+  });
+
+  it('given a NON-genesis head without the flag, should chain normally (the guard binds only the genesis link)', async () => {
+    const rows = makeIngestRows(1);
+    const priorHead = 'legacy-backfilled-head';
+    const expected = assignChainBatch(rows, { prevHash: priorHead });
+    stubLock(true);
+    stub(rows);
+    stub([{ event_hash: priorHead }]); // head — legacy rows planted
+    stub(); // BEGIN
+    stub([], 1); // INSERT
+    stub([], 1); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+      })),
+    );
+    stub([]); // unlock
+
+    const result = await processAuditChainer({ pool: mockPool });
+
+    expect(result.outcome).toBe('chained');
+    expect(result.verification).toEqual({ valid: true, verified: 1 });
   });
 });

--- a/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/audit-chainer-worker.test.ts
@@ -156,6 +156,36 @@ describe('processAuditChainer', () => {
     expect(mockNotifyAppendFailure).not.toHaveBeenCalled();
   });
 
+  it('given drained rows, should serialize the chained INSERT timestamp params as UTC ISO strings (a raw-pg Date param stores LOCAL wall clock in the tz-less column — false tamper on non-UTC processors)', async () => {
+    const rows = makeIngestRows(2);
+    const expected = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    stubLock(true);
+    stub(rows); // ingest SELECT
+    stub([]); // head SELECT — empty chain → genesis
+    stub(); // BEGIN
+    stub([], 2); // INSERT
+    stub([], 2); // DELETE
+    stub(); // COMMIT
+    stub(
+      expected.chainedRowPayloads.map((p) => ({
+        id: p.id,
+        emissionHash: p.emissionHash,
+        previousHash: p.previousHash,
+        eventHash: p.eventHash,
+      })),
+    ); // verify re-read
+    stub([]); // unlock
+
+    await processAuditChainer({ pool: mockPool });
+
+    // 18 params per row; timestamp is the 15th (index 14) in each row block.
+    const insertValues = mockQuery.mock.calls[4][1] as unknown[];
+    rows.forEach((row, i) => {
+      expect(insertValues[i * 18 + 14]).toBe(row.timestamp.toISOString());
+    });
+  });
+
   it('given an existing chain head, should link the first payload to it (not genesis)', async () => {
     const rows = makeIngestRows(2);
     const priorHead = 'existing-head-hash';

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -40,6 +40,11 @@ vi.mock('../siem-delivery-worker', () => ({
   processSiemDelivery: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mock audit chainer worker (dynamically imported by queue-manager)
+vi.mock('../audit-chainer-worker', () => ({
+  processAuditChainer: vi.fn().mockResolvedValue({ outcome: 'idle', drained: 0 }),
+}));
+
 // Mock workers
 vi.mock('../text-extractor', () => ({
   needsTextExtraction: vi.fn().mockReturnValue(false),
@@ -113,7 +118,7 @@ describe('QueueManager', () => {
       await qm.initialize();
 
       expect(mockBossStart).toHaveBeenCalledTimes(1);
-      expect(mockBossWork).toHaveBeenCalledTimes(8);
+      expect(mockBossWork).toHaveBeenCalledTimes(9);
       expect(mockBossWork.mock.calls[0][0]).toBe('ingest-file');
       expect(mockBossWork.mock.calls[1][0]).toBe('image-optimize');
       expect(mockBossWork.mock.calls[2][0]).toBe('text-extract');
@@ -122,7 +127,8 @@ describe('QueueManager', () => {
       expect(mockBossWork.mock.calls[5][0]).toBe('siem-delivery');
       expect(mockBossWork.mock.calls[6][0]).toBe('pull-verify');
       expect(mockBossWork.mock.calls[7][0]).toBe('account-erasure');
-      expect(mockBossCreateQueue).toHaveBeenCalledTimes(8);
+      expect(mockBossWork.mock.calls[8][0]).toBe('audit-chainer');
+      expect(mockBossCreateQueue).toHaveBeenCalledTimes(9);
       expect(mockBossCreateQueue).toHaveBeenCalledWith('ingest-file');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('pull-verify');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('image-optimize');
@@ -131,7 +137,12 @@ describe('QueueManager', () => {
       expect(mockBossCreateQueue).toHaveBeenCalledWith('video-process');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('siem-delivery');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('account-erasure');
+      expect(mockBossCreateQueue).toHaveBeenCalledWith('audit-chainer');
       expect(mockBossSchedule).toHaveBeenCalledWith('siem-delivery', '*/30 * * * * *', {}, { retryLimit: 0 });
+      // Same cadence + no-stack pattern as siem-delivery: retryLimit 0 so
+      // overlapping scheduled runs never pile up; the advisory lock inside
+      // the worker serializes any overlap that still happens.
+      expect(mockBossSchedule).toHaveBeenCalledWith('audit-chainer', '*/30 * * * * *', {}, { retryLimit: 0 });
     }, 30000);
 
     it('handles queue creation errors gracefully', async () => {
@@ -341,6 +352,7 @@ describe('QueueManager', () => {
       expect(status['text-extract']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
       expect(status['ocr-process']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
       expect(status['siem-delivery']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
+      expect(status['audit-chainer']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
     });
 
     it('maps queue states correctly', async () => {

--- a/apps/processor/src/workers/__tests__/siem-anchor-loader.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-anchor-loader.test.ts
@@ -192,7 +192,7 @@ describe('loadSecurityAuditHashableFields', () => {
   it('empty id array short-circuits with empty map', async () => {
     const client = createMockClient([]);
 
-    const result = await loadSecurityAuditHashableFields(client, []);
+    const result = await loadSecurityAuditHashableFields(client, [], { plane: 'main' });
 
     assert({
       given: 'an empty id array',
@@ -216,7 +216,7 @@ describe('loadSecurityAuditHashableFields', () => {
     };
     const client = createMockClient([{ rows: [row], rowCount: 1 }]);
 
-    const result = await loadSecurityAuditHashableFields(client, ['sec_1']);
+    const result = await loadSecurityAuditHashableFields(client, ['sec_1'], { plane: 'main' });
 
     assert({
       given: 'one security_audit_log id',
@@ -235,6 +235,86 @@ describe('loadSecurityAuditHashableFields', () => {
         client.calls[0].sql.includes('FROM security_audit_log') &&
         client.calls[0].sql.includes('WHERE id = ANY($1)'),
       expected: true,
+    });
+  });
+
+  it('main plane never selects emission_hash (legacy table has no such column) and pins emissionHash to null', async () => {
+    const row = {
+      id: 'sec_1',
+      eventType: 'auth.login.success',
+      serviceId: null,
+      resourceType: null,
+      resourceId: null,
+      details: null,
+      riskScore: null,
+      anomalyFlags: null,
+      timestamp: new Date('2026-04-10T09:00:00Z'),
+    };
+    const client = createMockClient([{ rows: [row], rowCount: 1 }]);
+
+    const result = await loadSecurityAuditHashableFields(client, ['sec_1'], { plane: 'main' });
+
+    assert({
+      given: 'a main-plane load',
+      should: 'not reference emission_hash in the SQL',
+      actual: client.calls[0].sql.includes('emission_hash'),
+      expected: false,
+    });
+    assert({
+      given: 'a main-plane row',
+      should: 'carry emissionHash null (legacy era)',
+      actual: result.get('sec_1')?.emissionHash,
+      expected: null,
+    });
+  });
+
+  it('admin plane selects emission_hash and threads it through as the era discriminator', async () => {
+    const rows = [
+      {
+        id: 'legacy_1',
+        eventType: 'auth.login.success',
+        serviceId: null,
+        resourceType: null,
+        resourceId: null,
+        details: null,
+        riskScore: null,
+        anomalyFlags: null,
+        timestamp: new Date('2026-04-10T09:00:00Z'),
+        emissionHash: null,
+      },
+      {
+        id: 'chainer_1',
+        eventType: 'data.read',
+        serviceId: 'web',
+        resourceType: 'page',
+        resourceId: 'p1',
+        details: null,
+        riskScore: null,
+        anomalyFlags: null,
+        timestamp: new Date('2026-04-10T09:01:00Z'),
+        emissionHash: 'a'.repeat(64),
+      },
+    ];
+    const client = createMockClient([{ rows, rowCount: 2 }]);
+
+    const result = await loadSecurityAuditHashableFields(client, ['legacy_1', 'chainer_1'], {
+      plane: 'admin',
+    });
+
+    assert({
+      given: 'an admin-plane load',
+      should: 'select emission_hash aliased to emissionHash',
+      actual: client.calls[0].sql.includes('emission_hash AS "emissionHash"'),
+      expected: true,
+    });
+    assert({
+      given: 'a backfilled legacy row and a chainer row in one batch',
+      should: 'preserve NULL vs set emission hashes per row',
+      actual: {
+        legacy: result.get('legacy_1')?.emissionHash,
+        chainer: result.get('chainer_1')?.emissionHash,
+      },
+      expected: { legacy: null, chainer: 'a'.repeat(64) },
     });
   });
 });

--- a/apps/processor/src/workers/__tests__/siem-delivery-preflight.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-preflight.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Unit tests for the SIEM chain-verification preflight's store routing and
+ * era-aware behavior (#890 Phase 2 leaf 7).
+ *
+ * The preflight now takes an explicit per-purpose client set instead of one
+ * client: cursors live in the Admin PG for both sources, activity_logs data
+ * stays on main, and security_audit_log data reads the plane the routing
+ * matrix selected. These tests drive the REAL preflight + verifier + hashers
+ * against pattern-matching client stubs that record which store served which
+ * query — the pool-per-operation matrix for the preflight, pinned.
+ */
+import { describe, it } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeChainHash } from '@pagespace/lib/audit/chain-step';
+import { computeLogHash } from '@pagespace/lib/monitoring/activity-logger';
+import type { AuditLogEntry } from '../../services/siem-adapter';
+import { runChainPreflight, type PreflightStores } from '../siem-delivery-preflight';
+
+interface RecordedCall {
+  sql: string;
+  params?: unknown[];
+}
+
+interface StubClient {
+  calls: RecordedCall[];
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+}
+
+type Responder = (sql: string, params?: unknown[]) => Record<string, unknown>[] | null;
+
+function createStubClient(respond: Responder): StubClient {
+  const calls: RecordedCall[] = [];
+  return {
+    calls,
+    query: async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params });
+      const rows = respond(sql, params);
+      if (rows === null) {
+        throw new Error(`Unhandled SQL in preflight test stub: ${sql.slice(0, 120)}`);
+      }
+      return { rows, rowCount: rows.length };
+    },
+  };
+}
+
+// --- security fixtures ------------------------------------------------------
+
+const T = (s: number) => new Date(Date.UTC(2026, 3, 10, 9, 0, s));
+
+interface SecurityFixtureRow {
+  id: string;
+  event: AuditEvent;
+  timestamp: Date;
+  previousHash: string;
+  eventHash: string;
+  emissionHash: string | null;
+}
+
+function legacySecurityRow(id: string, seconds: number, previousHash: string): SecurityFixtureRow {
+  const event: AuditEvent = {
+    eventType: 'auth.login.success',
+    serviceId: 'web',
+    resourceType: 'user',
+    resourceId: `u-${id}`,
+    details: { probe: id },
+  };
+  const timestamp = T(seconds);
+  return {
+    id,
+    event,
+    timestamp,
+    previousHash,
+    eventHash: computeSecurityEventHash(event, previousHash, timestamp),
+    emissionHash: null,
+  };
+}
+
+function chainerSecurityRow(id: string, seconds: number, previousHash: string): SecurityFixtureRow {
+  const event: AuditEvent = {
+    eventType: 'data.read',
+    serviceId: 'web',
+    resourceType: 'page',
+    resourceId: `p-${id}`,
+    details: { probe: id },
+  };
+  const timestamp = T(seconds);
+  const emissionHash = computeEmissionHash(event, timestamp);
+  return {
+    id,
+    event,
+    timestamp,
+    previousHash,
+    eventHash: computeChainHash(emissionHash, previousHash),
+    emissionHash,
+  };
+}
+
+function securityEntry(row: SecurityFixtureRow): AuditLogEntry {
+  return {
+    id: row.id,
+    source: 'security_audit_log',
+    timestamp: row.timestamp,
+    userId: null,
+    actorEmail: 'system@pagespace',
+    actorDisplayName: null,
+    isAiGenerated: false,
+    aiProvider: null,
+    aiModel: null,
+    aiConversationId: null,
+    operation: row.event.eventType,
+    resourceType: row.event.resourceType ?? 'unknown',
+    resourceId: row.event.resourceId ?? 'unknown',
+    resourceTitle: null,
+    driveId: null,
+    pageId: null,
+    metadata: null,
+    previousLogHash: row.previousHash,
+    logHash: row.eventHash,
+  };
+}
+
+function securityHashableRow(row: SecurityFixtureRow, plane: 'admin' | 'main'): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    id: row.id,
+    eventType: row.event.eventType,
+    serviceId: row.event.serviceId ?? null,
+    resourceType: row.event.resourceType ?? null,
+    resourceId: row.event.resourceId ?? null,
+    details: row.event.details ?? null,
+    riskScore: row.event.riskScore ?? null,
+    anomalyFlags: row.event.anomalyFlags ?? null,
+    timestamp: row.timestamp,
+  };
+  if (plane === 'admin') {
+    base.emissionHash = row.emissionHash;
+  }
+  return base;
+}
+
+// --- activity fixtures ------------------------------------------------------
+
+interface ActivityFixtureRow {
+  id: string;
+  timestamp: Date;
+  previousLogHash: string;
+  logHash: string;
+  fields: Record<string, unknown>;
+}
+
+function activityRow(id: string, seconds: number, previousLogHash: string): ActivityFixtureRow {
+  const timestamp = T(seconds);
+  const hashable = {
+    id,
+    timestamp,
+    operation: 'page.update',
+    resourceType: 'page',
+    resourceId: `p-${id}`,
+    driveId: 'd1',
+    pageId: `p-${id}`,
+    contentSnapshot: undefined,
+    previousValues: undefined,
+    newValues: undefined,
+    metadata: undefined,
+  };
+  return {
+    id,
+    timestamp,
+    previousLogHash,
+    logHash: computeLogHash(hashable, previousLogHash),
+    fields: {
+      id,
+      timestamp,
+      operation: 'page.update',
+      resourceType: 'page',
+      resourceId: `p-${id}`,
+      driveId: 'd1',
+      pageId: `p-${id}`,
+      contentSnapshot: null,
+      previousValues: null,
+      newValues: null,
+      metadata: null,
+    },
+  };
+}
+
+function activityEntry(row: ActivityFixtureRow): AuditLogEntry {
+  return {
+    id: row.id,
+    source: 'activity_logs',
+    timestamp: row.timestamp,
+    userId: 'u1',
+    actorEmail: 'user@example.com',
+    actorDisplayName: null,
+    isAiGenerated: false,
+    aiProvider: null,
+    aiModel: null,
+    aiConversationId: null,
+    operation: 'page.update',
+    resourceType: 'page',
+    resourceId: `p-${row.id}`,
+    resourceTitle: null,
+    driveId: 'd1',
+    pageId: `p-${row.id}`,
+    metadata: null,
+    previousLogHash: row.previousLogHash,
+    logHash: row.logHash,
+  };
+}
+
+// --- stores wiring ----------------------------------------------------------
+
+function cursorResponder(cursorBySource: Record<string, string>): Responder {
+  return (sql, params) => {
+    if (sql.includes('FROM siem_delivery_cursors WHERE id =')) {
+      const source = String(params?.[0]);
+      return [{ lastDeliveredId: cursorBySource[source] ?? null }];
+    }
+    return null;
+  };
+}
+
+describe('runChainPreflight store routing (#890 Phase 2 leaf 7)', () => {
+  // Shared fixture: a legacy security chain g -> s1 -> s2 living in the ADMIN
+  // store (s1 backfilled legacy row, s2 chainer-era row) with the cursor
+  // anchored at g; an activity chain a0 -> a1 on MAIN anchored at a0.
+  const g = legacySecurityRow('sec-g', 0, 'genesis');
+  const s1 = legacySecurityRow('sec-1', 1, g.eventHash);
+  const s2 = chainerSecurityRow('sec-2', 2, s1.eventHash);
+  const a0 = activityRow('act-0', 0, 'seed');
+  const a1 = activityRow('act-1', 1, a0.logHash);
+
+  function dedicatedStores(overrides?: Partial<PreflightStores>): {
+    stores: PreflightStores;
+    cursors: StubClient;
+    activityData: StubClient;
+    securityData: StubClient;
+    legacyStore: StubClient;
+  } {
+    const cursors = createStubClient(
+      cursorResponder({ security_audit_log: g.id, activity_logs: a0.id })
+    );
+    const activityData = createStubClient((sql, params) => {
+      if (sql.includes('SELECT "logHash" FROM activity_logs WHERE id = $1')) {
+        return params?.[0] === a0.id ? [{ logHash: a0.logHash }] : [];
+      }
+      if (sql.includes('FROM activity_logs') && sql.includes('id = ANY($1)')) {
+        return [a1.fields];
+      }
+      return null;
+    });
+    const securityData = createStubClient((sql, params) => {
+      if (sql.includes('SELECT event_hash AS "logHash" FROM security_audit_log WHERE id = $1')) {
+        return params?.[0] === g.id ? [{ logHash: g.eventHash }] : [];
+      }
+      if (sql.includes('FROM security_audit_log') && sql.includes('id = ANY($1)')) {
+        return [securityHashableRow(s1, 'admin'), securityHashableRow(s2, 'admin')];
+      }
+      return null;
+    });
+    const legacyStore = createStubClient((sql) => {
+      if (sql.includes('SELECT 1 FROM security_audit_log WHERE id = $1')) {
+        return [{ '?column?': 1 }];
+      }
+      return null;
+    });
+    return {
+      stores: {
+        cursors,
+        activityData,
+        securityData,
+        securityPlane: 'admin',
+        legacySecurityStore: legacyStore,
+        ...overrides,
+      },
+      cursors,
+      activityData,
+      securityData,
+      legacyStore,
+    };
+  }
+
+  const mergedBoth = [activityEntry(a1), securityEntry(s1), securityEntry(s2)];
+
+  it('given a clean dual-era batch, should verify each source against ITS store and pass', async () => {
+    const { stores, cursors, activityData, securityData } = dedicatedStores();
+
+    const result = await runChainPreflight(stores, mergedBoth);
+
+    assert({
+      given: 'a clean batch spanning a backfilled legacy row and a chainer-era row',
+      should: 'pass preflight',
+      actual: result,
+      expected: null,
+    });
+    assert({
+      given: 'the dedicated routing',
+      should: 'read both cursors from the cursors store only',
+      actual: {
+        cursorReads: cursors.calls.filter((c) => c.sql.includes('siem_delivery_cursors')).length,
+        cursorReadsOnActivity: activityData.calls.filter((c) => c.sql.includes('siem_delivery_cursors')).length,
+        cursorReadsOnSecurity: securityData.calls.filter((c) => c.sql.includes('siem_delivery_cursors')).length,
+      },
+      expected: { cursorReads: 2, cursorReadsOnActivity: 0, cursorReadsOnSecurity: 0 },
+    });
+    assert({
+      given: 'the dedicated routing',
+      should: 'load the security anchor + hashables from the ADMIN store and activity from MAIN',
+      actual: {
+        securityQueriesOnAdmin: securityData.calls.filter((c) => c.sql.includes('security_audit_log')).length >= 2,
+        securityQueriesOnMainData: activityData.calls.filter((c) => c.sql.includes('security_audit_log')).length,
+        activityQueriesOnMain: activityData.calls.filter((c) => c.sql.includes('activity_logs')).length >= 2,
+        activityQueriesOnAdmin: securityData.calls.filter((c) => c.sql.includes('activity_logs')).length,
+      },
+      expected: {
+        securityQueriesOnAdmin: true,
+        securityQueriesOnMainData: 0,
+        activityQueriesOnMain: true,
+        activityQueriesOnAdmin: 0,
+      },
+    });
+  });
+
+  it('given a tampered chainer-era row, should halt with hash_mismatch (era-aware recompute)', async () => {
+    const tamperedS2 = { ...securityEntry(s2) };
+    const { stores } = dedicatedStores();
+    // Serve tampered DATA for s2 from the admin store: details changed after
+    // chaining — the era-aware recompute must derive a different emission.
+    const securityData = createStubClient((sql, params) => {
+      if (sql.includes('SELECT event_hash AS "logHash" FROM security_audit_log WHERE id = $1')) {
+        return params?.[0] === g.id ? [{ logHash: g.eventHash }] : [];
+      }
+      if (sql.includes('FROM security_audit_log') && sql.includes('id = ANY($1)')) {
+        return [
+          securityHashableRow(s1, 'admin'),
+          { ...securityHashableRow(s2, 'admin'), details: { probe: 'FORGED' } },
+        ];
+      }
+      return null;
+    });
+
+    const result = await runChainPreflight(
+      { ...stores, securityData },
+      [securityEntry(s1), tamperedS2]
+    );
+
+    assert({
+      given: 'a chainer-era row whose details were modified in the admin store',
+      should: 'halt with tamper/hash_mismatch on that entry',
+      actual: result && result.kind === 'tamper'
+        ? { kind: result.kind, entryId: result.entryId, breakReason: result.breakReason }
+        : result,
+      expected: { kind: 'tamper', entryId: s2.id, breakReason: 'hash_mismatch' },
+    });
+  });
+
+  it('given the anchor row missing from admin but present in main, should defer with awaiting_backfill (and still verify activity)', async () => {
+    const { stores, legacyStore, activityData } = dedicatedStores({
+      securityData: createStubClient((sql) => {
+        if (sql.includes('SELECT event_hash AS "logHash" FROM security_audit_log WHERE id = $1')) {
+          return []; // anchor not yet backfilled into the admin store
+        }
+        return null;
+      }),
+    });
+
+    const result = await runChainPreflight(stores, mergedBoth);
+
+    assert({
+      given: 'a seeded cursor whose anchor row is not yet backfilled',
+      should: 'return awaiting_backfill for security_audit_log',
+      actual: result,
+      expected: {
+        kind: 'awaiting_backfill',
+        source: 'security_audit_log',
+        anchorId: g.id,
+      },
+    });
+    assert({
+      given: 'the awaiting-backfill probe',
+      should: 'check the legacy main store for the anchor row',
+      actual: legacyStore.calls.some((c) =>
+        c.sql.includes('SELECT 1 FROM security_audit_log WHERE id = $1') && c.params?.[0] === g.id
+      ),
+      expected: true,
+    });
+    assert({
+      given: 'a deferral on the security source',
+      should: 'still have verified activity_logs against main',
+      actual: activityData.calls.filter((c) => c.sql.includes('activity_logs')).length >= 2,
+      expected: true,
+    });
+  });
+
+  it('given the anchor row missing from BOTH stores, should fail closed with db_error (anchor loss is not backfill lag)', async () => {
+    const { stores } = dedicatedStores({
+      securityData: createStubClient((sql) => {
+        if (sql.includes('SELECT event_hash AS "logHash" FROM security_audit_log WHERE id = $1')) {
+          return [];
+        }
+        return null;
+      }),
+      legacySecurityStore: createStubClient((sql) => {
+        if (sql.includes('SELECT 1 FROM security_audit_log WHERE id = $1')) {
+          return [];
+        }
+        return null;
+      }),
+    });
+
+    const result = await runChainPreflight(stores, [securityEntry(s1)]);
+
+    assert({
+      given: 'an anchor row absent from admin AND main',
+      should: 'halt fail-closed as a db_error on the security source',
+      actual: result ? { kind: result.kind, source: result.source } : result,
+      expected: { kind: 'db_error', source: 'security_audit_log' },
+    });
+  });
+
+  it('given break-glass (securityPlane main, no legacy probe store), should verify the legacy chain on the main store without emission_hash SQL', async () => {
+    const cursors = createStubClient(cursorResponder({ security_audit_log: g.id }));
+    const mainData = createStubClient((sql, params) => {
+      if (sql.includes('SELECT event_hash AS "logHash" FROM security_audit_log WHERE id = $1')) {
+        return params?.[0] === g.id ? [{ logHash: g.eventHash }] : [];
+      }
+      if (sql.includes('FROM security_audit_log') && sql.includes('id = ANY($1)')) {
+        return [securityHashableRow(s1, 'main')];
+      }
+      return null;
+    });
+
+    const result = await runChainPreflight(
+      {
+        cursors,
+        activityData: mainData,
+        securityData: mainData,
+        securityPlane: 'main',
+        legacySecurityStore: null,
+      },
+      [securityEntry(s1)]
+    );
+
+    assert({
+      given: 'break-glass routing with a clean legacy chain',
+      should: 'pass preflight',
+      actual: result,
+      expected: null,
+    });
+    assert({
+      given: 'a main-plane hashable load',
+      should: 'never reference emission_hash',
+      actual: mainData.calls.some((c) => c.sql.includes('emission_hash')),
+      expected: false,
+    });
+  });
+});

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.integration.test.ts
@@ -585,7 +585,9 @@ describe.skipIf(!url)('SIEM delivery worker across the admin store flip (wire-co
 
       // New-era events land in the admin store BEFORE any backfill ran —
       // the exact transitional window leaf 5 flagged. (Fresh store, so this
-      // chain starts at genesis; leaf 8 reconciles the two chains.)
+      // chain starts at genesis; leaf 8 reconciles the two chains.) The
+      // era-fork guard refuses this on upgrades, so simulating the window
+      // requires the fresh-install flag (#890 Phase 2 FIX).
       await seedIngestRows(appPool, [
         {
           id: 'g1',
@@ -594,8 +596,13 @@ describe.skipIf(!url)('SIEM delivery worker across the admin store flip (wire-co
           emittedAt: T(60),
         },
       ]);
-      const chained = await processAuditChainer({ pool: procPool });
-      expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+      process.env.AUDIT_CHAINER_ALLOW_GENESIS = 'true';
+      try {
+        const chained = await processAuditChainer({ pool: procPool });
+        expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+      } finally {
+        delete process.env.AUDIT_CHAINER_ALLOW_GENESIS;
+      }
     });
 
     it('defers the security source (no delivery, no error, cursor pinned) while activity keeps flowing', async () => {

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.integration.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.integration.test.ts
@@ -1,0 +1,626 @@
+/**
+ * Cursor-continuity integration for the SIEM delivery worker across the
+ * #890 Phase 2 store flip (leaf 7), wire-connected on scratch Postgres.
+ *
+ * Two REAL databases on one scratch server play the two planes:
+ *   - the admin scratch DB (ADMIN_DATABASE_URL): migrated via migrateAdminDb,
+ *     login users provisioned, worker connects AS admin_processor_user
+ *     (admin_chainer + admin_siem) — grants proven over the wire;
+ *   - a sibling "main" DB holding the LEGACY tables (activity_logs,
+ *     security_audit_log, siem_delivery_cursors) with real hash chains.
+ *
+ * What this proves end to end:
+ *   1. First dedicated run SEEDS the admin cursors from the legacy watermark
+ *      (exact tuple copy, nothing delivered, legacy cursors untouched).
+ *   2. After the backfill plants legacy rows (original ids/timestamps/hashes,
+ *      NULL emission_hash, chain_seq preserved) and the chainer appends
+ *      new-era rows on top, delivery resumes EXACTLY ONCE: undelivered
+ *      legacy rows then chainer rows, chain-preflight passing across the
+ *      era boundary — including a pseudonymized row (PII nulled, hash
+ *      intact). No replay of already-shipped rows, no gap.
+ *   3. An idle rerun re-delivers nothing.
+ *   4. Pre-backfill, a seeded cursor whose anchor is still missing from the
+ *      admin store DEFERS the security source (no error, cursor pinned)
+ *      while activity_logs keeps delivering from main.
+ *
+ * The receipts table is deliberately NOT created on the main scratch DB: any
+ * matrix-violating receipt write fails loudly instead of passing silently.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run src/workers/__tests__/siem-delivery-worker.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import path from 'path';
+import { migrateAdminDb } from '@pagespace/db/migrate-admin';
+import { provisionAdminLoginUsers } from '@pagespace/db/provision-admin-users';
+import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeLogHash } from '@pagespace/lib/monitoring/activity-logger';
+
+// SIEM adapter: real config/validation types, but delivery is captured
+// in-memory — this suite proves DB wiring, not webhook transport (the
+// pipeline e2e covers that).
+const { deliveredBatches, mockDeliver } = vi.hoisted(() => {
+  const deliveredBatches: { id: string; source: string; timestamp: Date }[][] = [];
+  const mockDeliver = vi.fn(async (_config: unknown, entries: { id: string; source: string; timestamp: Date }[]) => {
+    deliveredBatches.push(entries.map((e) => ({ id: e.id, source: e.source, timestamp: e.timestamp })));
+    return {
+      success: true,
+      entriesDelivered: entries.length,
+      webhookStatus: 200,
+      responseHash: 'a'.repeat(64),
+      ackReceivedAt: new Date(),
+    };
+  });
+  return { deliveredBatches, mockDeliver };
+});
+
+vi.mock('../../services/siem-adapter', async () => {
+  const actual = await vi.importActual<typeof import('../../services/siem-adapter')>(
+    '../../services/siem-adapter'
+  );
+  return {
+    ...actual,
+    loadSiemConfig: () => ({
+      enabled: true,
+      type: 'webhook' as const,
+      webhook: {
+        url: 'https://siem.example.com/ingest',
+        secret: 'integration-secret',
+        batchSize: 100,
+        retryAttempts: 0,
+      },
+    }),
+    validateSiemConfig: () => ({ valid: true, errors: [] }),
+    deliverToSiemWithRetry: mockDeliver,
+  };
+});
+
+import { processSiemDelivery, resetSiemModeBannerForTests } from '../siem-delivery-worker';
+import { processAuditChainer } from '../audit-chainer-worker';
+
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+interface PgPool {
+  connect(): Promise<PgClient>;
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  end(): Promise<void>;
+}
+// @ts-expect-error -- pg has no bundled types; runtime cast below handles type safety
+import pg from 'pg';
+const { Pool } = pg as unknown as {
+  Pool: new (config: Record<string, unknown>) => PgPool;
+};
+
+const url = process.env.ADMIN_DATABASE_URL;
+const MAIN_DB_NAME = 'pagespace_main_siem_it';
+
+const PASSWORDS = {
+  ADMIN_APP_PASSWORD: 'appsecretsiemit1',
+  ADMIN_PROCESSOR_PASSWORD: 'procsecretsiemit1',
+} as const;
+
+const ALL_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+  'admin_app_user',
+  'admin_processor_user',
+  'admin_reader_user',
+] as const;
+
+function loginConfig(user: string, password: string) {
+  const parsed = new URL(url as string);
+  return {
+    host: parsed.hostname,
+    port: Number(parsed.port || 5432),
+    database: parsed.pathname.slice(1),
+    user,
+    password,
+    max: 2,
+  };
+}
+
+function mainDbUrl(): string {
+  const parsed = new URL(url as string);
+  parsed.pathname = `/${MAIN_DB_NAME}`;
+  return parsed.toString();
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+const T = (s: number) => new Date(Date.UTC(2026, 1, 1, 0, 0, s));
+
+interface LegacyRow {
+  id: string;
+  event: AuditEvent;
+  timestamp: Date;
+  previousHash: string;
+  eventHash: string;
+}
+
+function buildLegacyChain(count: number): LegacyRow[] {
+  const rows: LegacyRow[] = [];
+  let prev = 'genesis';
+  for (let i = 1; i <= count; i++) {
+    const event: AuditEvent = {
+      eventType: 'auth.login.success',
+      userId: `user-${i}`,
+      sessionId: `sess-${i}`,
+      serviceId: 'web',
+      resourceType: 'user',
+      resourceId: `u-${i}`,
+      ipAddress: '10.0.0.9',
+      userAgent: 'it-agent',
+      geoLocation: 'EU/Berlin',
+      details: { legacy: i },
+      // Exactly representable in float4 — the recompute reads risk_score back
+      // from a `real` column and the hash must be byte-identical.
+      riskScore: 0.5,
+    };
+    const timestamp = T(i);
+    const eventHash = computeSecurityEventHash(event, prev, timestamp);
+    rows.push({ id: `r${i}`, event, timestamp, previousHash: prev, eventHash });
+    prev = eventHash;
+  }
+  return rows;
+}
+
+async function insertLegacySecurityRows(pool: PgPool, rows: LegacyRow[], opts: { chainSeqBase?: number } = {}): Promise<void> {
+  for (const [idx, r] of rows.entries()) {
+    const cols = `id, timestamp, event_type, user_id, session_id, service_id, resource_type,
+       resource_id, ip_address, user_agent, geo_location, details, risk_score,
+       anomaly_flags, previous_hash, event_hash`;
+    const chainSeqCol = opts.chainSeqBase !== undefined ? ', chain_seq' : '';
+    const chainSeqParam = opts.chainSeqBase !== undefined ? ', $17' : '';
+    const params: unknown[] = [
+      r.id,
+      r.timestamp,
+      r.event.eventType,
+      r.event.userId ?? null,
+      r.event.sessionId ?? null,
+      r.event.serviceId ?? null,
+      r.event.resourceType ?? null,
+      r.event.resourceId ?? null,
+      r.event.ipAddress ?? null,
+      r.event.userAgent ?? null,
+      r.event.geoLocation ?? null,
+      r.event.details ? JSON.stringify(r.event.details) : null,
+      r.event.riskScore ?? null,
+      r.event.anomalyFlags ?? null,
+      r.previousHash,
+      r.eventHash,
+    ];
+    if (opts.chainSeqBase !== undefined) params.push(opts.chainSeqBase + idx + 1);
+    await pool.query(
+      `INSERT INTO security_audit_log (${cols}${chainSeqCol})
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16${chainSeqParam})`,
+      params
+    );
+  }
+}
+
+interface ActivityRow {
+  id: string;
+  timestamp: Date;
+  previousLogHash: string;
+  logHash: string;
+}
+
+function buildActivityChain(count: number): ActivityRow[] {
+  const rows: ActivityRow[] = [];
+  let prev = 'act-seed';
+  for (let i = 0; i < count; i++) {
+    const timestamp = T(i);
+    const logHash = computeLogHash(
+      {
+        id: `a${i}`,
+        timestamp,
+        operation: 'page.update',
+        resourceType: 'page',
+        resourceId: `p-${i}`,
+        driveId: 'd1',
+        pageId: `p-${i}`,
+      },
+      prev
+    );
+    rows.push({ id: `a${i}`, timestamp, previousLogHash: prev, logHash });
+    prev = logHash;
+  }
+  return rows;
+}
+
+async function insertActivityRows(pool: PgPool, rows: ActivityRow[]): Promise<void> {
+  for (const r of rows) {
+    await pool.query(
+      `INSERT INTO activity_logs (id, timestamp, "userId", "actorEmail", "actorDisplayName",
+         operation, "resourceType", "resourceId", "driveId", "pageId", "previousLogHash", "logHash")
+       VALUES ($1, $2, 'u1', 'user@example.com', NULL, 'page.update', 'page', $3, 'd1', $3, $4, $5)`,
+      [r.id, r.timestamp, `p-${r.id.slice(1)}`, r.previousLogHash, r.logHash]
+    );
+  }
+}
+
+async function setCursor(
+  pool: PgPool,
+  source: string,
+  lastDeliveredId: string,
+  lastDeliveredAt: Date,
+  deliveryCount: number
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "updatedAt")
+     VALUES ($1, $2, $3, $4, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastDeliveredId" = $2, "lastDeliveredAt" = $3, "deliveryCount" = $4, "updatedAt" = NOW()`,
+    [source, lastDeliveredId, lastDeliveredAt, deliveryCount]
+  );
+}
+
+async function readCursor(pool: PgPool, source: string) {
+  const r = await pool.query(
+    'SELECT "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError" FROM siem_delivery_cursors WHERE id = $1',
+    [source]
+  );
+  const row = r.rows[0];
+  if (!row) return undefined;
+  const at = row.lastDeliveredAt;
+  return {
+    lastDeliveredId: row.lastDeliveredId as string,
+    lastDeliveredAt: at instanceof Date ? at : new Date(String(at)),
+    deliveryCount: Number(row.deliveryCount),
+    lastError: (row.lastError as string | null) ?? null,
+  };
+}
+
+async function seedIngestRows(
+  appPool: PgPool,
+  rows: Array<{ id: string; event: AuditEvent; timestamp: Date; emittedAt: Date }>
+): Promise<void> {
+  for (const { id, event, timestamp, emittedAt } of rows) {
+    await appPool.query(
+      `INSERT INTO security_audit_ingest
+         (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+          ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+          anomaly_flags, timestamp, emission_hash, emitted_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16, $17)`,
+      [
+        id,
+        event.eventType,
+        event.userId ?? null,
+        event.sessionId ?? null,
+        event.serviceId ?? null,
+        event.resourceType ?? null,
+        event.resourceId ?? null,
+        event.ipAddress ?? null,
+        null,
+        event.userAgent ?? null,
+        event.geoLocation ?? null,
+        event.details ? JSON.stringify(event.details) : null,
+        event.riskScore ?? null,
+        event.anomalyFlags ?? null,
+        timestamp,
+        computeEmissionHash(event, timestamp),
+        emittedAt,
+      ]
+    );
+  }
+}
+
+// --- harness ------------------------------------------------------------
+
+const MAIN_TABLES_DDL = `
+  CREATE TABLE activity_logs (
+    id text PRIMARY KEY,
+    timestamp timestamptz NOT NULL,
+    "userId" text,
+    "actorEmail" text NOT NULL,
+    "actorDisplayName" text,
+    "isAiGenerated" boolean NOT NULL DEFAULT false,
+    "aiProvider" text,
+    "aiModel" text,
+    "aiConversationId" text,
+    operation text NOT NULL,
+    "resourceType" text NOT NULL,
+    "resourceId" text NOT NULL,
+    "resourceTitle" text,
+    "driveId" text,
+    "pageId" text,
+    metadata jsonb,
+    "contentSnapshot" text,
+    "previousValues" jsonb,
+    "newValues" jsonb,
+    "previousLogHash" text,
+    "logHash" text
+  );
+  CREATE TABLE security_audit_log (
+    id text PRIMARY KEY,
+    timestamp timestamptz NOT NULL,
+    event_type text NOT NULL,
+    user_id text,
+    session_id text,
+    service_id text,
+    resource_type text,
+    resource_id text,
+    ip_address text,
+    user_agent text,
+    geo_location text,
+    details jsonb,
+    risk_score real,
+    anomaly_flags text[],
+    previous_hash text NOT NULL,
+    event_hash text NOT NULL
+  );
+  CREATE TABLE siem_delivery_cursors (
+    id text PRIMARY KEY,
+    "lastDeliveredId" text,
+    "lastDeliveredAt" timestamptz,
+    "deliveryCount" integer NOT NULL DEFAULT 0,
+    "lastError" text,
+    "lastErrorAt" timestamptz,
+    "updatedAt" timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT cursor_pair_check CHECK (("lastDeliveredId" IS NULL) = ("lastDeliveredAt" IS NULL))
+  );
+`;
+// NOTE: siem_delivery_receipts is deliberately ABSENT from the main scratch
+// DB — a receipt write routed to main is a matrix violation and must explode.
+
+describe.skipIf(!url)('SIEM delivery worker across the admin store flip (wire-connected)', () => {
+  let adminOwner: PgPool;
+  let mainOwner: PgPool;
+  let appPool: PgPool;
+  let procPool: PgPool;
+
+  const workerDeps = () => ({
+    mainPool: mainOwner,
+    adminPool: procPool,
+    env: { ADMIN_DATABASE_URL: url },
+  });
+
+  async function resetBothStores(): Promise<void> {
+    // Close login pools BEFORE dropping their roles/schema — see recreate below.
+    await Promise.all([appPool?.end(), procPool?.end()]);
+    // Admin store: same fresh-DB reset as the db package's admin suites.
+    await adminOwner.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await adminOwner.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await adminOwner.query('CREATE SCHEMA public');
+    for (const role of ALL_ROLES) {
+      await adminOwner.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+    const previousCwd = process.cwd();
+    process.chdir(path.resolve(__dirname, '../../../../../packages/db'));
+    try {
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    } finally {
+      process.chdir(previousCwd);
+    }
+    const result = await provisionAdminLoginUsers({ ADMIN_DATABASE_URL: url, ...PASSWORDS });
+    expect(result.provisioned).toEqual(['admin_app_user', 'admin_processor_user']);
+
+    // Sessions opened before a schema reset hold the DROPPED public schema's
+    // OID in their search_path cache and stop seeing the recreated tables —
+    // fresh pools per reset.
+    appPool = new Pool(loginConfig('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD));
+    procPool = new Pool(loginConfig('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD));
+
+    // Main (legacy) store: minimal DDL matching the worker's raw SQL.
+    await mainOwner.query('DROP TABLE IF EXISTS activity_logs, security_audit_log, siem_delivery_cursors, siem_delivery_receipts');
+    await mainOwner.query(MAIN_TABLES_DDL);
+  }
+
+  beforeAll(async () => {
+    adminOwner = new Pool({ connectionString: url, max: 3 });
+    await adminOwner
+      .query(`CREATE DATABASE ${MAIN_DB_NAME}`)
+      .catch((err: unknown) => {
+        if ((err as { code?: string }).code !== '42P04') throw err; // 42P04 = already exists
+      });
+    mainOwner = new Pool({ connectionString: mainDbUrl(), max: 3 });
+    // appPool/procPool are created (and recreated) by resetBothStores.
+  });
+
+  afterAll(async () => {
+    await Promise.all([adminOwner?.end(), mainOwner?.end(), appPool?.end(), procPool?.end()]);
+  });
+
+  beforeEach(() => {
+    deliveredBatches.length = 0;
+    mockDeliver.mockClear();
+    resetSiemModeBannerForTests();
+  });
+
+  describe('flip with prompt backfill — exactly-once continuity', () => {
+    const legacy = buildLegacyChain(5); // r1..r5, r1..r3 already shipped pre-flip
+    const activity = buildActivityChain(2); // a0 shipped, a1 pending
+
+    beforeAll(async () => {
+      await resetBothStores();
+      await insertLegacySecurityRows(mainOwner, legacy);
+      await insertActivityRows(mainOwner, activity);
+      await setCursor(mainOwner, 'security_audit_log', 'r3', legacy[2].timestamp, 3);
+      await setCursor(mainOwner, 'activity_logs', 'a0', activity[0].timestamp, 1);
+    });
+
+    it('run 1 seeds the admin cursors from the legacy watermark and delivers nothing', async () => {
+      await processSiemDelivery(workerDeps());
+
+      expect(mockDeliver).not.toHaveBeenCalled();
+
+      const sec = await readCursor(procPool, 'security_audit_log');
+      const act = await readCursor(procPool, 'activity_logs');
+      expect(sec).toMatchObject({ lastDeliveredId: 'r3', deliveryCount: 3 });
+      expect(sec?.lastDeliveredAt.toISOString()).toBe(legacy[2].timestamp.toISOString());
+      expect(act).toMatchObject({ lastDeliveredId: 'a0', deliveryCount: 1 });
+
+      // The legacy cursors are untouched — the admin copies are now authoritative.
+      const legacySec = await readCursor(mainOwner, 'security_audit_log');
+      expect(legacySec).toMatchObject({ lastDeliveredId: 'r3', deliveryCount: 3 });
+    });
+
+    it('run 2 (admin security store still empty) ships pending activity from main; receipts land in ADMIN only', async () => {
+      await processSiemDelivery(workerDeps());
+
+      expect(deliveredBatches).toHaveLength(1);
+      expect(deliveredBatches[0].map((e) => `${e.source}:${e.id}`)).toEqual(['activity_logs:a1']);
+
+      const act = await readCursor(procPool, 'activity_logs');
+      expect(act).toMatchObject({ lastDeliveredId: 'a1', deliveryCount: 2, lastError: null });
+
+      // Receipt attestation went to the ADMIN receipts table (the main DB
+      // doesn't even have one — a misroute would have thrown).
+      const receipts = await adminOwner.query(
+        `SELECT source, "firstEntryId", "lastEntryId", "entryCount" FROM siem_delivery_receipts ORDER BY "deliveredAt" DESC`
+      );
+      expect(receipts.rows).toEqual([
+        { source: 'activity_logs', firstEntryId: 'a1', lastEntryId: 'a1', entryCount: 1 },
+      ]);
+
+      // Security cursor pinned at the seeded watermark — nothing to ship yet.
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'r3', deliveryCount: 3, lastError: null });
+    });
+
+    it('after backfill + chainer append + pseudonymization, delivery resumes exactly once across the era boundary', async () => {
+      // Backfill: plant ALL legacy rows into the admin store — original ids,
+      // timestamps, hashes, preserved chain_seq — then align the sequence.
+      await insertLegacySecurityRows(adminOwner, legacy, { chainSeqBase: 0 });
+      await adminOwner.query(`SELECT setval('security_audit_log_chain_seq_seq', 5)`);
+
+      // Pseudonymize r4 (undelivered!) the way the eraser role does: PII
+      // nulled, hash columns untouched. Chain verification and delivery must
+      // both survive this (#890 leaf 6 handoff).
+      await adminOwner.query(
+        `UPDATE security_audit_log SET ip_address = NULL, user_agent = NULL, geo_location = NULL, session_id = NULL WHERE id = 'r4'`
+      );
+
+      // New-era events e6, e7 flow through the REAL ingest + chainer.
+      const e6: AuditEvent = {
+        eventType: 'data.read',
+        userId: 'user-6',
+        serviceId: 'web',
+        resourceType: 'page',
+        resourceId: 'p-6',
+        details: { era: 'chainer', n: 6 },
+      };
+      const e7: AuditEvent = {
+        eventType: 'data.read',
+        userId: 'user-7',
+        serviceId: 'web',
+        resourceType: 'page',
+        resourceId: 'p-7',
+        details: { era: 'chainer', n: 7 },
+      };
+      await seedIngestRows(appPool, [
+        { id: 'e6', event: e6, timestamp: T(6), emittedAt: T(6) },
+        { id: 'e7', event: e7, timestamp: T(7), emittedAt: T(7) },
+      ]);
+      const chained = await processAuditChainer({ pool: procPool });
+      expect(chained).toMatchObject({ outcome: 'chained', drained: 2 });
+      expect(chained.verification?.valid).toBe(true);
+
+      // The chainer linked the new era onto the backfilled legacy head.
+      const boundary = await adminOwner.query(
+        `SELECT id, previous_hash FROM security_audit_log WHERE id = 'e6'`
+      );
+      expect(boundary.rows[0].previous_hash).toBe(legacy[4].eventHash);
+
+      await processSiemDelivery(workerDeps());
+
+      // EXACTLY the undelivered rows, in order, exactly once: r4 (erased),
+      // r5 (legacy), e6, e7 (chainer era). r1..r3 never replay.
+      expect(deliveredBatches).toHaveLength(1);
+      expect(deliveredBatches[0].map((e) => `${e.source}:${e.id}`)).toEqual([
+        'security_audit_log:r4',
+        'security_audit_log:r5',
+        'security_audit_log:e6',
+        'security_audit_log:e7',
+      ]);
+
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'e7', deliveryCount: 7, lastError: null });
+      expect(sec?.lastDeliveredAt.toISOString()).toBe(T(7).toISOString());
+
+      const receipts = await adminOwner.query(
+        `SELECT source, "firstEntryId", "lastEntryId", "entryCount" FROM siem_delivery_receipts WHERE source = 'security_audit_log'`
+      );
+      expect(receipts.rows).toEqual([
+        { source: 'security_audit_log', firstEntryId: 'r4', lastEntryId: 'e7', entryCount: 4 },
+      ]);
+    });
+
+    it('an idle rerun delivers nothing again — no replays after the flip settles', async () => {
+      await processSiemDelivery(workerDeps());
+
+      expect(mockDeliver).not.toHaveBeenCalled();
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({ lastDeliveredId: 'e7', deliveryCount: 7 });
+    });
+  });
+
+  describe('pre-backfill deferral — new-era rows exist but the anchor is not planted yet', () => {
+    const legacy = buildLegacyChain(3); // r1..r3, r1..r2 shipped pre-flip
+    const activity = buildActivityChain(2);
+
+    beforeAll(async () => {
+      await resetBothStores();
+      await insertLegacySecurityRows(mainOwner, legacy);
+      await insertActivityRows(mainOwner, activity);
+      await setCursor(mainOwner, 'security_audit_log', 'r2', legacy[1].timestamp, 2);
+      await setCursor(mainOwner, 'activity_logs', 'a0', activity[0].timestamp, 1);
+
+      // New-era events land in the admin store BEFORE any backfill ran —
+      // the exact transitional window leaf 5 flagged. (Fresh store, so this
+      // chain starts at genesis; leaf 8 reconciles the two chains.)
+      await seedIngestRows(appPool, [
+        {
+          id: 'g1',
+          event: { eventType: 'data.read', userId: 'user-g', resourceType: 'page', resourceId: 'p-g1' } as AuditEvent,
+          timestamp: T(60),
+          emittedAt: T(60),
+        },
+      ]);
+      const chained = await processAuditChainer({ pool: procPool });
+      expect(chained).toMatchObject({ outcome: 'chained', drained: 1 });
+    });
+
+    it('defers the security source (no delivery, no error, cursor pinned) while activity keeps flowing', async () => {
+      // Run 1: seeding only.
+      await processSiemDelivery(workerDeps());
+      expect(mockDeliver).not.toHaveBeenCalled();
+
+      // Run 2: security has a pending admin row (g1) but the anchor r2 is
+      // not backfilled — deferral must drop g1 from the batch and let a1 ship.
+      await processSiemDelivery(workerDeps());
+
+      expect(deliveredBatches).toHaveLength(1);
+      expect(deliveredBatches[0].map((e) => `${e.source}:${e.id}`)).toEqual(['activity_logs:a1']);
+
+      const sec = await readCursor(procPool, 'security_audit_log');
+      expect(sec).toMatchObject({
+        lastDeliveredId: 'r2',
+        deliveryCount: 2,
+        // A deferral is an expected deployment state, NOT an error — /health
+        // must not go red over it.
+        lastError: null,
+      });
+
+      const act = await readCursor(procPool, 'activity_logs');
+      expect(act).toMatchObject({ lastDeliveredId: 'a1', deliveryCount: 2 });
+    });
+  });
+});

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, vi } from 'vitest';
 import { assert } from '../../__tests__/riteway';
 
 const {
@@ -48,6 +48,11 @@ vi.mock('../../db', () => ({
       release: mockRelease,
     }),
   })),
+  // Never reached by the legacy-mode suite (break-glass routes everything to
+  // main); the dedicated-mode suite injects its own pools via deps instead.
+  getAdminPoolForWorker: vi.fn(() => {
+    throw new Error('getAdminPoolForWorker must not be called in break-glass mode tests');
+  }),
 }));
 
 // Default preflight stub: returns null (chain verifies clean, no halt). Tests
@@ -63,7 +68,7 @@ vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
   notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
 }));
 
-import { processSiemDelivery } from '../siem-delivery-worker';
+import { processSiemDelivery, resetSiemModeBannerForTests } from '../siem-delivery-worker';
 import { SIEM_SOURCES } from '../../services/siem-sources';
 import type { AuditLogSource } from '../../services/siem-adapter';
 
@@ -209,9 +214,20 @@ function findAllCallsContaining(needle: string): unknown[][] {
 describe('processSiemDelivery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // This suite exercises the LEGACY single-store worker behavior, which
+    // post-cutover (#890 Phase 2) is exactly the break-glass routing: every
+    // operation on the main pool, one client, unchanged query sequence. The
+    // dedicated-mode pool matrix has its own suite below.
+    vi.stubEnv('ADMIN_DATABASE_URL', '');
+    vi.stubEnv('ADMIN_DB_BREAK_GLASS', 'true');
+    resetSiemModeBannerForTests();
     // Default: preflight verifies clean. Individual tamper tests override this.
     mockRunChainPreflight.mockResolvedValue(null);
     mockNotifyChainPreflightFailure.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('short-circuit when SIEM disabled', async () => {
@@ -1497,6 +1513,7 @@ describe('processSiemDelivery', () => {
     stubSourceRows([makeSecurityRow('sec_clean', new Date('2026-04-10T12:05:00Z'))]);
 
     mockRunChainPreflight.mockResolvedValue({
+      kind: 'tamper',
       source: 'activity_logs',
       entryId: 'log_tampered',
       breakAtIndex: 0,
@@ -1529,6 +1546,7 @@ describe('processSiemDelivery', () => {
     stubSourceRows([]);
 
     mockRunChainPreflight.mockResolvedValue({
+      kind: 'tamper',
       source: 'activity_logs',
       entryId: 'log_tampered',
       breakAtIndex: 0,
@@ -1591,6 +1609,7 @@ describe('processSiemDelivery', () => {
     stubSourceRows([makeSecurityRow('sec_clean', new Date('2026-04-10T12:05:00Z'))]);
 
     mockRunChainPreflight.mockResolvedValue({
+      kind: 'tamper',
       source: 'activity_logs',
       entryId: 'log_tampered',
       breakAtIndex: 0,
@@ -1630,6 +1649,7 @@ describe('processSiemDelivery', () => {
     stubSourceRows([]);
 
     mockRunChainPreflight.mockResolvedValue({
+      kind: 'tamper',
       source: 'activity_logs',
       entryId: 'log_tampered',
       breakAtIndex: 0,
@@ -1720,6 +1740,7 @@ describe('processSiemDelivery', () => {
     stubSourceRows([]);
 
     mockRunChainPreflight.mockResolvedValue({
+      kind: 'tamper',
       source: 'activity_logs',
       entryId: 'log_tampered',
       breakAtIndex: 0,
@@ -1999,6 +2020,320 @@ describe('processSiemDelivery', () => {
       should: 'emit the receipt INSERT after the cursor advance UPSERT',
       actual: advanceIdx >= 0 && receiptIdx > advanceIdx,
       expected: true,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedicated-mode pool-per-operation matrix (#890 Phase 2 leaf 7).
+//
+// These tests inject BOTH pools via deps and tag every query with the store
+// that served it, pinning the cutover matrix:
+//   advisory lock            → main (rolling-deploy serialization)
+//   cursors + receipts       → admin (both sources)
+//   activity_logs data       → main (moves in Phase 5)
+//   security_audit_log data  → admin
+// plus the flip behaviors: legacy-cursor seeding, data-store-clock init, the
+// awaiting-backfill deferral, and the fail-mode halt.
+// ---------------------------------------------------------------------------
+
+interface TaggedStore {
+  calls: { sql: string; params?: unknown[] }[];
+  released: number;
+  connects: number;
+  pool: { connect(): Promise<{ query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>; release(): void }> };
+}
+
+type StoreResponder = (sql: string, params?: unknown[]) => Record<string, unknown>[] | null;
+
+function createTaggedStore(respond: StoreResponder): TaggedStore {
+  const store: TaggedStore = {
+    calls: [],
+    released: 0,
+    connects: 0,
+    pool: {
+      connect: async () => {
+        store.connects += 1;
+        return {
+          query: async (sql: string, params?: unknown[]) => {
+            store.calls.push({ sql, params });
+            const rows = respond(sql, params);
+            if (rows === null) {
+              throw new Error(`Unhandled SQL in tagged store: ${sql.slice(0, 120)}`);
+            }
+            return { rows, rowCount: rows.length };
+          },
+          release: () => {
+            store.released += 1;
+          },
+        };
+      },
+    },
+  };
+  return store;
+}
+
+const DEDICATED_ENV = { ADMIN_DATABASE_URL: 'postgresql://admin_processor_user:pw@admin-host:5432/pagespace_admin' };
+
+const CURSOR_TS = new Date('2026-04-10T10:00:00Z');
+
+function initializedCursorRow(id: string) {
+  return { lastDeliveredId: id, lastDeliveredAt: CURSOR_TS, deliveryCount: 3 };
+}
+
+describe('processSiemDelivery dedicated-mode pool matrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetSiemModeBannerForTests();
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+    mockRunChainPreflight.mockResolvedValue(null);
+    mockNotifyChainPreflightFailure.mockResolvedValue(undefined);
+  });
+
+  function respondMain(overrides?: StoreResponder): StoreResponder {
+    return (sql, params) => {
+      const custom = overrides?.(sql, params);
+      if (custom !== null && custom !== undefined) return custom;
+      if (sql.includes('pg_try_advisory_lock')) return [{ acquired: true }];
+      if (sql.includes('pg_advisory_unlock')) return [];
+      if (sql.includes('FROM activity_logs')) {
+        return [makeActivityRow('act_new', new Date('2026-04-10T12:00:00Z'))];
+      }
+      return null;
+    };
+  }
+
+  function respondAdmin(overrides?: StoreResponder): StoreResponder {
+    return (sql, params) => {
+      const custom = overrides?.(sql, params);
+      if (custom !== null && custom !== undefined) return custom;
+      if (sql.includes('FROM siem_delivery_cursors WHERE id =')) {
+        const source = String(params?.[0]);
+        return [initializedCursorRow(source === 'activity_logs' ? 'act_prev' : 'sec_prev')];
+      }
+      if (sql.includes('FROM security_audit_log')) {
+        return [makeSecurityRow('sec_new', new Date('2026-04-10T12:01:00Z'))];
+      }
+      if (sql === 'BEGIN' || sql === 'COMMIT') return [];
+      if (sql.includes('INSERT INTO siem_delivery_cursors')) return [];
+      if (sql.includes('INSERT INTO siem_delivery_receipts')) return [];
+      return null;
+    };
+  }
+
+  it('given a successful dual-source delivery, should route every operation to its matrix plane', async () => {
+    const main = createTaggedStore(respondMain());
+    const admin = createTaggedStore(respondAdmin());
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 2 });
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: DEDICATED_ENV });
+
+    const has = (store: TaggedStore, needle: string) =>
+      store.calls.filter((c) => c.sql.includes(needle)).length;
+
+    assert({
+      given: 'dedicated mode',
+      should: 'take and release the advisory lock on MAIN only',
+      actual: {
+        lockMain: has(main, 'pg_try_advisory_lock'),
+        unlockMain: has(main, 'pg_advisory_unlock'),
+        lockAdmin: has(admin, 'pg_try_advisory_lock') + has(admin, 'pg_advisory_unlock'),
+      },
+      expected: { lockMain: 1, unlockMain: 1, lockAdmin: 0 },
+    });
+    assert({
+      given: 'dedicated mode',
+      should: 'read BOTH cursors from admin and none from main',
+      actual: {
+        admin: has(admin, 'FROM siem_delivery_cursors'),
+        main: has(main, 'FROM siem_delivery_cursors'),
+      },
+      expected: { admin: 2, main: 0 },
+    });
+    assert({
+      given: 'dedicated mode',
+      should: 'read activity_logs data from MAIN and security_audit_log data from ADMIN',
+      actual: {
+        activityOnMain: has(main, 'FROM activity_logs'),
+        activityOnAdmin: has(admin, 'FROM activity_logs'),
+        securityOnAdmin: has(admin, 'FROM security_audit_log'),
+        securityOnMain: has(main, 'FROM security_audit_log'),
+      },
+      expected: { activityOnMain: 1, activityOnAdmin: 0, securityOnAdmin: 1, securityOnMain: 0 },
+    });
+    assert({
+      given: 'dedicated mode',
+      should: 'advance cursors and write receipts inside one ADMIN transaction, nothing on main',
+      actual: {
+        beginAdmin: admin.calls.filter((c) => c.sql === 'BEGIN').length,
+        commitAdmin: admin.calls.filter((c) => c.sql === 'COMMIT').length,
+        advancesAdmin: has(admin, '"deliveryCount" = $4'),
+        receiptsAdmin: has(admin, 'INSERT INTO siem_delivery_receipts'),
+        writesOnMain:
+          has(main, 'INSERT INTO siem_delivery_cursors') +
+          has(main, 'INSERT INTO siem_delivery_receipts') +
+          main.calls.filter((c) => c.sql === 'BEGIN').length,
+      },
+      expected: { beginAdmin: 1, commitAdmin: 1, advancesAdmin: 2, receiptsAdmin: 1, writesOnMain: 0 },
+    });
+    assert({
+      given: 'the run finished',
+      should: 'release both clients exactly once',
+      actual: { main: main.released, admin: admin.released },
+      expected: { main: 1, admin: 1 },
+    });
+  });
+
+  it('given an uninitialized admin cursor and an initialized legacy cursor, should seed the admin cursor with the EXACT legacy watermark and deliver nothing that run', async () => {
+    const legacyTuple = {
+      lastDeliveredId: 'legacy_row_42',
+      lastDeliveredAt: new Date('2026-04-09T08:30:00Z'),
+      deliveryCount: 977,
+    };
+    const main = createTaggedStore((sql, params) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ acquired: true }];
+      if (sql.includes('pg_advisory_unlock')) return [];
+      if (sql.includes('FROM siem_delivery_cursors WHERE id =')) {
+        // The LEGACY cursor read during seeding.
+        return [legacyTuple];
+      }
+      return null;
+    });
+    const seedWrites: unknown[][] = [];
+    const admin = createTaggedStore((sql, params) => {
+      if (sql.includes('FROM siem_delivery_cursors WHERE id =')) return []; // uninitialized
+      if (sql.includes('INSERT INTO siem_delivery_cursors')) {
+        seedWrites.push(params ?? []);
+        return [legacyTuple];
+      }
+      return null;
+    });
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: DEDICATED_ENV });
+
+    assert({
+      given: 'both sources uninitialized on admin with legacy cursors present',
+      should: 'copy each legacy tuple into the admin cursors table verbatim',
+      actual: seedWrites,
+      expected: [
+        ['activity_logs', 'legacy_row_42', legacyTuple.lastDeliveredAt, 977],
+        ['security_audit_log', 'legacy_row_42', legacyTuple.lastDeliveredAt, 977],
+      ],
+    });
+    assert({
+      given: 'a seeding run',
+      should: 'not query source rows, deliver, or write the legacy cursor',
+      actual: {
+        delivered: mockDeliverToSiemWithRetry.mock.calls.length,
+        mainDataReads: main.calls.filter((c) => c.sql.includes('FROM activity_logs')).length,
+        adminDataReads: admin.calls.filter((c) => c.sql.includes('FROM security_audit_log')).length,
+        legacyCursorWrites: main.calls.filter((c) => c.sql.includes('INSERT INTO siem_delivery_cursors')).length,
+      },
+      expected: { delivered: 0, mainDataReads: 0, adminDataReads: 0, legacyCursorWrites: 0 },
+    });
+  });
+
+  it('given NO cursor anywhere (fresh install), should plant activity_logs at the MAIN clock and security_audit_log inline on admin', async () => {
+    const plantedAt = new Date('2026-04-10T11:11:11Z');
+    const main = createTaggedStore((sql) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ acquired: true }];
+      if (sql.includes('pg_advisory_unlock')) return [];
+      if (sql.includes('FROM siem_delivery_cursors WHERE id =')) return []; // no legacy cursor
+      if (sql.includes('statement_timestamp() AS now')) return [{ now: plantedAt }];
+      return null;
+    });
+    const inits: { sql: string; params?: unknown[] }[] = [];
+    const admin = createTaggedStore((sql, params) => {
+      if (sql.includes('FROM siem_delivery_cursors WHERE id =')) return [];
+      if (sql.includes('INSERT INTO siem_delivery_cursors')) {
+        inits.push({ sql, params });
+        return [{ lastDeliveredId: '__cursor_init__', lastDeliveredAt: plantedAt, deliveryCount: 0 }];
+      }
+      return null;
+    });
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: DEDICATED_ENV });
+
+    assert({
+      given: 'a fresh install in dedicated mode',
+      should: 'sample the MAIN clock exactly once (for the main-plane data source)',
+      actual: main.calls.filter((c) => c.sql.includes('statement_timestamp() AS now')).length,
+      expected: 1,
+    });
+    assert({
+      given: 'the two init upserts (activity first, security second)',
+      should: 'plant activity_logs with the sampled main clock and security inline via statement_timestamp()',
+      actual: {
+        count: inits.length,
+        activityUsesParamClock: inits[0]?.params?.length === 3 && inits[0]?.params?.[2] === plantedAt,
+        securityUsesInlineClock:
+          inits[1]?.params?.length === 2 && inits[1]?.sql.includes('statement_timestamp()'),
+      },
+      expected: { count: 2, activityUsesParamClock: true, securityUsesInlineClock: true },
+    });
+  });
+
+  it('given preflight reports awaiting_backfill for security, should deliver ONLY activity entries and leave the security cursor untouched', async () => {
+    const main = createTaggedStore(respondMain());
+    const admin = createTaggedStore(respondAdmin());
+    mockRunChainPreflight.mockResolvedValue({
+      kind: 'awaiting_backfill',
+      source: 'security_audit_log',
+      anchorId: 'sec_prev',
+    });
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 1 });
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: DEDICATED_ENV });
+
+    const deliveredBatch = mockDeliverToSiemWithRetry.mock.calls[0]?.[1] as { source: string; id: string }[];
+    assert({
+      given: 'an awaiting-backfill deferral on the security source',
+      should: 'deliver a batch containing only activity_logs entries',
+      actual: deliveredBatch.map((e) => e.source),
+      expected: ['activity_logs'],
+    });
+
+    const advances = admin.calls.filter((c) => c.sql.includes('"deliveryCount" = $4'));
+    assert({
+      given: 'the deferral',
+      should: 'advance only the activity cursor and record NO error rows',
+      actual: {
+        advancedSources: advances.map((c) => c.params?.[0]),
+        errorWrites: admin.calls.filter((c) => c.sql.includes('"lastError" = $2')).length,
+      },
+      expected: { advancedSources: ['activity_logs'], errorWrites: 0 },
+    });
+  });
+
+  it('given fail mode (no admin URL, no break-glass), should halt before touching any pool', async () => {
+    const main = createTaggedStore(() => null);
+    const admin = createTaggedStore(() => null);
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: {} });
+
+    assert({
+      given: 'an unconfigured trust plane',
+      should: 'never connect to either store',
+      actual: { main: main.connects, admin: admin.connects },
+      expected: { main: 0, admin: 0 },
+    });
+  });
+
+  it('given the advisory lock is busy, should never open an admin connection', async () => {
+    const main = createTaggedStore((sql) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ acquired: false }];
+      return null;
+    });
+    const admin = createTaggedStore(() => null);
+
+    await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: DEDICATED_ENV });
+
+    assert({
+      given: 'a lock-busy run in dedicated mode',
+      should: 'skip the admin connect entirely',
+      actual: { adminConnects: admin.connects, mainReleased: main.released },
+      expected: { adminConnects: 0, mainReleased: 1 },
     });
   });
 });

--- a/apps/processor/src/workers/audit-chainer-worker.ts
+++ b/apps/processor/src/workers/audit-chainer-worker.ts
@@ -301,7 +301,12 @@ function buildChainedInsert(payloads: ChainedRowPayload[]): { text: string; valu
       p.details === null ? null : JSON.stringify(p.details),
       p.riskScore,
       p.anomalyFlags,
-      p.timestamp,
+      // Serialized explicitly: a raw-pg Date param stores LOCAL wall clock in
+      // the tz-less timestamp column, shifting the hashed instant on non-UTC
+      // processors (the UTC read parser in admin-pg-types.ts is the other
+      // half). A string (pool without the admin types config) is already the
+      // zone-free wall clock and passes through byte-identical.
+      p.timestamp instanceof Date ? p.timestamp.toISOString() : p.timestamp,
       p.emissionHash,
       p.previousHash,
       p.eventHash,

--- a/apps/processor/src/workers/audit-chainer-worker.ts
+++ b/apps/processor/src/workers/audit-chainer-worker.ts
@@ -23,6 +23,13 @@
  * production write path stays on the advisory-lock repository until leaf 5
  * cuts emission over, so the queue is simply empty until then.
  *
+ * ERA-FORK GUARD: chaining from a 'genesis' head is refused unless
+ * AUDIT_CHAINER_ALLOW_GENESIS=true — set ONLY on fresh installs. On upgrades
+ * the head is empty until the legacy backfill runs, and chaining new events
+ * from genesis there would fork the eras irrecoverably (see UPGRADE.md
+ * Phase 2); the ingest queue buffers losslessly until the backfill plants
+ * the legacy head.
+ *
  * ANCHORING (leaf 3): after a 'chained' run whose verify-on-append is green,
  * the fresh head (newHead + its chain_seq) is signed (pure core:
  * @pagespace/lib/audit/anchor) and published to the configured witness
@@ -89,7 +96,8 @@ const INGEST_COLUMNS = `id,
 // because the processor build is self-contained (see ../db).
 interface PgClient {
   query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
-  release(): void;
+  /** pg semantics: release(err) DESTROYS the connection instead of pooling it. */
+  release(destroyWithError?: Error): void;
 }
 
 interface PgPool {
@@ -117,7 +125,7 @@ export interface AnchorPublishSummary {
 }
 
 export interface AuditChainerRunResult {
-  outcome: 'disabled' | 'lock_busy' | 'idle' | 'chained';
+  outcome: 'disabled' | 'lock_busy' | 'idle' | 'genesis_refused' | 'chained';
   drained: number;
   verification?: SegmentVerificationResult;
   /** event_hash of the last appended row — the anchored head. */
@@ -359,6 +367,26 @@ export async function processAuditChainer(
 
     const ingestRows = ingest.rows as unknown as ChainableIngestRow[];
     const priorHead = await readChainHead(client);
+
+    // Era-fork guard (#890 Phase 2 FIX): an empty admin head means either a
+    // fresh install (nothing to backfill — chaining from genesis is correct)
+    // or an UPGRADE whose backfill has not run yet — chaining from genesis
+    // there forks the eras irrecoverably (chain columns are append-only;
+    // remediation is owner-level surgery, worse once anchors are published).
+    // Only the operator can tell the two apart, so a genesis link requires
+    // the explicit fresh-install flag; the ingest queue is a lossless buffer
+    // and simply holds the rows until the backfill plants the legacy head.
+    if (priorHead === GENESIS_PREVIOUS_HASH && process.env.AUDIT_CHAINER_ALLOW_GENESIS !== 'true') {
+      console.error(
+        `[audit-chainer] REFUSING to chain ${ingestRows.length} ingest row(s) from a GENESIS head: ` +
+          'the admin chain is empty. On a fresh install set AUDIT_CHAINER_ALLOW_GENESIS=true; on an ' +
+          'upgrade run the legacy backfill (scripts/backfill-audit-db.ts) first — the head becomes ' +
+          'non-genesis and chaining resumes on its own. Chaining now would fork the legacy and ' +
+          'emission eras irrecoverably. Ingest rows are buffered, not lost.',
+      );
+      return { outcome: 'genesis_refused', drained: 0 };
+    }
+
     const { chainedRowPayloads, newHead } = assignChainBatch(ingestRows, { prevHash: priorHead });
     const drainedIds = chainedRowPayloads.map((p) => p.id);
 
@@ -452,10 +480,23 @@ export async function processAuditChainer(
     throw error;
   } finally {
     if (lockAcquired) {
-      await client
-        .query('SELECT pg_advisory_unlock(hashtext($1))', [ADVISORY_LOCK_KEY])
-        .catch(() => undefined);
+      try {
+        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [ADVISORY_LOCK_KEY]);
+        client.release();
+      } catch (unlockError) {
+        // A session that failed to unlock may still hold the session-level
+        // advisory lock; returned to the pool alive it would leak the lock
+        // permanently (every future run lock_busy). Destroy it instead —
+        // Postgres releases session advisory locks when the backend dies.
+        const err =
+          unlockError instanceof Error ? unlockError : new Error(String(unlockError));
+        console.error(
+          `[audit-chainer] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool: ${err.message}`,
+        );
+        client.release(err);
+      }
+    } else {
+      client.release();
     }
-    client.release();
   }
 }

--- a/apps/processor/src/workers/audit-chainer-worker.ts
+++ b/apps/processor/src/workers/audit-chainer-worker.ts
@@ -1,0 +1,279 @@
+/**
+ * Audit chainer worker — the single writer of the security_audit_log chain
+ * (#890 Phase 2, leaf 2).
+ *
+ * Drains the Admin PG ingest queue (security_audit_ingest, filled by the
+ * lock-free emission path) in (emitted_at, id) order, assigns chain linkage
+ * via the pure core (@pagespace/lib/audit/chain-step — chainHash =
+ * H(emissionHash, prevHash)), appends the chained rows and deletes the
+ * drained queue rows in ONE transaction, then re-reads what it wrote and
+ * verifies it (verify-on-append). Exactly one process links hashes:
+ * serialization is by construction (run-level advisory lock on the ADMIN
+ * pool), not by contention — this replaces the per-request global
+ * pg_advisory_xact_lock.
+ *
+ * Identity: connects through ADMIN_DATABASE_URL, which for the processor is
+ * admin_processor_user (admin_chainer + admin_siem templates) — SELECT+DELETE
+ * on the ingest queue (the only DELETE in the trust plane), SELECT+INSERT on
+ * security_audit_log, and USAGE on the chain_seq sequence. Nothing more.
+ *
+ * Scheduled by pg-boss every 30s with retryLimit 0 (siem-delivery pattern):
+ * overlapping runs don't stack, and the advisory lock serializes any that
+ * still overlap. When ADMIN_DATABASE_URL is unset the worker no-ops — the
+ * production write path stays on the advisory-lock repository until leaf 5
+ * cuts emission over, so the queue is simply empty until then.
+ *
+ * ANCHORING HOOK (leaf 3): readChainHead below is the head the anchor
+ * publisher signs; after a 'chained' run, result.newHead is the fresh head.
+ */
+
+import {
+  assignChainBatch,
+  verifyAppendedSegment,
+  GENESIS_PREVIOUS_HASH,
+  type ChainableIngestRow,
+  type ChainedRowPayload,
+  type AppendedChainRow,
+  type SegmentVerificationResult,
+} from '@pagespace/lib/audit/chain-step';
+import { notifyChainAppendVerificationFailure } from '@pagespace/lib/audit/security-audit-alerting';
+import { getAdminPoolForWorker } from '../db';
+
+const ADVISORY_LOCK_KEY = 'audit-chainer';
+const DEFAULT_BATCH_SIZE = 500;
+
+// Column list for the drain SELECT — aliased to the camelCase shape the pure
+// core consumes (ChainableIngestRow). emitted_at is drain ordering only and
+// deliberately not selected: it is not chained content.
+const INGEST_COLUMNS = `id,
+        event_type AS "eventType",
+        user_id AS "userId",
+        session_id AS "sessionId",
+        service_id AS "serviceId",
+        resource_type AS "resourceType",
+        resource_id AS "resourceId",
+        ip_address AS "ipAddress",
+        ip_bidx AS "ipBidx",
+        user_agent AS "userAgent",
+        geo_location AS "geoLocation",
+        details,
+        risk_score AS "riskScore",
+        anomaly_flags AS "anomalyFlags",
+        timestamp,
+        emission_hash AS "emissionHash"`;
+
+// Minimal subset of pg's PoolClient API this worker uses — defined locally
+// because the processor build is self-contained (see ../db).
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+
+interface PgPool {
+  connect(): Promise<PgClient>;
+}
+
+export interface AuditChainerOverrides {
+  /** Injected pool (integration tests connect AS a specific login user). */
+  pool?: PgPool;
+  /** Drain batch size (default AUDIT_CHAINER_BATCH_SIZE env or 500). */
+  batchSize?: number;
+}
+
+export interface AuditChainerRunResult {
+  outcome: 'disabled' | 'lock_busy' | 'idle' | 'chained';
+  drained: number;
+  verification?: SegmentVerificationResult;
+  /** event_hash of the last appended row — the anchor publisher's input (leaf 3). */
+  newHead?: string;
+}
+
+function resolveBatchSize(override: number | undefined): number {
+  if (override !== undefined) return override;
+  const fromEnv = Number.parseInt(process.env.AUDIT_CHAINER_BATCH_SIZE ?? '', 10);
+  return Number.isInteger(fromEnv) && fromEnv > 0 ? fromEnv : DEFAULT_BATCH_SIZE;
+}
+
+/**
+ * Read the current chain head: event_hash of the highest chain_seq row, or
+ * the genesis sentinel on an empty chain. This is the single head-read hook —
+ * the anchoring leaf publishes exactly this value, and the backfill leaf's
+ * legacy-head anchor becomes the head this returns once backfill has run
+ * (the first post-cutover batch then links to it with no special casing).
+ */
+async function readChainHead(client: PgClient): Promise<string> {
+  const result = await client.query(
+    'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
+  );
+  return (result.rows[0] as { event_hash: string } | undefined)?.event_hash ?? GENESIS_PREVIOUS_HASH;
+}
+
+/** Build the multi-row parameterized INSERT for a chained batch, in payload order. */
+function buildChainedInsert(payloads: ChainedRowPayload[]): { text: string; values: unknown[] } {
+  const values: unknown[] = [];
+  const rows = payloads.map((p) => {
+    const base = values.length;
+    values.push(
+      p.id,
+      p.eventType,
+      p.userId,
+      p.sessionId,
+      p.serviceId,
+      p.resourceType,
+      p.resourceId,
+      p.ipAddress,
+      p.ipBidx,
+      p.userAgent,
+      p.geoLocation,
+      p.details === null ? null : JSON.stringify(p.details),
+      p.riskScore,
+      p.anomalyFlags,
+      p.timestamp,
+      p.emissionHash,
+      p.previousHash,
+      p.eventHash,
+    );
+    const placeholders = Array.from({ length: 18 }, (_, i) => `$${base + i + 1}`);
+    placeholders[11] = `${placeholders[11]}::jsonb`;
+    return `(${placeholders.join(', ')})`;
+  });
+
+  // chain_seq is deliberately absent: the table default (nextval on the
+  // chain sequence) assigns it per row IN VALUES ORDER, under this worker's
+  // single-writer lock — so chain_seq order always matches linkage order.
+  const text = `INSERT INTO security_audit_log
+      (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+       ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+       anomaly_flags, timestamp, emission_hash, previous_hash, event_hash)
+     VALUES ${rows.join(', ')}`;
+
+  return { text, values };
+}
+
+/**
+ * One chainer run: try-lock → drain a batch → chain (pure) → commit → verify.
+ * Returns a result summary; a run that cannot acquire the advisory lock is a
+ * clean no-op (another instance is the writer for this cycle).
+ */
+export async function processAuditChainer(
+  overrides: AuditChainerOverrides = {},
+): Promise<AuditChainerRunResult> {
+  if (!overrides.pool && !process.env.ADMIN_DATABASE_URL) {
+    // Trust plane not configured — nothing to drain (emission cutover is
+    // leaf 5; until then this is the expected state in unwired deploys).
+    return { outcome: 'disabled', drained: 0 };
+  }
+
+  const pool = overrides.pool ?? getAdminPoolForWorker();
+  const client = await pool.connect();
+  let lockAcquired = false;
+
+  try {
+    const lockResult = await client.query(
+      'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
+      [ADVISORY_LOCK_KEY],
+    );
+    lockAcquired = Boolean(lockResult.rows[0]?.acquired);
+    if (!lockAcquired) {
+      return { outcome: 'lock_busy', drained: 0 };
+    }
+
+    const batchSize = resolveBatchSize(overrides.batchSize);
+    const ingest = await client.query(
+      `SELECT ${INGEST_COLUMNS}
+       FROM security_audit_ingest
+       ORDER BY emitted_at, id
+       LIMIT $1`,
+      [batchSize],
+    );
+    if (ingest.rows.length === 0) {
+      // Idle poll — no log line (same rationale as siem-delivery: the vast
+      // majority of 30s cycles are idle).
+      return { outcome: 'idle', drained: 0 };
+    }
+
+    const ingestRows = ingest.rows as unknown as ChainableIngestRow[];
+    const priorHead = await readChainHead(client);
+    const { chainedRowPayloads, newHead } = assignChainBatch(ingestRows, { prevHash: priorHead });
+    const drainedIds = chainedRowPayloads.map((p) => p.id);
+
+    // Append + drain atomically: if either side fails, the queue keeps the
+    // rows and the next run re-drains them — no event can be lost between
+    // the queue and the chain, and no partial state can double-chain.
+    await client.query('BEGIN');
+    try {
+      const insert = buildChainedInsert(chainedRowPayloads);
+      await client.query(insert.text, insert.values);
+      await client.query('DELETE FROM security_audit_ingest WHERE id = ANY($1::text[])', [
+        drainedIds,
+      ]);
+      await client.query('COMMIT');
+    } catch (txnError) {
+      await client.query('ROLLBACK').catch(() => undefined);
+      throw txnError;
+    }
+
+    // Verify-on-append: re-read the segment AS STORED (not the in-memory
+    // payloads) and recompute every link from the persisted emission hashes.
+    const appended = await client.query(
+      `SELECT id,
+              emission_hash AS "emissionHash",
+              previous_hash AS "previousHash",
+              event_hash AS "eventHash"
+       FROM security_audit_log
+       WHERE id = ANY($1::text[])
+       ORDER BY chain_seq ASC`,
+      [drainedIds],
+    );
+    const verification = verifyAppendedSegment(
+      appended.rows as unknown as AppendedChainRow[],
+      { prevHash: priorHead },
+    );
+
+    if (!verification.valid) {
+      // Loud path: structured stderr for operators + the chain-verification
+      // alert surface (#544). The alert helper swallows handler errors
+      // internally, but wrap defensively — a broken alert surface must never
+      // mask the detection or skip the lock release in the finally.
+      console.error(
+        `[audit-chainer] VERIFY-ON-APPEND FAILED index=${verification.breakAtIndex} entry=${verification.entryId} reason=${verification.reason} expected=${verification.expectedHash} actual=${verification.actualHash} priorHead=${priorHead}`,
+      );
+      try {
+        await notifyChainAppendVerificationFailure({
+          entryId: verification.entryId,
+          breakAtIndex: verification.breakAtIndex,
+          breakReason: verification.reason,
+          expectedHash: verification.expectedHash,
+          actualHash: verification.actualHash,
+          segmentTotalRows: chainedRowPayloads.length,
+          priorHead,
+        });
+      } catch (alertError) {
+        const msg = alertError instanceof Error ? alertError.message : String(alertError);
+        console.warn(`[audit-chainer] Append verification alert failed: ${msg}`);
+      }
+    } else {
+      console.log(
+        `[audit-chainer] Chained ${chainedRowPayloads.length} events (verify-on-append ok, head ${newHead.prevHash.slice(0, 12)}…)`,
+      );
+    }
+
+    return {
+      outcome: 'chained',
+      drained: chainedRowPayloads.length,
+      verification,
+      newHead: newHead.prevHash,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[audit-chainer] Worker error:', message);
+    throw error;
+  } finally {
+    if (lockAcquired) {
+      await client
+        .query('SELECT pg_advisory_unlock(hashtext($1))', [ADVISORY_LOCK_KEY])
+        .catch(() => undefined);
+    }
+    client.release();
+  }
+}

--- a/apps/processor/src/workers/audit-chainer-worker.ts
+++ b/apps/processor/src/workers/audit-chainer-worker.ts
@@ -23,8 +23,13 @@
  * production write path stays on the advisory-lock repository until leaf 5
  * cuts emission over, so the queue is simply empty until then.
  *
- * ANCHORING HOOK (leaf 3): readChainHead below is the head the anchor
- * publisher signs; after a 'chained' run, result.newHead is the fresh head.
+ * ANCHORING (leaf 3): after a 'chained' run whose verify-on-append is green,
+ * the fresh head (newHead + its chain_seq) is signed (pure core:
+ * @pagespace/lib/audit/anchor) and published to the configured witness
+ * surfaces (S3 Object-Lock + the security_audit_anchors receipt table) per
+ * the interval policy (AUDIT_ANCHOR_EVERY_RUNS / AUDIT_ANCHOR_MIN_INTERVAL_S).
+ * Publish failure NEVER blocks or corrupts chaining — loud logging plus an
+ * alert on a repeated-failure streak.
  */
 
 import {
@@ -36,11 +41,29 @@ import {
   type AppendedChainRow,
   type SegmentVerificationResult,
 } from '@pagespace/lib/audit/chain-step';
-import { notifyChainAppendVerificationFailure } from '@pagespace/lib/audit/security-audit-alerting';
+import { buildAnchorPayload } from '@pagespace/lib/audit/anchor';
+import {
+  notifyChainAppendVerificationFailure,
+  notifyAnchorPublishFailure,
+} from '@pagespace/lib/audit/security-audit-alerting';
+import {
+  loadAnchorConfig,
+  validateAnchorConfig,
+  createS3AnchorPublisher,
+  createAnchorReceiptPublisher,
+  type AnchorConfig,
+  type AnchorPublisher,
+} from '../services/anchor-publishers';
+import { createS3Client } from '../s3-client';
 import { getAdminPoolForWorker } from '../db';
 
 const ADVISORY_LOCK_KEY = 'audit-chainer';
 const DEFAULT_BATCH_SIZE = 500;
+
+// Alert every time a publisher's consecutive-failure streak reaches a
+// multiple of this — a chain appending unwitnessed for long is exactly the
+// window a tamper needs.
+const ANCHOR_FAILURE_ALERT_STREAK = 3;
 
 // Column list for the drain SELECT — aliased to the camelCase shape the pure
 // core consumes (ChainableIngestRow). emitted_at is drain ordering only and
@@ -78,14 +101,51 @@ export interface AuditChainerOverrides {
   pool?: PgPool;
   /** Drain batch size (default AUDIT_CHAINER_BATCH_SIZE env or 500). */
   batchSize?: number;
+  /** Injected anchor config (default: loadAnchorConfig() from env). */
+  anchorConfig?: AnchorConfig;
+  /** Injected witness publishers (default: receipt + S3 when configured). */
+  anchorPublishers?: AnchorPublisher[];
+}
+
+/** What the anchoring hook did after a chained run (absent when anchoring is off). */
+export interface AnchorPublishSummary {
+  attempted: boolean;
+  skippedReason?: 'invalid_config' | 'missing_head_seq' | 'every_runs' | 'min_interval';
+  chainSeq?: number;
+  published?: string[];
+  failed?: string[];
 }
 
 export interface AuditChainerRunResult {
   outcome: 'disabled' | 'lock_busy' | 'idle' | 'chained';
   drained: number;
   verification?: SegmentVerificationResult;
-  /** event_hash of the last appended row — the anchor publisher's input (leaf 3). */
+  /** event_hash of the last appended row — the anchored head. */
   newHead?: string;
+  /** chain_seq of the last appended row (as stored by the table sequence). */
+  newHeadSeq?: number;
+  anchor?: AnchorPublishSummary;
+}
+
+// Anchor scheduling is process-level state: the interval policy spans runs,
+// and the single-writer lock means at most one live chainer per Admin PG —
+// module scope IS the right home for it.
+interface AnchorScheduleState {
+  runsSinceAnchor: number;
+  lastAnchorAtMs: number | null;
+  failureStreaks: Map<string, number>;
+}
+
+const anchorState: AnchorScheduleState = {
+  runsSinceAnchor: 0,
+  lastAnchorAtMs: null,
+  failureStreaks: new Map(),
+};
+
+export function resetAnchorPublishStateForTests(): void {
+  anchorState.runsSinceAnchor = 0;
+  anchorState.lastAnchorAtMs = null;
+  anchorState.failureStreaks.clear();
 }
 
 function resolveBatchSize(override: number | undefined): number {
@@ -106,6 +166,111 @@ async function readChainHead(client: PgClient): Promise<string> {
     'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
   );
   return (result.rows[0] as { event_hash: string } | undefined)?.event_hash ?? GENESIS_PREVIOUS_HASH;
+}
+
+/** Default witness surfaces: the receipt table always; S3 when configured. */
+function buildDefaultAnchorPublishers(config: AnchorConfig, pool: PgPool): AnchorPublisher[] {
+  const publishers: AnchorPublisher[] = [createAnchorReceiptPublisher({ pool })];
+  if (config.s3) {
+    publishers.push(createS3AnchorPublisher({ s3Client: createS3Client(), ...config.s3 }));
+  }
+  return publishers;
+}
+
+/**
+ * Anchor the verified head per the interval policy. Fire-and-forget contract:
+ * this function NEVER throws — a witness surface being down must not block
+ * chaining (the queue drain already committed). Failures log loudly and, on a
+ * repeated streak, escalate through the chain-alert surface.
+ */
+async function maybePublishAnchor(
+  head: string,
+  chainSeq: number | undefined,
+  pool: PgPool,
+  overrides: AuditChainerOverrides,
+): Promise<AnchorPublishSummary | undefined> {
+  const config = overrides.anchorConfig ?? loadAnchorConfig();
+  if (!config.enabled) {
+    return undefined;
+  }
+
+  const validation = validateAnchorConfig(config);
+  if (!validation.valid) {
+    console.error(
+      `[audit-chainer] Anchoring skipped — invalid config: ${validation.errors.join('; ')}`,
+    );
+    return { attempted: false, skippedReason: 'invalid_config' };
+  }
+
+  if (chainSeq === undefined || !Number.isFinite(chainSeq)) {
+    console.error('[audit-chainer] Anchoring skipped — appended head chain_seq unavailable');
+    return { attempted: false, skippedReason: 'missing_head_seq' };
+  }
+
+  anchorState.runsSinceAnchor += 1;
+  if (anchorState.runsSinceAnchor < config.everyRuns) {
+    return { attempted: false, skippedReason: 'every_runs' };
+  }
+  const nowMs = Date.now();
+  if (
+    config.minIntervalS > 0 &&
+    anchorState.lastAnchorAtMs !== null &&
+    nowMs - anchorState.lastAnchorAtMs < config.minIntervalS * 1000
+  ) {
+    return { attempted: false, skippedReason: 'min_interval' };
+  }
+
+  const publishers = overrides.anchorPublishers ?? buildDefaultAnchorPublishers(config, pool);
+  const anchor = buildAnchorPayload({
+    head,
+    chainSeq,
+    anchoredAt: new Date(nowMs),
+    secret: config.secret,
+  });
+
+  const published: string[] = [];
+  const failed: string[] = [];
+  for (const publisher of publishers) {
+    try {
+      await publisher.publish(anchor);
+      published.push(publisher.name);
+      anchorState.failureStreaks.delete(publisher.name);
+    } catch (error) {
+      failed.push(publisher.name);
+      const streak = (anchorState.failureStreaks.get(publisher.name) ?? 0) + 1;
+      anchorState.failureStreaks.set(publisher.name, streak);
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(
+        `[audit-chainer] ANCHOR PUBLISH FAILED publisher=${publisher.name} chainSeq=${chainSeq} head=${head} streak=${streak}: ${message}`,
+      );
+      if (streak % ANCHOR_FAILURE_ALERT_STREAK === 0) {
+        try {
+          await notifyAnchorPublishFailure({
+            publisherName: publisher.name,
+            consecutiveFailures: streak,
+            chainSeq,
+            head,
+            errorMessage: message,
+          });
+        } catch (alertError) {
+          const alertMessage = alertError instanceof Error ? alertError.message : String(alertError);
+          console.warn(`[audit-chainer] Anchor failure alert failed: ${alertMessage}`);
+        }
+      }
+    }
+  }
+
+  if (published.length > 0) {
+    // Only a witnessed head resets the schedule: on total failure the next
+    // chained run retries immediately instead of waiting out the interval.
+    anchorState.runsSinceAnchor = 0;
+    anchorState.lastAnchorAtMs = nowMs;
+    console.log(
+      `[audit-chainer] Anchored head chain_seq=${chainSeq} (${head.slice(0, 12)}…) to ${published.join('+')}`,
+    );
+  }
+
+  return { attempted: true, chainSeq, published, failed };
 }
 
 /** Build the multi-row parameterized INSERT for a chained batch, in payload order. */
@@ -215,11 +380,13 @@ export async function processAuditChainer(
 
     // Verify-on-append: re-read the segment AS STORED (not the in-memory
     // payloads) and recompute every link from the persisted emission hashes.
+    // chain_seq rides along so the anchor signs the head's stored seq.
     const appended = await client.query(
       `SELECT id,
               emission_hash AS "emissionHash",
               previous_hash AS "previousHash",
-              event_hash AS "eventHash"
+              event_hash AS "eventHash",
+              chain_seq AS "chainSeq"
        FROM security_audit_log
        WHERE id = ANY($1::text[])
        ORDER BY chain_seq ASC`,
@@ -258,11 +425,26 @@ export async function processAuditChainer(
       );
     }
 
+    // The head's stored chain_seq — pg returns bigint as string.
+    const lastAppended = appended.rows[appended.rows.length - 1] as
+      | { chainSeq?: string | number }
+      | undefined;
+    const newHeadSeq =
+      lastAppended?.chainSeq === undefined ? undefined : Number(lastAppended.chainSeq);
+
+    // Anchor only a head that just verified — a witness signature on a
+    // segment that failed verify-on-append would attest tampered data.
+    const anchor = verification.valid
+      ? await maybePublishAnchor(newHead.prevHash, newHeadSeq, pool, overrides)
+      : undefined;
+
     return {
       outcome: 'chained',
       drained: chainedRowPayloads.length,
       verification,
       newHead: newHead.prevHash,
+      ...(newHeadSeq === undefined ? {} : { newHeadSeq }),
+      ...(anchor === undefined ? {} : { anchor }),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -87,6 +87,7 @@ export class QueueManager {
       await this.boss.createQueue('video-process');
       await this.boss.createQueue('siem-delivery');
       await this.boss.createQueue('account-erasure');
+      await this.boss.createQueue('audit-chainer');
       console.log('PgBoss queues created/verified');
     } catch (err) {
       console.warn('Queue creation warning:', err instanceof Error ? err.message : err);
@@ -254,6 +255,21 @@ export class QueueManager {
         return { success: true };
       }
     );
+
+    // Audit chainer — single-writer drain of the Admin PG ingest queue into
+    // the security_audit_log hash chain (#890 Phase 2). Poll-based like
+    // siem-delivery (ignores job data); no-ops when ADMIN_DATABASE_URL is
+    // unset, and the run-level advisory lock serializes overlapping runs.
+    const { processAuditChainer } = await import('./audit-chainer-worker');
+    await this.boss.work('audit-chainer',
+      async () => {
+        await processAuditChainer();
+      }
+    );
+
+    // Every 30 seconds, retryLimit 0 so overlapping runs won't stack (same
+    // schedule contract as siem-delivery).
+    await this.boss.schedule('audit-chainer', '*/30 * * * * *', {}, { retryLimit: 0 });
   }
 
   async addJob<Q extends QueueName>(
@@ -307,7 +323,7 @@ export class QueueManager {
   }
 
   getQueueStatus(): Record<QueueName, QueueStats> {
-    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure'];
+    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure', 'audit-chainer'];
     const perQueue = this.cachedStates?.queues ?? {};
 
     const status = {} as Record<QueueName, QueueStats>;

--- a/apps/processor/src/workers/siem-anchor-loader.ts
+++ b/apps/processor/src/workers/siem-anchor-loader.ts
@@ -1,8 +1,9 @@
 import type { AuditLogSource } from '../services/siem-adapter';
 import type {
   ActivityLogHashableFields,
-  SecurityAuditHashableFields,
+  SecurityAuditEraFields,
 } from '../services/siem-chain-hashers';
+import type { SiemStorePlane } from '../services/siem-pool-routing';
 import { CURSOR_INIT_SENTINEL } from '../services/siem-sources';
 
 /**
@@ -33,14 +34,21 @@ interface PgClient {
   ): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
 }
 
+// pg parses timestamptz to Date under node, but string-typed rows appear in
+// some runtimes — same defensive coercion as the SIEM entry mappers. Hash
+// recomputation calls .toISOString(), so the coercion is load-bearing here.
+function toDate(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value);
+}
+
 /**
  * Load the anchor hash for a source — the logHash of the row identified
  * by cursor.lastDeliveredId. Returns null when:
  *   - lastDeliveredId is the CURSOR_INIT_SENTINEL (fresh cursor, nothing
  *     was ever delivered for this source → the caller skips verification)
- *   - the anchor row can no longer be found (pruned? deleted?) — we log a
- *     warn so an operator notices, but we don't halt delivery; a null
- *     anchor is treated the same as fresh init so the next batch ships.
+ *   - the anchor row can no longer be found — we log a warn so an operator
+ *     notices; the PREFLIGHT decides what a missing anchor means (backfill
+ *     lag → defer the source; genuine loss → halt fail-closed).
  */
 export async function loadAnchorHash(
   client: PgClient,
@@ -65,7 +73,7 @@ export async function loadAnchorHash(
   const row = result.rows[0] as { logHash: string | null } | undefined;
   if (!row) {
     console.warn(
-      `[siem-delivery] Anchor row not found source=${source} id=${lastDeliveredId} — treating as fresh init`
+      `[siem-delivery] Anchor row not found source=${source} id=${lastDeliveredId} — deferring to preflight (backfill lag vs anchor loss)`
     );
     return null;
   }
@@ -113,7 +121,7 @@ export async function loadActivityLogHashableFields(
     };
     map.set(row.id, {
       id: row.id,
-      timestamp: row.timestamp,
+      timestamp: toDate(row.timestamp),
       operation: row.operation,
       resourceType: row.resourceType,
       resourceId: row.resourceId,
@@ -137,14 +145,23 @@ export async function loadActivityLogHashableFields(
  * and folds fields into metadata, both of which would corrupt hash
  * recomputation. This loader stays coupled to the DB column names so the
  * formula in siem-chain-hashers.ts can mirror the write side byte-exactly.
+ *
+ * `plane` selects the store shape (#890 Phase 2): the admin table carries the
+ * nullable emission_hash era discriminator (NULL = backfilled legacy row,
+ * set = chainer-era row) and the SELECT must include it; the legacy main
+ * table has no such column, so main-plane rows are pinned to the legacy era.
  */
 export async function loadSecurityAuditHashableFields(
   client: PgClient,
-  ids: string[]
-): Promise<Map<string, SecurityAuditHashableFields>> {
+  ids: string[],
+  opts: { plane: SiemStorePlane }
+): Promise<Map<string, SecurityAuditEraFields>> {
   if (ids.length === 0) {
     return new Map();
   }
+
+  const emissionColumn =
+    opts.plane === 'admin' ? ',\n            emission_hash AS "emissionHash"' : '';
 
   const result = await client.query(
     `SELECT id,
@@ -155,13 +172,13 @@ export async function loadSecurityAuditHashableFields(
             details,
             risk_score AS "riskScore",
             anomaly_flags AS "anomalyFlags",
-            timestamp
+            timestamp${emissionColumn}
      FROM security_audit_log
      WHERE id = ANY($1)`,
     [ids]
   );
 
-  const map = new Map<string, SecurityAuditHashableFields>();
+  const map = new Map<string, SecurityAuditEraFields>();
   for (const raw of result.rows) {
     const row = raw as {
       id: string;
@@ -173,6 +190,7 @@ export async function loadSecurityAuditHashableFields(
       riskScore: number | null;
       anomalyFlags: string[] | null;
       timestamp: Date;
+      emissionHash?: string | null;
     };
     map.set(row.id, {
       eventType: row.eventType,
@@ -182,7 +200,8 @@ export async function loadSecurityAuditHashableFields(
       details: row.details,
       riskScore: row.riskScore,
       anomalyFlags: row.anomalyFlags,
-      timestamp: row.timestamp,
+      timestamp: toDate(row.timestamp),
+      emissionHash: opts.plane === 'admin' ? (row.emissionHash ?? null) : null,
     });
   }
 

--- a/apps/processor/src/workers/siem-delivery-preflight.ts
+++ b/apps/processor/src/workers/siem-delivery-preflight.ts
@@ -5,15 +5,16 @@ import {
 } from '../services/siem-chain-verifier';
 import {
   recomputeActivityLogHash,
-  recomputeSecurityAuditHash,
+  recomputeSecurityAuditHashEraAware,
   type ActivityLogHashableFields,
-  type SecurityAuditHashableFields,
+  type SecurityAuditEraFields,
 } from '../services/siem-chain-hashers';
 import {
   loadAnchorHash,
   loadActivityLogHashableFields,
   loadSecurityAuditHashableFields,
 } from './siem-anchor-loader';
+import type { SiemStorePlane } from '../services/siem-pool-routing';
 import { SIEM_SOURCES, CURSOR_INIT_SENTINEL } from '../services/siem-sources';
 
 /**
@@ -26,6 +27,14 @@ import { SIEM_SOURCES, CURSOR_INIT_SENTINEL } from '../services/siem-sources';
  * (services/siem-chain-hashers.ts). Returns `null` if every source verifies
  * clean, or a halt descriptor for the FIRST break encountered so the worker
  * can record a precise error on the correct cursor.
+ *
+ * Post-cutover (#890 Phase 2) the preflight straddles stores, so it takes an
+ * explicit per-purpose client set instead of one client:
+ *   - cursor re-reads      → the cursors store (Admin PG in dedicated mode)
+ *   - activity_logs data   → main (until Phase 5)
+ *   - security_audit_log   → the plane the routing matrix selected; on the
+ *     admin plane verification is ERA-AWARE (emission_hash NULL = legacy
+ *     formula, set = chainer H(emission, prev)).
  *
  * Extracted from the worker for two reasons:
  *   1. Existing worker tests were written pre-preflight and mock the DB at
@@ -42,6 +51,30 @@ interface PgClient {
     text: string,
     params?: unknown[]
   ): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+}
+
+/**
+ * Per-purpose clients for one preflight run. The worker composes this from
+ * the pool-per-operation matrix (services/siem-pool-routing.ts) so the
+ * preflight itself stays mode-agnostic.
+ */
+export interface PreflightStores {
+  /** siem_delivery_cursors re-reads — both sources. */
+  cursors: PgClient;
+  /** activity_logs anchor + hashable loads. */
+  activityData: PgClient;
+  /** security_audit_log anchor + hashable loads. */
+  securityData: PgClient;
+  /** Which plane securityData points at — selects the hashable SQL shape and era-aware verify. */
+  securityPlane: SiemStorePlane;
+  /**
+   * The legacy main-db security_audit_log store, provided only when
+   * securityData is the dedicated admin store. Used for exactly one thing:
+   * distinguishing "anchor row not yet backfilled" (row still present in the
+   * legacy store → awaiting_backfill, defer the source) from genuine anchor
+   * loss (row in neither store → fail closed).
+   */
+  legacySecurityStore: PgClient | null;
 }
 
 export interface PreflightHalt {
@@ -68,7 +101,21 @@ export interface PreflightDbError {
   message: string;
 }
 
-export type PreflightResult = PreflightHalt | PreflightDbError;
+/**
+ * Transitional cutover state (#890 Phase 2, leaves 7+8): the source's cursor
+ * was seeded from the legacy store, but the anchor row it points at has not
+ * been backfilled into the admin store yet. Not an error — the worker skips
+ * this source's entries for the run (its cursor stays put, so nothing is
+ * lost) and keeps delivering the other sources. Delivery resumes on the
+ * first run after the backfill plants the anchor row.
+ */
+export interface PreflightAwaitingBackfill {
+  kind: 'awaiting_backfill';
+  source: AuditLogSource;
+  anchorId: string;
+}
+
+export type PreflightResult = PreflightHalt | PreflightDbError | PreflightAwaitingBackfill;
 
 /**
  * Run chain verification across every source represented in the merged batch.
@@ -76,8 +123,12 @@ export type PreflightResult = PreflightHalt | PreflightDbError;
  * Contract:
  *   - Returns `null` if verification passes for every source (delivery
  *     proceeds).
- *   - Returns a PreflightHalt if any source's sub-batch fails. Sources are
- *     checked in SIEM_SOURCES order so diagnostics are stable across runs.
+ *   - Returns a PreflightHalt/PreflightDbError for the FIRST break
+ *     encountered. Sources are checked in SIEM_SOURCES order so diagnostics
+ *     are stable across runs.
+ *   - Returns PreflightAwaitingBackfill only when every OTHER source
+ *     verified clean — the worker may then deliver the remaining sources
+ *     after excluding the deferred one.
  *   - Sources whose cursor is still at CURSOR_INIT_SENTINEL are SKIPPED —
  *     the worker never delivers a batch whose anchor hash it can't recover
  *     without also running verification against that anchor, so we trust
@@ -89,7 +140,7 @@ export type PreflightResult = PreflightHalt | PreflightDbError;
  *     would defeat the point of the chain.
  */
 export async function runChainPreflight(
-  client: PgClient,
+  stores: PreflightStores,
   merged: readonly AuditLogEntry[]
 ): Promise<PreflightResult | null> {
   const bySource = new Map<AuditLogSource, AuditLogEntry[]>();
@@ -100,9 +151,13 @@ export async function runChainPreflight(
     bySource.get(entry.source)?.push(entry);
   }
 
+  let awaiting: PreflightAwaitingBackfill | null = null;
+
   for (const source of SIEM_SOURCES) {
     const entries = bySource.get(source) ?? [];
     if (entries.length === 0) continue;
+
+    const dataClient = source === 'activity_logs' ? stores.activityData : stores.securityData;
 
     let verificationResult: VerificationResult;
 
@@ -112,7 +167,7 @@ export async function runChainPreflight(
       // self-contained — the alternative (passing cursor state in from the
       // worker) couples this module to the worker's internal SourceState
       // shape for no real benefit.
-      const cursorResult = await client.query(
+      const cursorResult = await stores.cursors.query(
         'SELECT "lastDeliveredId" FROM siem_delivery_cursors WHERE id = $1',
         [source]
       );
@@ -126,8 +181,27 @@ export async function runChainPreflight(
         continue;
       }
 
-      const anchorHash = await loadAnchorHash(client, source, lastDeliveredId);
+      const anchorHash = await loadAnchorHash(dataClient, source, lastDeliveredId);
       if (anchorHash === null) {
+        if (
+          source === 'security_audit_log' &&
+          stores.securityPlane === 'admin' &&
+          stores.legacySecurityStore !== null
+        ) {
+          // The cursor was seeded from the legacy store at the flip. If the
+          // anchor row still exists over there, the backfill simply hasn't
+          // planted the legacy rows into the admin store yet — defer this
+          // source (cursor untouched, no error) instead of failing closed.
+          const probe = await stores.legacySecurityStore.query(
+            'SELECT 1 FROM security_audit_log WHERE id = $1',
+            [lastDeliveredId]
+          );
+          if ((probe.rowCount ?? probe.rows.length) > 0) {
+            awaiting = { kind: 'awaiting_backfill', source, anchorId: lastDeliveredId };
+            continue;
+          }
+        }
+
         // Fail closed: the anchor row pointed at by the cursor is gone.
         // This could be operational churn (pruning, GDPR erasure) OR
         // tampering — the two are indistinguishable from here, and letting
@@ -147,7 +221,7 @@ export async function runChainPreflight(
 
       if (source === 'activity_logs') {
         const hashableMap = await loadActivityLogHashableFields(
-          client,
+          dataClient,
           entries.map((e) => e.id)
         );
         verificationResult = verifyChainForSource({
@@ -170,22 +244,23 @@ export async function runChainPreflight(
         });
       } else {
         const hashableMap = await loadSecurityAuditHashableFields(
-          client,
-          entries.map((e) => e.id)
+          dataClient,
+          entries.map((e) => e.id),
+          { plane: stores.securityPlane }
         );
         verificationResult = verifyChainForSource({
           anchorHash,
           entries,
           recomputeHash: (entry, previousHash) => {
             const data = hashableMap.get(entry.id) as
-              | SecurityAuditHashableFields
+              | SecurityAuditEraFields
               | undefined;
             if (!data) {
               throw new Error(
                 `Hashable fields missing for security_audit_log entry ${entry.id}`
               );
             }
-            return recomputeSecurityAuditHash(data, previousHash);
+            return recomputeSecurityAuditHashEraAware(data, previousHash);
           },
         });
       }
@@ -207,5 +282,5 @@ export async function runChainPreflight(
     }
   }
 
-  return null;
+  return awaiting;
 }

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -17,17 +17,25 @@ import {
 } from '../services/security-audit-event-mapper';
 import { buildReceipts } from '../services/siem-receipt-builder';
 import { writeReceipts } from './siem-receipt-writer';
-import { runChainPreflight } from './siem-delivery-preflight';
+import { runChainPreflight, type PreflightStores } from './siem-delivery-preflight';
+import {
+  resolveSiemPoolRouting,
+  type SiemStorePlane,
+} from '../services/siem-pool-routing';
 import { SIEM_SOURCES, CURSOR_INIT_SENTINEL } from '../services/siem-sources';
 import { notifyChainPreflightFailure } from '@pagespace/lib/audit/security-audit-alerting';
-import { getPoolForWorker } from '../db';
+import { getPoolForWorker, getAdminPoolForWorker } from '../db';
 
 const DEFAULT_BATCH_SIZE = 100;
 
 // One advisory lock guards the whole worker run — not per-source. Key is kept
 // as 'activity_logs' for backward compatibility: renaming it would hash to a
 // different lock slot, so during a rolling deploy old/new workers would stop
-// serializing against each other and could race on cursor upserts.
+// serializing against each other and could race on cursor upserts. For the
+// same reason the lock stays on the MAIN pool even in dedicated mode (see
+// siem-pool-routing.ts) — pre-cutover workers only know that lock point, and
+// the cutover's cursor seed must happen under the same serialization they
+// advance the legacy cursor under.
 const ADVISORY_LOCK_KEY = 'activity_logs';
 
 // Stored in siem_delivery_cursors.lastDeliveredId when a cursor is first
@@ -64,6 +72,20 @@ interface PgClient {
   release(): void;
 }
 
+interface PgPoolLike {
+  connect(): Promise<PgClient>;
+}
+
+/**
+ * Injection surface for tests (unit + wire-connected integration). Defaults
+ * to the processor's module-level pools and process.env.
+ */
+export interface SiemDeliveryDeps {
+  mainPool?: PgPoolLike;
+  adminPool?: PgPoolLike;
+  env?: { ADMIN_DATABASE_URL?: string | undefined; ADMIN_DB_BREAK_GLASS?: string | undefined };
+}
+
 interface CursorRow {
   lastDeliveredId: string | null;
   lastDeliveredAt: Date | null;
@@ -76,21 +98,55 @@ interface SourceState {
   entries: AuditLogEntry[];
 }
 
+// Mode banners fire once per process, mirroring the break-glass observability
+// convention from the audit write path (#890 Phase 2 leaf 5). The 30s poll
+// cadence would otherwise turn a standing condition into ~2880 log lines/day.
+let modeBannerLogged: string | null = null;
+export function resetSiemModeBannerForTests(): void {
+  modeBannerLogged = null;
+}
+
+function logModeBannerOnce(kind: string, line: string, level: 'warn' | 'error'): void {
+  if (modeBannerLogged === kind) return;
+  modeBannerLogged = kind;
+  console[level](line);
+}
+
+// pg parses timestamptz to Date under node, but string-typed rows appear in
+// some runtimes — same defensive coercion as the mappers and cursor reader.
+function toCursorRow(raw: Record<string, unknown>): CursorRow {
+  const at = raw.lastDeliveredAt;
+  return {
+    lastDeliveredId: (raw.lastDeliveredId as string | null) ?? null,
+    lastDeliveredAt:
+      at === null || at === undefined ? null : at instanceof Date ? at : new Date(String(at)),
+    deliveryCount: Number(raw.deliveryCount ?? 0),
+  };
+}
+
 async function loadCursor(client: PgClient, source: AuditLogSource): Promise<CursorRow | undefined> {
   const result = await client.query(
     'SELECT "lastDeliveredId", "lastDeliveredAt", "deliveryCount" FROM siem_delivery_cursors WHERE id = $1',
     [source]
   );
-  return result.rows[0] as unknown as CursorRow | undefined;
+  return result.rows[0] ? toCursorRow(result.rows[0]) : undefined;
 }
 
-async function initCursor(client: PgClient, source: AuditLogSource): Promise<CursorRow> {
-  // Plant the cursor at the DATABASE clock, not `new Date()`. If the worker
-  // host clock runs ahead of Postgres, any rows whose server-side `timestamp`
-  // defaults landed between DB-now and app-now would be silently skipped on
-  // first init — the tuple cursor `(ts, id) > (app-now, sentinel)` would
-  // exclude them. Read the planted timestamp back via RETURNING so the
-  // in-memory cursor and the row actually match.
+async function initCursor(
+  client: PgClient,
+  source: AuditLogSource,
+  plantAt?: Date
+): Promise<CursorRow> {
+  // Plant the cursor at the DATA store's DB clock, not `new Date()`. If the
+  // clock the row timestamps come from runs ahead of the clock we plant at,
+  // any rows whose server-side `timestamp` defaults landed between the two
+  // nows would be silently skipped on first init — the tuple cursor
+  // `(ts, id) > (planted, sentinel)` would exclude them. When cursor store
+  // and data store are the same DB, statement_timestamp() inline is exact;
+  // when they differ (dedicated mode, activity_logs data on main but cursors
+  // on admin) the caller samples the DATA store's statement_timestamp() and
+  // passes it as `plantAt`. Read the planted timestamp back via RETURNING so
+  // the in-memory cursor and the row actually match.
   //
   // The caller only reaches this path while holding the worker advisory lock
   // AND after seeing `loadCursor` return either no row or a row with null
@@ -98,9 +154,13 @@ async function initCursor(client: PgClient, source: AuditLogSource): Promise<Cur
   // conditions imply we're the unique writer, so DO UPDATE unconditionally
   // overwrites the planted state without clobbering progress that isn't
   // there.
+  const plantedExpr = plantAt ? '$3' : 'statement_timestamp()';
+  const params: unknown[] = plantAt
+    ? [source, CURSOR_INIT_SENTINEL, plantAt]
+    : [source, CURSOR_INIT_SENTINEL];
   const result = await client.query(
     `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
-     VALUES ($1, $2, statement_timestamp(), 0, NULL, NULL, NOW())
+     VALUES ($1, $2, ${plantedExpr}, 0, NULL, NULL, NOW())
      ON CONFLICT (id) DO UPDATE SET
        "lastDeliveredId" = EXCLUDED."lastDeliveredId",
        "lastDeliveredAt" = EXCLUDED."lastDeliveredAt",
@@ -109,11 +169,46 @@ async function initCursor(client: PgClient, source: AuditLogSource): Promise<Cur
        "lastErrorAt" = NULL,
        "updatedAt" = NOW()
      RETURNING "lastDeliveredId", "lastDeliveredAt", "deliveryCount"`,
-    [source, CURSOR_INIT_SENTINEL]
+    params
   );
-  const row = result.rows[0] as unknown as CursorRow;
+  const row = toCursorRow(result.rows[0]);
   console.log(
     `[siem-delivery] Initialized cursor for source=${source} at ${row.lastDeliveredAt?.toISOString()} (no backfill)`
+  );
+  return row;
+}
+
+/**
+ * One-time cursor migration at the store flip (#890 Phase 2 leaf 7): copy an
+ * INITIALIZED legacy cursor tuple from the main DB into the admin cursors
+ * table, preserving the exact (lastDeliveredAt, lastDeliveredId) watermark
+ * and deliveryCount. Runs under the shared main-pool advisory lock — the
+ * same lock pre-cutover workers advance the legacy cursor under — so the
+ * seeded watermark is the legacy store's final word, not a racing snapshot.
+ * Guarded: only invoked when the admin-side cursor is missing/uninitialized,
+ * so re-runs and restarts are no-ops.
+ */
+async function seedCursorFromLegacy(
+  client: PgClient,
+  source: AuditLogSource,
+  legacy: CursorRow
+): Promise<CursorRow> {
+  const result = await client.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, NULL, NULL, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastDeliveredId" = EXCLUDED."lastDeliveredId",
+       "lastDeliveredAt" = EXCLUDED."lastDeliveredAt",
+       "deliveryCount" = EXCLUDED."deliveryCount",
+       "lastError" = NULL,
+       "lastErrorAt" = NULL,
+       "updatedAt" = NOW()
+     RETURNING "lastDeliveredId", "lastDeliveredAt", "deliveryCount"`,
+    [source, legacy.lastDeliveredId, legacy.lastDeliveredAt, legacy.deliveryCount]
+  );
+  const row = toCursorRow(result.rows[0]);
+  console.log(
+    `[siem-delivery] Seeded cursor for source=${source} from legacy store at ${row.lastDeliveredAt?.toISOString()} (id=${row.lastDeliveredId}, deliveryCount=${row.deliveryCount})`
   );
   return row;
 }
@@ -218,12 +313,20 @@ async function advanceCursor(
  * interleaves them by timestamp, and delivers a single unified batch to the
  * configured SIEM endpoint via the existing siem-adapter.
  *
+ * Post-cutover (#890 Phase 2) the worker straddles two stores per the
+ * pool-per-operation matrix in services/siem-pool-routing.ts:
+ * security_audit_log data (and its preflight loads) come from the Admin PG,
+ * activity_logs data stays on main until Phase 5, and the worker's own state
+ * (cursors + receipts, BOTH sources) lives in the Admin PG. The advisory
+ * lock stays on main so old and new workers serialize across a rolling
+ * deploy.
+ *
  * Scheduled by pg-boss every 30s. Expected max duration: ~4 minutes
  * (3 retries x 60s backoff cap + network time). The schedule uses
  * retryLimit: 0 so overlapping runs won't stack, and a single advisory lock
  * keeps overlapping invocations serialized across every source.
  */
-export async function processSiemDelivery(): Promise<void> {
+export async function processSiemDelivery(deps: SiemDeliveryDeps = {}): Promise<void> {
   const config = loadSiemConfig();
 
   if (!config.enabled) {
@@ -236,12 +339,46 @@ export async function processSiemDelivery(): Promise<void> {
     return;
   }
 
-  const pool = getPoolForWorker();
-  const client = await pool.connect();
+  const env = deps.env ?? {
+    ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+    ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+  };
+  const { decision, routing } = resolveSiemPoolRouting(env);
+  if (routing === null) {
+    // 'fail' — the trust plane is misconfigured and audit writes are being
+    // rejected. Neither store can be trusted as THE source, so delivering
+    // from either would be guessing; halt loudly instead. Nothing is lost:
+    // cursors don't move, and delivery resumes where it left off once the
+    // Admin PG is configured (or break-glass is armed).
+    logModeBannerOnce(
+      'fail',
+      `[siem-delivery] Admin DB mode 'fail' — SIEM delivery halted. ${decision.reason ?? ''}`,
+      'error'
+    );
+    return;
+  }
+  if (routing.mode === 'break-glass') {
+    logModeBannerOnce(
+      'break-glass',
+      '[siem-delivery] Admin DB break-glass armed — delivering from the LEGACY main-db stores (cursors, receipts, and both sources on main)',
+      'warn'
+    );
+  }
+
+  const mainPool = deps.mainPool ?? getPoolForWorker();
+  const mainClient = await mainPool.connect();
+  // Connected lazily AFTER the advisory lock so lock-busy runs don't burn an
+  // admin connection. Null in break-glass mode (routing sends nothing there).
+  let adminClient: PgClient | null = null;
+  const clientFor = (plane: SiemStorePlane): PgClient =>
+    plane === 'admin' && adminClient !== null ? adminClient : mainClient;
+  // Cursor writes must survive errors thrown before the admin client exists;
+  // resolved to the routed client once connected.
+  let cursorClient: PgClient | null = null;
   let lockAcquired = false;
 
   try {
-    const lockResult = await client.query(
+    const lockResult = await mainClient.query(
       'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
       [ADVISORY_LOCK_KEY]
     );
@@ -250,6 +387,12 @@ export async function processSiemDelivery(): Promise<void> {
     if (!lockAcquired) {
       return;
     }
+
+    if (routing.mode === 'dedicated') {
+      const adminPool = deps.adminPool ?? getAdminPoolForWorker();
+      adminClient = await adminPool.connect();
+    }
+    cursorClient = clientFor(routing.cursors);
 
     const batchSize = config.webhook?.batchSize ?? DEFAULT_BATCH_SIZE;
 
@@ -261,7 +404,8 @@ export async function processSiemDelivery(): Promise<void> {
     // *some* stable order so neither side gets dropped.
     const states: SourceState[] = [];
     for (const source of SIEM_SOURCES) {
-      let cursor = await loadCursor(client, source);
+      const dataClient = clientFor(routing.data[source]);
+      let cursor = await loadCursor(cursorClient, source);
 
       // Treat a null-timestamp row as uninitialized. The schema CHECK constraint
       // permits (lastDeliveredId, lastDeliveredAt) = (null, null), and the
@@ -272,16 +416,38 @@ export async function processSiemDelivery(): Promise<void> {
       // arrived during the failure window, which is the same exposure as a
       // brand-new source per Phase 7's no-backfill rule.
       if (!cursor || !cursor.lastDeliveredAt || !cursor.lastDeliveredId) {
+        // Cutover seed: before planting a fresh NOW() cursor, adopt the
+        // legacy main-db cursor if one was ever initialized — the watermark
+        // must survive the store flip so already-shipped rows never replay
+        // and not-yet-shipped legacy rows still deliver (via the backfill).
+        const legacy = routing.seedCursorFromLegacy ? await loadCursor(mainClient, source) : undefined;
+        if (legacy && legacy.lastDeliveredAt && legacy.lastDeliveredId) {
+          cursor = await seedCursorFromLegacy(cursorClient, source, legacy);
+          // Same contract as a fresh init: deliver nothing on the seeding
+          // run. The next poll (30s) starts from the seeded watermark.
+          states.push({ source, cursor, entries: [] });
+          continue;
+        }
+
         // Phase 7: plant cursor at NOW() and deliver zero historical rows.
         // Backfilling would break temporal audit semantics (customers would
-        // see events from months ago appearing today).
-        cursor = await initCursor(client, source);
+        // see events from months ago appearing today). When the cursor store
+        // and the data store are different DBs, sample the DATA store's
+        // clock for the plant (see initCursor).
+        if (routing.data[source] === routing.cursors) {
+          cursor = await initCursor(cursorClient, source);
+        } else {
+          const clockResult = await dataClient.query('SELECT statement_timestamp() AS now');
+          const rawNow = clockResult.rows[0]?.now;
+          const plantAt = rawNow instanceof Date ? rawNow : new Date(String(rawNow));
+          cursor = await initCursor(cursorClient, source, plantAt);
+        }
         states.push({ source, cursor, entries: [] });
         continue;
       }
 
       const entries = await queryRowsForSource(
-        client,
+        dataClient,
         source,
         cursor.lastDeliveredAt,
         cursor.lastDeliveredId,
@@ -319,7 +485,7 @@ export async function processSiemDelivery(): Promise<void> {
       .flatMap((s) => s.entries)
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
 
-    const merged = safeUntil
+    let merged = safeUntil
       ? allEntries.filter((e) => e.timestamp.getTime() <= safeUntil.getTime())
       : allEntries;
 
@@ -354,21 +520,48 @@ export async function processSiemDelivery(): Promise<void> {
     // metadata and substitutes defaults for null resourceType/resourceId,
     // which would corrupt recomputation. Loading the raw DB subset keeps
     // both mappers untouched.
-    const preflightResult = await runChainPreflight(client, merged);
-    if (preflightResult !== null) {
-      if (preflightResult.kind === 'db_error') {
-        // Preflight couldn't even load the data needed to verify. Halt
-        // delivery and surface the error on the affected source's cursor,
-        // but do NOT fire the chain verification webhook — a transient DB
-        // failure is not tamper, and a false tamper page erodes the
-        // alert's credibility. The next poll cycle will retry naturally.
-        await recordError(client, preflightResult.source, 'preflight_unavailable');
-        console.warn(
-          `[siem-delivery] Chain preflight data unavailable source=${preflightResult.source}: ${preflightResult.message}`
-        );
+    const preflightStores: PreflightStores = {
+      cursors: cursorClient,
+      activityData: clientFor(routing.data.activity_logs),
+      securityData: clientFor(routing.data.security_audit_log),
+      securityPlane: routing.data.security_audit_log,
+      legacySecurityStore: routing.awaitingBackfillProbe ? mainClient : null,
+    };
+    let preflightResult = await runChainPreflight(preflightStores, merged);
+
+    if (preflightResult !== null && preflightResult.kind === 'awaiting_backfill') {
+      // Transitional cutover window (#890 Phase 2 leaves 7+8): the seeded
+      // cursor's anchor row hasn't been backfilled into the admin store yet.
+      // Defer ONLY this source — its cursor stays put so nothing is lost or
+      // replayed — and keep the other sources flowing. NOT recorded as a
+      // cursor error: an expected deployment state must not page anyone or
+      // trip /health.
+      const deferred = preflightResult;
+      console.log(
+        `[siem-delivery] Deferring source=${deferred.source} — cursor anchor ${deferred.anchorId} not yet backfilled into the admin store`
+      );
+      merged = merged.filter((e) => e.source !== deferred.source);
+      preflightResult = null;
+      if (merged.length === 0) {
         return;
       }
+    }
 
+    if (preflightResult !== null && preflightResult.kind === 'db_error') {
+      // Preflight couldn't even load the data needed to verify. Halt
+      // delivery and surface the error on the affected source's cursor,
+      // but do NOT fire the chain verification webhook — a transient DB
+      // failure is not tamper, and a false tamper page erodes the
+      // alert's credibility. The next poll cycle will retry naturally.
+      await recordError(cursorClient, preflightResult.source, 'preflight_unavailable');
+      console.warn(
+        `[siem-delivery] Chain preflight data unavailable source=${preflightResult.source}: ${preflightResult.message}`
+      );
+      return;
+    }
+
+    if (preflightResult !== null && preflightResult.kind === 'tamper') {
+      const halt = preflightResult;
       // /health only ever shows the safe 'chain_tamper' class. The full
       // forensic detail (index, reason, expected/actual hashes) stays in the
       // operator-only channels below: the structured console.error line and
@@ -376,17 +569,13 @@ export async function processSiemDelivery(): Promise<void> {
       // not customer-controlled, but there is no reason to widen the
       // unauthenticated /health surface with them.
       const hashDetail = [
-        preflightResult.expectedHash !== null
-          ? `expected=${preflightResult.expectedHash}`
-          : null,
-        preflightResult.actualHash !== null
-          ? `actual=${preflightResult.actualHash}`
-          : null,
+        halt.expectedHash !== null ? `expected=${halt.expectedHash}` : null,
+        halt.actualHash !== null ? `actual=${halt.actualHash}` : null,
       ]
         .filter((s): s is string => s !== null)
         .join(' ');
 
-      await recordError(client, preflightResult.source, 'chain_tamper');
+      await recordError(cursorClient, halt.source, 'chain_tamper');
 
       // Fire the existing chain verification webhook. notifyChainPreflightFailure
       // swallows alert-handler errors internally, but we still wrap the call
@@ -394,16 +583,16 @@ export async function processSiemDelivery(): Promise<void> {
       // or drop the lock-release in the finally. The tamper-error write has
       // already been made above, so /health already shows the failure.
       const sourceBatchTotalEntries = merged.filter(
-        (e) => e.source === preflightResult.source
+        (e) => e.source === halt.source
       ).length;
       try {
         await notifyChainPreflightFailure({
-          auditSource: preflightResult.source,
-          entryId: preflightResult.entryId,
-          breakAtIndex: preflightResult.breakAtIndex,
-          breakReason: preflightResult.breakReason,
-          expectedHash: preflightResult.expectedHash,
-          actualHash: preflightResult.actualHash,
+          auditSource: halt.source,
+          entryId: halt.entryId,
+          breakAtIndex: halt.breakAtIndex,
+          breakReason: halt.breakReason,
+          expectedHash: halt.expectedHash,
+          actualHash: halt.actualHash,
           sourceBatchTotalEntries,
         });
       } catch (alertError) {
@@ -412,7 +601,7 @@ export async function processSiemDelivery(): Promise<void> {
       }
 
       console.error(
-        `[siem-delivery] CHAIN TAMPER DETECTED source=${preflightResult.source} index=${preflightResult.breakAtIndex} reason=${preflightResult.breakReason} entry=${preflightResult.entryId}${hashDetail ? ` ${hashDetail}` : ''}`
+        `[siem-delivery] CHAIN TAMPER DETECTED source=${halt.source} index=${halt.breakAtIndex} reason=${halt.breakReason} entry=${halt.entryId}${hashDetail ? ` ${hashDetail}` : ''}`
       );
       return;
     }
@@ -454,10 +643,13 @@ export async function processSiemDelivery(): Promise<void> {
     // never a correctness failure; an advanced cursor without a receipt
     // would be.
     //
+    // Both writes target the cursors/receipts store (Admin PG in dedicated
+    // mode), so the transaction never spans databases.
+    //
     // Sources with zero progress keep their cursor exactly where it was —
     // the loop body is a no-op for them.
     if (delivered.length > 0) {
-      await client.query('BEGIN');
+      await cursorClient.query('BEGIN');
       try {
         for (const state of states) {
           const lastDelivered = perSourceLastDelivered.get(state.source);
@@ -466,7 +658,7 @@ export async function processSiemDelivery(): Promise<void> {
           const count = perSourceDeliveredCount.get(state.source) ?? 0;
           const newCount = state.cursor.deliveryCount + count;
           await advanceCursor(
-            client,
+            cursorClient,
             state.source,
             lastDelivered.id,
             lastDelivered.timestamp,
@@ -486,15 +678,15 @@ export async function processSiemDelivery(): Promise<void> {
           deliveredEntries: delivered,
         });
         if (receipts.length > 0) {
-          await writeReceipts(client, receipts);
+          await writeReceipts(clientFor(routing.receipts), receipts);
         }
 
-        await client.query('COMMIT');
+        await cursorClient.query('COMMIT');
       } catch (txnError) {
         // Rollback before rethrowing so the catch block above doesn't
         // observe an open transaction. `.catch` swallows the rollback
         // failure deliberately — the original error is what matters.
-        await client.query('ROLLBACK').catch(() => undefined);
+        await cursorClient.query('ROLLBACK').catch(() => undefined);
         throw txnError;
       }
     }
@@ -516,7 +708,7 @@ export async function processSiemDelivery(): Promise<void> {
       const errorMessage = result.error ?? 'Unknown delivery error';
       const errorClass = result.errorClass ?? 'internal_error';
       for (const source of SIEM_SOURCES) {
-        await recordError(client, source, errorClass);
+        await recordError(cursorClient, source, errorClass);
       }
       const partial =
         result.entriesDelivered > 0
@@ -530,8 +722,14 @@ export async function processSiemDelivery(): Promise<void> {
     const message = error instanceof Error ? error.message : String(error);
 
     try {
-      for (const source of SIEM_SOURCES) {
-        await recordError(client, source, 'internal_error');
+      // cursorClient is null only when the failure happened before the
+      // cursor store was reachable (e.g. admin connect failed) — there is
+      // no cursor row to annotate in that case, the log line below is the
+      // only surface.
+      if (cursorClient !== null) {
+        for (const source of SIEM_SOURCES) {
+          await recordError(cursorClient, source, 'internal_error');
+        }
       }
     } catch {
       // best-effort only — don't mask the original error
@@ -543,10 +741,13 @@ export async function processSiemDelivery(): Promise<void> {
     throw error;
   } finally {
     if (lockAcquired) {
-      await client
+      await mainClient
         .query('SELECT pg_advisory_unlock(hashtext($1))', [ADVISORY_LOCK_KEY])
         .catch(() => undefined);
     }
-    client.release();
+    if (adminClient !== null) {
+      adminClient.release();
+    }
+    mainClient.release();
   }
 }

--- a/apps/web/src/app/api/admin/gdpr/__tests__/admin-gdpr-routes.test.ts
+++ b/apps/web/src/app/api/admin/gdpr/__tests__/admin-gdpr-routes.test.ts
@@ -26,6 +26,9 @@ vi.mock('@pagespace/lib/compliance/erasure/pseudonymize-repository', () => ({
   pseudonymizeActivityLogsForUser: vi.fn(),
   pseudonymizeSecurityAuditLogForUser: vi.fn(),
 }));
+vi.mock('@pagespace/lib/compliance/erasure/pseudonymize-targets', () => ({
+  resolveSecurityAuditErasureTargets: vi.fn(),
+}));
 vi.mock('@pagespace/lib/monitoring/hash-chain-verifier', () => ({ verifyHashChain: vi.fn() }));
 vi.mock('@pagespace/lib/audit/security-audit-chain-verifier', () => ({ verifySecurityAuditChain: vi.fn() }));
 vi.mock('@pagespace/lib/audit/security-audit', () => ({ securityAudit: { logEvent: vi.fn() } }));
@@ -37,6 +40,7 @@ import { dataSubjectRequestRepository } from '@pagespace/lib/repositories/data-s
 import { lodgeAndEnqueueErasure } from '@/lib/erasure/request-erasure';
 import { enqueueAccountErasure } from '@/lib/erasure/enqueue';
 import { pseudonymizeActivityLogsForUser, pseudonymizeSecurityAuditLogForUser } from '@pagespace/lib/compliance/erasure/pseudonymize-repository';
+import { resolveSecurityAuditErasureTargets } from '@pagespace/lib/compliance/erasure/pseudonymize-targets';
 import { verifyHashChain } from '@pagespace/lib/monitoring/hash-chain-verifier';
 import { verifySecurityAuditChain } from '@pagespace/lib/audit/security-audit-chain-verifier';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
@@ -111,12 +115,26 @@ describe('POST /api/admin/gdpr/erasure (force-delete escalation)', () => {
 
 describe('POST /api/admin/gdpr/pseudonymize', () => {
   const validChain = { isValid: true, breakPoint: null } as never;
+  const adminWrite = { __client: 'admin-eraser' };
+  const adminRead = { __client: 'admin-read' };
+  const mainDb = { __client: 'main' };
+  const dualTargets = {
+    ok: true,
+    mode: 'dedicated',
+    targets: [
+      { store: 'admin', write: adminWrite, read: adminRead },
+      { store: 'main', write: mainDb, read: mainDb },
+    ],
+  } as never;
 
   beforeEach(() => {
+    vi.mocked(resolveSecurityAuditErasureTargets).mockReturnValue(dualTargets);
     vi.mocked(verifyHashChain).mockResolvedValue(validChain);
     vi.mocked(verifySecurityAuditChain).mockResolvedValue(validChain);
     vi.mocked(pseudonymizeActivityLogsForUser).mockResolvedValue(3);
-    vi.mocked(pseudonymizeSecurityAuditLogForUser).mockResolvedValue(2);
+    vi.mocked(pseudonymizeSecurityAuditLogForUser)
+      .mockResolvedValueOnce(2) // admin store
+      .mockResolvedValueOnce(5); // main store (legacy rows)
     vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
   });
 
@@ -126,23 +144,76 @@ describe('POST /api/admin/gdpr/pseudonymize', () => {
     expect(pseudonymizeActivityLogsForUser).not.toHaveBeenCalled();
   });
 
-  it('given an already-broken chain, should refuse with 409 before mutating', async () => {
-    vi.mocked(verifyHashChain).mockResolvedValue({ isValid: false, breakPoint: {} } as never);
+  it('given no usable erasure targets (trust plane or eraser unconfigured), should refuse with 503 and the actionable reason — never a silent no-op', async () => {
+    vi.mocked(resolveSecurityAuditErasureTargets).mockReturnValue({
+      ok: false,
+      reason: 'Post-cutover audit PII lives in the Admin PG… ADMIN_ERASER_DATABASE_URL is not set',
+    } as never);
+    const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toContain('ADMIN_ERASER_DATABASE_URL');
+    expect(pseudonymizeActivityLogsForUser).not.toHaveBeenCalled();
+    expect(pseudonymizeSecurityAuditLogForUser).not.toHaveBeenCalled();
+  });
+
+  it('given an already-broken chain in ANY store, should refuse with 409 before mutating', async () => {
+    vi.mocked(verifySecurityAuditChain)
+      .mockResolvedValueOnce(validChain) // admin store
+      .mockResolvedValueOnce({ isValid: false, breakPoint: {} } as never); // main store
     const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
     expect(res.status).toBe(409);
     expect(pseudonymizeActivityLogsForUser).not.toHaveBeenCalled();
+    expect(pseudonymizeSecurityAuditLogForUser).not.toHaveBeenCalled();
   });
 
-  it('given a valid run, should pseudonymize, verify, self-audit and report counts', async () => {
+  it('given a valid dual-location run, should erase each store with ITS write client, verify each with ITS read client, self-audit and report per-store counts', async () => {
     const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
     const body = await res.json();
     expect(res.status).toBe(200);
+
+    // Writes go through the store-paired clients (eraser identity on admin).
+    expect(pseudonymizeSecurityAuditLogForUser).toHaveBeenNthCalledWith(1, 'u1', { db: adminWrite });
+    expect(pseudonymizeSecurityAuditLogForUser).toHaveBeenNthCalledWith(2, 'u1', { db: mainDb });
+
+    // Chain verification targets the stores the rows actually live in —
+    // before AND after (2 stores × 2 phases). Never the write client.
+    expect(verifySecurityAuditChain).toHaveBeenCalledTimes(4);
+    for (const call of vi.mocked(verifySecurityAuditChain).mock.calls) {
+      expect([adminRead, mainDb]).toContainEqual(call[1]!.db);
+    }
+
     expect(body.activityRowsPseudonymized).toBe(3);
-    expect(body.securityRowsPseudonymized).toBe(2);
+    expect(body.securityRowsPseudonymized).toBe(7); // 2 admin + 5 main
+    expect(body.securityRowsByStore).toEqual({ admin: 2, main: 5 });
+    expect(body.auditStoreMode).toBe('dedicated');
     expect(body.chainIntact).toBe(true);
     expect(securityAudit.logEvent).toHaveBeenCalledWith(
-      expect.objectContaining({ resourceId: 'u1', details: expect.objectContaining({ action: 'art17_pseudonymization' }) })
+      expect.objectContaining({
+        resourceId: 'u1',
+        details: expect.objectContaining({
+          action: 'art17_pseudonymization',
+          securityRowsByStore: { admin: 2, main: 5 },
+        }),
+      })
     );
+  });
+
+  it('given break-glass mode (single main target), should erase and verify only the main store', async () => {
+    vi.mocked(resolveSecurityAuditErasureTargets).mockReturnValue({
+      ok: true,
+      mode: 'break-glass',
+      targets: [{ store: 'main', write: mainDb, read: mainDb }],
+    } as never);
+    vi.mocked(pseudonymizeSecurityAuditLogForUser).mockReset().mockResolvedValue(4);
+
+    const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(pseudonymizeSecurityAuditLogForUser).toHaveBeenCalledTimes(1);
+    expect(pseudonymizeSecurityAuditLogForUser).toHaveBeenCalledWith('u1', { db: mainDb });
+    expect(verifySecurityAuditChain).toHaveBeenCalledTimes(2); // before + after, one store
+    expect(body.securityRowsByStore).toEqual({ main: 4 });
+    expect(body.auditStoreMode).toBe('break-glass');
   });
 
   it('given the chain breaks AFTER pseudonymization, should fail loudly with 500', async () => {
@@ -151,5 +222,17 @@ describe('POST /api/admin/gdpr/pseudonymize', () => {
       .mockResolvedValueOnce({ isValid: false, breakPoint: {} } as never); // after
     const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
     expect(res.status).toBe(500);
+  });
+
+  it('given a SECURITY store chain break after the run, should fail loudly with 500 naming the store', async () => {
+    vi.mocked(verifySecurityAuditChain)
+      .mockResolvedValueOnce(validChain) // before: admin
+      .mockResolvedValueOnce(validChain) // before: main
+      .mockResolvedValueOnce({ isValid: false, breakPoint: { entryId: 'x' } } as never) // after: admin
+      .mockResolvedValueOnce(validChain); // after: main
+    const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.securityChainByStore).toEqual({ admin: false, main: true });
   });
 });

--- a/apps/web/src/app/api/admin/gdpr/__tests__/admin-gdpr-routes.test.ts
+++ b/apps/web/src/app/api/admin/gdpr/__tests__/admin-gdpr-routes.test.ts
@@ -198,6 +198,32 @@ describe('POST /api/admin/gdpr/pseudonymize', () => {
     );
   });
 
+  it('given a store write failing part-way, should self-audit the partial state and return 500 telling the operator to re-run', async () => {
+    vi.mocked(pseudonymizeSecurityAuditLogForUser)
+      .mockReset()
+      .mockResolvedValueOnce(2) // admin store succeeds
+      .mockRejectedValueOnce(new Error('main db down')); // main store fails
+
+    const res = await post(pseudoPost, { userId: 'u1', legalBasis: 'dispute', confirmation: 'PSEUDONYMIZE u1' });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.failedStore).toBe('main');
+    expect(body.securityRowsByStore).toEqual({ admin: 2 });
+    expect(body.error).toContain('re-run');
+    // The completed mutations stay traceable even though the run failed.
+    expect(securityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceId: 'u1',
+        details: expect.objectContaining({
+          action: 'art17_pseudonymization_failed',
+          securityRowsByStore: { admin: 2 },
+          failedStore: 'main',
+        }),
+      })
+    );
+  });
+
   it('given break-glass mode (single main target), should erase and verify only the main store', async () => {
     vi.mocked(resolveSecurityAuditErasureTargets).mockReturnValue({
       ok: true,

--- a/apps/web/src/app/api/admin/gdpr/pseudonymize/route.ts
+++ b/apps/web/src/app/api/admin/gdpr/pseudonymize/route.ts
@@ -5,19 +5,28 @@ import {
   pseudonymizeActivityLogsForUser,
   pseudonymizeSecurityAuditLogForUser,
 } from '@pagespace/lib/compliance/erasure/pseudonymize-repository';
+import { resolveSecurityAuditErasureTargets } from '@pagespace/lib/compliance/erasure/pseudonymize-targets';
 import { verifyHashChain } from '@pagespace/lib/monitoring/hash-chain-verifier';
 import { verifySecurityAuditChain } from '@pagespace/lib/audit/security-audit-chain-verifier';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 
 /**
- * Art 17(3)(b) audit-log pseudonymization (#985).
+ * Art 17(3)(b) audit-log pseudonymization (#985, #890 Phase 2 leaf 6).
  *
  * The escalation path for a supervisory authority that disputes the retention
  * of `activity_logs` / `security_audit_log` under the legal-obligation
- * exemption. It overwrites ONLY the denormalized actor PII (never hash-chain or
- * content fields), verifies the tamper-evident chain before AND after (failing
- * loudly if the chain breaks), and self-audits the operation. Row deletion is
- * intentionally NOT offered — it would break the chain.
+ * exemption. It overwrites ONLY the denormalized actor PII (never hash-chain
+ * or content fields), verifies the tamper-evident chain before AND after
+ * (failing loudly if the chain breaks), and self-audits the operation. Row
+ * deletion is intentionally NOT offered — it would break the chain.
+ *
+ * Post-cutover, a subject's security-audit PII may be SPLIT across the Admin
+ * PG (new chained rows, updatable only by the eraser identity) and the main
+ * DB (legacy rows awaiting backfill). resolveSecurityAuditErasureTargets
+ * pairs each store with the connection allowed to write it and the one to
+ * verify it — so the chain checks target the stores the rows actually live
+ * in, and a missing eraser configuration refuses the run instead of
+ * misreporting a partial erasure as complete.
  */
 
 const bodySchema = z.object({
@@ -46,33 +55,61 @@ export const POST = withAdminAuth(async (admin, request) => {
     );
   }
 
-  // 1. Verify the chains are intact BEFORE we touch anything.
-  const [activityBefore, securityBefore] = await Promise.all([
+  // 0. Resolve which stores hold the subject's audit rows and which identity
+  //    may erase there. Refusal (no trust plane / no eraser) is loud — an
+  //    erasure that cannot reach every store must not run at all.
+  const resolved = resolveSecurityAuditErasureTargets();
+  if (!resolved.ok) {
+    loggers.auth.error(
+      `Refusing pseudonymization for user ${userId}: ${resolved.reason}`,
+      new Error('audit erasure targets unavailable')
+    );
+    return Response.json({ error: resolved.reason }, { status: 503 });
+  }
+  const { targets } = resolved;
+
+  // 1. Verify the chains are intact BEFORE we touch anything — each security
+  //    store verified via its own read connection.
+  const [activityBefore, ...securityBefore] = await Promise.all([
     verifyHashChain(),
-    verifySecurityAuditChain(),
+    ...targets.map((t) => verifySecurityAuditChain({}, { db: t.read })),
   ]);
-  if (!activityBefore.isValid || !securityBefore.isValid) {
+  const securityBeforeByStore = Object.fromEntries(
+    targets.map((t, i) => [t.store, securityBefore[i]!.isValid])
+  );
+  if (!activityBefore.isValid || securityBefore.some((r) => !r.isValid)) {
     return Response.json(
       {
         error: 'Refusing to pseudonymize: hash chain is already broken before the operation',
         activityChainValid: activityBefore.isValid,
-        securityChainValid: securityBefore.isValid,
+        securityChainValid: securityBefore.every((r) => r.isValid),
+        securityChainByStore: securityBeforeByStore,
       },
       { status: 409 }
     );
   }
 
-  // 2. Apply the denormalized-actor-only patches.
+  // 2. Apply the denormalized-actor-only patches — every store the subject's
+  //    rows live in, each through the identity allowed to write it.
   const activityRows = await pseudonymizeActivityLogsForUser(userId);
-  const securityRows = await pseudonymizeSecurityAuditLogForUser(userId);
+  const securityRowsByStore: Record<string, number> = {};
+  for (const target of targets) {
+    securityRowsByStore[target.store] = await pseudonymizeSecurityAuditLogForUser(userId, {
+      db: target.write,
+    });
+  }
+  const securityRows = Object.values(securityRowsByStore).reduce((sum, n) => sum + n, 0);
 
   // 3. Verify the chains STILL hold. Pseudonymization touches no hash input, so
   //    this must pass — if it doesn't, surface loudly (do not swallow).
-  const [activityAfter, securityAfter] = await Promise.all([
+  const [activityAfter, ...securityAfter] = await Promise.all([
     verifyHashChain(),
-    verifySecurityAuditChain(),
+    ...targets.map((t) => verifySecurityAuditChain({}, { db: t.read })),
   ]);
-  const chainIntact = activityAfter.isValid && securityAfter.isValid;
+  const securityChainByStore = Object.fromEntries(
+    targets.map((t, i) => [t.store, securityAfter[i]!.isValid])
+  );
+  const chainIntact = activityAfter.isValid && securityAfter.every((r) => r.isValid);
 
   // 4. Self-audit the operation (who, which subject, legal basis, counts).
   try {
@@ -84,8 +121,10 @@ export const POST = withAdminAuth(async (admin, request) => {
       details: {
         action: 'art17_pseudonymization',
         legalBasis,
+        auditStoreMode: resolved.mode,
         activityRowsPseudonymized: activityRows,
         securityRowsPseudonymized: securityRows,
+        securityRowsByStore,
         chainIntactAfter: chainIntact,
       },
     });
@@ -102,24 +141,30 @@ export const POST = withAdminAuth(async (admin, request) => {
       {
         error: 'Hash chain integrity lost after pseudonymization — investigate immediately',
         activityChainValid: activityAfter.isValid,
-        securityChainValid: securityAfter.isValid,
+        securityChainValid: securityAfter.every((r) => r.isValid),
+        securityChainByStore,
         activityBreakPoint: activityAfter.breakPoint,
-        securityBreakPoint: securityAfter.breakPoint,
+        securityBreakPoints: Object.fromEntries(
+          targets.map((t, i) => [t.store, securityAfter[i]!.breakPoint])
+        ),
       },
       { status: 500 }
     );
   }
 
   loggers.auth.info(
-    `Admin ${admin.id} pseudonymized user ${userId}: ` +
-      `${activityRows} activity rows, ${securityRows} security rows; chain intact`
+    `Admin ${admin.id} pseudonymized user ${userId} (${resolved.mode}): ` +
+      `${activityRows} activity rows, ${securityRows} security rows ` +
+      `(${targets.map((t) => `${t.store}=${securityRowsByStore[t.store]}`).join(', ')}); chain intact`
   );
 
   return Response.json({
     message: 'Pseudonymization complete; hash chain verified intact',
     userId,
+    auditStoreMode: resolved.mode,
     activityRowsPseudonymized: activityRows,
     securityRowsPseudonymized: securityRows,
+    securityRowsByStore,
     chainIntact,
   });
 });

--- a/apps/web/src/app/api/admin/gdpr/pseudonymize/route.ts
+++ b/apps/web/src/app/api/admin/gdpr/pseudonymize/route.ts
@@ -90,13 +90,55 @@ export const POST = withAdminAuth(async (admin, request) => {
   }
 
   // 2. Apply the denormalized-actor-only patches — every store the subject's
-  //    rows live in, each through the identity allowed to write it.
-  const activityRows = await pseudonymizeActivityLogsForUser(userId);
+  //    rows live in, each through the identity allowed to write it. A failure
+  //    part-way must leave the completed mutations traceable: self-audit the
+  //    partial state before surfacing. The patches are idempotent, so the
+  //    operator re-runs the same request to finish the remaining stores.
+  let activityRows = 0;
   const securityRowsByStore: Record<string, number> = {};
-  for (const target of targets) {
-    securityRowsByStore[target.store] = await pseudonymizeSecurityAuditLogForUser(userId, {
-      db: target.write,
-    });
+  try {
+    activityRows = await pseudonymizeActivityLogsForUser(userId);
+    for (const target of targets) {
+      securityRowsByStore[target.store] = await pseudonymizeSecurityAuditLogForUser(userId, {
+        db: target.write,
+      });
+    }
+  } catch (error) {
+    const failedStore =
+      targets.find((t) => !(t.store in securityRowsByStore))?.store ?? 'activity';
+    const message = error instanceof Error ? error.message : String(error);
+    try {
+      await securityAudit.logEvent({
+        eventType: 'data.write',
+        userId: admin.id,
+        resourceType: 'audit_logs',
+        resourceId: userId,
+        details: {
+          action: 'art17_pseudonymization_failed',
+          legalBasis,
+          auditStoreMode: resolved.mode,
+          activityRowsPseudonymized: activityRows,
+          securityRowsByStore,
+          failedStore,
+          error: message,
+        },
+      });
+    } catch (auditError) {
+      loggers.auth.error('Could not self-audit failed pseudonymization run:', auditError as Error);
+    }
+    loggers.auth.error(
+      `Pseudonymization for user ${userId} failed part-way at store '${failedStore}' — completed stores stay erased; re-run to finish`,
+      error as Error
+    );
+    return Response.json(
+      {
+        error: `Pseudonymization failed part-way at store '${failedStore}'. Completed mutations are audited; re-run the same request to finish the remaining stores.`,
+        activityRowsPseudonymized: activityRows,
+        securityRowsByStore,
+        failedStore,
+      },
+      { status: 500 }
+    );
   }
   const securityRows = Object.values(securityRowsByStore).reduce((sum, n) => sum + n, 0);
 

--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -2,13 +2,14 @@
  * Contract tests for /api/cron/verify-audit-chain
  *
  * Verifies: structured logging, no breakPoint in response (info disclosure),
- * generic error messages, and verifyAndAlert integration.
+ * generic error messages, and full-audit-verification integration (#890
+ * Phase 2, leaf 5: chain + anchors + co-stream where configured).
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockVerifyAndAlert, mockLoggers } = vi.hoisted(() => ({
-  mockVerifyAndAlert: vi.fn(),
+const { mockRunFullAuditVerification, mockLoggers } = vi.hoisted(() => ({
+  mockRunFullAuditVerification: vi.fn(),
   mockLoggers: {
     security: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
@@ -19,8 +20,8 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
-  verifyAndAlert: mockVerifyAndAlert,
+vi.mock('@pagespace/lib/audit/full-audit-verification', () => ({
+  runFullAuditVerification: mockRunFullAuditVerification,
 }));
 
 const mockAudit = vi.hoisted(() => vi.fn());
@@ -77,6 +78,25 @@ const BROKEN_CHAIN_RESULT = {
   },
 };
 
+const SKIPPED_ANCHORS = {
+  configured: false as const,
+  skippedReason: 'anchoring is not enabled (AUDIT_ANCHOR_ENABLED)',
+};
+const SKIPPED_CO_STREAM = {
+  configured: false as const,
+  skippedReason: 'no collector co-stream records supplied',
+};
+
+function fullResult(chain: typeof VALID_CHAIN_RESULT | typeof BROKEN_CHAIN_RESULT, overrides: Record<string, unknown> = {}) {
+  return {
+    chain,
+    anchors: SKIPPED_ANCHORS,
+    coStream: SKIPPED_CO_STREAM,
+    isValid: chain.isValid,
+    ...overrides,
+  };
+}
+
 function makeRequest(): Request {
   return new Request('http://localhost:3000/api/cron/verify-audit-chain');
 }
@@ -85,7 +105,7 @@ describe('/api/cron/verify-audit-chain', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(validateSignedCronRequest).mockReturnValue(null);
-    mockVerifyAndAlert.mockResolvedValue(VALID_CHAIN_RESULT);
+    mockRunFullAuditVerification.mockResolvedValue(fullResult(VALID_CHAIN_RESULT));
   });
 
   it('returns auth error when cron request is invalid', async () => {
@@ -118,7 +138,7 @@ describe('/api/cron/verify-audit-chain', () => {
   });
 
   it('returns invalid chain result without breakPoint in response', async () => {
-    mockVerifyAndAlert.mockResolvedValue(BROKEN_CHAIN_RESULT);
+    mockRunFullAuditVerification.mockResolvedValue(fullResult(BROKEN_CHAIN_RESULT));
 
     const response = await GET(makeRequest());
     const body = await response.json();
@@ -131,7 +151,7 @@ describe('/api/cron/verify-audit-chain', () => {
   });
 
   it('logs breakPoint details server-side on chain failure', async () => {
-    mockVerifyAndAlert.mockResolvedValue(BROKEN_CHAIN_RESULT);
+    mockRunFullAuditVerification.mockResolvedValue(fullResult(BROKEN_CHAIN_RESULT));
 
     await GET(makeRequest());
 
@@ -144,7 +164,7 @@ describe('/api/cron/verify-audit-chain', () => {
   });
 
   it('returns generic error message on exception', async () => {
-    mockVerifyAndAlert.mockRejectedValue(new Error('DB connection lost'));
+    mockRunFullAuditVerification.mockRejectedValue(new Error('DB connection lost'));
 
     const response = await GET(makeRequest());
     const body = await response.json();
@@ -157,7 +177,7 @@ describe('/api/cron/verify-audit-chain', () => {
 
   it('logs actual error server-side on exception', async () => {
     const error = new Error('DB connection lost');
-    mockVerifyAndAlert.mockRejectedValue(error);
+    mockRunFullAuditVerification.mockRejectedValue(error);
 
     await GET(makeRequest());
 
@@ -167,10 +187,51 @@ describe('/api/cron/verify-audit-chain', () => {
     );
   });
 
-  it('calls verifyAndAlert with periodic source', async () => {
+  it('calls runFullAuditVerification with periodic source and stopOnFirstBreak', async () => {
     await GET(makeRequest());
 
-    expect(mockVerifyAndAlert).toHaveBeenCalledWith('periodic', { stopOnFirstBreak: true });
+    expect(mockRunFullAuditVerification).toHaveBeenCalledWith({
+      source: 'periodic',
+      chain: { stopOnFirstBreak: true },
+    });
+  });
+
+  it('reports skipped anchor/co-stream checks with their reasons (explicit degradation)', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(body.anchors).toEqual(SKIPPED_ANCHORS);
+    expect(body.coStream).toEqual(SKIPPED_CO_STREAM);
+    expect(body.chainValid).toBe(true);
+  });
+
+  it('given a configured anchor check that fails, reports composite isValid=false while chainValid stays true', async () => {
+    mockRunFullAuditVerification.mockResolvedValue(
+      fullResult(VALID_CHAIN_RESULT, {
+        anchors: {
+          configured: true,
+          report: {
+            allMatch: false,
+            results: [],
+            counts: { match: 1, hash_mismatch: 1, seq_gap: 0, unverifiable: 0 },
+          },
+        },
+        isValid: false,
+      })
+    );
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(body.isValid).toBe(false);
+    expect(body.chainValid).toBe(true);
+    expect(body.anchors).toEqual({
+      configured: true,
+      allMatch: false,
+      counts: { match: 1, hash_mismatch: 1, seq_gap: 0, unverifiable: 0 },
+    });
+    // Anchor details beyond counts (hashes, seqs) never leak into the response.
+    expect(body.anchors).not.toHaveProperty('results');
   });
 
   it('logs audit event on successful chain verification', async () => {
@@ -183,7 +244,7 @@ describe('/api/cron/verify-audit-chain', () => {
   });
 
   it('logs audit event on failed chain verification', async () => {
-    mockVerifyAndAlert.mockResolvedValue(BROKEN_CHAIN_RESULT);
+    mockRunFullAuditVerification.mockResolvedValue(fullResult(BROKEN_CHAIN_RESULT));
 
     await GET(makeRequest());
 
@@ -194,7 +255,7 @@ describe('/api/cron/verify-audit-chain', () => {
   });
 
   it('does not log audit event when verification throws', async () => {
-    mockVerifyAndAlert.mockRejectedValue(new Error('DB connection lost'));
+    mockRunFullAuditVerification.mockRejectedValue(new Error('DB connection lost'));
 
     await GET(makeRequest());
 

--- a/apps/web/src/app/api/cron/verify-audit-chain/route.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/route.ts
@@ -1,4 +1,4 @@
-import { verifyAndAlert } from '@pagespace/lib/audit/security-audit-alerting';
+import { runFullAuditVerification } from '@pagespace/lib/audit/full-audit-verification';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
@@ -7,8 +7,13 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 /**
  * Cron endpoint to verify the security audit log hash chain integrity.
  *
- * Detects tampering in the security audit log by recomputing each entry's
- * hash and verifying chain links. Fires the registered alert handler on failure.
+ * Post-cutover (#890 Phase 2, leaf 5) this consults the FULL trust-plane
+ * verification: chain consistency (recompute + linkage, era-aware) AND
+ * anchor-vs-chain matching where anchoring is configured AND co-stream
+ * reconciliation where collector records are supplied (none here — the
+ * tamper drill passes them explicitly). Skipped checks are reported with a
+ * reason, never silent. Alerts fire inside the lib layer (verifyAndAlert /
+ * notifyAnchorVerificationFailure).
  *
  * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce, X-Cron-Signature headers.
  */
@@ -19,32 +24,42 @@ export async function GET(request: Request) {
   }
 
   try {
-    const result = await verifyAndAlert('periodic', { stopOnFirstBreak: true });
+    const { chain, anchors, coStream, isValid } = await runFullAuditVerification({
+      source: 'periodic',
+      chain: { stopOnFirstBreak: true },
+    });
 
-    if (!result.isValid) {
+    if (!chain.isValid) {
       loggers.security.error(
         '[SECURITY ALERT] Security audit hash chain integrity check FAILED.',
         {
-          breakPoint: result.breakPoint,
-          entriesVerified: result.entriesVerified,
-          invalidEntries: result.invalidEntries,
+          breakPoint: chain.breakPoint,
+          entriesVerified: chain.entriesVerified,
+          invalidEntries: chain.invalidEntries,
         }
       );
     } else {
       loggers.api.info(
-        `[Cron] Security audit chain verified: ${result.validEntries} entries valid`
+        `[Cron] Security audit chain verified: ${chain.validEntries} entries valid`
       );
     }
 
-    audit({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: result.isValid, entriesVerified: result.entriesVerified } });
+    audit({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid, entriesVerified: chain.entriesVerified } });
 
     return NextResponse.json({
       success: true,
-      isValid: result.isValid,
-      totalEntries: result.totalEntries,
-      entriesVerified: result.entriesVerified,
-      validEntries: result.validEntries,
-      invalidEntries: result.invalidEntries,
+      isValid,
+      chainValid: chain.isValid,
+      totalEntries: chain.totalEntries,
+      entriesVerified: chain.entriesVerified,
+      validEntries: chain.validEntries,
+      invalidEntries: chain.invalidEntries,
+      anchors: anchors.configured
+        ? { configured: true, allMatch: anchors.report.allMatch, counts: anchors.report.counts }
+        : { configured: false, skippedReason: anchors.skippedReason },
+      coStream: coStream.configured
+        ? { configured: true, verified: coStream.report.verified, counts: coStream.report.counts }
+        : { configured: false, skippedReason: coStream.skippedReason },
       timestamp: new Date().toISOString(),
     });
   } catch (error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,6 +183,9 @@ services:
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
       - ADMIN_DATABASE_URL=postgresql://admin_processor_user:admin-processor-password@postgres-admin:5432/pagespace_admin
+      # The local stack is always a fresh install — empty admin chain, genesis
+      # link is correct (#890 Phase 2 era-fork guard).
+      - AUDIT_CHAINER_ALLOW_GENESIS=true
       - PORT=3003
       - NODE_OPTIONS=--max-old-space-size=1024
       - ENABLE_OCR=${ENABLE_OCR:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - ADMIN_APP_PASSWORD=admin-app-password
       - ADMIN_PROCESSOR_PASSWORD=admin-processor-password
       - ADMIN_READER_PASSWORD=admin-reader-password
+      - ADMIN_ERASER_PASSWORD=admin-eraser-password
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
@@ -119,6 +120,8 @@ services:
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
       - ADMIN_DATABASE_URL=postgresql://admin_app_user:admin-app-password@postgres-admin:5432/pagespace_admin
+      # GDPR pseudonymization route — the only consumer of the eraser identity.
+      - ADMIN_ERASER_DATABASE_URL=postgresql://admin_gdpr_eraser_user:admin-eraser-password@postgres-admin:5432/pagespace_admin
       - NEXT_PUBLIC_REALTIME_URL=${NEXT_PUBLIC_REALTIME_URL}
       - PROCESSOR_URL=http://processor:3003
       - PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -183,9 +183,11 @@ services:
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
       - ADMIN_DATABASE_URL=postgresql://admin_processor_user:admin-processor-password@postgres-admin:5432/pagespace_admin
-      # The local stack is always a fresh install — empty admin chain, genesis
-      # link is correct (#890 Phase 2 era-fork guard).
-      - AUDIT_CHAINER_ALLOW_GENESIS=true
+      # Era-fork guard (#890 Phase 2): the volumes are persistent, so an
+      # upgraded stack can hold legacy security_audit_log rows — never default
+      # to genesis chaining. Fresh installs opt in via .env (.env.example
+      # ships it true); upgrades leave it unset until the backfill has run.
+      - AUDIT_CHAINER_ALLOW_GENESIS=${AUDIT_CHAINER_ALLOW_GENESIS:-}
       - PORT=3003
       - NODE_OPTIONS=--max-old-space-size=1024
       - ENABLE_OCR=${ENABLE_OCR:-false}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,14 @@ services:
 
   # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
   # chain, isolated from the app database in every deployment mode (#890).
-  # CREDENTIAL MODEL (Phase 1): the owner/bootstrap role goes ONLY to this
-  # container and the migrate one-shot — runtime services hold no admin
-  # credentials (the owner would bypass the drizzle-admin/0001 zero-trust
-  # grants). Phase 2 wires per-service LOGIN roles with the audit cutover.
+  # CREDENTIAL MODEL (Phase 2): the owner/bootstrap role goes ONLY to this
+  # container and the migrate one-shot (the owner would bypass the
+  # drizzle-admin/0001 zero-trust grants). Runtime services connect as
+  # per-service LOGIN users provisioned by db:provision:admin-users:
+  #   web       → admin_app_user       (admin_app: SELECT+INSERT audit chain)
+  #   processor → admin_processor_user (admin_chainer + admin_siem)
+  #   admin     → admin_reader_user    (admin_reader: read-only)
+  #   realtime  → none (no audit path)
   postgres-admin:
     image: postgres:17.5-alpine
     ports:
@@ -62,12 +66,18 @@ services:
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
       - ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admin
+      # Dev passwords for the per-service admin LOGIN users (provisioned below).
+      - ADMIN_APP_PASSWORD=admin-app-password
+      - ADMIN_PROCESSOR_PASSWORD=admin-processor-password
+      - ADMIN_READER_PASSWORD=admin-reader-password
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
         bun run db:migrate &&
         echo 'Starting admin database migrations...' &&
         bun run db:migrate:admin &&
+        echo 'Provisioning admin login users...' &&
+        bun run db:provision:admin-users &&
         echo 'Migrations complete, starting services...'
       "
     healthcheck:
@@ -108,6 +118,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://admin_app_user:admin-app-password@postgres-admin:5432/pagespace_admin
       - NEXT_PUBLIC_REALTIME_URL=${NEXT_PUBLIC_REALTIME_URL}
       - PROCESSOR_URL=http://processor:3003
       - PORT=3000
@@ -132,6 +143,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://admin_reader_user:admin-reader-password@postgres-admin:5432/pagespace_admin
       - ADMIN_URL=${ADMIN_URL:-http://localhost:3005}
       - NEXT_PUBLIC_WEB_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       - WEB_APP_INTERNAL_URL=http://web:3000
@@ -167,6 +179,7 @@ services:
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://user:password@postgres:5432/pagespace
+      - ADMIN_DATABASE_URL=postgresql://admin_processor_user:admin-processor-password@postgres-admin:5432/pagespace_admin
       - PORT=3003
       - NODE_OPTIONS=--max-old-space-size=1024
       - ENABLE_OCR=${ENABLE_OCR:-false}

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -85,15 +85,16 @@ Runtime services no longer touch the admin database as its owner. The
 `db:migrate:admin`, creating one least-privilege LOGIN user per service and
 attaching it to the NOLOGIN role templates from `drizzle-admin/0001`:
 
-| login user             | granted templates          | used by             |
-|------------------------|----------------------------|---------------------|
-| `admin_app_user`       | `admin_app`                | web                 |
-| `admin_processor_user` | `admin_chainer`, `admin_siem` | processor        |
-| `admin_reader_user`    | `admin_reader`             | admin app (read-only) |
+| login user               | granted templates          | used by             |
+|--------------------------|----------------------------|---------------------|
+| `admin_app_user`         | `admin_app`                | web                 |
+| `admin_processor_user`   | `admin_chainer`, `admin_siem` | processor        |
+| `admin_reader_user`      | `admin_reader`             | admin app (read-only) |
+| `admin_gdpr_eraser_user` | `admin_gdpr_eraser`        | web GDPR pseudonymization route (Art 17 — column-scoped UPDATE on exactly the 6 PII columns, via `ADMIN_ERASER_DATABASE_URL`) |
 
 `ADMIN_POSTGRES_*` (the owner) is now consumed **only** by the
 `postgres-admin` container and the `migrate` one-shot. The compose stack
-**refuses to start** without the three new password variables:
+**refuses to start** without the four new password variables:
 
 ```
 required variable ADMIN_APP_PASSWORD is missing a value:
@@ -102,11 +103,11 @@ ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRA
 
 ### Steps (tenant / self-host)
 
-1. Generate three passwords (alphanumeric is **required** — the compose stack
+1. Generate four passwords (alphanumeric is **required** — the compose stack
    embeds them in `ADMIN_DATABASE_URL` without URL-encoding):
 
    ```bash
-   for i in 1 2 3; do openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32; echo; done
+   for i in 1 2 3 4; do openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32; echo; done
    ```
 
 2. **Append** to the **existing** `.env` (mirroring the
@@ -117,6 +118,7 @@ ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRA
    ADMIN_APP_PASSWORD=<generated password 1>
    ADMIN_PROCESSOR_PASSWORD=<generated password 2>
    ADMIN_READER_PASSWORD=<generated password 3>
+   ADMIN_ERASER_PASSWORD=<generated password 4>
    ```
 
 3. Pull and restart the stack as usual. Provisioning is idempotent and
@@ -134,14 +136,19 @@ to the one-shot machine only (`migrate-admin.ts` prefers
 |------------------------------------|------------------------------|--------------------------|
 | GitHub Actions (repo secret)       | `ADMIN_DATABASE_URL_MIGRATE` | owner — migrations + provisioning only |
 | Fly `pagespace-web`                | `ADMIN_DATABASE_URL`         | `admin_app_user`         |
+| Fly `pagespace-web`                | `ADMIN_ERASER_DATABASE_URL`  | `admin_gdpr_eraser_user` (GDPR pseudonymization route only) |
 | Fly `pagespace-processor`          | `ADMIN_DATABASE_URL`         | `admin_processor_user`   |
 | Fly `pagespace-admin`              | `ADMIN_DATABASE_URL`         | `admin_reader_user`      |
 | Fly `pagespace-realtime`           | — (no audit path)            | —                        |
 
 Provisioning the login users on Fly: run `bun run db:provision:admin-users`
 once (e.g. on a one-shot machine or via `fly ssh console`) with
-`ADMIN_DATABASE_URL_MIGRATE` set to the owner URL and the three
+`ADMIN_DATABASE_URL_MIGRATE` set to the owner URL and the four
 `ADMIN_*_PASSWORD` values exported for that run — then set each app's
-runtime `ADMIN_DATABASE_URL` from the matrix above. With
-`ADMIN_DB_MIGRATIONS_ENABLED=true`, the CI step fails fast if
-`ADMIN_DATABASE_URL_MIGRATE` is missing.
+runtime `ADMIN_DATABASE_URL` (and web's `ADMIN_ERASER_DATABASE_URL`) from
+the matrix above. With `ADMIN_DB_MIGRATIONS_ENABLED=true`, the CI step fails
+fast if `ADMIN_DATABASE_URL_MIGRATE` is missing.
+
+Without `ADMIN_ERASER_DATABASE_URL`, the admin GDPR pseudonymization
+endpoint refuses with 503 (it never silently skips the Admin PG or falls
+back to another identity) — everything else is unaffected.

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -169,9 +169,13 @@ the admin chain head is. Run the backfill BEFORE the chainer's first run and
 the eras link seamlessly; let the chainer run first and it chains from
 `'genesis'`, which can never be joined to the legacy history (chain columns
 are append-only by design — no role can re-link them). The script refuses
-that state (`unlinked_emission_era`); prevention is this run order:
+that state (`unlinked_emission_era`), and the chainer itself refuses the
+genesis link outright: on an empty admin head it logs
+`REFUSING to chain … from a GENESIS head` and leaves the ingest rows
+buffered until the backfill plants the legacy head
+(`AUDIT_CHAINER_ALLOW_GENESIS` gate, below). Prevention is this run order:
 
-1. **Prereqs.** Admin PG provisioned + migrated through `drizzle-admin/0007`,
+1. **Prereqs.** Admin PG provisioned + migrated through `drizzle-admin/0008`,
    login users provisioned (previous sections). `ADMIN_DB_BREAK_GLASS` must
    NOT be set — the script refuses while break-glass is armed.
 2. **Stop the processor** (tenant: `docker compose stop processor`; Fly:
@@ -223,6 +227,21 @@ that state (`unlinked_emission_era`); prevention is this run order:
    PII columns, so the dual-store GDPR pseudonymization route keeps working
    against the retained legacy rows (Art 17 outlives the freeze).
 
+### `AUDIT_CHAINER_ALLOW_GENESIS` — fresh installs ONLY
+
+The chainer refuses to chain from a `'genesis'` (empty) admin head unless
+the processor has `AUDIT_CHAINER_ALLOW_GENESIS=true`:
+
+- **Fresh install** (no legacy `security_audit_log` rows anywhere): set it on
+  the processor — there is no legacy history, so the genesis link is correct
+  and there is nothing to backfill.
+- **Upgrade** (legacy rows exist in the main db): NEVER set it. The head
+  stays empty until step 4 above plants the legacy rows; the chainer's
+  refusal (`genesis_refused` outcome, loud log every 30s cycle) is the guard
+  that keeps a processor started too early from forking the eras. Once the
+  backfill lands, the head is non-genesis and chaining resumes on its own —
+  the flag is not needed afterwards on either path.
+
 ### Notes
 
 - **Break-glass after the freeze can no longer append to the legacy table.**
@@ -231,7 +250,9 @@ that state (`unlinked_emission_era`); prevention is this run order:
   history. Emergency unfreeze (owner, document the incident):
   `DROP TRIGGER security_audit_log_freeze ON security_audit_log;`
   `DROP TRIGGER security_audit_log_freeze_truncate ON security_audit_log;`
-- **If the chainer ran first** (`unlinked_emission_era` refusal): while the
+- **If the chainer ran first** (`unlinked_emission_era` refusal — only
+  reachable when `AUDIT_CHAINER_ALLOW_GENESIS=true` was wrongly set on an
+  upgrade): while the
   seeded SIEM cursor is still deferring, nothing external consumed the
   genesis-era rows — the owner can move them back into
   `security_audit_ingest` and delete them from the chained table, then run

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -152,3 +152,108 @@ fast if `ADMIN_DATABASE_URL_MIGRATE` is missing.
 Without `ADMIN_ERASER_DATABASE_URL`, the admin GDPR pseudonymization
 endpoint refuses with 503 (it never silently skips the Admin PG or falls
 back to another identity) — everything else is unaffected.
+
+## 2026-07 — Phase 2 security_audit_log backfill & legacy freeze (issue #890)
+
+Post-cutover, NEW security audit events chain in the Admin PG while all
+pre-cutover history still sits in the MAIN db — invisible to the default
+readers and to SIEM until it is backfilled. `scripts/backfill-audit-db.ts`
+copies every legacy row admin-ward byte-for-byte (id, `chain_seq`,
+`previous_hash`, `event_hash`, timestamp, encrypted PII columns preserved;
+`emission_hash` stays NULL as the legacy-era marker), proves the WHOLE chain
+genesis→head in the admin store, then — as a separate, explicitly confirmed
+step — write-freezes the legacy table.
+
+**ORDER IS LOAD-BEARING.** The chainer links its first batch onto whatever
+the admin chain head is. Run the backfill BEFORE the chainer's first run and
+the eras link seamlessly; let the chainer run first and it chains from
+`'genesis'`, which can never be joined to the legacy history (chain columns
+are append-only by design — no role can re-link them). The script refuses
+that state (`unlinked_emission_era`); prevention is this run order:
+
+1. **Prereqs.** Admin PG provisioned + migrated through `drizzle-admin/0007`,
+   login users provisioned (previous sections). `ADMIN_DB_BREAK_GLASS` must
+   NOT be set — the script refuses while break-glass is armed.
+2. **Stop the processor** (tenant: `docker compose stop processor`; Fly:
+   `fly scale count 0 -a pagespace-processor`). Web STAYS UP: with the
+   Phase 2 cutover live, its audit events buffer losslessly in
+   `security_audit_ingest`, which only the (stopped) chainer drains. SIEM
+   delivery is also paused with the processor — nothing advances cursors.
+3. **Dry-run** with the owner identities (never runtime roles — planting
+   rows, `setval`, and historical-partition DDL exceed their grants on
+   purpose):
+
+   ```bash
+   DATABASE_URL=<main owner url> \
+   ADMIN_DATABASE_URL_MIGRATE=<admin owner url> \
+     bun scripts/backfill-audit-db.ts
+   ```
+
+   Sanity-check the plan line: main row count, admin legacy/emission counts,
+   the anchor row (the SIEM cursor watermark, committed last).
+4. **Apply**: same command with `--apply`. The script holds the chainer's own
+   advisory lock for the whole run (a forgotten-running chainer no-ops
+   `lock_busy`), creates historical monthly partitions, copies in `chain_seq`
+   order (batched, resumable; reruns are idempotent via ON CONFLICT), aligns
+   `security_audit_log_chain_seq_seq` PAST the max legacy seq BEFORE the
+   chainer can run again, plants the SIEM anchor row LAST (so when the
+   deferral gate sees it, every legacy row is already visible), then asserts
+   row-count parity, head-hash equality, era-boundary linkage, and a FULL
+   era-aware genesis→head `verifySecurityAuditChain`. Exit 0 = all green;
+   anything else: fix, re-run (safe), do NOT proceed.
+5. **Start the processor.** Watch for `[audit-chainer] Chained N events
+   (verify-on-append ok…)` — the first batch links onto the legacy head —
+   and confirm SIEM: the `awaiting_backfill` deferral log line stops and the
+   security source resumes delivery exactly once from its watermark.
+6. **Soak**: the `verify-audit-chain` cron must be green (composite: chain +
+   anchors), and forensic queries now see full history.
+7. **Freeze** (separate invocation, deliberately not combinable with
+   `--apply`):
+
+   ```bash
+   AUDIT_FREEZE_CONFIRMED=true \
+   DATABASE_URL=<main owner url> \
+   ADMIN_DATABASE_URL_MIGRATE=<admin owner url> \
+     bun scripts/backfill-audit-db.ts --freeze
+   ```
+
+   Re-proves parity + genesis→head first, then revokes INSERT/DELETE/TRUNCATE
+   on the main table and installs guard triggers that raise on every write —
+   owner connections included — EXCEPT UPDATEs confined to the 6 eraser-scope
+   PII columns, so the dual-store GDPR pseudonymization route keeps working
+   against the retained legacy rows (Art 17 outlives the freeze).
+
+### Notes
+
+- **Break-glass after the freeze can no longer append to the legacy table.**
+  This is accepted by design: break-glass is an emergency-degraded mode, and
+  post-freeze its audit writes fail loudly instead of silently forking
+  history. Emergency unfreeze (owner, document the incident):
+  `DROP TRIGGER security_audit_log_freeze ON security_audit_log;`
+  `DROP TRIGGER security_audit_log_freeze_truncate ON security_audit_log;`
+- **If the chainer ran first** (`unlinked_emission_era` refusal): while the
+  seeded SIEM cursor is still deferring, nothing external consumed the
+  genesis-era rows — the owner can move them back into
+  `security_audit_ingest` and delete them from the chained table, then run
+  the backfill and let the chainer re-chain them onto the legacy head (exact
+  SQL in the script header). DO NOT do this if anchoring
+  (`AUDIT_ANCHOR_ENABLED`) was already on: published anchors are append-only
+  witnesses (receipts table + S3 Object-Lock) and would attest tamper
+  forever. In that case escalate; do not improvise.
+- **Legacy cursor still `__cursor_init__`** (SIEM initialized but never
+  delivered pre-flip): the seed copies the sentinel and there is no anchor
+  row to gate on — the run order above (backfill before the processor
+  starts) is the only protection. The script warns when it finds no anchor.
+- **DROP of the legacy table is deliberately NOT part of this procedure** —
+  it stays read-only through the soak period and is dropped by a Phase 6
+  follow-up (tracked on the #890 board) once the admin store has soaked.
+- **Rehearsal** (never against production): the wire-connected suites are the
+  runbook in test form —
+  `scripts/__tests__/backfill-audit-db.integration.test.ts` (plant/parity/
+  verify/freeze) and
+  `apps/processor/src/workers/__tests__/audit-backfill-flip.integration.test.ts`
+  (real chainer + SIEM choreography). Start a scratch PG16
+  (`docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 -e
+  POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e
+  POSTGRES_DB=pagespace_admin postgres:16`) and run both with
+  `ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin`.

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -77,3 +77,71 @@ ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admi
 - `ADMIN_DB_BREAK_GLASS=true` is a break-glass rollback flag only (audit
   writes fall back to the main DB and alert loudly). It is not a supported
   steady state — do not set it during a normal upgrade.
+
+## 2026-07 — Phase 2 per-service admin login users (issue #890)
+
+Runtime services no longer touch the admin database as its owner. The
+`migrate` one-shot now runs `db:provision:admin-users` after
+`db:migrate:admin`, creating one least-privilege LOGIN user per service and
+attaching it to the NOLOGIN role templates from `drizzle-admin/0001`:
+
+| login user             | granted templates          | used by             |
+|------------------------|----------------------------|---------------------|
+| `admin_app_user`       | `admin_app`                | web                 |
+| `admin_processor_user` | `admin_chainer`, `admin_siem` | processor        |
+| `admin_reader_user`    | `admin_reader`             | admin app (read-only) |
+
+`ADMIN_POSTGRES_*` (the owner) is now consumed **only** by the
+`postgres-admin` container and the `migrate` one-shot. The compose stack
+**refuses to start** without the three new password variables:
+
+```
+required variable ADMIN_APP_PASSWORD is missing a value:
+ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)
+```
+
+### Steps (tenant / self-host)
+
+1. Generate three passwords (alphanumeric is **required** — the compose stack
+   embeds them in `ADMIN_DATABASE_URL` without URL-encoding):
+
+   ```bash
+   for i in 1 2 3; do openssl rand -base64 48 | tr -dc 'a-zA-Z0-9' | head -c 32; echo; done
+   ```
+
+2. **Append** to the **existing** `.env` (mirroring the
+   `--- Admin Database (trust plane) ---` section of `env.tenant.template`;
+   as always, never re-run `generate-tenant-env.sh` on a live deployment):
+
+   ```dotenv
+   ADMIN_APP_PASSWORD=<generated password 1>
+   ADMIN_PROCESSOR_PASSWORD=<generated password 2>
+   ADMIN_READER_PASSWORD=<generated password 3>
+   ```
+
+3. Pull and restart the stack as usual. Provisioning is idempotent and
+   rotation-safe: re-running with a changed password rotates that login
+   user's password.
+
+### Fly (cloud) secret matrix
+
+Owner credentials never sit in any Fly app's runtime secrets. The CI admin
+migrate machine takes the owner URL from a **GitHub Actions secret** passed
+to the one-shot machine only (`migrate-admin.ts` prefers
+`ADMIN_DATABASE_URL_MIGRATE` over any inherited runtime URL):
+
+| where                              | secret                       | value (connects as)      |
+|------------------------------------|------------------------------|--------------------------|
+| GitHub Actions (repo secret)       | `ADMIN_DATABASE_URL_MIGRATE` | owner — migrations + provisioning only |
+| Fly `pagespace-web`                | `ADMIN_DATABASE_URL`         | `admin_app_user`         |
+| Fly `pagespace-processor`          | `ADMIN_DATABASE_URL`         | `admin_processor_user`   |
+| Fly `pagespace-admin`              | `ADMIN_DATABASE_URL`         | `admin_reader_user`      |
+| Fly `pagespace-realtime`           | — (no audit path)            | —                        |
+
+Provisioning the login users on Fly: run `bun run db:provision:admin-users`
+once (e.g. on a one-shot machine or via `fly ssh console`) with
+`ADMIN_DATABASE_URL_MIGRATE` set to the owner URL and the three
+`ADMIN_*_PASSWORD` values exported for that run — then set each app's
+runtime `ADMIN_DATABASE_URL` from the matrix above. With
+`ADMIN_DB_MIGRATIONS_ENABLED=true`, the CI step fails fast if
+`ADMIN_DATABASE_URL_MIGRATE` is missing.

--- a/infrastructure/__tests__/ci-admin-migrate.test.ts
+++ b/infrastructure/__tests__/ci-admin-migrate.test.ts
@@ -59,4 +59,24 @@ describe('docker-images.yml admin-DB migrate step', () => {
   it('given the main migrations step, should NOT be conditional (main DB always migrates)', () => {
     expect(steps[mainIdx].if).toBeUndefined();
   });
+
+  // #890 Phase 2 (leaf 0): the machine runs in the pagespace-web app, whose
+  // runtime ADMIN_DATABASE_URL secret is the least-privilege admin_app LOGIN.
+  // Migrations need the OWNER role, so the workflow passes a dedicated
+  // ADMIN_DATABASE_URL_MIGRATE from a GitHub secret to the one-shot machine —
+  // owner credentials never live in any Fly app's runtime secrets.
+  describe('owner-credential scoping (ADMIN_DATABASE_URL_MIGRATE)', () => {
+    it('given the admin migrations step, should pass ADMIN_DATABASE_URL_MIGRATE to the one-shot machine via --env', () => {
+      expect(adminStep.run).toMatch(/--env\s+ADMIN_DATABASE_URL_MIGRATE=/);
+    });
+
+    it('given the admin migrations step, should source ADMIN_DATABASE_URL_MIGRATE from GitHub secrets', () => {
+      expect(adminStep.env?.ADMIN_DATABASE_URL_MIGRATE).toContain('secrets.ADMIN_DATABASE_URL_MIGRATE');
+    });
+
+    it('given the admin migrations step, should fail fast when the migrate secret is missing (never fall back to the runtime login)', () => {
+      expect(adminStep.run).toMatch(/-z\s+"?\$\{?ADMIN_DATABASE_URL_MIGRATE\}?"?/);
+      expect(adminStep.run).toContain('exit 1');
+    });
+  });
 });

--- a/infrastructure/__tests__/env-template.test.ts
+++ b/infrastructure/__tests__/env-template.test.ts
@@ -83,6 +83,10 @@ describe('Tenant env template', () => {
     expect(templateVars.get('DEPLOYMENT_MODE')).toBe('tenant');
   });
 
+  it('given AUDIT_CHAINER_ALLOW_GENESIS, should be true — the template provisions FRESH installs (empty admin chain, genesis link is correct); upgrades must never carry it (#890 Phase 2 era-fork guard)', () => {
+    expect(templateVars.get('AUDIT_CHAINER_ALLOW_GENESIS')).toBe('true');
+  });
+
   it('given IMAGE_TAG, should default to latest', () => {
     expect(templateVars.get('IMAGE_TAG')).toBe('latest');
   });

--- a/infrastructure/__tests__/generate-tenant-env.test.ts
+++ b/infrastructure/__tests__/generate-tenant-env.test.ts
@@ -121,12 +121,28 @@ describe('generate-tenant-env.sh', () => {
       expect(val).toMatch(/^[a-zA-Z0-9]+$/);
     });
 
+    // #890 Phase 2: per-service Admin PG LOGIN passwords. Alphanumeric is
+    // load-bearing — the compose stack embeds them in ADMIN_DATABASE_URL
+    // without URL-encoding.
+    const loginPasswords = ['ADMIN_APP_PASSWORD', 'ADMIN_PROCESSOR_PASSWORD', 'ADMIN_READER_PASSWORD'];
+    it.each(loginPasswords)(
+      'given %s, should be at least 24 alphanumeric characters',
+      (v) => {
+        const val = env.get(v) ?? '';
+        expect(val.length).toBeGreaterThanOrEqual(24);
+        expect(val).toMatch(/^[a-zA-Z0-9]+$/);
+      },
+    );
+
     it('given all secrets, should all be unique (no reuse)', () => {
       const secrets = [
         env.get('ENCRYPTION_KEY'),
         env.get('CSRF_SECRET'),
         env.get('POSTGRES_PASSWORD'),
         env.get('ADMIN_POSTGRES_PASSWORD'),
+        env.get('ADMIN_APP_PASSWORD'),
+        env.get('ADMIN_PROCESSOR_PASSWORD'),
+        env.get('ADMIN_READER_PASSWORD'),
         env.get('CRON_SECRET'),
         env.get('REALTIME_BROADCAST_SECRET'),
       ];

--- a/infrastructure/__tests__/generate-tenant-env.test.ts
+++ b/infrastructure/__tests__/generate-tenant-env.test.ts
@@ -95,6 +95,10 @@ describe('generate-tenant-env.sh', () => {
     it('given the output, ADMIN_POSTGRES_USER should be pagespace', () => {
       expect(env.get('ADMIN_POSTGRES_USER')).toBe('pagespace');
     });
+
+    it('given the output, AUDIT_CHAINER_ALLOW_GENESIS should be true — the generator provisions FRESH installs, where the genesis link is correct (#890 Phase 2 era-fork guard)', () => {
+      expect(env.get('AUDIT_CHAINER_ALLOW_GENESIS')).toBe('true');
+    });
   });
 
   describe('secret generation', () => {

--- a/infrastructure/__tests__/generate-tenant-env.test.ts
+++ b/infrastructure/__tests__/generate-tenant-env.test.ts
@@ -124,7 +124,12 @@ describe('generate-tenant-env.sh', () => {
     // #890 Phase 2: per-service Admin PG LOGIN passwords. Alphanumeric is
     // load-bearing — the compose stack embeds them in ADMIN_DATABASE_URL
     // without URL-encoding.
-    const loginPasswords = ['ADMIN_APP_PASSWORD', 'ADMIN_PROCESSOR_PASSWORD', 'ADMIN_READER_PASSWORD'];
+    const loginPasswords = [
+      'ADMIN_APP_PASSWORD',
+      'ADMIN_PROCESSOR_PASSWORD',
+      'ADMIN_READER_PASSWORD',
+      'ADMIN_ERASER_PASSWORD',
+    ];
     it.each(loginPasswords)(
       'given %s, should be at least 24 alphanumeric characters',
       (v) => {
@@ -143,6 +148,7 @@ describe('generate-tenant-env.sh', () => {
         env.get('ADMIN_APP_PASSWORD'),
         env.get('ADMIN_PROCESSOR_PASSWORD'),
         env.get('ADMIN_READER_PASSWORD'),
+        env.get('ADMIN_ERASER_PASSWORD'),
         env.get('CRON_SECRET'),
         env.get('REALTIME_BROADCAST_SECRET'),
       ];

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -172,6 +172,10 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
       expect(getEnv(compose, 'realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
     });
 
+    it('given the processor service, AUDIT_CHAINER_ALLOW_GENESIS should be true — the local stack is always a fresh install (empty admin chain, nothing to backfill; #890 Phase 2 era-fork guard)', () => {
+      expect(getEnv(compose, 'processor').AUDIT_CHAINER_ALLOW_GENESIS).toBe('true');
+    });
+
     // #890 Phase 2 leaf 6: the GDPR pseudonymization route (web) erases PII
     // on the trust plane as its own column-scoped identity.
     it('given the web service, ADMIN_ERASER_DATABASE_URL should connect as admin_gdpr_eraser_user with the password migrate provisions', () => {

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -120,11 +120,12 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
       );
     });
 
-    it('given the migrate service, should receive all three per-service login passwords for provisioning', () => {
+    it('given the migrate service, should receive all four per-service login passwords for provisioning', () => {
       const env = getEnv(compose, 'migrate');
       expect(env.ADMIN_APP_PASSWORD).toBeTruthy();
       expect(env.ADMIN_PROCESSOR_PASSWORD).toBeTruthy();
       expect(env.ADMIN_READER_PASSWORD).toBeTruthy();
+      expect(env.ADMIN_ERASER_PASSWORD).toBeTruthy();
     });
   });
 
@@ -170,6 +171,22 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
     it('given the realtime service, should NOT wire ADMIN_DATABASE_URL (no audit path in realtime)', () => {
       expect(getEnv(compose, 'realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
     });
+
+    // #890 Phase 2 leaf 6: the GDPR pseudonymization route (web) erases PII
+    // on the trust plane as its own column-scoped identity.
+    it('given the web service, ADMIN_ERASER_DATABASE_URL should connect as admin_gdpr_eraser_user with the password migrate provisions', () => {
+      const url = getEnv(compose, 'web').ADMIN_ERASER_DATABASE_URL;
+      const provisionPassword = getEnv(compose, 'migrate').ADMIN_ERASER_PASSWORD;
+      expect(url).toContain(`://admin_gdpr_eraser_user:${provisionPassword}@`);
+      expect(url).toContain('@postgres-admin:5432/pagespace_admin');
+    });
+
+    it.each(['admin', 'processor', 'realtime'])(
+      'given the %s service, should NOT wire ADMIN_ERASER_DATABASE_URL (only the web GDPR route erases)',
+      (svc) => {
+        expect(getEnv(compose, svc)).not.toHaveProperty('ADMIN_ERASER_DATABASE_URL');
+      },
+    );
 
     it.each(['web', 'admin', 'processor', 'realtime'])(
       'given the %s service, should still receive DATABASE_URL pointing at the main postgres',

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -172,8 +172,10 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
       expect(getEnv(compose, 'realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
     });
 
-    it('given the processor service, AUDIT_CHAINER_ALLOW_GENESIS should be true — the local stack is always a fresh install (empty admin chain, nothing to backfill; #890 Phase 2 era-fork guard)', () => {
-      expect(getEnv(compose, 'processor').AUDIT_CHAINER_ALLOW_GENESIS).toBe('true');
+    it('given the processor service, AUDIT_CHAINER_ALLOW_GENESIS should pass through from .env — the volumes are persistent, so an upgraded stack can hold legacy rows and must NOT default to genesis chaining; fresh installs opt in via .env.example (#890 Phase 2 era-fork guard)', () => {
+      const value = String(getEnv(compose, 'processor').AUDIT_CHAINER_ALLOW_GENESIS ?? '');
+      expect(value).toContain('${AUDIT_CHAINER_ALLOW_GENESIS');
+      expect(value).not.toBe('true');
     });
 
     // #890 Phase 2 leaf 6: the GDPR pseudonymization route (web) erases PII

--- a/infrastructure/__tests__/root-compose.test.ts
+++ b/infrastructure/__tests__/root-compose.test.ts
@@ -111,25 +111,67 @@ describe('Root (dev/self-host) docker-compose configuration', () => {
       const url = getEnv(compose, 'migrate').ADMIN_DATABASE_URL;
       expect(url).toContain('@postgres-admin:5432/pagespace_admin');
     });
+
+    it('given the migrate service, should run db:provision:admin-users after db:migrate:admin', () => {
+      const command = String(compose.services.migrate.command);
+      expect(command).toContain('db:provision:admin-users');
+      expect(command.indexOf('db:migrate:admin')).toBeLessThan(
+        command.indexOf('db:provision:admin-users'),
+      );
+    });
+
+    it('given the migrate service, should receive all three per-service login passwords for provisioning', () => {
+      const env = getEnv(compose, 'migrate');
+      expect(env.ADMIN_APP_PASSWORD).toBeTruthy();
+      expect(env.ADMIN_PROCESSOR_PASSWORD).toBeTruthy();
+      expect(env.ADMIN_READER_PASSWORD).toBeTruthy();
+    });
   });
 
-  describe('ADMIN_DATABASE_URL wiring', () => {
-    const appServices = ['web', 'admin', 'processor', 'realtime'];
-
+  describe('ADMIN_DATABASE_URL wiring (per-service least-privilege LOGINs, #890 Phase 2)', () => {
     // Owner/bootstrap credentials bypass the drizzle-admin/0001 zero-trust
-    // grants, so only the migrate one-shot may hold them. Runtime services
-    // get per-service LOGIN roles with the Phase 2 audit-write cutover.
-    // (This pins the compose environment map; the dev stack's `env_file: .env`
-    // may still carry the var — the hard guarantee is the tenant stack, which
-    // uses explicit environment maps only.)
-    it.each(appServices)(
-      'given the %s runtime service, should NOT wire ADMIN_DATABASE_URL in the environment map (owner creds are migrate-only in Phase 1)',
-      (svc) => {
-        expect(getEnv(compose, svc)).not.toHaveProperty('ADMIN_DATABASE_URL');
+    // grants, so only the migrate one-shot may hold them. Each runtime
+    // service connects as its own LOGIN user attached to its role template:
+    // web → admin_app, processor → admin_chainer+admin_siem, admin → admin_reader.
+    const serviceLogins: [string, string, string][] = [
+      ['web', 'admin_app_user', 'ADMIN_APP_PASSWORD'],
+      ['processor', 'admin_processor_user', 'ADMIN_PROCESSOR_PASSWORD'],
+      ['admin', 'admin_reader_user', 'ADMIN_READER_PASSWORD'],
+    ];
+
+    it.each(serviceLogins)(
+      'given the %s service, ADMIN_DATABASE_URL should connect as %s at postgres-admin',
+      (svc, loginUser) => {
+        const url = getEnv(compose, svc).ADMIN_DATABASE_URL;
+        expect(url).toContain(`://${loginUser}:`);
+        expect(url).toContain('@postgres-admin:5432/pagespace_admin');
       },
     );
 
-    it.each(appServices)(
+    it.each(serviceLogins)(
+      'given the %s service, its login password should match the one migrate provisions via %s',
+      (svc, loginUser, passwordVar) => {
+        const url = getEnv(compose, svc).ADMIN_DATABASE_URL;
+        const provisionPassword = getEnv(compose, 'migrate')[passwordVar];
+        expect(url).toContain(`://${loginUser}:${provisionPassword}@`);
+      },
+    );
+
+    it.each(serviceLogins.map(([svc]) => svc))(
+      'given the %s service, should NOT connect to postgres-admin with the owner credentials',
+      (svc) => {
+        const url = getEnv(compose, svc).ADMIN_DATABASE_URL;
+        const ownerUrl = getEnv(compose, 'migrate').ADMIN_DATABASE_URL;
+        expect(url).not.toBe(ownerUrl);
+        expect(url).not.toContain('://user:');
+      },
+    );
+
+    it('given the realtime service, should NOT wire ADMIN_DATABASE_URL (no audit path in realtime)', () => {
+      expect(getEnv(compose, 'realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
+    });
+
+    it.each(['web', 'admin', 'processor', 'realtime'])(
       'given the %s service, should still receive DATABASE_URL pointing at the main postgres',
       (svc) => {
         const url = getEnv(compose, svc).DATABASE_URL;

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -433,12 +433,35 @@ describe('Tenant docker-compose configuration', () => {
       expect(offenders).toEqual([]);
     });
 
-    it('given the migrate service, should receive the three per-service login passwords with required-var guards', () => {
+    it('given the migrate service, should receive the four per-service login passwords with required-var guards', () => {
       const env = getEnv('migrate');
-      for (const v of ['ADMIN_APP_PASSWORD', 'ADMIN_PROCESSOR_PASSWORD', 'ADMIN_READER_PASSWORD']) {
+      for (const v of [
+        'ADMIN_APP_PASSWORD',
+        'ADMIN_PROCESSOR_PASSWORD',
+        'ADMIN_READER_PASSWORD',
+        'ADMIN_ERASER_PASSWORD',
+      ]) {
         expect(env[v]).toContain(`\${${v}:?`);
       }
     });
+
+    // #890 Phase 2 leaf 6: the GDPR pseudonymization route (web) erases PII
+    // on the trust plane as its own column-scoped identity.
+    it('given the web service, ADMIN_ERASER_DATABASE_URL should connect as admin_gdpr_eraser_user with a required-var password, never owner creds', () => {
+      const url = getEnv('web').ADMIN_ERASER_DATABASE_URL;
+      expect(url).toContain('://admin_gdpr_eraser_user:');
+      expect(url).toContain('${ADMIN_ERASER_PASSWORD:?');
+      expect(url).toContain('@postgres-admin:');
+      expect(url).not.toContain('ADMIN_POSTGRES_USER');
+      expect(url).not.toContain('ADMIN_POSTGRES_PASSWORD');
+    });
+
+    it.each(['processor', 'realtime'])(
+      'given the %s service, should NOT wire ADMIN_ERASER_DATABASE_URL (only the web GDPR route erases)',
+      (svc) => {
+        expect(getEnv(svc)).not.toHaveProperty('ADMIN_ERASER_DATABASE_URL');
+      },
+    );
 
     it('given the migrate service, should run db:provision:admin-users after db:migrate:admin', () => {
       const command = String(compose.services.migrate.command);

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -407,6 +407,14 @@ describe('Tenant docker-compose configuration', () => {
       },
     );
 
+    it('given the processor service, should pass AUDIT_CHAINER_ALLOW_GENESIS through from .env (fresh installs set it true; upgrades leave it unset — era-fork guard)', () => {
+      const value = String(getEnv('processor').AUDIT_CHAINER_ALLOW_GENESIS ?? '');
+      expect(value).toContain('${AUDIT_CHAINER_ALLOW_GENESIS');
+      // Optional on purpose: an unset var must not fail compose interpolation
+      // on upgraded stacks whose .env predates the flag.
+      expect(value).toContain(':-');
+    });
+
     it('given the realtime service, should NOT receive ADMIN_DATABASE_URL (no audit path in realtime)', () => {
       expect(getEnv('realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
     });

--- a/infrastructure/__tests__/tenant-compose.test.ts
+++ b/infrastructure/__tests__/tenant-compose.test.ts
@@ -379,17 +379,74 @@ describe('Tenant docker-compose configuration', () => {
 
     // Owner/bootstrap credentials would bypass the drizzle-admin/0001
     // zero-trust grants (the owner can DELETE/TRUNCATE its own tables), so
-    // runtime services must not receive them. Per-service LOGIN roles
-    // (admin_app / admin_chainer / admin_siem members) arrive with the
-    // Phase 2 audit-write cutover.
-    const runtimeServices = ['web', 'processor', 'realtime'];
+    // runtime services never receive them. Phase 2 (#890): each runtime
+    // service connects as its own least-privilege LOGIN user — web →
+    // admin_app_user (admin_app), processor → admin_processor_user
+    // (admin_chainer + admin_siem). The tenant stack has no admin app.
+    const serviceLogins: [string, string, string][] = [
+      ['web', 'admin_app_user', 'ADMIN_APP_PASSWORD'],
+      ['processor', 'admin_processor_user', 'ADMIN_PROCESSOR_PASSWORD'],
+    ];
 
-    it.each(runtimeServices)(
-      'given the %s runtime service, should NOT receive ADMIN_DATABASE_URL (owner creds are migrate-only in Phase 1)',
-      (svc) => {
-        expect(getEnv(svc)).not.toHaveProperty('ADMIN_DATABASE_URL');
+    it.each(serviceLogins)(
+      'given the %s runtime service, ADMIN_DATABASE_URL should connect as %s with a required-var %s',
+      (svc, loginUser, passwordVar) => {
+        const url = getEnv(svc).ADMIN_DATABASE_URL;
+        expect(url).toContain(`://${loginUser}:`);
+        expect(url).toContain(`\${${passwordVar}:?`);
+        expect(url).toContain('@postgres-admin:');
       },
     );
+
+    it.each(serviceLogins.map(([svc]) => svc))(
+      'given the %s runtime service, ADMIN_DATABASE_URL should NOT interpolate the owner credentials',
+      (svc) => {
+        const url = getEnv(svc).ADMIN_DATABASE_URL;
+        expect(url).not.toContain('ADMIN_POSTGRES_USER');
+        expect(url).not.toContain('ADMIN_POSTGRES_PASSWORD');
+      },
+    );
+
+    it('given the realtime service, should NOT receive ADMIN_DATABASE_URL (no audit path in realtime)', () => {
+      expect(getEnv('realtime')).not.toHaveProperty('ADMIN_DATABASE_URL');
+    });
+
+    it('given the raw YAML, owner credentials (ADMIN_POSTGRES_USER/PASSWORD) should be interpolated ONLY by postgres-admin and migrate', () => {
+      const raw = getRawYaml();
+      const serviceNames = Object.keys(compose.services);
+      const lines = raw.split('\n');
+      let currentService: string | null = null;
+      const offenders: string[] = [];
+      for (const line of lines) {
+        const svcMatch = line.match(/^ {2}([a-z-]+):\s*$/);
+        if (svcMatch && serviceNames.includes(svcMatch[1])) {
+          currentService = svcMatch[1];
+          continue;
+        }
+        if (line.trim().startsWith('#')) continue;
+        if (/\$\{ADMIN_POSTGRES_(USER|PASSWORD)/.test(line)) {
+          if (currentService !== 'postgres-admin' && currentService !== 'migrate') {
+            offenders.push(`${currentService}: ${line.trim()}`);
+          }
+        }
+      }
+      expect(offenders).toEqual([]);
+    });
+
+    it('given the migrate service, should receive the three per-service login passwords with required-var guards', () => {
+      const env = getEnv('migrate');
+      for (const v of ['ADMIN_APP_PASSWORD', 'ADMIN_PROCESSOR_PASSWORD', 'ADMIN_READER_PASSWORD']) {
+        expect(env[v]).toContain(`\${${v}:?`);
+      }
+    });
+
+    it('given the migrate service, should run db:provision:admin-users after db:migrate:admin', () => {
+      const command = String(compose.services.migrate.command);
+      expect(command).toContain('db:provision:admin-users');
+      expect(command.indexOf('db:migrate:admin')).toBeLessThan(
+        command.indexOf('db:provision:admin-users'),
+      );
+    });
 
     const redisEnvVars = ['REDIS_URL', 'REDIS_SESSION_URL', 'REDIS_RATE_LIMIT_URL', 'REDIS_PASSWORD'];
     const jwtEnvVars = ['JWT_SECRET', 'JWT_ISSUER', 'JWT_AUDIENCE'];
@@ -426,13 +483,14 @@ describe('Tenant docker-compose configuration', () => {
       );
     });
 
-    it('given every ADMIN_DATABASE_URL derivation, should use required-var syntax on the admin password', () => {
+    it('given every ADMIN_DATABASE_URL derivation, should use required-var syntax on its password', () => {
       const lines = getRawYaml()
         .split('\n')
         .filter((l) => !l.trim().startsWith('#') && l.includes('ADMIN_DATABASE_URL:'));
-      expect(lines.length).toBe(1); // migrate only — runtime services hold no admin creds in Phase 1
+      // migrate (owner) + web (admin_app_user) + processor (admin_processor_user)
+      expect(lines.length).toBe(3);
       for (const line of lines) {
-        expect(line).toMatch(/\$\{ADMIN_POSTGRES_PASSWORD:\?/);
+        expect(line).toMatch(/\$\{ADMIN_(POSTGRES|APP|PROCESSOR)_PASSWORD:\?/);
       }
     });
 

--- a/infrastructure/__tests__/upgrade-doc.test.ts
+++ b/infrastructure/__tests__/upgrade-doc.test.ts
@@ -50,4 +50,37 @@ describe('infrastructure/UPGRADE.md (operator upgrade note)', () => {
     expect(doc).toMatch(/append/i);
     expect(doc).toMatch(/existing/i);
   });
+
+  // #890 Phase 2 (leaf 0): per-service Admin PG LOGIN users + the Fly/CI
+  // owner-credential scoping. Operators upgrading a live tenant need the new
+  // password vars; cloud ops needs the secret matrix.
+  describe('Phase 2 section (per-service admin login users)', () => {
+    it('given the Phase 2 section, should show the three per-service password lines to append', () => {
+      expect(doc).toMatch(/ADMIN_APP_PASSWORD=/);
+      expect(doc).toMatch(/ADMIN_PROCESSOR_PASSWORD=/);
+      expect(doc).toMatch(/ADMIN_READER_PASSWORD=/);
+    });
+
+    it('given the Phase 2 section, should name the per-service login users and their role templates', () => {
+      for (const user of ['admin_app_user', 'admin_processor_user', 'admin_reader_user']) {
+        expect(doc).toContain(user);
+      }
+      for (const role of ['admin_app', 'admin_chainer', 'admin_siem', 'admin_reader']) {
+        expect(doc).toContain(role);
+      }
+    });
+
+    it('given the Fly secret matrix, should map each app to its URL and reserve ADMIN_DATABASE_URL_MIGRATE for the migrate one-shot', () => {
+      for (const app of ['pagespace-web', 'pagespace-processor', 'pagespace-admin']) {
+        expect(doc).toContain(app);
+      }
+      expect(doc).toContain('ADMIN_DATABASE_URL_MIGRATE');
+      // The owner URL must be described as GitHub-secret-only, never a Fly runtime secret.
+      expect(doc).toMatch(/GitHub/);
+    });
+
+    it('given the provisioning mechanism, should document db:provision:admin-users', () => {
+      expect(doc).toContain('db:provision:admin-users');
+    });
+  });
 });

--- a/infrastructure/__tests__/upgrade-doc.test.ts
+++ b/infrastructure/__tests__/upgrade-doc.test.ts
@@ -55,19 +55,29 @@ describe('infrastructure/UPGRADE.md (operator upgrade note)', () => {
   // owner-credential scoping. Operators upgrading a live tenant need the new
   // password vars; cloud ops needs the secret matrix.
   describe('Phase 2 section (per-service admin login users)', () => {
-    it('given the Phase 2 section, should show the three per-service password lines to append', () => {
+    it('given the Phase 2 section, should show the four per-service password lines to append', () => {
       expect(doc).toMatch(/ADMIN_APP_PASSWORD=/);
       expect(doc).toMatch(/ADMIN_PROCESSOR_PASSWORD=/);
       expect(doc).toMatch(/ADMIN_READER_PASSWORD=/);
+      expect(doc).toMatch(/ADMIN_ERASER_PASSWORD=/);
     });
 
     it('given the Phase 2 section, should name the per-service login users and their role templates', () => {
-      for (const user of ['admin_app_user', 'admin_processor_user', 'admin_reader_user']) {
+      for (const user of [
+        'admin_app_user',
+        'admin_processor_user',
+        'admin_reader_user',
+        'admin_gdpr_eraser_user',
+      ]) {
         expect(doc).toContain(user);
       }
-      for (const role of ['admin_app', 'admin_chainer', 'admin_siem', 'admin_reader']) {
+      for (const role of ['admin_app', 'admin_chainer', 'admin_siem', 'admin_reader', 'admin_gdpr_eraser']) {
         expect(doc).toContain(role);
       }
+    });
+
+    it('given the eraser identity (leaf 6), should document ADMIN_ERASER_DATABASE_URL for the web app', () => {
+      expect(doc).toContain('ADMIN_ERASER_DATABASE_URL');
     });
 
     it('given the Fly secret matrix, should map each app to its URL and reserve ADMIN_DATABASE_URL_MIGRATE for the migrate one-shot', () => {

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -135,6 +135,9 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
       ADMIN_DATABASE_URL: postgresql://admin_processor_user:${ADMIN_PROCESSOR_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      # Fresh installs set true in .env (generator/template); upgrades leave it
+      # unset so the chainer refuses to fork the eras pre-backfill (UPGRADE.md).
+      AUDIT_CHAINER_ALLOW_GENESIS: ${AUDIT_CHAINER_ALLOW_GENESIS:-}
       FILE_STORAGE_PATH: /data/files
       CACHE_PATH: /data/cache
       PORT: "3003"

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -87,6 +87,7 @@ services:
       ADMIN_APP_PASSWORD: ${ADMIN_APP_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
       ADMIN_PROCESSOR_PASSWORD: ${ADMIN_PROCESSOR_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
       ADMIN_READER_PASSWORD: ${ADMIN_READER_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
+      ADMIN_ERASER_PASSWORD: ${ADMIN_ERASER_PASSWORD:?ADMIN_ERASER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 GDPR eraser login user)}
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
@@ -190,6 +191,7 @@ services:
       NEXT_PUBLIC_DEPLOYMENT_MODE: tenant
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
       ADMIN_DATABASE_URL: postgresql://admin_app_user:${ADMIN_APP_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_ERASER_DATABASE_URL: postgresql://admin_gdpr_eraser_user:${ADMIN_ERASER_PASSWORD:?ADMIN_ERASER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 GDPR eraser login user)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /app/storage
       PROCESSOR_URL: http://processor:3003
       CRON_SECRET: ${CRON_SECRET}

--- a/infrastructure/docker-compose.tenant.yml
+++ b/infrastructure/docker-compose.tenant.yml
@@ -34,17 +34,20 @@ services:
   # Trust plane: dedicated Admin Postgres for the tamper-evident security audit
   # chain, isolated from the app database in every deployment mode (#890).
   #
-  # CREDENTIAL MODEL (Phase 1): ADMIN_POSTGRES_* is the OWNER/bootstrap role and
-  # is handed ONLY to this container and the migrate one-shot. Runtime services
-  # (web/processor/realtime) get no admin credentials — the owner would bypass
-  # the zero-trust grants in drizzle-admin/0001. Phase 2 wires per-service LOGIN
-  # roles (admin_app / admin_chainer / admin_siem members) when the audit write
-  # path actually moves here.
+  # CREDENTIAL MODEL (Phase 2): ADMIN_POSTGRES_* is the OWNER/bootstrap role and
+  # is handed ONLY to this container and the migrate one-shot — the owner would
+  # bypass the zero-trust grants in drizzle-admin/0001. Runtime services connect
+  # as per-service LOGIN users (provisioned by the migrate one-shot via
+  # db:provision:admin-users from the ADMIN_*_PASSWORD vars):
+  #   web       → admin_app_user       (admin_app template)
+  #   processor → admin_processor_user (admin_chainer + admin_siem templates)
+  #   realtime  → none (no audit path; the tenant stack has no admin app)
   #
   # UPGRADING an existing deployment: a pre-Phase-1 .env has no ADMIN_POSTGRES_*
-  # vars, so this stack refuses to start (required-var errors below) until they
-  # are APPENDED to the existing .env — see infrastructure/UPGRADE.md. Never
-  # re-run generate-tenant-env.sh on a live deployment.
+  # vars and a pre-Phase-2 .env has no ADMIN_APP/PROCESSOR/READER_PASSWORD vars,
+  # so this stack refuses to start (required-var errors below) until they are
+  # APPENDED to the existing .env — see infrastructure/UPGRADE.md. Never re-run
+  # generate-tenant-env.sh on a live deployment.
   postgres-admin:
     image: postgres:17.5-alpine
     restart: unless-stopped
@@ -81,12 +84,17 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
       ADMIN_DATABASE_URL: postgresql://${ADMIN_POSTGRES_USER:-pagespace}:${ADMIN_POSTGRES_PASSWORD:?ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admin DB)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
+      ADMIN_APP_PASSWORD: ${ADMIN_APP_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
+      ADMIN_PROCESSOR_PASSWORD: ${ADMIN_PROCESSOR_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
+      ADMIN_READER_PASSWORD: ${ADMIN_READER_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}
     command: >
       sh -c "
         echo 'Starting database migrations...' &&
         bun run db:migrate &&
         echo 'Starting admin database migrations...' &&
         bun run db:migrate:admin &&
+        echo 'Provisioning admin login users...' &&
+        bun run db:provision:admin-users &&
         echo 'Migrations complete'
       "
     networks:
@@ -125,6 +133,7 @@ services:
       - cache_storage:/data/cache
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://admin_processor_user:${ADMIN_PROCESSOR_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /data/files
       CACHE_PATH: /data/cache
       PORT: "3003"
@@ -180,6 +189,7 @@ services:
       DEPLOYMENT_MODE: tenant
       NEXT_PUBLIC_DEPLOYMENT_MODE: tenant
       DATABASE_URL: postgresql://${POSTGRES_USER:-pagespace}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-pagespace}
+      ADMIN_DATABASE_URL: postgresql://admin_app_user:${ADMIN_APP_PASSWORD:?ADMIN_APP/PROCESSOR/READER_PASSWORD missing from .env - see infrastructure/UPGRADE.md (Phase 2 admin login users)}@postgres-admin:5432/${ADMIN_POSTGRES_DB:-pagespace_admin}
       FILE_STORAGE_PATH: /app/storage
       PROCESSOR_URL: http://processor:3003
       CRON_SECRET: ${CRON_SECRET}

--- a/infrastructure/env.tenant.template
+++ b/infrastructure/env.tenant.template
@@ -24,13 +24,15 @@ ADMIN_POSTGRES_DB=pagespace_admin
 ADMIN_POSTGRES_USER=pagespace
 ADMIN_POSTGRES_PASSWORD=__GENERATE__
 # Per-service admin LOGIN users (#890 Phase 2): the migrate one-shot provisions
-# admin_app_user (web), admin_processor_user (processor) and admin_reader_user
+# admin_app_user (web), admin_processor_user (processor), admin_reader_user
+# (admin app) and admin_gdpr_eraser_user (web GDPR pseudonymization route)
 # from these; runtime services never hold the owner credentials above.
 # Must be URL-safe (the generator emits alphanumeric) — the compose stack
 # embeds them in ADMIN_DATABASE_URL without URL-encoding.
 ADMIN_APP_PASSWORD=__GENERATE__
 ADMIN_PROCESSOR_PASSWORD=__GENERATE__
 ADMIN_READER_PASSWORD=__GENERATE__
+ADMIN_ERASER_PASSWORD=__GENERATE__
 # ADMIN_DATABASE_SSL=false
 # ADMIN_DB_POOL_MAX=10
 # Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to

--- a/infrastructure/env.tenant.template
+++ b/infrastructure/env.tenant.template
@@ -38,6 +38,13 @@ ADMIN_ERASER_PASSWORD=__GENERATE__
 # Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to
 # fall back to the main DB and alerts loudly. Not a supported steady state.
 # ADMIN_DB_BREAK_GLASS=
+# FRESH INSTALLS ONLY (#890 Phase 2 era-fork guard): permits the audit chainer
+# to start a brand-new chain from 'genesis'. This template provisions fresh
+# tenants, so it is set here — but an UPGRADED stack must NEVER carry it: the
+# chainer's genesis refusal is what stops a too-early processor from forking
+# the legacy and emission eras before the backfill runs. See
+# infrastructure/UPGRADE.md (Phase 2 backfill & legacy freeze).
+AUDIT_CHAINER_ALLOW_GENESIS=true
 
 # --- Security Secrets ---
 ENCRYPTION_KEY=__GENERATE__

--- a/infrastructure/env.tenant.template
+++ b/infrastructure/env.tenant.template
@@ -23,6 +23,14 @@ POSTGRES_PASSWORD=__GENERATE__
 ADMIN_POSTGRES_DB=pagespace_admin
 ADMIN_POSTGRES_USER=pagespace
 ADMIN_POSTGRES_PASSWORD=__GENERATE__
+# Per-service admin LOGIN users (#890 Phase 2): the migrate one-shot provisions
+# admin_app_user (web), admin_processor_user (processor) and admin_reader_user
+# from these; runtime services never hold the owner credentials above.
+# Must be URL-safe (the generator emits alphanumeric) — the compose stack
+# embeds them in ADMIN_DATABASE_URL without URL-encoding.
+ADMIN_APP_PASSWORD=__GENERATE__
+ADMIN_PROCESSOR_PASSWORD=__GENERATE__
+ADMIN_READER_PASSWORD=__GENERATE__
 # ADMIN_DATABASE_SSL=false
 # ADMIN_DB_POOL_MAX=10
 # Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to

--- a/infrastructure/scripts/generate-tenant-env.sh
+++ b/infrastructure/scripts/generate-tenant-env.sh
@@ -67,6 +67,9 @@ POSTGRES_PASSWORD=$(alnum_secret 32)
 ADMIN_POSTGRES_DB=pagespace_admin
 ADMIN_POSTGRES_USER=pagespace
 ADMIN_POSTGRES_PASSWORD=$(alnum_secret 32)
+ADMIN_APP_PASSWORD=$(alnum_secret 32)
+ADMIN_PROCESSOR_PASSWORD=$(alnum_secret 32)
+ADMIN_READER_PASSWORD=$(alnum_secret 32)
 
 # --- Security Secrets ---
 ENCRYPTION_KEY=$(hex_secret 32)

--- a/infrastructure/scripts/generate-tenant-env.sh
+++ b/infrastructure/scripts/generate-tenant-env.sh
@@ -71,6 +71,10 @@ ADMIN_APP_PASSWORD=$(alnum_secret 32)
 ADMIN_PROCESSOR_PASSWORD=$(alnum_secret 32)
 ADMIN_READER_PASSWORD=$(alnum_secret 32)
 ADMIN_ERASER_PASSWORD=$(alnum_secret 32)
+# Fresh install: the audit chainer may start its chain from genesis. An
+# UPGRADED stack must never carry this flag (see infrastructure/UPGRADE.md,
+# Phase 2 backfill — era-fork guard).
+AUDIT_CHAINER_ALLOW_GENESIS=true
 
 # --- Security Secrets ---
 ENCRYPTION_KEY=$(hex_secret 32)

--- a/infrastructure/scripts/generate-tenant-env.sh
+++ b/infrastructure/scripts/generate-tenant-env.sh
@@ -70,6 +70,7 @@ ADMIN_POSTGRES_PASSWORD=$(alnum_secret 32)
 ADMIN_APP_PASSWORD=$(alnum_secret 32)
 ADMIN_PROCESSOR_PASSWORD=$(alnum_secret 32)
 ADMIN_READER_PASSWORD=$(alnum_secret 32)
+ADMIN_ERASER_PASSWORD=$(alnum_secret 32)
 
 # --- Security Secrets ---
 ENCRYPTION_KEY=$(hex_secret 32)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate": "bun run --filter '@pagespace/db' db:migrate",
     "db:generate:admin": "bun run --filter '@pagespace/db' db:generate:admin",
     "db:migrate:admin": "bun run --filter '@pagespace/db' db:migrate:admin",
+    "db:provision:admin-users": "bun run --filter '@pagespace/db' db:provision:admin-users",
     "test": "./scripts/test-with-db.sh",
     "test:turbo": "turbo run test",
     "test:unit": "turbo run test --filter=@pagespace/lib && bun run --filter 'web' test",

--- a/packages/db/drizzle-admin/0004_security_audit_ingest.sql
+++ b/packages/db/drizzle-admin/0004_security_audit_ingest.sql
@@ -1,0 +1,52 @@
+CREATE TABLE IF NOT EXISTS "security_audit_ingest" (
+	"id" text PRIMARY KEY NOT NULL,
+	"event_type" text NOT NULL,
+	"user_id" text,
+	"session_id" text,
+	"service_id" text,
+	"resource_type" text,
+	"resource_id" text,
+	"ip_address" text,
+	"ip_bidx" text,
+	"user_agent" text,
+	"geo_location" text,
+	"details" jsonb,
+	"risk_score" real,
+	"anomaly_flags" text[],
+	"timestamp" timestamp DEFAULT now() NOT NULL,
+	"emission_hash" text NOT NULL,
+	"emitted_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_ingest_drain" ON "security_audit_ingest" USING btree ("emitted_at","id");
+--> statement-breakpoint
+-- Zero-trust grants for the emission queue (#890 Phase 2, leaf 1).
+--
+-- security_audit_ingest is a TRANSIENT queue, not a chain table: the app
+-- fire-and-forgets rows in, the single-writer chainer drains them out. The
+-- grant matrix is accordingly narrower than the chain tables':
+--
+--   role              security_audit_ingest
+--   admin_app         INSERT only — fire-and-forget; the writer never reads
+--                     back (no SELECT, so even INSERT … RETURNING would fail)
+--   admin_chainer     SELECT + DELETE — the drain. This fulfills the DELETE
+--                     grant deferred by 0001 ("applies ONLY to the Phase 2
+--                     ingest table") and is the ONLY DELETE grant in the
+--                     trust plane. admin_chainer still cannot INSERT here
+--                     (rows enter via admin_app) and still holds no DELETE
+--                     on security_audit_log or any other table.
+--   admin_reader      SELECT (verification / cross-check visibility)
+--   everyone else     nothing (admin_gdpr_eraser erases on the durable chain
+--                     table — queue rows live too briefly to be an Art 17
+--                     surface; admin_siem reads the chain post-cutover, never
+--                     the queue; admin_maintenance owns no table privileges)
+--
+-- id is cuid2 (app-generated) and emitted_at defaults to now(): no sequence
+-- backs any column, so no sequence grants are needed.
+REVOKE ALL ON security_audit_ingest FROM PUBLIC;
+--> statement-breakpoint
+GRANT INSERT ON security_audit_ingest TO admin_app;
+--> statement-breakpoint
+GRANT SELECT, DELETE ON security_audit_ingest TO admin_chainer;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_ingest TO admin_reader;

--- a/packages/db/drizzle-admin/0005_emission_hash_column.sql
+++ b/packages/db/drizzle-admin/0005_emission_hash_column.sql
@@ -1,0 +1,20 @@
+-- emission_hash on the chained table (#890 Phase 2, leaf 2 — chainer).
+--
+-- The single-writer chainer copies each drained ingest row's emission_hash
+-- onto the security_audit_log row it appends, alongside the chain columns it
+-- assigns (previous_hash, event_hash = H(emission_hash, previous_hash)).
+-- Storing it makes verification recomputable from storage alone:
+-- verify-on-append re-derives every event_hash from stored emission_hash +
+-- linkage right after each batch commits.
+--
+-- NULLABLE by design: NULL marks a legacy-era row — written by the
+-- advisory-lock path pre-cutover, or backfilled — whose event_hash was
+-- computed over the full event payload (computeSecurityEventHash). The
+-- dual-era full verifier that walks both eras is the backfill leaf's scope.
+--
+-- ADMIN PLANE ONLY: the app-plane security_audit_log keeps its shape; the
+-- main db:generate pipeline stays no-drift. No index: verification reads walk
+-- chain_seq, which is already indexed. No grant changes: existing table-level
+-- SELECT/INSERT grants (0001, re-applied by 0002) cover new columns, and
+-- admin_gdpr_eraser's column-scoped UPDATE deliberately excludes it.
+ALTER TABLE "security_audit_log" ADD COLUMN "emission_hash" text;

--- a/packages/db/drizzle-admin/0006_security_audit_anchors.sql
+++ b/packages/db/drizzle-admin/0006_security_audit_anchors.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS "security_audit_anchors" (
+	"id" text PRIMARY KEY NOT NULL,
+	"version" integer NOT NULL,
+	"chain_seq" bigint NOT NULL,
+	"head_hash" text NOT NULL,
+	"anchored_at" timestamp with time zone NOT NULL,
+	"signature" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_security_audit_anchors_chain_seq" ON "security_audit_anchors" USING btree ("chain_seq");
+--> statement-breakpoint
+-- Zero-trust grants for the anchor receipt surface (#890 Phase 2, leaf 3).
+--
+-- security_audit_anchors is a WITNESS table: each row is a signed statement
+-- "at chain_seq S the head was H, at time T" (HMAC-SHA256, see
+-- packages/lib/src/audit/anchor.ts), published by the chainer beside the S3
+-- Object-Lock copy. Its whole value is append-only-ness, so the matrix is
+-- the narrowest in the trust plane:
+--
+--   role              security_audit_anchors
+--   admin_chainer     INSERT only — fire-and-forget receipt; the publisher
+--                     never reads back (no SELECT, INSERT … RETURNING fails)
+--   admin_reader      SELECT — the anchor-match verifier reads anchors back
+--   everyone else     nothing. NOBODY holds UPDATE, DELETE, or TRUNCATE:
+--                     a compromised trust-plane credential can add anchors
+--                     but never rewrite or remove a published one. (Retention
+--                     is a non-goal — anchors are tiny and kept forever.)
+--
+-- id is cuid2 (publisher-minted) and created_at defaults to now(): no
+-- sequence backs any column, so no sequence grants are needed.
+REVOKE ALL ON security_audit_anchors FROM PUBLIC;
+--> statement-breakpoint
+GRANT INSERT ON security_audit_anchors TO admin_chainer;
+--> statement-breakpoint
+GRANT SELECT ON security_audit_anchors TO admin_reader;

--- a/packages/db/drizzle-admin/0007_anchor_select_for_verifier.sql
+++ b/packages/db/drizzle-admin/0007_anchor_select_for_verifier.sql
@@ -1,0 +1,14 @@
+-- Anchor readback for the periodic verifier (#890 Phase 2, leaf 5).
+--
+-- The runtime cutover binds the periodic chain verifier (apps/web cron
+-- verify-audit-chain, connecting as admin_app) to the Admin PG, and that
+-- verifier now matches published anchors against the chain
+-- (matchAnchorsAgainstChain). admin_app therefore needs to READ the witness
+-- surface it is checking the chain against.
+--
+-- This deliberately widens the leaf-3 matrix by exactly one SELECT:
+-- anchors are public witness statements (seq, head hash, timestamp,
+-- signature — no PII), admin_app can already SELECT the chain itself, and
+-- the append-only invariant is untouched: still NOBODY holds UPDATE,
+-- DELETE, or TRUNCATE on security_audit_anchors.
+GRANT SELECT ON security_audit_anchors TO admin_app;

--- a/packages/db/drizzle-admin/0008_revoke_app_chain_insert.sql
+++ b/packages/db/drizzle-admin/0008_revoke_app_chain_insert.sql
@@ -1,0 +1,20 @@
+-- Revoke admin_app's chain-table INSERT (#890 Phase 2 FIX — REVIEW finding:
+-- zero-trust hole).
+--
+-- The Phase-1 grant matrix (0002) gave admin_app SELECT + INSERT on
+-- security_audit_log for the pre-chainer write path. The leaf-5 runtime
+-- cutover moved every app write to the security_audit_ingest queue (0004,
+-- INSERT-only), making the chain-table INSERT excess privilege: a
+-- compromised web credential could append chain-valid forged rows directly —
+-- bypassing emission hashing and the co-stream witness — and the chainer
+-- would link onto and anchor-witness them, invisible to the cron verifier.
+--
+-- Post-revoke, exactly one writer remains: admin_chainer (the processor's
+-- single-writer worker). admin_app keeps SELECT — the web-side readers and
+-- the periodic verifier read the chain and (0007) its anchors. Break-glass
+-- is unaffected: it writes the MAIN database, not this one.
+REVOKE INSERT ON security_audit_log FROM admin_app;
+--> statement-breakpoint
+-- The sequence USAGE existed only to serve the revoked INSERT's chain_seq
+-- default; the chainer keeps its own grant from 0002.
+REVOKE USAGE ON SEQUENCE security_audit_log_chain_seq_seq FROM admin_app;

--- a/packages/db/drizzle-admin/meta/0004_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0004_snapshot.json
@@ -1,0 +1,716 @@
+{
+  "id": "7fd59928-c027-4123-9516-6c95567dcb90",
+  "prevId": "58909d1a-a390-491b-a8ed-d58e41a440bc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_ingest": {
+      "name": "security_audit_ingest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_ingest_drain": {
+          "name": "idx_security_audit_ingest_drain",
+          "columns": [
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0005_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0005_snapshot.json
@@ -1,0 +1,722 @@
+{
+  "id": "82ea775f-4131-43e5-8559-7fda3f0f842f",
+  "prevId": "7fd59928-c027-4123-9516-6c95567dcb90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_ingest": {
+      "name": "security_audit_ingest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_ingest_drain": {
+          "name": "idx_security_audit_ingest_drain",
+          "columns": [
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0006_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0006_snapshot.json
@@ -1,0 +1,791 @@
+{
+  "id": "001a862d-0594-418a-8f72-f5be423dc57d",
+  "prevId": "82ea775f-4131-43e5-8559-7fda3f0f842f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_anchors": {
+      "name": "security_audit_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_hash": {
+          "name": "head_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_anchors_chain_seq": {
+          "name": "idx_security_audit_anchors_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_ingest": {
+      "name": "security_audit_ingest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_ingest_drain": {
+          "name": "idx_security_audit_ingest_drain",
+          "columns": [
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0007_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0007_snapshot.json
@@ -1,0 +1,791 @@
+{
+  "id": "29bbd5a3-e89d-492c-8354-292424631098",
+  "prevId": "001a862d-0594-418a-8f72-f5be423dc57d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_anchors": {
+      "name": "security_audit_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_hash": {
+          "name": "head_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_anchors_chain_seq": {
+          "name": "idx_security_audit_anchors_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_ingest": {
+      "name": "security_audit_ingest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_ingest_drain": {
+          "name": "idx_security_audit_ingest_drain",
+          "columns": [
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/0008_snapshot.json
+++ b/packages/db/drizzle-admin/meta/0008_snapshot.json
@@ -1,0 +1,791 @@
+{
+  "id": "db37a829-ea8e-4e7e-99d2-65ef01b2427f",
+  "prevId": "29bbd5a3-e89d-492c-8354-292424631098",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.security_audit_anchors": {
+      "name": "security_audit_anchors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "head_hash": {
+          "name": "head_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchored_at": {
+          "name": "anchored_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signature": {
+          "name": "signature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_anchors_chain_seq": {
+          "name": "idx_security_audit_anchors_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_ingest": {
+      "name": "security_audit_ingest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emitted_at": {
+          "name": "emitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_security_audit_ingest_drain": {
+          "name": "idx_security_audit_ingest_drain",
+          "columns": [
+            {
+              "expression": "emitted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emission_hash": {
+          "name": "emission_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1783659177987,
       "tag": "0003_harden_ensure_partitions",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1783670331991,
+      "tag": "0004_security_audit_ingest",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1783673960814,
       "tag": "0006_security_audit_anchors",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1783677044891,
+      "tag": "0007_anchor_select_for_verifier",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1783677044891,
       "tag": "0007_anchor_select_for_verifier",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1783689170084,
+      "tag": "0008_revoke_app_chain_insert",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783671997487,
       "tag": "0005_emission_hash_column",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783673960814,
+      "tag": "0006_security_audit_anchors",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle-admin/meta/_journal.json
+++ b/packages/db/drizzle-admin/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1783670331991,
       "tag": "0004_security_audit_ingest",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1783671997487,
+      "tag": "0005_emission_hash_column",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,6 +11,10 @@
       "types": "./dist/admin-db.d.ts",
       "default": "./dist/admin-db.js"
     },
+    "./admin-eraser-db": {
+      "types": "./dist/admin-eraser-db.d.ts",
+      "default": "./dist/admin-eraser-db.js"
+    },
     "./admin-schema": {
       "types": "./dist/admin-schema.d.ts",
       "default": "./dist/admin-schema.js"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -15,6 +15,14 @@
       "types": "./dist/admin-schema.d.ts",
       "default": "./dist/admin-schema.js"
     },
+    "./migrate-admin": {
+      "types": "./dist/migrate-admin.d.ts",
+      "default": "./dist/migrate-admin.js"
+    },
+    "./provision-admin-users": {
+      "types": "./dist/provision-admin-users.d.ts",
+      "default": "./dist/provision-admin-users.js"
+    },
     "./operators": {
       "types": "./dist/operators.d.ts",
       "default": "./dist/operators.js"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -269,6 +269,7 @@
     "db:migrate:local": "DATABASE_URL=postgresql://user:password@localhost:5432/pagespace tsx src/migrate.ts",
     "db:generate:admin": "drizzle-kit generate --config=drizzle-admin.config.ts",
     "db:migrate:admin": "tsx src/migrate-admin.ts",
+    "db:provision:admin-users": "tsx src/provision-admin-users.ts",
     "db:studio": "drizzle-kit studio",
     "db:seed": "tsx src/seed.ts",
     "lint": "eslint src",

--- a/packages/db/src/__tests__/admin-anchor-select-migration.test.ts
+++ b/packages/db/src/__tests__/admin-anchor-select-migration.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Static invariants of the anchor-readback grant migration (#890 Phase 2,
+ * leaf 5 — runtime cutover).
+ *
+ * The periodic chain verifier (apps/web cron, connecting as admin_app) now
+ * matches published anchors against the chain, so admin_app gains exactly one
+ * privilege: SELECT on security_audit_anchors. The append-only invariant of
+ * the witness surface must survive untouched — no role may ever hold UPDATE,
+ * DELETE, or TRUNCATE on it.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0007_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0007 anchor SELECT for the periodic verifier', () => {
+  it('should exist in the admin journal as migration 0007', () => {
+    expect(migrationFile).toBe('0007_anchor_select_for_verifier.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 7)?.tag).toBe('0007_anchor_select_for_verifier');
+  });
+
+  it('should grant exactly SELECT on security_audit_anchors to admin_app and nothing else', () => {
+    const statements = (code.match(/(GRANT|REVOKE)[^;]+;/g) ?? []).map((s) =>
+      s.replace(/\s+/g, ' ').trim(),
+    );
+    expect(statements).toEqual(['GRANT SELECT ON security_audit_anchors TO admin_app;']);
+  });
+
+  it('should keep the witness surface append-only — no UPDATE/DELETE/TRUNCATE appears anywhere', () => {
+    expect(code).not.toMatch(/\b(UPDATE|DELETE|TRUNCATE)\b/i);
+    expect(code).not.toMatch(/\bGRANT\s+ALL\b/i);
+  });
+
+  it('should touch no other table or role', () => {
+    expect(code).not.toMatch(/security_audit_log\b|security_audit_ingest|siem_delivery/);
+    expect(code).not.toMatch(/admin_chainer|admin_reader|admin_gdpr_eraser|admin_siem/);
+  });
+});

--- a/packages/db/src/__tests__/admin-anchors-migration.test.ts
+++ b/packages/db/src/__tests__/admin-anchors-migration.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Static invariants of the anchor-receipt-table migration (#890 Phase 2,
+ * leaf 3).
+ *
+ * security_audit_anchors is the SECOND witness surface beside S3 Object-Lock:
+ * the chainer's receipt publisher INSERTs one signed head per anchor. The
+ * grant matrix makes it append-only for every role — an attacker holding any
+ * provisioned trust-plane credential cannot rewrite or delete a published
+ * anchor. Live 42501 denials are proven by the chainer integration suite;
+ * these tests pin the migration SQL so CI catches a regressed matrix without
+ * a database.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0006_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0006 security_audit_anchors migration', () => {
+  it('should exist in the admin journal as migration 0006', () => {
+    expect(migrationFile).toBe('0006_security_audit_anchors.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 6)?.tag).toBe('0006_security_audit_anchors');
+  });
+
+  it('should create a PLAIN table (anchors are few and forever — no PARTITION BY) with every signed field NOT NULL', () => {
+    expect(code).toContain('CREATE TABLE IF NOT EXISTS "security_audit_anchors"');
+    expect(code).not.toContain('PARTITION BY');
+    expect(code).toContain('"version" integer NOT NULL');
+    expect(code).toContain('"chain_seq" bigint NOT NULL');
+    expect(code).toContain('"head_hash" text NOT NULL');
+    expect(code).toContain('"anchored_at" timestamp with time zone NOT NULL');
+    expect(code).toContain('"signature" text NOT NULL');
+    expect(code).toContain('"created_at" timestamp with time zone DEFAULT now() NOT NULL');
+  });
+
+  it('should index chain_seq for the verifier’s anchor-vs-chain matching', () => {
+    expect(code).toContain(
+      'CREATE INDEX IF NOT EXISTS "idx_security_audit_anchors_chain_seq" ON "security_audit_anchors" USING btree ("chain_seq")',
+    );
+  });
+
+  it('should revoke every ambient PUBLIC privilege on the anchors table', () => {
+    expect(code).toContain('REVOKE ALL ON security_audit_anchors FROM PUBLIC');
+  });
+
+  it('should grant admin_chainer INSERT and nothing else (fire-and-forget receipt: not even SELECT)', () => {
+    const chainerGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) =>
+      g.includes('admin_chainer'),
+    );
+    expect(chainerGrants).toEqual(['GRANT INSERT ON security_audit_anchors TO admin_chainer;']);
+  });
+
+  it('should grant admin_reader SELECT only (the verifier reads anchors back)', () => {
+    const readerGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) =>
+      g.includes('admin_reader'),
+    );
+    expect(readerGrants).toEqual(['GRANT SELECT ON security_audit_anchors TO admin_reader;']);
+  });
+
+  it('should grant NOBODY UPDATE, DELETE, TRUNCATE, or ALL — the witness surface is append-only for every role', () => {
+    const grants = code.match(/GRANT[^;]+;/g) ?? [];
+    expect(grants).toHaveLength(2);
+    for (const grant of grants) {
+      expect(grant).not.toMatch(/admin_app|admin_gdpr_eraser|admin_siem|admin_maintenance/);
+      expect(grant).not.toMatch(/\bUPDATE\b|\bDELETE\b|\bTRUNCATE\b/);
+      expect(grant).not.toMatch(/\bGRANT\s+ALL\b/);
+    }
+  });
+});

--- a/packages/db/src/__tests__/admin-db.test.ts
+++ b/packages/db/src/__tests__/admin-db.test.ts
@@ -165,4 +165,39 @@ describe('createAdminDbRegistry', () => {
       expect(deps.alert).not.toHaveBeenCalled();
     });
   });
+
+  describe('getMode() — resolved-mode readback for the audit bind point (#890 Phase 2, leaf 5)', () => {
+    it('given a dedicated env, should report dedicated without constructing a pool or alerting', () => {
+      const { deps } = makeDeps();
+      const decision = createAdminDbRegistry(deps).getMode();
+      expect(decision.mode).toBe('dedicated');
+      expect(deps.createPool).not.toHaveBeenCalled();
+      expect(deps.getMainDb).not.toHaveBeenCalled();
+      expect(deps.alert).not.toHaveBeenCalled();
+    });
+
+    it('given a break-glass env, should report break-glass WITHOUT firing the banner (observation, not activation)', () => {
+      const { deps } = makeDeps({ getEnv: () => BREAK_GLASS_ENV });
+      const decision = createAdminDbRegistry(deps).getMode();
+      expect(decision.mode).toBe('break-glass');
+      expect(deps.alert).not.toHaveBeenCalled();
+      expect(deps.getMainDb).not.toHaveBeenCalled();
+    });
+
+    it('given a fail env, should report fail with the actionable reason instead of throwing', () => {
+      const { deps } = makeDeps({ getEnv: () => ({}) });
+      const decision = createAdminDbRegistry(deps).getMode();
+      expect(decision.mode).toBe('fail');
+      expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);
+    });
+
+    it('should re-read env on every call (late-loaded dotenv wins, no caching)', () => {
+      let env: Record<string, string> = {};
+      const { deps } = makeDeps({ getEnv: () => env });
+      const registry = createAdminDbRegistry(deps);
+      expect(registry.getMode().mode).toBe('fail');
+      env = { ...DEDICATED_ENV };
+      expect(registry.getMode().mode).toBe('dedicated');
+    });
+  });
 });

--- a/packages/db/src/__tests__/admin-emission-column-migration.test.ts
+++ b/packages/db/src/__tests__/admin-emission-column-migration.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Static invariants of the emission-hash column migration (#890 Phase 2, leaf 2).
+ *
+ * The chainer copies each drained ingest row's emission_hash onto the chained
+ * security_audit_log row so verify-on-append (and the later dual-era full
+ * verifier) can recompute chainHash = H(emissionHash, prevHash) from storage.
+ * The column is NULLABLE by design: NULL marks a legacy-era row (written
+ * pre-cutover or backfilled) whose event_hash was computed by the advisory-lock
+ * path — the dual-era verifier is the backfill leaf's scope.
+ *
+ * ADMIN PLANE ONLY: the main-plane security_audit_log keeps its current shape;
+ * the main db:generate pipeline must stay no-drift.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+const MAIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0005_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0005 emission_hash column migration', () => {
+  it('should exist in the admin journal as migration 0005', () => {
+    expect(migrationFile).toBe('0005_emission_hash_column.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 5)?.tag).toBe('0005_emission_hash_column');
+  });
+
+  it('should add emission_hash to security_audit_log as NULLABLE text (NULL = legacy-era row)', () => {
+    expect(code).toContain('ALTER TABLE "security_audit_log" ADD COLUMN "emission_hash" text');
+    expect(code).not.toMatch(/emission_hash"?\s+text\s+NOT NULL/i);
+  });
+
+  it('should touch nothing else — no grants, no other tables, no drops', () => {
+    expect(code).not.toMatch(/\bGRANT\b|\bREVOKE\b/);
+    expect(code).not.toContain('security_audit_ingest');
+    expect(code).not.toContain('DROP');
+  });
+
+  it('should leave the MAIN plane untouched — no main migration mentions emission_hash', () => {
+    const mainMentions = readdirSync(MAIN_MIGRATIONS_DIR)
+      .filter((f) => f.endsWith('.sql'))
+      .filter((f) =>
+        readFileSync(path.join(MAIN_MIGRATIONS_DIR, f), 'utf8').includes('emission_hash'),
+      );
+    expect(mainMentions).toEqual([]);
+  });
+});

--- a/packages/db/src/__tests__/admin-eraser-db.test.ts
+++ b/packages/db/src/__tests__/admin-eraser-db.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the GDPR eraser connection to the Admin PG (#890 Phase 2,
+ * leaf 6). Pure mode decision + lazy registry wiring — no real connections.
+ *
+ * The eraser identity (admin_gdpr_eraser_user → admin_gdpr_eraser template,
+ * column-scoped UPDATE on exactly the 6 PII columns) is deliberately NOT part
+ * of the AdminDb registry: it must never fall back to the main DB or to the
+ * admin_app connection — an unavailable eraser refuses, it never degrades.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Pool } from 'pg';
+import {
+  resolveAdminEraserDbMode,
+  createAdminEraserDbRegistry,
+  ADMIN_ERASER_POOL_MAX,
+  ADMIN_ERASER_POOL_NAME,
+  type AdminEraserDbEnv,
+} from '../admin-eraser-db';
+import type { AdminPoolConfig } from '../admin-db-mode';
+
+const ENV_OK: AdminEraserDbEnv = {
+  ADMIN_ERASER_DATABASE_URL: 'postgresql://admin_gdpr_eraser_user:pw@host:5432/pagespace_admin',
+};
+
+describe('resolveAdminEraserDbMode', () => {
+  it('given a valid postgres URL, should be available', () => {
+    expect(resolveAdminEraserDbMode(ENV_OK)).toEqual({
+      mode: 'available',
+      reason: 'ADMIN_ERASER_DATABASE_URL is set',
+    });
+  });
+
+  it('given an unset URL, should be unavailable with an actionable reason (provision the eraser login, set the env)', () => {
+    const decision = resolveAdminEraserDbMode({});
+    expect(decision.mode).toBe('unavailable');
+    expect(decision.reason).toContain('ADMIN_ERASER_DATABASE_URL');
+    expect(decision.reason).toContain('admin_gdpr_eraser_user');
+  });
+
+  it('given an empty string, should treat it as unset', () => {
+    expect(resolveAdminEraserDbMode({ ADMIN_ERASER_DATABASE_URL: '' }).mode).toBe('unavailable');
+  });
+
+  it('given a non-postgres URL, should be unavailable and say the value is invalid (never used as-is)', () => {
+    const decision = resolveAdminEraserDbMode({ ADMIN_ERASER_DATABASE_URL: 'mysql://nope' });
+    expect(decision.mode).toBe('unavailable');
+    expect(decision.reason).toContain('not a postgres');
+  });
+});
+
+describe('createAdminEraserDbRegistry', () => {
+  const makeDeps = (env: AdminEraserDbEnv) => {
+    const pool = { on: vi.fn() } as unknown as Pool;
+    const deps = {
+      getEnv: vi.fn(() => env),
+      createPool: vi.fn((_config: AdminPoolConfig) => pool),
+      registerPool: vi.fn(),
+    };
+    return { deps, pool };
+  };
+
+  it('given an available env, should lazily build ONE pool, register it, and reuse the instance', () => {
+    const { deps } = makeDeps(ENV_OK);
+    const registry = createAdminEraserDbRegistry(deps);
+
+    expect(deps.createPool).not.toHaveBeenCalled(); // lazy — no pool on construction
+
+    const first = registry.getAdminEraserDb();
+    const second = registry.getAdminEraserDb();
+    expect(second).toBe(first);
+    expect(deps.createPool).toHaveBeenCalledTimes(1);
+    expect(deps.registerPool).toHaveBeenCalledWith(expect.anything(), ADMIN_ERASER_POOL_NAME);
+  });
+
+  it('given the pool config, should use the eraser URL, a small dedicated pool, and the shared SSL semantics', () => {
+    const { deps } = makeDeps({ ...ENV_OK, ADMIN_DATABASE_SSL: 'true' });
+    createAdminEraserDbRegistry(deps).getAdminEraserDb();
+
+    const config = deps.createPool.mock.calls[0]![0];
+    expect(config.connectionString).toBe(ENV_OK.ADMIN_ERASER_DATABASE_URL);
+    expect(config.max).toBe(ADMIN_ERASER_POOL_MAX);
+    expect(config.ssl).toEqual({ rejectUnauthorized: false });
+  });
+
+  it('given an unavailable env, should THROW with the reason — the eraser never falls back to another identity', () => {
+    const { deps } = makeDeps({});
+    const registry = createAdminEraserDbRegistry(deps);
+    expect(() => registry.getAdminEraserDb()).toThrow(/ADMIN_ERASER_DATABASE_URL/);
+    expect(deps.createPool).not.toHaveBeenCalled();
+  });
+
+  it('getMode should be a pure readback — no pool, no throw, re-reads env each call', () => {
+    const env: AdminEraserDbEnv = {};
+    const { deps } = makeDeps(env);
+    const registry = createAdminEraserDbRegistry({
+      ...deps,
+      getEnv: () => env,
+    });
+
+    expect(registry.getMode().mode).toBe('unavailable');
+    env.ADMIN_ERASER_DATABASE_URL = ENV_OK.ADMIN_ERASER_DATABASE_URL;
+    expect(registry.getMode().mode).toBe('available');
+    expect(deps.createPool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/db/src/__tests__/admin-grants.integration.test.ts
+++ b/packages/db/src/__tests__/admin-grants.integration.test.ts
@@ -91,6 +91,11 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
       `INSERT INTO security_audit_log (id, event_type, user_id, ip_address, previous_hash, event_hash)
        VALUES ('seed-row-1', 'auth.login', 'user-1', '203.0.113.7', 'GENESIS', 'hash-1')`,
     );
+    // Seed one ingest row as superuser for the queue's denial probes (0004).
+    await pool.query(
+      `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+       VALUES ('ingest-seed-1', 'auth.login', 'em-hash-1')`,
+    );
   });
 
   afterAll(async () => {
@@ -304,6 +309,110 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
     });
   });
 
+  describe('security_audit_ingest (Phase 2 emission queue, migration 0004)', () => {
+    describe('admin_app (emitter — INSERT-only, fire-and-forget)', () => {
+      it('should INSERT into security_audit_ingest', async () => {
+        await asRole('admin_app', async (client) => {
+          const { rowCount } = await client.query(
+            `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+             VALUES ('app-ingest-1', 'auth.login', 'em-hash-2')`,
+          );
+          expect(rowCount).toBe(1);
+        });
+      });
+
+      it('should be DENIED SELECT — the writer never reads back, and even INSERT … RETURNING fails', async () => {
+        await asRole('admin_app', async (client) => {
+          await expectDenied(client, `SELECT 1 FROM security_audit_ingest`);
+          await expectDenied(
+            client,
+            `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+             VALUES ('app-ingest-returning', 'auth.login', 'em-hash-x') RETURNING id`,
+          );
+        });
+      });
+
+      it('should be DENIED UPDATE, DELETE and TRUNCATE on the queue', async () => {
+        await asRole('admin_app', async (client) => {
+          await expectDenied(client, `UPDATE security_audit_ingest SET emission_hash = 'tampered' WHERE id = 'ingest-seed-1'`);
+          await expectDenied(client, `DELETE FROM security_audit_ingest WHERE id = 'ingest-seed-1'`);
+          await expectDenied(client, `TRUNCATE security_audit_ingest`);
+        });
+      });
+    });
+
+    describe('admin_chainer (drain — SELECT + DELETE here, and ONLY here)', () => {
+      it('should SELECT the queue in drain order and DELETE drained rows', async () => {
+        await asRole('admin_chainer', async (client) => {
+          const { rows } = await client.query(
+            `SELECT id, emission_hash FROM security_audit_ingest ORDER BY emitted_at, id`,
+          );
+          expect(rows.length).toBeGreaterThanOrEqual(2);
+          const { rowCount } = await client.query(
+            `DELETE FROM security_audit_ingest WHERE id = 'app-ingest-1'`,
+          );
+          expect(rowCount).toBe(1);
+        });
+      });
+
+      it('should be DENIED INSERT and UPDATE on the queue (rows enter via admin_app only, and are never rewritten)', async () => {
+        await asRole('admin_chainer', async (client) => {
+          await expectDenied(
+            client,
+            `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+             VALUES ('chainer-ingest-1', 'auth.login', 'em-hash-y')`,
+          );
+          await expectDenied(client, `UPDATE security_audit_ingest SET emission_hash = 'rewritten' WHERE id = 'ingest-seed-1'`);
+          await expectDenied(client, `TRUNCATE security_audit_ingest`);
+        });
+      });
+
+      it('should STILL be denied DELETE on security_audit_log — the drain grant does not leak to chain tables', async () => {
+        await asRole('admin_chainer', async (client) => {
+          await expectDenied(client, `DELETE FROM security_audit_log WHERE id = 'seed-row-1'`);
+        });
+      });
+    });
+
+    describe('every other role', () => {
+      it('admin_reader should SELECT only', async () => {
+        await asRole('admin_reader', async (client) => {
+          await client.query(`SELECT 1 FROM security_audit_ingest LIMIT 1`);
+          await expectDenied(
+            client,
+            `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+             VALUES ('reader-ingest-1', 'auth.login', 'em-hash-z')`,
+          );
+          await expectDenied(client, `UPDATE security_audit_ingest SET emission_hash = 'x' WHERE id = 'ingest-seed-1'`);
+          await expectDenied(client, `DELETE FROM security_audit_ingest WHERE id = 'ingest-seed-1'`);
+        });
+      });
+
+      it.each(['admin_gdpr_eraser', 'admin_siem', 'admin_maintenance'])(
+        '%s holds NOTHING on the queue (not even SELECT)',
+        async (role) => {
+          await asRole(role, async (client) => {
+            await expectDenied(client, `SELECT 1 FROM security_audit_ingest`);
+            await expectDenied(
+              client,
+              `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+               VALUES ('${role}-ingest-1', 'auth.login', 'em-hash-w')`,
+            );
+            await expectDenied(client, `DELETE FROM security_audit_ingest WHERE id = 'ingest-seed-1'`);
+          });
+        },
+      );
+
+      it('PUBLIC holds no privilege at all on the queue', async () => {
+        const { rows } = await pool.query(
+          `SELECT bool_or(has_table_privilege('public', 'security_audit_ingest'::regclass::oid, priv)) AS any_priv
+           FROM unnest(ARRAY['SELECT','INSERT','UPDATE','DELETE','TRUNCATE','REFERENCES','TRIGGER']) AS priv`,
+        );
+        expect(rows[0].any_priv).toBe(false);
+      });
+    });
+  });
+
   describe('re-runnability', () => {
     it('should apply cleanly on a fresh DB where the roles ALREADY exist at cluster level', async () => {
       // Roles are cluster-scoped: a re-provisioned database in the same
@@ -320,6 +429,20 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
                 has_table_privilege('admin_app', 'security_audit_log', 'DELETE') AS del`,
       );
       expect(rows[0]).toEqual({ ins: true, del: false });
+
+      // ...including the ingest queue's asymmetric matrix (0004).
+      const ingest = await pool.query(
+        `SELECT has_table_privilege('admin_app', 'security_audit_ingest', 'INSERT') AS app_ins,
+                has_table_privilege('admin_app', 'security_audit_ingest', 'SELECT') AS app_sel,
+                has_table_privilege('admin_chainer', 'security_audit_ingest', 'DELETE') AS chainer_del,
+                has_table_privilege('admin_chainer', 'security_audit_log', 'DELETE') AS chainer_chain_del`,
+      );
+      expect(ingest.rows[0]).toEqual({
+        app_ins: true,
+        app_sel: false,
+        chainer_del: true,
+        chainer_chain_del: false,
+      });
     });
   });
 });

--- a/packages/db/src/__tests__/admin-grants.integration.test.ts
+++ b/packages/db/src/__tests__/admin-grants.integration.test.ts
@@ -112,13 +112,14 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
   });
 
   describe('admin_app (web identity)', () => {
-    it('should INSERT into security_audit_log (incl. chain_seq sequence default)', async () => {
+    it('should be DENIED INSERT on security_audit_log and USAGE on its chain_seq sequence (post-cutover the app writes ONLY the ingest queue — 0008)', async () => {
       await asRole('admin_app', async (client) => {
-        const { rowCount } = await client.query(
+        await expectDenied(
+          client,
           `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
            VALUES ('app-row-1', 'auth.login', 'hash-1', 'hash-2')`,
         );
-        expect(rowCount).toBe(1);
+        await expectDenied(client, `SELECT nextval('security_audit_log_chain_seq_seq')`);
       });
     });
 
@@ -447,12 +448,20 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
 
       await migrateAdminDb({ ADMIN_DATABASE_URL: url });
 
-      // Grants are back on the fresh tables.
+      // Grants are back on the fresh tables — and the 0008 revoke re-applied:
+      // admin_app never regains chain-table INSERT or the sequence.
       const { rows } = await pool.query(
         `SELECT has_table_privilege('admin_app', 'security_audit_log', 'INSERT') AS ins,
+                has_table_privilege('admin_app', 'security_audit_log', 'SELECT') AS sel,
                 has_table_privilege('admin_app', 'security_audit_log', 'DELETE') AS del`,
       );
-      expect(rows[0]).toEqual({ ins: true, del: false });
+      expect(rows[0]).toEqual({ ins: false, sel: true, del: false });
+
+      const seq = await pool.query(
+        `SELECT has_sequence_privilege('admin_app', 'security_audit_log_chain_seq_seq', 'USAGE') AS app_seq,
+                has_sequence_privilege('admin_chainer', 'security_audit_log_chain_seq_seq', 'USAGE') AS chainer_seq`,
+      );
+      expect(seq.rows[0]).toEqual({ app_seq: false, chainer_seq: true });
 
       // ...including the ingest queue's asymmetric matrix (0004).
       const ingest = await pool.query(

--- a/packages/db/src/__tests__/admin-grants.integration.test.ts
+++ b/packages/db/src/__tests__/admin-grants.integration.test.ts
@@ -413,6 +413,30 @@ describe.skipIf(!url)('zero-trust roles on the Admin PG', () => {
     });
   });
 
+  describe('security_audit_anchors readback for the periodic verifier (migration 0007)', () => {
+    it('admin_app should SELECT anchors (the cron verifier matches them against the chain)', async () => {
+      await asRole('admin_app', async (client) => {
+        const { rows } = await client.query(
+          `SELECT version, chain_seq, head_hash, anchored_at, signature FROM security_audit_anchors`,
+        );
+        expect(Array.isArray(rows)).toBe(true);
+      });
+    });
+
+    it('admin_app should STILL be denied INSERT, UPDATE, DELETE and TRUNCATE on anchors (witness stays append-only, chainer-only writes)', async () => {
+      await asRole('admin_app', async (client) => {
+        await expectDenied(
+          client,
+          `INSERT INTO security_audit_anchors (id, version, chain_seq, head_hash, anchored_at, signature)
+           VALUES ('app-anchor-1', 1, 1, 'h', now(), 's')`,
+        );
+        await expectDenied(client, `UPDATE security_audit_anchors SET head_hash = 'tampered'`);
+        await expectDenied(client, `DELETE FROM security_audit_anchors`);
+        await expectDenied(client, `TRUNCATE security_audit_anchors`);
+      });
+    });
+  });
+
   describe('re-runnability', () => {
     it('should apply cleanly on a fresh DB where the roles ALREADY exist at cluster level', async () => {
       // Roles are cluster-scoped: a re-provisioned database in the same

--- a/packages/db/src/__tests__/admin-ingest-migration.test.ts
+++ b/packages/db/src/__tests__/admin-ingest-migration.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Static invariants of the ingest-table migration (#890 Phase 2, leaf 1).
+ *
+ * The live behavior (actual 42501 denials per role) is proven by
+ * admin-grants.integration.test.ts against a scratch Postgres. These tests
+ * pin the migration SQL itself so CI catches a regressed grant matrix
+ * (someone adding admin_app SELECT, widening the chainer's DELETE beyond
+ * the queue, …) without needing a database.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0004_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0004 security_audit_ingest migration', () => {
+  it('should exist in the admin journal as migration 0004', () => {
+    expect(migrationFile).toBe('0004_security_audit_ingest.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 4)?.tag).toBe('0004_security_audit_ingest');
+  });
+
+  it('should create a PLAIN table (transient queue — no PARTITION BY) with emission_hash and emitted_at NOT NULL', () => {
+    expect(code).toContain('CREATE TABLE IF NOT EXISTS "security_audit_ingest"');
+    expect(code).not.toContain('PARTITION BY');
+    expect(code).toContain('"emission_hash" text NOT NULL');
+    expect(code).toContain('"emitted_at" timestamp with time zone DEFAULT now() NOT NULL');
+  });
+
+  it('should carry no chain columns — chain_seq/previous_hash/event_hash belong to security_audit_log only', () => {
+    for (const chainColumn of ['chain_seq', 'previous_hash', 'event_hash']) {
+      expect(code).not.toContain(chainColumn);
+    }
+  });
+
+  it('should index (emitted_at, id) for the FIFO drain', () => {
+    expect(code).toContain(
+      'CREATE INDEX IF NOT EXISTS "idx_security_audit_ingest_drain" ON "security_audit_ingest" USING btree ("emitted_at","id")',
+    );
+  });
+
+  it('should revoke every ambient PUBLIC privilege on the ingest table', () => {
+    expect(code).toContain('REVOKE ALL ON security_audit_ingest FROM PUBLIC');
+  });
+
+  it('should grant admin_app INSERT and nothing else (fire-and-forget: not even SELECT)', () => {
+    const appGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) => g.includes('admin_app'));
+    expect(appGrants).toEqual(['GRANT INSERT ON security_audit_ingest TO admin_app;']);
+  });
+
+  it('should grant admin_chainer exactly SELECT + DELETE on the queue (the drain) and touch no other table', () => {
+    const chainerGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) => g.includes('admin_chainer'));
+    expect(chainerGrants).toEqual(['GRANT SELECT, DELETE ON security_audit_ingest TO admin_chainer;']);
+  });
+
+  it('should grant admin_reader SELECT only', () => {
+    const readerGrants = (code.match(/GRANT[^;]+;/g) ?? []).filter((g) => g.includes('admin_reader'));
+    expect(readerGrants).toEqual(['GRANT SELECT ON security_audit_ingest TO admin_reader;']);
+  });
+
+  it('should grant NOTHING to admin_gdpr_eraser, admin_siem, or admin_maintenance, and never GRANT ALL or TRUNCATE', () => {
+    const grants = code.match(/GRANT[^;]+;/g) ?? [];
+    expect(grants).toHaveLength(3);
+    for (const grant of grants) {
+      expect(grant).not.toMatch(/admin_gdpr_eraser|admin_siem|admin_maintenance/);
+      expect(grant).not.toMatch(/\bTRUNCATE\b/);
+      expect(grant).not.toMatch(/\bGRANT\s+ALL\b/);
+    }
+    // The queue's DELETE grant goes to the chainer alone.
+    const deleteGrants = grants.filter((g) => /\bDELETE\b/.test(g));
+    expect(deleteGrants).toEqual(['GRANT SELECT, DELETE ON security_audit_ingest TO admin_chainer;']);
+  });
+});

--- a/packages/db/src/__tests__/admin-login-users.integration.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.integration.test.ts
@@ -146,18 +146,32 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
   });
 
   describe('admin_app_user (web identity, connected over the wire)', () => {
-    it('should INSERT into security_audit_log and SELECT the chain head', async () => {
+    it('should be DENIED INSERT on security_audit_log + the chain_seq sequence (0008 — post-cutover the app writes ONLY the ingest queue) yet still SELECT the chain head', async () => {
       await asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, async (pool) => {
-        const { rowCount } = await pool.query(
-          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
-           VALUES ('login-app-row-1', 'auth.login', 'hash-1', 'hash-app-1')`,
-        );
-        expect(rowCount).toBe(1);
+        await expect(
+          pool.query(
+            `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+             VALUES ('login-app-row-1', 'auth.login', 'hash-1', 'hash-app-1')`,
+          ),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`SELECT nextval('security_audit_log_chain_seq_seq')`),
+        ).rejects.toMatchObject({ code: '42501' });
 
         const head = await pool.query(
           'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
         );
-        expect(head.rows[0].event_hash).toBe('hash-app-1');
+        expect(head.rows[0].event_hash).toBe('hash-1');
+      });
+    });
+
+    it('should still INSERT into security_audit_ingest (the one write the app keeps)', async () => {
+      await asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, async (pool) => {
+        const { rowCount } = await pool.query(
+          `INSERT INTO security_audit_ingest (id, event_type, emission_hash)
+           VALUES ('login-app-ingest-1', 'auth.login', 'em-login-app-1')`,
+        );
+        expect(rowCount).toBe(1);
       });
     });
 
@@ -189,7 +203,7 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
       await asLoginUser('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD, async (pool) => {
         const { rowCount } = await pool.query(
           `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
-           VALUES ('login-proc-row-1', 'auth.login', 'hash-app-1', 'hash-proc-1')`,
+           VALUES ('login-proc-row-1', 'auth.login', 'hash-1', 'hash-proc-1')`,
         );
         expect(rowCount).toBe(1);
         await expect(

--- a/packages/db/src/__tests__/admin-login-users.integration.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.integration.test.ts
@@ -28,6 +28,7 @@ const PASSWORDS = {
   ADMIN_APP_PASSWORD: 'app-secret-integration-1',
   ADMIN_PROCESSOR_PASSWORD: 'processor-secret-integration-1',
   ADMIN_READER_PASSWORD: 'reader-secret-integration-1',
+  ADMIN_ERASER_PASSWORD: 'eraser-secret-integration-1',
 } as const;
 
 const TEMPLATE_ROLES = [
@@ -93,6 +94,7 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
       'admin_app_user',
       'admin_processor_user',
       'admin_reader_user',
+      'admin_gdpr_eraser_user',
     ]);
 
     // Seed one chain row as owner for UPDATE/DELETE-denial probes.
@@ -106,13 +108,13 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
     await owner.end();
   });
 
-  it('should create the three login users as LOGIN with least-privilege attributes', async () => {
+  it('should create the four login users as LOGIN with least-privilege attributes', async () => {
     const { rows } = await owner.query(
       `SELECT rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole, rolreplication, rolbypassrls, rolinherit
        FROM pg_roles WHERE rolname = ANY($1) ORDER BY rolname`,
       [ADMIN_LOGIN_USERS.map((u) => u.user)],
     );
-    expect(rows).toHaveLength(3);
+    expect(rows).toHaveLength(4);
     for (const row of rows) {
       expect(row.rolcanlogin).toBe(true);
       expect(row.rolsuper).toBe(false);
@@ -136,6 +138,7 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
     const memberships = rows.map((r: { member: string; granted: string }) => `${r.member}→${r.granted}`);
     expect(memberships).toEqual([
       'admin_app_user→admin_app',
+      'admin_gdpr_eraser_user→admin_gdpr_eraser',
       'admin_processor_user→admin_chainer',
       'admin_processor_user→admin_siem',
       'admin_reader_user→admin_reader',
@@ -248,6 +251,64 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
     });
   });
 
+  describe('admin_gdpr_eraser_user (Art 17 erasure identity, connected over the wire)', () => {
+    it('should UPDATE exactly the 6 PII columns and leave chain columns untouched', async () => {
+      await asLoginUser('admin_gdpr_eraser_user', PASSWORDS.ADMIN_ERASER_PASSWORD, async (pool) => {
+        const { rowCount } = await pool.query(
+          `UPDATE security_audit_log
+           SET user_id = NULL, session_id = NULL, ip_address = NULL,
+               ip_bidx = NULL, user_agent = NULL, geo_location = NULL
+           WHERE id = 'seed-row-1'`,
+        );
+        expect(rowCount).toBe(1);
+      });
+      const { rows } = await owner.query(
+        `SELECT ip_address, event_hash, previous_hash FROM security_audit_log WHERE id = 'seed-row-1'`,
+      );
+      expect(rows[0]).toEqual({ ip_address: null, event_hash: 'hash-1', previous_hash: 'GENESIS' });
+    });
+
+    it.each(['event_hash', 'previous_hash', 'event_type', 'details'])(
+      'should be DENIED UPDATE on hash/content column %s (42501)',
+      async (column) => {
+        const literal = column === 'details' ? `'{}'::jsonb` : `'tampered'`;
+        await asLoginUser('admin_gdpr_eraser_user', PASSWORDS.ADMIN_ERASER_PASSWORD, async (pool) => {
+          await expect(
+            pool.query(`UPDATE security_audit_log SET ${column} = ${literal} WHERE id = 'seed-row-1'`),
+          ).rejects.toMatchObject({ code: '42501' });
+        });
+      },
+    );
+
+    it('should be DENIED INSERT, DELETE and TRUNCATE on security_audit_log (42501)', async () => {
+      await asLoginUser('admin_gdpr_eraser_user', PASSWORDS.ADMIN_ERASER_PASSWORD, async (pool) => {
+        await expect(
+          pool.query(
+            `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+             VALUES ('login-eraser-row', 'auth.login', 'x', 'y')`,
+          ),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`DELETE FROM security_audit_log WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(pool.query('TRUNCATE security_audit_log')).rejects.toMatchObject({
+          code: '42501',
+        });
+      });
+    });
+
+    it('should hold NOTHING on the ingest queue or SIEM tables (42501)', async () => {
+      await asLoginUser('admin_gdpr_eraser_user', PASSWORDS.ADMIN_ERASER_PASSWORD, async (pool) => {
+        await expect(pool.query('SELECT 1 FROM security_audit_ingest')).rejects.toMatchObject({
+          code: '42501',
+        });
+        await expect(
+          pool.query(`INSERT INTO siem_delivery_cursors (id) VALUES ('c-eraser')`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+  });
+
   describe('idempotency + rotation', () => {
     it('given a re-run with a changed password, should rotate it (old fails auth, new connects)', async () => {
       const rotated = 'app-secret-integration-ROTATED';
@@ -277,7 +338,11 @@ describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-user
         ADMIN_APP_PASSWORD: PASSWORDS.ADMIN_APP_PASSWORD,
       });
       expect(result.provisioned).toEqual(['admin_app_user']);
-      expect(result.skipped).toEqual(['admin_processor_user', 'admin_reader_user']);
+      expect(result.skipped).toEqual([
+        'admin_processor_user',
+        'admin_reader_user',
+        'admin_gdpr_eraser_user',
+      ]);
     });
 
     it('given ADMIN_DATABASE_URL_MIGRATE, should provision through it (owner path preference)', async () => {

--- a/packages/db/src/__tests__/admin-login-users.integration.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.integration.test.ts
@@ -6,9 +6,11 @@
  * creates — connecting AS each user over the wire (not SET ROLE), so the
  * probes exercise the same identity path a deployed service uses.
  *
- * Acceptance (leaf 0): admin_app_user can INSERT+SELECT security_audit_log
- * and is DENIED UPDATE/DELETE with a real 42501; processor/reader users get
- * exactly their templates' privileges; re-provisioning rotates passwords.
+ * Acceptance (post-cutover, admin migration 0008): admin_app_user can INSERT
+ * security_audit_ingest and SELECT security_audit_log, and is DENIED direct
+ * chain-table writes (INSERT/UPDATE/DELETE) with a real 42501; processor and
+ * reader users get exactly their templates' privileges; re-provisioning
+ * rotates passwords.
  *
  * Requires a running scratch Postgres (never the app DB):
  *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \

--- a/packages/db/src/__tests__/admin-login-users.integration.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.integration.test.ts
@@ -1,0 +1,292 @@
+/**
+ * LOGIN-user grant-denial tests for the Admin PG (#890 Phase 2, leaf 0 — gate).
+ *
+ * The Phase 1 grants suite proved the NOLOGIN role TEMPLATES; this suite
+ * proves the actual per-service LOGIN users that db:provision:admin-users
+ * creates — connecting AS each user over the wire (not SET ROLE), so the
+ * probes exercise the same identity path a deployed service uses.
+ *
+ * Acceptance (leaf 0): admin_app_user can INSERT+SELECT security_audit_log
+ * and is DENIED UPDATE/DELETE with a real 42501; processor/reader users get
+ * exactly their templates' privileges; re-provisioning rotates passwords.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run --config vitest.integration.config.ts src/__tests__/admin-login-users.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Pool } from 'pg';
+import { migrateAdminDb } from '../migrate-admin';
+import { provisionAdminLoginUsers } from '../provision-admin-users';
+import { ADMIN_LOGIN_USERS } from '../admin-login-users';
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+const PASSWORDS = {
+  ADMIN_APP_PASSWORD: 'app-secret-integration-1',
+  ADMIN_PROCESSOR_PASSWORD: 'processor-secret-integration-1',
+  ADMIN_READER_PASSWORD: 'reader-secret-integration-1',
+} as const;
+
+const TEMPLATE_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+] as const;
+
+/** Connection config for a login user against the same scratch server/db. */
+function loginConfig(user: string, password: string) {
+  const parsed = new URL(url as string);
+  return {
+    host: parsed.hostname,
+    port: Number(parsed.port || 5432),
+    database: parsed.pathname.slice(1),
+    user,
+    password,
+    max: 2,
+  };
+}
+
+/** Run fn on a pool connected AS the given login user, always cleaning up. */
+async function asLoginUser<T>(
+  user: string,
+  password: string,
+  fn: (pool: Pool) => Promise<T>,
+): Promise<T> {
+  const pool = new Pool(loginConfig(user, password));
+  try {
+    return await fn(pool);
+  } finally {
+    await pool.end();
+  }
+}
+
+describe.skipIf(!url)('per-service Admin PG LOGIN users (db:provision:admin-users)', () => {
+  let owner: Pool;
+
+  beforeAll(async () => {
+    owner = new Pool({ connectionString: url, max: 3 });
+    // Fresh-DB guarantee on the SCRATCH db (same reset as the grants suite),
+    // including the LOGIN users so provisioning is genuinely exercised.
+    await owner.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await owner.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await owner.query('CREATE SCHEMA public');
+    for (const role of [...TEMPLATE_ROLES, ...ADMIN_LOGIN_USERS.map((u) => u.user)]) {
+      await owner.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+
+    await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    const result = await provisionAdminLoginUsers({ ADMIN_DATABASE_URL: url, ...PASSWORDS });
+    expect(result.provisioned).toEqual([
+      'admin_app_user',
+      'admin_processor_user',
+      'admin_reader_user',
+    ]);
+
+    // Seed one chain row as owner for UPDATE/DELETE-denial probes.
+    await owner.query(
+      `INSERT INTO security_audit_log (id, event_type, user_id, ip_address, previous_hash, event_hash)
+       VALUES ('seed-row-1', 'auth.login', 'user-1', '203.0.113.7', 'GENESIS', 'hash-1')`,
+    );
+  });
+
+  afterAll(async () => {
+    await owner.end();
+  });
+
+  it('should create the three login users as LOGIN with least-privilege attributes', async () => {
+    const { rows } = await owner.query(
+      `SELECT rolname, rolcanlogin, rolsuper, rolcreatedb, rolcreaterole, rolreplication, rolbypassrls, rolinherit
+       FROM pg_roles WHERE rolname = ANY($1) ORDER BY rolname`,
+      [ADMIN_LOGIN_USERS.map((u) => u.user)],
+    );
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      expect(row.rolcanlogin).toBe(true);
+      expect(row.rolsuper).toBe(false);
+      expect(row.rolcreatedb).toBe(false);
+      expect(row.rolcreaterole).toBe(false);
+      expect(row.rolreplication).toBe(false);
+      expect(row.rolbypassrls).toBe(false);
+      expect(row.rolinherit).toBe(true);
+    }
+  });
+
+  it('should attach each login user to exactly its template roles', async () => {
+    const { rows } = await owner.query(`
+      SELECT member.rolname AS member, granted.rolname AS granted
+      FROM pg_auth_members m
+      JOIN pg_roles member ON member.oid = m.member
+      JOIN pg_roles granted ON granted.oid = m.roleid
+      WHERE member.rolname LIKE 'admin_%_user'
+      ORDER BY member.rolname, granted.rolname
+    `);
+    const memberships = rows.map((r: { member: string; granted: string }) => `${r.member}→${r.granted}`);
+    expect(memberships).toEqual([
+      'admin_app_user→admin_app',
+      'admin_processor_user→admin_chainer',
+      'admin_processor_user→admin_siem',
+      'admin_reader_user→admin_reader',
+    ]);
+  });
+
+  describe('admin_app_user (web identity, connected over the wire)', () => {
+    it('should INSERT into security_audit_log and SELECT the chain head', async () => {
+      await asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, async (pool) => {
+        const { rowCount } = await pool.query(
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('login-app-row-1', 'auth.login', 'hash-1', 'hash-app-1')`,
+        );
+        expect(rowCount).toBe(1);
+
+        const head = await pool.query(
+          'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1',
+        );
+        expect(head.rows[0].event_hash).toBe('hash-app-1');
+      });
+    });
+
+    it('should be DENIED UPDATE and DELETE on security_audit_log (42501)', async () => {
+      await asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, async (pool) => {
+        await expect(
+          pool.query(`UPDATE security_audit_log SET event_hash = 'tampered' WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`DELETE FROM security_audit_log WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+
+    it('should be DENIED TRUNCATE and any SIEM-table write (42501)', async () => {
+      await asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, async (pool) => {
+        await expect(pool.query('TRUNCATE security_audit_log')).rejects.toMatchObject({
+          code: '42501',
+        });
+        await expect(
+          pool.query(`INSERT INTO siem_delivery_cursors (id) VALUES ('c-app')`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+  });
+
+  describe('admin_processor_user (chainer + SIEM identity)', () => {
+    it('should SELECT+INSERT security_audit_log (chainer) and be DENIED UPDATE/DELETE', async () => {
+      await asLoginUser('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD, async (pool) => {
+        const { rowCount } = await pool.query(
+          `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+           VALUES ('login-proc-row-1', 'auth.login', 'hash-app-1', 'hash-proc-1')`,
+        );
+        expect(rowCount).toBe(1);
+        await expect(
+          pool.query(`UPDATE security_audit_log SET event_hash = 'x' WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`DELETE FROM security_audit_log WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+
+    it('should upsert siem_delivery_cursors and INSERT (write-once) siem_delivery_receipts', async () => {
+      await asLoginUser('admin_processor_user', PASSWORDS.ADMIN_PROCESSOR_PASSWORD, async (pool) => {
+        await pool.query(
+          `INSERT INTO siem_delivery_cursors (id, "deliveryCount") VALUES ('c-proc', 1)
+           ON CONFLICT (id) DO UPDATE SET "deliveryCount" = siem_delivery_cursors."deliveryCount" + 1`,
+        );
+        const receipts = await pool.query(
+          `INSERT INTO siem_delivery_receipts
+             ("receiptId", "deliveryId", source, "firstEntryId", "lastEntryId",
+              "firstEntryTimestamp", "lastEntryTimestamp", "entryCount", "deliveredAt")
+           VALUES ('r-proc', 'd-1', 'security_audit_log', 'seed-row-1', 'seed-row-1',
+                   now(), now(), 1, now())
+           RETURNING "receiptId"`,
+        );
+        expect(receipts.rowCount).toBe(1);
+        await expect(
+          pool.query(`DELETE FROM siem_delivery_cursors WHERE id = 'c-proc'`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+  });
+
+  describe('admin_reader_user (admin app identity)', () => {
+    it('should SELECT all three trust-plane tables', async () => {
+      await asLoginUser('admin_reader_user', PASSWORDS.ADMIN_READER_PASSWORD, async (pool) => {
+        for (const table of ['security_audit_log', 'siem_delivery_cursors', 'siem_delivery_receipts']) {
+          const { rows } = await pool.query(`SELECT count(*)::int AS n FROM ${table}`);
+          expect(rows[0].n).toBeGreaterThanOrEqual(0);
+        }
+      });
+    });
+
+    it('should be DENIED INSERT/UPDATE/DELETE everywhere (42501)', async () => {
+      await asLoginUser('admin_reader_user', PASSWORDS.ADMIN_READER_PASSWORD, async (pool) => {
+        await expect(
+          pool.query(
+            `INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+             VALUES ('login-reader-row', 'auth.login', 'x', 'y')`,
+          ),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`UPDATE siem_delivery_cursors SET "deliveryCount" = 99 WHERE id = 'c-proc'`),
+        ).rejects.toMatchObject({ code: '42501' });
+        await expect(
+          pool.query(`DELETE FROM security_audit_log WHERE id = 'seed-row-1'`),
+        ).rejects.toMatchObject({ code: '42501' });
+      });
+    });
+  });
+
+  describe('idempotency + rotation', () => {
+    it('given a re-run with a changed password, should rotate it (old fails auth, new connects)', async () => {
+      const rotated = 'app-secret-integration-ROTATED';
+      const result = await provisionAdminLoginUsers({
+        ADMIN_DATABASE_URL: url,
+        ...PASSWORDS,
+        ADMIN_APP_PASSWORD: rotated,
+      });
+      expect(result.provisioned).toContain('admin_app_user');
+
+      await expect(
+        asLoginUser('admin_app_user', PASSWORDS.ADMIN_APP_PASSWORD, (pool) => pool.query('SELECT 1')),
+      ).rejects.toMatchObject({ code: '28P01' }); // invalid_password
+
+      await asLoginUser('admin_app_user', rotated, async (pool) => {
+        const { rows } = await pool.query('SELECT 1 AS ok');
+        expect(rows[0].ok).toBe(1);
+      });
+
+      // Restore for any later probes.
+      await provisionAdminLoginUsers({ ADMIN_DATABASE_URL: url, ...PASSWORDS });
+    });
+
+    it('given a partial env, should provision only the present users and report the skipped ones', async () => {
+      const result = await provisionAdminLoginUsers({
+        ADMIN_DATABASE_URL: url,
+        ADMIN_APP_PASSWORD: PASSWORDS.ADMIN_APP_PASSWORD,
+      });
+      expect(result.provisioned).toEqual(['admin_app_user']);
+      expect(result.skipped).toEqual(['admin_processor_user', 'admin_reader_user']);
+    });
+
+    it('given ADMIN_DATABASE_URL_MIGRATE, should provision through it (owner path preference)', async () => {
+      const result = await provisionAdminLoginUsers({
+        ADMIN_DATABASE_URL: 'postgresql://admin_app_user:wrong@nowhere:1/never-used',
+        ADMIN_DATABASE_URL_MIGRATE: url,
+        ADMIN_READER_PASSWORD: PASSWORDS.ADMIN_READER_PASSWORD,
+      });
+      expect(result.provisioned).toEqual(['admin_reader_user']);
+    });
+  });
+});

--- a/packages/db/src/__tests__/admin-login-users.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Pure planning + SQL-building tests for per-service Admin PG LOGIN users
+ * (#890 Phase 2, leaf 0 — gate).
+ *
+ * drizzle-admin/0001 created NOLOGIN role TEMPLATES; actual login users are
+ * provisioned per-deploy from env passwords and attached with GRANT. All the
+ * logic (which users, validation, SQL text, literal escaping) is pure and
+ * pinned here; provision-admin-users.ts is the thin shell.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ADMIN_LOGIN_USERS,
+  planAdminLoginUsers,
+  buildLoginUserStatements,
+  quotePgLiteral,
+  type AdminLoginUserEnv,
+} from '../admin-login-users';
+
+const ALL_PASSWORDS: AdminLoginUserEnv = {
+  ADMIN_APP_PASSWORD: 'app-password-123',
+  ADMIN_PROCESSOR_PASSWORD: 'processor-password-123',
+  ADMIN_READER_PASSWORD: 'reader-password-123',
+};
+
+describe('ADMIN_LOGIN_USERS (the per-service identity matrix)', () => {
+  it('given the matrix, should map web to admin_app, processor to admin_chainer+admin_siem, admin app to admin_reader', () => {
+    expect(ADMIN_LOGIN_USERS).toEqual([
+      { user: 'admin_app_user', envVar: 'ADMIN_APP_PASSWORD', roles: ['admin_app'] },
+      {
+        user: 'admin_processor_user',
+        envVar: 'ADMIN_PROCESSOR_PASSWORD',
+        roles: ['admin_chainer', 'admin_siem'],
+      },
+      { user: 'admin_reader_user', envVar: 'ADMIN_READER_PASSWORD', roles: ['admin_reader'] },
+    ]);
+  });
+
+  it('given every user and role name, should be a safe lowercase SQL identifier (they are interpolated unquoted)', () => {
+    for (const spec of ADMIN_LOGIN_USERS) {
+      expect(spec.user).toMatch(/^[a-z_][a-z0-9_]*$/);
+      for (const role of spec.roles) {
+        expect(role).toMatch(/^[a-z_][a-z0-9_]*$/);
+      }
+    }
+  });
+});
+
+describe('planAdminLoginUsers', () => {
+  it('given all three passwords set, should provision all three users with their template roles', () => {
+    const plan = planAdminLoginUsers(ALL_PASSWORDS);
+    expect(plan.ok).toBe(true);
+    if (plan.ok) {
+      expect(plan.provision.map((p) => p.user)).toEqual([
+        'admin_app_user',
+        'admin_processor_user',
+        'admin_reader_user',
+      ]);
+      expect(plan.skipped).toEqual([]);
+      expect(plan.provision[1]!.roles).toEqual(['admin_chainer', 'admin_siem']);
+      expect(plan.provision[0]!.password).toBe('app-password-123');
+    }
+  });
+
+  it('given a password env var that is unset, should skip that user (and name it) without failing the others', () => {
+    const plan = planAdminLoginUsers({
+      ADMIN_APP_PASSWORD: 'app-password-123',
+      ADMIN_PROCESSOR_PASSWORD: 'processor-password-123',
+    });
+    expect(plan.ok).toBe(true);
+    if (plan.ok) {
+      expect(plan.provision.map((p) => p.user)).toEqual([
+        'admin_app_user',
+        'admin_processor_user',
+      ]);
+      expect(plan.skipped).toEqual(['admin_reader_user']);
+    }
+  });
+
+  it('given no passwords at all, should return an empty plan (nothing to provision is not an error)', () => {
+    const plan = planAdminLoginUsers({});
+    expect(plan.ok).toBe(true);
+    if (plan.ok) {
+      expect(plan.provision).toEqual([]);
+      expect(plan.skipped).toEqual([
+        'admin_app_user',
+        'admin_processor_user',
+        'admin_reader_user',
+      ]);
+    }
+  });
+
+  it('given a set-but-empty password, should refuse — a blank credential is a misconfigured deploy, never a skip', () => {
+    const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_APP_PASSWORD: '' });
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toContain('ADMIN_APP_PASSWORD');
+    }
+  });
+
+  it('given a password shorter than 8 characters, should refuse and name the env var (never the value)', () => {
+    const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_READER_PASSWORD: 'pw12345' });
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toContain('ADMIN_READER_PASSWORD');
+      expect(plan.reason).not.toContain('pw12345');
+    }
+  });
+
+  it('given a password containing whitespace or control characters, should refuse without echoing the value', () => {
+    for (const bad of ['pass word-123', 'pass\nword-123', 'pass\x00word-123']) {
+      const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_PROCESSOR_PASSWORD: bad });
+      expect(plan.ok).toBe(false);
+      if (!plan.ok) {
+        expect(plan.reason).toContain('ADMIN_PROCESSOR_PASSWORD');
+        expect(plan.reason).not.toContain(bad);
+      }
+    }
+  });
+
+  it('given a password containing a backslash, should refuse (escaping only guarantees quote-safety under standard_conforming_strings)', () => {
+    const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_APP_PASSWORD: 'back\\slash-123' });
+    expect(plan.ok).toBe(false);
+  });
+});
+
+describe('quotePgLiteral', () => {
+  it('given a plain value, should wrap it in single quotes', () => {
+    expect(quotePgLiteral('abc123')).toBe("'abc123'");
+  });
+
+  it('given embedded single quotes, should double them (injection-safe)', () => {
+    expect(quotePgLiteral("o'brien'); DROP ROLE admin_app; --")).toBe(
+      "'o''brien''); DROP ROLE admin_app; --'",
+    );
+  });
+
+  it('given a backslash or control character, should throw rather than emit ambiguous SQL', () => {
+    expect(() => quotePgLiteral('a\\b')).toThrow();
+    expect(() => quotePgLiteral('a\x00b')).toThrow();
+    expect(() => quotePgLiteral('a\nb')).toThrow();
+  });
+});
+
+describe('buildLoginUserStatements', () => {
+  const entry = {
+    user: 'admin_app_user',
+    roles: ['admin_app'],
+    password: "pw'quote-123",
+  };
+
+  it('given an entry, should emit guarded CREATE, an ALTER that always (re)sets LOGIN + password, then one GRANT per role', () => {
+    const statements = buildLoginUserStatements(entry);
+    expect(statements).toHaveLength(3);
+    expect(statements[0]).toContain("IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_app_user')");
+    expect(statements[0]).toContain('CREATE ROLE admin_app_user');
+    expect(statements[1]).toContain('ALTER ROLE admin_app_user WITH LOGIN');
+    expect(statements[2]).toBe('GRANT admin_app TO admin_app_user');
+  });
+
+  it('given the ALTER, should pin least-privilege attributes and INHERIT (template privileges apply without SET ROLE)', () => {
+    const alter = buildLoginUserStatements(entry)[1]!;
+    for (const attr of ['NOSUPERUSER', 'NOCREATEDB', 'NOCREATEROLE', 'NOREPLICATION', 'NOBYPASSRLS', 'INHERIT']) {
+      expect(alter).toContain(attr);
+    }
+    expect(alter).not.toMatch(/\bSUPERUSER\b/);
+  });
+
+  it('given the password, should embed it via quotePgLiteral (quotes doubled)', () => {
+    const alter = buildLoginUserStatements(entry)[1]!;
+    expect(alter).toContain("PASSWORD 'pw''quote-123'");
+  });
+
+  it('given a multi-role entry, should grant every template role', () => {
+    const statements = buildLoginUserStatements({
+      user: 'admin_processor_user',
+      roles: ['admin_chainer', 'admin_siem'],
+      password: 'processor-password-123',
+    });
+    expect(statements).toContain('GRANT admin_chainer TO admin_processor_user');
+    expect(statements).toContain('GRANT admin_siem TO admin_processor_user');
+  });
+
+  it('given a user or role name that is not a safe identifier, should throw', () => {
+    expect(() =>
+      buildLoginUserStatements({ user: 'bad"user', roles: ['admin_app'], password: 'x-123456' }),
+    ).toThrow();
+    expect(() =>
+      buildLoginUserStatements({ user: 'admin_app_user', roles: ['admin app'], password: 'x-123456' }),
+    ).toThrow();
+  });
+});

--- a/packages/db/src/__tests__/admin-login-users.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.test.ts
@@ -20,10 +20,11 @@ const ALL_PASSWORDS: AdminLoginUserEnv = {
   ADMIN_APP_PASSWORD: 'app-password-123',
   ADMIN_PROCESSOR_PASSWORD: 'processor-password-123',
   ADMIN_READER_PASSWORD: 'reader-password-123',
+  ADMIN_ERASER_PASSWORD: 'eraser-password-123',
 };
 
 describe('ADMIN_LOGIN_USERS (the per-service identity matrix)', () => {
-  it('given the matrix, should map web to admin_app, processor to admin_chainer+admin_siem, admin app to admin_reader', () => {
+  it('given the matrix, should map web to admin_app, processor to admin_chainer+admin_siem, admin app to admin_reader, GDPR erasure to admin_gdpr_eraser', () => {
     expect(ADMIN_LOGIN_USERS).toEqual([
       { user: 'admin_app_user', envVar: 'ADMIN_APP_PASSWORD', roles: ['admin_app'] },
       {
@@ -32,6 +33,11 @@ describe('ADMIN_LOGIN_USERS (the per-service identity matrix)', () => {
         roles: ['admin_chainer', 'admin_siem'],
       },
       { user: 'admin_reader_user', envVar: 'ADMIN_READER_PASSWORD', roles: ['admin_reader'] },
+      {
+        user: 'admin_gdpr_eraser_user',
+        envVar: 'ADMIN_ERASER_PASSWORD',
+        roles: ['admin_gdpr_eraser'],
+      },
     ]);
   });
 
@@ -46,7 +52,7 @@ describe('ADMIN_LOGIN_USERS (the per-service identity matrix)', () => {
 });
 
 describe('planAdminLoginUsers', () => {
-  it('given all three passwords set, should provision all three users with their template roles', () => {
+  it('given all four passwords set, should provision all four users with their template roles', () => {
     const plan = planAdminLoginUsers(ALL_PASSWORDS);
     expect(plan.ok).toBe(true);
     if (plan.ok) {
@@ -54,10 +60,12 @@ describe('planAdminLoginUsers', () => {
         'admin_app_user',
         'admin_processor_user',
         'admin_reader_user',
+        'admin_gdpr_eraser_user',
       ]);
       expect(plan.skipped).toEqual([]);
       expect(plan.provision[1]!.roles).toEqual(['admin_chainer', 'admin_siem']);
       expect(plan.provision[0]!.password).toBe('app-password-123');
+      expect(plan.provision[3]!.roles).toEqual(['admin_gdpr_eraser']);
     }
   });
 
@@ -72,7 +80,7 @@ describe('planAdminLoginUsers', () => {
         'admin_app_user',
         'admin_processor_user',
       ]);
-      expect(plan.skipped).toEqual(['admin_reader_user']);
+      expect(plan.skipped).toEqual(['admin_reader_user', 'admin_gdpr_eraser_user']);
     }
   });
 
@@ -85,6 +93,7 @@ describe('planAdminLoginUsers', () => {
         'admin_app_user',
         'admin_processor_user',
         'admin_reader_user',
+        'admin_gdpr_eraser_user',
       ]);
     }
   });
@@ -120,6 +129,14 @@ describe('planAdminLoginUsers', () => {
   it('given a password containing a backslash, should refuse (escaping only guarantees quote-safety under standard_conforming_strings)', () => {
     const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_APP_PASSWORD: 'back\\slash-123' });
     expect(plan.ok).toBe(false);
+  });
+
+  it('given an invalid ADMIN_ERASER_PASSWORD, should refuse the whole plan naming the eraser env var', () => {
+    const plan = planAdminLoginUsers({ ...ALL_PASSWORDS, ADMIN_ERASER_PASSWORD: 'short' });
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toContain('ADMIN_ERASER_PASSWORD');
+    }
   });
 });
 

--- a/packages/db/src/__tests__/admin-login-users.test.ts
+++ b/packages/db/src/__tests__/admin-login-users.test.ts
@@ -167,11 +167,23 @@ describe('buildLoginUserStatements', () => {
 
   it('given an entry, should emit guarded CREATE, an ALTER that always (re)sets LOGIN + password, then one GRANT per role', () => {
     const statements = buildLoginUserStatements(entry);
-    expect(statements).toHaveLength(3);
     expect(statements[0]).toContain("IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'admin_app_user')");
     expect(statements[0]).toContain('CREATE ROLE admin_app_user');
     expect(statements[1]).toContain('ALTER ROLE admin_app_user WITH LOGIN');
-    expect(statements[2]).toBe('GRANT admin_app TO admin_app_user');
+    expect(statements[statements.length - 1]).toBe('GRANT admin_app TO admin_app_user');
+  });
+
+  it('given an entry, should REVOKE every managed template role NOT in entry.roles — GRANT only adds, so re-provisioning after a template change must strip stale memberships', () => {
+    const statements = buildLoginUserStatements(entry);
+    for (const stale of ['admin_chainer', 'admin_siem', 'admin_reader', 'admin_gdpr_eraser']) {
+      expect(statements).toContain(`REVOKE ${stale} FROM admin_app_user`);
+    }
+    // Never revoke what this entry is about to hold.
+    expect(statements).not.toContain('REVOKE admin_app FROM admin_app_user');
+    // Revokes come before grants so a re-provision always ENDS granted.
+    expect(statements.indexOf('REVOKE admin_reader FROM admin_app_user')).toBeLessThan(
+      statements.indexOf('GRANT admin_app TO admin_app_user'),
+    );
   });
 
   it('given the ALTER, should pin least-privilege attributes and INHERIT (template privileges apply without SET ROLE)', () => {

--- a/packages/db/src/__tests__/admin-migrate-decision.test.ts
+++ b/packages/db/src/__tests__/admin-migrate-decision.test.ts
@@ -49,4 +49,59 @@ describe('resolveAdminMigrateDecision', () => {
       expect(decision.reason).toMatch(/postgres/);
     }
   });
+
+  // Phase 2 leaf 0 (gate): the runtime ADMIN_DATABASE_URL becomes a
+  // least-privilege LOGIN (admin_app etc.), so the migrate/provision path —
+  // which needs the OWNER role — takes a dedicated ADMIN_DATABASE_URL_MIGRATE
+  // that never reaches any runtime service.
+  describe('ADMIN_DATABASE_URL_MIGRATE preference', () => {
+    it('given both URLs set, should migrate against the dedicated migrate URL, not the runtime one', () => {
+      const decision = resolveAdminMigrateDecision({
+        ADMIN_DATABASE_URL: 'postgresql://admin_app_user:app-pw@host:5432/pagespace_admin',
+        ADMIN_DATABASE_URL_MIGRATE: 'postgresql://owner:owner-pw@host:5432/pagespace_admin',
+      });
+      expect(decision.ok).toBe(true);
+      if (decision.ok) {
+        expect(decision.poolConfig.connectionString).toBe(
+          'postgresql://owner:owner-pw@host:5432/pagespace_admin',
+        );
+      }
+    });
+
+    it('given only ADMIN_DATABASE_URL_MIGRATE set, should migrate against it', () => {
+      const decision = resolveAdminMigrateDecision({
+        ADMIN_DATABASE_URL_MIGRATE: 'postgresql://owner:owner-pw@host:5432/pagespace_admin',
+      });
+      expect(decision.ok).toBe(true);
+      if (decision.ok) {
+        expect(decision.poolConfig.connectionString).toBe(
+          'postgresql://owner:owner-pw@host:5432/pagespace_admin',
+        );
+      }
+    });
+
+    it('given an empty-string migrate URL, should fall back to ADMIN_DATABASE_URL (compose path unchanged)', () => {
+      const decision = resolveAdminMigrateDecision({
+        ADMIN_DATABASE_URL: 'postgresql://owner:owner-pw@postgres-admin:5432/pagespace_admin',
+        ADMIN_DATABASE_URL_MIGRATE: '',
+      });
+      expect(decision.ok).toBe(true);
+      if (decision.ok) {
+        expect(decision.poolConfig.connectionString).toBe(
+          'postgresql://owner:owner-pw@postgres-admin:5432/pagespace_admin',
+        );
+      }
+    });
+
+    it('given an invalid migrate URL scheme, should refuse rather than silently fall back to the runtime URL', () => {
+      const decision = resolveAdminMigrateDecision({
+        ADMIN_DATABASE_URL: 'postgresql://admin_app_user:app-pw@host:5432/pagespace_admin',
+        ADMIN_DATABASE_URL_MIGRATE: 'mysql://root@host:3306/nope',
+      });
+      expect(decision.ok).toBe(false);
+      if (!decision.ok) {
+        expect(decision.reason).toMatch(/postgres/);
+      }
+    });
+  });
 });

--- a/packages/db/src/__tests__/admin-migrate.integration.test.ts
+++ b/packages/db/src/__tests__/admin-migrate.integration.test.ts
@@ -45,6 +45,7 @@ describe.skipIf(!url)('db:migrate:admin against a scratch Admin PG', () => {
        ORDER BY c.relname`,
     );
     expect(rows.map((r: { table_name: string }) => r.table_name)).toEqual([
+      'security_audit_ingest',
       'security_audit_log',
       'siem_delivery_cursors',
       'siem_delivery_receipts',

--- a/packages/db/src/__tests__/admin-migrate.integration.test.ts
+++ b/packages/db/src/__tests__/admin-migrate.integration.test.ts
@@ -45,6 +45,7 @@ describe.skipIf(!url)('db:migrate:admin against a scratch Admin PG', () => {
        ORDER BY c.relname`,
     );
     expect(rows.map((r: { table_name: string }) => r.table_name)).toEqual([
+      'security_audit_anchors',
       'security_audit_ingest',
       'security_audit_log',
       'siem_delivery_cursors',

--- a/packages/db/src/__tests__/admin-partition.integration.test.ts
+++ b/packages/db/src/__tests__/admin-partition.integration.test.ts
@@ -350,14 +350,14 @@ describe.skipIf(!url)('upgrade path — partitioning a DB that already holds cha
     expect(Number(next.rows[0].chain_seq)).toBe(4);
   });
 
-  it('should hold the leaf-4 grant matrix on the re-created parents', async () => {
+  it('should hold the leaf-4 grant matrix on the re-created parents (as amended by the 0008 revoke — admin_app no longer INSERTs the chain)', async () => {
     const { rows } = await pool.query(
       `SELECT has_table_privilege('admin_app', 'security_audit_log', 'INSERT') AS app_ins,
               has_table_privilege('admin_app', 'security_audit_log', 'DELETE') AS app_del,
               has_table_privilege('admin_siem', 'siem_delivery_receipts', 'INSERT') AS siem_ins,
               has_table_privilege('admin_siem', 'siem_delivery_receipts', 'UPDATE') AS siem_upd`,
     );
-    expect(rows[0]).toEqual({ app_ins: true, app_del: false, siem_ins: true, siem_upd: false });
+    expect(rows[0]).toEqual({ app_ins: false, app_del: false, siem_ins: true, siem_upd: false });
   });
 });
 

--- a/packages/db/src/__tests__/admin-revoke-app-chain-insert-migration.test.ts
+++ b/packages/db/src/__tests__/admin-revoke-app-chain-insert-migration.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Static invariants of the admin_app chain-table revoke migration (#890
+ * Phase 2 FIX — REVIEW finding: zero-trust hole).
+ *
+ * Post-cutover admin_app INSERTs ONLY into security_audit_ingest; the
+ * chainer (admin_chainer) is the single writer of security_audit_log. The
+ * Phase-1 `GRANT SELECT, INSERT … TO admin_app` became excess privilege at
+ * the leaf-5 cutover: a compromised web credential could append chain-valid
+ * forged rows directly (no ingest, no emission discipline, no co-stream
+ * witness) and the chainer would link onto and anchor-witness them. 0008
+ * revokes exactly that — INSERT on the chain table and USAGE on its
+ * chain_seq sequence — while SELECT (readers, verifier) survives.
+ * Break-glass is unaffected: it writes the MAIN db.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import path from 'path';
+
+const ADMIN_MIGRATIONS_DIR = path.resolve(__dirname, '../../drizzle-admin');
+
+const migrationFile = readdirSync(ADMIN_MIGRATIONS_DIR).find((f) =>
+  /^0008_.*\.sql$/.test(f),
+);
+const sql = readFileSync(path.join(ADMIN_MIGRATIONS_DIR, migrationFile ?? ''), 'utf8');
+/** SQL with line comments stripped, so assertions never match prose. */
+const code = sql
+  .split('\n')
+  .filter((line) => !line.trimStart().startsWith('--'))
+  .join('\n');
+
+describe('drizzle-admin/0008 revoke admin_app chain-table INSERT', () => {
+  it('should exist in the admin journal as migration 0008', () => {
+    expect(migrationFile).toBe('0008_revoke_app_chain_insert.sql');
+    const journal = JSON.parse(
+      readFileSync(path.join(ADMIN_MIGRATIONS_DIR, 'meta/_journal.json'), 'utf8'),
+    ) as { entries: Array<{ idx: number; tag: string }> };
+    expect(journal.entries.find((e) => e.idx === 8)?.tag).toBe('0008_revoke_app_chain_insert');
+  });
+
+  it('should revoke exactly INSERT on security_audit_log and USAGE on its chain_seq sequence from admin_app, and grant nothing', () => {
+    const statements = (code.match(/(GRANT|REVOKE)[^;]+;/g) ?? []).map((s) =>
+      s.replace(/\s+/g, ' ').trim(),
+    );
+    expect(statements).toEqual([
+      'REVOKE INSERT ON security_audit_log FROM admin_app;',
+      'REVOKE USAGE ON SEQUENCE security_audit_log_chain_seq_seq FROM admin_app;',
+    ]);
+  });
+
+  it('should never revoke SELECT (readers/verifier keep reading the chain)', () => {
+    expect(code).not.toMatch(/REVOKE[^;]*SELECT/i);
+  });
+
+  it('should touch no other role — the chainer stays the single writer', () => {
+    expect(code).not.toMatch(/admin_chainer|admin_reader|admin_gdpr_eraser|admin_siem|admin_maintenance/);
+  });
+
+  it('should touch no other table', () => {
+    expect(code).not.toMatch(/security_audit_ingest|security_audit_anchors|siem_delivery/);
+  });
+});

--- a/packages/db/src/__tests__/admin-schema.test.ts
+++ b/packages/db/src/__tests__/admin-schema.test.ts
@@ -51,10 +51,13 @@ describe('admin-schema barrel', () => {
       expect(getTableName(adminSchema.securityAuditLog)).toBe('security_audit_log');
     });
 
-    it('should have the identical column set as the main instance (single source of truth)', () => {
+    it('should have the identical column set as the main instance plus ONLY emission_hash (single source of truth)', () => {
       const adminColumns = getTableColumns(adminSchema.securityAuditLog);
       const mainColumns = getTableColumns(mainSecurityAuditLog);
-      expect(Object.keys(adminColumns)).toEqual(Object.keys(mainColumns));
+      // The one deliberate plane-only delta (#890 Phase 2 leaf 2): the chained
+      // table stores the emission hash so verify-on-append recomputes from
+      // storage. Everything else must stay in lockstep with the main plane.
+      expect(Object.keys(adminColumns)).toEqual([...Object.keys(mainColumns), 'emissionHash']);
       for (const key of Object.keys(mainColumns)) {
         expect(adminColumns[key as keyof typeof adminColumns].name).toBe(
           mainColumns[key as keyof typeof mainColumns].name,
@@ -63,6 +66,14 @@ describe('admin-schema barrel', () => {
           mainColumns[key as keyof typeof mainColumns].columnType,
         );
       }
+    });
+
+    it('should keep emission_hash NULLABLE text (NULL = legacy-era row) on the admin plane only', () => {
+      const adminColumns = getTableColumns(adminSchema.securityAuditLog);
+      expect(adminColumns.emissionHash.name).toBe('emission_hash');
+      expect(adminColumns.emissionHash.columnType).toBe('PgText');
+      expect(adminColumns.emissionHash.notNull).toBe(false);
+      expect(Object.keys(getTableColumns(mainSecurityAuditLog))).not.toContain('emissionHash');
     });
 
     it('should have the identical index set as the main instance', () => {

--- a/packages/db/src/__tests__/admin-schema.test.ts
+++ b/packages/db/src/__tests__/admin-schema.test.ts
@@ -29,8 +29,9 @@ const exportedTables = Object.entries(adminSchema).filter(([, value]) =>
 );
 
 describe('admin-schema barrel', () => {
-  it('should export exactly the four trust-plane tables', () => {
+  it('should export exactly the five trust-plane tables', () => {
     expect(exportedTables.map(([key]) => key).sort()).toEqual([
+      'securityAuditAnchors',
       'securityAuditIngest',
       'securityAuditLog',
       'siemDeliveryCursors',
@@ -128,6 +129,31 @@ describe('admin-schema barrel', () => {
     });
   });
 
+  describe('securityAuditAnchors (Phase 2 anchor receipts)', () => {
+    it('should target security_audit_anchors and exist ONLY in the admin barrel (never the main schema)', async () => {
+      expect(getTableName(adminSchema.securityAuditAnchors)).toBe('security_audit_anchors');
+      const mainSchema = await import('../schema');
+      expect(Object.keys(mainSchema)).not.toContain('securityAuditAnchors');
+    });
+
+    it('should carry every signed anchor field NOT NULL and no foreign keys', () => {
+      expect(getTableConfig(adminSchema.securityAuditAnchors).foreignKeys).toHaveLength(0);
+      const columns = getTableColumns(adminSchema.securityAuditAnchors);
+      expect(Object.keys(columns).sort()).toEqual([
+        'anchoredAt',
+        'chainSeq',
+        'createdAt',
+        'headHash',
+        'id',
+        'signature',
+        'version',
+      ]);
+      for (const key of ['version', 'chainSeq', 'headHash', 'anchoredAt', 'signature'] as const) {
+        expect(columns[key].notNull, `${key} must be NOT NULL`).toBe(true);
+      }
+    });
+  });
+
   describe('SIEM tables carry no cross-plane FKs', () => {
     it('siemDeliveryCursors has no foreign keys', () => {
       expect(getTableConfig(adminSchema.siemDeliveryCursors).foreignKeys).toHaveLength(0);
@@ -144,12 +170,13 @@ describe('admin-schema barrel', () => {
       // (Record<string, never> ⇒ keyof query is never ⇒ excess properties) or
       // if the barrel gains/loses a table without this contract being updated.
       const querySurface: Record<keyof AdminDatabase['query'], true> = {
+        securityAuditAnchors: true,
         securityAuditIngest: true,
         securityAuditLog: true,
         siemDeliveryCursors: true,
         siemDeliveryReceipts: true,
       };
-      expect(Object.keys(querySurface)).toHaveLength(4);
+      expect(Object.keys(querySurface)).toHaveLength(5);
     });
   });
 });

--- a/packages/db/src/__tests__/admin-schema.test.ts
+++ b/packages/db/src/__tests__/admin-schema.test.ts
@@ -3,7 +3,8 @@
  *
  * The barrel selects which tables belong to the trust plane. Contract:
  *   - EXACTLY securityAuditLog + siemDeliveryCursors + siemDeliveryReceipts
- *     (analytics tables go to ClickHouse in Phase 3, activityLogs in Phase 5).
+ *     + securityAuditIngest (Phase 2 emission queue, trust-plane only —
+ *     analytics tables go to ClickHouse in Phase 3, activityLogs in Phase 5).
  *   - Single source of truth: the SIEM tables are the same objects as the
  *     main schema's; securityAuditLog shares one column/index definition via
  *     the defineSecurityAuditLogTable factory.
@@ -28,8 +29,9 @@ const exportedTables = Object.entries(adminSchema).filter(([, value]) =>
 );
 
 describe('admin-schema barrel', () => {
-  it('should export exactly the three trust-plane tables', () => {
+  it('should export exactly the four trust-plane tables', () => {
     expect(exportedTables.map(([key]) => key).sort()).toEqual([
+      'securityAuditIngest',
       'securityAuditLog',
       'siemDeliveryCursors',
       'siemDeliveryReceipts',
@@ -82,6 +84,39 @@ describe('admin-schema barrel', () => {
     });
   });
 
+  describe('securityAuditIngest (Phase 2 emission queue)', () => {
+    it('should target security_audit_ingest and exist ONLY in the admin barrel (never the main schema)', async () => {
+      expect(getTableName(adminSchema.securityAuditIngest)).toBe('security_audit_ingest');
+      const mainSchema = await import('../schema');
+      expect(Object.keys(mainSchema)).not.toContain('securityAuditIngest');
+    });
+
+    it('should carry no foreign keys and no chain columns (emission_hash/emitted_at instead)', () => {
+      expect(getTableConfig(adminSchema.securityAuditIngest).foreignKeys).toHaveLength(0);
+      const columns = getTableColumns(adminSchema.securityAuditIngest);
+      expect(Object.keys(columns)).not.toContain('chainSeq');
+      expect(Object.keys(columns)).not.toContain('previousHash');
+      expect(Object.keys(columns)).not.toContain('eventHash');
+      expect(columns.emissionHash.notNull).toBe(true);
+      expect(columns.emittedAt.notNull).toBe(true);
+    });
+
+    it('should mirror security_audit_log event-column shapes exactly (encryption columns included)', () => {
+      const ingestColumns = getTableColumns(adminSchema.securityAuditIngest);
+      const chainColumns = getTableColumns(mainSecurityAuditLog);
+      const eventColumnKeys = Object.keys(chainColumns).filter(
+        (key) => !['chainSeq', 'previousHash', 'eventHash'].includes(key),
+      );
+      for (const key of eventColumnKeys) {
+        const ingest = ingestColumns[key as keyof typeof ingestColumns];
+        const chain = chainColumns[key as keyof typeof chainColumns];
+        expect(ingest, `missing event column ${key}`).toBeDefined();
+        expect(ingest.name).toBe(chain.name);
+        expect(ingest.columnType).toBe(chain.columnType);
+      }
+    });
+  });
+
   describe('SIEM tables carry no cross-plane FKs', () => {
     it('siemDeliveryCursors has no foreign keys', () => {
       expect(getTableConfig(adminSchema.siemDeliveryCursors).foreignKeys).toHaveLength(0);
@@ -98,11 +133,12 @@ describe('admin-schema barrel', () => {
       // (Record<string, never> ⇒ keyof query is never ⇒ excess properties) or
       // if the barrel gains/loses a table without this contract being updated.
       const querySurface: Record<keyof AdminDatabase['query'], true> = {
+        securityAuditIngest: true,
         securityAuditLog: true,
         siemDeliveryCursors: true,
         siemDeliveryReceipts: true,
       };
-      expect(Object.keys(querySurface)).toHaveLength(3);
+      expect(Object.keys(querySurface)).toHaveLength(4);
     });
   });
 });

--- a/packages/db/src/admin-db-mode.ts
+++ b/packages/db/src/admin-db-mode.ts
@@ -98,12 +98,39 @@ export type AdminMigrateDecision =
   | { ok: false; reason: string };
 
 /**
+ * Env contract for the migrate/provision one-shots (#890 Phase 2, leaf 0).
+ * The runtime ADMIN_DATABASE_URL is a least-privilege LOGIN (admin_app etc.),
+ * which cannot run DDL — so the owner-credential path gets its own variable,
+ * ADMIN_DATABASE_URL_MIGRATE, that never reaches any runtime service (compose
+ * hands it to the migrate one-shot only; on Fly it is passed to the one-shot
+ * machine, not stored in any app's runtime secrets).
+ */
+export interface AdminMigrateEnv extends AdminDbEnv {
+  ADMIN_DATABASE_URL_MIGRATE?: string | undefined;
+}
+
+/**
+ * Prefer the dedicated migrate URL when set (empty string = unset, matching
+ * the ADMIN_DATABASE_URL contract). Invalid values are NOT silently skipped —
+ * they flow into resolveAdminDbMode and fail there, so a misconfigured
+ * migrate URL can never fall back to running DDL as the runtime login.
+ */
+export const resolveAdminMigrateEnv = (env: AdminMigrateEnv): AdminDbEnv => {
+  const migrateUrl = env.ADMIN_DATABASE_URL_MIGRATE;
+  if (migrateUrl !== undefined && migrateUrl !== '') {
+    return { ...env, ADMIN_DATABASE_URL: migrateUrl };
+  }
+  return env;
+};
+
+/**
  * db:migrate:admin gate — only 'dedicated' may migrate. Break-glass degrades
  * audit WRITES to the main DB at runtime, but running admin migrations there
  * would plant the drizzle_admin journal inside the app plane, so it refuses.
  */
-export const resolveAdminMigrateDecision = (env: AdminDbEnv): AdminMigrateDecision => {
-  const decision = resolveAdminDbMode(env);
+export const resolveAdminMigrateDecision = (env: AdminMigrateEnv): AdminMigrateDecision => {
+  const resolvedEnv = resolveAdminMigrateEnv(env);
+  const decision = resolveAdminDbMode(resolvedEnv);
   if (decision.mode === 'break-glass') {
     return {
       ok: false,
@@ -115,5 +142,5 @@ export const resolveAdminMigrateDecision = (env: AdminDbEnv): AdminMigrateDecisi
   if (decision.mode === 'fail') {
     return { ok: false, reason: decision.reason };
   }
-  return { ok: true, poolConfig: resolveAdminPoolConfig(env) };
+  return { ok: true, poolConfig: resolveAdminPoolConfig(resolvedEnv) };
 };

--- a/packages/db/src/admin-db.ts
+++ b/packages/db/src/admin-db.ts
@@ -18,6 +18,7 @@ import {
   resolveAdminDbMode,
   resolveAdminPoolConfig,
   type AdminDbEnv,
+  type AdminDbModeDecision,
   type AdminPoolConfig,
 } from './admin-db-mode';
 
@@ -44,6 +45,15 @@ export interface AdminDbDeps {
 
 export interface AdminDbRegistry {
   getAdminDb: () => AdminDatabase;
+  /**
+   * Resolved-mode readback for callers that must BRANCH on the mode without
+   * triggering init side effects (#890 Phase 2, leaf 5): the audit bind point
+   * routes writes to the ingest path only under 'dedicated' and keeps the
+   * legacy main-DB path under 'break-glass'. Pure observation — never
+   * constructs a pool, never alerts, never throws; re-reads env each call so
+   * late-loaded dotenv wins, same as init.
+   */
+  getMode: () => AdminDbModeDecision;
 }
 
 const breakGlassAlert = (reason: string): string =>
@@ -86,6 +96,9 @@ export function createAdminDbRegistry(deps: AdminDbDeps): AdminDbRegistry {
       if (!instance) instance = init();
       return instance;
     },
+    getMode() {
+      return resolveAdminDbMode(deps.getEnv());
+    },
   };
 }
 
@@ -110,3 +123,9 @@ const registry = createAdminDbRegistry({
  * loud alert) on first call, then returns the same instance for the process.
  */
 export const getAdminDb = (): AdminDatabase => registry.getAdminDb();
+
+/**
+ * Resolved Admin PG mode for the current process env. Side-effect free —
+ * see AdminDbRegistry.getMode().
+ */
+export const getAdminDbMode = (): AdminDbModeDecision => registry.getMode();

--- a/packages/db/src/admin-eraser-db.ts
+++ b/packages/db/src/admin-eraser-db.ts
@@ -1,0 +1,154 @@
+/**
+ * GDPR eraser connection to the Admin PG (#890 Phase 2, leaf 6).
+ *
+ * The Art 17 pseudonymization path must UPDATE the 6 PII columns on the
+ * trust-plane security_audit_log — a write the runtime web identity
+ * (admin_app, INSERT-only) rightly cannot perform. It runs as its own LOGIN
+ * user, admin_gdpr_eraser_user (template role admin_gdpr_eraser: SELECT +
+ * column-scoped UPDATE on exactly user_id, session_id, ip_address, ip_bidx,
+ * user_agent, geo_location — provisioned by db:provision:admin-users), over
+ * a small dedicated pool from ADMIN_ERASER_DATABASE_URL.
+ *
+ * Deliberately NOT part of the AdminDb registry: the eraser has no
+ * break-glass and no fallback. When the URL is missing the accessor THROWS
+ * with an actionable reason — erasure against the wrong store or via the
+ * wrong identity must never happen silently. (Under break-glass the whole
+ * audit surface lives in the main DB and the erasure path never asks for
+ * this client — see packages/lib pseudonymize-targets.)
+ */
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as adminSchema from './admin-schema';
+import type { AdminDatabase } from './admin-db';
+import { registerPool } from './pool-stats';
+import { resolveAdminPoolConfig, type AdminPoolConfig } from './admin-db-mode';
+
+export interface AdminEraserDbEnv {
+  ADMIN_ERASER_DATABASE_URL?: string | undefined;
+  ADMIN_DATABASE_SSL?: string | undefined;
+}
+
+export type AdminEraserDbModeDecision =
+  | { mode: 'available'; reason: string }
+  | { mode: 'unavailable'; reason: string };
+
+const isPostgresUrl = (url: string): boolean =>
+  url.startsWith('postgresql://') || url.startsWith('postgres://');
+
+export const resolveAdminEraserDbMode = (env: AdminEraserDbEnv): AdminEraserDbModeDecision => {
+  const url = env.ADMIN_ERASER_DATABASE_URL;
+
+  // Empty string is treated as unset, matching the ADMIN_DATABASE_URL contract.
+  if (url !== undefined && url !== '') {
+    if (!isPostgresUrl(url)) {
+      return {
+        mode: 'unavailable',
+        reason:
+          'ADMIN_ERASER_DATABASE_URL is set but is not a postgres:// or postgresql:// connection string. ' +
+          'Fix the URL — an invalid eraser target is never used as-is.',
+      };
+    }
+    return { mode: 'available', reason: 'ADMIN_ERASER_DATABASE_URL is set' };
+  }
+
+  return {
+    mode: 'unavailable',
+    reason:
+      'ADMIN_ERASER_DATABASE_URL is not set. GDPR audit pseudonymization on the Admin PG requires the ' +
+      'admin_gdpr_eraser_user LOGIN (provisioned by db:provision:admin-users from ADMIN_ERASER_PASSWORD). ' +
+      'Set ADMIN_ERASER_DATABASE_URL to the Admin PG with those credentials.',
+  };
+};
+
+/** Erasure is a rare, admin-triggered operation — two connections is plenty. */
+export const ADMIN_ERASER_POOL_MAX = 2;
+
+export const ADMIN_ERASER_POOL_NAME = 'admin-eraser';
+
+export interface AdminEraserDbDeps {
+  getEnv: () => AdminEraserDbEnv;
+  createPool: (config: AdminPoolConfig) => Pool;
+  registerPool: (pool: Pool, name: string) => void;
+}
+
+export interface AdminEraserDbRegistry {
+  /** Lazy per-process eraser client. Throws when unavailable — never falls back. */
+  getAdminEraserDb: () => AdminDatabase;
+  /** Side-effect-free mode readback (no pool, no throw) for callers that plan/branch. */
+  getMode: () => AdminEraserDbModeDecision;
+}
+
+export function createAdminEraserDbRegistry(deps: AdminEraserDbDeps): AdminEraserDbRegistry {
+  let instance: AdminDatabase | null = null;
+
+  return {
+    getAdminEraserDb() {
+      if (instance) return instance;
+
+      const env = deps.getEnv();
+      const decision = resolveAdminEraserDbMode(env);
+      if (decision.mode === 'unavailable') {
+        throw new Error(`adminEraserDb init failed: ${decision.reason}`);
+      }
+
+      // Reuse the shared pool settings (ssl semantics, keepAlive, timeouts)
+      // with the eraser URL and its own small max.
+      const pool = deps.createPool({
+        ...resolveAdminPoolConfig({
+          ADMIN_DATABASE_URL: env.ADMIN_ERASER_DATABASE_URL,
+          ADMIN_DATABASE_SSL: env.ADMIN_DATABASE_SSL,
+        }),
+        max: ADMIN_ERASER_POOL_MAX,
+      });
+      // Same idle-disconnect guard as the main/admin pools.
+      pool.on('error', () => {});
+      deps.registerPool(pool, ADMIN_ERASER_POOL_NAME);
+      instance = drizzle(pool, { schema: adminSchema });
+      return instance;
+    },
+    getMode() {
+      return resolveAdminEraserDbMode(deps.getEnv());
+    },
+  };
+}
+
+const registry = createAdminEraserDbRegistry({
+  // Env is read at init time, not import time, so late-loaded dotenv wins.
+  getEnv: () => ({
+    ADMIN_ERASER_DATABASE_URL: process.env.ADMIN_ERASER_DATABASE_URL,
+    ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
+  }),
+  createPool: (config) => new Pool(config),
+  registerPool,
+});
+
+/** Per-process eraser client accessor. Lazy; throws with the reason when unconfigured. */
+export const getAdminEraserDb = (): AdminDatabase => registry.getAdminEraserDb();
+
+/** Resolved eraser availability for the current process env. Side-effect free. */
+export const getAdminEraserDbMode = (): AdminEraserDbModeDecision =>
+  registry.getMode();
+
+export interface AdminAuditDbClient {
+  db: AdminDatabase;
+  end: () => Promise<void>;
+}
+
+/**
+ * Direct admin-schema-typed client over arbitrary credentials — for
+ * integration tests and one-shot scripts that connect AS a specific LOGIN
+ * user (owner, eraser, reader) without going through any registry.
+ */
+export const createAdminAuditDbClient = (config: {
+  connectionString: string;
+  ssl?: boolean;
+  max?: number;
+}): AdminAuditDbClient => {
+  const pool = new Pool({
+    connectionString: config.connectionString,
+    ssl: config.ssl ? { rejectUnauthorized: false } : false,
+    max: config.max ?? 2,
+  });
+  pool.on('error', () => {});
+  return { db: drizzle(pool, { schema: adminSchema }), end: () => pool.end() };
+};

--- a/packages/db/src/admin-login-users.ts
+++ b/packages/db/src/admin-login-users.ts
@@ -12,6 +12,9 @@
  *   admin_app_user         admin_app                    web (audit emission)
  *   admin_processor_user   admin_chainer, admin_siem    processor (chainer + SIEM workers)
  *   admin_reader_user      admin_reader                 admin app (read-only)
+ *   admin_gdpr_eraser_user admin_gdpr_eraser            web GDPR pseudonymization route
+ *                                                       (Art 17 — column-scoped UPDATE on
+ *                                                       exactly the 6 PII columns; leaf 6)
  *
  * Provisioning is idempotent and rotation-safe: CREATE is guarded, ALTER
  * always (re)sets LOGIN + password + least-privilege attributes, GRANT is
@@ -29,6 +32,7 @@ export interface AdminLoginUserEnv {
   ADMIN_APP_PASSWORD?: string | undefined;
   ADMIN_PROCESSOR_PASSWORD?: string | undefined;
   ADMIN_READER_PASSWORD?: string | undefined;
+  ADMIN_ERASER_PASSWORD?: string | undefined;
 }
 
 export const ADMIN_LOGIN_USERS: readonly AdminLoginUserSpec[] = [
@@ -39,6 +43,11 @@ export const ADMIN_LOGIN_USERS: readonly AdminLoginUserSpec[] = [
     roles: ['admin_chainer', 'admin_siem'],
   },
   { user: 'admin_reader_user', envVar: 'ADMIN_READER_PASSWORD', roles: ['admin_reader'] },
+  {
+    user: 'admin_gdpr_eraser_user',
+    envVar: 'ADMIN_ERASER_PASSWORD',
+    roles: ['admin_gdpr_eraser'],
+  },
 ];
 
 export interface AdminLoginUserProvision {

--- a/packages/db/src/admin-login-users.ts
+++ b/packages/db/src/admin-login-users.ts
@@ -128,10 +128,21 @@ export const quotePgLiteral = (value: string): string => {
 };
 
 /**
+ * Every template role the provisioner manages — the universe stale
+ * memberships are revoked from when a user's template set changes.
+ */
+export const ADMIN_MANAGED_TEMPLATE_ROLES: readonly string[] = [
+  ...new Set(ADMIN_LOGIN_USERS.flatMap((spec) => spec.roles)),
+];
+
+/**
  * SQL statements provisioning one LOGIN user: guarded CREATE (roles are
  * cluster-scoped and may pre-exist), an ALTER that unconditionally (re)sets
  * LOGIN + password + least-privilege attributes (so re-running rotates the
- * password and repairs drifted attributes), then one GRANT per template role.
+ * password and repairs drifted attributes), one REVOKE per managed template
+ * role the entry does NOT hold (GRANT only adds — without this a template
+ * change would leave the old membership in place forever), then one GRANT
+ * per template role.
  */
 export const buildLoginUserStatements = (entry: AdminLoginUserProvision): string[] => {
   assertSafeIdentifier(entry.user, 'login user');
@@ -153,5 +164,12 @@ export const buildLoginUserStatements = (entry: AdminLoginUserProvision): string
     `ALTER ROLE ${entry.user} WITH LOGIN PASSWORD ${quotePgLiteral(entry.password)} ` +
     'NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS INHERIT';
 
-  return [create, alter, ...entry.roles.map((role) => `GRANT ${role} TO ${entry.user}`)];
+  const stale = ADMIN_MANAGED_TEMPLATE_ROLES.filter((role) => !entry.roles.includes(role));
+
+  return [
+    create,
+    alter,
+    ...stale.map((role) => `REVOKE ${role} FROM ${entry.user}`),
+    ...entry.roles.map((role) => `GRANT ${role} TO ${entry.user}`),
+  ];
 };

--- a/packages/db/src/admin-login-users.ts
+++ b/packages/db/src/admin-login-users.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-service Admin PG LOGIN users — pure planning + SQL building (#890
+ * Phase 2, leaf 0). No I/O, no process.env reads; provision-admin-users.ts is
+ * the executing shell.
+ *
+ * drizzle-admin/0001 created NOLOGIN role TEMPLATES (admin_app,
+ * admin_chainer, admin_siem, admin_reader, …). Runtime services must never
+ * connect as the database owner (it bypasses every zero-trust grant), so each
+ * service gets its own LOGIN user attached to its template role(s):
+ *
+ *   login user             granted templates            used by
+ *   admin_app_user         admin_app                    web (audit emission)
+ *   admin_processor_user   admin_chainer, admin_siem    processor (chainer + SIEM workers)
+ *   admin_reader_user      admin_reader                 admin app (read-only)
+ *
+ * Provisioning is idempotent and rotation-safe: CREATE is guarded, ALTER
+ * always (re)sets LOGIN + password + least-privilege attributes, GRANT is
+ * natively idempotent. Passwords come from env (ADMIN_APP_PASSWORD etc.);
+ * an unset var skips that user, a set-but-invalid one refuses the whole run.
+ */
+
+export interface AdminLoginUserSpec {
+  user: string;
+  envVar: keyof AdminLoginUserEnv;
+  roles: string[];
+}
+
+export interface AdminLoginUserEnv {
+  ADMIN_APP_PASSWORD?: string | undefined;
+  ADMIN_PROCESSOR_PASSWORD?: string | undefined;
+  ADMIN_READER_PASSWORD?: string | undefined;
+}
+
+export const ADMIN_LOGIN_USERS: readonly AdminLoginUserSpec[] = [
+  { user: 'admin_app_user', envVar: 'ADMIN_APP_PASSWORD', roles: ['admin_app'] },
+  {
+    user: 'admin_processor_user',
+    envVar: 'ADMIN_PROCESSOR_PASSWORD',
+    roles: ['admin_chainer', 'admin_siem'],
+  },
+  { user: 'admin_reader_user', envVar: 'ADMIN_READER_PASSWORD', roles: ['admin_reader'] },
+];
+
+export interface AdminLoginUserProvision {
+  user: string;
+  roles: string[];
+  password: string;
+}
+
+export type AdminLoginUserPlan =
+  | { ok: true; provision: AdminLoginUserProvision[]; skipped: string[] }
+  | { ok: false; reason: string };
+
+const MIN_PASSWORD_LENGTH = 8;
+
+// Quote-escaping below guarantees literal-safety only under
+// standard_conforming_strings (on by default since PG 9.1) and only for
+// values free of backslashes and control characters — so those are rejected
+// outright, along with whitespace (never legitimate in generated secrets).
+const passwordProblem = (value: string): string | null => {
+  if (value.length === 0) return 'is set but empty';
+  if (value.length < MIN_PASSWORD_LENGTH) return `is shorter than ${MIN_PASSWORD_LENGTH} characters`;
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\\\x00-\x1f\x7f]/.test(value)) {
+    return 'contains whitespace, a backslash, or a control character';
+  }
+  return null;
+};
+
+/**
+ * Decide which LOGIN users to provision from the given env. Unset password →
+ * that user is skipped (named in `skipped`); set-but-invalid password → the
+ * whole plan refuses (a blank/garbled credential is a misconfigured deploy).
+ * Reasons never echo the password value.
+ */
+export const planAdminLoginUsers = (env: AdminLoginUserEnv): AdminLoginUserPlan => {
+  const provision: AdminLoginUserProvision[] = [];
+  const skipped: string[] = [];
+
+  for (const spec of ADMIN_LOGIN_USERS) {
+    const password = env[spec.envVar];
+    if (password === undefined) {
+      skipped.push(spec.user);
+      continue;
+    }
+    const problem = passwordProblem(password);
+    if (problem) {
+      return {
+        ok: false,
+        reason: `${spec.envVar} ${problem} — fix the deploy env; admin login users were NOT provisioned`,
+      };
+    }
+    provision.push({ user: spec.user, roles: [...spec.roles], password });
+  }
+
+  return { ok: true, provision, skipped };
+};
+
+const SAFE_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+const assertSafeIdentifier = (name: string, kind: string): void => {
+  if (!SAFE_IDENTIFIER.test(name)) {
+    throw new Error(`unsafe ${kind} identifier: ${JSON.stringify(name)}`);
+  }
+};
+
+/**
+ * Quote a value as a Postgres string literal: wrap in single quotes, double
+ * embedded quotes. Throws on backslashes and control characters — under
+ * standard_conforming_strings those are the only escape hatches left, and
+ * refusing them keeps this function injection-safe by construction.
+ */
+export const quotePgLiteral = (value: string): string => {
+  // eslint-disable-next-line no-control-regex
+  if (/[\\\x00-\x1f\x7f]/.test(value)) {
+    throw new Error('quotePgLiteral: value contains a backslash or control character');
+  }
+  return `'${value.split("'").join("''")}'`;
+};
+
+/**
+ * SQL statements provisioning one LOGIN user: guarded CREATE (roles are
+ * cluster-scoped and may pre-exist), an ALTER that unconditionally (re)sets
+ * LOGIN + password + least-privilege attributes (so re-running rotates the
+ * password and repairs drifted attributes), then one GRANT per template role.
+ */
+export const buildLoginUserStatements = (entry: AdminLoginUserProvision): string[] => {
+  assertSafeIdentifier(entry.user, 'login user');
+  for (const role of entry.roles) {
+    assertSafeIdentifier(role, 'role');
+  }
+
+  const create = [
+    'DO $$',
+    'BEGIN',
+    `  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${entry.user}') THEN`,
+    `    CREATE ROLE ${entry.user};`,
+    '  END IF;',
+    'END',
+    '$$',
+  ].join('\n');
+
+  const alter =
+    `ALTER ROLE ${entry.user} WITH LOGIN PASSWORD ${quotePgLiteral(entry.password)} ` +
+    'NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS INHERIT';
+
+  return [create, alter, ...entry.roles.map((role) => `GRANT ${role} TO ${entry.user}`)];
+};

--- a/packages/db/src/admin-schema.ts
+++ b/packages/db/src/admin-schema.ts
@@ -7,6 +7,7 @@
  *   - siemDeliveryCursors
  *   - siemDeliveryReceipts
  *   - securityAuditIngest (Phase 2 lock-free emission queue, trust-plane only)
+ *   - securityAuditAnchors (Phase 2 anchor receipts, trust-plane only)
  * The 4 analytics tables (systemLogs, apiMetrics, userActivities, errorLogs)
  * go to ClickHouse in Phase 3 — NOT into Admin PG. activityLogs joins in
  * Phase 5.
@@ -41,3 +42,8 @@ export {
   type InsertSecurityAuditIngest,
   type SelectSecurityAuditIngest,
 } from './schema/security-audit-ingest';
+export {
+  securityAuditAnchors,
+  type InsertSecurityAuditAnchor,
+  type SelectSecurityAuditAnchor,
+} from './schema/security-audit-anchors';

--- a/packages/db/src/admin-schema.ts
+++ b/packages/db/src/admin-schema.ts
@@ -21,10 +21,14 @@
  * This module is both the drizzle-kit schema entry (drizzle-admin.config.ts)
  * and the runtime schema bound to the adminDb client (admin-db.ts).
  */
-import { defineSecurityAuditLogTable } from './schema/security-audit';
+import { defineAdminSecurityAuditLogTable } from './schema/security-audit';
 
-/** Trust-plane instance of security_audit_log — identical shape, no users FK. */
-export const securityAuditLog = defineSecurityAuditLogTable({ crossPlaneUserFk: false });
+/**
+ * Trust-plane instance of security_audit_log — identical shape, no users FK,
+ * plus the nullable emission_hash column (chainer verify-on-append input;
+ * NULL = legacy-era row). See defineAdminSecurityAuditLogTable.
+ */
+export const securityAuditLog = defineAdminSecurityAuditLogTable();
 
 export type {
   SecurityEventType,

--- a/packages/db/src/admin-schema.ts
+++ b/packages/db/src/admin-schema.ts
@@ -6,9 +6,10 @@
  *   - securityAuditLog (tamper-evident chained table)
  *   - siemDeliveryCursors
  *   - siemDeliveryReceipts
+ *   - securityAuditIngest (Phase 2 lock-free emission queue, trust-plane only)
  * The 4 analytics tables (systemLogs, apiMetrics, userActivities, errorLogs)
- * go to ClickHouse in Phase 3 — NOT into Admin PG. The ingest table is a
- * Phase 2 migration; activityLogs joins in Phase 5.
+ * go to ClickHouse in Phase 3 — NOT into Admin PG. activityLogs joins in
+ * Phase 5.
  *
  * Source of truth stays in ./schema/* — the SIEM tables are plain re-exports,
  * and securityAuditLog is instantiated from the shared factory WITHOUT the
@@ -31,3 +32,8 @@ export type {
   SelectSecurityAuditLog,
 } from './schema/security-audit';
 export { siemDeliveryCursors, siemDeliveryReceipts } from './schema/monitoring';
+export {
+  securityAuditIngest,
+  type InsertSecurityAuditIngest,
+  type SelectSecurityAuditIngest,
+} from './schema/security-audit-ingest';

--- a/packages/db/src/migrate-admin.ts
+++ b/packages/db/src/migrate-admin.ts
@@ -3,7 +3,7 @@ import { Pool } from 'pg';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { runMigrations } from './migration-runner';
-import { resolveAdminMigrateDecision, type AdminDbEnv } from './admin-db-mode';
+import { resolveAdminMigrateDecision, type AdminMigrateEnv } from './admin-db-mode';
 
 /**
  * Admin PG (trust plane) migration entrypoint — db:migrate:admin (#890
@@ -21,7 +21,7 @@ export const ADMIN_MIGRATIONS_SCHEMA = 'drizzle_admin';
 export const ADMIN_MIGRATIONS_TABLE = '__drizzle_migrations';
 
 export async function migrateAdminDb(
-  env: AdminDbEnv,
+  env: AdminMigrateEnv,
   log: (message: string) => void = () => {},
 ): Promise<void> {
   const decision = resolveAdminMigrateDecision(env);
@@ -47,10 +47,15 @@ export async function migrateAdminDb(
 async function main() {
   console.log('Running admin (trust plane) migrations...');
   console.log('ADMIN_DATABASE_URL:', process.env.ADMIN_DATABASE_URL ? 'Set' : 'Not set');
+  console.log(
+    'ADMIN_DATABASE_URL_MIGRATE:',
+    process.env.ADMIN_DATABASE_URL_MIGRATE ? 'Set (preferred for migrations)' : 'Not set',
+  );
 
   await migrateAdminDb(
     {
       ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+      ADMIN_DATABASE_URL_MIGRATE: process.env.ADMIN_DATABASE_URL_MIGRATE,
       ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
       ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
       ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,

--- a/packages/db/src/provision-admin-users.ts
+++ b/packages/db/src/provision-admin-users.ts
@@ -1,0 +1,90 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+import {
+  resolveAdminMigrateDecision,
+  type AdminMigrateEnv,
+} from './admin-db-mode';
+import {
+  planAdminLoginUsers,
+  buildLoginUserStatements,
+  type AdminLoginUserEnv,
+} from './admin-login-users';
+
+/**
+ * Per-service Admin PG LOGIN user provisioning — db:provision:admin-users
+ * (#890 Phase 2, leaf 0). Thin shell over the pure planner/builder in
+ * admin-login-users.ts: connects with the OWNER credentials (same decision
+ * gate as db:migrate:admin — dedicated Admin PG only, never break-glass),
+ * creates/updates the login users whose passwords are present in env, and
+ * grants their NOLOGIN template roles. Idempotent; re-running rotates
+ * passwords. Runs from the migrate one-shot right after db:migrate:admin.
+ */
+
+export type ProvisionEnv = AdminMigrateEnv & AdminLoginUserEnv;
+
+export async function provisionAdminLoginUsers(
+  env: ProvisionEnv,
+  log: (message: string) => void = () => {},
+): Promise<{ provisioned: string[]; skipped: string[] }> {
+  const plan = planAdminLoginUsers(env);
+  if (!plan.ok) {
+    throw new Error(`db:provision:admin-users refused: ${plan.reason}`);
+  }
+
+  if (plan.skipped.length > 0) {
+    log(`Skipping (no password in env): ${plan.skipped.join(', ')}`);
+  }
+  if (plan.provision.length === 0) {
+    log('No admin login users to provision.');
+    return { provisioned: [], skipped: plan.skipped };
+  }
+
+  const decision = resolveAdminMigrateDecision(env);
+  if (!decision.ok) {
+    throw new Error(`db:provision:admin-users refused: ${decision.reason}`);
+  }
+
+  const pool = new Pool(decision.poolConfig);
+  try {
+    for (const entry of plan.provision) {
+      for (const statement of buildLoginUserStatements(entry)) {
+        await pool.query(statement);
+      }
+      log(`Provisioned ${entry.user} (granted: ${entry.roles.join(', ')})`);
+    }
+  } finally {
+    await pool.end();
+  }
+
+  return { provisioned: plan.provision.map((p) => p.user), skipped: plan.skipped };
+}
+
+async function main() {
+  console.log('Provisioning admin (trust plane) login users...');
+
+  await provisionAdminLoginUsers(
+    {
+      ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
+      ADMIN_DATABASE_URL_MIGRATE: process.env.ADMIN_DATABASE_URL_MIGRATE,
+      ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
+      ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
+      ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+      ADMIN_APP_PASSWORD: process.env.ADMIN_APP_PASSWORD,
+      ADMIN_PROCESSOR_PASSWORD: process.env.ADMIN_PROCESSOR_PASSWORD,
+      ADMIN_READER_PASSWORD: process.env.ADMIN_READER_PASSWORD,
+    },
+    console.log,
+  );
+
+  console.log('Admin login user provisioning finished.');
+  process.exit(0);
+}
+
+// Run only as a script (tsx src/provision-admin-users.ts) — importing this
+// module (e.g. from the integration test) must not trigger provisioning.
+if (process.argv[1]?.includes('provision-admin-users')) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/db/src/provision-admin-users.ts
+++ b/packages/db/src/provision-admin-users.ts
@@ -72,6 +72,7 @@ async function main() {
       ADMIN_APP_PASSWORD: process.env.ADMIN_APP_PASSWORD,
       ADMIN_PROCESSOR_PASSWORD: process.env.ADMIN_PROCESSOR_PASSWORD,
       ADMIN_READER_PASSWORD: process.env.ADMIN_READER_PASSWORD,
+      ADMIN_ERASER_PASSWORD: process.env.ADMIN_ERASER_PASSWORD,
     },
     console.log,
   );

--- a/packages/db/src/schema/security-audit-anchors.ts
+++ b/packages/db/src/schema/security-audit-anchors.ts
@@ -1,0 +1,53 @@
+/**
+ * Security Audit Anchors — the receipt witness surface for the externally
+ * anchored chain head (#890 Phase 2, leaf 3).
+ *
+ * TRUST-PLANE ONLY: this table exists exclusively in the Admin PG. It is
+ * exported from src/admin-schema.ts (the drizzle-admin pipeline) and must
+ * NEVER be added to the main schema barrel (src/schema.ts).
+ *
+ * After each anchor interval the chainer publishes a signed head statement
+ * (packages/lib/src/audit/anchor.ts) to S3 Object-Lock AND persists it here
+ * as a second, already-shipped witness surface (the siem_delivery_receipts
+ * precedent — its delivery-attestation shape does not fit anchor records,
+ * hence this sibling table). Grants make it append-only for EVERY role:
+ * admin_chainer INSERT only, admin_reader SELECT only, nobody UPDATE/DELETE —
+ * a compromised trust-plane credential can add anchors but never rewrite or
+ * remove one.
+ *
+ * Columns mirror the SignedAnchor payload exactly (version/source semantics
+ * live in the payload; `source` is a constant so it is not stored). Rows are
+ * written by the receipt publisher via raw SQL (writeReceipts precedent), so
+ * the cuid2 id is minted by the publisher, not $defaultFn.
+ */
+
+import { pgTable, text, timestamp, integer, bigint, index } from 'drizzle-orm/pg-core';
+import { createId } from '@paralleldrive/cuid2';
+
+export const securityAuditAnchors = pgTable('security_audit_anchors', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+
+  // Anchor payload format version (ANCHOR_VERSION at publish time).
+  version: integer('version').notNull(),
+
+  // chain_seq of the anchored head row.
+  chainSeq: bigint('chain_seq', { mode: 'number' }).notNull(),
+
+  // event_hash of the anchored head row.
+  headHash: text('head_hash').notNull(),
+
+  // Anchor time — signed content, supplied by the publisher's clock.
+  anchoredAt: timestamp('anchored_at', { withTimezone: true, mode: 'date' }).notNull(),
+
+  // HMAC-SHA256 (hex) over the canonical anchor content.
+  signature: text('signature').notNull(),
+
+  // Receipt-row arrival time — forensics only, not signed content.
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).defaultNow().notNull(),
+}, (table) => ({
+  // The verifier matches anchors against chain rows by seq.
+  chainSeqIdx: index('idx_security_audit_anchors_chain_seq').on(table.chainSeq),
+}));
+
+export type InsertSecurityAuditAnchor = typeof securityAuditAnchors.$inferInsert;
+export type SelectSecurityAuditAnchor = typeof securityAuditAnchors.$inferSelect;

--- a/packages/db/src/schema/security-audit-ingest.ts
+++ b/packages/db/src/schema/security-audit-ingest.ts
@@ -1,0 +1,73 @@
+/**
+ * Security Audit Ingest — transient queue for the lock-free write path
+ * (#890 Phase 2, leaf 1).
+ *
+ * TRUST-PLANE ONLY: this table exists exclusively in the Admin PG. It is
+ * exported from src/admin-schema.ts (the drizzle-admin pipeline) and must
+ * NEVER be added to the main schema barrel (src/schema.ts) — the app plane
+ * has no ingest table.
+ *
+ * The app computes a pure emission hash in-process and does ONE INSERT here
+ * — no advisory lock, no head read, no transaction. The single-writer
+ * chainer (processor, leaf 2) drains rows in (emitted_at, id) order, assigns
+ * chain_seq + chainHash on security_audit_log, then DELETEs the drained rows
+ * — the only DELETE grant anywhere in the trust plane, and it applies to
+ * this queue only, never to a chain table. Plain table by design: rows are
+ * transient, so the chain tables' monthly partitioning does not apply.
+ *
+ * Column shapes mirror security_audit_log's event columns exactly (id and
+ * ip encryption included — encryption still happens at emission); the chain
+ * columns (chain_seq, previous_hash, event_hash) are deliberately absent,
+ * replaced by emission_hash + emitted_at.
+ */
+
+import { pgTable, text, timestamp, real, jsonb, index } from 'drizzle-orm/pg-core';
+import { createId } from '@paralleldrive/cuid2';
+import type { SecurityEventType } from './security-audit';
+
+export const securityAuditIngest = pgTable('security_audit_ingest', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+
+  // Event classification
+  eventType: text('event_type').notNull().$type<SecurityEventType>(),
+
+  // Actor — no users FK even in shape: the Admin PG holds no app tables.
+  userId: text('user_id'),
+  sessionId: text('session_id'),
+  serviceId: text('service_id'),
+
+  // Target
+  resourceType: text('resource_type'),
+  resourceId: text('resource_id'),
+
+  // Request context — ip_address is AES-256-GCM ciphertext (+ ip_bidx blind
+  // index) when ENCRYPTION_KEY is configured, exactly as on security_audit_log.
+  ipAddress: text('ip_address'),
+  ipBidx: text('ip_bidx'),
+  userAgent: text('user_agent'),
+  geoLocation: text('geo_location'),
+
+  // Event details
+  details: jsonb('details').$type<Record<string, unknown>>(),
+
+  // Risk assessment
+  riskScore: real('risk_score'),
+  anomalyFlags: text('anomaly_flags').array(),
+
+  // Event time — hashed content (part of the emission hash).
+  timestamp: timestamp('timestamp', { mode: 'date' }).defaultNow().notNull(),
+
+  // Emission fingerprint: sha256 over the PII-excluded content payload,
+  // computed in-process (packages/lib/src/audit/emission-hash.ts). The
+  // chainer folds it into chainHash = H(emissionHash, prevHash).
+  emissionHash: text('emission_hash').notNull(),
+
+  // Queue-arrival time — drain order, not hashed content.
+  emittedAt: timestamp('emitted_at', { withTimezone: true, mode: 'date' }).defaultNow().notNull(),
+}, (table) => ({
+  // FIFO drain: the chainer reads ORDER BY emitted_at, id.
+  drainIdx: index('idx_security_audit_ingest_drain').on(table.emittedAt, table.id),
+}));
+
+export type InsertSecurityAuditIngest = typeof securityAuditIngest.$inferInsert;
+export type SelectSecurityAuditIngest = typeof securityAuditIngest.$inferSelect;

--- a/packages/db/src/schema/security-audit.ts
+++ b/packages/db/src/schema/security-audit.ts
@@ -19,6 +19,7 @@ import {
   jsonb,
   index,
   bigserial,
+  type ExtraConfigColumn,
 } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
@@ -85,8 +86,7 @@ export type SecurityEventType =
  * exactly once so the two instances can never drift. Only `crossPlaneUserFk`
  * differs between them.
  */
-export const defineSecurityAuditLogTable = (opts: { crossPlaneUserFk: boolean }) =>
-  pgTable('security_audit_log', {
+const securityAuditLogColumns = (opts: { crossPlaneUserFk: boolean }) => ({
   id: text('id').primaryKey().$defaultFn(() => createId()),
 
   // Event classification
@@ -132,7 +132,25 @@ export const defineSecurityAuditLogTable = (opts: { crossPlaneUserFk: boolean })
   // Hash chain integrity
   previousHash: text('previous_hash').notNull(),
   eventHash: text('event_hash').notNull(),
-}, (table) => ({
+});
+
+/** The columns the shared index set touches — structural so both planes' tables fit. */
+type SecurityAuditLogIndexColumns = Record<
+  | 'timestamp'
+  | 'userId'
+  | 'eventType'
+  | 'resourceType'
+  | 'resourceId'
+  | 'ipAddress'
+  | 'ipBidx'
+  | 'eventHash'
+  | 'chainSeq'
+  | 'riskScore'
+  | 'sessionId',
+  Partial<ExtraConfigColumn>
+>;
+
+const securityAuditLogIndexes = (table: SecurityAuditLogIndexColumns) => ({
   // Time-based queries (most common access pattern)
   timestampIdx: index('idx_security_audit_timestamp').on(table.timestamp),
   // User activity forensics
@@ -153,7 +171,37 @@ export const defineSecurityAuditLogTable = (opts: { crossPlaneUserFk: boolean })
   riskScoreIdx: index('idx_security_audit_risk_score').on(table.riskScore),
   // Session tracking
   sessionIdx: index('idx_security_audit_session').on(table.sessionId, table.timestamp),
-}));
+});
+
+export const defineSecurityAuditLogTable = (opts: { crossPlaneUserFk: boolean }) =>
+  pgTable('security_audit_log', securityAuditLogColumns(opts), securityAuditLogIndexes);
+
+/**
+ * Trust-plane (Admin PG) instance of security_audit_log (#890 Phase 2).
+ *
+ * Identical to the app-plane shape (columns + indexes come from the same
+ * builders above, so the planes cannot drift) with two deliberate deltas the
+ * shared factory cannot express:
+ *   - no cross-plane FK to `users` (the admin DB holds no app tables), and
+ *   - an extra NULLABLE `emission_hash` column: the chainer copies each
+ *     drained ingest row's emission hash here so verify-on-append can
+ *     recompute chainHash = H(emissionHash, prevHash) from storage. NULL
+ *     marks a legacy-era row (pre-cutover / backfilled) whose event_hash was
+ *     computed by the advisory-lock path. Verification reads walk chain_seq
+ *     (already indexed), so the column itself needs no index.
+ *
+ * This exists ONLY in src/admin-schema.ts / the drizzle-admin pipeline — the
+ * main-plane table above keeps its shape and main db:generate stays no-drift.
+ */
+export const defineAdminSecurityAuditLogTable = () =>
+  pgTable(
+    'security_audit_log',
+    {
+      ...securityAuditLogColumns({ crossPlaneUserFk: false }),
+      emissionHash: text('emission_hash'),
+    },
+    securityAuditLogIndexes,
+  );
 
 /**
  * Security Audit Log table - tamper-evident security event tracking.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -282,6 +282,16 @@
       "import": "./dist/audit/audit-ingest-writer.js",
       "require": "./dist/audit/audit-ingest-writer.js"
     },
+    "./audit/co-stream": {
+      "types": "./dist/audit/co-stream.d.ts",
+      "import": "./dist/audit/co-stream.js",
+      "require": "./dist/audit/co-stream.js"
+    },
+    "./audit/co-stream-reconciliation": {
+      "types": "./dist/audit/co-stream-reconciliation.d.ts",
+      "import": "./dist/audit/co-stream-reconciliation.js",
+      "require": "./dist/audit/co-stream-reconciliation.js"
+    },
     "./audit/mask-email": {
       "types": "./dist/audit/mask-email.d.ts",
       "import": "./dist/audit/mask-email.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -262,6 +262,16 @@
       "import": "./dist/audit/security-audit.js",
       "require": "./dist/audit/security-audit.js"
     },
+    "./audit/emission-hash": {
+      "types": "./dist/audit/emission-hash.d.ts",
+      "import": "./dist/audit/emission-hash.js",
+      "require": "./dist/audit/emission-hash.js"
+    },
+    "./audit/audit-ingest-writer": {
+      "types": "./dist/audit/audit-ingest-writer.d.ts",
+      "import": "./dist/audit/audit-ingest-writer.js",
+      "require": "./dist/audit/audit-ingest-writer.js"
+    },
     "./audit/mask-email": {
       "types": "./dist/audit/mask-email.d.ts",
       "import": "./dist/audit/mask-email.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -267,6 +267,11 @@
       "import": "./dist/audit/emission-hash.js",
       "require": "./dist/audit/emission-hash.js"
     },
+    "./audit/chain-step": {
+      "types": "./dist/audit/chain-step.d.ts",
+      "import": "./dist/audit/chain-step.js",
+      "require": "./dist/audit/chain-step.js"
+    },
     "./audit/audit-ingest-writer": {
       "types": "./dist/audit/audit-ingest-writer.d.ts",
       "import": "./dist/audit/audit-ingest-writer.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -272,6 +272,11 @@
       "import": "./dist/audit/chain-step.js",
       "require": "./dist/audit/chain-step.js"
     },
+    "./audit/anchor": {
+      "types": "./dist/audit/anchor.d.ts",
+      "import": "./dist/audit/anchor.js",
+      "require": "./dist/audit/anchor.js"
+    },
     "./audit/audit-ingest-writer": {
       "types": "./dist/audit/audit-ingest-writer.d.ts",
       "import": "./dist/audit/audit-ingest-writer.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1427,6 +1427,11 @@
       "import": "./dist/compliance/erasure/pseudonymize.js",
       "require": "./dist/compliance/erasure/pseudonymize.js"
     },
+    "./compliance/erasure/pseudonymize-targets": {
+      "types": "./dist/compliance/erasure/pseudonymize-targets.d.ts",
+      "import": "./dist/compliance/erasure/pseudonymize-targets.js",
+      "require": "./dist/compliance/erasure/pseudonymize-targets.js"
+    },
     "./compliance/erasure/pseudonymize-repository": {
       "types": "./dist/compliance/erasure/pseudonymize-repository.d.ts",
       "import": "./dist/compliance/erasure/pseudonymize-repository.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -292,6 +292,11 @@
       "import": "./dist/audit/co-stream-reconciliation.js",
       "require": "./dist/audit/co-stream-reconciliation.js"
     },
+    "./audit/full-audit-verification": {
+      "types": "./dist/audit/full-audit-verification.d.ts",
+      "import": "./dist/audit/full-audit-verification.js",
+      "require": "./dist/audit/full-audit-verification.js"
+    },
     "./audit/mask-email": {
       "types": "./dist/audit/mask-email.d.ts",
       "import": "./dist/audit/mask-email.js",

--- a/packages/lib/src/audit/__tests__/admin-db-seam.test.ts
+++ b/packages/lib/src/audit/__tests__/admin-db-seam.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Phase 2 gate (#890): the Phase 0 seams must TYPE-accept the AdminDatabase
+ * client (@pagespace/db/admin-db) so the later bind leaves can wire
+ * `createSecurityAuditRepository({ db: getAdminDb() })` without casts.
+ *
+ * Filed from PR #1982's convergence findings: `SecurityAuditRepositoryDeps.db`
+ * was `typeof defaultDb`, and AdminDatabase (NodePgDatabase over the 3-table
+ * admin schema) is NOT assignable to it. This suite is the compile-level pin —
+ * the `satisfies`/annotation lines below fail `tsc` if the seam ever narrows
+ * back — plus a behavioral smoke test that an AdminDatabase-typed client is
+ * actually used. Runtime behavior is pinned by the Phase 0 suites; nothing
+ * here may change it.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+  desc: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  eq: vi.fn(),
+}));
+
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+import { db as defaultDb } from '@pagespace/db/db';
+import {
+  createSecurityAuditRepository,
+  type SecurityAuditRepositoryDeps,
+} from '../security-audit-repository';
+import { queryAuditEvents, type AuditQueryDeps } from '../audit-query';
+import {
+  verifySecurityAuditChain,
+  type VerifySecurityChainDeps,
+} from '../security-audit-chain-verifier';
+import { computeSecurityEventHash } from '../security-audit';
+
+/**
+ * Behavioral mock shaped like the drizzle surface the repository uses, typed
+ * AS AdminDatabase at the deps boundary (the cast is on the MOCK — the deps
+ * property itself must accept the AdminDatabase type with no cast, which is
+ * exactly what the annotations below pin at compile time).
+ */
+function createAdminTypedMockDb(initialHead: string | undefined) {
+  const inserts: Array<Record<string, unknown>> = [];
+  let currentHead = initialHead;
+
+  const execute = (sqlObj: { strings: TemplateStringsArray; values: unknown[] }) => {
+    if (sqlObj.strings.join('').includes('pg_advisory_xact_lock')) {
+      return Promise.resolve({ rows: [] });
+    }
+    return Promise.resolve({ rows: currentHead ? [{ event_hash: currentHead }] : [] });
+  };
+  const insert = () => ({
+    values: (value: Record<string, unknown>) => {
+      inserts.push(value);
+      currentHead = value.eventHash as string;
+      return Promise.resolve(undefined);
+    },
+  });
+  const tx = { execute, insert };
+  const db = {
+    execute,
+    transaction: async (callback: (transactionClient: typeof tx) => Promise<void>) =>
+      callback(tx),
+  } as unknown as AdminDatabase;
+
+  return { db, inserts };
+}
+
+describe('Phase 0 seams accept the AdminDatabase client (Phase 2 gate)', () => {
+  describe('compile-level: deps types are satisfied by AdminDatabase AND the main db', () => {
+    it('SecurityAuditRepositoryDeps.db accepts AdminDatabase and typeof db', () => {
+      // These annotations are the test: they fail tsc if the seam narrows.
+      const adminDeps: SecurityAuditRepositoryDeps = { db: {} as AdminDatabase };
+      const mainDeps: SecurityAuditRepositoryDeps = { db: defaultDb };
+      expect(adminDeps.db).toBeDefined();
+      expect(mainDeps.db).toBeDefined();
+    });
+
+    it('VerifySecurityChainDeps.db accepts AdminDatabase and typeof db', () => {
+      const adminDeps: VerifySecurityChainDeps = { db: {} as AdminDatabase };
+      const mainDeps: VerifySecurityChainDeps = { db: defaultDb };
+      expect(adminDeps.db).toBeDefined();
+      expect(mainDeps.db).toBeDefined();
+    });
+
+    it('AuditQueryDeps.db accepts AdminDatabase and typeof db', () => {
+      const adminDeps: AuditQueryDeps = { db: {} as AdminDatabase };
+      const mainDeps: AuditQueryDeps = { db: defaultDb };
+      expect(adminDeps.db).toBeDefined();
+      expect(mainDeps.db).toBeDefined();
+    });
+  });
+
+  describe('behavioral smoke: an AdminDatabase-typed client is accepted and used', () => {
+    it('createSecurityAuditRepository appends through the admin-typed client with unchanged chain semantics', async () => {
+      const { db, inserts } = createAdminTypedMockDb(undefined);
+      const repo = createSecurityAuditRepository({ db });
+      const now = new Date('2026-07-10T00:00:00Z');
+
+      await repo.appendEvent({ eventType: 'auth.login.success', userId: 'user-1' }, { now });
+
+      expect(inserts).toHaveLength(1);
+      expect(inserts[0]!.previousHash).toBe('genesis');
+      expect(inserts[0]!.eventHash).toBe(
+        computeSecurityEventHash({ eventType: 'auth.login.success', userId: 'user-1' }, 'genesis', now),
+      );
+    });
+
+    it('readChainHead reads through the admin-typed client', async () => {
+      const { db } = createAdminTypedMockDb('admin-head-hash');
+      const repo = createSecurityAuditRepository({ db });
+
+      await expect(repo.readChainHead()).resolves.toBe('admin-head-hash');
+    });
+
+    it('verifySecurityAuditChain runs against an admin-typed client', async () => {
+      const select = vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ count: 0 }]) }),
+      });
+      const findMany = vi.fn().mockResolvedValue([]);
+      const db = { select, query: { securityAuditLog: { findMany } } } as unknown as AdminDatabase;
+
+      const result = await verifySecurityAuditChain({}, { db });
+
+      expect(select).toHaveBeenCalled();
+      expect(result.isValid).toBe(true);
+    });
+
+    it('queryAuditEvents runs against an admin-typed client', async () => {
+      const orderBy = vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue([]),
+        then: (resolveFn: (v: unknown[]) => void) => resolveFn([]),
+      });
+      const where = vi.fn().mockReturnValue({ orderBy });
+      const from = vi.fn().mockReturnValue({ where });
+      const select = vi.fn().mockReturnValue({ from });
+      const db = { select } as unknown as AdminDatabase;
+
+      await expect(queryAuditEvents({}, { db })).resolves.toEqual([]);
+
+      expect(select).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/anchor.test.ts
+++ b/packages/lib/src/audit/__tests__/anchor.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Golden-vector + property suite for the anchor pure core (#890 Phase 2,
+ * leaf 3).
+ *
+ * An anchor is a signed statement "at chain_seq S the head was H, at time T"
+ * published to stores the Admin PG credentials cannot touch (S3 Object-Lock
+ * WORM + the anchor-receipt table). These tests pin:
+ *   - the canonical payload bytes (stableStringify, sorted keys)
+ *   - the HMAC-SHA256 signature as LITERAL hex — if a pinned vector ever
+ *     fails, anchor semantics changed and every anchor already published to
+ *     the WORM store no longer verifies against a recomputation
+ *   - the anchor-match verdicts the dual-era full verifier (backfill leaf)
+ *     consumes: match / hash_mismatch / seq_gap / unverifiable
+ */
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+
+import {
+  ANCHOR_VERSION,
+  ANCHOR_SOURCE,
+  buildAnchorPayload,
+  canonicalAnchorContent,
+  serializeSignedAnchor,
+  verifyAnchorSignature,
+  matchAnchorsAgainstChain,
+  type SignedAnchor,
+} from '../anchor';
+import { computeChainHash, GENESIS_PREVIOUS_HASH } from '../chain-step';
+
+const sha256 = (s: string) => createHash('sha256').update(s).digest('hex');
+
+// ————— Pinned vectors (computed once from the canonical formula) —————
+const HEAD_1 = '71a0b19471f8217d02dc7f3bc837604edd727727e914a12e60cfda7b2dccdf5c';
+const HEAD_2 = 'f710123696cee3d4d774e3a40be86cfe230e1a71de8c83e3de9460f327178be3';
+const V1_SECRET = 'anchor-secret-alpha';
+const V1_CANONICAL =
+  '{"anchoredAt":"2026-02-01T00:00:00.000Z","chainSeq":1,"head":"71a0b19471f8217d02dc7f3bc837604edd727727e914a12e60cfda7b2dccdf5c","source":"pagespace-audit-chain","version":1}';
+const V1_SIGNATURE = 'de8a4c43af47b1856d3fb492972168eab4705ae32784b8ff2621d6ceafb045e8';
+const V1_SERIALIZED =
+  '{"anchoredAt":"2026-02-01T00:00:00.000Z","chainSeq":1,"head":"71a0b19471f8217d02dc7f3bc837604edd727727e914a12e60cfda7b2dccdf5c","signature":"de8a4c43af47b1856d3fb492972168eab4705ae32784b8ff2621d6ceafb045e8","source":"pagespace-audit-chain","version":1}';
+const V2_SIGNATURE = '39573db3446f7ea1340b477266cd644835bdfb97bdfb739e9d18992cba68591d';
+
+const v1Input = {
+  head: HEAD_1,
+  chainSeq: 1,
+  anchoredAt: new Date('2026-02-01T00:00:00.000Z'),
+  secret: V1_SECRET,
+};
+
+describe('buildAnchorPayload golden vectors (pinned)', () => {
+  it('given the v1 input, should produce the pinned canonical payload and HMAC-SHA256 signature', () => {
+    const anchor = buildAnchorPayload(v1Input);
+
+    expect(anchor).toEqual({
+      version: ANCHOR_VERSION,
+      source: ANCHOR_SOURCE,
+      chainSeq: 1,
+      head: HEAD_1,
+      anchoredAt: '2026-02-01T00:00:00.000Z',
+      signature: V1_SIGNATURE,
+    });
+    expect(canonicalAnchorContent(anchor)).toBe(V1_CANONICAL);
+  });
+
+  it('given a large chainSeq and millisecond timestamp, should match the pinned signature', () => {
+    const anchor = buildAnchorPayload({
+      head: HEAD_2,
+      chainSeq: 987654321,
+      anchoredAt: new Date('2026-02-15T12:34:56.789Z'),
+      secret: 'anchor-secret-beta',
+    });
+
+    expect(anchor.signature).toBe(V2_SIGNATURE);
+  });
+
+  it('given the same input twice, should be deterministic (no ambient clock or randomness)', () => {
+    expect(buildAnchorPayload(v1Input)).toEqual(buildAnchorPayload(v1Input));
+  });
+
+  it('given any single differing field, should produce a different signature', () => {
+    const base = buildAnchorPayload(v1Input).signature;
+
+    expect(buildAnchorPayload({ ...v1Input, head: HEAD_2 }).signature).not.toBe(base);
+    expect(buildAnchorPayload({ ...v1Input, chainSeq: 2 }).signature).not.toBe(base);
+    expect(
+      buildAnchorPayload({ ...v1Input, anchoredAt: new Date('2026-02-01T00:00:00.001Z') }).signature,
+    ).not.toBe(base);
+    expect(buildAnchorPayload({ ...v1Input, secret: 'other-secret' }).signature).not.toBe(base);
+  });
+});
+
+describe('serializeSignedAnchor', () => {
+  it('given the v1 anchor, should serialize to the pinned canonical bytes (the exact WORM object body)', () => {
+    const anchor = buildAnchorPayload(v1Input);
+
+    expect(serializeSignedAnchor(anchor)).toBe(V1_SERIALIZED);
+  });
+
+  it('given a serialized anchor round-tripped through JSON, should verify (publish → fetch → verify)', () => {
+    const anchor = buildAnchorPayload(v1Input);
+    const roundTripped = JSON.parse(serializeSignedAnchor(anchor)) as SignedAnchor;
+
+    expect(verifyAnchorSignature(roundTripped, V1_SECRET)).toBe(true);
+  });
+});
+
+describe('verifyAnchorSignature', () => {
+  const anchor = buildAnchorPayload(v1Input);
+
+  it('given an untampered anchor and the right secret, should verify', () => {
+    expect(verifyAnchorSignature(anchor, V1_SECRET)).toBe(true);
+  });
+
+  it('given the wrong secret, should reject', () => {
+    expect(verifyAnchorSignature(anchor, 'wrong-secret')).toBe(false);
+  });
+
+  it('given any tampered content field, should reject', () => {
+    expect(verifyAnchorSignature({ ...anchor, head: HEAD_2 }, V1_SECRET)).toBe(false);
+    expect(verifyAnchorSignature({ ...anchor, chainSeq: 2 }, V1_SECRET)).toBe(false);
+    expect(
+      verifyAnchorSignature({ ...anchor, anchoredAt: '2026-02-01T00:00:00.001Z' }, V1_SECRET),
+    ).toBe(false);
+    expect(verifyAnchorSignature({ ...anchor, version: 2 }, V1_SECRET)).toBe(false);
+    expect(verifyAnchorSignature({ ...anchor, source: 'evil' }, V1_SECRET)).toBe(false);
+  });
+
+  it('given a tampered signature (every single-hex-digit mutation of the first 8 chars), should reject', () => {
+    // Property-style sweep: no prefix of a valid signature is accepted.
+    for (let i = 0; i < 8; i++) {
+      const flipped =
+        anchor.signature.slice(0, i) +
+        (anchor.signature[i] === '0' ? '1' : '0') +
+        anchor.signature.slice(i + 1);
+      expect(verifyAnchorSignature({ ...anchor, signature: flipped }, V1_SECRET)).toBe(false);
+    }
+  });
+
+  it('given randomized inputs, build → verify should always round-trip (property)', () => {
+    for (let i = 0; i < 50; i++) {
+      const built = buildAnchorPayload({
+        head: sha256(`head-${i}`),
+        chainSeq: i * 7919 + 1,
+        anchoredAt: new Date(Date.UTC(2026, i % 12, (i % 27) + 1, i % 24, i % 60, i % 60, i * 13 % 1000)),
+        secret: `secret-${i}`,
+      });
+      expect(verifyAnchorSignature(built, `secret-${i}`)).toBe(true);
+      expect(verifyAnchorSignature(built, `secret-${i + 1}`)).toBe(false);
+    }
+  });
+});
+
+describe('matchAnchorsAgainstChain', () => {
+  const secret = 'match-secret';
+  const anchorAt = (chainSeq: number, head: string, at = '2026-03-01T00:00:00.000Z') =>
+    buildAnchorPayload({ head, chainSeq, anchoredAt: new Date(at), secret });
+
+  // A tiny real chain built with the leaf-2 pure core, so anchor-match is
+  // proven against genuine chain hashes rather than synthetic strings.
+  const e1 = sha256('emission-1');
+  const e2 = sha256('emission-2');
+  const e3 = sha256('emission-3');
+  const h1 = computeChainHash(e1, GENESIS_PREVIOUS_HASH);
+  const h2 = computeChainHash(e2, h1);
+  const h3 = computeChainHash(e3, h2);
+  const chain = new Map<number, string>([
+    [1, h1],
+    [2, h2],
+    [3, h3],
+  ]);
+
+  it('given anchors matching the chain at every anchored seq, should report match for each and allMatch', () => {
+    const report = matchAnchorsAgainstChain([anchorAt(1, h1), anchorAt(3, h3)], chain, secret);
+
+    expect(report.allMatch).toBe(true);
+    expect(report.results).toEqual([
+      { chainSeq: 1, verdict: 'match', anchorHead: h1, chainHead: h1 },
+      { chainSeq: 3, verdict: 'match', anchorHead: h3, chainHead: h3 },
+    ]);
+    expect(report.counts).toEqual({ match: 2, hash_mismatch: 0, seq_gap: 0, unverifiable: 0 });
+  });
+
+  it('given an anchor whose head differs from the chain row at that seq, should report hash_mismatch (tamper signal)', () => {
+    const report = matchAnchorsAgainstChain([anchorAt(2, sha256('forged-head'))], chain, secret);
+
+    expect(report.allMatch).toBe(false);
+    expect(report.results[0]).toEqual({
+      chainSeq: 2,
+      verdict: 'hash_mismatch',
+      anchorHead: sha256('forged-head'),
+      chainHead: h2,
+    });
+  });
+
+  it('given an anchor at a seq the chain has no row for, should report seq_gap (rows missing below an anchored head)', () => {
+    const report = matchAnchorsAgainstChain([anchorAt(7, sha256('beyond'))], chain, secret);
+
+    expect(report.allMatch).toBe(false);
+    expect(report.results[0]).toEqual({
+      chainSeq: 7,
+      verdict: 'seq_gap',
+      anchorHead: sha256('beyond'),
+      chainHead: null,
+    });
+  });
+
+  it('given an anchor whose signature does not verify, should report unverifiable WITHOUT consulting the chain', () => {
+    const forged: SignedAnchor = { ...anchorAt(1, h1), signature: '0'.repeat(64) };
+    let lookups = 0;
+
+    const report = matchAnchorsAgainstChain(
+      [forged],
+      (seq) => {
+        lookups++;
+        return chain.get(seq) ?? null;
+      },
+      secret,
+    );
+
+    expect(report.results[0]).toEqual({
+      chainSeq: 1,
+      verdict: 'unverifiable',
+      anchorHead: h1,
+      chainHead: null,
+    });
+    expect(lookups).toBe(0);
+    expect(report.allMatch).toBe(false);
+  });
+
+  it('given an anchor signed with a different secret, should report unverifiable (rotated/unknown key)', () => {
+    const otherKey = buildAnchorPayload({
+      head: h1,
+      chainSeq: 1,
+      anchoredAt: new Date('2026-03-01T00:00:00.000Z'),
+      secret: 'rotated-away',
+    });
+
+    const report = matchAnchorsAgainstChain([otherKey], chain, secret);
+
+    expect(report.results[0].verdict).toBe('unverifiable');
+  });
+
+  it('given a mixed set in unsorted order, should return results sorted by chainSeq with per-verdict counts', () => {
+    const report = matchAnchorsAgainstChain(
+      [
+        anchorAt(3, h3), // match
+        { ...anchorAt(1, h1), signature: 'f'.repeat(64) }, // unverifiable
+        anchorAt(9, sha256('x')), // seq_gap
+        anchorAt(2, sha256('y')), // hash_mismatch
+      ],
+      chain,
+      secret,
+    );
+
+    expect(report.results.map((r) => r.chainSeq)).toEqual([1, 2, 3, 9]);
+    expect(report.results.map((r) => r.verdict)).toEqual([
+      'unverifiable',
+      'hash_mismatch',
+      'match',
+      'seq_gap',
+    ]);
+    expect(report.counts).toEqual({ match: 1, hash_mismatch: 1, seq_gap: 1, unverifiable: 1 });
+    expect(report.allMatch).toBe(false);
+  });
+
+  it('given no anchors at all, should NOT report allMatch (an unwitnessed chain is unverified, not verified)', () => {
+    const report = matchAnchorsAgainstChain([], chain, secret);
+
+    expect(report.allMatch).toBe(false);
+    expect(report.results).toEqual([]);
+    expect(report.counts).toEqual({ match: 0, hash_mismatch: 0, seq_gap: 0, unverifiable: 0 });
+  });
+
+  it('given a function lookup and a Map lookup over the same chain, should produce identical reports', () => {
+    const anchors = [anchorAt(1, h1), anchorAt(2, h2), anchorAt(3, h3)];
+
+    const viaMap = matchAnchorsAgainstChain(anchors, chain, secret);
+    const viaFn = matchAnchorsAgainstChain(anchors, (seq) => chain.get(seq) ?? null, secret);
+
+    expect(viaFn).toEqual(viaMap);
+    expect(viaMap.allMatch).toBe(true);
+  });
+
+  it('given anchors generated across a growing synthetic chain, should all match (property: anchoring every head is consistent)', () => {
+    let prev = GENESIS_PREVIOUS_HASH;
+    const lookup = new Map<number, string>();
+    const anchors: SignedAnchor[] = [];
+    for (let seq = 1; seq <= 40; seq++) {
+      prev = computeChainHash(sha256(`e-${seq}`), prev);
+      lookup.set(seq, prev);
+      anchors.push(anchorAt(seq, prev, `2026-03-01T00:00:${String(seq % 60).padStart(2, '0')}.000Z`));
+    }
+
+    const report = matchAnchorsAgainstChain(anchors, lookup, secret);
+
+    expect(report.allMatch).toBe(true);
+    expect(report.counts.match).toBe(40);
+  });
+});

--- a/packages/lib/src/audit/__tests__/audit-db-binding.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-db-binding.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Audit DB binding tests (#890 Phase 2, leaf 5 — runtime cutover).
+ *
+ * resolveAuditDbBinding() is THE resolved-mode call site every default audit
+ * read/write path hangs off:
+ *   dedicated   → the Admin PG client (trust plane)
+ *   break-glass → the MAIN db client — NOT the admin-schema-typed main-pool
+ *                 client getAdminDb() returns, because the admin schema maps
+ *                 emission_hash (admin migration 0005, admin plane only) and
+ *                 the main-plane table has no such column: admin-shaped
+ *                 SELECTs against the main DB would 42703.
+ *   fail        → throws the actionable reason (fail-fast preserved)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockAdminDb, mockMainDb, mockGetAdminDbMode, mockGetAdminDb } = vi.hoisted(() => ({
+  mockAdminDb: { kind: 'admin-db' },
+  mockMainDb: { kind: 'main-db' },
+  mockGetAdminDbMode: vi.fn(),
+  mockGetAdminDb: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/admin-db', () => ({
+  getAdminDb: mockGetAdminDb,
+  getAdminDbMode: mockGetAdminDbMode,
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: mockMainDb,
+}));
+
+import { resolveAuditDbBinding, resetAuditDbBindingForTests } from '../audit-db-binding';
+
+describe('resolveAuditDbBinding()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAuditDbBindingForTests();
+    mockGetAdminDb.mockReturnValue(mockAdminDb);
+  });
+
+  describe('dedicated mode', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' });
+    });
+
+    it('given dedicated, should bind to the Admin PG client', () => {
+      const binding = resolveAuditDbBinding();
+      expect(binding.mode).toBe('dedicated');
+      expect(binding.db).toBe(mockAdminDb);
+    });
+
+    it('should cache the binding — one mode resolution and one getAdminDb per process', () => {
+      const first = resolveAuditDbBinding();
+      const second = resolveAuditDbBinding();
+      expect(second).toBe(first);
+      expect(mockGetAdminDbMode).toHaveBeenCalledTimes(1);
+      expect(mockGetAdminDb).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('break-glass mode', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'break-glass', reason: 'flag armed' });
+    });
+
+    it('given break-glass, should bind to the MAIN db client (legacy path intact)', () => {
+      const binding = resolveAuditDbBinding();
+      expect(binding.mode).toBe('break-glass');
+      expect(binding.db).toBe(mockMainDb);
+    });
+
+    it('given break-glass, should never touch getAdminDb — the admin-schema-typed main-pool client is shape-unsafe for main-plane reads', () => {
+      resolveAuditDbBinding();
+      expect(mockGetAdminDb).not.toHaveBeenCalled();
+    });
+
+    it('should carry the decision reason for observability at the bind point', () => {
+      expect(resolveAuditDbBinding().reason).toBe('flag armed');
+    });
+  });
+
+  describe('fail mode', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({
+        mode: 'fail',
+        reason: 'ADMIN_DATABASE_URL is not set. The Admin PG (trust plane) is required.',
+      });
+    });
+
+    it('given fail, should throw the actionable reason', () => {
+      expect(() => resolveAuditDbBinding()).toThrowError(/ADMIN_DATABASE_URL/);
+    });
+
+    it('should throw on every call — a failed resolution is never cached as a binding', () => {
+      expect(() => resolveAuditDbBinding()).toThrow();
+      expect(() => resolveAuditDbBinding()).toThrow();
+      expect(mockGetAdminDbMode).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('resetAuditDbBindingForTests() clears the cache so mode changes are re-observed', () => {
+    mockGetAdminDbMode.mockReturnValue({ mode: 'dedicated', reason: 'set' });
+    expect(resolveAuditDbBinding().db).toBe(mockAdminDb);
+
+    resetAuditDbBindingForTests();
+    mockGetAdminDbMode.mockReturnValue({ mode: 'break-glass', reason: 'flag armed' });
+    expect(resolveAuditDbBinding().db).toBe(mockMainDb);
+  });
+});

--- a/packages/lib/src/audit/__tests__/audit-ingest-writer.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-ingest-writer.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit suite for createAuditIngestWriter (#890 Phase 2, leaf 1).
+ *
+ * The ingest writer is the lock-free replacement for the advisory-lock
+ * append path: encrypt IP + pure emission hash + ONE INSERT into
+ * security_audit_ingest. These tests prove the O(1) shape mechanically —
+ * the injected db receives exactly one insert() and NEVER a transaction,
+ * raw execute (lock/head read), or select.
+ *
+ * NOT yet bound to production flow: audit-log.ts / the securityAudit
+ * singleton still use the advisory-lock repository until leaf 5 cuts over.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import { securityAuditIngest } from '@pagespace/db/admin-schema';
+import { createAuditIngestWriter, type AuditIngestWriterDeps } from '../audit-ingest-writer';
+import { computeEmissionHash } from '../emission-hash';
+import type { AuditEvent } from '../security-audit';
+
+interface CapturedInsert {
+  table: unknown;
+  values: Record<string, unknown>;
+}
+
+function createMockDb() {
+  const inserts: CapturedInsert[] = [];
+
+  const insert = vi.fn((table: unknown) => ({
+    values: (values: Record<string, unknown>) => {
+      inserts.push({ table, values });
+      return Promise.resolve(undefined);
+    },
+  }));
+  // Forbidden surfaces — present on the mock so a regression that starts
+  // calling them fails these assertions rather than throwing opaquely.
+  const transaction = vi.fn();
+  const execute = vi.fn();
+  const select = vi.fn();
+
+  const db = { insert, transaction, execute, select } as unknown as AuditIngestWriterDeps['db'];
+
+  return { db, inserts, insert, transaction, execute, select };
+}
+
+describe('createAuditIngestWriter', () => {
+  describe('writeToIngest', () => {
+    it('should perform exactly ONE insert into security_audit_ingest — no transaction, no advisory lock, no head read', async () => {
+      const { db, inserts, insert, transaction, execute, select } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+
+      await writer.writeToIngest(
+        { eventType: 'auth.login.success', userId: 'user1' },
+        { now: new Date('2026-01-25T10:00:00.000Z') }
+      );
+
+      expect(insert).toHaveBeenCalledTimes(1);
+      expect(inserts).toHaveLength(1);
+      expect(inserts[0]!.table).toBe(securityAuditIngest);
+      expect(transaction).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      expect(select).not.toHaveBeenCalled();
+    });
+
+    it('should store the emission hash computed by the pure fn (byte-identical to computeEmissionHash)', async () => {
+      const { db, inserts } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+      const event: AuditEvent = {
+        eventType: 'data.export',
+        userId: 'user123',
+        resourceType: 'drive',
+        resourceId: 'drive-42',
+        details: { format: 'pdf' },
+        riskScore: 0.2,
+      };
+      const now = new Date('2026-01-25T10:00:02.000Z');
+
+      await writer.writeToIngest(event, { now });
+
+      expect(inserts[0]!.values.emissionHash).toBe(computeEmissionHash(event, now));
+      expect(inserts[0]!.values.timestamp).toEqual(now);
+    });
+
+    it('should write no chain fields — chain_seq/previousHash/eventHash belong to the chainer (leaf 2)', async () => {
+      const { db, inserts } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+
+      await writer.writeToIngest(
+        { eventType: 'auth.logout', userId: 'user1' },
+        { now: new Date('2026-01-25T10:00:00.000Z') }
+      );
+
+      const values = inserts[0]!.values;
+      expect(values).not.toHaveProperty('previousHash');
+      expect(values).not.toHaveProperty('eventHash');
+      expect(values).not.toHaveProperty('chainSeq');
+    });
+
+    it('should carry every event column through to the row', async () => {
+      const { db, inserts } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+      const now = new Date('2026-01-25T10:00:03.000Z');
+      const event: AuditEvent = {
+        eventType: 'security.anomaly.detected',
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        serviceId: 'web',
+        resourceType: 'account',
+        resourceId: 'acct-1',
+        userAgent: 'UA/1.0',
+        geoLocation: 'US-CA',
+        details: { flag: 'impossible_travel' },
+        riskScore: 0.9,
+        anomalyFlags: ['impossible_travel'],
+      };
+
+      await writer.writeToIngest(event, { now });
+
+      expect(inserts[0]!.values).toMatchObject({
+        eventType: 'security.anomaly.detected',
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        serviceId: 'web',
+        resourceType: 'account',
+        resourceId: 'acct-1',
+        userAgent: 'UA/1.0',
+        geoLocation: 'US-CA',
+        details: { flag: 'impossible_travel' },
+        riskScore: 0.9,
+        anomalyFlags: ['impossible_travel'],
+        timestamp: now,
+      });
+    });
+
+    it('encrypts the IP address at rest (ciphertext + blind index) while the emission hash excludes it', async () => {
+      const { db, inserts } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+      const now = new Date('2026-01-25T10:00:04.000Z');
+
+      await writer.writeToIngest({ eventType: 'auth.login.success', ipAddress: '10.0.0.5' }, { now });
+
+      const values = inserts[0]!.values;
+      expect(values.ipAddress).not.toBe('10.0.0.5');
+      expect(values.ipBidx).toEqual(expect.any(String));
+      // Emission hash is identical with or without the IP — PII-excluded.
+      expect(values.emissionHash).toBe(computeEmissionHash({ eventType: 'auth.login.success' }, now));
+    });
+
+    it('given no override, should stamp the event timestamp itself (new Date())', async () => {
+      const { db, inserts } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+      const before = Date.now();
+
+      await writer.writeToIngest({ eventType: 'auth.login.success' });
+
+      const timestamp = inserts[0]!.values.timestamp as Date;
+      expect(timestamp.getTime()).toBeGreaterThanOrEqual(before);
+      expect(timestamp.getTime()).toBeLessThanOrEqual(Date.now());
+      expect(inserts[0]!.values.emissionHash).toBe(
+        computeEmissionHash({ eventType: 'auth.login.success' }, timestamp)
+      );
+    });
+
+    it('given the insert rejects, should propagate the error to the caller (audit() wrapper owns the catch)', async () => {
+      const failure = new Error('admin pg unreachable');
+      const db = {
+        insert: vi.fn(() => ({ values: () => Promise.reject(failure) })),
+        transaction: vi.fn(),
+        execute: vi.fn(),
+        select: vi.fn(),
+      } as unknown as AuditIngestWriterDeps['db'];
+      const writer = createAuditIngestWriter({ db });
+
+      await expect(writer.writeToIngest({ eventType: 'auth.login.success' })).rejects.toBe(failure);
+    });
+
+    it('DI: two writers built from two distinct db clients never cross-touch', async () => {
+      const a = createMockDb();
+      const b = createMockDb();
+      const writerA = createAuditIngestWriter({ db: a.db });
+      createAuditIngestWriter({ db: b.db });
+
+      await writerA.writeToIngest({ eventType: 'auth.login.success' });
+
+      expect(a.inserts).toHaveLength(1);
+      expect(b.inserts).toHaveLength(0);
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/audit-ingest-writer.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-ingest-writer.test.ts
@@ -10,10 +10,12 @@
  * NOT yet bound to production flow: audit-log.ts / the securityAudit
  * singleton still use the advisory-lock repository until leaf 5 cuts over.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import { securityAuditIngest } from '@pagespace/db/admin-schema';
+import { loggers } from '../../logging/logger-config';
 import { createAuditIngestWriter, type AuditIngestWriterDeps } from '../audit-ingest-writer';
+import { CO_STREAM_LOG_MESSAGE } from '../co-stream';
 import { computeEmissionHash } from '../emission-hash';
 import type { AuditEvent } from '../security-audit';
 
@@ -183,6 +185,121 @@ describe('createAuditIngestWriter', () => {
 
       expect(a.inserts).toHaveLength(1);
       expect(b.inserts).toHaveLength(0);
+    });
+  });
+
+  describe('witness co-stream (leaf 4)', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    function createCoStreamLogger() {
+      const lines: Array<{ message: string; metadata: Record<string, unknown> }> = [];
+      return {
+        lines,
+        coStreamLogger: {
+          info: vi.fn((message: string, metadata?: Record<string, unknown>) => {
+            lines.push({ message, metadata: metadata ?? {} });
+          }),
+        },
+      };
+    }
+
+    it('given a successful insert, should emit exactly ONE co-stream line with the exact allowlisted shape', async () => {
+      const { db, inserts } = createMockDb();
+      const { lines, coStreamLogger } = createCoStreamLogger();
+      const writer = createAuditIngestWriter({ db, coStreamLogger });
+      const now = new Date('2026-02-01T00:10:00.000Z');
+      const event: AuditEvent = {
+        eventType: 'security.anomaly.detected',
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        ipAddress: '10.0.0.5',
+        userAgent: 'UA/1.0',
+        geoLocation: 'US-CA',
+        details: { flag: 'impossible_travel' },
+        riskScore: 0.9,
+      };
+
+      await writer.writeToIngest(event, { now });
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0]!.message).toBe(CO_STREAM_LOG_MESSAGE);
+      // Exact allowlist — nothing beyond the four witness fields, PII-free
+      // by construction (no details, no IPs even encrypted).
+      expect(Object.keys(lines[0]!.metadata).sort()).toEqual([
+        'emissionHash', 'emittedAt', 'eventId', 'eventType',
+      ]);
+      expect(lines[0]!.metadata).toEqual({
+        eventId: inserts[0]!.values.id,
+        emissionHash: inserts[0]!.values.emissionHash,
+        eventType: 'security.anomaly.detected',
+        emittedAt: now.toISOString(),
+      });
+    });
+
+    it('the co-stream eventId IS the ingest row id (writer-generated), so reconciliation can match by id', async () => {
+      const { db, inserts } = createMockDb();
+      const { lines, coStreamLogger } = createCoStreamLogger();
+      const writer = createAuditIngestWriter({ db, coStreamLogger });
+
+      await writer.writeToIngest({ eventType: 'auth.login.success' });
+      await writer.writeToIngest({ eventType: 'auth.login.success' });
+
+      expect(inserts[0]!.values.id).toEqual(expect.any(String));
+      expect(lines[0]!.metadata.eventId).toBe(inserts[0]!.values.id);
+      expect(lines[1]!.metadata.eventId).toBe(inserts[1]!.values.id);
+      expect(lines[0]!.metadata.eventId).not.toBe(lines[1]!.metadata.eventId);
+    });
+
+    it('given the co-stream logger throws, the write still succeeds — best-effort witness, log-internal errors swallowed', async () => {
+      const { db, inserts } = createMockDb();
+      const coStreamLogger = {
+        info: vi.fn(() => {
+          throw new Error('collector down');
+        }),
+      };
+      const writer = createAuditIngestWriter({ db, coStreamLogger });
+
+      await expect(writer.writeToIngest({ eventType: 'auth.login.success' })).resolves.toBeUndefined();
+      expect(inserts).toHaveLength(1);
+      expect(coStreamLogger.info).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the insert rejects, should emit NO co-stream line — the witness never records an event the store refused', async () => {
+      const { coStreamLogger } = createCoStreamLogger();
+      const db = {
+        insert: vi.fn(() => ({ values: () => Promise.reject(new Error('admin pg unreachable')) })),
+        transaction: vi.fn(),
+        execute: vi.fn(),
+        select: vi.fn(),
+      } as unknown as AuditIngestWriterDeps['db'];
+      const writer = createAuditIngestWriter({ db, coStreamLogger });
+
+      await expect(writer.writeToIngest({ eventType: 'auth.login.success' })).rejects.toThrow('admin pg unreachable');
+      expect(coStreamLogger.info).not.toHaveBeenCalled();
+    });
+
+    it('given no coStreamLogger dep, defaults to the security-category structured logger (stdout under LOG_DESTINATION stdout/both)', async () => {
+      const securityInfo = vi.spyOn(loggers.security, 'info').mockImplementation(() => undefined);
+      const { db } = createMockDb();
+      const writer = createAuditIngestWriter({ db });
+
+      await writer.writeToIngest(
+        { eventType: 'auth.login.success' },
+        { now: new Date('2026-02-01T00:10:00.000Z') }
+      );
+
+      expect(securityInfo).toHaveBeenCalledTimes(1);
+      expect(securityInfo).toHaveBeenCalledWith(
+        CO_STREAM_LOG_MESSAGE,
+        expect.objectContaining({
+          eventId: expect.any(String),
+          emissionHash: expect.any(String),
+          eventType: 'auth.login.success',
+          emittedAt: '2026-02-01T00:10:00.000Z',
+        })
+      );
     });
   });
 });

--- a/packages/lib/src/audit/__tests__/audit-query.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-query.test.ts
@@ -27,6 +27,13 @@ const { mockDb, mockSecurityAuditLog } = vi.hoisted(() => {
 vi.mock('@pagespace/db/db', () => ({
   db: mockDb,
 }));
+// Default binding (#890 Phase 2, leaf 5): dedicated mode resolves the Admin
+// PG client. Point it at the same mockDb so the "default db" expectations
+// below exercise the post-cutover default.
+vi.mock('@pagespace/db/admin-db', () => ({
+  getAdminDbMode: vi.fn(() => ({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' })),
+  getAdminDb: vi.fn(() => mockDb),
+}));
 vi.mock('@pagespace/db/schema/security-audit', () => ({
   securityAuditLog: mockSecurityAuditLog,
 }));
@@ -200,11 +207,29 @@ describe('queryAuditEvents()', () => {
       expect(result).toEqual(injectedEvents);
     });
 
-    it('given no injected client, should fall back to the default db (parity with today)', async () => {
+    it('given no injected client, should fall back to the resolved audit binding (Admin PG in dedicated mode)', async () => {
       const result = await queryAuditEvents({});
 
       expect(mockDb.select).toHaveBeenCalled();
       expect(result).toEqual(mockEvents);
+    });
+
+    it('PARITY: identical filters against the injected admin client and the default binding produce identical results', async () => {
+      const rows = [
+        { id: 'evt-a', eventType: 'auth.login.success', userId: 'user-1', ipAddress: null },
+        { id: 'evt-b', eventType: 'auth.login.success', userId: 'user-1', ipAddress: null },
+      ];
+      const injectedAdminDb = createInjectedDb(rows);
+      mockDb._chain.orderBy.mockResolvedValue(rows);
+
+      const viaInjected = await queryAuditEvents(
+        { userId: 'user-1', eventType: 'auth.login.success' },
+        { db: injectedAdminDb as unknown as AuditQueryDeps['db'] },
+      );
+      const viaDefault = await queryAuditEvents({ userId: 'user-1', eventType: 'auth.login.success' });
+
+      expect(viaInjected).toEqual(viaDefault);
+      expect(viaInjected).toEqual(rows);
     });
   });
 });

--- a/packages/lib/src/audit/__tests__/audit-test-helpers.ts
+++ b/packages/lib/src/audit/__tests__/audit-test-helpers.ts
@@ -1,4 +1,6 @@
 import { computeSecurityEventHash, type AuditEvent } from '../security-audit';
+import { computeEmissionHash } from '../emission-hash';
+import { computeChainHash } from '../chain-step';
 
 export interface MockSecurityAuditEntry {
   id: string;
@@ -17,6 +19,11 @@ export interface MockSecurityAuditEntry {
   timestamp: Date;
   previousHash: string;
   eventHash: string;
+  /**
+   * Chainer-era rows (#890 Phase 2) carry the emission hash; legacy rows
+   * read as null/undefined (the main-plane table has no such column).
+   */
+  emissionHash?: string | null;
 }
 
 export function createValidSecurityChain(count: number): MockSecurityAuditEntry[] {
@@ -69,6 +76,64 @@ export function createValidSecurityChainWithEventTypes(
 
     previousHash = eventHash;
   });
+
+  return entries;
+}
+
+/**
+ * Builds a valid CHAINER-ERA chain segment (#890 Phase 2): each row carries
+ * emission_hash = computeEmissionHash(event, timestamp) and
+ * event_hash = computeChainHash(emission_hash, previous_hash) — the
+ * single-writer chainer's semantics, verified era-aware by the periodic
+ * verifier since leaf 5.
+ *
+ * `previousHash` lets a chainer segment continue a legacy chain (the era
+ * boundary the backfill leaf plants): pass the legacy head's event_hash.
+ */
+export function createValidChainerEraChain(
+  count: number,
+  opts: { previousHash?: string; startIndex?: number } = {}
+): MockSecurityAuditEntry[] {
+  const entries: MockSecurityAuditEntry[] = [];
+  let previousHash = opts.previousHash ?? 'genesis';
+  const startIndex = opts.startIndex ?? 0;
+
+  for (let i = 0; i < count; i++) {
+    const timestamp = new Date(Date.now() + (startIndex + i) * 1000);
+    const event: AuditEvent = {
+      eventType: 'auth.login.success',
+      userId: 'user-123',
+      sessionId: `session-${startIndex + i}`,
+      resourceType: 'page',
+      resourceId: `page-${startIndex + i}`,
+      details: { seq: startIndex + i },
+    };
+
+    const emissionHash = computeEmissionHash(event, timestamp);
+    const eventHash = computeChainHash(emissionHash, previousHash);
+
+    entries.push({
+      id: `chained-${startIndex + i + 1}`,
+      eventType: event.eventType,
+      userId: 'user-123',
+      sessionId: `session-${startIndex + i}`,
+      serviceId: null,
+      resourceType: 'page',
+      resourceId: `page-${startIndex + i}`,
+      ipAddress: '127.0.0.1',
+      userAgent: 'test-agent',
+      geoLocation: null,
+      details: { seq: startIndex + i },
+      riskScore: null,
+      anomalyFlags: null,
+      timestamp,
+      previousHash,
+      eventHash,
+      emissionHash,
+    });
+
+    previousHash = eventHash;
+  }
 
   return entries;
 }

--- a/packages/lib/src/audit/__tests__/chain-step.test.ts
+++ b/packages/lib/src/audit/__tests__/chain-step.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Golden-vector + property suite for the pure chainer core (#890 Phase 2, leaf 2).
+ *
+ * chainHash = H(emissionHash, prevHash): sha256 over stableStringify of
+ * EXACTLY those two fields. These vectors pin the chain-step semantics the
+ * single-writer chainer worker relies on — if this suite ever fails, every
+ * chained row already written no longer verifies against a recomputation.
+ *
+ * The emission-hash inputs reuse the pinned vectors from emission-hash.test.ts
+ * so the two suites together pin the full emission → chain pipeline.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  computeChainHash,
+  assignChainBatch,
+  verifyAppendedSegment,
+  GENESIS_PREVIOUS_HASH,
+  type ChainableIngestRow,
+} from '../chain-step';
+
+// Pinned emission hashes (from emission-hash.test.ts golden vectors).
+const EMISSION_MINIMAL = '7b3bd93e3b22380b60bed2ea1dfff9aa72b0281a969a44ab2a8b77db9a8bc1c8';
+const EMISSION_DETAILS = 'bb51071ec93aa6e42a169d0584c01ba3a210e8ad83546b14bc1215767fee7e55';
+const EMISSION_ALL_FIELDS = '8b5ae1d30aa91211ac8df78efce42c3700101ee5714516709ec9bf9c2d1697d8';
+
+// Pinned chain-step outputs (literal hex — never recompute these in-test).
+const GENESIS_STEP = '45362581a9ee89d1d0edea1b93f365f36cd5852b950dfe41398537d68a31f77e';
+const SECOND_STEP = 'c1cffb8442bbb89dce1830da98141a41fd73fbdf5ccf40897a300ea1efd61d8d';
+const THIRD_STEP = 'abbb75afebf9c7fea40e9e767601ec191fa3823648ddea9b4d307cf1e6364852';
+// A cutover-shaped step: prevHash is an arbitrary legacy chain head, not
+// 'genesis' — the backfill leaf supplies that anchor; the fn just takes it.
+const LEGACY_HEAD = 'a3f1c2d4e5b6978810213243546576879809aabbccddeeff0011223344556677';
+const LEGACY_ANCHOR_STEP = '88e49d230ef72c5ae98565eb42312029470d85b29e03490e640336f7cae68f91';
+
+/** Deterministic pseudo-random ingest rows (seeded LCG — no Math.random). */
+function makeIngestRows(count: number, seed = 42): ChainableIngestRow[] {
+  let state = seed;
+  const next = () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+  return Array.from({ length: count }, (_, i) => ({
+    id: `ingest-${seed}-${i}`,
+    eventType: (['auth.login.success', 'data.read', 'data.write', 'authz.access.denied'] as const)[
+      Math.floor(next() * 4)
+    ],
+    userId: next() > 0.5 ? `user-${Math.floor(next() * 100)}` : null,
+    sessionId: next() > 0.5 ? `sess-${Math.floor(next() * 100)}` : null,
+    serviceId: 'web',
+    resourceType: next() > 0.5 ? 'page' : null,
+    resourceId: next() > 0.5 ? `res-${Math.floor(next() * 100)}` : null,
+    ipAddress: next() > 0.5 ? `ciphertext-${i}` : null,
+    ipBidx: next() > 0.5 ? `bidx-${i}` : null,
+    userAgent: null,
+    geoLocation: null,
+    details: next() > 0.5 ? { step: i, nested: { flag: next() > 0.5 } } : null,
+    riskScore: next() > 0.7 ? Math.floor(next() * 100) / 100 : null,
+    anomalyFlags: next() > 0.8 ? ['brute_force'] : null,
+    timestamp: new Date(Date.UTC(2026, 0, 25, 10, 0, i)),
+    emissionHash: `${'0'.repeat(56)}${(seed * 1000 + i).toString(16).padStart(8, '0')}`,
+  }));
+}
+
+describe('computeChainHash golden vectors (pinned)', () => {
+  it('given the minimal emission hash and the genesis sentinel, should match the pinned hash', () => {
+    expect(computeChainHash(EMISSION_MINIMAL, GENESIS_PREVIOUS_HASH)).toBe(GENESIS_STEP);
+  });
+
+  it('given each successive emission hash and the previous chain hash, should match the pinned chain', () => {
+    expect(computeChainHash(EMISSION_DETAILS, GENESIS_STEP)).toBe(SECOND_STEP);
+    expect(computeChainHash(EMISSION_ALL_FIELDS, SECOND_STEP)).toBe(THIRD_STEP);
+  });
+
+  it('given a legacy chain head as prevHash (cutover anchor shape), should match the pinned hash', () => {
+    expect(computeChainHash(EMISSION_MINIMAL, LEGACY_HEAD)).toBe(LEGACY_ANCHOR_STEP);
+  });
+
+  it('given swapped arguments, should NOT produce the same hash (fields are named, not positional)', () => {
+    expect(computeChainHash(GENESIS_STEP, EMISSION_MINIMAL)).not.toBe(
+      computeChainHash(EMISSION_MINIMAL, GENESIS_STEP),
+    );
+  });
+
+  it('given a different previous hash for the same emission hash, should produce a different chain hash', () => {
+    expect(computeChainHash(EMISSION_MINIMAL, GENESIS_STEP)).not.toBe(GENESIS_STEP);
+    expect(computeChainHash(EMISSION_MINIMAL, 'genesis')).toBe(GENESIS_STEP);
+  });
+
+  it('should export the same genesis sentinel the legacy advisory-lock chain uses', () => {
+    expect(GENESIS_PREVIOUS_HASH).toBe('genesis');
+  });
+});
+
+describe('assignChainBatch', () => {
+  it('given an empty batch, should return no payloads and the unchanged head (identity)', () => {
+    const head = { prevHash: LEGACY_HEAD };
+
+    const result = assignChainBatch([], head);
+
+    expect(result.chainedRowPayloads).toEqual([]);
+    expect(result.newHead).toEqual({ prevHash: LEGACY_HEAD });
+  });
+
+  it('given ordered rows, should link row N previous_hash to row N-1 event_hash (linkage property)', () => {
+    const rows = makeIngestRows(50);
+
+    const { chainedRowPayloads, newHead } = assignChainBatch(rows, {
+      prevHash: GENESIS_PREVIOUS_HASH,
+    });
+
+    expect(chainedRowPayloads).toHaveLength(50);
+    expect(chainedRowPayloads[0].previousHash).toBe(GENESIS_PREVIOUS_HASH);
+    for (let i = 1; i < chainedRowPayloads.length; i++) {
+      expect(chainedRowPayloads[i].previousHash).toBe(chainedRowPayloads[i - 1].eventHash);
+    }
+    expect(newHead.prevHash).toBe(chainedRowPayloads[chainedRowPayloads.length - 1].eventHash);
+  });
+
+  it('given the same rows and head twice, should produce identical output (determinism property)', () => {
+    const head = { prevHash: LEGACY_HEAD };
+
+    const first = assignChainBatch(makeIngestRows(25, 7), head);
+    const second = assignChainBatch(makeIngestRows(25, 7), head);
+
+    expect(second).toEqual(first);
+  });
+
+  it('given each payload, should carry emission_hash unchanged and event_hash = computeChainHash(emissionHash, previousHash)', () => {
+    const rows = makeIngestRows(20, 99);
+
+    const { chainedRowPayloads } = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    for (let i = 0; i < rows.length; i++) {
+      const payload = chainedRowPayloads[i];
+      expect(payload.emissionHash).toBe(rows[i].emissionHash);
+      expect(payload.eventHash).toBe(computeChainHash(payload.emissionHash, payload.previousHash));
+    }
+  });
+
+  it('given ingest rows, should copy every event column onto the payload verbatim (id included)', () => {
+    const [row] = makeIngestRows(1, 3);
+
+    const { chainedRowPayloads } = assignChainBatch([row], { prevHash: GENESIS_PREVIOUS_HASH });
+    const [payload] = chainedRowPayloads;
+
+    expect(payload.id).toBe(row.id);
+    expect(payload.eventType).toBe(row.eventType);
+    expect(payload.userId).toBe(row.userId);
+    expect(payload.sessionId).toBe(row.sessionId);
+    expect(payload.serviceId).toBe(row.serviceId);
+    expect(payload.resourceType).toBe(row.resourceType);
+    expect(payload.resourceId).toBe(row.resourceId);
+    expect(payload.ipAddress).toBe(row.ipAddress);
+    expect(payload.ipBidx).toBe(row.ipBidx);
+    expect(payload.userAgent).toBe(row.userAgent);
+    expect(payload.geoLocation).toBe(row.geoLocation);
+    expect(payload.details).toEqual(row.details);
+    expect(payload.riskScore).toBe(row.riskScore);
+    expect(payload.anomalyFlags).toEqual(row.anomalyFlags);
+    expect(payload.timestamp).toEqual(row.timestamp);
+  });
+
+  it('given a batch starting from a previous batch head, should continue the chain seamlessly (batch-boundary property)', () => {
+    const rows = makeIngestRows(30, 11);
+
+    const whole = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+    const firstHalf = assignChainBatch(rows.slice(0, 15), { prevHash: GENESIS_PREVIOUS_HASH });
+    const secondHalf = assignChainBatch(rows.slice(15), firstHalf.newHead);
+
+    expect([...firstHalf.chainedRowPayloads, ...secondHalf.chainedRowPayloads]).toEqual(
+      whole.chainedRowPayloads,
+    );
+    expect(secondHalf.newHead).toEqual(whole.newHead);
+  });
+
+  it('should not mutate the input rows or head (purity)', () => {
+    const rows = makeIngestRows(5, 21);
+    const snapshot = structuredClone(rows);
+    const head = { prevHash: GENESIS_PREVIOUS_HASH };
+
+    assignChainBatch(rows, head);
+
+    expect(rows).toEqual(snapshot);
+    expect(head).toEqual({ prevHash: GENESIS_PREVIOUS_HASH });
+  });
+});
+
+describe('verifyAppendedSegment', () => {
+  const assign = (count: number, prevHash: string, seed = 42) =>
+    assignChainBatch(makeIngestRows(count, seed), { prevHash });
+
+  it('given a segment produced by assignChainBatch, should verify green (round-trip)', () => {
+    const { chainedRowPayloads } = assign(40, GENESIS_PREVIOUS_HASH);
+
+    const result = verifyAppendedSegment(chainedRowPayloads, {
+      prevHash: GENESIS_PREVIOUS_HASH,
+    });
+
+    expect(result).toEqual({ valid: true, verified: 40 });
+  });
+
+  it('given an empty segment, should verify green with zero rows', () => {
+    expect(verifyAppendedSegment([], { prevHash: LEGACY_HEAD })).toEqual({
+      valid: true,
+      verified: 0,
+    });
+  });
+
+  it('given a tampered emission_hash, should report hash_mismatch at the exact row', () => {
+    const { chainedRowPayloads } = assign(10, GENESIS_PREVIOUS_HASH);
+    const tampered = chainedRowPayloads.map((row, i) =>
+      i === 4 ? { ...row, emissionHash: `${'f'.repeat(64)}` } : row,
+    );
+
+    const result = verifyAppendedSegment(tampered, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.breakAtIndex).toBe(4);
+      expect(result.entryId).toBe(tampered[4].id);
+      expect(result.reason).toBe('hash_mismatch');
+      expect(result.expectedHash).toBe(
+        computeChainHash(`${'f'.repeat(64)}`, tampered[3].eventHash),
+      );
+      expect(result.actualHash).toBe(chainedRowPayloads[4].eventHash);
+    }
+  });
+
+  it('given a broken previous_hash link, should report linkage_break at the exact row', () => {
+    const { chainedRowPayloads } = assign(10, GENESIS_PREVIOUS_HASH);
+    const tampered = chainedRowPayloads.map((row, i) =>
+      i === 6 ? { ...row, previousHash: `${'a'.repeat(64)}` } : row,
+    );
+
+    const result = verifyAppendedSegment(tampered, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.breakAtIndex).toBe(6);
+      expect(result.reason).toBe('linkage_break');
+      expect(result.expectedHash).toBe(tampered[5].eventHash);
+      expect(result.actualHash).toBe(`${'a'.repeat(64)}`);
+    }
+  });
+
+  it('given a NULL emission_hash (legacy-era row shape), should report missing_emission_hash — the chainer never writes those', () => {
+    const { chainedRowPayloads } = assign(3, GENESIS_PREVIOUS_HASH);
+    const tampered = chainedRowPayloads.map((row, i) =>
+      i === 1 ? { ...row, emissionHash: null } : row,
+    );
+
+    const result = verifyAppendedSegment(tampered, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.breakAtIndex).toBe(1);
+      expect(result.reason).toBe('missing_emission_hash');
+    }
+  });
+
+  it('given the wrong prior head, should fail at index 0 with linkage_break', () => {
+    const { chainedRowPayloads } = assign(5, LEGACY_HEAD);
+
+    const result = verifyAppendedSegment(chainedRowPayloads, {
+      prevHash: GENESIS_PREVIOUS_HASH,
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.breakAtIndex).toBe(0);
+      expect(result.reason).toBe('linkage_break');
+      expect(result.expectedHash).toBe(GENESIS_PREVIOUS_HASH);
+      expect(result.actualHash).toBe(LEGACY_HEAD);
+    }
+  });
+
+  it('given a re-linked but re-hashed tail (attacker rebuilds the chain after the tamper point), should still fail against the prior head... unless the whole segment is consistent — which anchoring (leaf 3) exists to catch', () => {
+    // A fully self-consistent forged segment DOES verify against linkage —
+    // that is exactly why heads are anchored to an external witness. This
+    // test documents the boundary of what verify-on-append can prove.
+    const rows = makeIngestRows(5, 77);
+    const forged = assignChainBatch(rows, { prevHash: GENESIS_PREVIOUS_HASH });
+
+    const againstRightHead = verifyAppendedSegment(forged.chainedRowPayloads, {
+      prevHash: GENESIS_PREVIOUS_HASH,
+    });
+    const againstWrongHead = verifyAppendedSegment(forged.chainedRowPayloads, {
+      prevHash: LEGACY_HEAD,
+    });
+
+    expect(againstRightHead.valid).toBe(true);
+    expect(againstWrongHead.valid).toBe(false);
+  });
+});

--- a/packages/lib/src/audit/__tests__/co-stream-reconciliation.test.ts
+++ b/packages/lib/src/audit/__tests__/co-stream-reconciliation.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit suite for runCoStreamReconciliation (#890 Phase 2, leaf 4).
+ *
+ * The consumer stub wires the pure reconciliation core (co-stream.ts) to
+ * Admin PG store reads: windowed chained rows + an INDEPENDENT read of the
+ * window's latest chained head (ORDER BY chain_seq DESC LIMIT 1). No cron
+ * wiring here — the tamper drill (Phase 6) and the dual-era verifier
+ * (backfill leaf) call it with collector-supplied records.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  runCoStreamReconciliation,
+  type RunCoStreamReconciliationDeps,
+} from '../co-stream-reconciliation';
+import {
+  reconcileCoStream,
+  type CoStreamRecord,
+  type CoStreamStoreRow,
+  type ReconciliationWindow,
+} from '../co-stream';
+
+const WINDOW: ReconciliationWindow = {
+  start: new Date('2026-02-01T00:00:00.000Z'),
+  end: new Date('2026-02-01T01:00:00.000Z'),
+};
+
+const RECORDS: CoStreamRecord[] = [
+  {
+    eventId: 'evt-1',
+    emissionHash: 'h1',
+    eventType: 'auth.login.success',
+    emittedAt: '2026-02-01T00:10:00.000Z',
+  },
+  {
+    eventId: 'evt-2',
+    emissionHash: 'h2',
+    eventType: 'auth.logout',
+    emittedAt: '2026-02-01T00:20:00.000Z',
+  },
+];
+
+const STORE_ROWS: CoStreamStoreRow[] = [
+  {
+    id: 'evt-1',
+    emissionHash: 'h1',
+    eventType: 'auth.login.success',
+    timestamp: new Date('2026-02-01T00:10:00.000Z'),
+    chainSeq: 41,
+    eventHash: 'c41',
+  },
+  {
+    id: 'evt-2',
+    emissionHash: 'h2',
+    eventType: 'auth.logout',
+    timestamp: new Date('2026-02-01T00:20:00.000Z'),
+    chainSeq: 42,
+    eventHash: 'c42',
+  },
+];
+
+interface CapturedSelect {
+  whereArg: unknown;
+  orderByArgs: unknown[] | null;
+  limitArg: number | null;
+}
+
+function createMockAdminDb(queuedResults: unknown[][]) {
+  const selects: CapturedSelect[] = [];
+  let queryIndex = 0;
+
+  const select = vi.fn(() => {
+    const call: CapturedSelect = { whereArg: null, orderByArgs: null, limitArg: null };
+    selects.push(call);
+    const result = queuedResults[queryIndex++] ?? [];
+    const builder = {
+      from: vi.fn(() => builder),
+      where: vi.fn((where: unknown) => {
+        call.whereArg = where;
+        return builder;
+      }),
+      orderBy: vi.fn((...args: unknown[]) => {
+        call.orderByArgs = args;
+        return builder;
+      }),
+      limit: vi.fn((n: number) => {
+        call.limitArg = n;
+        return builder;
+      }),
+      then: (resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) =>
+        Promise.resolve(result).then(resolve, reject),
+    };
+    return builder;
+  });
+
+  const db = { select } as unknown as RunCoStreamReconciliationDeps['db'];
+  return { db, select, selects };
+}
+
+describe('runCoStreamReconciliation', () => {
+  it('reads windowed store rows + the window-latest chained head and returns exactly the pure-core report', async () => {
+    const headRow = { chainSeq: 42, eventHash: 'c42' };
+    const { db, select } = createMockAdminDb([STORE_ROWS, [headRow]]);
+
+    const report = await runCoStreamReconciliation({ records: RECORDS, db, window: WINDOW });
+
+    expect(select).toHaveBeenCalledTimes(2);
+    expect(report).toEqual(reconcileCoStream(RECORDS, STORE_ROWS, WINDOW, headRow));
+    expect(report.verified).toBe(true);
+    expect(report.head.matches).toBe(true);
+  });
+
+  it('the head read is independent: ORDER BY … LIMIT 1, while the row read is unordered and unlimited', async () => {
+    const { db, selects } = createMockAdminDb([STORE_ROWS, [{ chainSeq: 42, eventHash: 'c42' }]]);
+
+    await runCoStreamReconciliation({ records: RECORDS, db, window: WINDOW });
+
+    const [rowsQuery, headQuery] = selects;
+    expect(rowsQuery!.whereArg).not.toBeNull();
+    expect(rowsQuery!.orderByArgs).toBeNull();
+    expect(rowsQuery!.limitArg).toBeNull();
+    expect(headQuery!.whereArg).not.toBeNull();
+    expect(headQuery!.orderByArgs).not.toBeNull();
+    expect(headQuery!.limitArg).toBe(1);
+  });
+
+  it('given no chained rows in the window, passes a null head — the report is unverified', async () => {
+    const { db } = createMockAdminDb([[], []]);
+
+    const report = await runCoStreamReconciliation({ records: RECORDS, db, window: WINDOW });
+
+    expect(report.head.latestChainedHead).toBeNull();
+    expect(report.head.matches).toBe(false);
+    expect(report.verified).toBe(false);
+    expect(report.counts.missing_from_store).toBe(2);
+  });
+
+  it('propagates store read errors to the caller — the drill/verifier owns failure handling', async () => {
+    const failure = new Error('admin pg unreachable');
+    const db = {
+      select: vi.fn(() => ({
+        from: () => ({
+          where: () => Promise.reject(failure),
+        }),
+      })),
+    } as unknown as RunCoStreamReconciliationDeps['db'];
+
+    await expect(runCoStreamReconciliation({ records: [], db, window: WINDOW })).rejects.toBe(failure);
+  });
+});

--- a/packages/lib/src/audit/__tests__/co-stream.test.ts
+++ b/packages/lib/src/audit/__tests__/co-stream.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Pure-core suite for the witness co-stream (#890 Phase 2, leaf 4).
+ *
+ * The co-stream is the second independent witness: at emission time each
+ * event's emission hash also goes to stdout → the log collector —
+ * infrastructure the database credentials cannot touch. Reconciling
+ * co-stream records against the store detects tampering (hash divergence)
+ * AND suppression (an attacker deleting ingest rows before chaining leaves
+ * a co-stream record they cannot recall). Anchors witness the HEAD; the
+ * co-stream witnesses EVERY EVENT.
+ *
+ * Golden vectors pin the record shape; property tests pin
+ * order-independence, window-boundary handling, and empty-set semantics
+ * (empty ≠ verified — same precedent as matchAnchorsAgainstChain).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  CO_STREAM_LOG_MESSAGE,
+  buildCoStreamRecord,
+  reconcileCoStream,
+  type CoStreamRecord,
+  type CoStreamRecordInput,
+  type CoStreamStoreRow,
+  type ChainedHeadRef,
+  type ReconciliationWindow,
+} from '../co-stream';
+
+const WINDOW: ReconciliationWindow = {
+  start: new Date('2026-02-01T00:00:00.000Z'),
+  end: new Date('2026-02-01T01:00:00.000Z'),
+};
+
+function record(overrides: Partial<CoStreamRecord> = {}): CoStreamRecord {
+  return {
+    eventId: 'evt-1',
+    emissionHash: 'hash-1',
+    eventType: 'auth.login.success',
+    emittedAt: '2026-02-01T00:10:00.000Z',
+    ...overrides,
+  };
+}
+
+function storeRow(overrides: Partial<CoStreamStoreRow> = {}): CoStreamStoreRow {
+  return {
+    id: 'evt-1',
+    emissionHash: 'hash-1',
+    eventType: 'auth.login.success',
+    timestamp: new Date('2026-02-01T00:10:00.000Z'),
+    chainSeq: 1,
+    eventHash: 'chain-1',
+    ...overrides,
+  };
+}
+
+const HEAD_1: ChainedHeadRef = { chainSeq: 1, eventHash: 'chain-1' };
+
+describe('buildCoStreamRecord', () => {
+  it('golden vector: pins the exact record shape and serialization bytes', () => {
+    const built = buildCoStreamRecord({
+      eventId: 'nz9x2k4m8p1q3r5t7v0w1y2z',
+      emissionHash: 'a3f5b8c1d4e7f0a2b5c8d1e4f7a0b3c6d9e2f5a8b1c4d7e0f3a6b9c2d5e8f1a4',
+      eventType: 'auth.login.success',
+      emittedAt: new Date('2026-02-01T00:10:00.000Z'),
+    });
+
+    expect(built).toEqual({
+      eventId: 'nz9x2k4m8p1q3r5t7v0w1y2z',
+      emissionHash: 'a3f5b8c1d4e7f0a2b5c8d1e4f7a0b3c6d9e2f5a8b1c4d7e0f3a6b9c2d5e8f1a4',
+      eventType: 'auth.login.success',
+      emittedAt: '2026-02-01T00:10:00.000Z',
+    });
+    expect(JSON.stringify(built)).toBe(
+      '{"eventId":"nz9x2k4m8p1q3r5t7v0w1y2z",'
+      + '"emissionHash":"a3f5b8c1d4e7f0a2b5c8d1e4f7a0b3c6d9e2f5a8b1c4d7e0f3a6b9c2d5e8f1a4",'
+      + '"eventType":"auth.login.success",'
+      + '"emittedAt":"2026-02-01T00:10:00.000Z"}'
+    );
+  });
+
+  it('PII allowlist: extra fields on the input can NEVER leak into the record (explicit pick, not spread)', () => {
+    const hostileInput = {
+      eventId: 'evt-1',
+      emissionHash: 'hash-1',
+      eventType: 'auth.login.success',
+      emittedAt: new Date('2026-02-01T00:10:00.000Z'),
+      // Everything below must be dropped by construction.
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      ipAddress: '10.0.0.5',
+      userAgent: 'UA/1.0',
+      geoLocation: 'US-CA',
+      details: { secret: 'pii' },
+      riskScore: 0.9,
+    } as CoStreamRecordInput;
+
+    const built = buildCoStreamRecord(hostileInput);
+
+    expect(Object.keys(built).sort()).toEqual(['emissionHash', 'emittedAt', 'eventId', 'eventType']);
+    const serialized = JSON.stringify(built);
+    expect(serialized).not.toContain('user-1');
+    expect(serialized).not.toContain('10.0.0.5');
+    expect(serialized).not.toContain('pii');
+  });
+
+  it('exports a stable log-line message constant for collector-side filtering', () => {
+    expect(CO_STREAM_LOG_MESSAGE).toBe('security_audit.costream');
+  });
+});
+
+describe('reconcileCoStream', () => {
+  describe('per-event verdicts', () => {
+    it('given a record present in both sides with equal hashes, should verdict "verified"', () => {
+      const report = reconcileCoStream([record()], [storeRow()], WINDOW, HEAD_1);
+
+      expect(report.results).toEqual([
+        { eventId: 'evt-1', verdict: 'verified', coStreamHash: 'hash-1', storeHash: 'hash-1' },
+      ]);
+      expect(report.counts).toEqual({
+        verified: 1,
+        missing_from_store: 0,
+        missing_from_costream: 0,
+        hash_mismatch: 0,
+      });
+      expect(report.verified).toBe(true);
+    });
+
+    it('given a co-stream record with no store row, should verdict "missing_from_store" (suppression signal)', () => {
+      const report = reconcileCoStream([record()], [], WINDOW, null);
+
+      expect(report.results).toEqual([
+        { eventId: 'evt-1', verdict: 'missing_from_store', coStreamHash: 'hash-1', storeHash: null },
+      ]);
+      expect(report.counts.missing_from_store).toBe(1);
+      expect(report.verified).toBe(false);
+    });
+
+    it('given a store row with no co-stream record, should verdict "missing_from_costream" (collector gap)', () => {
+      const report = reconcileCoStream([], [storeRow()], WINDOW, HEAD_1);
+
+      expect(report.results).toEqual([
+        { eventId: 'evt-1', verdict: 'missing_from_costream', coStreamHash: null, storeHash: 'hash-1' },
+      ]);
+      expect(report.counts.missing_from_costream).toBe(1);
+      expect(report.verified).toBe(false);
+    });
+
+    it('given both sides with differing hashes, should verdict "hash_mismatch" (tamper signal)', () => {
+      const report = reconcileCoStream(
+        [record()],
+        [storeRow({ emissionHash: 'hash-REWRITTEN' })],
+        WINDOW,
+        HEAD_1,
+      );
+
+      expect(report.results).toEqual([
+        { eventId: 'evt-1', verdict: 'hash_mismatch', coStreamHash: 'hash-1', storeHash: 'hash-REWRITTEN' },
+      ]);
+      expect(report.verified).toBe(false);
+    });
+
+    it('given a store row whose stored emission_hash is NULL, should verdict "hash_mismatch" — a witnessed event whose stored fingerprint is gone cannot be confirmed', () => {
+      const report = reconcileCoStream([record()], [storeRow({ emissionHash: null })], WINDOW, HEAD_1);
+
+      expect(report.results[0]!.verdict).toBe('hash_mismatch');
+      expect(report.results[0]!.storeHash).toBeNull();
+      expect(report.verified).toBe(false);
+    });
+
+    it('given duplicate co-stream lines with the SAME hash (at-least-once log delivery), should collapse them to one verdict', () => {
+      const report = reconcileCoStream([record(), record()], [storeRow()], WINDOW, HEAD_1);
+
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.verdict).toBe('verified');
+      expect(report.verified).toBe(true);
+    });
+
+    it('given duplicate co-stream lines that DISAGREE on the hash, should verdict "hash_mismatch" — an inconsistent witness proves nothing', () => {
+      const report = reconcileCoStream(
+        [record(), record({ emissionHash: 'hash-FORGED' })],
+        [storeRow()],
+        WINDOW,
+        HEAD_1,
+      );
+
+      expect(report.results).toHaveLength(1);
+      expect(report.results[0]!.verdict).toBe('hash_mismatch');
+      expect(report.verified).toBe(false);
+    });
+
+    it('results are sorted by eventId ascending regardless of input order', () => {
+      const report = reconcileCoStream(
+        [record({ eventId: 'evt-c' }), record({ eventId: 'evt-a' })],
+        [storeRow({ id: 'evt-b', chainSeq: 2, eventHash: 'chain-2' })],
+        WINDOW,
+        { chainSeq: 2, eventHash: 'chain-2' },
+      );
+
+      expect(report.results.map((r) => r.eventId)).toEqual(['evt-a', 'evt-b', 'evt-c']);
+    });
+  });
+
+  describe('order-independence (property)', () => {
+    it('shuffling both inputs yields the identical report', () => {
+      const records = [
+        record({ eventId: 'evt-1', emissionHash: 'h1' }),
+        record({ eventId: 'evt-2', emissionHash: 'h2' }),
+        record({ eventId: 'evt-3', emissionHash: 'h3-costream' }),
+        record({ eventId: 'evt-5', emissionHash: 'h5' }),
+      ];
+      const rows = [
+        storeRow({ id: 'evt-1', emissionHash: 'h1', chainSeq: 1, eventHash: 'c1' }),
+        storeRow({ id: 'evt-2', emissionHash: 'h2', chainSeq: 2, eventHash: 'c2' }),
+        storeRow({ id: 'evt-3', emissionHash: 'h3-store', chainSeq: 3, eventHash: 'c3' }),
+        storeRow({ id: 'evt-4', emissionHash: 'h4', chainSeq: 4, eventHash: 'c4' }),
+      ];
+      const head: ChainedHeadRef = { chainSeq: 4, eventHash: 'c4' };
+
+      const baseline = reconcileCoStream(records, rows, WINDOW, head);
+      const shuffled = reconcileCoStream(
+        [records[3]!, records[1]!, records[2]!, records[0]!],
+        [rows[2]!, rows[3]!, rows[0]!, rows[1]!],
+        WINDOW,
+        head,
+      );
+
+      expect(shuffled).toEqual(baseline);
+      expect(baseline.counts).toEqual({
+        verified: 2,
+        missing_from_store: 1,
+        missing_from_costream: 1,
+        hash_mismatch: 1,
+      });
+    });
+  });
+
+  describe('window-boundary handling', () => {
+    it('window is [start, end): a record AT start is included, a record AT end is excluded', () => {
+      const atStart = record({ eventId: 'evt-start', emittedAt: WINDOW.start.toISOString() });
+      const atEnd = record({ eventId: 'evt-end', emittedAt: WINDOW.end.toISOString() });
+      const rowAtStart = storeRow({ id: 'evt-start', timestamp: new Date(WINDOW.start) });
+
+      const report = reconcileCoStream([atStart, atEnd], [rowAtStart], WINDOW, HEAD_1);
+
+      expect(report.results.map((r) => r.eventId)).toEqual(['evt-start']);
+    });
+
+    it('out-of-window entries on EITHER side produce no verdicts — no false suppression/gap signals from outside the window', () => {
+      const before = record({ eventId: 'evt-before', emittedAt: '2026-01-31T23:59:59.999Z' });
+      const after = record({ eventId: 'evt-after', emittedAt: '2026-02-01T01:00:00.001Z' });
+      const rowBefore = storeRow({ id: 'row-before', timestamp: new Date('2026-01-31T23:00:00.000Z'), chainSeq: 7, eventHash: 'c7' });
+      const rowAfter = storeRow({ id: 'row-after', timestamp: new Date('2026-02-01T02:00:00.000Z'), chainSeq: 9, eventHash: 'c9' });
+
+      const report = reconcileCoStream([before, after], [rowBefore, rowAfter], WINDOW, null);
+
+      expect(report.results).toEqual([]);
+      expect(report.head.windowStoreHead).toBeNull();
+    });
+
+    it('a co-stream record with an unparseable emittedAt is never silently window-included', () => {
+      const garbled = record({ eventId: 'evt-garbled', emittedAt: 'not-a-date' });
+
+      const report = reconcileCoStream([garbled, record()], [storeRow()], WINDOW, HEAD_1);
+
+      expect(report.results.map((r) => r.eventId)).toEqual(['evt-1']);
+    });
+  });
+
+  describe('head-equality check', () => {
+    it('given the windowed store head equals the independently-read latest chained head, head.matches is true', () => {
+      const rows = [
+        storeRow({ id: 'evt-1', chainSeq: 1, eventHash: 'c1' }),
+        storeRow({ id: 'evt-2', chainSeq: 2, eventHash: 'c2' }),
+      ];
+      const report = reconcileCoStream(
+        [record({ eventId: 'evt-1' }), record({ eventId: 'evt-2' })],
+        rows,
+        WINDOW,
+        { chainSeq: 2, eventHash: 'c2' },
+      );
+
+      expect(report.head).toEqual({
+        windowStoreHead: { chainSeq: 2, eventHash: 'c2' },
+        latestChainedHead: { chainSeq: 2, eventHash: 'c2' },
+        matches: true,
+      });
+      expect(report.verified).toBe(true);
+    });
+
+    it('given the heads disagree (tail rows deleted between reads, or an anchor-supplied head), head.matches is false and the report is unverified even with all events verified', () => {
+      const report = reconcileCoStream(
+        [record()],
+        [storeRow()],
+        WINDOW,
+        { chainSeq: 5, eventHash: 'chain-5' },
+      );
+
+      expect(report.head.matches).toBe(false);
+      expect(report.counts.verified).toBe(1);
+      expect(report.verified).toBe(false);
+    });
+
+    it('given no latest chained head supplied, head.matches is false — an unwitnessed head is never "matched by default"', () => {
+      const report = reconcileCoStream([record()], [storeRow()], WINDOW, null);
+
+      expect(report.head).toEqual({
+        windowStoreHead: { chainSeq: 1, eventHash: 'chain-1' },
+        latestChainedHead: null,
+        matches: false,
+      });
+      expect(report.verified).toBe(false);
+    });
+  });
+
+  describe('empty-set semantics', () => {
+    it('given both sides empty, should report verified=false — empty ≠ verified (leaf-3 precedent)', () => {
+      const report = reconcileCoStream([], [], WINDOW, null);
+
+      expect(report.verified).toBe(false);
+      expect(report.results).toEqual([]);
+      expect(report.counts).toEqual({
+        verified: 0,
+        missing_from_store: 0,
+        missing_from_costream: 0,
+        hash_mismatch: 0,
+      });
+      expect(report.head).toEqual({ windowStoreHead: null, latestChainedHead: null, matches: false });
+    });
+
+    it('given both sides empty but a chained head supplied, still verified=false — zero witnessed events verify nothing', () => {
+      const report = reconcileCoStream([], [], WINDOW, HEAD_1);
+
+      expect(report.verified).toBe(false);
+    });
+  });
+
+  describe('purity', () => {
+    it('does not mutate its inputs', () => {
+      const records = [record({ eventId: 'evt-2' }), record({ eventId: 'evt-1' })];
+      const rows = [storeRow({ id: 'evt-2', chainSeq: 2, eventHash: 'c2' }), storeRow()];
+      const recordsSnapshot = records.map((r) => ({ ...r }));
+      const rowsSnapshot = rows.map((r) => ({ ...r }));
+
+      reconcileCoStream(records, rows, WINDOW, HEAD_1);
+
+      expect(records).toEqual(recordsSnapshot);
+      expect(rows).toEqual(rowsSnapshot);
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/emission-hash.test.ts
+++ b/packages/lib/src/audit/__tests__/emission-hash.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Golden-vector suite for computeEmissionHash (#890 Phase 2, leaf 1).
+ *
+ * The emission hash is the lock-free write path's content fingerprint:
+ * sha256 over stableStringify of the SAME PII-excluded field set as
+ * computeSecurityEventHash, but WITHOUT previousHash — chaining
+ * (chainHash = H(emissionHash, prevHash)) is the single-writer chainer's
+ * job (leaf 2), never the emitter's.
+ *
+ * Pinned literal hex outputs: if this suite ever fails, emission-hash
+ * semantics changed and every ingest row already emitted (plus its
+ * co-streamed stdout record) no longer verifies against a recomputation.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { computeEmissionHash } from '../emission-hash';
+import { computeSecurityEventHash, type AuditEvent } from '../security-audit';
+
+const MINIMAL_HASH = '7b3bd93e3b22380b60bed2ea1dfff9aa72b0281a969a44ab2a8b77db9a8bc1c8';
+const DETAILS_HASH = 'bb51071ec93aa6e42a169d0584c01ba3a210e8ad83546b14bc1215767fee7e55';
+const ALL_FIELDS_HASH = '8b5ae1d30aa91211ac8df78efce42c3700101ee5714516709ec9bf9c2d1697d8';
+const UNICODE_HASH = 'ffc6e82da4dacaf06f8ac4464ddf6e53a1b6e212f29b57fec7eb4d0ba4918d5b';
+
+describe('computeEmissionHash golden vectors (pinned)', () => {
+  it('given a minimal event, should match the pinned hash', () => {
+    const event: AuditEvent = { eventType: 'auth.login.success' };
+
+    const hash = computeEmissionHash(event, new Date('2026-01-25T10:00:00.000Z'));
+
+    expect(hash).toBe(MINIMAL_HASH);
+  });
+
+  it('given an event with a details jsonb payload, should match the pinned hash', () => {
+    const event: AuditEvent = {
+      eventType: 'data.export',
+      resourceType: 'drive',
+      resourceId: 'drive-42',
+      details: { format: 'pdf', pageCount: 12, tags: ['q1', 'report'] },
+      riskScore: 0.2,
+    };
+
+    const hash = computeEmissionHash(event, new Date('2026-01-25T10:00:02.000Z'));
+
+    expect(hash).toBe(DETAILS_HASH);
+  });
+
+  it('given every PII field present, should match the pinned hash AND equal the PII-stripped equivalent (proves PII exclusion)', () => {
+    const timestamp = new Date('2026-01-25T10:00:03.000Z');
+    const withPii: AuditEvent = {
+      eventType: 'security.anomaly.detected',
+      userId: 'user-pii-123',
+      sessionId: 'sess-pii-456',
+      serviceId: 'web',
+      resourceType: 'account',
+      resourceId: 'acct-1',
+      ipAddress: '203.0.113.7',
+      userAgent: 'Mozilla/5.0 (PII-Agent)',
+      geoLocation: 'US-CA',
+      details: { flag: 'impossible_travel' },
+      riskScore: 0.9,
+      anomalyFlags: ['impossible_travel', 'new_device'],
+    };
+    const withoutPii: AuditEvent = {
+      eventType: 'security.anomaly.detected',
+      serviceId: 'web',
+      resourceType: 'account',
+      resourceId: 'acct-1',
+      details: { flag: 'impossible_travel' },
+      riskScore: 0.9,
+      anomalyFlags: ['impossible_travel', 'new_device'],
+    };
+
+    const hashWithPii = computeEmissionHash(withPii, timestamp);
+    const hashWithoutPii = computeEmissionHash(withoutPii, timestamp);
+
+    expect(hashWithPii).toBe(ALL_FIELDS_HASH);
+    expect(hashWithPii).toBe(hashWithoutPii);
+  });
+
+  it('given unicode content and reversed key order, should produce the same pinned hash (stableStringify stress)', () => {
+    const timestamp = new Date('2026-01-25T10:00:04.000Z');
+    const a: AuditEvent = {
+      eventType: 'data.write',
+      resourceType: 'page',
+      resourceId: 'page-ü',
+      details: { title: '日本語テスト', emoji: '🔒', z_last: 1, a_first: 2 },
+    };
+    const b: AuditEvent = {
+      eventType: 'data.write',
+      resourceType: 'page',
+      resourceId: 'page-ü',
+      details: { a_first: 2, z_last: 1, emoji: '🔒', title: '日本語テスト' },
+    };
+
+    const hashA = computeEmissionHash(a, timestamp);
+    const hashB = computeEmissionHash(b, timestamp);
+
+    expect(hashA).toBe(UNICODE_HASH);
+    expect(hashA).toBe(hashB);
+  });
+
+  it('given the same event and timestamp, should NOT equal computeSecurityEventHash under any previousHash (previousHash is excluded by construction)', () => {
+    const event: AuditEvent = { eventType: 'auth.login.success' };
+    const timestamp = new Date('2026-01-25T10:00:00.000Z');
+
+    const emission = computeEmissionHash(event, timestamp);
+
+    // The chain hash varies with previousHash; the emission hash is a pure
+    // content fingerprint and must match neither variant.
+    expect(emission).not.toBe(computeSecurityEventHash(event, 'genesis', timestamp));
+    expect(emission).not.toBe(computeSecurityEventHash(event, MINIMAL_HASH, timestamp));
+  });
+
+  it('given two different timestamps for an otherwise identical event, should produce different hashes (timestamp is content)', () => {
+    const event: AuditEvent = { eventType: 'auth.login.success' };
+
+    const first = computeEmissionHash(event, new Date('2026-01-25T10:00:00.000Z'));
+    const second = computeEmissionHash(event, new Date('2026-01-25T10:00:01.000Z'));
+
+    expect(first).toBe(MINIMAL_HASH);
+    expect(second).not.toBe(first);
+  });
+});

--- a/packages/lib/src/audit/__tests__/full-audit-verification.test.ts
+++ b/packages/lib/src/audit/__tests__/full-audit-verification.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Full audit verification suite (#890 Phase 2, leaf 5).
+ *
+ * The composite verifier consults chain + anchors + co-stream where
+ * configured and degrades EXPLICITLY (skippedReason, never silence)
+ * everywhere else. Anchors are fabricated with the real pure anchor core so
+ * signature verification runs for real; chain verification and co-stream
+ * reconciliation are injected stubs (their own suites prove them).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { state, mockGetAdminDbMode, mockGetAdminDb, mockLoggers } = vi.hoisted(() => {
+  const state = {
+    anchorRows: [] as Array<{
+      version: number;
+      chainSeq: number;
+      headHash: string;
+      anchoredAt: Date;
+      signature: string;
+    }>,
+    chainRows: [] as Array<{ chainSeq: number; eventHash: string }>,
+  };
+  return {
+    state,
+    mockGetAdminDbMode: vi.fn(),
+    mockGetAdminDb: vi.fn(),
+    mockLoggers: {
+      security: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    },
+  };
+});
+
+const { adminDbMock, mainDbMock } = vi.hoisted(() => {
+  // select() dispatch: anchors read is select().from().orderBy().limit();
+  // chain-row read is select().from().where().
+  const adminDbMock = {
+    select: vi.fn(() => ({
+      from: () => ({
+        orderBy: () => ({ limit: async (n: number) => state.anchorRows.slice(0, n) }),
+        where: async () => state.chainRows,
+      }),
+    })),
+  };
+  const mainDbMock = { select: vi.fn() };
+  return { adminDbMock, mainDbMock };
+});
+
+vi.mock('@pagespace/db/admin-db', () => ({
+  getAdminDb: mockGetAdminDb,
+  getAdminDbMode: mockGetAdminDbMode,
+}));
+vi.mock('@pagespace/db/db', () => ({ db: mainDbMock }));
+vi.mock('../../logging/logger-config', () => ({ loggers: mockLoggers }));
+
+import { buildAnchorPayload } from '../anchor';
+import {
+  anchorRowToSignedAnchor,
+  combineAuditVerdicts,
+  runFullAuditVerification,
+  type StoredAnchorRow,
+} from '../full-audit-verification';
+import { resetAuditDbBindingForTests } from '../audit-db-binding';
+import { setChainAlertHandler } from '../security-audit-alerting';
+import type { SecurityChainVerificationResult } from '../security-audit-chain-verifier';
+import type { CoStreamReconciliationReport, CoStreamRecord } from '../co-stream';
+
+const SECRET = 'full-audit-verification-test-secret';
+
+const validChainResult = (): SecurityChainVerificationResult => ({
+  isValid: true,
+  totalEntries: 10,
+  entriesVerified: 10,
+  validEntries: 10,
+  invalidEntries: 0,
+  breakPoint: null,
+  firstEntryId: 'e1',
+  lastEntryId: 'e10',
+  verificationStartedAt: new Date(),
+  verificationCompletedAt: new Date(),
+  durationMs: 1,
+});
+
+const invalidChainResult = (): SecurityChainVerificationResult => ({
+  ...validChainResult(),
+  isValid: false,
+  invalidEntries: 1,
+});
+
+/** Publish-shaped anchor receipt row for a given head. */
+function anchorRow(chainSeq: number, head: string): StoredAnchorRow {
+  const anchor = buildAnchorPayload({
+    head,
+    chainSeq,
+    anchoredAt: new Date('2026-07-10T00:00:00.000Z'),
+    secret: SECRET,
+  });
+  return {
+    version: anchor.version,
+    chainSeq: anchor.chainSeq,
+    headHash: anchor.head,
+    anchoredAt: new Date(anchor.anchoredAt),
+    signature: anchor.signature,
+  };
+}
+
+const verifiedCoStreamReport = (): CoStreamReconciliationReport => ({
+  verified: true,
+  results: [],
+  counts: { verified: 1, missing_from_store: 0, missing_from_costream: 0, hash_mismatch: 0 },
+  head: { matches: true, windowStoreHead: { chainSeq: 1, eventHash: 'h' }, latestChainedHead: { chainSeq: 1, eventHash: 'h' } },
+} as unknown as CoStreamReconciliationReport);
+
+const failedCoStreamReport = (): CoStreamReconciliationReport => ({
+  ...verifiedCoStreamReport(),
+  verified: false,
+} as CoStreamReconciliationReport);
+
+describe('anchorRowToSignedAnchor', () => {
+  it('round-trips a published anchor so its signature still verifies', () => {
+    const row = anchorRow(42, 'a'.repeat(64));
+    const rebuilt = anchorRowToSignedAnchor(row);
+    expect(rebuilt).toMatchObject({
+      version: 1,
+      source: 'pagespace-audit-chain',
+      chainSeq: 42,
+      head: 'a'.repeat(64),
+      anchoredAt: '2026-07-10T00:00:00.000Z',
+    });
+  });
+});
+
+describe('combineAuditVerdicts (pure)', () => {
+  const chainOk = { isValid: true };
+  const chainBad = { isValid: false };
+  const anchorsOff = { configured: false as const, skippedReason: 'off' };
+  const anchorsOk = { configured: true as const, report: { allMatch: true, results: [], counts: { match: 1, hash_mismatch: 0, seq_gap: 0, unverifiable: 0 } } };
+  const anchorsBad = { configured: true as const, report: { ...anchorsOk.report, allMatch: false } };
+  const coOff = { configured: false as const, skippedReason: 'off' };
+  const coOk = { configured: true as const, report: verifiedCoStreamReport() };
+  const coBad = { configured: true as const, report: failedCoStreamReport() };
+
+  it('passes when every configured check passes', () => {
+    expect(combineAuditVerdicts({ chain: chainOk, anchors: anchorsOff, coStream: coOff })).toBe(true);
+    expect(combineAuditVerdicts({ chain: chainOk, anchors: anchorsOk, coStream: coOk })).toBe(true);
+  });
+
+  it('fails on chain failure regardless of the rest', () => {
+    expect(combineAuditVerdicts({ chain: chainBad, anchors: anchorsOk, coStream: coOk })).toBe(false);
+  });
+
+  it('fails on configured-anchor mismatch', () => {
+    expect(combineAuditVerdicts({ chain: chainOk, anchors: anchorsBad, coStream: coOff })).toBe(false);
+  });
+
+  it('fails on configured-co-stream failure', () => {
+    expect(combineAuditVerdicts({ chain: chainOk, anchors: anchorsOff, coStream: coBad })).toBe(false);
+  });
+
+  it('skipped checks never fail the run', () => {
+    expect(combineAuditVerdicts({ chain: chainOk, anchors: anchorsOff, coStream: coOff })).toBe(true);
+  });
+});
+
+describe('runFullAuditVerification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAuditDbBindingForTests();
+    state.anchorRows.length = 0;
+    state.chainRows.length = 0;
+    mockGetAdminDb.mockReturnValue(adminDbMock);
+    mockGetAdminDbMode.mockReturnValue({ mode: 'dedicated', reason: 'set' });
+  });
+
+  afterEach(() => {
+    setChainAlertHandler(null);
+  });
+
+  const anchorEnv = { AUDIT_ANCHOR_ENABLED: 'true', AUDIT_ANCHOR_SECRET: SECRET };
+
+  it('threads the binding db into chain verification and defaults to chain-only when anchors/co-stream are off', async () => {
+    const verifyChain = vi.fn().mockResolvedValue(validChainResult());
+
+    const result = await runFullAuditVerification(
+      { source: 'periodic', chain: { stopOnFirstBreak: true } },
+      { env: {}, verifyChain },
+    );
+
+    expect(verifyChain).toHaveBeenCalledWith('periodic', { stopOnFirstBreak: true }, { db: adminDbMock });
+    expect(result.isValid).toBe(true);
+    expect(result.anchors.configured).toBe(false);
+    expect(result.coStream).toMatchObject({ configured: false });
+    // The skip is reported, never silent.
+    expect(mockLoggers.security.info).toHaveBeenCalledWith(
+      expect.stringContaining('anchor check skipped'),
+      expect.objectContaining({ skippedReason: expect.stringContaining('AUDIT_ANCHOR_ENABLED') }),
+    );
+  });
+
+  it('given enabled anchoring but a missing secret, should skip with an explicit reason', async () => {
+    const result = await runFullAuditVerification(
+      {},
+      { env: { AUDIT_ANCHOR_ENABLED: 'true' }, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+    expect(result.anchors).toMatchObject({
+      configured: false,
+      skippedReason: expect.stringContaining('AUDIT_ANCHOR_SECRET'),
+    });
+  });
+
+  it('given anchoring enabled but no anchors published yet, should skip (not fail) with an explicit reason', async () => {
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+    expect(result.anchors).toMatchObject({
+      configured: false,
+      skippedReason: expect.stringContaining('no anchors'),
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('given anchors that match the chain, should verify clean (chain AND anchors)', async () => {
+    const head5 = 'b'.repeat(64);
+    const head9 = 'c'.repeat(64);
+    state.anchorRows.push(anchorRow(5, head5), anchorRow(9, head9));
+    state.chainRows.push({ chainSeq: 5, eventHash: head5 }, { chainSeq: 9, eventHash: head9 });
+
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+
+    expect(result.anchors).toMatchObject({ configured: true });
+    if (result.anchors.configured) {
+      expect(result.anchors.report.allMatch).toBe(true);
+      expect(result.anchors.report.counts.match).toBe(2);
+    }
+    expect(result.isValid).toBe(true);
+    expect(mockLoggers.security.error).not.toHaveBeenCalled();
+  });
+
+  it('given a chain rewritten under a witnessed head, should fail, log a security error, and fire the anchor_verify alert', async () => {
+    const witnessedHead = 'd'.repeat(64);
+    state.anchorRows.push(anchorRow(7, witnessedHead));
+    state.chainRows.push({ chainSeq: 7, eventHash: 'e'.repeat(64) }); // rewritten
+
+    const handler = vi.fn();
+    setChainAlertHandler(handler);
+
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+
+    expect(result.isValid).toBe(false);
+    if (result.anchors.configured) {
+      expect(result.anchors.report.counts.hash_mismatch).toBe(1);
+    }
+    expect(mockLoggers.security.error).toHaveBeenCalledWith(
+      expect.stringContaining('Anchor-vs-chain verification FAILED'),
+      expect.anything(),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    const alert = handler.mock.calls[0]![0];
+    expect(alert.source).toBe('anchor_verify');
+    expect(alert.result.breakPoint.description).toContain('chain_seq 7');
+  });
+
+  it('given a missing chain row below a witnessed head, should fail with a seq_gap', async () => {
+    state.anchorRows.push(anchorRow(3, 'f'.repeat(64)));
+    // no chain row at seq 3
+
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+
+    expect(result.isValid).toBe(false);
+    if (result.anchors.configured) {
+      expect(result.anchors.report.counts.seq_gap).toBe(1);
+    }
+  });
+
+  it('given a forged anchor signature, should count it unverifiable and fail', async () => {
+    const row = anchorRow(4, 'a'.repeat(64));
+    state.anchorRows.push({ ...row, signature: '0'.repeat(64) });
+    state.chainRows.push({ chainSeq: 4, eventHash: 'a'.repeat(64) });
+
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+
+    expect(result.isValid).toBe(false);
+    if (result.anchors.configured) {
+      expect(result.anchors.report.counts.unverifiable).toBe(1);
+    }
+  });
+
+  it('given co-stream records, should run reconciliation against the binding db and fold the verdict in', async () => {
+    const reconcileCoStream = vi.fn().mockResolvedValue(verifiedCoStreamReport());
+    const window = { start: new Date('2026-07-10T00:00:00Z'), end: new Date('2026-07-10T01:00:00Z') };
+    const records: CoStreamRecord[] = [
+      { eventId: 'e1', emissionHash: 'h', eventType: 'data.read', emittedAt: '2026-07-10T00:30:00.000Z' },
+    ];
+
+    const result = await runFullAuditVerification(
+      { coStream: { records, window } },
+      { env: {}, verifyChain: vi.fn().mockResolvedValue(validChainResult()), reconcileCoStream },
+    );
+
+    expect(reconcileCoStream).toHaveBeenCalledWith({ records, db: adminDbMock, window });
+    expect(result.coStream).toMatchObject({ configured: true });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('given a failed co-stream reconciliation, should fail and log a security error', async () => {
+    const reconcileCoStream = vi.fn().mockResolvedValue(failedCoStreamReport());
+    const window = { start: new Date(0), end: new Date(1) };
+
+    const result = await runFullAuditVerification(
+      { coStream: { records: [], window } },
+      { env: {}, verifyChain: vi.fn().mockResolvedValue(validChainResult()), reconcileCoStream },
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(mockLoggers.security.error).toHaveBeenCalledWith(
+      expect.stringContaining('Co-stream reconciliation FAILED'),
+      expect.anything(),
+    );
+  });
+
+  it('given break-glass, should run the chain check on the MAIN db and skip anchors + co-stream explicitly', async () => {
+    mockGetAdminDbMode.mockReturnValue({ mode: 'break-glass', reason: 'armed' });
+    const verifyChain = vi.fn().mockResolvedValue(validChainResult());
+
+    const result = await runFullAuditVerification(
+      { coStream: { records: [], window: { start: new Date(0), end: new Date(1) } } },
+      { env: anchorEnv, verifyChain },
+    );
+
+    expect(verifyChain).toHaveBeenCalledWith('manual', undefined, { db: mainDbMock });
+    expect(result.anchors).toMatchObject({
+      configured: false,
+      skippedReason: expect.stringContaining('break-glass'),
+    });
+    expect(result.coStream).toMatchObject({
+      configured: false,
+      skippedReason: expect.stringContaining('break-glass'),
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it('given an invalid chain, should fail even when anchors and co-stream are skipped', async () => {
+    const result = await runFullAuditVerification(
+      {},
+      { env: {}, verifyChain: vi.fn().mockResolvedValue(invalidChainResult()) },
+    );
+    expect(result.isValid).toBe(false);
+  });
+});

--- a/packages/lib/src/audit/__tests__/full-audit-verification.test.ts
+++ b/packages/lib/src/audit/__tests__/full-audit-verification.test.ts
@@ -33,11 +33,15 @@ const { state, mockGetAdminDbMode, mockGetAdminDb, mockLoggers } = vi.hoisted(()
 const { adminDbMock, mainDbMock } = vi.hoisted(() => {
   // select() dispatch: anchors read is select().from().orderBy().limit();
   // chain-row read is select().from().where().
+  // select() dispatch: anchors read is select().from().orderBy().limit();
+  // chain-row read is select().from().where(); the zero-receipt chain probe
+  // is select().from().limit().
   const adminDbMock = {
     select: vi.fn(() => ({
       from: () => ({
         orderBy: () => ({ limit: async (n: number) => state.anchorRows.slice(0, n) }),
         where: async () => state.chainRows,
+        limit: async (n: number) => state.chainRows.slice(0, n),
       }),
     })),
   };
@@ -207,7 +211,8 @@ describe('runFullAuditVerification', () => {
     });
   });
 
-  it('given anchoring enabled but no anchors published yet, should skip (not fail) with an explicit reason', async () => {
+  it('given anchoring enabled, zero receipts, and an EMPTY chain, should skip (not fail) with an explicit reason — nothing to witness yet', async () => {
+    // state.chainRows empty → the chain probe sees no rows.
     const result = await runFullAuditVerification(
       {},
       { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
@@ -217,6 +222,35 @@ describe('runFullAuditVerification', () => {
       skippedReason: expect.stringContaining('no anchors'),
     });
     expect(result.isValid).toBe(true);
+  });
+
+  it('given anchoring enabled, zero receipts, but a NON-EMPTY chain, should FAIL and fire the anchor_verify alert (a DB-owner purging receipts must not degrade to "not configured")', async () => {
+    state.chainRows.push({ chainSeq: 1, eventHash: 'a'.repeat(64) });
+    const handler = vi.fn();
+    setChainAlertHandler(handler);
+
+    const result = await runFullAuditVerification(
+      {},
+      { env: anchorEnv, verifyChain: vi.fn().mockResolvedValue(validChainResult()) },
+    );
+
+    expect(result.anchors).toMatchObject({
+      configured: true,
+      failure: 'no_receipts_for_nonempty_chain',
+    });
+    if (result.anchors.configured) {
+      expect(result.anchors.report.allMatch).toBe(false);
+    }
+    expect(result.isValid).toBe(false);
+    expect(mockLoggers.security.error).toHaveBeenCalledWith(
+      expect.stringContaining('zero anchor receipts'),
+      expect.anything(),
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    const alert = handler.mock.calls[0]![0];
+    expect(alert.source).toBe('anchor_verify');
+    expect(alert.result.isValid).toBe(false);
+    expect(alert.result.breakPoint.description).toContain('zero anchor receipts');
   });
 
   it('given anchors that match the chain, should verify clean (chain AND anchors)', async () => {

--- a/packages/lib/src/audit/__tests__/phase0-regression.test.ts
+++ b/packages/lib/src/audit/__tests__/phase0-regression.test.ts
@@ -30,6 +30,15 @@ vi.mock('@pagespace/db/db', () => ({
     },
   },
 }));
+// Phase 2 (leaf 5): default readers resolve the adminDb binding; dedicated
+// mode returns getAdminDb(), pointed at the same default-db mock above.
+vi.mock('@pagespace/db/admin-db', async () => {
+  const { db } = await import('@pagespace/db/db');
+  return {
+    getAdminDbMode: vi.fn(() => ({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' })),
+    getAdminDb: vi.fn(() => db),
+  };
+});
 vi.mock('@pagespace/db/schema/security-audit', () => ({ securityAuditLog: {} }));
 vi.mock('@pagespace/db/operators', () => ({
   desc: vi.fn(),
@@ -346,21 +355,17 @@ describe('3. DI completeness sweep (no singleton fallthrough)', () => {
     expect(result.isValid).toBe(true);
   });
 
-  it('given ADMIN_DATABASE_URL is set, its presence has no effect on any audit reader (readers stay on the injected/default db until Phase 2 wires the adminDb registry)', async () => {
-    const prev = process.env.ADMIN_DATABASE_URL;
-    process.env.ADMIN_DATABASE_URL = 'postgres://not-yet-wired-up/pagespace_admin';
-    try {
-      // No deps injected -> falls back to the (mocked) default db, exactly as
-      // it would with the env var absent. Only the adminDb registry
-      // (@pagespace/db/admin-db) reads this variable, and no audit reader
-      // consults that registry yet, so its presence must be a complete no-op.
-      const result = await verifySecurityAuditChain();
-      expect(result.isValid).toBe(true);
-      expect(result.totalEntries).toBe(0);
-    } finally {
-      if (prev === undefined) delete process.env.ADMIN_DATABASE_URL;
-      else process.env.ADMIN_DATABASE_URL = prev;
-    }
+  it('PHASE 2 CUTOVER (leaf 5): given no injected deps, audit readers resolve the adminDb binding (dedicated → Admin PG client)', async () => {
+    // Phase 0 pinned the opposite ("readers stay on the default db until
+    // Phase 2 wires the adminDb registry"). This session IS that wiring: the
+    // default read path now goes through resolveAuditDbBinding(), whose
+    // dedicated mode returns getAdminDb() — mocked at the top of this file
+    // to the same default-db mock, proving the registry is consulted.
+    const result = await verifySecurityAuditChain();
+    expect(result.isValid).toBe(true);
+    expect(result.totalEntries).toBe(0);
+    const adminDbModule = await import('@pagespace/db/admin-db');
+    expect(vi.mocked(adminDbModule.getAdminDb)).toHaveBeenCalled();
   });
 });
 

--- a/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
@@ -73,6 +73,7 @@ import {
   getChainAlertHandler,
   verifyAndAlert,
   notifyChainAppendVerificationFailure,
+  notifyAnchorPublishFailure,
   startPeriodicVerification,
   stopPeriodicVerification,
   isPeriodicVerificationRunning,
@@ -327,6 +328,46 @@ describe('security-audit-alerting (#544)', () => {
         (call) => (call[0] as ChainVerificationAlert).result.breakPoint?.description,
       );
       expect(new Set(descriptions).size).toBe(3);
+    });
+  });
+
+  describe('notifyAnchorPublishFailure (#890 Phase 2 anchoring — repeated witness-publish failure)', () => {
+    const details = {
+      publisherName: 's3',
+      consecutiveFailures: 3,
+      chainSeq: 128,
+      head: 'head-hash-128',
+      errorMessage: 'bucket gone',
+    };
+
+    it('given no registered handler, should be a silent no-op (processor context)', async () => {
+      await expect(notifyAnchorPublishFailure(details)).resolves.toBeUndefined();
+    });
+
+    it('given a registered handler, should fire an anchor_publish-sourced alert naming publisher, streak, and head', async () => {
+      const handler = vi.fn();
+      setChainAlertHandler(handler);
+
+      await notifyAnchorPublishFailure(details);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const alert: ChainVerificationAlert = handler.mock.calls[0][0];
+      expect(alert.source).toBe('anchor_publish');
+      expect(alert.result.isValid).toBe(false);
+      expect(alert.result.breakPoint?.storedHash).toBe('head-hash-128');
+      expect(alert.result.breakPoint?.description).toContain('s3');
+      expect(alert.result.breakPoint?.description).toContain('3 consecutive');
+      expect(alert.result.breakPoint?.description).toContain('chain_seq 128');
+      expect(alert.result.breakPoint?.description).toContain('bucket gone');
+    });
+
+    it('given a throwing handler, should swallow the error and log it (alerting must never break the chainer)', async () => {
+      setChainAlertHandler(() => {
+        throw new Error('alert transport down');
+      });
+
+      await expect(notifyAnchorPublishFailure(details)).resolves.toBeUndefined();
+      expect(mockLoggers.security.error).toHaveBeenCalled();
     });
   });
 });

--- a/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
@@ -72,6 +72,7 @@ import {
   setChainAlertHandler,
   getChainAlertHandler,
   verifyAndAlert,
+  notifyChainAppendVerificationFailure,
   startPeriodicVerification,
   stopPeriodicVerification,
   isPeriodicVerificationRunning,
@@ -266,6 +267,66 @@ describe('security-audit-alerting (#544)', () => {
       stopPeriodicVerification();
       stopPeriodicVerification();
       expect(isPeriodicVerificationRunning()).toBe(false);
+    });
+  });
+
+  describe('notifyChainAppendVerificationFailure (#890 Phase 2 chainer verify-on-append)', () => {
+    const details = {
+      entryId: 'chained-row-4',
+      breakAtIndex: 4,
+      breakReason: 'hash_mismatch' as const,
+      expectedHash: 'expected-hash',
+      actualHash: 'actual-hash',
+      segmentTotalRows: 12,
+      priorHead: 'prior-head-hash',
+    };
+
+    it('given no registered handler, should be a silent no-op (processor context)', async () => {
+      await expect(notifyChainAppendVerificationFailure(details)).resolves.toBeUndefined();
+    });
+
+    it('given a registered handler, should fire an append-sourced alert with a synthetic result describing the break', async () => {
+      const handler = vi.fn();
+      setChainAlertHandler(handler);
+
+      await notifyChainAppendVerificationFailure(details);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const alert: ChainVerificationAlert = handler.mock.calls[0][0];
+      expect(alert.source).toBe('append');
+      expect(alert.result.isValid).toBe(false);
+      expect(alert.result.totalEntries).toBe(12);
+      expect(alert.result.entriesVerified).toBe(5);
+      expect(alert.result.validEntries).toBe(4);
+      expect(alert.result.invalidEntries).toBe(1);
+      expect(alert.result.breakPoint?.entryId).toBe('chained-row-4');
+      expect(alert.result.breakPoint?.storedHash).toBe('actual-hash');
+      expect(alert.result.breakPoint?.computedHash).toBe('expected-hash');
+      expect(alert.result.breakPoint?.previousHashUsed).toBe('prior-head-hash');
+      expect(alert.result.breakPoint?.description).toContain('verify-on-append');
+    });
+
+    it('given a throwing handler, should swallow the error and log it (alerting must never mask the detection)', async () => {
+      setChainAlertHandler(() => {
+        throw new Error('alert transport down');
+      });
+
+      await expect(notifyChainAppendVerificationFailure(details)).resolves.toBeUndefined();
+      expect(mockLoggers.security.error).toHaveBeenCalled();
+    });
+
+    it('given each break reason, should render a distinct human description', async () => {
+      const handler = vi.fn();
+      setChainAlertHandler(handler);
+
+      for (const breakReason of ['hash_mismatch', 'linkage_break', 'missing_emission_hash'] as const) {
+        await notifyChainAppendVerificationFailure({ ...details, breakReason });
+      }
+
+      const descriptions = handler.mock.calls.map(
+        (call) => (call[0] as ChainVerificationAlert).result.breakPoint?.description,
+      );
+      expect(new Set(descriptions).size).toBe(3);
     });
   });
 });

--- a/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-alerting.test.ts
@@ -47,6 +47,15 @@ vi.mock('@pagespace/db/db', () => ({
     },
   },
 }));
+// Phase 2 (leaf 5): default readers resolve the adminDb binding; dedicated
+// mode returns getAdminDb(), pointed at the same default-db mock above.
+vi.mock('@pagespace/db/admin-db', async () => {
+  const { db } = await import('@pagespace/db/db');
+  return {
+    getAdminDbMode: vi.fn(() => ({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' })),
+    getAdminDb: vi.fn(() => db),
+  };
+});
 vi.mock('@pagespace/db/schema/security-audit', () => ({
   securityAuditLog: {
     id: 'id',

--- a/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
@@ -423,7 +423,7 @@ describe('security-audit-chain-verifier', () => {
         expect(result.breakPoint?.entryId).toBe(entries[1]!.id);
       });
 
-      it('given a tampered event_hash in a chainer-era row, should detect the chain-hash mismatch', async () => {
+      it('given a tampered event_hash in a chainer-era row, should detect the chain-hash mismatch AT the tampered row', async () => {
         const entries = createValidChainerEraChain(3);
         entries[1] = { ...entries[1]!, eventHash: 'a'.repeat(64) };
         mockEntries = entries;
@@ -431,7 +431,7 @@ describe('security-audit-chain-verifier', () => {
         const result = await verifySecurityAuditChain();
 
         expect(result.isValid).toBe(false);
-        expect(result.breakPoint?.entryId).toBeTruthy();
+        expect(result.breakPoint?.entryId).toBe(entries[1]!.id);
       });
 
       it('given a legacy chain continued by a chainer-era segment (the backfill era boundary), should verify clean across the boundary', async () => {

--- a/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   createValidSecurityChain,
   createValidSecurityChainWithEventTypes,
+  createValidChainerEraChain,
   type MockSecurityAuditEntry,
 } from './audit-test-helpers';
 
@@ -63,6 +64,16 @@ vi.mock('@pagespace/db/db', () => ({
     },
   },
 }));
+// Default binding (#890 Phase 2, leaf 5): dedicated mode resolves the Admin
+// PG client — point it at the same mock so default-db expectations exercise
+// the post-cutover default.
+vi.mock('@pagespace/db/admin-db', async () => {
+  const { db } = await import('@pagespace/db/db');
+  return {
+    getAdminDbMode: vi.fn(() => ({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' })),
+    getAdminDb: vi.fn(() => db),
+  };
+});
 vi.mock('@pagespace/db/schema/security-audit', () => ({
   securityAuditLog: {
     id: 'id',
@@ -341,7 +352,7 @@ describe('security-audit-chain-verifier', () => {
         expect(result.totalEntries).toBe(3);
       });
 
-      it('given no injected client, should fall back to the default db (parity with today)', async () => {
+      it('given no injected client, should fall back to the resolved audit binding (Admin PG in dedicated mode)', async () => {
         mockEntries = createValidSecurityChain(2);
 
         const result = await verifySecurityAuditChain();
@@ -350,6 +361,101 @@ describe('security-audit-chain-verifier', () => {
         expect(mockDefaultDb.query.securityAuditLog.findMany).toHaveBeenCalled();
         expect(result.isValid).toBe(true);
         expect(result.entriesVerified).toBe(2);
+      });
+
+      it('PARITY: the same chain verifies to the same verdict via the injected admin client and the default binding', async () => {
+        const entries = createValidSecurityChain(4);
+        mockEntries = entries;
+        const injectedDb = createInjectedDb(entries);
+
+        const viaDefault = await verifySecurityAuditChain();
+        const viaInjected = await verifySecurityAuditChain(
+          {},
+          { db: injectedDb as unknown as VerifySecurityChainDeps['db'] },
+        );
+
+        expect(viaInjected.isValid).toBe(viaDefault.isValid);
+        expect(viaInjected.entriesVerified).toBe(viaDefault.entriesVerified);
+        expect(viaInjected.validEntries).toBe(viaDefault.validEntries);
+        expect(viaInjected.breakPoint).toEqual(viaDefault.breakPoint);
+      });
+    });
+
+    /**
+     * Era-aware verification (#890 Phase 2, leaf 5). Chainer-written rows
+     * carry emission_hash and event_hash = H(emission_hash, previous_hash)
+     * (chain-step semantics) — NOT computeSecurityEventHash. The verifier
+     * must recompute per row era or it false-alarms on every post-cutover
+     * row the moment it binds to the Admin PG.
+     */
+    describe('era-aware verification (chainer-era rows)', () => {
+      it('given a valid chainer-era chain, should verify clean', async () => {
+        mockEntries = createValidChainerEraChain(5);
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(true);
+        expect(result.validEntries).toBe(5);
+        expect(result.invalidEntries).toBe(0);
+        expect(result.breakPoint).toBeNull();
+      });
+
+      it('given tampered payload data in a chainer-era row, should detect the emission mismatch', async () => {
+        const entries = createValidChainerEraChain(4);
+        entries[2] = { ...entries[2]!, details: { seq: 999, injected: true } };
+        mockEntries = entries;
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(false);
+        expect(result.breakPoint?.entryId).toBe(entries[2]!.id);
+        expect(result.breakPoint?.description).toMatch(/[Ee]mission/);
+      });
+
+      it('given a tampered stored emission_hash (payload intact), should still detect it', async () => {
+        const entries = createValidChainerEraChain(3);
+        entries[1] = { ...entries[1]!, emissionHash: 'f'.repeat(64) };
+        mockEntries = entries;
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(false);
+        expect(result.breakPoint?.entryId).toBe(entries[1]!.id);
+      });
+
+      it('given a tampered event_hash in a chainer-era row, should detect the chain-hash mismatch', async () => {
+        const entries = createValidChainerEraChain(3);
+        entries[1] = { ...entries[1]!, eventHash: 'a'.repeat(64) };
+        mockEntries = entries;
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(false);
+        expect(result.breakPoint?.entryId).toBeTruthy();
+      });
+
+      it('given a legacy chain continued by a chainer-era segment (the backfill era boundary), should verify clean across the boundary', async () => {
+        const legacy = createValidSecurityChain(3);
+        const legacyHead = legacy[legacy.length - 1]!.eventHash;
+        const chained = createValidChainerEraChain(3, { previousHash: legacyHead, startIndex: 3 });
+        mockEntries = [...legacy, ...chained];
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(true);
+        expect(result.validEntries).toBe(6);
+        expect(result.breakPoint).toBeNull();
+      });
+
+      it('given a linkage break AT the era boundary, should detect it', async () => {
+        const legacy = createValidSecurityChain(2);
+        const chained = createValidChainerEraChain(2, { previousHash: 'not-the-legacy-head', startIndex: 2 });
+        mockEntries = [...legacy, ...chained];
+
+        const result = await verifySecurityAuditChain();
+
+        expect(result.isValid).toBe(false);
+        expect(result.breakPoint?.entryId).toBe(chained[0]!.id);
       });
     });
   });

--- a/packages/lib/src/audit/__tests__/security-audit-cutover.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-cutover.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Runtime-cutover suite (#890 Phase 2, leaf 5).
+ *
+ * Pins the DEFAULT wiring of the securityAudit singleton after the bind:
+ *
+ *   dedicated   → logEvent routes through the lock-free ingest writer on the
+ *                 Admin PG (ONE insert, no advisory lock, no transaction, no
+ *                 head read) with the co-stream witness line.
+ *   break-glass → the OLD advisory-lock chained append against the main DB,
+ *                 plus loud observability at the bind point: structured
+ *                 security error + real alert (security-audit-alerting
+ *                 channel, source 'break_glass') + a self-recorded security
+ *                 event — each exactly once per process.
+ *   fail        → logEvent REJECTS (never throws synchronously) so the
+ *                 fire-and-forget audit() wrapper degrades to a warn log.
+ *
+ * The 248 audit()/auditRequest() call sites are pinned by asserting the
+ * securityAudit public surface is byte-for-byte the pre-cutover one and that
+ * audit() still never throws.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { state, mockGetAdminDbMode, mockGetAdminDb, mockLoggers } = vi.hoisted(() => {
+  const state = {
+    adminInserts: [] as Array<Record<string, unknown>>,
+    mainInserts: [] as Array<Record<string, unknown>>,
+    mainExecutedSql: [] as Array<{ strings: TemplateStringsArray; values: unknown[] }>,
+    adminInsertError: null as Error | null,
+  };
+  return {
+    state,
+    mockGetAdminDbMode: vi.fn(),
+    mockGetAdminDb: vi.fn(),
+    mockLoggers: {
+      security: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    },
+  };
+});
+
+const { adminDbMock, mainDbMock } = vi.hoisted(() => {
+  const adminDbMock = {
+    insert: vi.fn(() => ({
+      values: (values: Record<string, unknown>) => {
+        if (state.adminInsertError) return Promise.reject(state.adminInsertError);
+        state.adminInserts.push(values);
+        return Promise.resolve(undefined);
+      },
+    })),
+    transaction: vi.fn(),
+    execute: vi.fn(),
+    select: vi.fn(),
+  };
+
+  const mainTx = {
+    execute: (sqlObj: { strings: TemplateStringsArray; values: unknown[] }) => {
+      state.mainExecutedSql.push(sqlObj);
+      return Promise.resolve({ rows: [] });
+    },
+    insert: () => ({
+      values: (values: Record<string, unknown>) => {
+        state.mainInserts.push(values);
+        return Promise.resolve(undefined);
+      },
+    }),
+  };
+  const mainDbMock = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    transaction: vi.fn(async (callback: any) => callback(mainTx)),
+    insert: vi.fn(),
+    execute: vi.fn(),
+    select: vi.fn(),
+  };
+  return { adminDbMock, mainDbMock };
+});
+
+vi.mock('@pagespace/db/admin-db', () => ({
+  getAdminDb: mockGetAdminDb,
+  getAdminDbMode: mockGetAdminDbMode,
+}));
+vi.mock('@pagespace/db/db', () => ({ db: mainDbMock }));
+vi.mock('@pagespace/db/schema/security-audit', () => ({ securityAuditLog: {} }));
+vi.mock('@pagespace/db/admin-schema', () => ({ securityAuditIngest: {} }));
+vi.mock('@pagespace/db/operators', () => ({
+  desc: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  gte: vi.fn(),
+  lte: vi.fn(),
+  eq: vi.fn(),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+}));
+vi.mock('../../logging/logger-config', () => ({ loggers: mockLoggers }));
+
+async function loadFreshModules() {
+  vi.resetModules();
+  const securityAuditModule = await import('../security-audit');
+  const alerting = await import('../security-audit-alerting');
+  const auditLog = await import('../audit-log');
+  return { securityAuditModule, alerting, auditLog };
+}
+
+const lockSqlSeen = () =>
+  state.mainExecutedSql.filter((s) => s.strings.join('').includes('pg_advisory_xact_lock'));
+
+describe('securityAudit default wiring cutover', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.adminInserts.length = 0;
+    state.mainInserts.length = 0;
+    state.mainExecutedSql.length = 0;
+    state.adminInsertError = null;
+    mockGetAdminDb.mockReturnValue(adminDbMock);
+  });
+
+  afterEach(async () => {
+    // Never leak a registered alert handler into another suite.
+    const alerting = await import('../security-audit-alerting');
+    alerting.setChainAlertHandler(null);
+  });
+
+  describe('dedicated mode (Admin PG configured)', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' });
+    });
+
+    it('given logEvent, should perform exactly ONE ingest insert on the Admin PG with the emission hash', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({
+        eventType: 'auth.login.success',
+        userId: 'user-1',
+        ipAddress: '1.2.3.4',
+      });
+
+      expect(state.adminInserts).toHaveLength(1);
+      expect(state.adminInserts[0]).toMatchObject({
+        eventType: 'auth.login.success',
+        userId: 'user-1',
+      });
+      expect(state.adminInserts[0]!.emissionHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(state.adminInserts[0]!.id).toEqual(expect.any(String));
+    });
+
+    it('given logEvent, should be LOCK-FREE on the request path — no advisory lock, no transaction, no head read, main db untouched', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+
+      expect(lockSqlSeen()).toHaveLength(0);
+      expect(adminDbMock.transaction).not.toHaveBeenCalled();
+      expect(adminDbMock.execute).not.toHaveBeenCalled();
+      expect(adminDbMock.select).not.toHaveBeenCalled();
+      expect(mainDbMock.transaction).not.toHaveBeenCalled();
+      expect(mainDbMock.insert).not.toHaveBeenCalled();
+    });
+
+    it('given logEvent, should emit the co-stream witness line after the insert', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+
+      expect(mockLoggers.security.info).toHaveBeenCalledWith(
+        'security_audit.costream',
+        expect.objectContaining({
+          eventType: 'data.write',
+          emissionHash: state.adminInserts[0]!.emissionHash,
+          eventId: state.adminInserts[0]!.id,
+        }),
+      );
+    });
+
+    it('given a convenience wrapper (logAuthSuccess), should route through the same ingest path', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logAuthSuccess('u1', 's1', '9.9.9.9', 'UA');
+
+      expect(state.adminInserts).toHaveLength(1);
+      expect(state.adminInserts[0]).toMatchObject({ eventType: 'auth.login.success', userId: 'u1' });
+      expect(lockSqlSeen()).toHaveLength(0);
+    });
+
+    it('given the ingest insert fails, audit() should stay fire-and-forget (warn log, no throw)', async () => {
+      const { auditLog } = await loadFreshModules();
+      state.adminInsertError = new Error('admin pg down');
+
+      expect(() =>
+        auditLog.audit({ eventType: 'auth.login.failure', ipAddress: '1.1.1.1' }),
+      ).not.toThrow();
+
+      await vi.waitFor(() => {
+        expect(mockLoggers.security.warn).toHaveBeenCalledWith(
+          expect.stringContaining('audit write failed'),
+          expect.objectContaining({ error: expect.any(Error) }),
+        );
+      });
+    });
+
+    it('should keep the securityAudit public surface identical (zero-call-site contract)', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+      expect(Object.keys(securityAuditModule.securityAudit).sort()).toEqual(
+        [
+          'initialize',
+          'isInitialized',
+          'logAccessDenied',
+          'logAnomalyDetected',
+          'logAuthFailure',
+          'logAuthSuccess',
+          'logBruteForceDetected',
+          'logDataAccess',
+          'logEvent',
+          'logLogout',
+          'logRateLimited',
+          'logTokenCreated',
+          'logTokenRevoked',
+          'queryEvents',
+        ].sort(),
+      );
+    });
+  });
+
+  describe('break-glass mode (ADMIN_DB_BREAK_GLASS armed)', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'break-glass', reason: 'flag armed' });
+    });
+
+    it('given logEvent, should use the OLD advisory-lock chained append against the MAIN db', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await vi.waitFor(() => expect(state.mainInserts.length).toBeGreaterThanOrEqual(2));
+
+      // Advisory lock taken for each append (the pre-cutover semantics).
+      expect(lockSqlSeen().length).toBeGreaterThanOrEqual(2);
+      const eventTypes = state.mainInserts.map((v) => v.eventType);
+      expect(eventTypes).toContain('data.read');
+      // The Admin PG is never touched.
+      expect(mockGetAdminDb).not.toHaveBeenCalled();
+      expect(state.adminInserts).toHaveLength(0);
+    });
+
+    it('should self-record ONE break-glass security event in the degraded chain', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+
+      await vi.waitFor(() => {
+        const breakGlassEvents = state.mainInserts.filter(
+          (v) =>
+            v.eventType === 'security.suspicious.activity' &&
+            Array.isArray(v.anomalyFlags) &&
+            (v.anomalyFlags as string[]).includes('admin_db_break_glass'),
+        );
+        expect(breakGlassEvents).toHaveLength(1);
+        expect(breakGlassEvents[0]!.details).toMatchObject({ breakGlass: true, reason: 'flag armed' });
+      });
+    });
+
+    it('should fire a REAL alert through the security-audit-alerting channel (source break_glass), once per process', async () => {
+      const { securityAuditModule, alerting } = await loadFreshModules();
+      const handler = vi.fn();
+      alerting.setChainAlertHandler(handler);
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+
+      await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(1));
+      const alert = handler.mock.calls[0]![0];
+      expect(alert.source).toBe('break_glass');
+      expect(alert.result.isValid).toBe(false);
+      expect(alert.result.breakPoint.description).toContain('ADMIN_DATABASE_URL');
+      expect(alert.result.breakPoint.description).toContain('MAIN application database');
+    });
+
+    it('should log the structured security banner exactly once per process', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+
+      const banners = mockLoggers.security.error.mock.calls.filter(([msg]) =>
+        String(msg).includes('BREAK-GLASS'),
+      );
+      expect(banners).toHaveLength(1);
+      expect(banners[0]![1]).toMatchObject({ reason: 'flag armed' });
+    });
+  });
+
+  describe('fail mode (no Admin PG, flag not armed)', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({
+        mode: 'fail',
+        reason: 'ADMIN_DATABASE_URL is not set. The Admin PG (trust plane) is required.',
+      });
+    });
+
+    it('given logEvent, should REJECT (not throw synchronously) with the actionable reason', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      let promise: Promise<void> | undefined;
+      expect(() => {
+        promise = securityAuditModule.securityAudit.logEvent({ eventType: 'data.read' });
+      }).not.toThrow();
+      await expect(promise).rejects.toThrow(/ADMIN_DATABASE_URL/);
+    });
+
+    it('given audit(), should stay fire-and-forget — the rejection surfaces as a warn log', async () => {
+      const { auditLog } = await loadFreshModules();
+
+      expect(() => auditLog.audit({ eventType: 'data.read', userId: 'u' })).not.toThrow();
+
+      await vi.waitFor(() => {
+        expect(mockLoggers.security.warn).toHaveBeenCalledWith(
+          expect.stringContaining('audit write failed'),
+          expect.objectContaining({ error: expect.any(Error) }),
+        );
+      });
+    });
+
+    it('initialize/isInitialized remain synchronous and safe (no binding resolution)', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+      await expect(securityAuditModule.securityAudit.initialize()).resolves.toBeUndefined();
+      expect(securityAuditModule.securityAudit.isInitialized()).toBe(true);
+    });
+  });
+});

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -56,6 +56,15 @@ vi.mock('@pagespace/db/db', () => ({
     }),
   },
 }));
+// Phase 2 (leaf 5): default readers resolve the adminDb binding; dedicated
+// mode returns getAdminDb(), pointed at the same default-db mock above.
+vi.mock('@pagespace/db/admin-db', async () => {
+  const { db } = await import('@pagespace/db/db');
+  return {
+    getAdminDbMode: vi.fn(() => ({ mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' })),
+    getAdminDb: vi.fn(() => db),
+  };
+});
 vi.mock('@pagespace/db/schema/security-audit', () => ({
   securityAuditLog: {},
 }));

--- a/packages/lib/src/audit/anchor.ts
+++ b/packages/lib/src/audit/anchor.ts
@@ -1,0 +1,210 @@
+/**
+ * External anchoring — the pure core (#890 Phase 2, leaf 3).
+ *
+ * A hash chain whose head lives in the database it protects proves nothing to
+ * anyone who doesn't already trust that database: an attacker who owns the
+ * Admin PG can rewrite from genesis. An ANCHOR is a signed statement
+ * "at chain_seq S the head was H, at time T" published to stores the Admin PG
+ * credentials cannot touch (S3 Object-Lock WORM + the append-only
+ * security_audit_anchors receipt table). After anchoring, tampering requires
+ * compromising app DB + Admin PG + the witness.
+ *
+ * This module is pure — no I/O, no Date.now, no env. The publisher shells
+ * (apps/processor/src/services/anchor-publishers.ts) and the chainer hook do
+ * the clocks and writes. Signature semantics are pinned by literal-hex golden
+ * vectors in __tests__/anchor.test.ts.
+ *
+ * Signing: HMAC-SHA256 over stableStringify of the content fields (sorted
+ * keys, signature excluded) — the same canonicalization the chain hashes use.
+ * Verification recomputes the HMAC over the anchor's OWN content fields
+ * (including its stored version/source, so future versions still verify) and
+ * compares via secureCompare — the repo's hash-then-compare convention, never
+ * raw timingSafeEqual on unhashed values.
+ */
+
+import { createHmac } from 'crypto';
+import { stableStringify } from '../utils/stable-stringify';
+import { secureCompare } from '../auth/secure-compare';
+
+/** Payload format version — bump on any change to the signed field set. */
+export const ANCHOR_VERSION = 1;
+
+/** Fixed source marker so a witness store can index anchors among other objects. */
+export const ANCHOR_SOURCE = 'pagespace-audit-chain';
+
+/** The signed content fields — everything the signature covers. */
+export interface AnchorContent {
+  version: number;
+  source: string;
+  /** chain_seq of the anchored head row. */
+  chainSeq: number;
+  /** event_hash of the anchored head row. */
+  head: string;
+  /** Anchor time as an ISO-8601 string (Date is serialized at build time). */
+  anchoredAt: string;
+}
+
+/** A complete anchor: content plus its HMAC-SHA256 signature (hex). */
+export interface SignedAnchor extends AnchorContent {
+  signature: string;
+}
+
+export interface BuildAnchorPayloadInput {
+  head: string;
+  chainSeq: number;
+  anchoredAt: Date;
+  secret: string;
+}
+
+/**
+ * Canonical bytes of an anchor's CONTENT (signature excluded) — exactly what
+ * the HMAC is computed over. Field values are taken from the anchor itself,
+ * so anchors from other versions re-canonicalize faithfully.
+ */
+export function canonicalAnchorContent(anchor: AnchorContent): string {
+  const content: AnchorContent = {
+    version: anchor.version,
+    source: anchor.source,
+    chainSeq: anchor.chainSeq,
+    head: anchor.head,
+    anchoredAt: anchor.anchoredAt,
+  };
+  return stableStringify(content);
+}
+
+/**
+ * Build a signed anchor for a chain head. Deterministic: same input, same
+ * anchor — the caller supplies the clock.
+ */
+export function buildAnchorPayload(input: BuildAnchorPayloadInput): SignedAnchor {
+  const content: AnchorContent = {
+    version: ANCHOR_VERSION,
+    source: ANCHOR_SOURCE,
+    chainSeq: input.chainSeq,
+    head: input.head,
+    anchoredAt: input.anchoredAt.toISOString(),
+  };
+
+  const signature = createHmac('sha256', input.secret)
+    .update(canonicalAnchorContent(content))
+    .digest('hex');
+
+  return { ...content, signature };
+}
+
+/**
+ * Canonical publish form of a signed anchor (sorted keys, signature
+ * included) — the exact byte body written to the WORM store, so an object
+ * fetched back can be compared byte-for-byte against a recomputation.
+ */
+export function serializeSignedAnchor(anchor: SignedAnchor): string {
+  return stableStringify({ ...anchor });
+}
+
+/**
+ * Verify an anchor's signature: recompute the HMAC over the anchor's own
+ * content fields and hash-compare against the stored signature.
+ */
+export function verifyAnchorSignature(anchor: SignedAnchor, secret: string): boolean {
+  const expected = createHmac('sha256', secret)
+    .update(canonicalAnchorContent(anchor))
+    .digest('hex');
+  return secureCompare(expected, anchor.signature);
+}
+
+/**
+ * Chain-side lookup: event_hash at a given chain_seq, or null/undefined when
+ * the chain has no row at that seq. A Map works for preloaded rows; a
+ * function lets the caller wrap any in-memory index.
+ */
+export type AnchorChainLookup =
+  | ReadonlyMap<number, string>
+  | ((chainSeq: number) => string | null | undefined);
+
+export type AnchorMatchVerdict =
+  /** Chain row exists at the anchored seq and its hash equals the anchored head. */
+  | 'match'
+  /** Chain row exists but its hash differs — the chain was rewritten (tamper signal). */
+  | 'hash_mismatch'
+  /** No chain row at the anchored seq — rows below a witnessed head are missing. */
+  | 'seq_gap'
+  /** The anchor's signature does not verify (forged, corrupted, or rotated key). */
+  | 'unverifiable';
+
+export interface AnchorMatchResult {
+  chainSeq: number;
+  verdict: AnchorMatchVerdict;
+  anchorHead: string;
+  /** Hash found in the chain at that seq; null when absent or not consulted. */
+  chainHead: string | null;
+}
+
+export interface AnchorChainMatchReport {
+  /**
+   * True only when EVERY anchor matched AND at least one anchor exists — an
+   * unwitnessed chain is unverified, never "verified by default". Full
+   * verification requires chain-consistency AND allMatch.
+   */
+  allMatch: boolean;
+  /** One verdict per anchor, sorted by chainSeq ascending. */
+  results: AnchorMatchResult[];
+  counts: Record<AnchorMatchVerdict, number>;
+}
+
+/**
+ * Match a set of anchors against chain rows.
+ *
+ * Per anchor: an invalid signature is 'unverifiable' (the chain is not even
+ * consulted — a statement we cannot authenticate proves nothing either way);
+ * a missing row at the anchored seq is 'seq_gap'; a differing hash is
+ * 'hash_mismatch'; equality is 'match'. The dual-era full verifier (backfill
+ * leaf) combines this report with chain-consistency into its final verdict.
+ */
+export function matchAnchorsAgainstChain(
+  anchors: readonly SignedAnchor[],
+  chain: AnchorChainLookup,
+  secret: string,
+): AnchorChainMatchReport {
+  const lookup = typeof chain === 'function' ? chain : (seq: number) => chain.get(seq);
+
+  const results = anchors
+    .map((anchor): AnchorMatchResult => {
+      if (!verifyAnchorSignature(anchor, secret)) {
+        return {
+          chainSeq: anchor.chainSeq,
+          verdict: 'unverifiable',
+          anchorHead: anchor.head,
+          chainHead: null,
+        };
+      }
+
+      const chainHead = lookup(anchor.chainSeq) ?? null;
+      if (chainHead === null) {
+        return { chainSeq: anchor.chainSeq, verdict: 'seq_gap', anchorHead: anchor.head, chainHead: null };
+      }
+
+      return {
+        chainSeq: anchor.chainSeq,
+        verdict: chainHead === anchor.head ? 'match' : 'hash_mismatch',
+        anchorHead: anchor.head,
+        chainHead,
+      };
+    })
+    .sort((a, b) => a.chainSeq - b.chainSeq);
+
+  const counts: Record<AnchorMatchVerdict, number> = {
+    match: 0,
+    hash_mismatch: 0,
+    seq_gap: 0,
+    unverifiable: 0,
+  };
+  for (const result of results) {
+    counts[result.verdict]++;
+  }
+
+  return {
+    allMatch: results.length > 0 && counts.match === results.length,
+    results,
+    counts,
+  };
+}

--- a/packages/lib/src/audit/audit-db-binding.ts
+++ b/packages/lib/src/audit/audit-db-binding.ts
@@ -1,0 +1,56 @@
+/**
+ * Audit DB binding — the resolved-mode call site for every default audit
+ * read/write path (#890 Phase 2, leaf 5 — runtime cutover).
+ *
+ * One decision, taken lazily once per process:
+ *
+ *   dedicated   → the Admin PG client (trust plane). Writes go through the
+ *                 lock-free ingest writer; reads (queries, chain verifier,
+ *                 cron) hit the admin store.
+ *   break-glass → the MAIN db client, i.e. the pre-cutover legacy path,
+ *                 both writes (advisory-lock chained append) and reads.
+ *                 Deliberately NOT getAdminDb()'s main-pool client: that one
+ *                 is admin-schema-typed and maps emission_hash (admin
+ *                 migration 0005, admin plane only), so its generated
+ *                 SELECTs would 42703 against the main-plane table.
+ *   fail        → throw the actionable reason. A process without a trust
+ *                 plane and without the armed break-glass flag must not
+ *                 write or read audit data as if nothing were wrong.
+ *
+ * Break-glass OBSERVABILITY (security event + alert) is owned by the write
+ * bind point in security-audit.ts — this module only decides and reports.
+ */
+
+import { db as mainDb } from '@pagespace/db/db';
+import { getAdminDb, getAdminDbMode, type AdminDatabase } from '@pagespace/db/admin-db';
+
+export type AuditDbBinding =
+  | { mode: 'dedicated'; reason: string; db: AdminDatabase }
+  | { mode: 'break-glass'; reason: string; db: typeof mainDb };
+
+let cached: AuditDbBinding | null = null;
+
+/**
+ * Resolve (and cache) the audit DB binding for this process.
+ * Throws in fail mode — every call, never caching the failure.
+ */
+export function resolveAuditDbBinding(): AuditDbBinding {
+  if (cached) return cached;
+
+  const decision = getAdminDbMode();
+  switch (decision.mode) {
+    case 'dedicated':
+      cached = { mode: 'dedicated', reason: decision.reason, db: getAdminDb() };
+      return cached;
+    case 'break-glass':
+      cached = { mode: 'break-glass', reason: decision.reason, db: mainDb };
+      return cached;
+    case 'fail':
+      throw new Error(`audit db binding failed: ${decision.reason}`);
+  }
+}
+
+/** Test hook: clear the cached binding so mode changes are re-observed. */
+export function resetAuditDbBindingForTests(): void {
+  cached = null;
+}

--- a/packages/lib/src/audit/audit-ingest-writer.ts
+++ b/packages/lib/src/audit/audit-ingest-writer.ts
@@ -20,9 +20,10 @@
  * a throwing logger never fails the write, and a failed insert is never
  * witnessed.
  *
- * NOT bound to production flow yet: the securityAudit singleton and
- * audit-log.ts stay on the advisory-lock repository until leaf 5 cuts over
- * (same staging precedent as Phase 0's readChainHead).
+ * Bound to production flow since leaf 5: the securityAudit singleton routes
+ * logEvent through this writer whenever the Admin PG resolves 'dedicated'
+ * (security-audit.ts getDefaultAppendPath); break-glass keeps the legacy
+ * advisory-lock repository against the main DB.
  */
 
 import { createId } from '@paralleldrive/cuid2';

--- a/packages/lib/src/audit/audit-ingest-writer.ts
+++ b/packages/lib/src/audit/audit-ingest-writer.ts
@@ -1,0 +1,83 @@
+/**
+ * Audit Ingest Writer — lock-free emission shell (#890 Phase 2, leaf 1).
+ *
+ * Replaces the advisory-lock append path for the request-side write:
+ * encrypt the IP, compute the pure emission hash (emission-hash.ts), and do
+ * ONE INSERT into security_audit_ingest on the Admin PG. No transaction, no
+ * pg_advisory_xact_lock, no chain-head read — chaining (chain_seq +
+ * chainHash) is the single-writer chainer's job (leaf 2).
+ *
+ * Fire-and-forget compatible: errors propagate to the caller; the audit()
+ * wrapper in audit-log.ts already catches. The insert never reads back
+ * (no RETURNING) — admin_app's grant is INSERT-only by design.
+ *
+ * NOT bound to production flow yet: the securityAudit singleton and
+ * audit-log.ts stay on the advisory-lock repository until leaf 5 cuts over
+ * (same staging precedent as Phase 0's readChainHead).
+ */
+
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+import { securityAuditIngest } from '@pagespace/db/admin-schema';
+import { deriveIndexKey } from '../encryption/blind-index';
+import { encryptAuditIp } from '../encryption/audit-ip-crypto';
+import { computeEmissionHash } from './emission-hash';
+import type { AuditEvent } from './security-audit';
+
+/**
+ * Derive the blind-index key from ENCRYPTION_KEY, or null when no usable key
+ * is configured (e.g. dev/test) so audit IPs fall back to plaintext storage.
+ * Mirrors security-audit-repository.ts — the emission path must encrypt
+ * exactly like the append path it replaces.
+ */
+function auditIndexKey(): Buffer | null {
+  const master = process.env.ENCRYPTION_KEY ?? '';
+  return master.length >= 32 ? deriveIndexKey(master) : null;
+}
+
+export interface AuditIngestWriterDeps {
+  db: AdminDatabase;
+}
+
+export interface WriteToIngestOptions {
+  /** Override the event timestamp (default: `new Date()`). Mainly for tests. */
+  now?: Date;
+}
+
+export interface AuditIngestWriter {
+  writeToIngest(event: AuditEvent, opts?: WriteToIngestOptions): Promise<void>;
+}
+
+/**
+ * Build an audit ingest writer backed by the given Admin PG client.
+ */
+export function createAuditIngestWriter({ db }: AuditIngestWriterDeps): AuditIngestWriter {
+  async function writeToIngest(event: AuditEvent, opts: WriteToIngestOptions = {}): Promise<void> {
+    const timestamp = opts.now ?? new Date();
+
+    const emissionHash = computeEmissionHash(event, timestamp);
+
+    // GDPR #965/#969: encrypt the IP at rest + populate its blind index.
+    // ipAddress is excluded from the emission hash, so this is chain-safe.
+    const { ipAddress: storedIp, ipBidx } = await encryptAuditIp(event.ipAddress, auditIndexKey());
+
+    await db.insert(securityAuditIngest).values({
+      eventType: event.eventType,
+      userId: event.userId,
+      sessionId: event.sessionId,
+      serviceId: event.serviceId,
+      resourceType: event.resourceType,
+      resourceId: event.resourceId,
+      ipAddress: storedIp,
+      ipBidx,
+      userAgent: event.userAgent,
+      geoLocation: event.geoLocation,
+      details: event.details,
+      riskScore: event.riskScore,
+      anomalyFlags: event.anomalyFlags,
+      timestamp,
+      emissionHash,
+    });
+  }
+
+  return { writeToIngest };
+}

--- a/packages/lib/src/audit/audit-ingest-writer.ts
+++ b/packages/lib/src/audit/audit-ingest-writer.ts
@@ -9,17 +9,29 @@
  *
  * Fire-and-forget compatible: errors propagate to the caller; the audit()
  * wrapper in audit-log.ts already catches. The insert never reads back
- * (no RETURNING) — admin_app's grant is INSERT-only by design.
+ * (no RETURNING) — admin_app's grant is INSERT-only by design; the row id
+ * is generated HERE (same cuid2 as the schema default) so the witness
+ * co-stream can carry it without a read-back.
+ *
+ * Witness co-stream (leaf 4): after a successful INSERT, ONE structured
+ * security-category log line carries the PII-free witness record
+ * (co-stream.ts) to stdout → the log collector — the second independent
+ * record the database credentials cannot touch. Best-effort by design:
+ * a throwing logger never fails the write, and a failed insert is never
+ * witnessed.
  *
  * NOT bound to production flow yet: the securityAudit singleton and
  * audit-log.ts stay on the advisory-lock repository until leaf 5 cuts over
  * (same staging precedent as Phase 0's readChainHead).
  */
 
+import { createId } from '@paralleldrive/cuid2';
 import type { AdminDatabase } from '@pagespace/db/admin-db';
 import { securityAuditIngest } from '@pagespace/db/admin-schema';
 import { deriveIndexKey } from '../encryption/blind-index';
 import { encryptAuditIp } from '../encryption/audit-ip-crypto';
+import { loggers } from '../logging/logger-config';
+import { buildCoStreamRecord, CO_STREAM_LOG_MESSAGE, type CoStreamRecord } from './co-stream';
 import { computeEmissionHash } from './emission-hash';
 import type { AuditEvent } from './security-audit';
 
@@ -34,8 +46,19 @@ function auditIndexKey(): Buffer | null {
   return master.length >= 32 ? deriveIndexKey(master) : null;
 }
 
+/** The one logger surface the co-stream needs — LogInput-compatible metadata. */
+export interface CoStreamLogger {
+  info(message: string, metadata?: CoStreamRecord): void;
+}
+
 export interface AuditIngestWriterDeps {
   db: AdminDatabase;
+  /**
+   * Structured logger for the witness line. Defaults to the security
+   * category of the shared logger, whose LOG_DESTINATION semantics put the
+   * line on stdout under both 'stdout' (immediate) and 'both' (flushed).
+   */
+  coStreamLogger?: CoStreamLogger;
 }
 
 export interface WriteToIngestOptions {
@@ -50,17 +73,25 @@ export interface AuditIngestWriter {
 /**
  * Build an audit ingest writer backed by the given Admin PG client.
  */
-export function createAuditIngestWriter({ db }: AuditIngestWriterDeps): AuditIngestWriter {
+export function createAuditIngestWriter({
+  db,
+  coStreamLogger = loggers.security,
+}: AuditIngestWriterDeps): AuditIngestWriter {
   async function writeToIngest(event: AuditEvent, opts: WriteToIngestOptions = {}): Promise<void> {
     const timestamp = opts.now ?? new Date();
 
     const emissionHash = computeEmissionHash(event, timestamp);
+
+    // Generated here instead of by the column default: the co-stream record
+    // must carry the row id, and INSERT-only grants forbid a read-back.
+    const eventId = createId();
 
     // GDPR #965/#969: encrypt the IP at rest + populate its blind index.
     // ipAddress is excluded from the emission hash, so this is chain-safe.
     const { ipAddress: storedIp, ipBidx } = await encryptAuditIp(event.ipAddress, auditIndexKey());
 
     await db.insert(securityAuditIngest).values({
+      id: eventId,
       eventType: event.eventType,
       userId: event.userId,
       sessionId: event.sessionId,
@@ -77,6 +108,18 @@ export function createAuditIngestWriter({ db }: AuditIngestWriterDeps): AuditIng
       timestamp,
       emissionHash,
     });
+
+    // Witness co-stream: only after the store accepted the event, and never
+    // able to fail the write — a lost witness line is a collector gap the
+    // reconciliation reports, not a lost audit event.
+    try {
+      coStreamLogger.info(
+        CO_STREAM_LOG_MESSAGE,
+        buildCoStreamRecord({ eventId, emissionHash, eventType: event.eventType, emittedAt: timestamp }),
+      );
+    } catch {
+      // Best-effort witness — log-internal errors are swallowed by design.
+    }
   }
 
   return { writeToIngest };

--- a/packages/lib/src/audit/audit-query.ts
+++ b/packages/lib/src/audit/audit-query.ts
@@ -5,20 +5,23 @@
  * so callers don't need a class instance or initialization ceremony.
  */
 
-import { db as defaultDb } from '@pagespace/db/db';
 import { desc, and, or, gte, lte, eq } from '@pagespace/db/operators';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { SelectSecurityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { QueryEventsOptions } from './security-audit';
 import type { SecurityAuditDatabase } from './security-audit-repository';
+import { resolveAuditDbBinding } from './audit-db-binding';
 import { deriveIndexKey } from '../encryption/blind-index';
 import { auditIpBlindIndex } from '../encryption/audit-ip-crypto';
 import { decryptField } from '../encryption/field-crypto';
 
 export interface AuditQueryDeps {
   /**
-   * Drizzle client to query — the main app db or the Admin PG client
-   * (#890 Phase 2). Defaults to the main app db.
+   * Drizzle client to query — the main app db or the Admin PG client.
+   * Defaults to the resolved audit binding (#890 Phase 2, leaf 5): the
+   * Admin PG when dedicated, the main db under break-glass. Until the
+   * backfill leaf migrates legacy rows, default reads in dedicated mode see
+   * only post-cutover events (transitional dual-location state).
    */
   db?: SecurityAuditDatabase;
 }
@@ -31,7 +34,7 @@ export async function queryAuditEvents(
   options: QueryEventsOptions,
   deps: AuditQueryDeps = {}
 ): Promise<SelectSecurityAuditLog[]> {
-  const db = deps.db ?? defaultDb;
+  const db = deps.db ?? resolveAuditDbBinding().db;
   const conditions = [];
 
   if (options.userId) {

--- a/packages/lib/src/audit/audit-query.ts
+++ b/packages/lib/src/audit/audit-query.ts
@@ -10,13 +10,17 @@ import { desc, and, or, gte, lte, eq } from '@pagespace/db/operators';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { SelectSecurityAuditLog } from '@pagespace/db/schema/security-audit';
 import type { QueryEventsOptions } from './security-audit';
+import type { SecurityAuditDatabase } from './security-audit-repository';
 import { deriveIndexKey } from '../encryption/blind-index';
 import { auditIpBlindIndex } from '../encryption/audit-ip-crypto';
 import { decryptField } from '../encryption/field-crypto';
 
 export interface AuditQueryDeps {
-  /** Drizzle client to query. Defaults to the main app db. */
-  db?: typeof defaultDb;
+  /**
+   * Drizzle client to query — the main app db or the Admin PG client
+   * (#890 Phase 2). Defaults to the main app db.
+   */
+  db?: SecurityAuditDatabase;
 }
 
 /**

--- a/packages/lib/src/audit/chain-step.ts
+++ b/packages/lib/src/audit/chain-step.ts
@@ -1,0 +1,205 @@
+/**
+ * Chain step — the pure core of the single-writer audit chainer
+ * (#890 Phase 2, leaf 2).
+ *
+ * The lock-free write path splits hashing in two:
+ *   - emission: `computeEmissionHash` (emission-hash.ts) — a pure content
+ *     fingerprint computed in-process by the emitter, no head read, no lock.
+ *   - chaining (THIS module): `chainHash = H(emissionHash, prevHash)` —
+ *     sha256 over stableStringify of exactly those two fields, assigned by
+ *     the single chainer worker, so serialization is by construction.
+ *
+ * 'genesis' sentinel: the same sentinel the legacy advisory-lock chain uses
+ * for a first row with no predecessor. After cutover the first chained row
+ * anchors to the LEGACY chain head instead — the backfill leaf owns supplying
+ * that anchor; these functions just take prevHash as an input.
+ *
+ * Everything here is pure — no I/O, no Date.now, no db. The worker shell
+ * (apps/processor/src/workers/audit-chainer-worker.ts) does the reads/writes.
+ * Semantics are pinned by golden vectors in __tests__/chain-step.test.ts.
+ */
+
+import { createHash } from 'crypto';
+import { stableStringify } from '../utils/stable-stringify';
+import type { SecurityEventType } from '@pagespace/db/schema/security-audit';
+
+/**
+ * previousHash sentinel for a chain with no predecessor row. Matches the
+ * legacy advisory-lock repository's sentinel so pre- and post-cutover chains
+ * share one grammar.
+ */
+export const GENESIS_PREVIOUS_HASH = 'genesis';
+
+/**
+ * Compute the SHA-256 chain hash linking one emission to the chain head.
+ *
+ * @param emissionHash - The row's pure content fingerprint (emission-hash.ts)
+ * @param previousChainHash - event_hash of the predecessor row, the legacy
+ *   head at cutover, or GENESIS_PREVIOUS_HASH for an empty chain
+ * @returns Hexadecimal SHA-256 hash string
+ */
+export function computeChainHash(emissionHash: string, previousChainHash: string): string {
+  const payload = {
+    emissionHash,
+    previousHash: previousChainHash,
+  };
+
+  return createHash('sha256').update(stableStringify(payload)).digest('hex');
+}
+
+/**
+ * An ingest-queue row ready for chaining. Structurally matches
+ * SelectSecurityAuditIngest (minus emittedAt, which is drain ordering, not
+ * chained content) so the worker can pass drained rows straight through.
+ */
+export interface ChainableIngestRow {
+  id: string;
+  eventType: SecurityEventType;
+  userId: string | null;
+  sessionId: string | null;
+  serviceId: string | null;
+  resourceType: string | null;
+  resourceId: string | null;
+  ipAddress: string | null;
+  ipBidx: string | null;
+  userAgent: string | null;
+  geoLocation: string | null;
+  details: Record<string, unknown> | null;
+  riskScore: number | null;
+  anomalyFlags: string[] | null;
+  timestamp: Date;
+  emissionHash: string;
+}
+
+/** The chain head: event_hash of the highest chain_seq row (or a sentinel/anchor). */
+export interface ChainHead {
+  prevHash: string;
+}
+
+/**
+ * A fully-chained row ready to INSERT into security_audit_log. chain_seq is
+ * deliberately absent — it is assigned by the table's sequence at insert,
+ * in payload order, under the chainer's single-writer lock.
+ */
+export interface ChainedRowPayload extends ChainableIngestRow {
+  previousHash: string;
+  eventHash: string;
+}
+
+export interface ChainBatchAssignment {
+  chainedRowPayloads: ChainedRowPayload[];
+  newHead: ChainHead;
+}
+
+/**
+ * Assign chain linkage to an ordered batch of drained ingest rows.
+ *
+ * Pure fold: row N's previousHash is row N-1's eventHash (the given head for
+ * row 0), eventHash = computeChainHash(emissionHash, previousHash). Batches
+ * compose: feeding one batch's newHead into the next yields the identical
+ * chain as assigning both in a single batch.
+ */
+export function assignChainBatch(
+  ingestRows: readonly ChainableIngestRow[],
+  head: ChainHead,
+): ChainBatchAssignment {
+  let prevHash = head.prevHash;
+
+  const chainedRowPayloads = ingestRows.map((row) => {
+    const eventHash = computeChainHash(row.emissionHash, prevHash);
+    const payload: ChainedRowPayload = { ...row, previousHash: prevHash, eventHash };
+    prevHash = eventHash;
+    return payload;
+  });
+
+  return { chainedRowPayloads, newHead: { prevHash } };
+}
+
+/**
+ * The chained-row subset verification needs. emissionHash is nullable here
+ * because the STORED column is nullable (NULL marks a legacy-era/backfilled
+ * row) — but rows the chainer just appended must always carry it.
+ */
+export interface AppendedChainRow {
+  id: string;
+  emissionHash: string | null;
+  previousHash: string;
+  eventHash: string;
+}
+
+export type SegmentVerificationResult =
+  | { valid: true; verified: number }
+  | {
+      valid: false;
+      verified: number;
+      breakAtIndex: number;
+      entryId: string;
+      reason: 'missing_emission_hash' | 'linkage_break' | 'hash_mismatch';
+      expectedHash: string | null;
+      actualHash: string | null;
+    };
+
+/**
+ * Re-verify a just-appended segment against the head it was chained from:
+ * recompute every chainHash from the STORED emission_hash and check linkage.
+ *
+ * This is verify-on-append — continuous verification at write time instead of
+ * daily-cron-only. Scope boundary: a fully self-consistent forged segment
+ * passes linkage by construction; catching that requires the externally
+ * anchored head (leaf 3), not this function.
+ *
+ * Rows must be given in chain_seq order. Verifying rows written before the
+ * emission-hash era (NULL emission_hash) is the dual-era full verifier's job
+ * (backfill leaf), not this function's — a NULL here is a hard failure.
+ */
+export function verifyAppendedSegment(
+  chainedRows: readonly AppendedChainRow[],
+  priorHead: ChainHead,
+): SegmentVerificationResult {
+  let prevHash = priorHead.prevHash;
+
+  for (let i = 0; i < chainedRows.length; i++) {
+    const row = chainedRows[i];
+
+    if (row.emissionHash === null) {
+      return {
+        valid: false,
+        verified: i,
+        breakAtIndex: i,
+        entryId: row.id,
+        reason: 'missing_emission_hash',
+        expectedHash: null,
+        actualHash: null,
+      };
+    }
+
+    if (row.previousHash !== prevHash) {
+      return {
+        valid: false,
+        verified: i,
+        breakAtIndex: i,
+        entryId: row.id,
+        reason: 'linkage_break',
+        expectedHash: prevHash,
+        actualHash: row.previousHash,
+      };
+    }
+
+    const recomputed = computeChainHash(row.emissionHash, prevHash);
+    if (recomputed !== row.eventHash) {
+      return {
+        valid: false,
+        verified: i,
+        breakAtIndex: i,
+        entryId: row.id,
+        reason: 'hash_mismatch',
+        expectedHash: recomputed,
+        actualHash: row.eventHash,
+      };
+    }
+
+    prevHash = row.eventHash;
+  }
+
+  return { valid: true, verified: chainedRows.length };
+}

--- a/packages/lib/src/audit/co-stream-reconciliation.ts
+++ b/packages/lib/src/audit/co-stream-reconciliation.ts
@@ -1,0 +1,71 @@
+/**
+ * Co-stream reconciliation consumer — the store-read shell (#890 Phase 2,
+ * leaf 4).
+ *
+ * Wires the pure reconciliation core (co-stream.ts) to Admin PG reads:
+ * chained rows in the window plus an INDEPENDENT second read of the
+ * window's latest chained head (ORDER BY chain_seq DESC LIMIT 1) for the
+ * head-equality check — two reads that disagree mean the row set is stale
+ * or the tail was rewritten between them.
+ *
+ * Deliberately NOT a scheduled job: the tamper drill (Phase 6) and the
+ * dual-era verifier (backfill leaf) call it with collector-supplied
+ * records. Read errors propagate — the caller owns failure handling.
+ */
+
+import { and, desc, gte, lt } from 'drizzle-orm';
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+import { securityAuditLog } from '@pagespace/db/admin-schema';
+import {
+  reconcileCoStream,
+  type CoStreamRecord,
+  type CoStreamReconciliationReport,
+  type CoStreamStoreRow,
+  type ReconciliationWindow,
+} from './co-stream';
+
+export interface RunCoStreamReconciliationDeps {
+  /** Witness records from the log collector (parsed CO_STREAM_LOG_MESSAGE lines). */
+  records: readonly CoStreamRecord[];
+  db: AdminDatabase;
+  window: ReconciliationWindow;
+}
+
+/**
+ * Reconcile collector-supplied co-stream records against the chained store
+ * over a window. Reads only — reader-role credentials suffice.
+ */
+export async function runCoStreamReconciliation({
+  records,
+  db,
+  window,
+}: RunCoStreamReconciliationDeps): Promise<CoStreamReconciliationReport> {
+  const windowFilter = and(
+    gte(securityAuditLog.timestamp, window.start),
+    lt(securityAuditLog.timestamp, window.end),
+  );
+
+  const storeRows: CoStreamStoreRow[] = await db
+    .select({
+      id: securityAuditLog.id,
+      emissionHash: securityAuditLog.emissionHash,
+      eventType: securityAuditLog.eventType,
+      timestamp: securityAuditLog.timestamp,
+      chainSeq: securityAuditLog.chainSeq,
+      eventHash: securityAuditLog.eventHash,
+    })
+    .from(securityAuditLog)
+    .where(windowFilter);
+
+  const [headRow] = await db
+    .select({
+      chainSeq: securityAuditLog.chainSeq,
+      eventHash: securityAuditLog.eventHash,
+    })
+    .from(securityAuditLog)
+    .where(windowFilter)
+    .orderBy(desc(securityAuditLog.chainSeq))
+    .limit(1);
+
+  return reconcileCoStream(records, storeRows, window, headRow ?? null);
+}

--- a/packages/lib/src/audit/co-stream.ts
+++ b/packages/lib/src/audit/co-stream.ts
@@ -1,0 +1,247 @@
+/**
+ * Witness co-stream — the pure core (#890 Phase 2, leaf 4).
+ *
+ * The co-stream is the SECOND independent witness: at emission time each
+ * audit event's emission hash also goes to stdout → the log collector —
+ * infrastructure the database credentials cannot touch. Anchors (anchor.ts)
+ * witness the HEAD; the co-stream witnesses EVERY EVENT. Reconciling
+ * co-stream records against the store detects both tampering (hash
+ * divergence) and suppression (an attacker deleting ingest rows before
+ * chaining leaves a co-stream record they cannot recall).
+ *
+ * The record is PII-free BY CONSTRUCTION: exactly {eventId, emissionHash,
+ * eventType, emittedAt} — no details jsonb, no IPs even encrypted, no
+ * user/session ids. buildCoStreamRecord is an explicit field pick (never a
+ * spread) so nothing beyond the allowlist can ever reach the log line;
+ * __tests__/co-stream.test.ts proves it against a hostile input.
+ *
+ * This module is pure — no I/O, no Date.now, no db. The emission shell is
+ * audit-ingest-writer.ts (one structured-logger line after a successful
+ * ingest INSERT); the store-read shell is co-stream-reconciliation.ts.
+ * Record-shape bytes are pinned by a golden vector.
+ */
+
+import type { SecurityEventType } from '@pagespace/db/schema/security-audit';
+
+/**
+ * Log-line message of every co-stream emission — the collector-side filter
+ * key (grep/Vector match on this string picks the witness stream out of the
+ * security category).
+ */
+export const CO_STREAM_LOG_MESSAGE = 'security_audit.costream';
+
+/**
+ * One witness line: the full allowlist, nothing else. A type alias (not an
+ * interface) so it carries an implicit index signature and satisfies the
+ * structured logger's LogInput metadata parameter.
+ */
+export type CoStreamRecord = {
+  /** Ingest row id (writer-generated cuid2) — the reconciliation join key. */
+  eventId: string;
+  /** Pure content fingerprint (emission-hash.ts) — the tamper check. */
+  emissionHash: string;
+  eventType: SecurityEventType;
+  /** Event timestamp (the emission-hash input) as an ISO-8601 string. */
+  emittedAt: string;
+};
+
+/**
+ * Builder input. Extra properties on a wider object are accepted by TS
+ * structural typing but can never survive into the record — the builder
+ * picks explicitly.
+ */
+export interface CoStreamRecordInput {
+  eventId: string;
+  emissionHash: string;
+  eventType: SecurityEventType;
+  emittedAt: Date;
+}
+
+/**
+ * Build the witness record via an explicit allowlist pick. Deliberately NOT
+ * a spread: a caller passing a whole event row must still yield exactly the
+ * four witness fields.
+ */
+export function buildCoStreamRecord(input: CoStreamRecordInput): CoStreamRecord {
+  return {
+    eventId: input.eventId,
+    emissionHash: input.emissionHash,
+    eventType: input.eventType,
+    emittedAt: input.emittedAt.toISOString(),
+  };
+}
+
+/**
+ * The chained-store row subset reconciliation needs (admin-plane
+ * security_audit_log). emissionHash is nullable because the STORED column
+ * is nullable (NULL = legacy-era row) — but every co-stream-era row must
+ * carry it, so a witnessed event matching a NULL-hash row is a tamper
+ * signal, not a legacy case.
+ */
+export interface CoStreamStoreRow {
+  id: string;
+  emissionHash: string | null;
+  eventType: SecurityEventType;
+  /** Event timestamp — same value the co-stream record's emittedAt carries. */
+  timestamp: Date;
+  chainSeq: number;
+  eventHash: string;
+}
+
+/** Half-open reconciliation window: [start, end). */
+export interface ReconciliationWindow {
+  start: Date;
+  end: Date;
+}
+
+/** A chained head reference: event_hash at a chain_seq. */
+export interface ChainedHeadRef {
+  chainSeq: number;
+  eventHash: string;
+}
+
+export type CoStreamEventVerdict =
+  /** Present in both, hashes equal. */
+  | 'verified'
+  /** Witnessed at emission but absent from the store — suppression signal. */
+  | 'missing_from_store'
+  /** In the store but never witnessed — collector gap. */
+  | 'missing_from_costream'
+  /** Present in both but the hashes diverge (or the stored/witnessed hash is unusable) — tamper signal. */
+  | 'hash_mismatch';
+
+export interface CoStreamEventResult {
+  eventId: string;
+  verdict: CoStreamEventVerdict;
+  /** Witnessed hash; null when absent from the co-stream or self-contradictory. */
+  coStreamHash: string | null;
+  /** Stored hash; null when absent from the store or stored as NULL. */
+  storeHash: string | null;
+}
+
+export interface CoStreamHeadCheck {
+  /** Head derived from the store rows given: max chain_seq in the window. */
+  windowStoreHead: ChainedHeadRef | null;
+  /**
+   * Independently-read head the caller supplies — a separate store query
+   * (co-stream-reconciliation.ts) or a stronger external witness (anchor).
+   */
+  latestChainedHead: ChainedHeadRef | null;
+  /** True only when BOTH heads exist and agree on seq and hash. */
+  matches: boolean;
+}
+
+export interface CoStreamReconciliationReport {
+  /**
+   * True only when ≥1 event reconciled, EVERY verdict is 'verified', and the
+   * head check matches. Empty ≠ verified (matchAnchorsAgainstChain precedent).
+   */
+  verified: boolean;
+  /** One result per eventId, sorted ascending — deterministic regardless of input order. */
+  results: CoStreamEventResult[];
+  counts: Record<CoStreamEventVerdict, number>;
+  head: CoStreamHeadCheck;
+}
+
+const inWindow = (at: number, window: ReconciliationWindow): boolean =>
+  Number.isFinite(at) && at >= window.start.getTime() && at < window.end.getTime();
+
+/**
+ * Reconcile witness records against chained store rows over a window.
+ *
+ * Pure set comparison keyed by eventId — order-independent on both sides.
+ * Entries outside [start, end) on EITHER side are ignored, so a window never
+ * yields false suppression/gap signals for events beyond its edges.
+ * Duplicate co-stream lines (at-least-once log delivery) collapse when they
+ * agree; disagreeing duplicates make that event 'hash_mismatch' — an
+ * inconsistent witness proves nothing.
+ */
+export function reconcileCoStream(
+  coStreamRecords: readonly CoStreamRecord[],
+  storeRows: readonly CoStreamStoreRow[],
+  window: ReconciliationWindow,
+  latestChainedHead: ChainedHeadRef | null,
+): CoStreamReconciliationReport {
+  // Witness side: dedupe by eventId; conflicting hashes poison the entry.
+  const witnessed = new Map<string, { hash: string; conflicted: boolean }>();
+  for (const record of coStreamRecords) {
+    if (!inWindow(Date.parse(record.emittedAt), window)) continue;
+    const existing = witnessed.get(record.eventId);
+    if (!existing) {
+      witnessed.set(record.eventId, { hash: record.emissionHash, conflicted: false });
+    } else if (existing.hash !== record.emissionHash) {
+      existing.conflicted = true;
+    }
+  }
+
+  const stored = new Map<string, CoStreamStoreRow>();
+  for (const row of storeRows) {
+    if (!inWindow(row.timestamp.getTime(), window)) continue;
+    stored.set(row.id, row);
+  }
+
+  const results: CoStreamEventResult[] = [];
+
+  for (const [eventId, witness] of witnessed) {
+    const row = stored.get(eventId);
+    if (!row) {
+      results.push({
+        eventId,
+        verdict: 'missing_from_store',
+        coStreamHash: witness.conflicted ? null : witness.hash,
+        storeHash: null,
+      });
+      continue;
+    }
+    const matched =
+      !witness.conflicted && row.emissionHash !== null && row.emissionHash === witness.hash;
+    results.push({
+      eventId,
+      verdict: matched ? 'verified' : 'hash_mismatch',
+      coStreamHash: witness.conflicted ? null : witness.hash,
+      storeHash: row.emissionHash,
+    });
+  }
+
+  for (const [eventId, row] of stored) {
+    if (witnessed.has(eventId)) continue;
+    results.push({
+      eventId,
+      verdict: 'missing_from_costream',
+      coStreamHash: null,
+      storeHash: row.emissionHash,
+    });
+  }
+
+  results.sort((a, b) => (a.eventId < b.eventId ? -1 : a.eventId > b.eventId ? 1 : 0));
+
+  const counts: Record<CoStreamEventVerdict, number> = {
+    verified: 0,
+    missing_from_store: 0,
+    missing_from_costream: 0,
+    hash_mismatch: 0,
+  };
+  for (const result of results) {
+    counts[result.verdict]++;
+  }
+
+  let windowStoreHead: ChainedHeadRef | null = null;
+  for (const row of stored.values()) {
+    if (windowStoreHead === null || row.chainSeq > windowStoreHead.chainSeq) {
+      windowStoreHead = { chainSeq: row.chainSeq, eventHash: row.eventHash };
+    }
+  }
+
+  const matches =
+    windowStoreHead !== null &&
+    latestChainedHead !== null &&
+    windowStoreHead.chainSeq === latestChainedHead.chainSeq &&
+    windowStoreHead.eventHash === latestChainedHead.eventHash;
+
+  return {
+    verified: results.length > 0 && counts.verified === results.length && matches,
+    results,
+    counts,
+    head: { windowStoreHead, latestChainedHead, matches },
+  };
+}

--- a/packages/lib/src/audit/emission-hash.ts
+++ b/packages/lib/src/audit/emission-hash.ts
@@ -1,0 +1,43 @@
+/**
+ * Emission hash — pure content fingerprint for the lock-free audit write
+ * path (#890 Phase 2, leaf 1).
+ *
+ * Computed in-process at emission time over the SAME PII-excluded field set
+ * as computeSecurityEventHash (security-audit.ts) but WITHOUT previousHash:
+ * chain linkage (chainHash = H(emissionHash, prevHash)) belongs to the
+ * single-writer chainer (leaf 2), so the emitter needs no lock, no head
+ * read, and no transaction — one INSERT into the Admin PG ingest table.
+ *
+ * Excluded: userId, sessionId, ipAddress, userAgent, geoLocation (GDPR
+ * right-to-erasure targets, #541) and previousHash (chain-step input).
+ * Included: eventType, serviceId, resourceType, resourceId, details,
+ *           riskScore, anomalyFlags, timestamp.
+ *
+ * Semantics are pinned by golden vectors in __tests__/emission-hash.test.ts.
+ */
+
+import { createHash } from 'crypto';
+import { stableStringify } from '../utils/stable-stringify';
+import type { AuditEvent } from './security-audit';
+
+/**
+ * Compute the SHA-256 emission hash for a security event.
+ *
+ * @param event - The event data (PII fields are ignored)
+ * @param timestamp - Event timestamp (part of the hashed content)
+ * @returns Hexadecimal SHA-256 hash string
+ */
+export function computeEmissionHash(event: AuditEvent, timestamp: Date): string {
+  const payload = {
+    anomalyFlags: event.anomalyFlags ?? null,
+    details: event.details ?? null,
+    eventType: event.eventType,
+    resourceId: event.resourceId ?? null,
+    resourceType: event.resourceType ?? null,
+    riskScore: event.riskScore ?? null,
+    serviceId: event.serviceId ?? null,
+    timestamp: timestamp.toISOString(),
+  };
+
+  return createHash('sha256').update(stableStringify(payload)).digest('hex');
+}

--- a/packages/lib/src/audit/full-audit-verification.ts
+++ b/packages/lib/src/audit/full-audit-verification.ts
@@ -1,0 +1,278 @@
+/**
+ * Full audit verification — chain + anchors + co-stream (#890 Phase 2,
+ * leaf 5).
+ *
+ * The periodic verifier no longer proves only internal chain consistency:
+ * a chain whose head lives in its own DB proves nothing to an attacker who
+ * owns that DB. Where configured, this composite additionally
+ *   - matches published anchors against the chain (matchAnchorsAgainstChain,
+ *     leaf 3): tamper under a witnessed head becomes visible, and
+ *   - reconciles collector-supplied co-stream records against the store
+ *     (runCoStreamReconciliation, leaf 4): suppression/tamper of stored
+ *     rows against the second independent record.
+ *
+ * Degrades explicitly, never silently: every skipped check carries a
+ * skippedReason in the result, and every failed check logs a security error
+ * and (for anchors) fires the alert channel.
+ *
+ * Anchors and co-stream exist only in the dedicated Admin PG — under
+ * break-glass both checks are skipped (the legacy main-DB chain has neither
+ * surface).
+ */
+
+import { desc, inArray } from 'drizzle-orm';
+import { securityAuditAnchors, securityAuditLog } from '@pagespace/db/admin-schema';
+import { loggers } from '../logging/logger-config';
+import {
+  matchAnchorsAgainstChain,
+  ANCHOR_SOURCE,
+  type AnchorChainMatchReport,
+  type SignedAnchor,
+} from './anchor';
+import {
+  runCoStreamReconciliation,
+  type RunCoStreamReconciliationDeps,
+} from './co-stream-reconciliation';
+import type { CoStreamReconciliationReport, CoStreamRecord, ReconciliationWindow } from './co-stream';
+import { resolveAuditDbBinding, type AuditDbBinding } from './audit-db-binding';
+import {
+  verifyAndAlert,
+  notifyAnchorVerificationFailure,
+} from './security-audit-alerting';
+import type { SecurityChainVerificationResult } from './security-audit-chain-verifier';
+import type { VerifySecurityChainOptions, VerifySecurityChainDeps } from './security-audit-chain-verifier';
+
+/** Row shape of security_audit_anchors as read back for verification. */
+export interface StoredAnchorRow {
+  version: number;
+  chainSeq: number;
+  headHash: string;
+  anchoredAt: Date;
+  signature: string;
+}
+
+/**
+ * Rebuild the SignedAnchor payload from its receipt row. Pure. The
+ * signature covers the anchor's OWN fields (verifyAnchorSignature
+ * recomputes from them), so a faithful column round-trip verifies and any
+ * receipt tamper renders the anchor 'unverifiable'.
+ */
+export function anchorRowToSignedAnchor(row: StoredAnchorRow): SignedAnchor {
+  return {
+    version: row.version,
+    source: ANCHOR_SOURCE,
+    chainSeq: row.chainSeq,
+    head: row.headHash,
+    anchoredAt: row.anchoredAt.toISOString(),
+    signature: row.signature,
+  };
+}
+
+export type AnchorCheckOutcome =
+  | { configured: false; skippedReason: string }
+  | { configured: true; report: AnchorChainMatchReport };
+
+export type CoStreamCheckOutcome =
+  | { configured: false; skippedReason: string }
+  | { configured: true; report: CoStreamReconciliationReport };
+
+export interface FullAuditVerificationResult {
+  chain: SecurityChainVerificationResult;
+  anchors: AnchorCheckOutcome;
+  coStream: CoStreamCheckOutcome;
+  /**
+   * Chain-consistency AND anchor-match AND co-stream reconciliation, each
+   * counted only where configured. A skipped check never fails the run —
+   * but it is reported, never hidden.
+   */
+  isValid: boolean;
+}
+
+/**
+ * Pure verdict combination: every CONFIGURED check must pass.
+ */
+export function combineAuditVerdicts(result: {
+  chain: Pick<SecurityChainVerificationResult, 'isValid'>;
+  anchors: AnchorCheckOutcome;
+  coStream: CoStreamCheckOutcome;
+}): boolean {
+  if (!result.chain.isValid) return false;
+  if (result.anchors.configured && !result.anchors.report.allMatch) return false;
+  if (result.coStream.configured && !result.coStream.report.verified) return false;
+  return true;
+}
+
+export interface AnchorVerificationEnv {
+  AUDIT_ANCHOR_ENABLED?: string | undefined;
+  AUDIT_ANCHOR_SECRET?: string | undefined;
+}
+
+export interface RunFullAuditVerificationOptions {
+  source?: 'periodic' | 'manual';
+  chain?: VerifySecurityChainOptions;
+  /**
+   * Collector-supplied co-stream records + window. Absent → the co-stream
+   * check is skipped (the web cron has no collector reader; the Phase 6
+   * tamper drill and the backfill verifier pass records explicitly).
+   */
+  coStream?: { records: readonly CoStreamRecord[]; window: ReconciliationWindow };
+  /** Most-recent anchors to verify per run (default 25). */
+  anchorLimit?: number;
+}
+
+export interface RunFullAuditVerificationDeps {
+  /** Anchor gating env; defaults to process.env. */
+  env?: AnchorVerificationEnv;
+  /** Chain verification runner; defaults to verifyAndAlert. */
+  verifyChain?: (
+    source: 'periodic' | 'manual',
+    options?: VerifySecurityChainOptions,
+    deps?: VerifySecurityChainDeps
+  ) => Promise<SecurityChainVerificationResult>;
+  /** Co-stream reconciliation runner; defaults to runCoStreamReconciliation. */
+  reconcileCoStream?: (
+    deps: RunCoStreamReconciliationDeps
+  ) => Promise<CoStreamReconciliationReport>;
+}
+
+const DEFAULT_ANCHOR_LIMIT = 25;
+
+async function checkAnchors(
+  binding: AuditDbBinding,
+  env: AnchorVerificationEnv,
+  anchorLimit: number
+): Promise<AnchorCheckOutcome> {
+  if (binding.mode !== 'dedicated') {
+    return {
+      configured: false,
+      skippedReason:
+        'anchor verification requires the dedicated Admin PG — break-glass is active',
+    };
+  }
+  if (env.AUDIT_ANCHOR_ENABLED !== 'true') {
+    return { configured: false, skippedReason: 'anchoring is not enabled (AUDIT_ANCHOR_ENABLED)' };
+  }
+  const secret = env.AUDIT_ANCHOR_SECRET;
+  if (!secret) {
+    return {
+      configured: false,
+      skippedReason:
+        'AUDIT_ANCHOR_ENABLED is true but AUDIT_ANCHOR_SECRET is unset — anchors cannot be verified',
+    };
+  }
+
+  const anchorRows: StoredAnchorRow[] = await binding.db
+    .select({
+      version: securityAuditAnchors.version,
+      chainSeq: securityAuditAnchors.chainSeq,
+      headHash: securityAuditAnchors.headHash,
+      anchoredAt: securityAuditAnchors.anchoredAt,
+      signature: securityAuditAnchors.signature,
+    })
+    .from(securityAuditAnchors)
+    .orderBy(desc(securityAuditAnchors.chainSeq))
+    .limit(anchorLimit);
+
+  if (anchorRows.length === 0) {
+    return {
+      configured: false,
+      skippedReason: 'anchoring is enabled but no anchors have been published yet',
+    };
+  }
+
+  const seqs = anchorRows.map((row) => row.chainSeq);
+  const chainRows = await binding.db
+    .select({ chainSeq: securityAuditLog.chainSeq, eventHash: securityAuditLog.eventHash })
+    .from(securityAuditLog)
+    .where(inArray(securityAuditLog.chainSeq, seqs));
+
+  const chainBySeq = new Map<number, string>(
+    chainRows.map((row) => [Number(row.chainSeq), row.eventHash]),
+  );
+
+  const report = matchAnchorsAgainstChain(
+    anchorRows.map(anchorRowToSignedAnchor),
+    chainBySeq,
+    secret,
+  );
+  return { configured: true, report };
+}
+
+/**
+ * Run the composite verification against the resolved audit binding.
+ * Chain-verification alerts flow through verifyAndAlert exactly as before;
+ * anchor failures additionally fire the 'anchor_verify' alert; co-stream
+ * failures log a security error (their consumers own deeper handling).
+ */
+export async function runFullAuditVerification(
+  options: RunFullAuditVerificationOptions = {},
+  deps: RunFullAuditVerificationDeps = {}
+): Promise<FullAuditVerificationResult> {
+  const binding = resolveAuditDbBinding();
+  const env: AnchorVerificationEnv = deps.env ?? {
+    AUDIT_ANCHOR_ENABLED: process.env.AUDIT_ANCHOR_ENABLED,
+    AUDIT_ANCHOR_SECRET: process.env.AUDIT_ANCHOR_SECRET,
+  };
+  const verifyChain = deps.verifyChain ?? verifyAndAlert;
+  const reconcile = deps.reconcileCoStream ?? runCoStreamReconciliation;
+
+  const chain = await verifyChain(options.source ?? 'manual', options.chain, { db: binding.db });
+
+  const anchors = await checkAnchors(binding, env, options.anchorLimit ?? DEFAULT_ANCHOR_LIMIT);
+  if (anchors.configured && !anchors.report.allMatch) {
+    const firstBad = anchors.report.results.find((r) => r.verdict !== 'match');
+    loggers.security.error(
+      '[FullAuditVerification] Anchor-vs-chain verification FAILED — the chain disagrees with its external witness',
+      { counts: anchors.report.counts, firstFailure: firstBad },
+    );
+    if (firstBad) {
+      await notifyAnchorVerificationFailure({
+        anchorsChecked: anchors.report.results.length,
+        hashMismatches: anchors.report.counts.hash_mismatch,
+        seqGaps: anchors.report.counts.seq_gap,
+        unverifiable: anchors.report.counts.unverifiable,
+        firstFailure: {
+          chainSeq: firstBad.chainSeq,
+          verdict: firstBad.verdict as 'hash_mismatch' | 'seq_gap' | 'unverifiable',
+          anchorHead: firstBad.anchorHead,
+          chainHead: firstBad.chainHead,
+        },
+      });
+    }
+  } else if (!anchors.configured) {
+    loggers.security.info('[FullAuditVerification] anchor check skipped', {
+      skippedReason: anchors.skippedReason,
+    });
+  }
+
+  let coStream: CoStreamCheckOutcome;
+  if (!options.coStream) {
+    coStream = { configured: false, skippedReason: 'no collector co-stream records supplied' };
+  } else if (binding.mode !== 'dedicated') {
+    coStream = {
+      configured: false,
+      skippedReason:
+        'co-stream reconciliation requires the dedicated Admin PG — break-glass is active',
+    };
+  } else {
+    const report = await reconcile({
+      records: options.coStream.records,
+      db: binding.db,
+      window: options.coStream.window,
+    });
+    coStream = { configured: true, report };
+    if (!report.verified) {
+      loggers.security.error(
+        '[FullAuditVerification] Co-stream reconciliation FAILED — store and witness stream disagree',
+        { counts: report.counts, head: report.head },
+      );
+    }
+  }
+
+  return {
+    chain,
+    anchors,
+    coStream,
+    isValid: combineAuditVerdicts({ chain, anchors, coStream }),
+  };
+}

--- a/packages/lib/src/audit/full-audit-verification.ts
+++ b/packages/lib/src/audit/full-audit-verification.ts
@@ -38,6 +38,7 @@ import { resolveAuditDbBinding, type AuditDbBinding } from './audit-db-binding';
 import {
   verifyAndAlert,
   notifyAnchorVerificationFailure,
+  notifyAnchorReceiptsMissing,
 } from './security-audit-alerting';
 import type { SecurityChainVerificationResult } from './security-audit-chain-verifier';
 import type { VerifySecurityChainOptions, VerifySecurityChainDeps } from './security-audit-chain-verifier';
@@ -70,7 +71,18 @@ export function anchorRowToSignedAnchor(row: StoredAnchorRow): SignedAnchor {
 
 export type AnchorCheckOutcome =
   | { configured: false; skippedReason: string }
-  | { configured: true; report: AnchorChainMatchReport };
+  | {
+      configured: true;
+      report: AnchorChainMatchReport;
+      /**
+       * Set when anchoring is enabled and the chain is non-empty but ZERO
+       * receipts exist (#890 Phase 2 FIX): the report is then the empty
+       * match (allMatch=false), and this marker names why. Under the
+       * threat model a receipt purge must fail verification, never degrade
+       * to "not configured".
+       */
+      failure?: 'no_receipts_for_nonempty_chain';
+    };
 
 export type CoStreamCheckOutcome =
   | { configured: false; skippedReason: string }
@@ -174,9 +186,25 @@ async function checkAnchors(
     .limit(anchorLimit);
 
   if (anchorRows.length === 0) {
+    // Zero receipts is benign ONLY while the chain itself is empty (fresh
+    // install, first anchor not due yet). With chain rows present it is a
+    // verification FAILURE: either the chainer never witnessed anything, or
+    // the receipts were purged — a DB-owning attacker's first move.
+    const chainProbe = await binding.db
+      .select({ chainSeq: securityAuditLog.chainSeq })
+      .from(securityAuditLog)
+      .limit(1);
+    if (chainProbe.length === 0) {
+      return {
+        configured: false,
+        skippedReason:
+          'anchoring is enabled but no anchors have been published yet (chain is empty — nothing to witness)',
+      };
+    }
     return {
-      configured: false,
-      skippedReason: 'anchoring is enabled but no anchors have been published yet',
+      configured: true,
+      failure: 'no_receipts_for_nonempty_chain',
+      report: matchAnchorsAgainstChain([], new Map(), secret),
     };
   }
 
@@ -219,7 +247,13 @@ export async function runFullAuditVerification(
   const chain = await verifyChain(options.source ?? 'manual', options.chain, { db: binding.db });
 
   const anchors = await checkAnchors(binding, env, options.anchorLimit ?? DEFAULT_ANCHOR_LIMIT);
-  if (anchors.configured && !anchors.report.allMatch) {
+  if (anchors.configured && anchors.failure === 'no_receipts_for_nonempty_chain') {
+    loggers.security.error(
+      '[FullAuditVerification] Anchor verification FAILED — anchoring is enabled and the chain is non-empty, but zero anchor receipts exist (never witnessed, or the receipt table was purged)',
+      { failure: anchors.failure },
+    );
+    await notifyAnchorReceiptsMissing({ chainRowsSeen: 1 });
+  } else if (anchors.configured && !anchors.report.allMatch) {
     const firstBad = anchors.report.results.find((r) => r.verdict !== 'match');
     loggers.security.error(
       '[FullAuditVerification] Anchor-vs-chain verification FAILED — the chain disagrees with its external witness',

--- a/packages/lib/src/audit/security-audit-alerting.ts
+++ b/packages/lib/src/audit/security-audit-alerting.ts
@@ -29,7 +29,7 @@ import {
 export interface ChainVerificationAlert {
   result: SecurityChainVerificationResult;
   triggeredAt: Date;
-  source: 'periodic' | 'manual' | 'preflight';
+  source: 'periodic' | 'manual' | 'preflight' | 'append';
 }
 
 /**
@@ -174,6 +174,85 @@ export async function notifyChainPreflightFailure(
     await alertHandler(alert);
   } catch (error) {
     loggers.security.error('[SecurityAuditAlerting] Preflight alert handler failed:', { error });
+  }
+}
+
+/**
+ * Details of a verify-on-append failure caught by the audit chainer worker
+ * (#890 Phase 2). Shapes mirror PreflightChainBreakDetails, but the source is
+ * the just-appended security_audit_log segment re-read after commit, not a
+ * SIEM delivery batch — reasons come from verifyAppendedSegment (chain-step.ts).
+ */
+export interface AppendVerificationFailureDetails {
+  /** id of the chained row at which verification broke. */
+  entryId: string;
+  /** 0-based index inside the just-appended segment. */
+  breakAtIndex: number;
+  /** Classification from verifyAppendedSegment. */
+  breakReason: 'hash_mismatch' | 'linkage_break' | 'missing_emission_hash';
+  expectedHash: string | null;
+  actualHash: string | null;
+  /** Total rows in the appended segment. */
+  segmentTotalRows: number;
+  /** The chain head the segment was chained from (for forensics). */
+  priorHead: string;
+}
+
+/**
+ * Fire a verify-on-append failure alert through the globally-registered
+ * handler. Called by the audit chainer worker when its post-commit
+ * re-verification of a just-written segment fails — the loud path beside the
+ * worker's own console.error. Same contract as notifyChainPreflightFailure:
+ * no registered handler → no-op; handler errors are swallowed with a logged
+ * error so a broken alert surface never masks the detection itself.
+ */
+export async function notifyChainAppendVerificationFailure(
+  details: AppendVerificationFailureDetails
+): Promise<void> {
+  if (!alertHandler) return;
+
+  const now = new Date();
+  const reasonMessage =
+    details.breakReason === 'hash_mismatch'
+      ? 'Recomputed chain hash does not match the stored event_hash'
+      : details.breakReason === 'linkage_break'
+        ? 'previous_hash does not link to the preceding row'
+        : 'Chainer-written row has no stored emission_hash';
+
+  const syntheticResult: SecurityChainVerificationResult = {
+    isValid: false,
+    totalEntries: details.segmentTotalRows,
+    entriesVerified: details.breakAtIndex + 1,
+    validEntries: details.breakAtIndex,
+    invalidEntries: 1,
+    breakPoint: {
+      entryId: details.entryId,
+      timestamp: now,
+      position: details.breakAtIndex,
+      storedHash: details.actualHash ?? '',
+      computedHash: details.expectedHash ?? '',
+      previousHashUsed: details.priorHead,
+      description: `Chainer verify-on-append break at segment[${details.breakAtIndex}] (${details.entryId}): ${reasonMessage}`,
+    },
+    firstEntryId: null,
+    lastEntryId: details.entryId,
+    verificationStartedAt: now,
+    verificationCompletedAt: now,
+    durationMs: 0,
+  };
+
+  const alert: ChainVerificationAlert = {
+    result: syntheticResult,
+    triggeredAt: now,
+    source: 'append',
+  };
+
+  try {
+    await alertHandler(alert);
+  } catch (error) {
+    loggers.security.error('[SecurityAuditAlerting] Append verification alert handler failed:', {
+      error,
+    });
   }
 }
 

--- a/packages/lib/src/audit/security-audit-alerting.ts
+++ b/packages/lib/src/audit/security-audit-alerting.ts
@@ -415,6 +415,70 @@ export async function notifyAnchorVerificationFailure(
 }
 
 /**
+ * Details of a zero-receipt anchor verification failure (#890 Phase 2 FIX).
+ * Fired by the full audit verifier when anchoring is enabled and the chain
+ * is non-empty but NO anchor receipts exist: under the epic's threat model
+ * (attacker owns the audit DB) a purge of the receipt table must read as a
+ * failed verification, never as "anchoring not configured yet".
+ */
+export interface AnchorReceiptsMissingDetails {
+  /** How many chain rows exist while zero receipts do (probe count, ≥1). */
+  chainRowsSeen: number;
+}
+
+/**
+ * Fire a zero-receipt anchor-verification failure alert through the
+ * globally-registered handler. Same contract as the other notify helpers:
+ * no handler → no-op; handler errors are swallowed with a logged error.
+ */
+export async function notifyAnchorReceiptsMissing(
+  details: AnchorReceiptsMissingDetails
+): Promise<void> {
+  if (!alertHandler) return;
+
+  const now = new Date();
+  const syntheticResult: SecurityChainVerificationResult = {
+    isValid: false,
+    totalEntries: 0,
+    entriesVerified: 0,
+    validEntries: 0,
+    invalidEntries: 0,
+    breakPoint: {
+      entryId: 'anchor-receipts-missing',
+      timestamp: now,
+      position: 0,
+      storedHash: '',
+      computedHash: '',
+      previousHashUsed: '',
+      description:
+        `Anchor verification FAILED: anchoring is enabled and the chain is non-empty (≥${details.chainRowsSeen} row(s) seen), ` +
+        'but zero anchor receipts exist. Either the chainer has never published a witness (check its logs and the ' +
+        'AUDIT_ANCHOR_* env), or the receipt table was purged — which is exactly what a DB-owning attacker rewriting ' +
+        'the chain would do first. Verify against the S3 WORM witness before trusting this chain.',
+    },
+    firstEntryId: null,
+    lastEntryId: null,
+    verificationStartedAt: now,
+    verificationCompletedAt: now,
+    durationMs: 0,
+  };
+
+  const alert: ChainVerificationAlert = {
+    result: syntheticResult,
+    triggeredAt: now,
+    source: 'anchor_verify',
+  };
+
+  try {
+    await alertHandler(alert);
+  } catch (error) {
+    loggers.security.error('[SecurityAuditAlerting] Anchor receipts-missing alert handler failed:', {
+      error,
+    });
+  }
+}
+
+/**
  * Details of an active Admin-DB break-glass degrade (#890 Phase 2, leaf 5).
  * Fired ONCE per process by the audit write bind point when the resolved
  * mode is 'break-glass': audit writes are going to the MAIN application

--- a/packages/lib/src/audit/security-audit-alerting.ts
+++ b/packages/lib/src/audit/security-audit-alerting.ts
@@ -29,7 +29,14 @@ import {
 export interface ChainVerificationAlert {
   result: SecurityChainVerificationResult;
   triggeredAt: Date;
-  source: 'periodic' | 'manual' | 'preflight' | 'append' | 'anchor_publish';
+  source:
+    | 'periodic'
+    | 'manual'
+    | 'preflight'
+    | 'append'
+    | 'anchor_publish'
+    | 'anchor_verify'
+    | 'break_glass';
 }
 
 /**
@@ -325,6 +332,147 @@ export async function notifyAnchorPublishFailure(
     await alertHandler(alert);
   } catch (error) {
     loggers.security.error('[SecurityAuditAlerting] Anchor publish alert handler failed:', {
+      error,
+    });
+  }
+}
+
+/**
+ * Details of a failed anchor-vs-chain verification (#890 Phase 2, leaf 5).
+ * Fired by the full audit verifier when matchAnchorsAgainstChain reports
+ * anything but a clean match: a hash_mismatch means the chain was rewritten
+ * under a witnessed head — the exact tamper class chain-consistency alone
+ * cannot see; a seq_gap means rows below a witnessed head are missing; an
+ * unverifiable anchor means the witness statement itself cannot be trusted.
+ */
+export interface AnchorVerificationFailureDetails {
+  anchorsChecked: number;
+  hashMismatches: number;
+  seqGaps: number;
+  unverifiable: number;
+  /** The lowest-seq failing anchor, for forensics. */
+  firstFailure: {
+    chainSeq: number;
+    verdict: 'hash_mismatch' | 'seq_gap' | 'unverifiable';
+    anchorHead: string;
+    chainHead: string | null;
+  };
+}
+
+/**
+ * Fire an anchor-verification failure alert through the globally-registered
+ * handler. Same contract as the other notify helpers: no handler → no-op;
+ * handler errors are swallowed with a logged error.
+ */
+export async function notifyAnchorVerificationFailure(
+  details: AnchorVerificationFailureDetails
+): Promise<void> {
+  if (!alertHandler) return;
+
+  const now = new Date();
+  const syntheticResult: SecurityChainVerificationResult = {
+    isValid: false,
+    totalEntries: details.anchorsChecked,
+    entriesVerified: details.anchorsChecked,
+    validEntries:
+      details.anchorsChecked -
+      (details.hashMismatches + details.seqGaps + details.unverifiable),
+    invalidEntries: details.hashMismatches + details.seqGaps + details.unverifiable,
+    breakPoint: {
+      entryId: `anchor-${details.firstFailure.chainSeq}`,
+      timestamp: now,
+      position: 0,
+      storedHash: details.firstFailure.chainHead ?? '',
+      computedHash: details.firstFailure.anchorHead,
+      previousHashUsed: '',
+      description:
+        `Anchor verification FAILED: ${details.hashMismatches} hash mismatch(es), ${details.seqGaps} seq gap(s), ` +
+        `${details.unverifiable} unverifiable of ${details.anchorsChecked} anchors checked. ` +
+        `First failure at chain_seq ${details.firstFailure.chainSeq} (${details.firstFailure.verdict}): ` +
+        `witnessed head ${details.firstFailure.anchorHead}, chain has ${details.firstFailure.chainHead ?? 'no row'}. ` +
+        'A mismatch under a witnessed head means the chain was rewritten after anchoring.',
+    },
+    firstEntryId: null,
+    lastEntryId: null,
+    verificationStartedAt: now,
+    verificationCompletedAt: now,
+    durationMs: 0,
+  };
+
+  const alert: ChainVerificationAlert = {
+    result: syntheticResult,
+    triggeredAt: now,
+    source: 'anchor_verify',
+  };
+
+  try {
+    await alertHandler(alert);
+  } catch (error) {
+    loggers.security.error('[SecurityAuditAlerting] Anchor verification alert handler failed:', {
+      error,
+    });
+  }
+}
+
+/**
+ * Details of an active Admin-DB break-glass degrade (#890 Phase 2, leaf 5).
+ * Fired ONCE per process by the audit write bind point when the resolved
+ * mode is 'break-glass': audit writes are going to the MAIN application
+ * database — an emergency rollback state, never a supported steady state.
+ */
+export interface AdminDbBreakGlassDetails {
+  /** The mode-decision reason from resolveAdminDbMode. */
+  reason: string;
+}
+
+/**
+ * Fire an Admin-DB break-glass alert through the globally-registered handler.
+ * Same contract as the other notify helpers: no handler → no-op; handler
+ * errors are swallowed with a logged error so a broken alert surface never
+ * breaks the (already degraded) audit path. The console banner and the
+ * self-recorded security event fire regardless — this is the third,
+ * externally-routable channel.
+ */
+export async function notifyAdminDbBreakGlass(
+  details: AdminDbBreakGlassDetails
+): Promise<void> {
+  if (!alertHandler) return;
+
+  const now = new Date();
+  const syntheticResult: SecurityChainVerificationResult = {
+    isValid: false,
+    totalEntries: 0,
+    entriesVerified: 0,
+    validEntries: 0,
+    invalidEntries: 0,
+    breakPoint: {
+      entryId: 'admin-db-break-glass',
+      timestamp: now,
+      position: 0,
+      storedHash: '',
+      computedHash: '',
+      previousHashUsed: '',
+      description:
+        `Admin DB break-glass is ACTIVE: audit writes are degraded to the MAIN application database (${details.reason}). ` +
+        'Provision the Admin PG, set ADMIN_DATABASE_URL, and disarm ADMIN_DB_BREAK_GLASS.',
+    },
+    firstEntryId: null,
+    lastEntryId: null,
+    verificationStartedAt: now,
+    verificationCompletedAt: now,
+    durationMs: 0,
+  };
+
+  const alert: ChainVerificationAlert = {
+    result: syntheticResult,
+    triggeredAt: now,
+    source: 'break_glass',
+  };
+
+  try {
+    await alertHandler(alert);
+  } catch (error) {
+    loggers.security.error('[SecurityAuditAlerting] Break-glass alert handler failed:', {
       error,
     });
   }

--- a/packages/lib/src/audit/security-audit-alerting.ts
+++ b/packages/lib/src/audit/security-audit-alerting.ts
@@ -29,7 +29,7 @@ import {
 export interface ChainVerificationAlert {
   result: SecurityChainVerificationResult;
   triggeredAt: Date;
-  source: 'periodic' | 'manual' | 'preflight' | 'append';
+  source: 'periodic' | 'manual' | 'preflight' | 'append' | 'anchor_publish';
 }
 
 /**
@@ -251,6 +251,80 @@ export async function notifyChainAppendVerificationFailure(
     await alertHandler(alert);
   } catch (error) {
     loggers.security.error('[SecurityAuditAlerting] Append verification alert handler failed:', {
+      error,
+    });
+  }
+}
+
+/**
+ * Details of a repeated anchor-publish failure (#890 Phase 2, leaf 3). Fired
+ * by the chainer's anchor hook when a witness surface (S3 Object-Lock or the
+ * receipt table) keeps rejecting publishes — chaining itself is unaffected
+ * (publish failure never blocks it), but a chain running unwitnessed for long
+ * is exactly the window a tamper needs, so operators must hear about it.
+ */
+export interface AnchorPublishFailureDetails {
+  /** Which publisher kept failing ('s3' | 'receipt'). */
+  publisherName: string;
+  /** Length of the current consecutive-failure streak for that publisher. */
+  consecutiveFailures: number;
+  /** chain_seq of the head that could not be anchored. */
+  chainSeq: number;
+  /** event_hash of the head that could not be anchored. */
+  head: string;
+  /** Message of the most recent publish error. */
+  errorMessage: string;
+}
+
+/**
+ * Fire a repeated anchor-publish failure alert through the globally-registered
+ * handler. Same contract as the other notify helpers: no handler → no-op;
+ * handler errors are swallowed with a logged error so a broken alert surface
+ * never breaks the chainer.
+ *
+ * The synthetic result reuses the chain-verification alert shape (the one
+ * registered handler surface): isValid=false marks "the trust plane needs
+ * attention", and the breakPoint description carries the anchor specifics —
+ * handlers distinguish via source='anchor_publish'.
+ */
+export async function notifyAnchorPublishFailure(
+  details: AnchorPublishFailureDetails
+): Promise<void> {
+  if (!alertHandler) return;
+
+  const now = new Date();
+  const syntheticResult: SecurityChainVerificationResult = {
+    isValid: false,
+    totalEntries: 0,
+    entriesVerified: 0,
+    validEntries: 0,
+    invalidEntries: 0,
+    breakPoint: {
+      entryId: `anchor-${details.chainSeq}`,
+      timestamp: now,
+      position: 0,
+      storedHash: details.head,
+      computedHash: '',
+      previousHashUsed: '',
+      description: `Anchor publish to '${details.publisherName}' failed ${details.consecutiveFailures} consecutive times for head at chain_seq ${details.chainSeq}: ${details.errorMessage}. The chain is appending unwitnessed.`,
+    },
+    firstEntryId: null,
+    lastEntryId: null,
+    verificationStartedAt: now,
+    verificationCompletedAt: now,
+    durationMs: 0,
+  };
+
+  const alert: ChainVerificationAlert = {
+    result: syntheticResult,
+    triggeredAt: now,
+    source: 'anchor_publish',
+  };
+
+  try {
+    await alertHandler(alert);
+  } catch (error) {
+    loggers.security.error('[SecurityAuditAlerting] Anchor publish alert handler failed:', {
       error,
     });
   }

--- a/packages/lib/src/audit/security-audit-chain-verifier.ts
+++ b/packages/lib/src/audit/security-audit-chain-verifier.ts
@@ -11,13 +11,15 @@
  * - 'genesis' as the chain start (no chainSeed concept)
  */
 
-import { db as defaultDb } from '@pagespace/db/db';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import { asc, count, and, gte, lte, type SQL } from 'drizzle-orm';
 import { loggers } from '../logging/logger-config';
 import { computeSecurityEventHash, type AuditEvent } from './security-audit';
+import { computeEmissionHash } from './emission-hash';
+import { computeChainHash } from './chain-step';
 import type { AdminDatabase } from '@pagespace/db/admin-db';
 import type { SecurityAuditDatabase } from './security-audit-repository';
+import { resolveAuditDbBinding } from './audit-db-binding';
 
 export interface SecurityChainBreakPoint {
   entryId: string;
@@ -53,8 +55,11 @@ export interface VerifySecurityChainOptions {
 
 export interface VerifySecurityChainDeps {
   /**
-   * Drizzle client to read from — the main app db or the Admin PG client
-   * (#890 Phase 2). Defaults to the main app db.
+   * Drizzle client to read from — the main app db or the Admin PG client.
+   * Defaults to the resolved audit binding (#890 Phase 2, leaf 5): the
+   * Admin PG when dedicated, the main db under break-glass. Until the
+   * backfill leaf migrates legacy rows, the default in dedicated mode
+   * verifies only the post-cutover chain.
    */
   db?: SecurityAuditDatabase;
 }
@@ -79,6 +84,75 @@ interface StoredSecurityEntry {
   timestamp: Date;
   previousHash: string;
   eventHash: string;
+  /**
+   * Chainer-era rows (#890 Phase 2) carry the emission hash; legacy rows
+   * read as null (admin plane) or undefined (main plane, no such column).
+   */
+  emissionHash?: string | null;
+}
+
+export interface StoredEntryHashCheck {
+  hashValid: boolean;
+  /** The event hash this entry SHOULD carry — reported on break points. */
+  computedHash: string;
+  /** Human description of the mismatch; null when valid. */
+  reason: string | null;
+}
+
+/**
+ * Era-aware per-row hash verification (#890 Phase 2, leaf 5). Pure.
+ *
+ * Chainer-era rows (emission_hash present) are verified with chain-step
+ * semantics: the emission hash is RECOMPUTED from the stored payload
+ * (payload tamper detection), compared to the stored emission_hash (witness
+ * column tamper detection), and event_hash must equal
+ * H(emission_hash, previous_hash). Legacy rows (no emission_hash) keep the
+ * original computeSecurityEventHash check. Chain LINKAGE (previousHash vs
+ * the prior row's eventHash) is era-independent and stays with the caller.
+ */
+export function verifyStoredEntryHash(entry: StoredSecurityEntry): StoredEntryHashCheck {
+  // Reconstruct the hashed event from stored fields (PII excluded per #541)
+  const event: AuditEvent = {
+    eventType: entry.eventType as AuditEvent['eventType'],
+    serviceId: entry.serviceId ?? undefined,
+    resourceType: entry.resourceType ?? undefined,
+    resourceId: entry.resourceId ?? undefined,
+    details: entry.details ?? undefined,
+    riskScore: entry.riskScore ?? undefined,
+    anomalyFlags: entry.anomalyFlags ?? undefined,
+  };
+
+  if (entry.emissionHash !== null && entry.emissionHash !== undefined) {
+    const recomputedEmission = computeEmissionHash(event, entry.timestamp);
+    const expectedEventHash = computeChainHash(recomputedEmission, entry.previousHash);
+
+    if (recomputedEmission !== entry.emissionHash) {
+      return {
+        hashValid: false,
+        computedHash: expectedEventHash,
+        reason:
+          'Emission hash mismatch - entry data or the stored emission_hash may have been modified',
+      };
+    }
+    if (expectedEventHash !== entry.eventHash) {
+      return {
+        hashValid: false,
+        computedHash: expectedEventHash,
+        reason:
+          'Chain hash mismatch - event_hash does not equal H(emission_hash, previous_hash)',
+      };
+    }
+    return { hashValid: true, computedHash: expectedEventHash, reason: null };
+  }
+
+  const computedHash = computeSecurityEventHash(event, entry.previousHash, entry.timestamp);
+  return computedHash === entry.eventHash
+    ? { hashValid: true, computedHash, reason: null }
+    : {
+        hashValid: false,
+        computedHash,
+        reason: 'Hash mismatch - entry data may have been modified',
+      };
 }
 
 /**
@@ -99,7 +173,7 @@ export async function verifySecurityAuditChain(
     stopOnFirstBreak = true,
     batchSize = 1000,
   } = options;
-  const db = deps.db ?? defaultDb;
+  const db = deps.db ?? resolveAuditDbBinding().db;
 
   const verificationStartedAt = new Date();
   let totalEntries = 0;
@@ -179,26 +253,11 @@ export async function verifySecurityAuditChain(
         }
         lastEntryId = entry.id;
 
-        // Reconstruct AuditEvent from stored fields (PII excluded from hash per #541)
-        const event: AuditEvent = {
-          eventType: entry.eventType as AuditEvent['eventType'],
-          serviceId: entry.serviceId ?? undefined,
-          resourceType: entry.resourceType ?? undefined,
-          resourceId: entry.resourceId ?? undefined,
-          details: entry.details ?? undefined,
-          riskScore: entry.riskScore ?? undefined,
-          anomalyFlags: entry.anomalyFlags ?? undefined,
-        };
-
-        // Recompute hash
-        const computedHash = computeSecurityEventHash(
-          event,
-          entry.previousHash,
-          entry.timestamp
-        );
-
-        // Check hash validity
-        const hashValid = computedHash === entry.eventHash;
+        // Era-aware hash check: chain-step semantics for chainer-era rows,
+        // computeSecurityEventHash for legacy rows (#890 Phase 2, leaf 5).
+        const hashCheck = verifyStoredEntryHash(entry);
+        const computedHash = hashCheck.computedHash;
+        const hashValid = hashCheck.hashValid;
 
         // Check chain-link validity (previousHash should match prior entry's eventHash)
         const chainLinkValid = previousEntryHash === null
@@ -214,7 +273,7 @@ export async function verifySecurityAuditChain(
 
           if (!breakPoint) {
             const reason = !hashValid
-              ? 'Hash mismatch - entry data may have been modified'
+              ? hashCheck.reason ?? 'Hash mismatch - entry data may have been modified'
               : 'Chain link broken - previousHash does not match prior entry eventHash';
 
             breakPoint = {

--- a/packages/lib/src/audit/security-audit-chain-verifier.ts
+++ b/packages/lib/src/audit/security-audit-chain-verifier.ts
@@ -16,6 +16,8 @@ import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import { asc, count, and, gte, lte, type SQL } from 'drizzle-orm';
 import { loggers } from '../logging/logger-config';
 import { computeSecurityEventHash, type AuditEvent } from './security-audit';
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+import type { SecurityAuditDatabase } from './security-audit-repository';
 
 export interface SecurityChainBreakPoint {
   entryId: string;
@@ -50,8 +52,11 @@ export interface VerifySecurityChainOptions {
 }
 
 export interface VerifySecurityChainDeps {
-  /** Drizzle client to read from. Defaults to the main app db. */
-  db?: typeof defaultDb;
+  /**
+   * Drizzle client to read from — the main app db or the Admin PG client
+   * (#890 Phase 2). Defaults to the main app db.
+   */
+  db?: SecurityAuditDatabase;
 }
 
 /**
@@ -152,7 +157,12 @@ export async function verifySecurityAuditChain(
 
       if (currentBatchSize <= 0) break;
 
-      const entries = await db.query.securityAuditLog.findMany({
+      // Both union members expose query.securityAuditLog over the same table,
+      // but their .d.ts signatures don't unify into a callable union when lib
+      // builds against packages/db/dist. Narrow to the AdminDatabase view —
+      // the least capable of the two (no relations) — which cannot widen what
+      // this call can do.
+      const entries = await (db as AdminDatabase).query.securityAuditLog.findMany({
         where: conditions.length > 0 ? and(...conditions) : undefined,
         orderBy: [asc(securityAuditLog.chainSeq)],
         offset,

--- a/packages/lib/src/audit/security-audit-repository.ts
+++ b/packages/lib/src/audit/security-audit-repository.ts
@@ -10,6 +10,7 @@
  */
 
 import type { db as defaultDb } from '@pagespace/db/db';
+import type { AdminDatabase } from '@pagespace/db/admin-db';
 import { sql } from '@pagespace/db/operators';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
 import { deriveIndexKey } from '../encryption/blind-index';
@@ -32,7 +33,15 @@ function auditIndexKey(): Buffer | null {
   return master.length >= 32 ? deriveIndexKey(master) : null;
 }
 
-type ChainHeadExecutor = Pick<typeof defaultDb, 'execute'>;
+/**
+ * Any Drizzle client the audit seams may bind to: the main app db (Phase 0
+ * behavior, unchanged) or the Admin PG trust-plane client (#890 Phase 2).
+ * A union — not a widening to a structural `any`-alike — so both sides keep
+ * their full schema type safety.
+ */
+export type SecurityAuditDatabase = typeof defaultDb | AdminDatabase;
+
+type ChainHeadExecutor = Pick<SecurityAuditDatabase, 'execute'>;
 
 async function fetchChainHead(executor: ChainHeadExecutor): Promise<string> {
   const lastRecord = await executor.execute(sql`
@@ -46,7 +55,7 @@ async function fetchChainHead(executor: ChainHeadExecutor): Promise<string> {
 }
 
 export interface SecurityAuditRepositoryDeps {
-  db: typeof defaultDb;
+  db: SecurityAuditDatabase;
 }
 
 export interface AppendEventOptions {

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -10,17 +10,25 @@
  * - Convenience methods for common events
  * - Query interface for forensic analysis
  *
- * Concurrency: logEvent() uses pg_advisory_xact_lock to serialize
- * hash chain writes. The previous hash is always read from the database
- * inside the advisory lock, so multi-instance deployments are safe.
+ * Concurrency (#890 Phase 2, leaf 5 cutover): with a dedicated Admin PG,
+ * logEvent() is LOCK-FREE — pure emission hash + one INSERT into the ingest
+ * queue; the single-writer chainer assigns chain_seq/chainHash out of band.
+ * Under break-glass only, the legacy pg_advisory_xact_lock append against
+ * the main DB remains, with the previous hash read inside the lock.
  */
 
 import { createHash } from 'crypto';
-import { db } from '@pagespace/db/db';
 import type { SecurityEventType, SelectSecurityAuditLog } from '@pagespace/db/schema/security-audit';
 import { queryAuditEvents } from './audit-query';
 import { stableStringify } from '../utils/stable-stringify';
-import { createSecurityAuditRepository, type SecurityAuditRepository } from './security-audit-repository';
+import {
+  createSecurityAuditRepository,
+  type AppendEventOptions,
+} from './security-audit-repository';
+import { createAuditIngestWriter } from './audit-ingest-writer';
+import { resolveAuditDbBinding, type AuditDbBinding } from './audit-db-binding';
+import { notifyAdminDbBreakGlass } from './security-audit-alerting';
+import { loggers } from '../logging/logger-config';
 
 /**
  * Audit event input structure
@@ -100,8 +108,18 @@ export function computeSecurityEventHash(
  */
 export { SECURITY_AUDIT_CHAIN_LOCK_KEY as CHAIN_LOCK_KEY } from './security-audit-repository';
 
+/**
+ * The one write capability the service needs. Satisfied by BOTH append
+ * backends of the cutover (#890 Phase 2, leaf 5): the legacy advisory-lock
+ * repository (SecurityAuditRepository) and the lock-free ingest writer
+ * adapter built in getDefaultAppendPath().
+ */
+export interface AuditAppendPath {
+  appendEvent(event: AuditEvent, opts?: AppendEventOptions): Promise<void>;
+}
+
 export interface SecurityAuditServiceDeps {
-  repository: SecurityAuditRepository;
+  repository: AuditAppendPath;
 }
 
 export interface SecurityAuditService {
@@ -320,24 +338,102 @@ export function createSecurityAuditService({ repository }: SecurityAuditServiceD
 }
 
 /**
- * Lazily build the default repository instance. Deferred (rather than built
- * eagerly at module load) so module load order between security-audit.ts
- * and security-audit-repository.ts never matters.
+ * Break-glass append path (#890 Phase 2, leaf 5 + folded break-glass
+ * observability task): the OLD advisory-lock chained append against the
+ * main DB, made LOUD at the moment it is chosen. Emitted exactly once per
+ * process, at the resolved-mode call site:
+ *   1. a structured security-category error (the log-plane banner),
+ *   2. a real alert through the security-audit-alerting channel,
+ *   3. a self-recorded security event in the (degraded) chain itself, so
+ *      the degrade is visible in forensic queries and SIEM deliveries.
+ * The event goes through the repository directly — not audit() — so the
+ * emission can never recurse into this bind point.
  */
-let defaultRepository: SecurityAuditRepository | null = null;
-function getDefaultRepository(): SecurityAuditRepository {
-  if (!defaultRepository) {
-    defaultRepository = createSecurityAuditRepository({ db });
-  }
-  return defaultRepository;
+function buildBreakGlassAppendPath(binding: Extract<AuditDbBinding, { mode: 'break-glass' }>): AuditAppendPath {
+  const repository = createSecurityAuditRepository({ db: binding.db });
+
+  loggers.security.error(
+    '[SecurityAudit] ADMIN DB BREAK-GLASS ACTIVE — audit writes are degraded to the main application database',
+    { reason: binding.reason },
+  );
+
+  void notifyAdminDbBreakGlass({ reason: binding.reason });
+
+  repository
+    .appendEvent({
+      eventType: 'security.suspicious.activity',
+      serviceId: 'security-audit',
+      resourceType: 'trust_plane',
+      resourceId: 'admin_db',
+      riskScore: 0.9,
+      anomalyFlags: ['admin_db_break_glass'],
+      details: { breakGlass: true, reason: binding.reason },
+    })
+    .catch((error: unknown) => {
+      loggers.security.error('[SecurityAudit] failed to record the break-glass security event', {
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    });
+
+  return repository;
 }
+
+/**
+ * Lazily resolve the default append path (#890 Phase 2, leaf 5 cutover).
+ * Deferred (rather than built eagerly at module load) so module load order
+ * never matters and env is read after late-loaded dotenv.
+ *
+ *   dedicated   → lock-free ingest writer on the Admin PG: pure emission
+ *                 hash + ONE INSERT, no advisory lock, no head read, no
+ *                 transaction. Chaining belongs to the single-writer
+ *                 chainer worker.
+ *   break-glass → the legacy chained append against the main DB, with loud
+ *                 observability (see buildBreakGlassAppendPath).
+ *   fail        → resolveAuditDbBinding throws; logEvent rejects per event
+ *                 and the audit() wrapper surfaces it as a warn log.
+ */
+let defaultAppendPath: AuditAppendPath | null = null;
+function getDefaultAppendPath(): AuditAppendPath {
+  if (!defaultAppendPath) {
+    const binding = resolveAuditDbBinding();
+    if (binding.mode === 'dedicated') {
+      const writer = createAuditIngestWriter({ db: binding.db });
+      defaultAppendPath = {
+        appendEvent: (event, opts) => writer.writeToIngest(event, opts),
+      };
+    } else {
+      defaultAppendPath = buildBreakGlassAppendPath(binding);
+    }
+  }
+  return defaultAppendPath;
+}
+
+/**
+ * Lazy async proxy over the resolved append path. Resolution happens INSIDE
+ * the async appendEvent so a fail-mode throw becomes a rejection — the
+ * fire-and-forget audit() wrapper attaches .catch() and must never see a
+ * synchronous throw from logEvent.
+ */
+const lazyDefaultAppendPath: AuditAppendPath = {
+  appendEvent: async (event, opts) => getDefaultAppendPath().appendEvent(event, opts),
+};
 
 let defaultService: SecurityAuditService | null = null;
 function getDefaultService(): SecurityAuditService {
   if (!defaultService) {
-    defaultService = createSecurityAuditService({ repository: getDefaultRepository() });
+    defaultService = createSecurityAuditService({ repository: lazyDefaultAppendPath });
   }
   return defaultService;
+}
+
+/**
+ * Test hook: drop the cached default append path + service so a test can
+ * re-resolve under a different admin-db mode (pair with
+ * resetAuditDbBindingForTests).
+ */
+export function resetDefaultSecurityAuditForTests(): void {
+  defaultAppendPath = null;
+  defaultService = null;
 }
 
 /**

--- a/packages/lib/src/compliance/erasure/__tests__/gdpr-eraser.integration.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/gdpr-eraser.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * End-to-end GDPR pseudonymization via the eraser role on the Admin PG
+ * (#890 Phase 2, leaf 6 — the acceptance proof).
+ *
+ * Connected AS the provisioned admin_gdpr_eraser_user LOGIN over the wire
+ * (no SET ROLE, no owner shortcuts), against a REAL chainer-era chain built
+ * with the production hash functions:
+ *
+ *   1. genesis→head verifies BEFORE erasure,
+ *   2. pseudonymizeSecurityAuditLogForUser nulls the subject's PII columns
+ *      (including ip_bidx) and ONLY the subject's,
+ *   3. genesis→head STILL verifies AFTER — erasure is provably chain-safe
+ *      because emission/chain hashes exclude PII by design,
+ *   4. the eraser connection CANNOT touch hash columns or INSERT/DELETE
+ *      (real 42501, Phase 1 grant-denial pattern).
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run src/compliance/erasure/__tests__/gdpr-eraser.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import { sql } from 'drizzle-orm';
+import { migrateAdminDb } from '@pagespace/db/migrate-admin';
+import { provisionAdminLoginUsers } from '@pagespace/db/provision-admin-users';
+import {
+  createAdminAuditDbClient,
+  type AdminAuditDbClient,
+} from '@pagespace/db/admin-eraser-db';
+import { securityAuditLog } from '@pagespace/db/admin-schema';
+import { computeEmissionHash } from '../../../audit/emission-hash';
+import { computeChainHash, GENESIS_PREVIOUS_HASH } from '../../../audit/chain-step';
+import { verifySecurityAuditChain } from '../../../audit/security-audit-chain-verifier';
+import type { AuditEvent } from '../../../audit/security-audit';
+import { pseudonymizeSecurityAuditLogForUser } from '../pseudonymize-repository';
+
+const url = process.env.ADMIN_DATABASE_URL;
+
+const ERASER_PASSWORD = 'eraser-secret-e2e-1';
+const SUBJECT = 'subject-user';
+const BYSTANDER = 'other-user';
+
+const ALL_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+  'admin_app_user',
+  'admin_processor_user',
+  'admin_reader_user',
+  'admin_gdpr_eraser_user',
+] as const;
+
+const eraserUrl = (): string => {
+  const parsed = new URL(url as string);
+  parsed.username = 'admin_gdpr_eraser_user';
+  parsed.password = ERASER_PASSWORD;
+  return parsed.toString();
+};
+
+/** Build one chainer-era row with the production hash functions. */
+function buildChainedRow(i: number, userId: string, previousHash: string) {
+  const timestamp = new Date(Date.UTC(2026, 5, 1, 0, 0, i));
+  const event: AuditEvent = {
+    eventType: 'auth.login.success',
+    userId,
+    serviceId: 'web',
+    details: { probe: 'gdpr-eraser-e2e', i },
+  };
+  const emissionHash = computeEmissionHash(event, timestamp);
+  const eventHash = computeChainHash(emissionHash, previousHash);
+  return {
+    eventHash,
+    values: {
+      id: `e2e-row-${i}`,
+      eventType: event.eventType,
+      userId,
+      sessionId: `session-${userId}-${i}`,
+      serviceId: 'web',
+      ipAddress: `203.0.113.${i}`,
+      ipBidx: `bidx-${userId}-${i}`,
+      userAgent: 'e2e-agent/1.0',
+      geoLocation: 'EU',
+      details: event.details as Record<string, unknown>,
+      timestamp,
+      previousHash,
+      eventHash,
+      emissionHash,
+    },
+  };
+}
+
+describe.skipIf(!url)('GDPR pseudonymization via admin_gdpr_eraser_user (wire-connected)', () => {
+  let owner: AdminAuditDbClient;
+  let eraser: AdminAuditDbClient;
+
+  beforeAll(async () => {
+    owner = createAdminAuditDbClient({ connectionString: url as string, max: 3 });
+
+    // Fresh-DB guarantee on the SCRATCH db — same reset as the db package's
+    // admin integration suites, including LOGIN users so provisioning runs.
+    await owner.db.execute(sql`DROP SCHEMA IF EXISTS public CASCADE`);
+    await owner.db.execute(sql`DROP SCHEMA IF EXISTS drizzle_admin CASCADE`);
+    await owner.db.execute(sql`CREATE SCHEMA public`);
+    for (const role of ALL_ROLES) {
+      await owner.db.execute(
+        sql.raw(`
+          DO $$ BEGIN
+            IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+              DROP OWNED BY ${role};
+              DROP ROLE ${role};
+            END IF;
+          END $$;
+        `),
+      );
+    }
+
+    // migrateAdminDb resolves its migrations folder relative to CWD
+    // (packages/db convention) — hop there for the migration call only.
+    const previousCwd = process.cwd();
+    process.chdir(path.resolve(__dirname, '../../../../../db'));
+    try {
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    } finally {
+      process.chdir(previousCwd);
+    }
+
+    const provisioned = await provisionAdminLoginUsers({
+      ADMIN_DATABASE_URL: url,
+      ADMIN_ERASER_PASSWORD: ERASER_PASSWORD,
+    });
+    expect(provisioned.provisioned).toEqual(['admin_gdpr_eraser_user']);
+
+    // Seed a REAL 5-row chain: subject rows interleaved with a bystander's.
+    let previousHash = GENESIS_PREVIOUS_HASH;
+    for (let i = 0; i < 5; i++) {
+      const built = buildChainedRow(i, i % 2 === 0 ? SUBJECT : BYSTANDER, previousHash);
+      await owner.db.insert(securityAuditLog).values(built.values);
+      previousHash = built.eventHash;
+    }
+
+    eraser = createAdminAuditDbClient({ connectionString: eraserUrl(), max: 2 });
+  }, 120_000);
+
+  afterAll(async () => {
+    await Promise.all([owner?.end(), eraser?.end()]);
+  });
+
+  it('given the seeded chain, should verify genesis→head BEFORE erasure', async () => {
+    const result = await verifySecurityAuditChain({}, { db: owner.db });
+    expect(result.isValid).toBe(true);
+    expect(result.entriesVerified).toBe(5);
+    expect(result.invalidEntries).toBe(0);
+  });
+
+  it('given the subject, should null exactly the subject PII (incl. ip_bidx) via the eraser connection AND the chain must still verify', async () => {
+    const rows = await pseudonymizeSecurityAuditLogForUser(SUBJECT, { db: eraser.db });
+    expect(rows).toBe(3);
+
+    const after = await owner.db.query.securityAuditLog.findMany({
+      orderBy: (t, { asc }) => [asc(t.chainSeq)],
+    });
+    expect(after).toHaveLength(5);
+    for (const row of after) {
+      if (row.id === 'e2e-row-0' || row.id === 'e2e-row-2' || row.id === 'e2e-row-4') {
+        // Subject rows: every erasable PII column is gone…
+        expect(row.ipAddress).toBeNull();
+        expect(row.ipBidx).toBeNull();
+        expect(row.userAgent).toBeNull();
+        expect(row.geoLocation).toBeNull();
+        expect(row.sessionId).toBeNull();
+      } else {
+        // …bystander rows are untouched.
+        expect(row.ipAddress).not.toBeNull();
+        expect(row.ipBidx).not.toBeNull();
+        expect(row.userAgent).not.toBeNull();
+      }
+    }
+
+    // The erasure is chain-safe: hashes exclude PII by design, so the full
+    // genesis→head verification still passes — read via the ERASER connection
+    // (SELECT is in its grant) and cross-checked via the owner.
+    const viaEraser = await verifySecurityAuditChain({}, { db: eraser.db });
+    expect(viaEraser.isValid).toBe(true);
+    expect(viaEraser.entriesVerified).toBe(5);
+    expect(viaEraser.invalidEntries).toBe(0);
+
+    const viaOwner = await verifySecurityAuditChain({}, { db: owner.db });
+    expect(viaOwner.isValid).toBe(true);
+  });
+
+  it('the eraser connection CANNOT touch hash columns, INSERT, or DELETE (real 42501)', async () => {
+    const expect42501 = async (promise: Promise<unknown>) => {
+      const error = await promise.then(
+        () => null,
+        (e: unknown) => e as { code?: string; cause?: { code?: string } },
+      );
+      expect(error).not.toBeNull();
+      expect(error!.code ?? error!.cause?.code).toBe('42501');
+    };
+
+    await expect42501(
+      eraser.db.execute(
+        sql`UPDATE security_audit_log SET event_hash = 'tampered' WHERE id = 'e2e-row-0'`,
+      ),
+    );
+    await expect42501(
+      eraser.db.execute(
+        sql`UPDATE security_audit_log SET previous_hash = 'tampered' WHERE id = 'e2e-row-0'`,
+      ),
+    );
+    await expect42501(
+      eraser.db.execute(
+        sql`UPDATE security_audit_log SET emission_hash = 'tampered' WHERE id = 'e2e-row-0'`,
+      ),
+    );
+    await expect42501(
+      eraser.db.execute(
+        sql`INSERT INTO security_audit_log (id, event_type, previous_hash, event_hash)
+            VALUES ('eraser-insert', 'auth.login.success', 'x', 'y')`,
+      ),
+    );
+    await expect42501(
+      eraser.db.execute(sql`DELETE FROM security_audit_log WHERE id = 'e2e-row-0'`),
+    );
+
+    // Nothing above may have changed the chain.
+    const still = await verifySecurityAuditChain({}, { db: owner.db });
+    expect(still.isValid).toBe(true);
+  });
+});

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize-repository.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize-repository.test.ts
@@ -14,20 +14,22 @@ import {
   pseudonymizeSecurityAuditLogForUser,
 } from '../pseudonymize-repository';
 import { db } from '@pagespace/db/db';
+import type { SecurityAuditDatabase } from '../../../audit/security-audit-repository';
 
-function mockUpdateReturning(rows: unknown[]) {
+function updateChain(rows: unknown[]) {
   const returningFn = vi.fn().mockResolvedValue(rows);
   const whereFn = vi.fn().mockReturnValue({ returning: returningFn });
   const setFn = vi.fn().mockReturnValue({ where: whereFn });
-  vi.mocked(db.update).mockReturnValue({ set: setFn } as never);
-  return { setFn };
+  const update = vi.fn().mockReturnValue({ set: setFn });
+  return { update, setFn };
 }
 
 beforeEach(() => vi.clearAllMocks());
 
 describe('pseudonymizeActivityLogsForUser', () => {
-  it('should set the activity-log actor patch and return the row count', async () => {
-    const { setFn } = mockUpdateReturning([{ id: '1' }, { id: '2' }]);
+  it('should set the activity-log actor patch on the main db and return the row count', async () => {
+    const { update, setFn } = updateChain([{ id: '1' }, { id: '2' }]);
+    vi.mocked(db.update).mockImplementation(update as never);
     const count = await pseudonymizeActivityLogsForUser('u1');
     expect(count).toBe(2);
     expect(setFn.mock.calls[0][0]).toEqual({
@@ -39,15 +41,37 @@ describe('pseudonymizeActivityLogsForUser', () => {
 });
 
 describe('pseudonymizeSecurityAuditLogForUser', () => {
-  it('should null the non-hashed PII columns and return the row count', async () => {
-    const { setFn } = mockUpdateReturning([{ id: '1' }]);
-    const count = await pseudonymizeSecurityAuditLogForUser('u1');
+  it('should null the non-hashed PII columns (incl. ipBidx) ON THE INJECTED STORE and return the row count', async () => {
+    const { update, setFn } = updateChain([{ id: '1' }]);
+    const store = { update } as unknown as SecurityAuditDatabase;
+
+    const count = await pseudonymizeSecurityAuditLogForUser('u1', { db: store });
+
     expect(count).toBe(1);
+    expect(update).toHaveBeenCalledTimes(1);
     expect(setFn.mock.calls[0][0]).toEqual({
       ipAddress: null,
+      ipBidx: null,
       userAgent: null,
       geoLocation: null,
       sessionId: null,
     });
+    // The injected client is the ONLY thing written — never the ambient main db.
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('given two different stores (dual-location erasure), should write each store exactly once', async () => {
+    const adminChain = updateChain([{ id: 'a1' }, { id: 'a2' }]);
+    const mainChain = updateChain([{ id: 'm1' }]);
+    const adminStore = { update: adminChain.update } as unknown as SecurityAuditDatabase;
+    const mainStore = { update: mainChain.update } as unknown as SecurityAuditDatabase;
+
+    const adminRows = await pseudonymizeSecurityAuditLogForUser('u1', { db: adminStore });
+    const mainRows = await pseudonymizeSecurityAuditLogForUser('u1', { db: mainStore });
+
+    expect(adminRows).toBe(2);
+    expect(mainRows).toBe(1);
+    expect(adminChain.update).toHaveBeenCalledTimes(1);
+    expect(mainChain.update).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize-targets.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize-targets.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Store-targeting for Art 17 security-audit pseudonymization (#890 Phase 2,
+ * leaf 6). Pure plan: which store(s) hold the subject's audit PII and which
+ * identity may erase there — plus the shell that binds plans to clients.
+ *
+ * Transitional dual-location state (leaf 5 cutover): NEW rows live in the
+ * Admin PG, LEGACY rows remain in the main DB until the backfill leaf plants
+ * them. Erasure is legally time-bound, so it must cover BOTH stores NOW —
+ * a partial erasure that reports success is worse than a loud refusal.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({ db: { __store: 'main' } }));
+vi.mock('@pagespace/db/admin-db', () => ({
+  getAdminDbMode: vi.fn(),
+  getAdminDb: vi.fn(() => ({ __store: 'admin-read' })),
+}));
+vi.mock('@pagespace/db/admin-eraser-db', () => ({
+  getAdminEraserDbMode: vi.fn(),
+  getAdminEraserDb: vi.fn(() => ({ __store: 'admin-eraser' })),
+}));
+
+import {
+  planSecurityAuditErasure,
+  resolveSecurityAuditErasureTargets,
+} from '../pseudonymize-targets';
+import { getAdminDbMode, getAdminDb } from '@pagespace/db/admin-db';
+import { getAdminEraserDbMode, getAdminEraserDb } from '@pagespace/db/admin-eraser-db';
+
+describe('planSecurityAuditErasure (pure)', () => {
+  it('given dedicated mode with the eraser configured, should target BOTH stores (admin post-cutover rows + main legacy rows)', () => {
+    const plan = planSecurityAuditErasure({
+      auditMode: 'dedicated',
+      eraserMode: 'available',
+    });
+    expect(plan).toEqual({ ok: true, mode: 'dedicated', stores: ['admin', 'main'] });
+  });
+
+  it('given dedicated mode WITHOUT the eraser, should refuse the whole erasure with an actionable reason — never a partial run', () => {
+    const plan = planSecurityAuditErasure({
+      auditMode: 'dedicated',
+      eraserMode: 'unavailable',
+      eraserReason: 'ADMIN_ERASER_DATABASE_URL is not set. …',
+    });
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toContain('ADMIN_ERASER_DATABASE_URL is not set');
+      // Must explain WHY main-only would be wrong (post-cutover PII lives in the Admin PG).
+      expect(plan.reason).toMatch(/Admin PG/);
+      expect(plan.reason).toMatch(/partial/i);
+    }
+  });
+
+  it('given break-glass mode, should target only the main store (the entire audit surface lives there)', () => {
+    const plan = planSecurityAuditErasure({
+      auditMode: 'break-glass',
+      eraserMode: 'unavailable',
+    });
+    expect(plan).toEqual({ ok: true, mode: 'break-glass', stores: ['main'] });
+  });
+
+  it('given fail mode, should refuse loudly with the audit reason — a misconfigured trust plane never silently no-ops an erasure', () => {
+    const plan = planSecurityAuditErasure({
+      auditMode: 'fail',
+      eraserMode: 'available',
+      auditReason: 'ADMIN_DATABASE_URL is not set. …',
+    });
+    expect(plan.ok).toBe(false);
+    if (!plan.ok) {
+      expect(plan.reason).toContain('ADMIN_DATABASE_URL is not set');
+    }
+  });
+});
+
+describe('resolveSecurityAuditErasureTargets (shell)', () => {
+  it('given dedicated + eraser, should bind admin writes to the ERASER client, admin reads to the admin client, and main to the main db', () => {
+    vi.mocked(getAdminDbMode).mockReturnValue({ mode: 'dedicated', reason: 'set' });
+    vi.mocked(getAdminEraserDbMode).mockReturnValue({ mode: 'available', reason: 'set' });
+
+    const resolved = resolveSecurityAuditErasureTargets();
+    expect(resolved.ok).toBe(true);
+    if (resolved.ok) {
+      expect(resolved.mode).toBe('dedicated');
+      expect(resolved.targets.map((t) => t.store)).toEqual(['admin', 'main']);
+      expect(resolved.targets[0]!.write).toEqual({ __store: 'admin-eraser' });
+      expect(resolved.targets[0]!.read).toEqual({ __store: 'admin-read' });
+      expect(resolved.targets[1]!.write).toEqual({ __store: 'main' });
+      expect(resolved.targets[1]!.read).toEqual({ __store: 'main' });
+    }
+  });
+
+  it('given break-glass, should bind the single main target WITHOUT touching any admin client', () => {
+    vi.mocked(getAdminDbMode).mockReturnValue({ mode: 'break-glass', reason: 'armed' });
+    vi.mocked(getAdminEraserDbMode).mockReturnValue({ mode: 'unavailable', reason: 'unset' });
+    vi.mocked(getAdminDb).mockClear();
+    vi.mocked(getAdminEraserDb).mockClear();
+
+    const resolved = resolveSecurityAuditErasureTargets();
+    expect(resolved.ok).toBe(true);
+    if (resolved.ok) {
+      expect(resolved.mode).toBe('break-glass');
+      expect(resolved.targets.map((t) => t.store)).toEqual(['main']);
+      expect(resolved.targets[0]!.write).toEqual({ __store: 'main' });
+    }
+    expect(getAdminDb).not.toHaveBeenCalled();
+    expect(getAdminEraserDb).not.toHaveBeenCalled();
+  });
+
+  it('given a refusing plan, should return it without constructing any client', () => {
+    vi.mocked(getAdminDbMode).mockReturnValue({ mode: 'fail', reason: 'no trust plane' });
+    vi.mocked(getAdminEraserDbMode).mockReturnValue({ mode: 'unavailable', reason: 'unset' });
+    vi.mocked(getAdminEraserDb).mockClear();
+
+    const resolved = resolveSecurityAuditErasureTargets();
+    expect(resolved.ok).toBe(false);
+    if (!resolved.ok) {
+      expect(resolved.reason).toContain('no trust plane');
+    }
+    expect(getAdminEraserDb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
@@ -64,5 +64,15 @@ describe('assertPseudonymizationPatchSafe', () => {
     expect(SECURITY_AUDIT_HASHED_FIELDS.has('eventHash')).toBe(true);
     expect(SECURITY_AUDIT_HASHED_FIELDS.has('previousHash')).toBe(true);
     expect(SECURITY_AUDIT_HASHED_FIELDS.has('details')).toBe(true);
+    // emission_hash is a chain column on the admin plane (#890 Phase 2,
+    // admin 0005): a patch nulling it must be rejected here, not only by
+    // the eraser role's column-scoped grant.
+    expect(SECURITY_AUDIT_HASHED_FIELDS.has('emissionHash')).toBe(true);
+  });
+
+  it('given a patch that nulls emissionHash, should throw loudly', () => {
+    expect(() =>
+      assertPseudonymizationPatchSafe({ emissionHash: null }, SECURITY_AUDIT_HASHED_FIELDS)
+    ).toThrow(/hash-chain/i);
   });
 });

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize.test.ts
@@ -26,10 +26,13 @@ describe('activity-log pseudonymization patch', () => {
 });
 
 describe('security-audit pseudonymization patch', () => {
-  it('should null only the non-hashed denormalized PII columns', () => {
+  it('should null only the non-hashed denormalized PII columns, including the ip blind index', () => {
     const patch = buildSecurityAuditPseudonymizationPatch();
     expect(patch).toEqual({
       ipAddress: null,
+      // The blind index is DERIVED from the IP — leaving it while nulling
+      // ip_address keeps the subject's IP linkable by equality (#890 leaf 6).
+      ipBidx: null,
       userAgent: null,
       geoLocation: null,
       sessionId: null,

--- a/packages/lib/src/compliance/erasure/pseudonymize-repository.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize-repository.ts
@@ -1,17 +1,25 @@
 /**
- * Repository edges for Art 17(3)(b) audit pseudonymization (#985).
+ * Repository edges for Art 17(3)(b) audit pseudonymization (#985, #890 leaf 6).
  *
  * Each function applies the pure patch from `pseudonymize.ts` to the rows owned
  * by a user, after asserting the patch cannot touch a hash-chained column.
  * Returns the number of rows pseudonymized. The hash chain is NOT recomputed —
  * the patched columns are not hash inputs, so the chain stays valid by
- * construction (and the admin route verifies this before/after).
+ * construction (and the admin route verifies this before/after, per store).
+ *
+ * Activity logs live only in the main DB (their move is a later phase).
+ * Security-audit rows are transitionally SPLIT across the Admin PG and the
+ * main DB, so that function takes the target store explicitly — callers get
+ * it from resolveSecurityAuditErasureTargets, which pairs each store with
+ * the identity allowed to write it (eraser LOGIN on admin, app on main).
  */
 
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { securityAuditLog } from '@pagespace/db/schema/security-audit';
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+import type { SecurityAuditDatabase } from '../../audit/security-audit-repository';
 import {
   ACTIVITY_LOG_HASHED_FIELDS,
   SECURITY_AUDIT_HASHED_FIELDS,
@@ -33,11 +41,23 @@ export async function pseudonymizeActivityLogsForUser(userId: string): Promise<n
   return rows.length;
 }
 
-export async function pseudonymizeSecurityAuditLogForUser(userId: string): Promise<number> {
+export interface SecurityAuditPseudonymizeDeps {
+  /** The store to erase in — REQUIRED so no caller silently targets the wrong plane. */
+  db: SecurityAuditDatabase;
+}
+
+export async function pseudonymizeSecurityAuditLogForUser(
+  userId: string,
+  deps: SecurityAuditPseudonymizeDeps,
+): Promise<number> {
   const patch = buildSecurityAuditPseudonymizationPatch();
   assertPseudonymizationPatchSafe(patch, SECURITY_AUDIT_HASHED_FIELDS);
 
-  const rows = await db
+  // Same union-narrowing as the chain verifier (leaf 0 finding): the two
+  // clients' generic signatures don't unify into a callable union against
+  // packages/db/dist .d.ts. AdminDatabase is the least-capable member, so
+  // the cast cannot widen what this UPDATE can do.
+  const rows = await (deps.db as AdminDatabase)
     .update(securityAuditLog)
     .set(patch)
     .where(eq(securityAuditLog.userId, userId))

--- a/packages/lib/src/compliance/erasure/pseudonymize-targets.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize-targets.ts
@@ -1,0 +1,123 @@
+/**
+ * Store-targeting for Art 17 security-audit pseudonymization (#890 Phase 2,
+ * leaf 6).
+ *
+ * Since the runtime cutover (leaf 5) a subject's security-audit PII can be
+ * SPLIT across two stores: post-cutover rows live in the Admin PG
+ * (trust plane), legacy rows remain in the main DB until the backfill leaf
+ * plants them under the admin chain. Erasure is legally time-bound
+ * (Art 17), so a pseudonymization run must cover BOTH stores now — and each
+ * store is written by the identity that is allowed to touch it:
+ *
+ *   admin  → the eraser LOGIN (admin_gdpr_eraser_user: SELECT + column-scoped
+ *            UPDATE on exactly the 6 PII columns) via ADMIN_ERASER_DATABASE_URL.
+ *            Chain verification reads use the regular admin client.
+ *   main   → the app's main-db connection (the legacy table has no role
+ *            split; this is the pre-cutover behavior, unchanged).
+ *
+ * Refusal over partial success: in dedicated mode with no eraser configured,
+ * the WHOLE erasure refuses with an actionable reason. Erasing only the main
+ * store while post-cutover PII sits unreachable in the Admin PG would report
+ * completion that did not happen. Under break-glass the entire audit surface
+ * (reads + writes) is the main DB, so the plan collapses to main-only. In
+ * fail mode there is no trust plane and no armed fallback — the erasure
+ * refuses loudly (never a silent no-op) until the deploy is fixed.
+ *
+ * planSecurityAuditErasure is the pure core; resolveSecurityAuditErasureTargets
+ * is the thin shell binding plans to live clients.
+ */
+
+import { db as mainDb } from '@pagespace/db/db';
+import { getAdminDb, getAdminDbMode, type AdminDbModeName } from '@pagespace/db/admin-db';
+import {
+  getAdminEraserDb,
+  getAdminEraserDbMode,
+} from '@pagespace/db/admin-eraser-db';
+import type { SecurityAuditDatabase } from '../../audit/security-audit-repository';
+
+export type SecurityAuditErasureStore = 'admin' | 'main';
+
+export interface SecurityAuditErasurePlanInput {
+  auditMode: AdminDbModeName;
+  eraserMode: 'available' | 'unavailable';
+  auditReason?: string;
+  eraserReason?: string;
+}
+
+export type SecurityAuditErasurePlan =
+  | { ok: true; mode: 'dedicated' | 'break-glass'; stores: SecurityAuditErasureStore[] }
+  | { ok: false; reason: string };
+
+/** Pure: which stores an erasure run must touch, or why it must refuse. */
+export function planSecurityAuditErasure(
+  input: SecurityAuditErasurePlanInput,
+): SecurityAuditErasurePlan {
+  switch (input.auditMode) {
+    case 'fail':
+      return {
+        ok: false,
+        reason:
+          `Audit store unavailable — refusing to pseudonymize (never a silent no-op): ` +
+          `${input.auditReason ?? 'trust plane not configured'}`,
+      };
+    case 'break-glass':
+      // The whole audit surface (writes AND reads) is the main DB; there are
+      // no admin-store rows the eraser identity could reach.
+      return { ok: true, mode: 'break-glass', stores: ['main'] };
+    case 'dedicated':
+      if (input.eraserMode === 'unavailable') {
+        return {
+          ok: false,
+          reason:
+            'Post-cutover audit PII lives in the Admin PG, which only the eraser identity may update — ' +
+            'refusing a partial (main-only) erasure that would misreport completion. ' +
+            `${input.eraserReason ?? 'ADMIN_ERASER_DATABASE_URL is not configured.'}`,
+        };
+      }
+      // Dual-location: admin (post-cutover chained rows) AND main (legacy
+      // rows awaiting backfill). Both must be pseudonymized in one run.
+      return { ok: true, mode: 'dedicated', stores: ['admin', 'main'] };
+  }
+}
+
+export interface SecurityAuditErasureTarget {
+  store: SecurityAuditErasureStore;
+  /** Connection the PII UPDATE runs on (eraser identity for admin; app identity for main). */
+  write: SecurityAuditDatabase;
+  /** Connection the before/after chain verification reads from. */
+  read: SecurityAuditDatabase;
+}
+
+export type ResolvedSecurityAuditErasureTargets =
+  | { ok: true; mode: 'dedicated' | 'break-glass'; targets: SecurityAuditErasureTarget[] }
+  | { ok: false; reason: string };
+
+/**
+ * Shell: resolve the current process's erasure targets. Never constructs a
+ * client for a store the plan does not include, and never falls back across
+ * identities — an unavailable eraser refuses the run.
+ */
+export function resolveSecurityAuditErasureTargets(): ResolvedSecurityAuditErasureTargets {
+  const auditDecision = getAdminDbMode();
+  const eraserDecision = getAdminEraserDbMode();
+
+  const plan = planSecurityAuditErasure({
+    auditMode: auditDecision.mode,
+    eraserMode: eraserDecision.mode,
+    auditReason: auditDecision.reason,
+    eraserReason: eraserDecision.reason,
+  });
+  if (!plan.ok) return plan;
+
+  const targets = plan.stores.map((store): SecurityAuditErasureTarget => {
+    if (store === 'admin') {
+      return { store, write: getAdminEraserDb(), read: getAdminDb() };
+    }
+    // Main-plane rows: writes and chain-verification reads both use the main
+    // db client (NOT getAdminDb()'s admin-schema-typed client — leaf 5 pin:
+    // admin-shaped SELECTs would 42703 on emission_hash against main).
+    return { store, write: mainDb, read: mainDb };
+  });
+
+  return { ok: true, mode: plan.mode, targets };
+}

--- a/packages/lib/src/compliance/erasure/pseudonymize.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize.ts
@@ -63,6 +63,13 @@ export interface ActivityLogPseudonymPatch {
 
 export interface SecurityAuditPseudonymPatch {
   ipAddress: null;
+  /**
+   * ip_bidx is the deterministic blind index over ip_address (equality
+   * forensics). It is derived FROM the erased PII, so it must be nulled with
+   * it — otherwise the subject's IP stays linkable by blind-index equality.
+   * It is inside the eraser role's 6-column UPDATE scope (#890 Phase 1).
+   */
+  ipBidx: null;
   userAgent: null;
   geoLocation: null;
   sessionId: null;
@@ -76,7 +83,7 @@ export function buildActivityLogPseudonymizationPatch(): ActivityLogPseudonymPat
 }
 
 export function buildSecurityAuditPseudonymizationPatch(): SecurityAuditPseudonymPatch {
-  return { ipAddress: null, userAgent: null, geoLocation: null, sessionId: null };
+  return { ipAddress: null, ipBidx: null, userAgent: null, geoLocation: null, sessionId: null };
 }
 
 /**

--- a/packages/lib/src/compliance/erasure/pseudonymize.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize.ts
@@ -53,6 +53,12 @@ export const SECURITY_AUDIT_HASHED_FIELDS: ReadonlySet<string> = new Set([
   // Stored chain columns
   'eventHash',
   'chainSeq',
+  // Admin-plane chain column (#890 Phase 2, admin 0005): NULL marks a
+  // backfilled legacy-era row, present marks a chainer-era row whose
+  // event_hash = H(emission_hash, previous_hash). Nulling it would forge an
+  // era downgrade — forbidden here as defense-in-depth beside the eraser
+  // role's column-scoped UPDATE grant.
+  'emissionHash',
 ]);
 
 export interface ActivityLogPseudonymPatch {

--- a/packages/lib/src/config/__tests__/env-validation.test.ts
+++ b/packages/lib/src/config/__tests__/env-validation.test.ts
@@ -213,6 +213,32 @@ describe('env-validation', () => {
       }
     });
 
+    it('given a valid ADMIN_ERASER_DATABASE_URL, should parse and expose it (GDPR eraser identity, #890 leaf 6)', () => {
+      const env = {
+        ...baseEnv,
+        ADMIN_ERASER_DATABASE_URL:
+          'postgresql://admin_gdpr_eraser_user:pw@postgres-admin:5432/pagespace_admin',
+      };
+
+      const result = serverEnvSchema.safeParse(env);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_ERASER_DATABASE_URL).toBe(env.ADMIN_ERASER_DATABASE_URL);
+      }
+    });
+
+    it('given a non-postgres ADMIN_ERASER_DATABASE_URL, should fail; unset should parse (route-level refusal, not boot-level)', () => {
+      const bad = serverEnvSchema.safeParse({
+        ...baseEnv,
+        ADMIN_ERASER_DATABASE_URL: 'http://nope',
+      });
+      expect(bad.success).toBe(false);
+
+      const unset = serverEnvSchema.safeParse(baseEnv);
+      expect(unset.success).toBe(true);
+    });
+
     it('given ADMIN_DATABASE_URL unset with ADMIN_DB_BREAK_GLASS=true, should parse and expose the flag (degrade-loudly path)', () => {
       const env = {
         ...baseEnv,

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -32,6 +32,19 @@ export const serverEnvSchema = z
     ADMIN_DATABASE_SSL: z.enum(['true', 'false']).optional(),
     ADMIN_DB_POOL_MAX: z.coerce.number().int().positive().optional(),
 
+    // GDPR eraser identity (#890 Phase 2, leaf 6): the web pseudonymization
+    // route connects to the Admin PG as admin_gdpr_eraser_user through this
+    // URL. Optional at the schema level — when unset, the pseudonymize route
+    // refuses (503) via the eraser client, never at app boot.
+    ADMIN_ERASER_DATABASE_URL: z
+      .string()
+      .min(1, 'ADMIN_ERASER_DATABASE_URL must not be empty when set')
+      .refine(
+        (url) => url.startsWith('postgresql://') || url.startsWith('postgres://'),
+        'ADMIN_ERASER_DATABASE_URL must be a valid PostgreSQL connection string'
+      )
+      .optional(),
+
     // Break-glass rollback ONLY: arms the fallback that permits audit writes to
     // the main DB (which must alert loudly) when the Admin PG is unavailable.
     // Never a supported steady state. Accept any string so a stray value (e.g.

--- a/scripts/__tests__/backfill-audit-db.integration.test.ts
+++ b/scripts/__tests__/backfill-audit-db.integration.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Rehearsal integration for scripts/backfill-audit-db.ts (#890 Phase 2,
+ * leaf 8) — the zero-loss capstone, wire-connected on scratch Postgres.
+ *
+ * Two REAL databases on one scratch server play the two planes:
+ *   - the admin scratch DB (ADMIN_DATABASE_URL): migrated via migrateAdminDb
+ *     through 0007 (partitioned chain tables, roles, emission column);
+ *   - a sibling "main" DB holding the legacy security_audit_log (chain_seq
+ *     bigserial, ip_bidx — the real main shape) with a REAL hash chain built
+ *     by computeSecurityEventHash, plus siem_delivery_cursors.
+ *
+ * What this proves end to end:
+ *   1. Dry-run plans and writes nothing.
+ *   2. --apply plants every legacy row preserving id/chain_seq/hashes/NULLed
+ *      PII, creates the historical monthly partitions (DEFAULT stays empty),
+ *      aligns the chain sequence, commits the SIEM anchor row LAST, and the
+ *      FULL genesis→head era-aware verification passes with row-count +
+ *      head-hash parity.
+ *   3. Reruns are idempotent (0 planted, no dupes) and converge new main
+ *      tail rows (zero-loss).
+ *   4. Precondition refusals: an emission era already chained from 'genesis'
+ *      aborts (the leaf-7 unresolved case), a moved main head aborts, and
+ *      break-glass aborts — all without planting a single row.
+ *   5. A tampered admin row is caught by the in-run verification.
+ *   6. --freeze re-proves parity + chain, then write-freezes the main table:
+ *      INSERT/DELETE/TRUNCATE and non-PII UPDATE raise (owner included),
+ *      while the GDPR pseudonymization UPDATE keeps working; a probe user's
+ *      INSERT grant is revoked; the freeze refuses when the backfill has not
+ *      run; rerunning the freeze is idempotent.
+ *
+ * Requires a running scratch Postgres (never the app DB):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run __tests__/backfill-audit-db.integration.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import path from 'path';
+import { migrateAdminDb } from '@pagespace/db/migrate-admin';
+import { createAdminAuditDbClient, type AdminAuditDbClient } from '@pagespace/db/admin-eraser-db';
+import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
+import { computeEmissionHash } from '@pagespace/lib/audit/emission-hash';
+import { computeChainHash } from '@pagespace/lib/audit/chain-step';
+import {
+  runAuditBackfill,
+  freezeLegacySecurityAuditLog,
+  type PoolLike,
+} from '../backfill-audit-db';
+
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+interface PgPool extends PoolLike {
+  connect(): Promise<PgClient>;
+  end(): Promise<void>;
+}
+// pg is not hoisted to the repo root (scripts/ has no package.json), so
+// resolve it through @pagespace/db's module context — the same physical
+// driver the db package itself uses.
+import { createRequire } from 'node:module';
+const requireFromTest = createRequire(import.meta.url);
+const requireFromDb = createRequire(requireFromTest.resolve('@pagespace/db/db'));
+const { Pool } = requireFromDb('pg') as unknown as {
+  Pool: new (config: Record<string, unknown>) => PgPool;
+};
+
+const url = process.env.ADMIN_DATABASE_URL;
+const MAIN_DB_NAME = 'pagespace_main_backfill_it';
+const PROBE_ROLE = 'main_backfill_probe';
+
+const ADMIN_ROLES = [
+  'admin_app',
+  'admin_chainer',
+  'admin_gdpr_eraser',
+  'admin_reader',
+  'admin_siem',
+  'admin_maintenance',
+  'admin_app_user',
+  'admin_processor_user',
+  'admin_reader_user',
+] as const;
+
+function mainDbUrl(): string {
+  const parsed = new URL(url as string);
+  parsed.pathname = `/${MAIN_DB_NAME}`;
+  return parsed.toString();
+}
+
+// Real main-plane shape: chain_seq bigserial, ip_bidx, timestamp WITHOUT tz.
+const MAIN_TABLES_DDL = `
+  CREATE TABLE security_audit_log (
+    id text PRIMARY KEY,
+    event_type text NOT NULL,
+    user_id text,
+    session_id text,
+    service_id text,
+    resource_type text,
+    resource_id text,
+    ip_address text,
+    ip_bidx text,
+    user_agent text,
+    geo_location text,
+    details jsonb,
+    risk_score real,
+    anomaly_flags text[],
+    timestamp timestamp DEFAULT now() NOT NULL,
+    chain_seq bigserial NOT NULL,
+    previous_hash text NOT NULL,
+    event_hash text NOT NULL
+  );
+  CREATE TABLE siem_delivery_cursors (
+    id text PRIMARY KEY,
+    "lastDeliveredId" text,
+    "lastDeliveredAt" timestamp,
+    "deliveryCount" integer NOT NULL DEFAULT 0,
+    "lastError" text,
+    "lastErrorAt" timestamp,
+    "updatedAt" timestamp NOT NULL DEFAULT now()
+  );
+`;
+
+// --- fixtures ---------------------------------------------------------------
+
+// Local-time Dates: the main column is timestamp WITHOUT time zone, so the pg
+// driver round-trips local wall-clock — hashes recompute byte-identically.
+const T = (month: number, s: number) => new Date(2026, month - 1, 1, 0, 0, s);
+
+interface LegacyRow {
+  id: string;
+  event: AuditEvent;
+  timestamp: Date;
+  previousHash: string;
+  eventHash: string;
+}
+
+function buildLegacyChain(timestamps: Date[]): LegacyRow[] {
+  const rows: LegacyRow[] = [];
+  let prev = 'genesis';
+  timestamps.forEach((timestamp, idx) => {
+    const i = idx + 1;
+    const event: AuditEvent = {
+      eventType: 'auth.login.success',
+      userId: `user-${i}`,
+      sessionId: `sess-${i}`,
+      serviceId: 'web',
+      resourceType: 'user',
+      resourceId: `u-${i}`,
+      ipAddress: '10.1.2.3',
+      userAgent: 'rehearsal-agent',
+      geoLocation: 'EU/Berlin',
+      details: { legacy: i },
+      // Exactly representable in float4 — read back from `real` must hash identically.
+      riskScore: 0.5,
+    };
+    const eventHash = computeSecurityEventHash(event, prev, timestamp);
+    rows.push({ id: `r${i}`, event, timestamp, previousHash: prev, eventHash });
+    prev = eventHash;
+  });
+  return rows;
+}
+
+async function insertMainRows(pool: PgPool, rows: LegacyRow[], seqBase = 0): Promise<void> {
+  for (const [idx, r] of rows.entries()) {
+    await pool.query(
+      `INSERT INTO security_audit_log
+         (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+          ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+          anomaly_flags, timestamp, chain_seq, previous_hash, event_hash)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13,$14,$15,$16,$17,$18)`,
+      [
+        r.id,
+        r.event.eventType,
+        r.event.userId ?? null,
+        r.event.sessionId ?? null,
+        r.event.serviceId ?? null,
+        r.event.resourceType ?? null,
+        r.event.resourceId ?? null,
+        r.event.ipAddress ?? null,
+        `bidx-${r.id}`,
+        r.event.userAgent ?? null,
+        r.event.geoLocation ?? null,
+        r.event.details ? JSON.stringify(r.event.details) : null,
+        r.event.riskScore ?? null,
+        r.event.anomalyFlags ?? null,
+        // UTC-rendered, exactly as drizzle wrote production rows (its
+        // timestamp mapToDriverValue is toISOString; reads assume +0000).
+        // Raw pg Date params would store LOCAL wall clock and break hashes.
+        r.timestamp.toISOString(),
+        seqBase + idx + 1,
+        r.previousHash,
+        r.eventHash,
+      ]
+    );
+  }
+}
+
+describe.skipIf(!url)('backfill-audit-db rehearsal (wire-connected)', () => {
+  let adminOwner: PgPool;
+  let mainOwner: PgPool;
+  let adminClient: AdminAuditDbClient;
+
+  async function resetBothStores(): Promise<void> {
+    // Recreate the drizzle client per reset: sessions opened before a schema
+    // reset cache the dropped public schema's OID and stop seeing tables.
+    await adminClient?.end();
+    await adminOwner.query('DROP SCHEMA IF EXISTS public CASCADE');
+    await adminOwner.query('DROP SCHEMA IF EXISTS drizzle_admin CASCADE');
+    await adminOwner.query('CREATE SCHEMA public');
+    for (const role of ADMIN_ROLES) {
+      await adminOwner.query(`
+        DO $$ BEGIN
+          IF EXISTS (SELECT FROM pg_roles WHERE rolname = '${role}') THEN
+            DROP OWNED BY ${role};
+            DROP ROLE ${role};
+          END IF;
+        END $$;
+      `);
+    }
+    const previousCwd = process.cwd();
+    process.chdir(path.resolve(__dirname, '../../packages/db'));
+    try {
+      await migrateAdminDb({ ADMIN_DATABASE_URL: url });
+    } finally {
+      process.chdir(previousCwd);
+    }
+    adminClient = createAdminAuditDbClient({ connectionString: url as string });
+
+    await mainOwner.query(
+      'DROP TABLE IF EXISTS security_audit_log, siem_delivery_cursors CASCADE'
+    );
+    await mainOwner.query('DROP FUNCTION IF EXISTS security_audit_log_freeze_guard() CASCADE');
+    await mainOwner.query(MAIN_TABLES_DDL);
+  }
+
+  const backfillDeps = (overrides: Record<string, unknown> = {}) => ({
+    main: mainOwner,
+    adminPool: adminOwner,
+    adminDb: adminClient.db,
+    batchSize: 2, // small on purpose — exercises multi-batch commits
+    log: () => {},
+    ...overrides,
+  });
+
+  beforeAll(async () => {
+    adminOwner = new Pool({ connectionString: url, max: 4 });
+    await adminOwner.query(`CREATE DATABASE ${MAIN_DB_NAME}`).catch((err: unknown) => {
+      if ((err as { code?: string }).code !== '42P04') throw err; // already exists
+    });
+    mainOwner = new Pool({ connectionString: mainDbUrl(), max: 4 });
+  });
+
+  afterAll(async () => {
+    await mainOwner
+      ?.query(`DROP OWNED BY ${PROBE_ROLE}; DROP ROLE IF EXISTS ${PROBE_ROLE}`)
+      .catch(() => undefined);
+    await Promise.all([adminClient?.end(), adminOwner?.end(), mainOwner?.end()]);
+  });
+
+  describe('plant → verify → converge (the rehearsal proper)', () => {
+    // r1..r3 in January 2026, r4..r7 in February — two historical months.
+    const legacy = buildLegacyChain([T(1, 1), T(1, 2), T(1, 3), T(2, 4), T(2, 5), T(2, 6), T(2, 7)]);
+
+    beforeAll(async () => {
+      await resetBothStores();
+      await insertMainRows(mainOwner, legacy);
+      // SIEM shipped r1..r3 pre-flip; the admin cursor does not exist yet, so
+      // the MAIN watermark is the anchor the future seed will copy.
+      await mainOwner.query(
+        `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount")
+         VALUES ('security_audit_log', 'r3', $1, 3)`,
+        [legacy[2].timestamp]
+      );
+      // A pre-backfill GDPR erasure already nulled r2's PII in main — the
+      // copy must carry the nulls verbatim and still verify (hash excludes PII).
+      await mainOwner.query(
+        `UPDATE security_audit_log
+         SET ip_address = NULL, ip_bidx = NULL, user_agent = NULL, geo_location = NULL, session_id = NULL
+         WHERE id = 'r2'`
+      );
+    });
+
+    it('dry-run plans without writing a single row', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: true });
+      expect(summary.outcome).toBe('planned');
+      expect(summary.precondition).toEqual({ ok: true, state: 'pre_chainer' });
+      expect(summary.anchorRowId).toBe('r3');
+      const count = await adminOwner.query('SELECT count(*)::int AS n FROM security_audit_log');
+      expect(count.rows[0].n).toBe(0);
+    });
+
+    it('--apply plants everything, seq-aligned, anchor last, genesis→head GREEN with parity', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+
+      expect(summary.outcome).toBe('backfilled');
+      expect(summary.planted).toBe(7);
+      expect(summary.anchorRowId).toBe('r3');
+      expect(summary.anchorPlanted).toBe(true);
+      expect(summary.parity).toEqual({ ok: true, failures: [] });
+
+      // THE core proof: the whole admin chain verifies genesis→head.
+      expect(summary.verification?.isValid).toBe(true);
+      expect(summary.verification?.totalEntries).toBe(7);
+      expect(summary.verification?.entriesVerified).toBe(7);
+      expect(summary.verification?.invalidEntries).toBe(0);
+      console.log('[rehearsal] genesis→head verification:', JSON.stringify(summary.verification));
+
+      // Anchor-committed-last, after every batch AND the sequence alignment.
+      const journal = summary.journal;
+      expect(journal[journal.length - 1]).toBe('anchor:r3');
+      expect(journal.indexOf('setval:7')).toBeGreaterThan(-1);
+      expect(journal.indexOf('setval:7')).toBeLessThan(journal.indexOf('anchor:r3'));
+      for (const entry of journal.filter((j) => j.startsWith('plant:'))) {
+        expect(journal.indexOf(entry)).toBeLessThan(journal.indexOf('setval:7'));
+      }
+
+      // Historical partitions created; the DEFAULT partition stayed empty.
+      expect(summary.partitionsCreated).toEqual(
+        expect.arrayContaining(['security_audit_log_p2026_01', 'security_audit_log_p2026_02'])
+      );
+      const inDefault = await adminOwner.query(
+        'SELECT count(*)::int AS n FROM security_audit_log_default'
+      );
+      expect(inDefault.rows[0].n).toBe(0);
+
+      // Row-for-row equality of everything the chain covers + PII columns —
+      // including r2's pre-erasure NULLs carried verbatim.
+      const adminRows = await adminOwner.query(
+        `SELECT id, chain_seq::int AS seq, previous_hash, event_hash, emission_hash,
+                ip_address, ip_bidx, user_agent, geo_location, session_id
+         FROM security_audit_log ORDER BY chain_seq`
+      );
+      expect(adminRows.rows.map((r) => `${r.id}:${r.seq}`)).toEqual(
+        legacy.map((r, i) => `${r.id}:${i + 1}`)
+      );
+      for (const [i, row] of adminRows.rows.entries()) {
+        expect(row.previous_hash).toBe(legacy[i].previousHash);
+        expect(row.event_hash).toBe(legacy[i].eventHash);
+        expect(row.emission_hash).toBeNull(); // the legacy-era marker
+      }
+      const erased = adminRows.rows.find((r) => r.id === 'r2');
+      expect(erased).toMatchObject({
+        ip_address: null,
+        ip_bidx: null,
+        user_agent: null,
+        geo_location: null,
+        session_id: null,
+      });
+
+      // Head-hash parity, asserted independently of the summary.
+      const mainHead = await mainOwner.query(
+        'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1'
+      );
+      const adminHead = await adminOwner.query(
+        'SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1'
+      );
+      expect(adminHead.rows[0].event_hash).toBe(mainHead.rows[0].event_hash);
+
+      // Sequence aligned: the chainer's next chain_seq exceeds the legacy range.
+      const next = await adminOwner.query(
+        `SELECT nextval('security_audit_log_chain_seq_seq')::int AS v`
+      );
+      expect(next.rows[0].v).toBeGreaterThan(7);
+    });
+
+    it('rerun is idempotent: nothing re-planted, no dupes, still GREEN', async () => {
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('backfilled');
+      expect(summary.planted).toBe(0);
+      expect(summary.parity?.ok).toBe(true);
+      expect(summary.verification?.isValid).toBe(true);
+      const count = await adminOwner.query('SELECT count(*)::int AS n FROM security_audit_log');
+      expect(count.rows[0].n).toBe(7);
+    });
+
+    it('converges a main tail row appended after the first run (zero-loss)', async () => {
+      const [r8] = buildLegacyChain([T(2, 8)]).map((row) => ({
+        ...row,
+        id: 'r8',
+        previousHash: legacy[6].eventHash,
+        eventHash: computeSecurityEventHash(row.event, legacy[6].eventHash, row.timestamp),
+      }));
+      await insertMainRows(mainOwner, [r8], 7);
+
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('backfilled');
+      expect(summary.planted).toBe(1);
+      expect(summary.parity?.ok).toBe(true);
+      expect(summary.verification?.isValid).toBe(true);
+      expect(summary.verification?.totalEntries).toBe(8);
+    });
+
+    it('detects an admin-side tamper during the rerun verification', async () => {
+      await adminOwner.query(
+        `UPDATE security_audit_log SET event_hash = 'tampered' WHERE id = 'r5'`
+      );
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.verification?.isValid).toBe(false);
+      expect(summary.verification?.breakPoint?.entryId).toBe('r5');
+      // repair for the freeze block below
+      await adminOwner.query(`UPDATE security_audit_log SET event_hash = $1 WHERE id = 'r5'`, [
+        legacy[4].eventHash,
+      ]);
+      const repaired = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(repaired.verification?.isValid).toBe(true);
+    });
+
+    describe('--freeze (same seeded state, after verification)', () => {
+      it('re-proves parity + chain, then freezes', async () => {
+        // a probe user with an explicit INSERT grant, to prove the revoke
+        await mainOwner.query(`
+          DO $$ BEGIN
+            IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${PROBE_ROLE}') THEN
+              CREATE ROLE ${PROBE_ROLE} LOGIN PASSWORD 'probesecret1';
+            END IF;
+          END $$;
+        `);
+        await mainOwner.query(`GRANT INSERT, DELETE ON security_audit_log TO ${PROBE_ROLE}`);
+
+        const result = await freezeLegacySecurityAuditLog({
+          main: mainOwner,
+          admin: adminOwner,
+          adminDb: adminClient.db,
+        });
+        expect(result.outcome).toBe('frozen');
+        expect(result.parity?.ok).toBe(true);
+        expect(result.verification?.isValid).toBe(true);
+      });
+
+      it('blocks INSERT, DELETE, TRUNCATE, and non-PII UPDATE — for the OWNER too', async () => {
+        await expect(
+          mainOwner.query(
+            `INSERT INTO security_audit_log (id, event_type, timestamp, chain_seq, previous_hash, event_hash)
+             VALUES ('frozen-probe', 'auth.login.success', now(), 999, 'x', 'y')`
+          )
+        ).rejects.toThrow(/write-frozen/);
+        await expect(
+          mainOwner.query(`DELETE FROM security_audit_log WHERE id = 'r1'`)
+        ).rejects.toThrow(/write-frozen/);
+        await expect(mainOwner.query('TRUNCATE security_audit_log')).rejects.toThrow(
+          /write-frozen/
+        );
+        await expect(
+          mainOwner.query(`UPDATE security_audit_log SET event_hash = 'evil' WHERE id = 'r1'`)
+        ).rejects.toThrow(/write-frozen/);
+        await expect(
+          mainOwner.query(`UPDATE security_audit_log SET details = '{}'::jsonb WHERE id = 'r1'`)
+        ).rejects.toThrow(/write-frozen/);
+      });
+
+      it('revoked the probe user\'s write grants (grant-denial)', async () => {
+        const grants = await mainOwner.query(
+          `SELECT privilege_type FROM information_schema.role_table_grants
+           WHERE table_name = 'security_audit_log' AND grantee = '${PROBE_ROLE}'
+             AND privilege_type IN ('INSERT', 'DELETE', 'TRUNCATE')`
+        );
+        expect(grants.rows).toEqual([]);
+
+        const probePool = new Pool({
+          connectionString: (() => {
+            const parsed = new URL(mainDbUrl());
+            parsed.username = PROBE_ROLE;
+            parsed.password = 'probesecret1';
+            return parsed.toString();
+          })(),
+          max: 1,
+        });
+        try {
+          await expect(
+            probePool.query(
+              `INSERT INTO security_audit_log (id, event_type, timestamp, chain_seq, previous_hash, event_hash)
+               VALUES ('probe-row', 'auth.login.success', now(), 998, 'x', 'y')`
+            )
+          ).rejects.toThrow(/permission denied|write-frozen/);
+        } finally {
+          await probePool.end();
+        }
+      });
+
+      it('keeps the GDPR pseudonymization UPDATE working (Art 17 outlives the freeze)', async () => {
+        const result = await mainOwner.query(
+          `UPDATE security_audit_log
+           SET ip_address = NULL, ip_bidx = NULL, user_agent = NULL, geo_location = NULL, session_id = NULL
+           WHERE user_id = 'user-4'`
+        );
+        expect(result.rowCount).toBe(1);
+        const chainCols = await mainOwner.query(
+          `SELECT previous_hash, event_hash FROM security_audit_log WHERE user_id = 'user-4'`
+        );
+        expect(chainCols.rows[0].event_hash).toBe(legacy[3].eventHash);
+      });
+
+      it('is idempotent — freezing again succeeds and changes nothing', async () => {
+        const result = await freezeLegacySecurityAuditLog({
+          main: mainOwner,
+          admin: adminOwner,
+          adminDb: adminClient.db,
+        });
+        expect(result.outcome).toBe('frozen');
+      });
+    });
+  });
+
+  describe('refusal paths (fresh stores each)', () => {
+    it("aborts on an emission era already chained from 'genesis' — the chainer-ran-first state", async () => {
+      await resetBothStores();
+      const legacy = buildLegacyChain([T(2, 1), T(2, 2)]);
+      await insertMainRows(mainOwner, legacy);
+
+      // Simulate the chainer having run before backfill: one emission-era row
+      // hanging off 'genesis' in the admin store.
+      const event: AuditEvent = { eventType: 'data.read', userId: 'user-g', resourceType: 'page', resourceId: 'p-g' };
+      const ts = T(7, 1);
+      const emission = computeEmissionHash(event, ts);
+      await adminOwner.query(
+        `INSERT INTO security_audit_log
+           (id, event_type, user_id, resource_type, resource_id, timestamp, emission_hash, previous_hash, event_hash)
+         VALUES ('g1', $1, 'user-g', 'page', 'p-g', $2, $3, 'genesis', $4)`,
+        [event.eventType, ts.toISOString(), emission, computeChainHash(emission, 'genesis')]
+      );
+
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('aborted');
+      expect(summary.precondition).toMatchObject({ ok: false, reason: 'unlinked_emission_era' });
+      const planted = await adminOwner.query(
+        'SELECT count(*)::int AS n FROM security_audit_log WHERE emission_hash IS NULL'
+      );
+      expect(planted.rows[0].n).toBe(0);
+    });
+
+    it('aborts on a main head that moved past the frozen era boundary', async () => {
+      await resetBothStores();
+      const legacy = buildLegacyChain([T(2, 1), T(2, 2)]);
+      await insertMainRows(mainOwner, legacy);
+
+      // The boundary linked onto head r2… then main grew r3 (break-glass).
+      const event: AuditEvent = { eventType: 'data.read', userId: 'user-g', resourceType: 'page', resourceId: 'p-g' };
+      const ts = T(7, 1);
+      const emission = computeEmissionHash(event, ts);
+      await adminOwner.query(
+        `INSERT INTO security_audit_log
+           (id, event_type, user_id, resource_type, resource_id, timestamp, chain_seq, emission_hash, previous_hash, event_hash)
+         VALUES ('g1', $1, 'user-g', 'page', 'p-g', $2, 3, $3, $4, $5)`,
+        [event.eventType, ts.toISOString(), emission, legacy[1].eventHash, computeChainHash(emission, legacy[1].eventHash)]
+      );
+      const tail = buildLegacyChain([T(2, 3)]).map((row) => ({
+        ...row,
+        id: 'r3',
+        previousHash: legacy[1].eventHash,
+        eventHash: computeSecurityEventHash(row.event, legacy[1].eventHash, row.timestamp),
+      }));
+      await insertMainRows(mainOwner, tail, 2);
+
+      const summary = await runAuditBackfill({ ...backfillDeps(), dryRun: false });
+      expect(summary.outcome).toBe('aborted');
+      expect(summary.precondition).toMatchObject({ ok: false, reason: 'boundary_mismatch' });
+    });
+
+    it('aborts when break-glass is armed, and the freeze refuses too', async () => {
+      await resetBothStores();
+      await insertMainRows(mainOwner, buildLegacyChain([T(2, 1)]));
+
+      const summary = await runAuditBackfill({
+        ...backfillDeps({ breakGlassArmed: true }),
+        dryRun: false,
+      });
+      expect(summary.outcome).toBe('aborted');
+      expect(summary.precondition).toMatchObject({ ok: false, reason: 'break_glass_armed' });
+
+      const freeze = await freezeLegacySecurityAuditLog({
+        main: mainOwner,
+        admin: adminOwner,
+        adminDb: adminClient.db,
+        breakGlassArmed: true,
+      });
+      expect(freeze.outcome).toBe('refused');
+    });
+
+    it('the freeze refuses when the backfill has not run (main rows, empty admin)', async () => {
+      await resetBothStores();
+      await insertMainRows(mainOwner, buildLegacyChain([T(2, 1), T(2, 2)]));
+
+      const result = await freezeLegacySecurityAuditLog({
+        main: mainOwner,
+        admin: adminOwner,
+        adminDb: adminClient.db,
+      });
+      expect(result.outcome).toBe('refused');
+      expect(result.refusals.join(' ')).toMatch(/backfill/i);
+
+      // …and the table is still writable (no partial freeze).
+      const insert = await mainOwner.query(
+        `INSERT INTO security_audit_log (id, event_type, timestamp, chain_seq, previous_hash, event_hash)
+         VALUES ('still-writable', 'auth.login.success', now(), 99, 'x', 'y')`
+      );
+      expect(insert.rowCount).toBe(1);
+    });
+  });
+});

--- a/scripts/__tests__/backfill-audit-db.test.ts
+++ b/scripts/__tests__/backfill-audit-db.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Unit tests for the pure core of scripts/backfill-audit-db.ts (#890 Phase 2,
+ * leaf 8 — backfill + flip + freeze).
+ *
+ * Everything here is pure decision logic: precondition assessment (the
+ * era-boundary crux — a chainer that already chained from 'genesis' before
+ * legacy rows were planted is an unrecoverable-in-place state and MUST abort),
+ * sequence alignment planning, SIEM anchor-row resolution (leaf 7's
+ * anchor-committed-last invariant), historical partition month planning,
+ * post-plant parity assessment, CLI/env resolution, and the freeze-guard SQL
+ * builder whose mutable-column allowlist must stay in lockstep with the GDPR
+ * pseudonymization patch. The imperative shells are covered by
+ * backfill-audit-db.integration.test.ts on scratch Postgres.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assessBackfillPreconditions,
+  planSequenceTarget,
+  resolveAnchorRowId,
+  monthPartitionsForRange,
+  assessBackfillParity,
+  resolveBackfillCliMode,
+  resolveBackfillEnv,
+  buildFreezeGuardFunctionSql,
+  ERASER_MUTABLE_COLUMNS,
+  FROZEN_IMMUTABLE_COLUMNS,
+  SIEM_CURSOR_INIT_SENTINEL,
+  CHAINER_ADVISORY_LOCK_KEY,
+  type BackfillStoreState,
+} from '../backfill-audit-db';
+import { buildSecurityAuditPseudonymizationPatch } from '@pagespace/lib/compliance/erasure/pseudonymize';
+
+const baseState: BackfillStoreState = {
+  breakGlassArmed: false,
+  mainCount: 5,
+  mainMaxSeq: 5,
+  mainHeadHash: 'head-5',
+  adminLegacyCount: 0,
+  adminEmission: null,
+};
+
+describe('assessBackfillPreconditions', () => {
+  it('given break-glass armed, should refuse regardless of store state', () => {
+    const result = assessBackfillPreconditions({ ...baseState, breakGlassArmed: true });
+    expect(result).toMatchObject({ ok: false, reason: 'break_glass_armed' });
+  });
+
+  it('given an empty main table, should proceed as a no-op (nothing to backfill)', () => {
+    const result = assessBackfillPreconditions({
+      ...baseState,
+      mainCount: 0,
+      mainMaxSeq: 0,
+      mainHeadHash: null,
+    });
+    expect(result).toEqual({ ok: true, state: 'empty_main' });
+  });
+
+  it('given no emission-era rows in admin, should proceed (clean pre-chainer state)', () => {
+    const result = assessBackfillPreconditions(baseState);
+    expect(result).toEqual({ ok: true, state: 'pre_chainer' });
+  });
+
+  it('given emission-era rows chained from genesis while main has history, should ABORT unlinked_emission_era', () => {
+    // The leaf-7 unresolved case: the chainer ran BEFORE backfill, so the
+    // emission era grew from 'genesis' and can never link onto the legacy
+    // head — nobody holds UPDATE on chain columns, so re-linking in place is
+    // impossible by design. The only correct move is refusal + runbook.
+    const result = assessBackfillPreconditions({
+      ...baseState,
+      adminEmission: { count: 3, minSeq: 1, earliestPrevHash: 'genesis' },
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'unlinked_emission_era' });
+  });
+
+  it('given an emission era already linked onto the main head, should proceed (idempotent rerun)', () => {
+    const result = assessBackfillPreconditions({
+      ...baseState,
+      adminLegacyCount: 5,
+      adminEmission: { count: 2, minSeq: 6, earliestPrevHash: 'head-5' },
+    });
+    expect(result).toEqual({ ok: true, state: 'boundary_linked' });
+  });
+
+  it('given an emission era linked to neither genesis nor the main head, should ABORT boundary_mismatch', () => {
+    // e.g. break-glass appended rows to main AFTER the era boundary froze —
+    // the main head moved and the planted boundary no longer matches.
+    const result = assessBackfillPreconditions({
+      ...baseState,
+      mainHeadHash: 'head-6-after-break-glass',
+      mainMaxSeq: 6,
+      mainCount: 6,
+      adminLegacyCount: 5,
+      adminEmission: { count: 2, minSeq: 6, earliestPrevHash: 'head-5' },
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'boundary_mismatch' });
+  });
+
+  it('given a linked boundary whose emission seqs overlap legacy seqs, should ABORT seq_collision', () => {
+    const result = assessBackfillPreconditions({
+      ...baseState,
+      adminLegacyCount: 4,
+      adminEmission: { count: 2, minSeq: 5, earliestPrevHash: 'head-5' },
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'seq_collision' });
+  });
+});
+
+describe('planSequenceTarget', () => {
+  it('given a planted legacy range, should target the max planted seq (nextval then exceeds it)', () => {
+    expect(planSequenceTarget({ mainMaxSeq: 42, adminMaxSeq: 0 })).toBe(42);
+  });
+
+  it('given emission rows already beyond the legacy range, should never lower the sequence', () => {
+    expect(planSequenceTarget({ mainMaxSeq: 42, adminMaxSeq: 44 })).toBe(44);
+  });
+
+  it('given nothing planted anywhere, should skip setval (setval(0) is invalid)', () => {
+    expect(planSequenceTarget({ mainMaxSeq: 0, adminMaxSeq: 0 })).toBeNull();
+  });
+});
+
+describe('resolveAnchorRowId', () => {
+  it('given a seeded admin cursor, should anchor on its lastDeliveredId', () => {
+    expect(resolveAnchorRowId({ adminCursorId: 'r3', mainCursorId: 'r2' })).toBe('r3');
+  });
+
+  it('given no admin cursor yet, should fall back to the legacy main cursor (the future seed value)', () => {
+    expect(resolveAnchorRowId({ adminCursorId: null, mainCursorId: 'r2' })).toBe('r2');
+  });
+
+  it('given only sentinel cursors, should not gate on any anchor row', () => {
+    expect(
+      resolveAnchorRowId({
+        adminCursorId: SIEM_CURSOR_INIT_SENTINEL,
+        mainCursorId: SIEM_CURSOR_INIT_SENTINEL,
+      })
+    ).toBeNull();
+    expect(resolveAnchorRowId({ adminCursorId: null, mainCursorId: null })).toBeNull();
+  });
+
+  it('given a sentinel admin cursor but a real main cursor, should anchor on the main watermark', () => {
+    expect(
+      resolveAnchorRowId({ adminCursorId: SIEM_CURSOR_INIT_SENTINEL, mainCursorId: 'r7' })
+    ).toBe('r7');
+  });
+});
+
+describe('monthPartitionsForRange', () => {
+  it('given a multi-month legacy range, should plan one monthly partition per covered month', () => {
+    const months = monthPartitionsForRange('2025-11-14 08:00:00', '2026-02-01 00:00:00');
+    expect(months).toEqual([
+      { name: 'security_audit_log_p2025_11', from: '2025-11-01', to: '2025-12-01' },
+      { name: 'security_audit_log_p2025_12', from: '2025-12-01', to: '2026-01-01' },
+      { name: 'security_audit_log_p2026_01', from: '2026-01-01', to: '2026-02-01' },
+      { name: 'security_audit_log_p2026_02', from: '2026-02-01', to: '2026-03-01' },
+    ]);
+  });
+
+  it('given a single-month range, should plan exactly that month', () => {
+    expect(monthPartitionsForRange('2026-02-03 10:00:00', '2026-02-20 10:00:00')).toEqual([
+      { name: 'security_audit_log_p2026_02', from: '2026-02-01', to: '2026-03-01' },
+    ]);
+  });
+
+  it('given an absurd range, should throw rather than plan thousands of DDL statements', () => {
+    expect(() => monthPartitionsForRange('1990-01-01 00:00:00', '2026-01-01 00:00:00')).toThrow(
+      /range/i
+    );
+  });
+});
+
+describe('assessBackfillParity', () => {
+  const good = {
+    mainCount: 5,
+    adminLegacyCount: 5,
+    mainHeadHash: 'h5',
+    adminLegacyHeadHash: 'h5',
+    emissionBoundaryPrevHash: 'h5',
+  };
+
+  it('given counts, heads, and boundary all matching, should pass', () => {
+    expect(assessBackfillParity(good)).toEqual({ ok: true, failures: [] });
+  });
+
+  it('given no emission era yet, should pass on counts + heads alone', () => {
+    expect(assessBackfillParity({ ...good, emissionBoundaryPrevHash: null })).toEqual({
+      ok: true,
+      failures: [],
+    });
+  });
+
+  it('given a row-count mismatch, should fail naming the counts', () => {
+    const result = assessBackfillParity({ ...good, adminLegacyCount: 4 });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/count/i);
+  });
+
+  it('given a head-hash mismatch, should fail naming the heads', () => {
+    const result = assessBackfillParity({ ...good, adminLegacyHeadHash: 'other' });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/head/i);
+  });
+
+  it('given an emission boundary that does not link off the legacy head, should fail', () => {
+    const result = assessBackfillParity({ ...good, emissionBoundaryPrevHash: 'genesis' });
+    expect(result.ok).toBe(false);
+    expect(result.failures.join(' ')).toMatch(/boundary/i);
+  });
+
+  it('given an empty main store, should pass vacuously', () => {
+    expect(
+      assessBackfillParity({
+        mainCount: 0,
+        adminLegacyCount: 0,
+        mainHeadHash: null,
+        adminLegacyHeadHash: null,
+        emissionBoundaryPrevHash: null,
+      })
+    ).toEqual({ ok: true, failures: [] });
+  });
+});
+
+describe('resolveBackfillCliMode', () => {
+  it('given no flags, should default to the dry-run plan', () => {
+    expect(resolveBackfillCliMode([], {})).toEqual({ ok: true, command: 'plan' });
+  });
+
+  it('given --apply, should run the live backfill', () => {
+    expect(resolveBackfillCliMode(['--apply'], {})).toEqual({ ok: true, command: 'apply' });
+  });
+
+  it('given --freeze without explicit confirmation, should refuse (freeze breaks break-glass appends)', () => {
+    const result = resolveBackfillCliMode(['--freeze'], {});
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/AUDIT_FREEZE_CONFIRMED/);
+  });
+
+  it('given --freeze with AUDIT_FREEZE_CONFIRMED=true, should freeze', () => {
+    expect(resolveBackfillCliMode(['--freeze'], { AUDIT_FREEZE_CONFIRMED: 'true' })).toEqual({
+      ok: true,
+      command: 'freeze',
+    });
+  });
+
+  it('given both --apply and --freeze, should refuse (operator must verify between the steps)', () => {
+    const result = resolveBackfillCliMode(['--apply', '--freeze'], {
+      AUDIT_FREEZE_CONFIRMED: 'true',
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('given an unknown flag, should refuse rather than silently ignore it', () => {
+    const result = resolveBackfillCliMode(['--aply'], {});
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('resolveBackfillEnv', () => {
+  it('given both URLs, should prefer the owner migrate URL for the admin side', () => {
+    const result = resolveBackfillEnv({
+      DATABASE_URL: 'postgres://main',
+      ADMIN_DATABASE_URL: 'postgres://runtime',
+      ADMIN_DATABASE_URL_MIGRATE: 'postgres://owner',
+    });
+    expect(result).toEqual({
+      ok: true,
+      mainUrl: 'postgres://main',
+      adminUrl: 'postgres://owner',
+      breakGlassArmed: false,
+    });
+  });
+
+  it('given only the runtime admin URL, should use it (self-host: owner IS the runtime URL holder)', () => {
+    const result = resolveBackfillEnv({
+      DATABASE_URL: 'postgres://main',
+      ADMIN_DATABASE_URL: 'postgres://runtime',
+    });
+    expect(result).toMatchObject({ ok: true, adminUrl: 'postgres://runtime' });
+  });
+
+  it('given a missing main or admin URL, should refuse with the variable named', () => {
+    const noAdmin = resolveBackfillEnv({ DATABASE_URL: 'postgres://main' });
+    expect(noAdmin.ok).toBe(false);
+    if (!noAdmin.ok) expect(noAdmin.error).toMatch(/ADMIN_DATABASE_URL/);
+
+    const noMain = resolveBackfillEnv({ ADMIN_DATABASE_URL: 'postgres://runtime' });
+    expect(noMain.ok).toBe(false);
+    if (!noMain.ok) expect(noMain.error).toMatch(/DATABASE_URL/);
+  });
+
+  it('given ADMIN_DB_BREAK_GLASS=true, should flag break-glass so preconditions refuse', () => {
+    const result = resolveBackfillEnv({
+      DATABASE_URL: 'postgres://main',
+      ADMIN_DATABASE_URL: 'postgres://runtime',
+      ADMIN_DB_BREAK_GLASS: 'true',
+    });
+    expect(result).toMatchObject({ ok: true, breakGlassArmed: true });
+  });
+});
+
+describe('freeze guard column partition', () => {
+  it('should keep the mutable allowlist in lockstep with the eraser grant (6 PII columns)', () => {
+    expect([...ERASER_MUTABLE_COLUMNS].sort()).toEqual(
+      ['geo_location', 'ip_address', 'ip_bidx', 'session_id', 'user_agent', 'user_id'].sort()
+    );
+  });
+
+  it('should allow every column the GDPR pseudonymization patch writes', () => {
+    // The main-store erasure leg keeps running until the legacy table drops
+    // (Art 17 is time-bound) — if the patch ever writes a column the freeze
+    // guard treats as immutable, erasure would 500 in production.
+    const patchColumns: Record<string, string> = {
+      ipAddress: 'ip_address',
+      ipBidx: 'ip_bidx',
+      userAgent: 'user_agent',
+      geoLocation: 'geo_location',
+      sessionId: 'session_id',
+      userId: 'user_id',
+    };
+    for (const key of Object.keys(buildSecurityAuditPseudonymizationPatch())) {
+      const column = patchColumns[key];
+      expect(column, `unmapped pseudonymization patch key ${key}`).toBeDefined();
+      expect(ERASER_MUTABLE_COLUMNS).toContain(column);
+    }
+  });
+
+  it('should freeze every chain-relevant column and cover the whole table with no overlap', () => {
+    const all = [...ERASER_MUTABLE_COLUMNS, ...FROZEN_IMMUTABLE_COLUMNS].sort();
+    expect(all).toEqual(
+      [
+        'id',
+        'event_type',
+        'user_id',
+        'session_id',
+        'service_id',
+        'resource_type',
+        'resource_id',
+        'ip_address',
+        'ip_bidx',
+        'user_agent',
+        'geo_location',
+        'details',
+        'risk_score',
+        'anomaly_flags',
+        'timestamp',
+        'chain_seq',
+        'previous_hash',
+        'event_hash',
+      ].sort()
+    );
+    for (const column of FROZEN_IMMUTABLE_COLUMNS) {
+      expect(ERASER_MUTABLE_COLUMNS).not.toContain(column);
+    }
+  });
+
+  it('should build a guard that raises for immutable columns and never mentions mutable ones', () => {
+    const sql = buildFreezeGuardFunctionSql();
+    for (const column of FROZEN_IMMUTABLE_COLUMNS) {
+      expect(sql).toContain(`NEW.${column} IS DISTINCT FROM OLD.${column}`);
+    }
+    for (const column of ERASER_MUTABLE_COLUMNS) {
+      expect(sql).not.toContain(`NEW.${column} IS DISTINCT FROM OLD.${column}`);
+    }
+    expect(sql).toMatch(/RAISE EXCEPTION/);
+  });
+});
+
+describe('cross-module pins', () => {
+  it('should pin the SIEM cursor sentinel to the value siem-sources.ts uses', () => {
+    // The script cannot import apps/processor (not a package); this literal
+    // pin plus the processor-side integration pin catch drift from both ends.
+    expect(SIEM_CURSOR_INIT_SENTINEL).toBe('__cursor_init__');
+  });
+
+  it("should pin the advisory lock key to the chainer's", () => {
+    expect(CHAINER_ADVISORY_LOCK_KEY).toBe('audit-chainer');
+  });
+});

--- a/scripts/__tests__/backfill-audit-db.test.ts
+++ b/scripts/__tests__/backfill-audit-db.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  readCursorId,
   assessBackfillPreconditions,
   planSequenceTarget,
   resolveAnchorRowId,
@@ -362,6 +363,36 @@ describe('freeze guard column partition', () => {
       expect(sql).not.toContain(`NEW.${column} IS DISTINCT FROM OLD.${column}`);
     }
     expect(sql).toMatch(/RAISE EXCEPTION/);
+  });
+});
+
+describe('readCursorId', () => {
+  const undefinedTable = () => {
+    const err = new Error('relation "siem_delivery_cursors" does not exist') as Error & {
+      code: string;
+    };
+    err.code = '42P01';
+    return err;
+  };
+
+  it('given a missing cursors table on the MAIN side, should tolerate it (odd installs) and resolve null', async () => {
+    const db = { query: async () => Promise.reject(undefinedTable()) };
+    await expect(readCursorId(db, 'security_audit_log', 'main')).resolves.toBeNull();
+  });
+
+  it('given a missing cursors table on the ADMIN side, should abort — a broken admin schema must never silently fall back to the main cursor', async () => {
+    const db = { query: async () => Promise.reject(undefinedTable()) };
+    await expect(readCursorId(db, 'security_audit_log', 'admin')).rejects.toThrow('does not exist');
+  });
+
+  it('given any non-42P01 error on either side, should abort', async () => {
+    const db = { query: async () => Promise.reject(new Error('connection refused')) };
+    await expect(readCursorId(db, 'security_audit_log', 'main')).rejects.toThrow('connection refused');
+  });
+
+  it('given a cursor row, should return its lastDeliveredId', async () => {
+    const db = { query: async () => ({ rows: [{ lastDeliveredId: 'evt-42' }], rowCount: 1 }) };
+    await expect(readCursorId(db, 'security_audit_log', 'admin')).resolves.toBe('evt-42');
   });
 });
 

--- a/scripts/backfill-audit-db.ts
+++ b/scripts/backfill-audit-db.ts
@@ -459,15 +459,21 @@ interface GatheredState extends BackfillStoreState {
 
 const num = (v: unknown): number => Number(v ?? 0);
 
-async function readCursorId(db: QueryExecutor, source: string): Promise<string | null> {
+export async function readCursorId(
+  db: QueryExecutor,
+  source: string,
+  side: 'main' | 'admin'
+): Promise<string | null> {
   try {
     const r = await db.query('SELECT "lastDeliveredId" FROM siem_delivery_cursors WHERE id = $1', [
       source,
     ]);
     return (r.rows[0]?.lastDeliveredId as string | undefined) ?? null;
   } catch (error) {
-    // 42P01 undefined_table — tolerable only on the MAIN side of odd installs.
-    if ((error as { code?: string }).code === '42P01') return null;
+    // 42P01 undefined_table — tolerable only on the MAIN side of odd installs;
+    // a missing ADMIN cursors table is a broken admin schema and must abort
+    // (falling back to the main cursor would mask it).
+    if (side === 'main' && (error as { code?: string }).code === '42P01') return null;
     throw error;
   }
 }
@@ -506,8 +512,8 @@ export async function gatherBackfillState(deps: {
 
   const emissionCount = num(emissionAgg.rows[0]?.count);
   const [adminCursorId, mainCursorId] = await Promise.all([
-    readCursorId(deps.admin, SIEM_SECURITY_SOURCE),
-    readCursorId(deps.main, SIEM_SECURITY_SOURCE),
+    readCursorId(deps.admin, SIEM_SECURITY_SOURCE, 'admin'),
+    readCursorId(deps.main, SIEM_SECURITY_SOURCE, 'main'),
   ]);
 
   return {

--- a/scripts/backfill-audit-db.ts
+++ b/scripts/backfill-audit-db.ts
@@ -1,0 +1,1076 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: migrate legacy security_audit_log history into the Admin PG
+ * trust plane, prove the dual-era chain end to end, then write-freeze the
+ * legacy table (#890 Phase 2, leaf 8 — the cutover capstone).
+ *
+ * POST-CUTOVER STATE THIS RESOLVES: new audit events chain in the Admin PG
+ * (ingest → single-writer chainer); every pre-cutover event still sits in the
+ * MAIN db's security_audit_log, invisible to the default readers and SIEM.
+ * This script copies each legacy row admin-ward byte-for-byte — id, chain_seq,
+ * previous_hash, event_hash, timestamp, encrypted PII columns preserved;
+ * emission_hash left NULL as the legacy-era marker — so the admin store holds
+ * ONE chain from genesis through the era boundary to the live head.
+ *
+ * ERA-BOUNDARY SEQUENCING (the crux): the chainer links its FIRST batch onto
+ * whatever readChainHead() returns. Run the backfill BEFORE the chainer's
+ * first run and that head is the legacy head — the eras link with zero
+ * special-casing. Run the chainer first and it chains from 'genesis'; the two
+ * eras can then NEVER be joined, because re-linking would rewrite chain
+ * columns and no role (deliberately, including this script's owner identity
+ * acting through the append-only design) holds a supported UPDATE path on
+ * them. Enforcement here is threefold:
+ *   1. the runbook (infrastructure/UPGRADE.md) orders: processor STOPPED →
+ *      backfill → processor started. Web stays up throughout — events buffer
+ *      losslessly in security_audit_ingest, which only the chainer drains;
+ *   2. the script takes the chainer's own advisory lock
+ *      (hashtext('audit-chainer')) on the admin pool for the whole run, so a
+ *      forgotten-running chainer is provably excluded while rows are planted
+ *      and the sequence is aligned;
+ *   3. preconditions ABORT if an emission era already grew from 'genesis'
+ *      (see UNLINKED-ERA REMEDIATION below) or if the boundary no longer
+ *      matches the main head.
+ *
+ * SIEM VISIBILITY INVARIANT (leaf 7): the delivery worker defers the security
+ * source ('awaiting_backfill') until the row its seeded cursor points at (the
+ * ANCHOR row) is visible in the admin store — and from that moment every
+ * legacy row must already be visible, or rows would land behind the cursor
+ * and never deliver. The script therefore plants the anchor row LAST, in its
+ * own transaction, after every other row and the sequence alignment have
+ * committed.
+ *
+ * SEQUENCE ALIGNMENT: legacy rows are planted with their original chain_seq;
+ * security_audit_log_chain_seq_seq is then setval'd to the max planted seq
+ * (never lowered) BEFORE the advisory lock is released, so the chainer's next
+ * batch continues numbering after the legacy range instead of colliding with
+ * it (chain_seq has no unique constraint — collisions must be prevented, not
+ * caught).
+ *
+ * UNLINKED-ERA REMEDIATION (manual, owner-level — the script only refuses):
+ * if the chainer DID run first, the admin store holds an emission-era chain
+ * from 'genesis'. While the SIEM cursor is still deferring (it always is for
+ * a real seeded cursor — that is the deferral's purpose), nothing external
+ * has consumed that chain, so the owner may move those rows back to the
+ * queue and let the chainer re-chain them after backfill:
+ *   INSERT INTO security_audit_ingest (id, event_type, user_id, session_id,
+ *     service_id, resource_type, resource_id, ip_address, ip_bidx, user_agent,
+ *     geo_location, details, risk_score, anomaly_flags, timestamp,
+ *     emission_hash, emitted_at)
+ *   SELECT id, event_type, user_id, session_id, service_id, resource_type,
+ *     resource_id, ip_address, ip_bidx, user_agent, geo_location, details,
+ *     risk_score, anomaly_flags, timestamp, emission_hash, now()
+ *   FROM security_audit_log WHERE emission_hash IS NOT NULL;
+ *   DELETE FROM security_audit_log WHERE emission_hash IS NOT NULL; -- owner only
+ * DO NOT do this if anchoring was already enabled (AUDIT_ANCHOR_ENABLED):
+ * published anchors (receipt table AND S3 Object-Lock) are append-only
+ * witnesses of the genesis-era heads and would report tamper forever after.
+ * In that case escalate — do not improvise.
+ *
+ * FREEZE (--freeze, separate invocation AFTER verification + SIEM release):
+ * re-verifies parity + the full admin chain, then revokes INSERT/DELETE/
+ * TRUNCATE on the main table and installs guard triggers that raise on any
+ * write EXCEPT UPDATEs confined to the 6 eraser-scope PII columns — the main
+ * erasure leg (GDPR Art 17 is time-bound) must keep working until the table
+ * is dropped post-soak. The triggers bind the OWNER too (a plain REVOKE
+ * cannot: production connects as the table owner, which REVOKE does not
+ * restrict). Consequence, accepted by design: once frozen, BREAK-GLASS CAN NO
+ * LONGER APPEND to the legacy table — break-glass is an emergency-degraded
+ * mode; after the freeze its audit writes fail loudly instead of forking the
+ * history. Unfreeze (emergency only, as owner):
+ *   DROP TRIGGER security_audit_log_freeze ON security_audit_log;
+ *   DROP TRIGGER security_audit_log_freeze_truncate ON security_audit_log;
+ *
+ * Usage (operator identities: main DATABASE_URL owner-ish; admin side
+ * PREFERS ADMIN_DATABASE_URL_MIGRATE — the owner — over ADMIN_DATABASE_URL,
+ * because planting rows + setval + historical partition DDL exceed every
+ * runtime role's grants ON PURPOSE):
+ *   bun scripts/backfill-audit-db.ts               # dry-run plan (default, safe)
+ *   bun scripts/backfill-audit-db.ts --apply       # plant + setval + anchor + verify
+ *   AUDIT_FREEZE_CONFIRMED=true \
+ *     bun scripts/backfill-audit-db.ts --freeze    # verify, then write-freeze main
+ *
+ * Idempotent + resumable: every insert is ON CONFLICT DO NOTHING on the
+ * (id, timestamp) partition key, batches commit in chain_seq order behind a
+ * resume watermark, setval never lowers the sequence, and a rerun that finds
+ * nothing to plant just re-verifies. Exit 0 only when parity (row counts +
+ * head hashes + boundary linkage) AND the full genesis→head verification are
+ * green.
+ *
+ * Rehearsal (never against production):
+ *   docker run --rm -d --name pagespace-admin-smoke -p 55432:5432 \
+ *     -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=pagespace_admin postgres:16
+ *   cd scripts && ADMIN_DATABASE_URL=postgresql://admin:admin@localhost:55432/pagespace_admin \
+ *     bunx vitest run __tests__/backfill-audit-db.integration.test.ts
+ */
+
+import {
+  verifySecurityAuditChain,
+  type SecurityChainVerificationResult,
+} from '@pagespace/lib/audit/security-audit-chain-verifier';
+import type { AdminDatabase } from '@pagespace/db/admin-db';
+
+// ─── cross-module pins (not importable: apps/processor is not a package) ────
+
+/** Chainer advisory-lock key — apps/processor/src/workers/audit-chainer-worker.ts. */
+export const CHAINER_ADVISORY_LOCK_KEY = 'audit-chainer';
+/** SIEM initialized-but-never-delivered sentinel — apps/processor/src/services/siem-sources.ts. */
+export const SIEM_CURSOR_INIT_SENTINEL = '__cursor_init__';
+
+const SIEM_SECURITY_SOURCE = 'security_audit_log';
+const DEFAULT_BATCH_SIZE = 1000;
+const MAX_PARTITION_MONTHS = 240;
+
+// ─── pure core ───────────────────────────────────────────────────────────────
+
+export interface EmissionEraState {
+  count: number;
+  minSeq: number;
+  earliestPrevHash: string;
+}
+
+export interface BackfillStoreState {
+  breakGlassArmed: boolean;
+  mainCount: number;
+  mainMaxSeq: number;
+  mainHeadHash: string | null;
+  adminLegacyCount: number;
+  adminEmission: EmissionEraState | null;
+}
+
+export type BackfillPrecondition =
+  | { ok: true; state: 'empty_main' | 'pre_chainer' | 'boundary_linked' }
+  | {
+      ok: false;
+      reason: 'break_glass_armed' | 'unlinked_emission_era' | 'boundary_mismatch' | 'seq_collision';
+      detail: string;
+    };
+
+/**
+ * Decide whether planting legacy rows is provably safe. Pure — the shell
+ * gathers state, this rules on it. The genesis case is the leaf-7 flagged
+ * "chainer ran before backfill" state: refusal is the ONLY correct automated
+ * response (see UNLINKED-ERA REMEDIATION in the header).
+ */
+export function assessBackfillPreconditions(s: BackfillStoreState): BackfillPrecondition {
+  if (s.breakGlassArmed) {
+    return {
+      ok: false,
+      reason: 'break_glass_armed',
+      detail:
+        'ADMIN_DB_BREAK_GLASS=true — audit writes are falling back to the main db, so the legacy table is not static. Disarm break-glass and re-run.',
+    };
+  }
+  if (s.mainCount === 0) {
+    return { ok: true, state: 'empty_main' };
+  }
+  if (s.adminEmission === null) {
+    return { ok: true, state: 'pre_chainer' };
+  }
+  if (s.adminEmission.earliestPrevHash === 'genesis') {
+    return {
+      ok: false,
+      reason: 'unlinked_emission_era',
+      detail:
+        `The admin store already holds ${s.adminEmission.count} emission-era row(s) chained from 'genesis' — the chainer ran before the backfill, and the legacy and emission eras can no longer be linked in place. ` +
+        'Follow the UNLINKED-ERA REMEDIATION section of scripts/backfill-audit-db.ts / infrastructure/UPGRADE.md.',
+    };
+  }
+  if (s.adminEmission.earliestPrevHash !== s.mainHeadHash) {
+    return {
+      ok: false,
+      reason: 'boundary_mismatch',
+      detail:
+        `The earliest emission-era row links onto ${s.adminEmission.earliestPrevHash}, but the main head is ${s.mainHeadHash ?? '<empty>'} — the main table changed after the era boundary froze (break-glass appends?). ` +
+        'Those main-tail rows cannot join the admin chain; reconcile manually before re-running.',
+    };
+  }
+  if (s.adminEmission.minSeq <= s.mainMaxSeq) {
+    return {
+      ok: false,
+      reason: 'seq_collision',
+      detail: `Emission-era rows start at chain_seq ${s.adminEmission.minSeq} but the legacy range extends to ${s.mainMaxSeq} — planting would create duplicate chain_seq values.`,
+    };
+  }
+  return { ok: true, state: 'boundary_linked' };
+}
+
+/**
+ * The setval target after planting: high enough that the chainer's next
+ * nextval() exceeds every planted seq, and never LOWER than what the admin
+ * sequence already reached (an idempotent rerun must not rewind it under a
+ * live emission era). Null = nothing planted anywhere, skip setval
+ * (setval below 1 is a Postgres error).
+ */
+export function planSequenceTarget(i: { mainMaxSeq: number; adminMaxSeq: number }): number | null {
+  const target = Math.max(i.mainMaxSeq, i.adminMaxSeq);
+  return target > 0 ? target : null;
+}
+
+/**
+ * The SIEM anchor row to commit LAST (leaf 7 invariant). The admin cursor is
+ * authoritative once seeded; before the first post-flip delivery run it does
+ * not exist yet, in which case the legacy main cursor holds the watermark the
+ * seed WILL copy. Sentinel/absent cursors gate nothing — for those the
+ * runbook's backfill-before-first-delivery ordering is the protection.
+ */
+export function resolveAnchorRowId(i: {
+  adminCursorId: string | null;
+  mainCursorId: string | null;
+}): string | null {
+  if (i.adminCursorId !== null && i.adminCursorId !== SIEM_CURSOR_INIT_SENTINEL) {
+    return i.adminCursorId;
+  }
+  if (i.mainCursorId !== null && i.mainCursorId !== SIEM_CURSOR_INIT_SENTINEL) {
+    return i.mainCursorId;
+  }
+  return null;
+}
+
+export interface MonthPartition {
+  name: string;
+  from: string;
+  to: string;
+}
+
+/**
+ * Monthly partitions covering [minTs, maxTs] (Postgres timestamp text), named
+ * exactly like drizzle-admin/0002's seeding (security_audit_log_pYYYY_MM).
+ * Planting into missing months would silently land rows in the DEFAULT
+ * partition — never lost, but it poisons admin_ensure_partitions for those
+ * months (Postgres refuses to carve a month out of a non-empty DEFAULT).
+ */
+export function monthPartitionsForRange(minTs: string, maxTs: string): MonthPartition[] {
+  const parse = (ts: string): { y: number; m: number } => {
+    const match = /^(\d{4})-(\d{2})/.exec(ts);
+    if (!match) throw new Error(`Unparseable timestamp: ${ts}`);
+    return { y: Number(match[1]), m: Number(match[2]) };
+  };
+  const lo = parse(minTs);
+  const hi = parse(maxTs);
+  const months = (hi.y - lo.y) * 12 + (hi.m - lo.m) + 1;
+  if (months < 1 || months > MAX_PARTITION_MONTHS) {
+    throw new Error(
+      `Refusing to plan ${months} monthly partitions for range ${minTs}..${maxTs} — check the source timestamps.`
+    );
+  }
+  const result: MonthPartition[] = [];
+  for (let i = 0; i < months; i++) {
+    const y = lo.y + Math.floor((lo.m - 1 + i) / 12);
+    const m = ((lo.m - 1 + i) % 12) + 1;
+    const nextY = m === 12 ? y + 1 : y;
+    const nextM = m === 12 ? 1 : m + 1;
+    const pad = (n: number) => String(n).padStart(2, '0');
+    result.push({
+      name: `security_audit_log_p${y}_${pad(m)}`,
+      from: `${y}-${pad(m)}-01`,
+      to: `${nextY}-${pad(nextM)}-01`,
+    });
+  }
+  return result;
+}
+
+export interface ParityInput {
+  mainCount: number;
+  adminLegacyCount: number;
+  mainHeadHash: string | null;
+  adminLegacyHeadHash: string | null;
+  /** previous_hash of the earliest emission-era row; null when no emission era exists yet. */
+  emissionBoundaryPrevHash: string | null;
+}
+
+/** Zero-loss checks: row-count parity, head-hash equality, era-boundary linkage. Pure. */
+export function assessBackfillParity(p: ParityInput): { ok: boolean; failures: string[] } {
+  const failures: string[] = [];
+  if (p.mainCount !== p.adminLegacyCount) {
+    failures.push(
+      `row-count mismatch: main has ${p.mainCount} rows, admin holds ${p.adminLegacyCount} legacy rows`
+    );
+  }
+  if (p.mainHeadHash !== p.adminLegacyHeadHash) {
+    failures.push(
+      `head-hash mismatch: main head ${p.mainHeadHash ?? '<empty>'} vs admin legacy head ${p.adminLegacyHeadHash ?? '<empty>'}`
+    );
+  }
+  if (p.emissionBoundaryPrevHash !== null && p.emissionBoundaryPrevHash !== p.mainHeadHash) {
+    failures.push(
+      `era-boundary mismatch: earliest emission row links onto ${p.emissionBoundaryPrevHash}, expected the legacy head ${p.mainHeadHash ?? '<empty>'}`
+    );
+  }
+  return { ok: failures.length === 0, failures };
+}
+
+export type BackfillCliMode =
+  | { ok: true; command: 'plan' | 'apply' | 'freeze' }
+  | { ok: false; error: string };
+
+export function resolveBackfillCliMode(
+  argv: string[],
+  env: Record<string, string | undefined>
+): BackfillCliMode {
+  const unknown = argv.filter((a) => a !== '--apply' && a !== '--freeze');
+  if (unknown.length > 0) {
+    return { ok: false, error: `Unknown argument(s): ${unknown.join(', ')} (expected --apply or --freeze)` };
+  }
+  const apply = argv.includes('--apply');
+  const freeze = argv.includes('--freeze');
+  if (apply && freeze) {
+    return {
+      ok: false,
+      error:
+        'Refusing --apply and --freeze in one run: verify the backfill and confirm SIEM released awaiting_backfill BEFORE freezing (see infrastructure/UPGRADE.md).',
+    };
+  }
+  if (freeze) {
+    if (env.AUDIT_FREEZE_CONFIRMED !== 'true') {
+      return {
+        ok: false,
+        error:
+          'Refusing to freeze: set AUDIT_FREEZE_CONFIRMED=true only AFTER the backfill verified genesis→head and SIEM resumed delivery. Freezing revokes ALL appends to the legacy table — including break-glass.',
+      };
+    }
+    return { ok: true, command: 'freeze' };
+  }
+  return { ok: true, command: apply ? 'apply' : 'plan' };
+}
+
+export type BackfillEnv =
+  | { ok: true; mainUrl: string; adminUrl: string; breakGlassArmed: boolean }
+  | { ok: false; error: string };
+
+export function resolveBackfillEnv(env: Record<string, string | undefined>): BackfillEnv {
+  const mainUrl = env.DATABASE_URL;
+  if (!mainUrl) return { ok: false, error: 'DATABASE_URL is not set (main db, legacy table source)' };
+  const adminUrl = env.ADMIN_DATABASE_URL_MIGRATE ?? env.ADMIN_DATABASE_URL;
+  if (!adminUrl) {
+    return {
+      ok: false,
+      error:
+        'Neither ADMIN_DATABASE_URL_MIGRATE nor ADMIN_DATABASE_URL is set — the backfill needs the Admin PG owner identity (runtime roles cannot plant rows or setval).',
+    };
+  }
+  return { ok: true, mainUrl, adminUrl, breakGlassArmed: env.ADMIN_DB_BREAK_GLASS === 'true' };
+}
+
+// ─── freeze SQL (pure builders/constants) ────────────────────────────────────
+
+/**
+ * The 6 columns admin_gdpr_eraser may UPDATE (drizzle-admin/0002 grant) — the
+ * ONLY mutations the frozen legacy table still accepts, because the main-store
+ * erasure leg keeps running until the table drops. user_id is in scope (the
+ * grant permits future full unlinking) though today's patch retains it.
+ */
+export const ERASER_MUTABLE_COLUMNS = [
+  'user_id',
+  'session_id',
+  'ip_address',
+  'ip_bidx',
+  'user_agent',
+  'geo_location',
+] as const;
+
+/** Every other column — chain content and classification — is immutable once frozen. */
+export const FROZEN_IMMUTABLE_COLUMNS = [
+  'id',
+  'event_type',
+  'service_id',
+  'resource_type',
+  'resource_id',
+  'details',
+  'risk_score',
+  'anomaly_flags',
+  'timestamp',
+  'chain_seq',
+  'previous_hash',
+  'event_hash',
+] as const;
+
+export const FREEZE_GUARD_FUNCTION_NAME = 'security_audit_log_freeze_guard';
+export const FREEZE_TRIGGER_NAME = 'security_audit_log_freeze';
+export const FREEZE_TRUNCATE_TRIGGER_NAME = 'security_audit_log_freeze_truncate';
+
+const FREEZE_MESSAGE =
+  'security_audit_log is write-frozen: history migrated to the Admin PG (#890 Phase 2 backfill). ' +
+  'Only PII-column pseudonymization UPDATEs are permitted until the post-soak DROP. ' +
+  'See infrastructure/UPGRADE.md (Phase 2 backfill & freeze).';
+
+export function buildFreezeGuardFunctionSql(): string {
+  const immutableChecks = FROZEN_IMMUTABLE_COLUMNS.map(
+    (c) => `NEW.${c} IS DISTINCT FROM OLD.${c}`
+  ).join('\n        OR ');
+  return `
+CREATE OR REPLACE FUNCTION ${FREEZE_GUARD_FUNCTION_NAME}() RETURNS trigger
+LANGUAGE plpgsql AS $freeze$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF ${immutableChecks}
+    THEN
+      RAISE EXCEPTION '${FREEZE_MESSAGE}';
+    END IF;
+    RETURN NEW;
+  END IF;
+  RAISE EXCEPTION '${FREEZE_MESSAGE}';
+END
+$freeze$;`;
+}
+
+// Grants are revoked from every current holder INCLUDING the owner's explicit
+// grants; the triggers are what actually stop the owner (Postgres owners
+// bypass their own ACLs). UPDATE is deliberately NOT revoked — the guard
+// trigger scopes it to the eraser columns instead.
+const FREEZE_REVOKE_SQL = `
+DO $freeze_revoke$
+DECLARE g record;
+BEGIN
+  FOR g IN
+    SELECT DISTINCT grantee FROM information_schema.role_table_grants
+    WHERE table_schema = 'public' AND table_name = 'security_audit_log'
+      AND privilege_type IN ('INSERT', 'DELETE', 'TRUNCATE')
+  LOOP
+    IF g.grantee = 'PUBLIC' THEN
+      REVOKE INSERT, DELETE, TRUNCATE ON security_audit_log FROM PUBLIC;
+    ELSE
+      EXECUTE format('REVOKE INSERT, DELETE, TRUNCATE ON security_audit_log FROM %I', g.grantee);
+    END IF;
+  END LOOP;
+END
+$freeze_revoke$;`;
+
+// ─── imperative shell ────────────────────────────────────────────────────────
+
+export interface QueryExecutor {
+  query(
+    text: string,
+    params?: unknown[]
+  ): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+}
+
+export interface PoolLike extends QueryExecutor {
+  connect(): Promise<QueryExecutor & { release(): void }>;
+}
+
+interface GatheredState extends BackfillStoreState {
+  mainMinTs: string | null;
+  mainMaxTs: string | null;
+  adminMaxSeq: number;
+  adminLegacyMaxSeq: number;
+  adminLegacyHeadHash: string | null;
+  anchorRowId: string | null;
+}
+
+const num = (v: unknown): number => Number(v ?? 0);
+
+async function readCursorId(db: QueryExecutor, source: string): Promise<string | null> {
+  try {
+    const r = await db.query('SELECT "lastDeliveredId" FROM siem_delivery_cursors WHERE id = $1', [
+      source,
+    ]);
+    return (r.rows[0]?.lastDeliveredId as string | undefined) ?? null;
+  } catch (error) {
+    // 42P01 undefined_table — tolerable only on the MAIN side of odd installs.
+    if ((error as { code?: string }).code === '42P01') return null;
+    throw error;
+  }
+}
+
+export async function gatherBackfillState(deps: {
+  main: QueryExecutor;
+  admin: QueryExecutor;
+  breakGlassArmed: boolean;
+}): Promise<GatheredState> {
+  const [mainAgg, mainHead, legacyAgg, legacyHead, emissionAgg, emissionEarliest, adminAgg] =
+    await Promise.all([
+      deps.main.query(
+        `SELECT count(*)::text AS count, COALESCE(max(chain_seq), 0)::text AS max_seq,
+                min(timestamp)::text AS min_ts, max(timestamp)::text AS max_ts
+         FROM security_audit_log`
+      ),
+      deps.main.query('SELECT event_hash FROM security_audit_log ORDER BY chain_seq DESC LIMIT 1'),
+      deps.admin.query(
+        `SELECT count(*)::text AS count, COALESCE(max(chain_seq), 0)::text AS max_seq
+         FROM security_audit_log WHERE emission_hash IS NULL`
+      ),
+      deps.admin.query(
+        `SELECT event_hash FROM security_audit_log WHERE emission_hash IS NULL
+         ORDER BY chain_seq DESC LIMIT 1`
+      ),
+      deps.admin.query(
+        `SELECT count(*)::text AS count, COALESCE(min(chain_seq), 0)::text AS min_seq
+         FROM security_audit_log WHERE emission_hash IS NOT NULL`
+      ),
+      deps.admin.query(
+        `SELECT previous_hash FROM security_audit_log WHERE emission_hash IS NOT NULL
+         ORDER BY chain_seq ASC LIMIT 1`
+      ),
+      deps.admin.query('SELECT COALESCE(max(chain_seq), 0)::text AS max_seq FROM security_audit_log'),
+    ]);
+
+  const emissionCount = num(emissionAgg.rows[0]?.count);
+  const [adminCursorId, mainCursorId] = await Promise.all([
+    readCursorId(deps.admin, SIEM_SECURITY_SOURCE),
+    readCursorId(deps.main, SIEM_SECURITY_SOURCE),
+  ]);
+
+  return {
+    breakGlassArmed: deps.breakGlassArmed,
+    mainCount: num(mainAgg.rows[0]?.count),
+    mainMaxSeq: num(mainAgg.rows[0]?.max_seq),
+    mainHeadHash: (mainHead.rows[0]?.event_hash as string | undefined) ?? null,
+    mainMinTs: (mainAgg.rows[0]?.min_ts as string | null) ?? null,
+    mainMaxTs: (mainAgg.rows[0]?.max_ts as string | null) ?? null,
+    adminLegacyCount: num(legacyAgg.rows[0]?.count),
+    adminLegacyMaxSeq: num(legacyAgg.rows[0]?.max_seq),
+    adminLegacyHeadHash: (legacyHead.rows[0]?.event_hash as string | undefined) ?? null,
+    adminEmission:
+      emissionCount > 0
+        ? {
+            count: emissionCount,
+            minSeq: num(emissionAgg.rows[0]?.min_seq),
+            earliestPrevHash: (emissionEarliest.rows[0]?.previous_hash as string) ?? 'genesis',
+          }
+        : null,
+    adminMaxSeq: num(adminAgg.rows[0]?.max_seq),
+    anchorRowId: resolveAnchorRowId({ adminCursorId, mainCursorId }),
+  };
+}
+
+// Every value travels as text (SELECT-side casts, INSERT-side casts back) so
+// no driver type mapping — Date parsing, float4 widening — can perturb a byte
+// of what the hash chain covers. The genesis→head verify would catch any
+// corruption anyway; text round-tripping makes it a non-event.
+const COPY_SELECT_COLUMNS = `id, event_type, user_id, session_id, service_id, resource_type,
+        resource_id, ip_address, ip_bidx, user_agent, geo_location,
+        details::text AS details, risk_score::text AS risk_score,
+        anomaly_flags::text AS anomaly_flags, timestamp::text AS ts,
+        chain_seq::text AS chain_seq, previous_hash, event_hash`;
+
+const COPY_INSERT_CASTS = [
+  '', '', '', '', '', '', '', '', '', '', '',
+  '::jsonb', '::real', '::text[]', '::timestamp', '::bigint', '', '',
+];
+
+function buildCopyInsert(rows: Record<string, unknown>[]): { text: string; values: unknown[] } {
+  const values: unknown[] = [];
+  const tuples = rows.map((r) => {
+    const fields = [
+      r.id, r.event_type, r.user_id, r.session_id, r.service_id, r.resource_type,
+      r.resource_id, r.ip_address, r.ip_bidx, r.user_agent, r.geo_location,
+      r.details, r.risk_score, r.anomaly_flags, r.ts, r.chain_seq,
+      r.previous_hash, r.event_hash,
+    ];
+    const base = values.length;
+    values.push(...fields);
+    return `(${fields.map((_, i) => `$${base + i + 1}${COPY_INSERT_CASTS[i]}`).join(', ')})`;
+  });
+  // emission_hash is deliberately absent → NULL, the legacy-era marker.
+  const text = `INSERT INTO security_audit_log
+      (id, event_type, user_id, session_id, service_id, resource_type, resource_id,
+       ip_address, ip_bidx, user_agent, geo_location, details, risk_score,
+       anomaly_flags, timestamp, chain_seq, previous_hash, event_hash)
+     VALUES ${tuples.join(', ')}
+     ON CONFLICT DO NOTHING`;
+  return { text, values };
+}
+
+async function copyPass(opts: {
+  main: QueryExecutor;
+  admin: QueryExecutor;
+  fromSeq: number;
+  excludeId: string | null;
+  batchSize: number;
+  journal: string[];
+  log: (line: string) => void;
+}): Promise<number> {
+  let cursor = opts.fromSeq;
+  let planted = 0;
+  for (;;) {
+    const batch = await opts.main.query(
+      `SELECT ${COPY_SELECT_COLUMNS}
+       FROM security_audit_log
+       WHERE chain_seq > $1::bigint AND ($2::text IS NULL OR id <> $2)
+       ORDER BY chain_seq ASC
+       LIMIT $3`,
+      [cursor, opts.excludeId, opts.batchSize]
+    );
+    if (batch.rows.length === 0) return planted;
+    const insert = buildCopyInsert(batch.rows);
+    const result = await opts.admin.query(insert.text, insert.values);
+    planted += result.rowCount ?? 0;
+    cursor = num(batch.rows[batch.rows.length - 1].chain_seq);
+    opts.journal.push(`plant:${result.rowCount ?? 0}@seq<=${cursor}`);
+    opts.log(`  planted ${planted} rows (through chain_seq ${cursor})…`);
+    if (batch.rows.length < opts.batchSize) return planted;
+  }
+}
+
+async function plantAnchorRow(opts: {
+  main: QueryExecutor;
+  admin: QueryExecutor;
+  anchorRowId: string;
+  journal: string[];
+}): Promise<boolean> {
+  const row = await opts.main.query(
+    `SELECT ${COPY_SELECT_COLUMNS} FROM security_audit_log WHERE id = $1`,
+    [opts.anchorRowId]
+  );
+  if (row.rows.length === 0) {
+    // Cursor points past the legacy era (already released) — nothing to gate.
+    opts.journal.push('anchor:absent-from-main');
+    return false;
+  }
+  const insert = buildCopyInsert(row.rows);
+  const result = await opts.admin.query(insert.text, insert.values);
+  opts.journal.push(`anchor:${opts.anchorRowId}`);
+  return (result.rowCount ?? 0) > 0;
+}
+
+async function ensureHistoricalPartitions(opts: {
+  admin: QueryExecutor;
+  minTs: string;
+  maxTs: string;
+  journal: string[];
+}): Promise<string[]> {
+  const created: string[] = [];
+  for (const month of monthPartitionsForRange(opts.minTs, opts.maxTs)) {
+    const exists = await opts.admin.query('SELECT to_regclass($1) AS reg', [month.name]);
+    if (exists.rows[0]?.reg !== null) continue;
+    try {
+      // Identifiers are script-generated (digits only) — no injection surface.
+      await opts.admin.query(
+        `CREATE TABLE IF NOT EXISTS ${month.name} PARTITION OF security_audit_log
+         FOR VALUES FROM ('${month.from}') TO ('${month.to}')`
+      );
+      created.push(month.name);
+      opts.journal.push(`partition:${month.name}`);
+    } catch (error) {
+      throw new Error(
+        `Failed to create partition ${month.name} — if the DEFAULT partition already holds rows for that month, ` +
+          `move them out first (see drizzle-admin/0003 repair note). Cause: ${(error as Error).message}`
+      );
+    }
+  }
+  return created;
+}
+
+async function alignChainSequence(opts: {
+  admin: QueryExecutor;
+  target: number;
+  journal: string[];
+}): Promise<void> {
+  // GREATEST with the live last_value: never rewind a sequence the chainer
+  // already advanced past the legacy range.
+  await opts.admin.query(
+    `SELECT setval('security_audit_log_chain_seq_seq',
+       GREATEST($1::bigint, (SELECT last_value FROM security_audit_log_chain_seq_seq)))`,
+    [opts.target]
+  );
+  opts.journal.push(`setval:${opts.target}`);
+}
+
+export interface BackfillSummary {
+  outcome: 'planned' | 'backfilled' | 'aborted';
+  precondition: BackfillPrecondition;
+  planted: number;
+  anchorRowId: string | null;
+  anchorPlanted: boolean;
+  partitionsCreated: string[];
+  sequenceTarget: number | null;
+  journal: string[];
+  warnings: string[];
+  parity: { ok: boolean; failures: string[] } | null;
+  verification: SecurityChainVerificationResult | null;
+}
+
+export interface BackfillDeps {
+  main: QueryExecutor;
+  adminPool: PoolLike;
+  adminDb: AdminDatabase;
+  breakGlassArmed?: boolean;
+  batchSize?: number;
+  log?: (line: string) => void;
+}
+
+/**
+ * The full backfill run: chainer-exclusion lock → preconditions → historical
+ * partitions → batched seq-ordered copy (anchor excluded) → setval →
+ * anchor-committed-last → parity + full genesis→head verification. Plan mode
+ * (dryRun) gathers, rules, and reports without taking the lock or writing.
+ */
+export async function runAuditBackfill(
+  deps: BackfillDeps & { dryRun: boolean }
+): Promise<BackfillSummary> {
+  const log = deps.log ?? (() => {});
+  const batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE;
+  const breakGlassArmed = deps.breakGlassArmed ?? false;
+  const journal: string[] = [];
+  const warnings: string[] = [];
+
+  const summarize = (
+    outcome: BackfillSummary['outcome'],
+    precondition: BackfillPrecondition,
+    rest: Partial<BackfillSummary> = {}
+  ): BackfillSummary => ({
+    outcome,
+    precondition,
+    planted: 0,
+    anchorRowId: null,
+    anchorPlanted: false,
+    partitionsCreated: [],
+    sequenceTarget: null,
+    journal,
+    warnings,
+    parity: null,
+    verification: null,
+    ...rest,
+  });
+
+  if (deps.dryRun) {
+    const state = await gatherBackfillState({
+      main: deps.main,
+      admin: deps.adminPool,
+      breakGlassArmed,
+    });
+    const precondition = assessBackfillPreconditions(state);
+    log(
+      `PLAN: main=${state.mainCount} rows (max seq ${state.mainMaxSeq}), admin legacy=${state.adminLegacyCount}, ` +
+        `emission era=${state.adminEmission ? `${state.adminEmission.count} rows from seq ${state.adminEmission.minSeq}` : 'none'}, ` +
+        `anchor row=${state.anchorRowId ?? 'none'}`
+    );
+    if (!precondition.ok) {
+      log(`WOULD ABORT (${precondition.reason}): ${precondition.detail}`);
+      return summarize('aborted', precondition, { anchorRowId: state.anchorRowId });
+    }
+    log(
+      `Would plant ~${Math.max(state.mainCount - state.adminLegacyCount, 0)} rows, ` +
+        `setval → ${planSequenceTarget({ mainMaxSeq: state.mainMaxSeq, adminMaxSeq: state.adminMaxSeq }) ?? 'skip'}, ` +
+        `then verify genesis→head.`
+    );
+    return summarize('planned', precondition, { anchorRowId: state.anchorRowId });
+  }
+
+  // Hold the chainer's own advisory lock for the entire live run: even a
+  // processor someone forgot to stop is provably excluded while rows are
+  // planted and the sequence is aligned. Session lock on a dedicated
+  // connection; pg_advisory_lock BLOCKS until any in-flight chainer cycle
+  // finishes rather than racing it.
+  const lockClient = await deps.adminPool.connect();
+  let locked = false;
+  try {
+    log(`Acquiring chainer exclusion lock ('${CHAINER_ADVISORY_LOCK_KEY}')…`);
+    await lockClient.query('SELECT pg_advisory_lock(hashtext($1))', [CHAINER_ADVISORY_LOCK_KEY]);
+    locked = true;
+
+    // Gather UNDER the lock — the chainer cannot move the boundary anymore.
+    let state = await gatherBackfillState({
+      main: deps.main,
+      admin: deps.adminPool,
+      breakGlassArmed,
+    });
+    const precondition = assessBackfillPreconditions(state);
+    if (!precondition.ok) {
+      log(`ABORT (${precondition.reason}): ${precondition.detail}`);
+      return summarize('aborted', precondition, { anchorRowId: state.anchorRowId });
+    }
+    if (precondition.ok && precondition.state === 'empty_main') {
+      log('Main security_audit_log is empty — nothing to backfill.');
+      return summarize('backfilled', precondition, {
+        parity: { ok: true, failures: [] },
+        verification: await verifySecurityAuditChain({ stopOnFirstBreak: true }, { db: deps.adminDb }),
+      });
+    }
+
+    const anchorRowId = state.anchorRowId;
+    if (anchorRowId !== null && state.adminLegacyCount === 0) {
+      // First run: sanity — the anchor gate is what makes mid-backfill
+      // visibility safe; note when there is none to gate on.
+      log(`Anchor row (SIEM cursor watermark): ${anchorRowId} — committed last.`);
+    }
+    if (anchorRowId === null) {
+      warnings.push(
+        'No SIEM anchor row (cursor absent or __cursor_init__): per the runbook this backfill MUST complete before the first post-flip SIEM delivery run.'
+      );
+    }
+
+    const partitionsCreated =
+      state.mainMinTs && state.mainMaxTs
+        ? await ensureHistoricalPartitions({
+            admin: deps.adminPool,
+            minTs: state.mainMinTs,
+            maxTs: state.mainMaxTs,
+            journal,
+          })
+        : [];
+
+    // Batched, resumable copy in chain_seq order, anchor row excluded.
+    let planted = await copyPass({
+      main: deps.main,
+      admin: deps.adminPool,
+      fromSeq: state.adminLegacyMaxSeq,
+      excludeId: anchorRowId,
+      batchSize,
+      journal,
+      log,
+    });
+
+    // Align the sequence BEFORE the anchor row becomes visible and BEFORE the
+    // lock is released — from the chainer's next run onward, nextval() is
+    // beyond every legacy seq.
+    const sequenceTarget = planSequenceTarget({
+      mainMaxSeq: state.mainMaxSeq,
+      adminMaxSeq: state.adminMaxSeq,
+    });
+    if (sequenceTarget !== null) {
+      await alignChainSequence({ admin: deps.adminPool, target: sequenceTarget, journal });
+      log(`Sequence aligned: security_audit_log_chain_seq_seq → ${sequenceTarget}.`);
+    }
+
+    // Anchor-committed-last: the moment this row is visible, every legacy row
+    // already is — the SIEM deferral releases into a complete history.
+    let anchorPlanted = false;
+    if (anchorRowId !== null) {
+      anchorPlanted = await plantAnchorRow({
+        main: deps.main,
+        admin: deps.adminPool,
+        anchorRowId,
+        journal,
+      });
+      planted += anchorPlanted ? 1 : 0;
+      log(`Anchor row ${anchorRowId} ${anchorPlanted ? 'planted' : 'already present / not a legacy row'}.`);
+    }
+
+    // Parity; on count mismatch run ONE full recovery rescan (covers holes a
+    // crashed earlier run could theoretically leave) before failing.
+    state = await gatherBackfillState({ main: deps.main, admin: deps.adminPool, breakGlassArmed });
+    if (state.mainCount !== state.adminLegacyCount) {
+      warnings.push(
+        `count mismatch after primary pass (main=${state.mainCount}, admin legacy=${state.adminLegacyCount}) — running full rescan`
+      );
+      const rescanned = await copyPass({
+        main: deps.main,
+        admin: deps.adminPool,
+        fromSeq: 0,
+        excludeId: null,
+        batchSize,
+        journal,
+        log,
+      });
+      journal.push(`rescan:${rescanned}`);
+      planted += rescanned;
+      if (state.mainMaxSeq > 0) {
+        await alignChainSequence({ admin: deps.adminPool, target: state.mainMaxSeq, journal });
+      }
+      state = await gatherBackfillState({ main: deps.main, admin: deps.adminPool, breakGlassArmed });
+    }
+
+    const parity = assessBackfillParity({
+      mainCount: state.mainCount,
+      adminLegacyCount: state.adminLegacyCount,
+      mainHeadHash: state.mainHeadHash,
+      adminLegacyHeadHash: state.adminLegacyHeadHash,
+      emissionBoundaryPrevHash: state.adminEmission?.earliestPrevHash ?? null,
+    });
+    for (const failure of parity.failures) log(`PARITY FAILURE: ${failure}`);
+
+    // The leaf's core proof: the WHOLE admin chain — legacy era, boundary,
+    // emission era — verifies genesis→head, era-aware (leaf 5 verifier).
+    log('Verifying admin chain genesis→head…');
+    const verification = await verifySecurityAuditChain(
+      { stopOnFirstBreak: true },
+      { db: deps.adminDb }
+    );
+    log(
+      `Verification: isValid=${verification.isValid} entries=${verification.entriesVerified}/${verification.totalEntries}` +
+        (verification.breakPoint ? ` BREAK: ${verification.breakPoint.description}` : '')
+    );
+
+    return summarize('backfilled', precondition, {
+      planted,
+      anchorRowId,
+      anchorPlanted,
+      partitionsCreated,
+      sequenceTarget,
+      parity,
+      verification,
+    });
+  } finally {
+    if (locked) {
+      await lockClient
+        .query('SELECT pg_advisory_unlock(hashtext($1))', [CHAINER_ADVISORY_LOCK_KEY])
+        .catch(() => undefined);
+    }
+    lockClient.release();
+  }
+}
+
+export interface FreezeSummary {
+  outcome: 'frozen' | 'refused';
+  refusals: string[];
+  parity: { ok: boolean; failures: string[] } | null;
+  verification: SecurityChainVerificationResult | null;
+}
+
+/**
+ * Write-freeze the legacy main table — only after re-proving parity and the
+ * full admin chain in the same invocation, so a freeze can never seal a
+ * store that disagrees with the history it supposedly preserved.
+ */
+export async function freezeLegacySecurityAuditLog(deps: {
+  main: QueryExecutor;
+  admin: QueryExecutor;
+  adminDb: AdminDatabase;
+  breakGlassArmed?: boolean;
+  log?: (line: string) => void;
+}): Promise<FreezeSummary> {
+  const log = deps.log ?? (() => {});
+  const refusals: string[] = [];
+
+  const state = await gatherBackfillState({
+    main: deps.main,
+    admin: deps.admin,
+    breakGlassArmed: deps.breakGlassArmed ?? false,
+  });
+  if (state.breakGlassArmed) {
+    refusals.push('ADMIN_DB_BREAK_GLASS=true — break-glass writes to the main table; freezing now would break the active audit path.');
+  }
+  if (state.mainCount > 0 && state.adminLegacyCount === 0) {
+    refusals.push('The admin store holds no legacy rows — run the backfill (--apply) first.');
+  }
+
+  const parity =
+    state.mainCount === 0
+      ? { ok: true, failures: [] }
+      : assessBackfillParity({
+          mainCount: state.mainCount,
+          adminLegacyCount: state.adminLegacyCount,
+          mainHeadHash: state.mainHeadHash,
+          adminLegacyHeadHash: state.adminLegacyHeadHash,
+          emissionBoundaryPrevHash: state.adminEmission?.earliestPrevHash ?? null,
+        });
+  if (!parity.ok) refusals.push(...parity.failures);
+
+  let verification: SecurityChainVerificationResult | null = null;
+  if (refusals.length === 0) {
+    verification = await verifySecurityAuditChain({ stopOnFirstBreak: true }, { db: deps.adminDb });
+    if (!verification.isValid) {
+      refusals.push(
+        `Admin chain verification failed: ${verification.breakPoint?.description ?? 'invalid entries'}`
+      );
+    }
+  }
+
+  if (refusals.length > 0) {
+    for (const r of refusals) log(`FREEZE REFUSED: ${r}`);
+    return { outcome: 'refused', refusals, parity, verification };
+  }
+
+  log('Freezing main security_audit_log (revoke + guard triggers)…');
+  await deps.main.query(buildFreezeGuardFunctionSql());
+  await deps.main.query(`DROP TRIGGER IF EXISTS ${FREEZE_TRIGGER_NAME} ON security_audit_log`);
+  await deps.main.query(
+    `CREATE TRIGGER ${FREEZE_TRIGGER_NAME}
+     BEFORE INSERT OR UPDATE OR DELETE ON security_audit_log
+     FOR EACH ROW EXECUTE FUNCTION ${FREEZE_GUARD_FUNCTION_NAME}()`
+  );
+  await deps.main.query(
+    `DROP TRIGGER IF EXISTS ${FREEZE_TRUNCATE_TRIGGER_NAME} ON security_audit_log`
+  );
+  await deps.main.query(
+    `CREATE TRIGGER ${FREEZE_TRUNCATE_TRIGGER_NAME}
+     BEFORE TRUNCATE ON security_audit_log
+     FOR EACH STATEMENT EXECUTE FUNCTION ${FREEZE_GUARD_FUNCTION_NAME}()`
+  );
+  await deps.main.query(FREEZE_REVOKE_SQL);
+  log('Legacy table frozen: INSERT/DELETE/TRUNCATE raise; UPDATE limited to eraser PII columns.');
+
+  return { outcome: 'frozen', refusals: [], parity, verification };
+}
+
+// ─── CLI ─────────────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  (async () => {
+    // scripts/ has no package.json, so pg/dotenv are not resolvable from here
+    // directly — borrow @pagespace/db's module context (its own driver).
+    const { createRequire } = await import('node:module');
+    const requireFromDb = createRequire(
+      createRequire(import.meta.url).resolve('@pagespace/db/db')
+    );
+    requireFromDb('dotenv/config');
+
+    const mode = resolveBackfillCliMode(process.argv.slice(2), process.env);
+    if (!mode.ok) {
+      console.error(`❌ ${mode.error}`);
+      process.exit(1);
+    }
+    const env = resolveBackfillEnv(process.env);
+    if (!env.ok) {
+      console.error(`❌ ${env.error}`);
+      process.exit(1);
+    }
+
+    const { Pool } = requireFromDb('pg') as unknown as {
+      Pool: new (config: Record<string, unknown>) => PoolLike & { end(): Promise<void> };
+    };
+    const { createAdminAuditDbClient } = await import('@pagespace/db/admin-eraser-db');
+
+    const mainPool = new Pool({ connectionString: env.mainUrl, max: 3 });
+    const adminPool = new Pool({
+      connectionString: env.adminUrl,
+      max: 4,
+      ssl:
+        process.env.ADMIN_DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
+    });
+    const adminClient = createAdminAuditDbClient({
+      connectionString: env.adminUrl,
+      ssl: process.env.ADMIN_DATABASE_SSL === 'true',
+    });
+
+    const log = (line: string) => console.log(line);
+    let exitCode = 1;
+    try {
+      if (mode.command === 'freeze') {
+        const result = await freezeLegacySecurityAuditLog({
+          main: mainPool,
+          admin: adminPool,
+          adminDb: adminClient.db,
+          breakGlassArmed: env.breakGlassArmed,
+          log,
+        });
+        exitCode = result.outcome === 'frozen' ? 0 : 1;
+        console.log(
+          result.outcome === 'frozen'
+            ? '✅ Legacy security_audit_log write-frozen. Break-glass can no longer append to it (documented, accepted).'
+            : `❌ Freeze refused:\n  - ${result.refusals.join('\n  - ')}`
+        );
+      } else {
+        const result = await runAuditBackfill({
+          main: mainPool,
+          adminPool,
+          adminDb: adminClient.db,
+          breakGlassArmed: env.breakGlassArmed,
+          dryRun: mode.command === 'plan',
+          log,
+        });
+        const green =
+          result.outcome === 'planned' ||
+          (result.outcome === 'backfilled' &&
+            result.parity?.ok === true &&
+            result.verification?.isValid === true);
+        exitCode = green ? 0 : 1;
+        for (const w of result.warnings) console.warn(`⚠ ${w}`);
+        console.log(
+          `${green ? '✅' : '❌'} ${result.outcome}: planted=${result.planted} ` +
+            `partitions=${result.partitionsCreated.length} setval=${result.sequenceTarget ?? 'skipped'} ` +
+            `anchor=${result.anchorRowId ?? 'none'}${result.anchorPlanted ? ' (planted last)' : ''} ` +
+            `parity=${result.parity ? (result.parity.ok ? 'ok' : 'FAILED') : 'n/a'} ` +
+            `verify=${result.verification ? (result.verification.isValid ? `GREEN (${result.verification.entriesVerified} entries)` : 'FAILED') : 'n/a'}`
+        );
+      }
+    } catch (error) {
+      console.error('❌ backfill-audit-db failed:', error);
+      exitCode = 1;
+    } finally {
+      await Promise.all([mainPool.end(), adminPool.end(), adminClient.end()]).catch(() => undefined);
+    }
+    process.exit(exitCode);
+  })();
+}


### PR DESCRIPTION
Part of #890 (Phase 2 of the DB decomposition / zero-trust logging epic). Builds on Phase 0 (#1976, repository seam) and Phase 1 (#1982, Admin PG plumbing + roles).

## Why

- **Kills the global advisory lock on the request path.** Today every authenticated request that writes an audit event serializes through `pg_advisory_xact_lock` (a head read + chained INSERT under a global lock). Phase 2 replaces that with hash-at-emission: the app computes a pure emission hash and does exactly one INSERT into an Admin-PG ingest table — no lock, no head read, no cross-DB transaction.
- **The audit chain leaves the app DB.** A tamper-evident chain whose head lives in the same database it protects is provable to no one who doesn't already trust that database. The chain now lives in the dedicated Admin PG (`pagespace-db-admin`), written by a single-writer chainer with its own credentials.
- **Externally-anchored tamper evidence.** Signed head hashes are published to S3 Object-Lock (WORM) and a SIEM receipt table, and emission hashes co-stream to stdout as a second independent record — tampering now requires compromising the app DB **and** the Admin PG **and** the external witness.

## Architecture

```
app (admin_app, INSERT-only)
  └─ emission: pure emissionHash → 1 INSERT into security_audit_ingest
       └─ co-stream: witness record {eventId, emissionHash, …} → stdout/collector
processor (admin_processor: chainer + siem)
  └─ chainer worker (single writer, advisory lock on its own plane):
       drain ingest in batches → assign chain_seq + chainHash = H(emissionHash, prevHash)
       → verify-on-append → anchor hook
  └─ anchoring: signed head (HMAC-SHA256 over stableStringify) → S3 Object-Lock
       + security_audit_anchors receipts (append-only)
verification (cron, admin_app read + admin_reader)
  └─ composite verdict = chain consistency AND anchor match AND (optional) co-stream reconciliation
```

- **Emission** (`emission-hash.ts`, `audit-ingest-writer.ts`): pure `computeEmissionHash` (golden-vector pinned), one INSERT, co-stream after insert resolves.
- **Chainer** (`chain-step.ts`, `audit-chainer-worker.ts`): pure `computeChainHash`/`assignChainBatch`/`verifyAppendedSegment`; worker drains `security_audit_ingest` every 30s, verify-on-append, refuses genesis-head chaining on upgrade deployments unless `AUDIT_CHAINER_ALLOW_GENESIS=true` (fresh installs only).
- **Anchoring** (`anchor.ts`, `anchor-publishers.ts`): `SignedAnchor {version, chainSeq, head, anchoredAt, signature}`; publishes only heads that passed verification; S3 Object-Lock COMPLIANCE mode behind a capability flag.
- **Cutover** (`audit-db-binding.ts`): mode-resolved bind — `dedicated` → ingest writer on Admin PG; `break-glass` → old advisory-lock path on main DB (rollback flag with loud observability: banner + alert + self-recorded audit event); `fail` → audit degrades to warn, never throws into request handlers. All 248 call sites and the `securityAudit` surface are pinned byte-identical.
- **GDPR** (leaf 6): dual-store erasure via the column-scoped `admin_gdpr_eraser_user` (6 PII columns, `ip_bidx` now included); chain verification still passes post-erasure — proven end-to-end on a live chain.
- **SIEM** (leaf 7): delivery sources security events + all cursors/receipts from Admin PG, cursor seeded once from the legacy watermark with an `awaiting_backfill` deferral (no replays, no gaps across the flip).
- **Backfill + freeze** (leaf 8, `scripts/backfill-audit-db.ts`): copies legacy rows with `chain_seq` preserved and text-cast byte fidelity, proves dual-era genesis→head **before** completing, holds the chainer's own lock for the whole run, aborts on era-fork/seq-collision/break-glass preconditions; `--freeze` installs guard triggers (owner-proof — plain REVOKE is a no-op for table owners) that allow only the 6 eraser-column UPDATEs. Legacy table drop deferred past soak.

## Security posture

Zero-trust role matrix (all live-probed by 42501 wire tests as the provisioned LOGIN users, not SET ROLE):

| identity | ingest | chain table | anchors | DELETE anywhere |
|---|---|---|---|---|
| `admin_app` (web) | INSERT-only | SELECT-only | SELECT-only | never |
| `admin_chainer` (processor) | SELECT+DELETE (drain — the only trust-plane DELETE) | INSERT + seq | INSERT-only | queue only |
| `admin_siem` (processor) | — | SELECT | SELECT | never |
| `admin_gdpr_eraser` (web, GDPR route) | — | UPDATE on 6 PII columns only | — | never |
| `admin_reader` | SELECT | SELECT | SELECT | never |

Retention will be `SECURITY DEFINER` partition drops — no DELETE grant ever exists on chain tables.

### Adversarial review: 3 MAJOR findings, all fixed in-branch

1. **`admin_app` kept chain-table INSERT + `chain_seq` USAGE after cutover** (Phase-1-era grant became excess privilege): a compromised web credential could append chain-valid forged rows directly, bypassing ingest/emission discipline/co-stream, and the chainer would link and anchor them. **Fixed** (db6b3e88a): admin migration 0008 revokes both; traced that nothing in dedicated mode inserts the admin chain as `admin_app`; flipped 42501 probes + re-runnability re-proof green.
2. **Anchor verification was circular under the epic's own threat model**: it read only the receipts table *inside* the Admin PG, and zero receipts degraded to "not configured yet" → `isValid: true` — a DB-owning attacker deletes receipts, rewrites the chain, and verification passes. **Fixed** (b77cc07ad): anchors-enabled + non-empty chain + zero receipts now **fails closed** and fires the `anchor_verify` alert. True S3 readback is a filed follow-up (see gates below).
3. **TZ false-tamper hazard (pre-existing, surface widened by leaf 7)**: raw-pg reads of tz-less timestamp columns parse as local time, so any processor with TZ≠UTC recomputed shifted hashes → false `chain_tamper` halts. **Fixed** (11099bed9): pg OID 1114 is parsed as UTC on the admin pools, pinned by non-UTC-TZ recompute tests.

Also fixed: unlock-failure now destroys the pooled connection (advisory-lock leak → permanent silent `lock_busy`), genesis era-fork guard (above), and `emissionHash` added to the pseudonymization-safety denylist.

## ⚠ TRUST PLANE IS OFF BY DEFAULT

The chainer, anchoring (`AUDIT_ANCHOR_ENABLED`), and backfill are all inert until explicitly enabled. **Before enabling in prod, these gates must be met** (filed as tasks on the Phase 2/6 board):

- **Alert-channel wiring** (`coqoix17vizg12q2tprbm769`) — no production code registers `setChainAlertHandler`; every tamper/break-glass/anchor alert is currently a silent no-op beyond structured log lines. Wire a real handler (web instrumentation + processor init) before relying on the trust plane.
- **S3 Object-Lock verification** (`u9s9plnqmowcu225afm8s99p`) — Tigris Object-Lock support is unverified; provision the anchors bucket with Object-Lock at creation, prove an object resists deletion, and add S3 readback to composite verification (receipts-only anchor matching is advisory, not adversarial). Includes the TZ=UTC entrypoint belt-and-suspenders pin.
- **Backfill runbook** (infrastructure/UPGRADE.md) — stop processor → dry-run → `--apply` → restart → confirm SIEM release → soak → `AUDIT_FREEZE_CONFIRMED=true --freeze`. The processor must stay stopped from write-flip to backfill completion (ingest is a lossless buffer; the genesis guard refuses era-forks regardless).

Other deferred follow-ups (filed, out of scope here): chainer stall/queue-depth observability + request-path pool timeout (`trl9l77e3zzm982e8ync6837`), CI scratch-PG integration job (`nur5u08ccmb28sh5qw64m9jt`) — the live grant/wire matrix currently runs only locally — and legacy table drop past soak (`cit0l7s7k3h35pwxnaikb8b1`).

## Testing

Everything below re-verified on this exact HEAD after rebase (no-op — branch sits on current master):

- **Unit**: lib audit 318/318 (23 files); db 377 passed (+8 pre-existing live-DB env failures in `activity-logs-compliance`, master baseline); processor 1056 passed (+5 pre-existing magika env failures, master baseline); typecheck 16/16; both `db:generate` pipelines no-drift.
- **Docker integration matrix** (fresh scratch PG16, wire-connected as the provisioned LOGIN users): admin db suites 94/94 (migrate fresh+rerun through 0008, grants 42501 matrix, login users, partitioning) · chainer drain-cycle 9/9 · SIEM wire 5/5 (admin + sibling legacy DB, exactly-once across the flip) · backfill-flip 8/8 (real chainer + SIEM + real script; lock exclusion, era boundary, genesis refusal) · backfill unit+rehearsal 53/53 · GDPR-eraser e2e 3/3 (live chain, erasure as eraser LOGIN, chain still verifies).
- TDD throughout: every behavior red→green; all chain math is pure functions with golden-vector tests.

Production emission behavior is unchanged in cloud mode until `ADMIN_DATABASE_URL` is provisioned; break-glass rolls back to the legacy path with loud observability.

## Review round 1 (Codex + CodeRabbit, commit 79b995592)

All 10 review threads addressed (9 fixed, 1 declined with reasoning on the thread):

- **UTC-safe chained INSERT** (Codex P2): the chainer's raw-pg INSERT serializes the timestamp as a UTC ISO string — the write-side half of the OID-1114 UTC read parser.
- **Genesis flag passthrough** (Codex P2): root compose no longer hardcodes `AUDIT_CHAINER_ALLOW_GENESIS=true`; fresh installs opt in via `.env.example`, upgrades stay guarded.
- **Engine-independent pg timestamp parse**: field-by-field `Date.UTC` parse replaces implementation-defined `new Date()` on space-separated wire strings.
- **Stale-role revoke on re-provision**: provisioning now REVOKEs managed template roles an entry no longer holds (GRANT only adds).
- **Partial-erasure failure audit**: a GDPR store write failing part-way self-audits per-store progress before returning 500 with re-run guidance.
- **Backfill cursor fail-loud**: 42P01 tolerance scoped to the main side; a missing admin cursors table aborts.
- Plus: `.env.example` eraser-password example, stale test-header text, exact tampered-entry assertion.
- Declined: eraser grants on the transient ingest queue (≤30s buffer; idempotent re-run covers it; would break the zero-trust grant matrix — full rationale on the thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pDRM1MhVFFuxCdLgimjqi
