### PR TITLE
fix(auth): decrypt stored email before sending step-up magic link

### DIFF
--- a/packages/lib/src/auth/__tests__/step-up-service.test.ts
+++ b/packages/lib/src/auth/__tests__/step-up-service.test.ts
@@ -76,6 +76,7 @@ import {
 } from '../step-up-service';
 import { computeActionBindingHash } from '../step-up-decisions';
 import { computeMcpTokenActionBinding, normalizeDriveScopes } from '../mcp-token-scopes';
+import { encryptField } from '../../encryption/field-crypto';
 
 type MockFn = ReturnType<typeof vi.fn>;
 type MockDb = {
@@ -414,6 +415,26 @@ describe('step-up-service', () => {
       expect(mockSendEmail).toHaveBeenCalledWith(
         expect.objectContaining({ to: 'user@example.com' }),
       );
+    });
+
+    it('decrypts an encrypted-at-rest stored email before handing it to sendEmail', async () => {
+      const prevKey = process.env.ENCRYPTION_KEY;
+      process.env.ENCRYPTION_KEY = 'step-up-service-test-master-key-32-chars!!';
+      try {
+        const ciphertext = await encryptField('user@example.com');
+        expect(ciphertext).not.toBe('user@example.com');
+        mockDb.query.users.findFirst.mockResolvedValue({ id: 'user-1', email: ciphertext });
+
+        const result = await requestMagicLinkStepUp({ userId: 'user-1', actionBinding: { clientId: 'cli-1' } });
+
+        expect(result.ok).toBe(true);
+        expect(mockSendEmail).toHaveBeenCalledWith(
+          expect.objectContaining({ to: 'user@example.com' }),
+        );
+      } finally {
+        if (prevKey === undefined) delete process.env.ENCRYPTION_KEY;
+        else process.env.ENCRYPTION_KEY = prevKey;
+      }
     });
   });
 

--- a/packages/lib/src/auth/step-up-service.ts
+++ b/packages/lib/src/auth/step-up-service.ts
@@ -37,6 +37,7 @@ import {
   type AuthenticatorTransportFuture,
 } from '@simplewebauthn/server';
 import { hashToken, generateToken } from './token-utils';
+import { decryptField } from '../encryption/field-crypto';
 import { PASSKEY_CONFIG, type AuthenticationOptionsWithHints } from './passkey-service';
 import {
   STEP_UP_CHALLENGE_EXPIRY_MINUTES,
@@ -308,7 +309,7 @@ export async function requestMagicLinkStepUp(input: unknown): Promise<RequestMag
 
   const confirmUrl = `${resolveAppUrl()}/api/auth/step-up/magic-link/verify?token=${encodeURIComponent(token)}`;
   await sendEmail({
-    to: user.email,
+    to: await decryptField(user.email),
     subject: 'Confirm this action in PageSpace',
     react: React.createElement(StepUpConfirmationEmail, { confirmUrl }),
   });


### PR DESCRIPTION
## Problem

`pagespace login` (CLI OAuth consent) fails for any user **without a passkey**:

```
Error: Failed to send email: Invalid `to` field. The email address needs to follow the `email@example.com` format.
  at sendEmail (packages/lib/dist/services/email-service.js:66)
  at requestMagicLinkStepUp (packages/lib/dist/auth/step-up-service.js:267)
```

The step-up ceremony tries WebAuthn first and falls back to the magic-link email only on `NO_PASSKEY` (`apps/web/src/lib/auth/step-up-ceremony.ts`), so passkey holders never hit this path — which is why it went unnoticed.

## Root cause

`requestMagicLinkStepUp` reads `users.email` directly via `db.query.users.findFirst` and passes it to `sendEmail` as the `to` address. Since the PII encryption-at-rest cutover, that column stores AES-GCM ciphertext, so Resend rejects it. Same missed-decrypt class as the earlier admin display routes; a grep for `to: user.email` / `email: user.email` in `packages/lib` shows this was the only remaining offender (`notification-email-service.ts` already decrypts via `decryptUserRow`).

## Fix

Wrap the address in the existing `decryptField` helper (`packages/lib/src/encryption/field-crypto.ts`), which passes legacy plaintext rows through unchanged — safe for any not-yet-encrypted rows.

## Tests

- New regression test encrypts an email with the real `encryptField`, seeds it as the stored user row, and asserts `sendEmail` receives the plaintext address. Verified it **fails** against the unfixed code and passes with the fix.
- Full `step-up-service.test.ts` suite: 18/18 pass (vitest). `packages/lib` typecheck clean.

## Deploy note

Requires a prod web deploy to take effect — CLI login for passkey-less users stays broken until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012R4XRxkUARuz691yCZDfrG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Step-up confirmation emails are now sent correctly when email addresses are stored encrypted.
  * Existing authentication flows and validation behavior remain unchanged.

* **Tests**
  * Added coverage to verify encrypted email addresses are decrypted before sending step-up emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->