### PR TITLE
[sprites 1-1] Pure session-key derivation decoupled from sandboxId

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -34,6 +34,7 @@ import {
   type SocketLike,
 } from './terminal/agent-terminal-handler';
 import { handleTerminalActivityRequest } from './terminal/terminal-activity';
+import { deriveAgentTerminalSessionKey, agentTerminalScopeFromNames } from './terminal/agent-terminal-session-key';
 import { createTerminalSessionMap } from './terminal/terminal-session-map';
 import { openPtyShell } from './terminal/sprites-shell';
 import { getRealtimeSpritesSdk } from './terminal/realtime-sprites-client';
@@ -164,26 +165,29 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
 }
 
 /**
- * The in-memory `agentTerminalSessionMap` key for a (scope, name) target.
- * Machine and project scope share the SAME owning Machine's Sprite
- * (`sandboxId`) — see `resolveProjectOrMachineLocation` in `agent-terminals.ts`
- * — so the scope discriminant (not just `sandboxId` + `name`) is required to
- * keep e.g. a machine-scope "cli" terminal and a project-scope "cli" terminal
- * on the SAME machine from colliding onto one shared PTY session.
+ * Shell adapter over the pure `deriveAgentTerminalSessionKey`
+ * (`agent-terminal-session-key.ts`): maps the transport's optional
+ * (projectName, branchName) pair into the discriminated scope and keys off the
+ * owning Machine Terminal page id (`terminalId`), NOT the Sprite `sandboxId`.
+ * Keying on `terminalId` means a warm reattach never has to resolve the Sprite
+ * before the fast-path map lookup can run.
  */
 function buildAgentTerminalSessionKey({
-  sandboxId,
+  terminalId,
   projectName,
   branchName,
   name,
 }: {
-  sandboxId: string;
+  terminalId: string;
   projectName?: string;
   branchName?: string;
   name: string;
 }): string {
-  const scope = branchName ? `branch:${projectName}:${branchName}` : projectName ? `project:${projectName}` : 'machine';
-  return `${sandboxId}:agent:${scope}:${name}`;
+  return deriveAgentTerminalSessionKey({
+    terminalId,
+    scope: agentTerminalScopeFromNames({ projectName, branchName }),
+    name,
+  });
 }
 
 /**
@@ -303,7 +307,7 @@ async function makeAgentTerminalCheckAuth({
     agentTerminalId: resolved.agentTerminalId,
     sandboxId: resolved.sandboxId,
     cwd: resolved.cwd,
-    sessionKey: buildAgentTerminalSessionKey({ sandboxId: resolved.sandboxId, projectName, branchName, name }),
+    sessionKey: buildAgentTerminalSessionKey({ terminalId, projectName, branchName, name }),
     sprite,
     releaseSlot,
     command: spec.command,
@@ -641,16 +645,16 @@ const requestListener = (req: IncomingMessage, res: ServerResponse) => {
                 {
                     sessionMap: agentTerminalSessionMap,
                     // The machine's conventional 'shell' agent terminal (the retired
-                    // human `terminal:*` family's replacement) lives under the SAME
-                    // sandboxId a fresh/resumed acquireTerminalSandbox call for this
-                    // (tenant, drive, page) would resolve to — look that sandboxId up
-                    // from the persisted terminal_sessions record (no provisioning) and
-                    // rebuild the exact in-memory sessionKey agent-terminal-handler.ts uses.
+                    // human `terminal:*` family's replacement) is keyed on the owning
+                    // Terminal page id (`pageId` == the checkAuth `terminalId`), so its
+                    // in-memory sessionKey is derivable WITHOUT resolving the Sprite. We
+                    // still gate on the persisted terminal_sessions record existing (no
+                    // provisioning) so we only target a shell that has actually run.
                     resolveSessionKey: async ({ tenantId, driveId, pageId }) => {
                         const store = await dbTerminalSessionStorePromise;
                         const key = deriveTerminalSessionKey({ tenantId, driveId, pageId, secret: getSandboxSessionSecret() });
                         const record = await store.findBySessionKey(key);
-                        return record ? buildAgentTerminalSessionKey({ sandboxId: record.sandboxId, name: SHELL_AGENT_TERMINAL_NAME }) : null;
+                        return record ? buildAgentTerminalSessionKey({ terminalId: pageId, name: SHELL_AGENT_TERMINAL_NAME }) : null;
                     },
                 },
                 body,

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-session-key.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-session-key.test.ts
@@ -1,0 +1,150 @@
+import { describe, it } from 'vitest';
+import { assert } from './riteway';
+import {
+  deriveAgentTerminalSessionKey,
+  agentTerminalScopeFromNames,
+  type AgentTerminalScope,
+} from '../agent-terminal-session-key';
+
+describe('agentTerminalScopeFromNames', () => {
+  it('maps absent project/branch to a machine scope', () => {
+    assert({
+      given: 'no project and no branch name',
+      should: 'derive a machine scope',
+      actual: agentTerminalScopeFromNames({}),
+      expected: { kind: 'machine' } satisfies AgentTerminalScope,
+    });
+  });
+
+  it('maps a project name alone to a project scope', () => {
+    assert({
+      given: 'a project name without a branch',
+      should: 'derive a project scope',
+      actual: agentTerminalScopeFromNames({ projectName: 'my-proj' }),
+      expected: { kind: 'project', projectName: 'my-proj' } satisfies AgentTerminalScope,
+    });
+  });
+
+  it('maps a project + branch name to a branch scope', () => {
+    assert({
+      given: 'a project name and a branch name',
+      should: 'derive a branch scope',
+      actual: agentTerminalScopeFromNames({ projectName: 'my-proj', branchName: 'feat/x' }),
+      expected: { kind: 'branch', projectName: 'my-proj', branchName: 'feat/x' } satisfies AgentTerminalScope,
+    });
+  });
+
+  it('ignores a branch name with no project name (cannot form a branch scope)', () => {
+    assert({
+      given: 'a branch name but no project name',
+      should: 'fall back to a machine scope',
+      actual: agentTerminalScopeFromNames({ branchName: 'feat/x' }),
+      expected: { kind: 'machine' } satisfies AgentTerminalScope,
+    });
+  });
+});
+
+describe('deriveAgentTerminalSessionKey', () => {
+  it('derives a stable key with zero I/O from terminalId, scope and name', () => {
+    assert({
+      given: 'a machine-scope terminal',
+      should: 'encode terminalId, scope and name into the key',
+      actual: deriveAgentTerminalSessionKey({
+        terminalId: 'term-1',
+        scope: { kind: 'machine' },
+        name: 'shell',
+      }),
+      expected: 'term-1:agent:machine:shell',
+    });
+  });
+
+  it('is deterministic across repeated derivation (warm reattach)', () => {
+    const params = {
+      terminalId: 'term-1',
+      scope: { kind: 'branch', projectName: 'proj', branchName: 'main' } as const,
+      name: 'cli',
+    };
+    assert({
+      given: 'the same terminal reopened across connects',
+      should: 'produce an identical key each time',
+      actual: deriveAgentTerminalSessionKey(params) === deriveAgentTerminalSessionKey(params),
+      expected: true,
+    });
+  });
+
+  it('produces distinct keys for terminals differing only by scope', () => {
+    const machine = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'machine' }, name: 'cli' });
+    const project = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'project', projectName: 'p' }, name: 'cli' });
+    assert({
+      given: 'two terminals differing only by scope',
+      should: 'produce distinct keys',
+      actual: machine !== project,
+      expected: true,
+    });
+  });
+
+  it('produces distinct keys for terminals differing only by name', () => {
+    const a = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'machine' }, name: 'shell' });
+    const b = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'machine' }, name: 'cli' });
+    assert({
+      given: 'two terminals differing only by name',
+      should: 'produce distinct keys',
+      actual: a !== b,
+      expected: true,
+    });
+  });
+
+  it('produces distinct keys for terminals differing only by terminalId', () => {
+    const a = deriveAgentTerminalSessionKey({ terminalId: 't1', scope: { kind: 'machine' }, name: 'cli' });
+    const b = deriveAgentTerminalSessionKey({ terminalId: 't2', scope: { kind: 'machine' }, name: 'cli' });
+    assert({
+      given: 'two terminals differing only by terminalId',
+      should: 'produce distinct keys',
+      actual: a !== b,
+      expected: true,
+    });
+  });
+
+  it('avoids collisions when a separator character appears inside a component', () => {
+    // Naive `${a}:${b}` joins collide when a colon lands inside a component:
+    // project "a", branch "b:c" would join identically to project "a:b", branch "c".
+    const left = deriveAgentTerminalSessionKey({
+      terminalId: 't',
+      scope: { kind: 'branch', projectName: 'a', branchName: 'b:c' },
+      name: 'cli',
+    });
+    const right = deriveAgentTerminalSessionKey({
+      terminalId: 't',
+      scope: { kind: 'branch', projectName: 'a:b', branchName: 'c' },
+      name: 'cli',
+    });
+    assert({
+      given: 'branch scopes whose colon falls at a different component boundary',
+      should: 'produce distinct keys via unambiguous encoding',
+      actual: left !== right,
+      expected: true,
+    });
+  });
+
+  it('avoids collisions when a terminalId contains a separator', () => {
+    const a = deriveAgentTerminalSessionKey({ terminalId: 'a:agent:machine', scope: { kind: 'machine' }, name: 'x' });
+    const b = deriveAgentTerminalSessionKey({ terminalId: 'a', scope: { kind: 'machine' }, name: 'x' });
+    assert({
+      given: 'a terminalId containing the structural separators',
+      should: 'not collide with a shorter terminalId',
+      actual: a !== b,
+      expected: true,
+    });
+  });
+
+  it('avoids collisions between a project named "machine" and a real machine scope', () => {
+    const machine = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'machine' }, name: 'cli' });
+    const projMachine = deriveAgentTerminalSessionKey({ terminalId: 't', scope: { kind: 'project', projectName: 'machine' }, name: 'cli' });
+    assert({
+      given: 'a project literally named "machine"',
+      should: 'not collide with the machine scope',
+      actual: machine !== projMachine,
+      expected: true,
+    });
+  });
+});

--- a/apps/realtime/src/terminal/__tests__/riteway.ts
+++ b/apps/realtime/src/terminal/__tests__/riteway.ts
@@ -1,0 +1,13 @@
+import { expect } from 'vitest';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+export const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};

--- a/apps/realtime/src/terminal/agent-terminal-session-key.ts
+++ b/apps/realtime/src/terminal/agent-terminal-session-key.ts
@@ -1,0 +1,88 @@
+/**
+ * Pure derivation of the in-memory `agentTerminalSessionMap` key for a
+ * (terminal, scope, name) target.
+ *
+ * The key is deliberately derived from the OWNING Machine Terminal page id
+ * (`terminalId`) rather than the Sprite `sandboxId`. `terminalId` is known the
+ * instant a socket connects (it rides in on the handshake), whereas resolving
+ * `sandboxId` requires a Sprite/DB round-trip. Keying on `terminalId` lets a
+ * warm reattach hit the fast-path map lookup with ZERO I/O — the platform then
+ * wakes the paused Sprite lazily on the next exec (docs.sprites.dev/lifecycle,
+ * warm wake 100–500ms). Keying on `sandboxId` forced full resolution before the
+ * lookup could even run.
+ *
+ * Machine and project scope share the SAME owning Machine's Sprite, so the
+ * scope discriminant (not just terminalId + name) is required to keep e.g. a
+ * machine-scope "cli" terminal and a project-scope "cli" terminal on the SAME
+ * machine from colliding onto one shared PTY session.
+ *
+ * This module is pure: explicit params in, string out. No DB, no Sprite SDK, no
+ * ambient state. The realtime shell wires it up.
+ */
+
+/** The three universal Terminal scopes (`agent-terminals.ts`). */
+export type AgentTerminalScope =
+  | { kind: 'machine' }
+  | { kind: 'project'; projectName: string }
+  | { kind: 'branch'; projectName: string; branchName: string };
+
+/**
+ * Map the optional (projectName, branchName) pair the transport carries into
+ * the discriminated scope. A branch scope needs both names; a lone branch name
+ * with no project cannot form one and degrades to a machine scope.
+ */
+export function agentTerminalScopeFromNames({
+  projectName,
+  branchName,
+}: {
+  projectName?: string;
+  branchName?: string;
+}): AgentTerminalScope {
+  if (projectName && branchName) {
+    return { kind: 'branch', projectName, branchName };
+  }
+  if (projectName) {
+    return { kind: 'project', projectName };
+  }
+  return { kind: 'machine' };
+}
+
+/**
+ * Encode the scope into an unambiguous token. Each variable component is
+ * `encodeURIComponent`-escaped so the structural `:` separators can never
+ * appear inside a component — a naive `${projectName}:${branchName}` join would
+ * collide (project "a"/branch "b:c" vs project "a:b"/branch "c"). The fixed
+ * `machine` / `project` / `branch` discriminants keep scopes of different kinds
+ * apart even when a project is literally named "machine".
+ */
+function encodeScope(scope: AgentTerminalScope): string {
+  switch (scope.kind) {
+    case 'branch':
+      return `branch:${encodeURIComponent(scope.projectName)}:${encodeURIComponent(scope.branchName)}`;
+    case 'project':
+      return `project:${encodeURIComponent(scope.projectName)}`;
+    case 'machine':
+      return 'machine';
+  }
+}
+
+/**
+ * Derive the stable, collision-free server-side session-map key. Pure and
+ * deterministic: the same (terminalId, scope, name) always yields the same key,
+ * so a reopened terminal reattaches to its existing session.
+ *
+ * NOTE: this is the SERVER-side map key only. It is intentionally distinct from
+ * the frontend `agent-terminal:*` sessionId wire format
+ * (`TerminalPanes.tsx`) — do not conflate the two.
+ */
+export function deriveAgentTerminalSessionKey({
+  terminalId,
+  scope,
+  name,
+}: {
+  terminalId: string;
+  scope: AgentTerminalScope;
+  name: string;
+}): string {
+  return `${encodeURIComponent(terminalId)}:agent:${encodeScope(scope)}:${encodeURIComponent(name)}`;
+}


### PR DESCRIPTION
## Summary

Makes the realtime in-memory agent-terminal **session-map key derivable WITHOUT resolving the Sprite**, so a warm reattach never needs a Sprite API call. Previously the key was derived from `resolved.sandboxId`, forcing full Sprite resolution before the fast-path map lookup could even run. Per docs.sprites.dev/lifecycle, the platform wakes a paused Sprite automatically on the next exec (warm wake 100–500ms) — our key derivation was what made reattach expensive.

The key now derives from the owning **Machine Terminal page id (`terminalId`)** — known the instant a socket connects — via a new pure function.

## Requirements → how satisfied

- [x] **Given terminalId, scope (machine | project:{projectName} | branch:{projectName,branchName}), and terminal name, derive a stable session key as a pure function with zero I/O.**
  New `apps/realtime/src/terminal/agent-terminal-session-key.ts`: `deriveAgentTerminalSessionKey({ terminalId, scope, name })` + `AgentTerminalScope` discriminated union. No DB, no Sprite SDK, no ambient state — explicit params in, string out.
- [x] **Given the same terminal reopened across connects, produce an identical key (determinism).**
  Pure/deterministic; covered by a determinism test.
- [x] **Given two terminals differing only in scope, name, or terminalId, produce distinct keys (no naive-join collisions — unambiguous encoding).**
  Each variable component is `encodeURIComponent`-escaped, so structural `:` separators can never appear inside a component. Fixed `machine`/`project`/`branch` discriminants keep scope kinds apart (e.g. a project literally named "machine" ≠ machine scope). Tests cover scope/name/terminalId distinctness **and** the colon-in-component case (project `a`/branch `b:c` vs project `a:b`/branch `c`).
- [x] **Given the existing frontend `agent-terminal:*` sessionId wire format, leave it untouched (server-side map key only).**
  `TerminalPanes.tsx` not touched. Only the server-side map key source changed.

## Shell wiring (behavior otherwise identical)

- `buildAgentTerminalSessionKey` in `index.ts` is now a thin adapter over the pure function, keyed on `terminalId` instead of `sandboxId`.
- Both call sites swapped:
  - checkAuth (`makeAgentTerminalCheckAuth`) — `terminalId` is already a param.
  - terminal-activity `resolveSessionKey` — uses `pageId`, which **equals** the checkAuth `terminalId` for the machine shell (`agent-terminal-handler.ts:422` sets the session's `pageId: terminalId`). The persisted-record lookup is retained purely as an existence gate.
- Realtime restarts clear the in-memory map, so the server-side key-format change is migration-free.

## Test evidence

New pure tests (RED → GREEN):
```
✓ src/terminal/__tests__/agent-terminal-session-key.test.ts (12 tests) 8ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

Full realtime suite (terminal + index), no regressions:
```
✓ src/terminal/__tests__/agent-terminal-handler.test.ts (58 tests)
✓ src/__tests__/index.test.ts (101 tests)
 Test Files  8 passed (8)
      Tests  277 passed (277)
```

`bunx turbo run typecheck --filter=realtime` → clean. `eslint` on changed files → clean. No `any`, bun only, work done in an isolated pu worktree.

## Why this is behavior-identical (no reattach-to-dead-PTY risk)

The reattach fast-path (`agent-terminal-handler.ts:369-382`) reuses an existing session's `PtyShell` by key without re-validating the Sprite, so the swap is only safe if `terminalId ↔ sandboxId` is 1:1 for a terminal's lifetime. It is — and not just "usually": **`sandboxId` is not a platform-assigned per-VM identifier, it is the deterministic Sprite name derived from the terminal's identity.** In `sprites.ts:393` the driver sets `sandboxId: sprite.name`, where `spriteName = name.slice(0, 63)` and `name` is the terminal session key `deriveTerminalSessionKey({ tenantId, driveId, pageId, secret })` (`sprites.ts:576`, `terminal-session-manager.ts:226`). So `sandboxId` is a pure function of `(tenant, drive, pageId)` — a **fixed** terminal maps to a **fixed** `sandboxId` across create, resume, pause/wake, and transparent re-provision (`getOrCreate` recreates under the same name — `terminal-session-manager.ts:280-282`, "the sandboxId stays stable").

Consequently a "stable terminalId maps to a *changed* sandboxId" event — the premise of the only reattach-to-dead-PTY scenario — **cannot occur**. The old `sandboxId`-keyed scheme was therefore *already* keyed on a deterministic function of the terminal identity; it never had a "changed-sandbox → new key → fresh session" self-heal to lose. Old key `${stableSandboxId}:agent:…` and new key `${terminalId}:agent:…` are both stable and both 1:1 with the terminal, so the map behaves identically — the swap just makes the key derivable without resolving the Sprite. (This is the exact question an automated review pass flagged as PLAUSIBLE-pending-confirmation; `sprites.ts:393` is the confirmation that refutes it.)

The `resolveSessionKey` shell-reattach path (`index.ts:657`) carries the *same* `pageId === terminalId` requirement the old code did: the old activity key was `truncate(sessionKey(tenant,drive,pageId))` and the checkAuth key was `truncate(sessionKey(tenant,drive,terminalId))`, so matching already required `pageId === terminalId` — structurally guaranteed for the machine shell (`agent-terminal-handler.ts:422` sets the session's `pageId: terminalId`). No new assumption is introduced.

## Notes for the orchestrator

- Out-of-scope leaves untouched: onConnect reordering (1-3), checkAuth split (1-2). In current code `checkAuth` still resolves the Sprite before the map lookup; this leaf only moves the key *source* so 1-3 can later reorder without needing resolution.
- The invariant swap is `same Sprite → same sandboxId` → `same Terminal page → same terminalId/pageId`; verified `pageId === terminalId` at `agent-terminal-handler.ts:422` and sandbox-stability at `terminal-session-manager.ts:280-282`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
