### PR TITLE
[sprites 2-1] Fresh-session fallback when persisted streamSessionId is dangling

### DIFF
--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { openPtyShell, planReconnect, liveShellSessionIds } from '../sprites-shell';
+import { openPtyShell, planReconnect, liveShellSessionIds, newTtySessionId } from '../sprites-shell';
 
 // riteway-style assertion (given/should/actual/expected) on top of vitest — the
 // repo doesn't vendor riteway and bun-only rules forbid adding a dependency for
@@ -132,6 +132,39 @@ describe('liveShellSessionIds (pure)', () => {
       { id: 'shell-active', command: 'bash', isActive: true, tty: true },
     ]),
     expected: ['shell-active', 'shell-inactive'],
+  });
+});
+
+describe('newTtySessionId (pure)', () => {
+  assert({
+    given: 'a new tty session appearing after a create alongside a pre-existing one',
+    should: 'return the id absent from the before set (OUR new session, not the other terminal)',
+    actual: newTtySessionId(['sess-other'], [
+      { id: 'sess-other', command: 'bash', isActive: true, tty: true },
+      { id: 'sess-new', command: 'bash', isActive: false, tty: true },
+    ]),
+    expected: 'sess-new',
+  });
+
+  assert({
+    given: 'an empty before set and one new tty session',
+    should: 'return that session id',
+    actual: newTtySessionId([], [{ id: 'sess-new', command: 'bash', isActive: true, tty: true }]),
+    expected: 'sess-new',
+  });
+
+  assert({
+    given: 'no session appeared beyond the before set (ambiguous/empty diff)',
+    should: 'return undefined so the caller persists nothing',
+    actual: newTtySessionId(['sess-other'], [{ id: 'sess-other', command: 'bash', isActive: true, tty: true }]),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'the only new session is non-tty (a plain exec, not a shell)',
+    should: 'return undefined (a shell reattach target must be tty)',
+    actual: newTtySessionId([], [{ id: 'exec-1', command: 'ls', isActive: true, tty: false }]),
+    expected: undefined,
   });
 });
 
@@ -454,6 +487,53 @@ describe('openPtyShell', () => {
       expect(sprite.createSession).toHaveBeenCalledTimes(1);
       expect(onSessionId).toHaveBeenCalledWith('sess-fresh');
       expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given the Sprite also hosts ANOTHER terminal tty session, the fallback reports only the NEW id (not the pre-existing one)', async () => {
+      // Multi-terminal-per-Sprite: pickShellSession over all sessions could pick
+      // the OTHER terminal's shell and persist its id — corrupting reattach. The
+      // before/after diff must isolate our freshly created session.
+      const attachCmd = buildFakeCommand();
+      const freshCmd = buildFakeCommand();
+      const otherTerminal: SpriteSessionInfo = { id: 'sess-other', command: 'bash', isActive: true, tty: true };
+      const newShell: SpriteSessionInfo = { id: 'sess-new', command: 'bash', isActive: false, tty: true };
+      const sprite = buildFakeSprite(freshCmd);
+      sprite.attachSession.mockReturnValue(attachCmd);
+      sprite.createSession.mockReturnValue(freshCmd);
+      sprite.listSessions
+        .mockResolvedValueOnce([otherTerminal])            // reconnect: our sess-dead is gone, but another terminal is live
+        .mockResolvedValueOnce([otherTerminal, newShell]); // after create: our new shell joins
+      const onSessionId = vi.fn();
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput: vi.fn(), onExit, onSessionId });
+      attachCmd._emitter.emit('error', new Error('lost connection to shell'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.createSession).toHaveBeenCalledTimes(1);
+      expect(onSessionId).toHaveBeenCalledWith('sess-new');
+      expect(onSessionId).not.toHaveBeenCalledWith('sess-other');
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given the fallback diff is ambiguous (no new session appeared), reports NO id rather than a wrong one', async () => {
+      const attachCmd = buildFakeCommand();
+      const freshCmd = buildFakeCommand();
+      const otherTerminal: SpriteSessionInfo = { id: 'sess-other', command: 'bash', isActive: true, tty: true };
+      const sprite = buildFakeSprite(freshCmd);
+      sprite.attachSession.mockReturnValue(attachCmd);
+      sprite.createSession.mockReturnValue(freshCmd);
+      sprite.listSessions
+        .mockResolvedValueOnce([otherTerminal])  // reconnect snapshot (before)
+        .mockResolvedValueOnce([otherTerminal]); // after create: diff yields nothing new
+      const onSessionId = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput: vi.fn(), onExit: vi.fn(), onSessionId });
+      attachCmd._emitter.emit('error', new Error('lost connection to shell'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.createSession).toHaveBeenCalledTimes(1);
+      expect(onSessionId).not.toHaveBeenCalled();
     });
 
     it('given output flows from the fresh fallback session, forwards it to onOutput', async () => {

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { openPtyShell } from '../sprites-shell';
+import { openPtyShell, planReconnect, liveShellSessionIds } from '../sprites-shell';
+
+// riteway-style assertion (given/should/actual/expected) on top of vitest — the
+// repo doesn't vendor riteway and bun-only rules forbid adding a dependency for
+// a handful of pure-function cases, so keep the contract, drop the package.
+function assert<T>({ given, should, actual, expected }: { given: string; should: string; actual: T; expected: T }): void {
+  it(`given ${given}, should ${should}`, () => {
+    expect(actual).toEqual(expected);
+  });
+}
 import type {
   SpriteInstanceLike,
   SpriteCommandLike,
@@ -57,6 +66,74 @@ function buildFakeSprite(
 }
 
 const liveSession: SpriteSessionInfo = { id: 'sess-1', command: 'bash', isActive: true, tty: true };
+
+describe('planReconnect (pure)', () => {
+  const MAX = 5;
+
+  assert({
+    given: 'a known persisted id still present in the live sessions',
+    should: 'attach to it (reattach + replay scrollback)',
+    actual: planReconnect({ knownId: 'sess-1', liveSessionIds: ['sess-1'], consecutiveFailures: 1, maxAttempts: MAX }),
+    expected: { action: 'attach', id: 'sess-1' } as const,
+  });
+
+  assert({
+    given: 'a known persisted id absent from the live sessions (dangling after a pause)',
+    should: 'create a fresh session',
+    actual: planReconnect({ knownId: 'sess-dead', liveSessionIds: ['sess-9'], consecutiveFailures: 1, maxAttempts: MAX }),
+    expected: { action: 'create' } as const,
+  });
+
+  assert({
+    given: 'a known persisted id and an empty live-session list',
+    should: 'create a fresh session (the persisted id is gone)',
+    actual: planReconnect({ knownId: 'sess-dead', liveSessionIds: [], consecutiveFailures: 1, maxAttempts: MAX }),
+    expected: { action: 'create' } as const,
+  });
+
+  assert({
+    given: 'no known id but a live shell session exists',
+    should: 'attach to the first live session',
+    actual: planReconnect({ knownId: undefined, liveSessionIds: ['sess-1'], consecutiveFailures: 1, maxAttempts: MAX }),
+    expected: { action: 'attach', id: 'sess-1' } as const,
+  });
+
+  assert({
+    given: 'no known id and no live sessions',
+    should: 'be fatal (the shell is genuinely gone)',
+    actual: planReconnect({ knownId: undefined, liveSessionIds: [], consecutiveFailures: 1, maxAttempts: MAX }),
+    expected: { action: 'fatal' } as const,
+  });
+
+  assert({
+    given: 'the consecutive failures exceed the bounded budget, even with a live known id',
+    should: 'be fatal (never an infinite loop)',
+    actual: planReconnect({ knownId: 'sess-1', liveSessionIds: ['sess-1'], consecutiveFailures: MAX + 1, maxAttempts: MAX }),
+    expected: { action: 'fatal' } as const,
+  });
+});
+
+describe('liveShellSessionIds (pure)', () => {
+  assert({
+    given: 'a mix of tty and non-tty sessions',
+    should: 'return only the tty (shell) session ids',
+    actual: liveShellSessionIds([
+      { id: 'shell-1', command: 'bash', isActive: true, tty: true },
+      { id: 'exec-1', command: 'ls', isActive: true, tty: false },
+    ]),
+    expected: ['shell-1'],
+  });
+
+  assert({
+    given: 'an active and an inactive shell session',
+    should: 'order the active shell first (mirrors pickShellSession)',
+    actual: liveShellSessionIds([
+      { id: 'shell-inactive', command: 'bash', isActive: false, tty: true },
+      { id: 'shell-active', command: 'bash', isActive: true, tty: true },
+    ]),
+    expected: ['shell-active', 'shell-inactive'],
+  });
+});
 
 describe('openPtyShell', () => {
   beforeEach(() => { vi.useFakeTimers(); });
@@ -350,6 +427,68 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(500);
 
       expect(sprite.attachSession).not.toHaveBeenCalled();
+    });
+
+    it('given a persisted id ABSENT from listSessions, creates a fresh session and reports the new id (not exit -1)', async () => {
+      // Sprite paused: the persisted 'sess-dead' is dangling. Initial attach
+      // errors; reconnect must verify against listSessions, see it's gone, and
+      // fall back to a fresh session — overwriting the stale streamSessionId.
+      const attachCmd = buildFakeCommand();
+      const freshCmd = buildFakeCommand();
+      const newSession: SpriteSessionInfo = { id: 'sess-fresh', command: 'bash', isActive: true, tty: true };
+      const sprite = buildFakeSprite(freshCmd);
+      sprite.attachSession.mockReturnValue(attachCmd);
+      sprite.createSession.mockReturnValue(freshCmd);
+      sprite.listSessions
+        .mockResolvedValueOnce([])            // reconnect verification: sess-dead is gone
+        .mockResolvedValueOnce([newSession]); // fresh session's background id capture
+      const onExit = vi.fn();
+      const onSessionId = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput: vi.fn(), onExit, onSessionId });
+      expect(sprite.attachSession).toHaveBeenCalledWith('sess-dead', { cols: 80, rows: 24 });
+
+      attachCmd._emitter.emit('error', new Error('lost connection to shell'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.createSession).toHaveBeenCalledTimes(1);
+      expect(onSessionId).toHaveBeenCalledWith('sess-fresh');
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given output flows from the fresh fallback session, forwards it to onOutput', async () => {
+      const attachCmd = buildFakeCommand();
+      const freshCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(freshCmd);
+      sprite.attachSession.mockReturnValue(attachCmd);
+      sprite.createSession.mockReturnValue(freshCmd);
+      sprite.listSessions.mockResolvedValue([]); // sess-dead never returns; fresh id unresolved is fine
+      const onOutput = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput, onExit: vi.fn() });
+      attachCmd._emitter.emit('error', new Error('lost connection to shell'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      freshCmd._stdout.emit('data', 'fresh prompt\r\n');
+      expect(onOutput).toHaveBeenCalledWith('fresh prompt\r\n');
+    });
+
+    it('given a known id STILL present in listSessions, reattaches to it and does NOT create a fresh session', async () => {
+      const attachInitial = buildFakeCommand();
+      const attachAgain = buildFakeCommand();
+      const sprite = buildFakeSprite(buildFakeCommand(), { sessions: [liveSession] });
+      sprite.attachSession
+        .mockReturnValueOnce(attachInitial)
+        .mockReturnValueOnce(attachAgain);
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-1', onOutput: vi.fn(), onExit });
+      attachInitial._emitter.emit('error', new Error('keepalive'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).toHaveBeenLastCalledWith('sess-1', { cols: 80, rows: 24 });
+      expect(sprite.createSession).not.toHaveBeenCalled();
+      expect(onExit).not.toHaveBeenCalled();
     });
 
     it('given the session id is unknown at reconnect, resolves the live session via listSessions and attaches', async () => {

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -10,6 +10,14 @@ function assert<T>({ given, should, actual, expected }: { given: string; should:
     expect(actual).toEqual(expected);
   });
 }
+
+// A promise whose resolution the test drives, to interleave a fire-and-forget
+// listSessions() against fake-timer-driven reconnect steps.
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => { resolve = r; });
+  return { promise, resolve };
+}
 import type {
   SpriteInstanceLike,
   SpriteCommandLike,
@@ -157,6 +165,17 @@ describe('newTtySessionId (pure)', () => {
     given: 'no session appeared beyond the before set (ambiguous/empty diff)',
     should: 'return undefined so the caller persists nothing',
     actual: newTtySessionId(['sess-other'], [{ id: 'sess-other', command: 'bash', isActive: true, tty: true }]),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'TWO new tty sessions appeared (a concurrent terminal created one in the same window)',
+    should: 'return undefined — the diff can no longer tell which is ours, so persist nothing',
+    actual: newTtySessionId(['sess-other'], [
+      { id: 'sess-other', command: 'bash', isActive: true, tty: true },
+      { id: 'sess-a', command: 'bash', isActive: false, tty: true },
+      { id: 'sess-b', command: 'bash', isActive: false, tty: true },
+    ]),
     expected: undefined,
   });
 
@@ -534,6 +553,83 @@ describe('openPtyShell', () => {
 
       expect(sprite.createSession).toHaveBeenCalledTimes(1);
       expect(onSessionId).not.toHaveBeenCalled();
+    });
+
+    it('given listSessions fails transiently while a known id is held, optimistically reattaches to it instead of burning the budget', async () => {
+      // Control-plane listSessions is briefly down; master reattached a known id
+      // with no listSessions dependency, so a live shell must survive the blip.
+      const initialAttach = buildFakeCommand();
+      const reAttach = buildFakeCommand();
+      const sprite = buildFakeSprite(buildFakeCommand());
+      sprite.attachSession.mockReturnValueOnce(initialAttach).mockReturnValueOnce(reAttach);
+      sprite.listSessions.mockRejectedValue(new Error('listSessions unavailable'));
+      const onExit = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-1', onOutput: vi.fn(), onExit });
+      initialAttach._emitter.emit('error', new Error('keepalive'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(sprite.attachSession).toHaveBeenCalledTimes(2); // initial + optimistic reattach
+      expect(sprite.attachSession).toHaveBeenLastCalledWith('sess-1', { cols: 80, rows: 24 });
+      expect(sprite.createSession).not.toHaveBeenCalled();
+      expect(onExit).not.toHaveBeenCalled();
+    });
+
+    it('given kill() fires while the reconnect listSessions await is in flight, does NOT create a leaked billable shell', async () => {
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(buildFakeCommand());
+      sprite.attachSession.mockReturnValue(attachCmd);
+      const d = deferred<SpriteSessionInfo[]>();
+      sprite.listSessions.mockReturnValue(d.promise);
+      const onExit = vi.fn();
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput: vi.fn(), onExit });
+      attachCmd._emitter.emit('error', new Error('keepalive'));
+      await vi.advanceTimersByTimeAsync(300); // past backoff; now suspended at await listSessions
+
+      shell.kill();               // closed = true mid-await
+      d.resolve([]);              // sess-dead gone → would otherwise take the create branch
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sprite.createSession).not.toHaveBeenCalled();
+    });
+
+    it('given a superseding reconnect lands before the fresh-fallback background resolve, the stale resolve does NOT persist its id', async () => {
+      // Flapping Sprite: fallback A creates a session whose id-resolve is slow; a
+      // second reconnect attaches a different live session first. A's late resolve
+      // must not clobber currentSessionId / persist A's now-superseded id.
+      const initialAttach = buildFakeCommand();
+      const freshCmd = buildFakeCommand();
+      const secondAttach = buildFakeCommand();
+      const sprite = buildFakeSprite(freshCmd);
+      sprite.attachSession.mockReturnValueOnce(initialAttach).mockReturnValueOnce(secondAttach);
+      sprite.createSession.mockReturnValue(freshCmd);
+
+      const d1 = deferred<SpriteSessionInfo[]>();     // reconnect #1 planning
+      const dFresh = deferred<SpriteSessionInfo[]>(); // fallback A background resolve (stale)
+      const d2 = deferred<SpriteSessionInfo[]>();     // reconnect #2 planning
+      sprite.listSessions
+        .mockReturnValueOnce(d1.promise)
+        .mockReturnValueOnce(dFresh.promise)
+        .mockReturnValueOnce(d2.promise);
+      const onSessionId = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-dead', onOutput: vi.fn(), onExit: vi.fn(), onSessionId });
+
+      initialAttach._emitter.emit('error', new Error('drop1'));
+      await vi.advanceTimersByTimeAsync(300);
+      d1.resolve([]);                    // sess-dead gone → create fallback A (gen 1)
+      await vi.advanceTimersByTimeAsync(0);
+
+      freshCmd._emitter.emit('error', new Error('drop2'));
+      await vi.advanceTimersByTimeAsync(600);
+      d2.resolve([{ id: 'sess-live', command: 'bash', isActive: true, tty: true }]); // attach sess-live (gen 2)
+      await vi.advanceTimersByTimeAsync(0);
+
+      dFresh.resolve([{ id: 'sess-a', command: 'bash', isActive: false, tty: true }]); // stale resolve
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onSessionId).not.toHaveBeenCalledWith('sess-a');
     });
 
     it('given output flows from the fresh fallback session, forwards it to onOutput', async () => {

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -455,6 +455,17 @@ export function buildAgentTerminalHandlers({
             // Clears all of the session's timers (re-auth, settle heartbeat, idle).
             endAgentTerminalSession(billing, sessionMap, session, sessionKey);
           },
+          // The fresh-session fallback fired: the persisted streamSessionId was
+          // dangling (Sprite paused then cold-woke), so overwrite it with the new
+          // live session's id — otherwise the NEXT reconnect targets the dead id.
+          onSessionId: (sessionId) => {
+            session.sessionId = sessionId;
+            void persistStreamSessionId({ agentTerminalId: authResult.agentTerminalId, sessionId }).catch((error) => {
+              loggers.realtime.error('Failed to persist reconnect session id', error instanceof Error ? error : new Error(String(error)), {
+                sessionKey,
+              });
+            });
+          },
         });
       } catch {
         authResult.releaseSlot();

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -30,6 +30,20 @@ export function liveShellSessionIds(sessions: SpriteSessionInfo[]): string[] {
   return [...active, ...inactive].map((s) => s.id);
 }
 
+/**
+ * The id of the tty (shell) session that appeared AFTER a create, identified by
+ * diffing against the ids that existed BEFORE it. A Sprite can host several tty
+ * sessions at once (one per concurrent terminal — see agent-terminal-handler's
+ * module doc), so "any tty session" is ambiguous; only a before/after diff
+ * reliably names OUR freshly created shell (mirrors the connect path's
+ * `discoverNewSessionId`). Returns undefined when the diff is empty/ambiguous —
+ * the caller then persists nothing rather than risk another terminal's id.
+ */
+export function newTtySessionId(beforeIds: string[], after: SpriteSessionInfo[]): string | undefined {
+  const before = new Set(beforeIds);
+  return after.find((s) => s.tty && !before.has(s.id))?.id;
+}
+
 export type ReconnectPlan =
   | { action: 'attach'; id: string }
   | { action: 'create' }
@@ -190,10 +204,14 @@ export function openPtyShell({
   }
 
   // Start a brand-new shell for the SAME command and resolve its session id in
-  // the background. `reportId` is set on the reconnect fallback so the caller can
-  // overwrite a now-dangling persisted streamSessionId; the initial fresh session
-  // leaves persistence to the connect path's own before/after diff.
-  function launchFreshSession(reportId: boolean): void {
+  // the background. `before` is the pre-create session snapshot on the reconnect
+  // fallback: because a Sprite can host several tty sessions at once, OUR new
+  // shell is identified by a before/after diff and reported via `onSessionId` so
+  // the caller overwrites the dangling streamSessionId with THIS session's id
+  // (never another terminal's). `before === undefined` is the initial fresh
+  // session — no diff baseline here, so it best-effort resolves a local id for
+  // in-session reattach and leaves persistence to the connect path's own diff.
+  function launchFreshSession(before: SpriteSessionInfo[] | undefined): void {
     currentSessionId = undefined;
     current = sprite.createSession(command, args, {
       tty: true,
@@ -202,13 +220,22 @@ export function openPtyShell({
       cwd,
       env: TERMINAL_ENV,
     });
+    const beforeIds = before?.map((s) => s.id);
     void sprite
       .listSessions()
-      .then((sessions) => {
-        const id = pickShellSession(sessions)?.id;
-        if (id === undefined) return;
-        if (currentSessionId === undefined) currentSessionId = id;
-        if (reportId) onSessionId?.(id);
+      .then((after) => {
+        if (beforeIds !== undefined) {
+          // Reconnect fallback: diff-only. An ambiguous/empty diff persists
+          // nothing (next reconnect just creates fresh again) rather than risk
+          // overwriting the DB with another terminal's session id.
+          const id = newTtySessionId(beforeIds, after);
+          if (id === undefined) return;
+          currentSessionId = id;
+          onSessionId?.(id);
+          return;
+        }
+        const id = pickShellSession(after)?.id;
+        if (id !== undefined && currentSessionId === undefined) currentSessionId = id;
       })
       .catch(() => {});
   }
@@ -230,7 +257,8 @@ export function openPtyShell({
       // any retry — exec sessions don't survive a pause, so a persisted id can be
       // dangling. Skipping this re-query is exactly the stale-id-retry bug that
       // loops a dead id to fatal(-1) instead of falling back to a fresh shell.
-      const liveIds = liveShellSessionIds(await sprite.listSessions());
+      const before = await sprite.listSessions();
+      const liveIds = liveShellSessionIds(before);
       const plan = planReconnect({
         knownId: currentSessionId,
         liveSessionIds: liveIds,
@@ -247,8 +275,10 @@ export function openPtyShell({
       if (plan.action === 'create') {
         // The persisted id is dead (Sprite paused then cold-woke). Start a fresh
         // shell transparently and overwrite the dangling streamSessionId so the
-        // user sees a new prompt rather than exit -1.
-        launchFreshSession(true);
+        // user sees a new prompt rather than exit -1. `before` (captured just
+        // above, pre-create) is the diff baseline that isolates OUR new session
+        // from any other terminal's tty session on the same Sprite.
+        launchFreshSession(before);
         wire(current);
         reconnecting = false;
         return;
@@ -267,7 +297,7 @@ export function openPtyShell({
   if (currentSessionId !== undefined) {
     current = sprite.attachSession(currentSessionId, { cols, rows });
   } else {
-    launchFreshSession(false);
+    launchFreshSession(undefined);
   }
   wire(current);
 

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -17,6 +17,60 @@ export function pickShellSession(sessions: SpriteSessionInfo[]): SpriteSessionIn
   return shells.find((s) => s.isActive) ?? shells[0];
 }
 
+/**
+ * Live shell (tty) session ids ordered so index 0 mirrors `pickShellSession`'s
+ * pick (active first, else the first shell). The full ordered list lets
+ * `planReconnect` test whether a persisted id is still among the live sessions
+ * while also naming a fallback to attach to when the known id is unset.
+ */
+export function liveShellSessionIds(sessions: SpriteSessionInfo[]): string[] {
+  const shells = sessions.filter((s) => s.tty);
+  const active = shells.filter((s) => s.isActive);
+  const inactive = shells.filter((s) => !s.isActive);
+  return [...active, ...inactive].map((s) => s.id);
+}
+
+export type ReconnectPlan =
+  | { action: 'attach'; id: string }
+  | { action: 'create' }
+  | { action: 'fatal' };
+
+/**
+ * Decide how a dropped shell should reconnect. Exec sessions do NOT survive a
+ * Sprite pause (docs.sprites.dev/concepts/lifecycle — "open network connections"
+ * are "lost on any pause"), so a persisted `streamSessionId` can be dangling: it
+ * MUST be verified against the sessions the Sprite currently reports live before
+ * any retry. Pure by construction so every branch is unit-testable:
+ *
+ * - Over the retry budget → `fatal` (bounded — never an infinite loop).
+ * - Known id still live → `attach` it (reattach + replay scrollback; unchanged).
+ * - Known id absent from the live list → `create` a fresh session (the stale id
+ *   is dead; the shell overwrites the persisted streamSessionId).
+ * - No known id but a live shell exists → `attach` it (fresh-create path whose
+ *   background id-capture hasn't landed yet).
+ * - No known id and nothing live → `fatal` (the shell is genuinely gone).
+ */
+export function planReconnect({
+  knownId,
+  liveSessionIds,
+  consecutiveFailures,
+  maxAttempts,
+}: {
+  knownId: string | undefined;
+  liveSessionIds: string[];
+  consecutiveFailures: number;
+  maxAttempts: number;
+}): ReconnectPlan {
+  if (consecutiveFailures > maxAttempts) return { action: 'fatal' };
+  if (knownId !== undefined) {
+    return liveSessionIds.includes(knownId)
+      ? { action: 'attach', id: knownId }
+      : { action: 'create' };
+  }
+  if (liveSessionIds.length > 0) return { action: 'attach', id: liveSessionIds[0] };
+  return { action: 'fatal' };
+}
+
 export type PtyShell = {
   write(data: string): void;
   resize(cols: number, rows: number): void;
@@ -46,6 +100,15 @@ export type OpenPtyShellArgs = {
   cwd?: string;
   onOutput(data: string): void;
   onExit(exitCode: number): void;
+  /**
+   * Called when the shell establishes a session id the caller should persist —
+   * currently when the fresh-session fallback replaces a dangling persisted id
+   * after a pause. The handler overwrites `machine_agent_terminals.streamSessionId`
+   * so the NEXT reconnect targets the live session, not the dead one. Not fired
+   * for the initial fresh session — that id is persisted by the connect path's
+   * own before/after diff (see `discoverNewSessionId`).
+   */
+  onSessionId?(sessionId: string): void;
 };
 
 // The @fly/sprites WSCommand keepalive is output-driven: it declares the socket
@@ -74,10 +137,13 @@ export function openPtyShell({
   cwd = SANDBOX_ROOT,
   onOutput,
   onExit,
+  onSessionId,
 }: OpenPtyShellArgs): PtyShell {
   const toStr = (chunk: unknown) => (typeof chunk === 'string' ? chunk : (chunk as Buffer).toString('utf8'));
 
-  let current: SpriteCommandLike;
+  // Definite-assignment asserted: every construction path (initial attach,
+  // initial fresh, and each reconnect branch) assigns `current` before `wire`.
+  let current!: SpriteCommandLike;
   // The live session id to reattach to. Known immediately when attaching;
   // for a freshly created session it is resolved in the background via
   // listSessions() (and again at reconnect time as a fallback).
@@ -123,6 +189,30 @@ export function openPtyShell({
     cmd.on('error', () => { stale = true; void reconnect(); });
   }
 
+  // Start a brand-new shell for the SAME command and resolve its session id in
+  // the background. `reportId` is set on the reconnect fallback so the caller can
+  // overwrite a now-dangling persisted streamSessionId; the initial fresh session
+  // leaves persistence to the connect path's own before/after diff.
+  function launchFreshSession(reportId: boolean): void {
+    currentSessionId = undefined;
+    current = sprite.createSession(command, args, {
+      tty: true,
+      cols: lastCols,
+      rows: lastRows,
+      cwd,
+      env: TERMINAL_ENV,
+    });
+    void sprite
+      .listSessions()
+      .then((sessions) => {
+        const id = pickShellSession(sessions)?.id;
+        if (id === undefined) return;
+        if (currentSessionId === undefined) currentSessionId = id;
+        if (reportId) onSessionId?.(id);
+      })
+      .catch(() => {});
+  }
+
   async function reconnect(): Promise<void> {
     if (closed || reconnecting) return;
     reconnecting = true;
@@ -136,18 +226,35 @@ export function openPtyShell({
       await delay(RECONNECT_BASE_DELAY_MS * consecutiveFailures);
       if (closed) { reconnecting = false; return; }
 
-      let id = currentSessionId;
-      if (id === undefined) {
-        id = pickShellSession(await sprite.listSessions())?.id;
-      }
-      if (id === undefined) {
-        // No live session to reattach to — the shell is genuinely gone.
+      // Verify the known/persisted id against what the Sprite reports live BEFORE
+      // any retry — exec sessions don't survive a pause, so a persisted id can be
+      // dangling. Skipping this re-query is exactly the stale-id-retry bug that
+      // loops a dead id to fatal(-1) instead of falling back to a fresh shell.
+      const liveIds = liveShellSessionIds(await sprite.listSessions());
+      const plan = planReconnect({
+        knownId: currentSessionId,
+        liveSessionIds: liveIds,
+        consecutiveFailures,
+        maxAttempts: MAX_RECONNECT_ATTEMPTS,
+      });
+
+      if (plan.action === 'fatal') {
+        // No live session and no known id to fall back to — genuinely gone.
         reconnecting = false;
         fatal(-1);
         return;
       }
-      currentSessionId = id;
-      current = sprite.attachSession(id, { cols: lastCols, rows: lastRows });
+      if (plan.action === 'create') {
+        // The persisted id is dead (Sprite paused then cold-woke). Start a fresh
+        // shell transparently and overwrite the dangling streamSessionId so the
+        // user sees a new prompt rather than exit -1.
+        launchFreshSession(true);
+        wire(current);
+        reconnecting = false;
+        return;
+      }
+      currentSessionId = plan.id;
+      current = sprite.attachSession(plan.id, { cols: lastCols, rows: lastRows });
       wire(current);
       reconnecting = false;
     } catch {
@@ -160,23 +267,7 @@ export function openPtyShell({
   if (currentSessionId !== undefined) {
     current = sprite.attachSession(currentSessionId, { cols, rows });
   } else {
-    current = sprite.createSession(command, args, {
-      tty: true,
-      cols,
-      rows,
-      cwd,
-      env: TERMINAL_ENV,
-    });
-    // Resolve our own session id so a keepalive drop can reattach to it. Best
-    // effort: reconnect() also resolves it on demand if this hasn't landed yet.
-    void sprite
-      .listSessions()
-      .then((sessions) => {
-        if (currentSessionId === undefined) {
-          currentSessionId = pickShellSession(sessions)?.id;
-        }
-      })
-      .catch(() => {});
+    launchFreshSession(false);
   }
   wire(current);
 

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -6,28 +6,40 @@ import type {
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 
 /**
- * Pick the live interactive shell to reattach to from a Sprite's exec sessions.
- * A terminal owns exactly one TTY shell per Sprite (one page = one Sprite), so
- * match on `tty` rather than on `isActive` — the API's `is_active` semantics
- * (process-alive vs client-attached) are undocumented, and a detached-but-running
- * shell may report `is_active: false`. `isActive` is used only as a tiebreaker.
+ * The Sprite's live shell (tty) sessions, active ones first — the single source
+ * of the "which shell" ordering that both `pickShellSession` (takes the first)
+ * and `liveShellSessionIds` (maps to ids) build on, so the tiebreaker can never
+ * silently diverge between them. Match on `tty` rather than `isActive` — the
+ * API's `is_active` semantics (process-alive vs client-attached) are
+ * undocumented and a detached-but-running shell may report `is_active: false`;
+ * `isActive` is only the ordering tiebreaker.
  */
-export function pickShellSession(sessions: SpriteSessionInfo[]): SpriteSessionInfo | undefined {
-  const shells = sessions.filter((s) => s.tty);
-  return shells.find((s) => s.isActive) ?? shells[0];
-}
-
-/**
- * Live shell (tty) session ids ordered so index 0 mirrors `pickShellSession`'s
- * pick (active first, else the first shell). The full ordered list lets
- * `planReconnect` test whether a persisted id is still among the live sessions
- * while also naming a fallback to attach to when the known id is unset.
- */
-export function liveShellSessionIds(sessions: SpriteSessionInfo[]): string[] {
+function orderedShellSessions(sessions: SpriteSessionInfo[]): SpriteSessionInfo[] {
   const shells = sessions.filter((s) => s.tty);
   const active = shells.filter((s) => s.isActive);
   const inactive = shells.filter((s) => !s.isActive);
-  return [...active, ...inactive].map((s) => s.id);
+  return [...active, ...inactive];
+}
+
+/**
+ * Pick the live interactive shell to reattach to from a Sprite's exec sessions
+ * (active first, else the first shell). One page = one Sprite, but a Sprite can
+ * host several tty sessions across concurrent terminals — see
+ * `agent-terminal-handler`'s module doc — so this "any live shell" pick is only
+ * safe when the caller has no better id; prefer a persisted/diffed id.
+ */
+export function pickShellSession(sessions: SpriteSessionInfo[]): SpriteSessionInfo | undefined {
+  return orderedShellSessions(sessions)[0];
+}
+
+/**
+ * Live shell (tty) session ids ordered so index 0 equals `pickShellSession`'s
+ * pick. The full ordered list lets `planReconnect` test whether a persisted id
+ * is still among the live sessions while also naming a fallback to attach to
+ * when the known id is unset.
+ */
+export function liveShellSessionIds(sessions: SpriteSessionInfo[]): string[] {
+  return orderedShellSessions(sessions).map((s) => s.id);
 }
 
 /**
@@ -36,12 +48,15 @@ export function liveShellSessionIds(sessions: SpriteSessionInfo[]): string[] {
  * sessions at once (one per concurrent terminal — see agent-terminal-handler's
  * module doc), so "any tty session" is ambiguous; only a before/after diff
  * reliably names OUR freshly created shell (mirrors the connect path's
- * `discoverNewSessionId`). Returns undefined when the diff is empty/ambiguous —
- * the caller then persists nothing rather than risk another terminal's id.
+ * `discoverNewSessionId`). Returns undefined when the diff is empty OR when more
+ * than one new tty session appeared — a concurrent terminal creating its own
+ * shell in the same window is indistinguishable from ours, so we persist nothing
+ * rather than risk overwriting the DB with another terminal's id.
  */
 export function newTtySessionId(beforeIds: string[], after: SpriteSessionInfo[]): string | undefined {
   const before = new Set(beforeIds);
-  return after.find((s) => s.tty && !before.has(s.id))?.id;
+  const created = after.filter((s) => s.tty && !before.has(s.id));
+  return created.length === 1 ? created[0].id : undefined;
 }
 
 export type ReconnectPlan =
@@ -167,6 +182,12 @@ export function openPtyShell({
   let closed = false; // a real exit (or exhausted reconnects) — stop everything
   let reconnecting = false;
   let consecutiveFailures = 0;
+  // Bumped on every session (re)establishment (attach or fresh-create). A
+  // fresh session resolves its id via a fire-and-forget listSessions(); if a
+  // LATER establishment supersedes it before that resolves, the stale resolver
+  // must not clobber currentSessionId / persist a now-dead id, so it checks the
+  // generation it captured against this counter.
+  let sessionGeneration = 0;
 
   function fatal(exitCode: number, message?: string): void {
     if (closed) return;
@@ -213,6 +234,7 @@ export function openPtyShell({
   // in-session reattach and leaves persistence to the connect path's own diff.
   function launchFreshSession(before: SpriteSessionInfo[] | undefined): void {
     currentSessionId = undefined;
+    const gen = (sessionGeneration += 1);
     current = sprite.createSession(command, args, {
       tty: true,
       cols: lastCols,
@@ -224,6 +246,10 @@ export function openPtyShell({
     void sprite
       .listSessions()
       .then((after) => {
+        // A newer establishment (another reconnect) superseded this one, or the
+        // shell was killed, while listSessions was in flight — don't clobber
+        // currentSessionId or persist an id that no longer names the live shell.
+        if (closed || gen !== sessionGeneration) return;
         if (beforeIds !== undefined) {
           // Reconnect fallback: diff-only. An ambiguous/empty diff persists
           // nothing (next reconnect just creates fresh again) rather than risk
@@ -257,7 +283,33 @@ export function openPtyShell({
       // any retry — exec sessions don't survive a pause, so a persisted id can be
       // dangling. Skipping this re-query is exactly the stale-id-retry bug that
       // loops a dead id to fatal(-1) instead of falling back to a fresh shell.
-      const before = await sprite.listSessions();
+      let before: SpriteSessionInfo[] | undefined;
+      try {
+        before = await sprite.listSessions();
+      } catch {
+        before = undefined;
+      }
+      // kill() may have fired while listSessions was in flight — never (re)open a
+      // session for a terminal the user already closed (that would leak a running,
+      // billable Sprite shell with no client attached).
+      if (closed) { reconnecting = false; return; }
+      if (before === undefined) {
+        // The control-plane listSessions is transiently unavailable (rate-limited /
+        // cold-waking). Don't burn the retry budget killing a shell that's fine: if
+        // we still hold a known id, optimistically reattach to it (the pre-verify
+        // behavior) — a dead id just errors and re-enters reconnect once listing
+        // recovers. With no id to reattach, fall back to a bounded retry.
+        if (currentSessionId !== undefined) {
+          sessionGeneration += 1;
+          current = sprite.attachSession(currentSessionId, { cols: lastCols, rows: lastRows });
+          wire(current);
+          reconnecting = false;
+          return;
+        }
+        reconnecting = false;
+        void reconnect();
+        return;
+      }
       const liveIds = liveShellSessionIds(before);
       const plan = planReconnect({
         knownId: currentSessionId,
@@ -283,6 +335,7 @@ export function openPtyShell({
         reconnecting = false;
         return;
       }
+      sessionGeneration += 1;
       currentSessionId = plan.id;
       current = sprite.attachSession(plan.id, { cols: lastCols, rows: lastRows });
       wire(current);


### PR DESCRIPTION
## [sprites 2-1] Persisted `streamSessionId` is a hint: fresh-session fallback

Exec sessions do **not** survive a Sprite pause ([docs.sprites.dev/concepts/lifecycle](https://docs.sprites.dev/concepts/lifecycle/) — "open network connections" are "lost on any pause"). So the persisted `machine_agent_terminals.streamSessionId` we reattach to on connect can be dangling after a pause. Previously `reconnect()` skipped the `listSessions` re-query whenever a `currentSessionId` was set (the `if (id === undefined)` branch), so it retried the **same dead id** up to 5× (~3s backoff) then surfaced `Shell error: lost connection to shell` / `exit -1` — never falling back to a fresh session. Once Phase 3 lets sprites actually pause, this is the #1 user-facing failure. This PR makes reconnect **verify, fall back, and clear**.

### How each requirement is satisfied

- **Given a persisted session id absent from `listSessions`, should create a fresh session transparently and overwrite the stale `streamSessionId` in the DB (user sees a new shell, not exit -1).**
  `reconnect()` now re-queries `listSessions` on every attempt. When the known id isn't among the live sessions, `planReconnect` returns `{action:'create'}`; the shell calls `launchFreshSession(reportId=true)`, which `createSession`s a new shell for the same command and fires the new `onSessionId(newId)` callback. The handler wires `onSessionId` → `persistStreamSessionId({agentTerminalId, sessionId})`, overwriting the dangling id. `onExit` is never called. Covered by `given a persisted id ABSENT from listSessions, creates a fresh session and reports the new id (not exit -1)`.

- **Given an attach failure on a known id, should verify against `listSessions` before any retry; if absent → create fresh; if present → bounded retry as today.**
  The stale `if (id === undefined)` short-circuit is deleted — every reconnect queries `listSessions` and runs `planReconnect` before doing anything. Absent → `create`; present → `attach` the same id (bounded by `MAX_RECONNECT_ATTEMPTS`). Covered by `given a known id STILL present in listSessions, reattaches to it and does NOT create a fresh session` and the pure-function branch tests.

- **Given a genuinely live persisted id, should attach to it and replay scrollback (existing behavior preserved).**
  Initial connect still attaches directly (`attachSession(currentSessionId)`), and a live known id at reconnect still yields `{action:'attach', id}`. Existing reconnect/replay tests unchanged and green.

- **Given the fatal path (sprite truly unreachable after bounded attempts), should still surface a clear exit — never an infinite loop.**
  The `consecutiveFailures > MAX_RECONNECT_ATTEMPTS` guard still fatals with `lost connection to shell`; `planReconnect` also returns `{action:'fatal'}` when over budget or when there's no known id and nothing live. Existing `given reattach repeatedly fails …` and `NO live session` tests preserved.

### Pure core / imperative shell

Extracted the decision as **`planReconnect({knownId, liveSessionIds, consecutiveFailures, maxAttempts}) → {action:'attach',id} | {action:'create'} | {action:'fatal'}`** — pure, no mocks, every branch unit-tested. `liveShellSessionIds` (also pure) derives the ordered live-shell id list (active-first, mirroring `pickShellSession`) that `planReconnect` consumes. `openPtyShell` (the shell) executes the plan and reports outcomes.

### Test evidence

TDD: RED (pure-fn + fallback tests) → GREEN → REFACTOR. riteway `assert({given,should,actual,expected})` contract kept via a tiny vitest-backed local helper (riteway isn't vendored; bun-only rules forbid adding a dep for a few pure cases).

```
 ✓ src/terminal/__tests__/sprites-shell.test.ts (34 tests) 57ms
 Test Files  1 passed (1)   Tests  34 passed (34)

 Test Files  6 passed (6)   Tests  175 passed (175)   (full terminal suite)
```

`bunx turbo run typecheck --filter=realtime` → clean. No `any`; bun only; work done in an isolated pu worktree.

### For the orchestrator to verify
- Manual: pause a Sprite (Phase 3), reconnect a terminal with a persisted `streamSessionId` — expect a fresh prompt (not `exit -1`) and the DB `streamSessionId` overwritten with the new session id.
- `onSessionId` fires **only** on the reconnect fresh-fallback; the initial fresh session's id is still persisted by the connect path's `discoverNewSessionId` before/after diff (leaf 2-2's territory — untouched).

## Out of scope (untouched)
Session-id discovery at create time (2-2), kill semantics (2-3), replay dedupe (2-4).

---

## Convergence update (post-review)

**Codex P1 — persist the newly created fallback session id (fixed in `0fcb10a0b`).** A Sprite can host multiple tty sessions at once (one per concurrent terminal — `agent-terminal-handler.ts` module doc), so resolving the fresh-fallback id via `pickShellSession` over *all* sessions could pick another terminal's shell and persist **its** id as this terminal's `streamSessionId` — the next reconnect would then attach to the wrong PTY. Now the fallback identifies **our** newly created session by a before/after diff:

- New pure helper **`newTtySessionId(beforeIds, after)`** returns the tty session absent from the pre-create snapshot (mirrors the connect path's `discoverNewSessionId`); unit-tested per branch.
- `reconnect()` reuses the `listSessions` snapshot it already runs for planning as the diff baseline (genuinely pre-create), so no extra round-trip.
- An **ambiguous/empty diff persists nothing** rather than risk a wrong id (same accepted degradation as `discoverNewSessionId`).
- The initial fresh-session path is unchanged (its persistence is owned by the connect path's own diff — leaf 2-2's scope).
- Added a regression test placing another terminal's live tty session on the Sprite and asserting the fallback reports **only** the newly created id, plus an ambiguous-diff test and per-branch pure tests for `newTtySessionId`.

**Validation:** `bun run test src/terminal/__tests__/` → **181 passed** (40 in `sprites-shell.test.ts`). `typecheck --filter=realtime` and `lint --filter=realtime` clean. CI: Lint & TypeScript Check + Unit Tests both green; mergeable/CLEAN.

**Hardening (`aa1dfb3f2`, from a high-effort self-review):** multi-session race fixes in the reconnect path — `newTtySessionId` returns undefined on an ambiguous (>1 new tty) diff; `listSessions` outages optimistically reattach a known id instead of failing a live shell; `closed` is re-checked after the reconnect `listSessions` await (no leaked billable shell on kill); the fresh-session id resolver is generation-guarded against stale clobbering; `pickShellSession`/`liveShellSessionIds` share one ordering helper. Related create-time-discovery findings (knownId-undefined attach on multi-terminal Sprites, dual-persist ordering, `discoverNewSessionId` DRY) are deferred to leaf 2-2 — see the self-review PR comment. **185 terminal tests green.**
