### PR TITLE
fix(audit): adminDb default to main-DB (unconfigured), not fail — prod audit-write incident (#890)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,10 +20,18 @@ ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admi
 # ADMIN_ERASER_PASSWORD=admin-eraser-password
 # ADMIN_DATABASE_SSL=true
 # ADMIN_DB_POOL_MAX=10
-# Break-glass rollback ONLY: setting ADMIN_DB_BREAK_GLASS=true permits audit
-# writes to fall back to the main DB and alerts loudly. It is not a supported
-# steady state — leave unset. Without it, an unset ADMIN_DATABASE_URL fails
-# fast at adminDb init.
+# When ADMIN_DATABASE_URL is UNSET, audit writes go to the MAIN application
+# database SILENTLY — the pre-trust-plane default. Set ADMIN_DATABASE_URL to
+# adopt the dedicated Admin PG. Two flags change the unconfigured behavior:
+#
+# AUDIT_TRUST_PLANE_REQUIRED=true — opt-in enforcement. In a deployment that
+# HAS adopted the trust plane, arm this so a missing ADMIN_DATABASE_URL fails
+# fast at adminDb init instead of silently falling back to the main DB.
+# AUDIT_TRUST_PLANE_REQUIRED=true
+#
+# ADMIN_DB_BREAK_GLASS=true — explicit emergency override. Also routes audit
+# writes to the main DB, but alerts LOUDLY on every process. Use only as a
+# deliberate emergency rollback; leave unset for normal operation.
 # ADMIN_DB_BREAK_GLASS=true
 # Fresh installs ONLY: lets the audit chainer start the admin chain from
 # genesis (empty head). Correct when copying this template for a NEW stack —

--- a/.env.example
+++ b/.env.example
@@ -20,18 +20,28 @@ ADMIN_DATABASE_URL=postgresql://user:password@postgres-admin:5432/pagespace_admi
 # ADMIN_ERASER_PASSWORD=admin-eraser-password
 # ADMIN_DATABASE_SSL=true
 # ADMIN_DB_POOL_MAX=10
-# When ADMIN_DATABASE_URL is UNSET, audit writes go to the MAIN application
-# database SILENTLY — the pre-trust-plane default. Set ADMIN_DATABASE_URL to
-# adopt the dedicated Admin PG. Two flags change the unconfigured behavior:
+# adminDb mode is resolved from ADMIN_DATABASE_URL + two flags. Precedence,
+# highest first:
+#   1. ADMIN_DATABASE_URL set but NOT a postgres URL        -> fail (misconfig)
+#   2. URL unset + AUDIT_TRUST_PLANE_REQUIRED=true          -> fail (declared, unconfigured)
+#   3. URL unset + ADMIN_DB_BREAK_GLASS=true                -> break-glass (main DB + LOUD alert)
+#   4. URL unset + neither flag                             -> main-db (main DB, SILENT)
+# (URL set to a valid postgres URL -> dedicated Admin PG.) With URL unset and
+# BOTH flags armed, AUDIT_TRUST_PLANE_REQUIRED wins -> fail.
+#
+# "Fail-closed" applies to FLAG PARSING only: exactly 'true' arms a flag ('TRUE',
+# '1', ' true ', '' do not). It does NOT mean both flags halt — break-glass=true
+# deliberately DEGRADES to the main DB (loudly); only AUDIT_TRUST_PLANE_REQUIRED
+# (or an invalid URL) halts.
 #
 # AUDIT_TRUST_PLANE_REQUIRED=true — opt-in enforcement. In a deployment that
 # HAS adopted the trust plane, arm this so a missing ADMIN_DATABASE_URL fails
 # fast at adminDb init instead of silently falling back to the main DB.
 # AUDIT_TRUST_PLANE_REQUIRED=true
 #
-# ADMIN_DB_BREAK_GLASS=true — explicit emergency override. Also routes audit
-# writes to the main DB, but alerts LOUDLY on every process. Use only as a
-# deliberate emergency rollback; leave unset for normal operation.
+# ADMIN_DB_BREAK_GLASS=true — explicit emergency override. Routes audit writes
+# to the main DB and alerts LOUDLY on every process. Use only as a deliberate
+# emergency rollback; leave unset for normal operation.
 # ADMIN_DB_BREAK_GLASS=true
 # Fresh installs ONLY: lets the audit chainer start the admin chain from
 # genesis (empty head). Correct when copying this template for a NEW stack —

--- a/.env.onprem.example
+++ b/.env.onprem.example
@@ -34,9 +34,16 @@ ADMIN_DATABASE_URL=postgresql://pagespace:another_strong_password@localhost:5433
 # ADMIN_READER_PASSWORD=unique_strong_password_3
 # ADMIN_DATABASE_SSL=false
 # ADMIN_DB_POOL_MAX=10
-# Break-glass rollback ONLY: ADMIN_DB_BREAK_GLASS=true permits audit writes to
-# fall back to the main DB and alerts loudly. Not a supported steady state —
-# leave unset. Without it, an unset ADMIN_DATABASE_URL fails fast at startup.
+# If ADMIN_DATABASE_URL is left UNSET, audit writes fall back to the MAIN
+# database SILENTLY (the pre-trust-plane default). On-prem stacks ship the
+# postgres-admin container, so set ADMIN_DATABASE_URL as above. Two flags tune
+# the unconfigured behavior:
+# AUDIT_TRUST_PLANE_REQUIRED=true — opt-in enforcement: makes an unset
+#   ADMIN_DATABASE_URL fail fast at startup instead of silently using main.
+#   Arm it once you have adopted the dedicated Admin PG.
+# AUDIT_TRUST_PLANE_REQUIRED=true
+# ADMIN_DB_BREAK_GLASS=true — explicit emergency override: routes audit writes
+#   to the main DB and alerts LOUDLY. Not a supported steady state — leave unset.
 # ADMIN_DB_BREAK_GLASS=true
 
 # ---------------------------------------------------------------------------

--- a/.env.onprem.example
+++ b/.env.onprem.example
@@ -36,8 +36,18 @@ ADMIN_DATABASE_URL=postgresql://pagespace:another_strong_password@localhost:5433
 # ADMIN_DB_POOL_MAX=10
 # If ADMIN_DATABASE_URL is left UNSET, audit writes fall back to the MAIN
 # database SILENTLY (the pre-trust-plane default). On-prem stacks ship the
-# postgres-admin container, so set ADMIN_DATABASE_URL as above. Two flags tune
-# the unconfigured behavior:
+# postgres-admin container, so set ADMIN_DATABASE_URL as above.
+#
+# adminDb mode precedence, highest first:
+#   1. ADMIN_DATABASE_URL set but NOT a postgres URL -> fail (misconfig)
+#   2. URL unset + AUDIT_TRUST_PLANE_REQUIRED=true    -> fail (declared, unconfigured)
+#   3. URL unset + ADMIN_DB_BREAK_GLASS=true          -> break-glass (main DB + LOUD alert)
+#   4. URL unset + neither flag                       -> main-db (main DB, SILENT)
+# With URL unset and BOTH flags armed, AUDIT_TRUST_PLANE_REQUIRED wins -> fail.
+# "Fail-closed" applies to FLAG PARSING only (exactly 'true' arms a flag); it
+# does NOT mean both flags halt — break-glass=true deliberately DEGRADES to main
+# (loudly), only AUDIT_TRUST_PLANE_REQUIRED (or an invalid URL) halts.
+#
 # AUDIT_TRUST_PLANE_REQUIRED=true — opt-in enforcement: makes an unset
 #   ADMIN_DATABASE_URL fail fast at startup instead of silently using main.
 #   Arm it once you have adopted the dedicated Admin PG.

--- a/apps/processor/src/services/__tests__/siem-pool-routing.test.ts
+++ b/apps/processor/src/services/__tests__/siem-pool-routing.test.ts
@@ -70,11 +70,39 @@ describe('resolveSiemPoolRouting', () => {
     });
   });
 
-  it('given no admin URL and no break-glass flag, should return no routing (worker halts loudly)', () => {
+  it('given no admin URL and no flags (main-db default), should route every operation to main — silently, like the legacy worker', () => {
     const { decision, routing } = resolveSiemPoolRouting({});
 
     assert({
-      given: 'unconfigured trust plane',
+      given: 'unconfigured trust plane, no enforcement flag',
+      should: 'resolve mode main-db (the silent pre-trust-plane default)',
+      actual: decision.mode,
+      expected: 'main-db',
+    });
+    assert({
+      given: 'main-db mode',
+      should: 'route everything to the main pool, identical to break-glass but silent',
+      actual: routing,
+      expected: {
+        mode: 'main-db',
+        advisoryLock: 'main',
+        cursors: 'main',
+        receipts: 'main',
+        data: {
+          activity_logs: 'main',
+          security_audit_log: 'main',
+        },
+        seedCursorFromLegacy: false,
+        awaitingBackfillProbe: false,
+      },
+    });
+  });
+
+  it('given AUDIT_TRUST_PLANE_REQUIRED armed but no URL, should return no routing (worker halts loudly)', () => {
+    const { decision, routing } = resolveSiemPoolRouting({ AUDIT_TRUST_PLANE_REQUIRED: 'true' });
+
+    assert({
+      given: 'trust plane declared required but unconfigured',
       should: 'resolve mode fail',
       actual: decision.mode,
       expected: 'fail',

--- a/apps/processor/src/services/siem-pool-routing.ts
+++ b/apps/processor/src/services/siem-pool-routing.ts
@@ -21,6 +21,9 @@ import type { AuditLogSource } from './siem-adapter';
  *   - 'break-glass' → everything on main: writes degraded to the legacy
  *                     table, so delivery, cursors, and receipts all revert
  *                     to the exact pre-cutover worker behavior.
+ *   - 'main-db'     → identical routing to break-glass (everything on main),
+ *                     but SILENT: the unconfigured pre-trust-plane default,
+ *                     not an emergency degrade, so the worker logs no banner.
  *   - 'fail'        → no routing. Writes are being rejected; delivering from
  *                     either store would be guessing. The worker halts loudly.
  */
@@ -28,7 +31,7 @@ import type { AuditLogSource } from './siem-adapter';
 export type SiemStorePlane = 'main' | 'admin';
 
 export interface SiemPoolRouting {
-  mode: 'dedicated' | 'break-glass';
+  mode: 'dedicated' | 'break-glass' | 'main-db';
   /**
    * Always 'main' until Phase 5: the lock key ('activity_logs', hashed) and
    * its host DB must stay stable across a rolling deploy so old-code and
@@ -88,6 +91,15 @@ const BREAK_GLASS_ROUTING: SiemPoolRouting = {
   awaitingBackfillProbe: false,
 };
 
+// Identical routing to break-glass (everything on main), but mode 'main-db':
+// the unconfigured pre-trust-plane default. The worker keys its loud degrade
+// banner on 'break-glass' only, so main-db delivers from the main stores
+// silently.
+const MAIN_DB_ROUTING: SiemPoolRouting = {
+  ...BREAK_GLASS_ROUTING,
+  mode: 'main-db',
+};
+
 export function resolveSiemPoolRouting(env: AdminDbEnv): SiemPoolRoutingResolution {
   const decision = resolveAdminDbMode(env);
   switch (decision.mode) {
@@ -95,6 +107,8 @@ export function resolveSiemPoolRouting(env: AdminDbEnv): SiemPoolRoutingResoluti
       return { decision, routing: DEDICATED_ROUTING };
     case 'break-glass':
       return { decision, routing: BREAK_GLASS_ROUTING };
+    case 'main-db':
+      return { decision, routing: MAIN_DB_ROUTING };
     case 'fail':
       return { decision, routing: null };
   }

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -2306,17 +2306,41 @@ describe('processSiemDelivery dedicated-mode pool matrix', () => {
     });
   });
 
-  it('given fail mode (no admin URL, no break-glass), should halt before touching any pool', async () => {
+  it('given fail mode (AUDIT_TRUST_PLANE_REQUIRED armed, no admin URL), should halt before touching any pool', async () => {
     const main = createTaggedStore(() => null);
+    const admin = createTaggedStore(() => null);
+
+    await processSiemDelivery({
+      mainPool: main.pool,
+      adminPool: admin.pool,
+      env: { AUDIT_TRUST_PLANE_REQUIRED: 'true' },
+    });
+
+    assert({
+      given: 'a declared-but-unconfigured trust plane',
+      should: 'never connect to either store',
+      actual: { main: main.connects, admin: admin.connects },
+      expected: { main: 0, admin: 0 },
+    });
+  });
+
+  it('given main-db mode (no admin URL, no flags), should proceed on the MAIN pool (never admin), not halt', async () => {
+    // Unconfigured default: delivery runs against main, exactly like break-glass
+    // but silent. A lock-busy run proves the worker reached the main pool and
+    // routed nothing to admin (rather than halting at resolution like fail mode).
+    const main = createTaggedStore((sql) => {
+      if (sql.includes('pg_try_advisory_lock')) return [{ acquired: false }];
+      return null;
+    });
     const admin = createTaggedStore(() => null);
 
     await processSiemDelivery({ mainPool: main.pool, adminPool: admin.pool, env: {} });
 
     assert({
-      given: 'an unconfigured trust plane',
-      should: 'never connect to either store',
-      actual: { main: main.connects, admin: admin.connects },
-      expected: { main: 0, admin: 0 },
+      given: 'an unconfigured trust plane with no enforcement flag',
+      should: 'connect to main (not halt) and never touch the admin pool',
+      actual: { main: main.connects, admin: admin.connects, mainReleased: main.released },
+      expected: { main: 1, admin: 0, mainReleased: 1 },
     });
   });
 

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -342,6 +342,7 @@ export async function processSiemDelivery(deps: SiemDeliveryDeps = {}): Promise<
   const env = deps.env ?? {
     ADMIN_DATABASE_URL: process.env.ADMIN_DATABASE_URL,
     ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+    AUDIT_TRUST_PLANE_REQUIRED: process.env.AUDIT_TRUST_PLANE_REQUIRED,
   };
   const { decision, routing } = resolveSiemPoolRouting(env);
   if (routing === null) {

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -13,6 +13,55 @@ emits everything below.
 > It is a provisioning tool for new tenants only. Upgrades are always
 > append-only edits to the existing `.env`.
 
+## 2026-07 — Audit trust-plane mode contract (issue #890)
+
+How a deployment's `adminDb` mode is resolved from env — this governs where
+security audit writes land:
+
+| `ADMIN_DATABASE_URL` | flags | mode | behavior |
+|----------------------|-------|------|----------|
+| set, valid postgres URL | — | `dedicated` | writes to the dedicated Admin PG (trust plane) |
+| set, **invalid** URL | — | `fail` | halts (a positive misconfiguration must never silently degrade) |
+| unset | `AUDIT_TRUST_PLANE_REQUIRED=true` | `fail` | halts loudly — you declared the trust plane required but did not configure it |
+| unset | `ADMIN_DB_BREAK_GLASS=true` | `break-glass` | writes to the **main** DB + a LOUD alert on every process (explicit emergency override) |
+| unset | neither flag | `main-db` | writes to the **main** DB, **SILENTLY** — the pre-trust-plane default |
+
+Precedence when several apply: invalid-URL `fail` > `AUDIT_TRUST_PLANE_REQUIRED`
+`fail` > `break-glass` > `main-db`. Both flags are fail-closed — only the exact
+string `true` arms them.
+
+**Unconfigured deployments need no action.** If you have not adopted the
+dedicated Admin PG, leave `ADMIN_DATABASE_URL` unset and both flags unset: audit
+writes run against the main application database exactly as they did before the
+trust-plane epic, with no alert noise. Set `AUDIT_TRUST_PLANE_REQUIRED=true`
+**only** if you WANT a missing `ADMIN_DATABASE_URL` to fail closed (i.e. you have
+adopted the trust plane and a missing URL should halt rather than fall back).
+`ADMIN_DB_BREAK_GLASS` is now purely an explicit emergency override.
+
+> **Why this changed:** an earlier revision made an unset `ADMIN_DATABASE_URL`
+> resolve to `fail`. Because audit writes are fire-and-forget, every write then
+> threw and was swallowed as a warn log — security audit logging was silently
+> broken wherever the Admin PG had not been provisioned. The default is now
+> `main-db` (silent, working); loud failure is opt-in.
+
+### Post-merge prod step (Fly) — drop the break-glass alert noise
+
+The incident was mitigated live by setting `ADMIN_DB_BREAK_GLASS=true` on the
+Fly apps, which restored main-DB audit writes but fires a loud alert on every
+process. Once this change is deployed, the unconfigured→`main-db`-silent default
+takes over, so **unset the break-glass flag** on each app to stop the noise:
+
+```bash
+fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-web
+fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-processor
+fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-realtime
+fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-admin
+```
+
+Do this only AFTER the new code is deployed to each app. With the flag gone and
+`ADMIN_DATABASE_URL` still unset, each app resolves to `main-db` and audit
+writes continue against the main DB silently.
+
 ## 2026-07 — Phase 1 admin database (issue #890)
 
 The stack now runs a second PostgreSQL container, `postgres-admin` (the
@@ -74,9 +123,10 @@ ADMIN_POSTGRES_* missing from .env - see infrastructure/UPGRADE.md (Phase 1 admi
   `postgres-admin` container and the `migrate` one-shot. Runtime services
   (web/processor/realtime) hold no admin credentials in Phase 1 — per-service
   least-privilege LOGIN roles arrive with the Phase 2 audit-write cutover.
-- `ADMIN_DB_BREAK_GLASS=true` is a break-glass rollback flag only (audit
+- `ADMIN_DB_BREAK_GLASS=true` is an explicit emergency override only (audit
   writes fall back to the main DB and alert loudly). It is not a supported
-  steady state — do not set it during a normal upgrade.
+  steady state — do not set it during a normal upgrade. See the trust-plane
+  behavior section below for the full mode contract.
 
 ## 2026-07 — Phase 2 per-service admin login users (issue #890)
 

--- a/infrastructure/UPGRADE.md
+++ b/infrastructure/UPGRADE.md
@@ -26,9 +26,23 @@ security audit writes land:
 | unset | `ADMIN_DB_BREAK_GLASS=true` | `break-glass` | writes to the **main** DB + a LOUD alert on every process (explicit emergency override) |
 | unset | neither flag | `main-db` | writes to the **main** DB, **SILENTLY** — the pre-trust-plane default |
 
-Precedence when several apply: invalid-URL `fail` > `AUDIT_TRUST_PLANE_REQUIRED`
-`fail` > `break-glass` > `main-db`. Both flags are fail-closed — only the exact
-string `true` arms them.
+Precedence when several apply (highest first):
+
+1. **`ADMIN_DATABASE_URL` set but invalid** → `fail` (a positive misconfiguration
+   must never silently degrade — beats every flag).
+2. **`AUDIT_TRUST_PLANE_REQUIRED=true`** (URL unset) → `fail` (declared enforcement
+   wins over both the emergency override and the silent default).
+3. **`ADMIN_DB_BREAK_GLASS=true`** (URL unset, not required) → `break-glass`.
+4. **neither flag** (URL unset) → `main-db`.
+
+So with URL unset and BOTH flags armed, `AUDIT_TRUST_PLANE_REQUIRED` wins → `fail`
+(the stricter declared intent is honored).
+
+"Fail-closed" here refers only to **flag PARSING**: `true` is the sole value that
+arms either flag (`TRUE`, `1`, ` true `, `''` do not). It does NOT mean both
+flags fail the process — `ADMIN_DB_BREAK_GLASS=true` deliberately *degrades* to
+the main DB (loudly); only `AUDIT_TRUST_PLANE_REQUIRED=true` (or an invalid URL)
+halts.
 
 **Unconfigured deployments need no action.** If you have not adopted the
 dedicated Admin PG, leave `ADMIN_DATABASE_URL` unset and both flags unset: audit
@@ -61,6 +75,16 @@ fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-admin
 Do this only AFTER the new code is deployed to each app. With the flag gone and
 `ADMIN_DATABASE_URL` still unset, each app resolves to `main-db` and audit
 writes continue against the main DB silently.
+
+> ⚠️ This is safe **only because** `AUDIT_TRUST_PLANE_REQUIRED` is NOT set on
+> these apps (unset → precedence rule 4 → `main-db`). If you had armed
+> `AUDIT_TRUST_PLANE_REQUIRED=true` without configuring `ADMIN_DATABASE_URL`,
+> unsetting break-glass would drop the app to `fail` (precedence rule 2) and
+> break audit writes again. In that case, first set a valid `ADMIN_DATABASE_URL`
+> (adopt the trust plane) or unset `AUDIT_TRUST_PLANE_REQUIRED` before removing
+> break-glass. Verify with `fly secrets list -a <app>` that neither
+> `ADMIN_DATABASE_URL` nor `AUDIT_TRUST_PLANE_REQUIRED` is present before running
+> the unset commands above.
 
 ## 2026-07 — Phase 1 admin database (issue #890)
 

--- a/packages/db/src/__tests__/admin-db-mode.test.ts
+++ b/packages/db/src/__tests__/admin-db-mode.test.ts
@@ -1,14 +1,24 @@
 /**
  * Pure-core tests for the Admin PG (trust plane) connection registry decision
- * logic (#890 Phase 1). The three-state contract:
+ * logic (#890). The FIVE-state contract (post prod audit-write incident):
  *
- *   ADMIN_DATABASE_URL set               → 'dedicated'  (connect to Admin PG)
- *   URL unset + ADMIN_DB_BREAK_GLASS
- *     exactly 'true'                     → 'break-glass' (degrade to main DB, alert)
- *   URL unset + no armed flag            → 'fail'        (fail-fast at init)
+ *   URL set + VALID postgres URL                    → 'dedicated'
+ *   URL set + INVALID URL                           → 'fail'   (positive misconfig)
+ *   URL unset + AUDIT_TRUST_PLANE_REQUIRED='true'   → 'fail'   (declared, not configured)
+ *   URL unset + ADMIN_DB_BREAK_GLASS='true'         → 'break-glass' (main DB + LOUD alert)
+ *   URL unset + neither flag                        → 'main-db' (NEW DEFAULT: main DB, SILENT)
  *
- * Break-glass arming is fail-closed: any value other than the exact string
- * 'true' ('TRUE', '1', ' true ', '') does NOT arm the fallback.
+ * Precedence when several apply:
+ *   invalid-URL fail > TRUST_PLANE_REQUIRED fail > break-glass > main-db.
+ *
+ * The 'main-db' default is the incident fix: before this, an unconfigured
+ * ADMIN_DATABASE_URL resolved to 'fail', so every prod audit write threw and
+ * was swallowed by the fire-and-forget audit() wrapper — security audit
+ * logging was silently broken. Unconfigured now means silent, pre-epic
+ * main-DB behavior; loud failure is opt-in via AUDIT_TRUST_PLANE_REQUIRED.
+ *
+ * Both flags are fail-closed: only the exact string 'true' arms them
+ * ('TRUE', '1', ' true ', '' do not).
  */
 import { describe, it, expect } from 'vitest';
 import {
@@ -39,6 +49,14 @@ describe('resolveAdminDbMode', () => {
       });
       expect(decision.mode).toBe('dedicated');
     });
+
+    it('given ADMIN_DATABASE_URL set AND AUDIT_TRUST_PLANE_REQUIRED armed, should resolve dedicated (the trust plane IS configured)', () => {
+      const decision = resolveAdminDbMode({
+        ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
+        AUDIT_TRUST_PLANE_REQUIRED: 'true',
+      });
+      expect(decision.mode).toBe('dedicated');
+    });
   });
 
   describe('URL validation (validate-on-init)', () => {
@@ -58,9 +76,14 @@ describe('resolveAdminDbMode', () => {
       expect(decision.mode).toBe('fail');
     });
 
-    it('given an empty-string URL and no flag, should fail (empty is treated as unset)', () => {
-      const decision = resolveAdminDbMode({ ADMIN_DATABASE_URL: '' });
+    it('given an invalid URL, should fail even when neither flag is set (positive misconfig beats the main-db default)', () => {
+      const decision = resolveAdminDbMode({ ADMIN_DATABASE_URL: 'mysql://host/db' });
       expect(decision.mode).toBe('fail');
+    });
+
+    it('given an empty-string URL and no flag, should resolve main-db (empty is treated as unset → silent default)', () => {
+      const decision = resolveAdminDbMode({ ADMIN_DATABASE_URL: '' });
+      expect(decision.mode).toBe('main-db');
     });
 
     it('given an empty-string URL and armed break-glass, should resolve break-glass (empty is treated as unset)', () => {
@@ -72,32 +95,58 @@ describe('resolveAdminDbMode', () => {
     });
   });
 
+  describe('main-db default (THE incident fix — unconfigured is silent, not fatal)', () => {
+    it('given URL unset and no flags, should resolve main-db (pre-epic silent behavior)', () => {
+      const decision = resolveAdminDbMode({});
+      expect(decision.mode).toBe('main-db');
+    });
+
+    it('given main-db, reason should describe the silent unconfigured default without demanding an alert', () => {
+      const decision = resolveAdminDbMode({});
+      expect(decision.mode).toBe('main-db');
+      expect(decision.reason).toContain('ADMIN_DATABASE_URL');
+      expect(decision.reason.toLowerCase()).toContain('main');
+    });
+
+    it.each(['TRUE', 'True', '1', ' true ', 'yes', 'false', ''])(
+      "given URL unset and a non-'true' break-glass value %j, should resolve main-db (flag not armed, silent default)",
+      (flag) => {
+        const decision = resolveAdminDbMode({ ADMIN_DB_BREAK_GLASS: flag });
+        expect(decision.mode).toBe('main-db');
+      },
+    );
+
+    it.each(['TRUE', '1', ' true ', 'yes', 'false', ''])(
+      "given a non-'true' AUDIT_TRUST_PLANE_REQUIRED value %j, should NOT force fail (fail-closed → main-db)",
+      (flag) => {
+        const decision = resolveAdminDbMode({ AUDIT_TRUST_PLANE_REQUIRED: flag });
+        expect(decision.mode).toBe('main-db');
+      },
+    );
+  });
+
   describe('break-glass arming (fail-closed)', () => {
     it("given URL unset and flag exactly 'true', should resolve break-glass", () => {
       const decision = resolveAdminDbMode({ ADMIN_DB_BREAK_GLASS: 'true' });
       expect(decision.mode).toBe('break-glass');
     });
-
-    it.each(['TRUE', 'True', '1', ' true ', 'yes', 'false', ''])(
-      "given URL unset and flag %j, should NOT arm break-glass (fail-closed)",
-      (flag) => {
-        const decision = resolveAdminDbMode({ ADMIN_DB_BREAK_GLASS: flag });
-        expect(decision.mode).toBe('fail');
-      },
-    );
   });
 
-  describe('fail-fast mode', () => {
-    it('given URL unset and no flag, should fail', () => {
-      const decision = resolveAdminDbMode({});
+  describe("AUDIT_TRUST_PLANE_REQUIRED='true' (operator DECLARED enforcement but did not configure)", () => {
+    it('given URL unset and required armed, should fail loudly', () => {
+      const decision = resolveAdminDbMode({ AUDIT_TRUST_PLANE_REQUIRED: 'true' });
       expect(decision.mode).toBe('fail');
+      expect(decision.reason).toContain('AUDIT_TRUST_PLANE_REQUIRED');
+      expect(decision.reason).toContain('ADMIN_DATABASE_URL');
     });
 
-    it('given fail, reason should name both ADMIN_DATABASE_URL and ADMIN_DB_BREAK_GLASS so the operator knows both exits', () => {
-      const decision = resolveAdminDbMode({});
+    it('given required armed AND break-glass armed (no URL), fail should win — the stricter declared intent is honored', () => {
+      const decision = resolveAdminDbMode({
+        AUDIT_TRUST_PLANE_REQUIRED: 'true',
+        ADMIN_DB_BREAK_GLASS: 'true',
+      });
       expect(decision.mode).toBe('fail');
-      expect(decision.reason).toContain('ADMIN_DATABASE_URL');
-      expect(decision.reason).toContain('ADMIN_DB_BREAK_GLASS');
+      expect(decision.reason).toContain('AUDIT_TRUST_PLANE_REQUIRED');
     });
   });
 });

--- a/packages/db/src/__tests__/admin-db.test.ts
+++ b/packages/db/src/__tests__/admin-db.test.ts
@@ -18,6 +18,10 @@ const DEDICATED_ENV = {
   ADMIN_DATABASE_URL: 'postgresql://admin:pw@host:5432/pagespace_admin',
 };
 const BREAK_GLASS_ENV = { ADMIN_DB_BREAK_GLASS: 'true' };
+// Unconfigured trust plane, no enforcement flag → silent main-db default.
+const MAIN_DB_ENV = {};
+// Enforcement declared but not configured → fail-fast.
+const FAIL_ENV = { AUDIT_TRUST_PLANE_REQUIRED: 'true' };
 
 const makeFakePool = () => ({ on: vi.fn() }) as unknown as Pool;
 
@@ -135,34 +139,52 @@ describe('createAdminDbRegistry', () => {
     });
   });
 
-  describe('fail-fast mode (URL unset, no armed flag)', () => {
-    it('should throw an actionable error naming ADMIN_DATABASE_URL and the break-glass flag', () => {
-      const { deps } = makeDeps({ getEnv: () => ({}) });
+  describe('main-db mode (URL unset, no armed flag — THE incident fix)', () => {
+    it('should return the main db itself, SILENTLY (adminDb === db, no alert)', () => {
+      const { deps, fakeMainDb } = makeDeps({ getEnv: () => MAIN_DB_ENV });
+      const adminDb = createAdminDbRegistry(deps).getAdminDb();
+      expect(adminDb).toBe(fakeMainDb);
+      expect(deps.alert).not.toHaveBeenCalled();
+    });
+
+    it('should not throw and not construct a dedicated pool', () => {
+      const { deps } = makeDeps({ getEnv: () => MAIN_DB_ENV });
+      const registry = createAdminDbRegistry(deps);
+      expect(() => registry.getAdminDb()).not.toThrow();
+      expect(deps.createPool).not.toHaveBeenCalled();
+      expect(deps.registerPool).not.toHaveBeenCalled();
+    });
+
+    it("given a non-'true' break-glass value, should resolve main-db silently (flag not armed)", () => {
+      const { deps, fakeMainDb } = makeDeps({
+        getEnv: () => ({ ADMIN_DB_BREAK_GLASS: 'TRUE' }),
+      });
+      const adminDb = createAdminDbRegistry(deps).getAdminDb();
+      expect(adminDb).toBe(fakeMainDb);
+      expect(deps.alert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fail-fast mode (AUDIT_TRUST_PLANE_REQUIRED armed, no URL)', () => {
+    it('should throw an actionable error naming ADMIN_DATABASE_URL and AUDIT_TRUST_PLANE_REQUIRED', () => {
+      const { deps } = makeDeps({ getEnv: () => FAIL_ENV });
       const registry = createAdminDbRegistry(deps);
       expect(() => registry.getAdminDb()).toThrowError(/ADMIN_DATABASE_URL/);
-      expect(() => registry.getAdminDb()).toThrowError(/ADMIN_DB_BREAK_GLASS/);
+      expect(() => registry.getAdminDb()).toThrowError(/AUDIT_TRUST_PLANE_REQUIRED/);
     });
 
     it('should throw on every call, not just the first', () => {
-      const { deps } = makeDeps({ getEnv: () => ({}) });
+      const { deps } = makeDeps({ getEnv: () => FAIL_ENV });
       const registry = createAdminDbRegistry(deps);
       expect(() => registry.getAdminDb()).toThrow();
       expect(() => registry.getAdminDb()).toThrow();
     });
 
     it('should not touch the main db or any pool before throwing', () => {
-      const { deps } = makeDeps({ getEnv: () => ({}) });
+      const { deps } = makeDeps({ getEnv: () => FAIL_ENV });
       expect(() => createAdminDbRegistry(deps).getAdminDb()).toThrow();
       expect(deps.getMainDb).not.toHaveBeenCalled();
       expect(deps.createPool).not.toHaveBeenCalled();
-    });
-
-    it("given a non-'true' break-glass value, should still fail fast (fail-closed arming)", () => {
-      const { deps } = makeDeps({
-        getEnv: () => ({ ADMIN_DB_BREAK_GLASS: 'TRUE' }),
-      });
-      expect(() => createAdminDbRegistry(deps).getAdminDb()).toThrow();
-      expect(deps.alert).not.toHaveBeenCalled();
     });
   });
 
@@ -184,15 +206,23 @@ describe('createAdminDbRegistry', () => {
       expect(deps.getMainDb).not.toHaveBeenCalled();
     });
 
-    it('given a fail env, should report fail with the actionable reason instead of throwing', () => {
-      const { deps } = makeDeps({ getEnv: () => ({}) });
+    it('given a main-db env (unconfigured), should report main-db without alerting or touching the main db', () => {
+      const { deps } = makeDeps({ getEnv: () => MAIN_DB_ENV });
+      const decision = createAdminDbRegistry(deps).getMode();
+      expect(decision.mode).toBe('main-db');
+      expect(deps.alert).not.toHaveBeenCalled();
+      expect(deps.getMainDb).not.toHaveBeenCalled();
+    });
+
+    it('given a fail env (enforcement declared, unconfigured), should report fail with the actionable reason instead of throwing', () => {
+      const { deps } = makeDeps({ getEnv: () => FAIL_ENV });
       const decision = createAdminDbRegistry(deps).getMode();
       expect(decision.mode).toBe('fail');
       expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);
     });
 
     it('should re-read env on every call (late-loaded dotenv wins, no caching)', () => {
-      let env: Record<string, string> = {};
+      let env: Record<string, string> = { ...FAIL_ENV };
       const { deps } = makeDeps({ getEnv: () => env });
       const registry = createAdminDbRegistry(deps);
       expect(registry.getMode().mode).toBe('fail');

--- a/packages/db/src/__tests__/admin-migrate-decision.test.ts
+++ b/packages/db/src/__tests__/admin-migrate-decision.test.ts
@@ -31,8 +31,16 @@ describe('resolveAdminMigrateDecision', () => {
     }
   });
 
-  it('given no URL and no flag, should refuse with the fail-fast reason', () => {
+  it('given no URL and no flag (main-db default), should refuse — migrations only run against a dedicated Admin PG', () => {
     const decision = resolveAdminMigrateDecision({});
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);
+    }
+  });
+
+  it('given AUDIT_TRUST_PLANE_REQUIRED armed but no URL, should refuse with the fail-fast reason', () => {
+    const decision = resolveAdminMigrateDecision({ AUDIT_TRUST_PLANE_REQUIRED: 'true' });
     expect(decision.ok).toBe(false);
     if (!decision.ok) {
       expect(decision.reason).toMatch(/ADMIN_DATABASE_URL/);

--- a/packages/db/src/admin-db-mode.ts
+++ b/packages/db/src/admin-db-mode.ts
@@ -1,14 +1,30 @@
 /**
  * Pure decision logic for the Admin PG (trust plane) connection registry
- * (#890 Phase 1). No I/O, no process.env reads — callers pass env values in.
+ * (#890). No I/O, no process.env reads — callers pass env values in.
  *
- * Three-state contract:
- *   ADMIN_DATABASE_URL set (valid postgres URL)      → 'dedicated'
- *   URL unset + ADMIN_DB_BREAK_GLASS exactly 'true'  → 'break-glass'
- *   URL unset + flag not armed                       → 'fail'
+ * FIVE-state contract (post prod audit-write incident):
+ *   URL set + VALID postgres URL                    → 'dedicated'
+ *   URL set + INVALID URL                           → 'fail'   (positive misconfig — stop)
+ *   URL unset + AUDIT_TRUST_PLANE_REQUIRED='true'   → 'fail'   (declared but not configured)
+ *   URL unset + ADMIN_DB_BREAK_GLASS='true'         → 'break-glass' (main DB + LOUD alert)
+ *   URL unset + neither flag                        → 'main-db' (DEFAULT: main DB, SILENT)
  *
- * A set-but-invalid URL is 'fail' even when break-glass is armed: a
- * misconfigured deploy must stop, never silently degrade to the main DB.
+ * Precedence when several apply:
+ *   invalid-URL fail > TRUST_PLANE_REQUIRED fail > break-glass > main-db.
+ *
+ * Why 'main-db' is the default: the trust plane (dedicated Admin PG) has not
+ * been adopted in every deployment. The pre-adoption behavior is exactly the
+ * pre-epic one — audit rows live in the MAIN application database. Making an
+ * unconfigured ADMIN_DATABASE_URL resolve to 'fail' broke that silently: every
+ * audit write threw and was swallowed by the fire-and-forget audit() wrapper,
+ * so security audit logging stopped in prod with no signal. 'main-db' restores
+ * the silent, working default; loud failure is now OPT-IN via
+ * AUDIT_TRUST_PLANE_REQUIRED='true' (declare you want the trust plane and it
+ * fails closed when unconfigured), and break-glass remains a purely explicit
+ * emergency override that keeps the loud alert.
+ *
+ * A set-but-invalid URL is always 'fail', even with a flag armed: a positive
+ * misconfiguration must stop, never silently degrade to the main DB.
  */
 
 export interface AdminDbEnv {
@@ -16,9 +32,16 @@ export interface AdminDbEnv {
   ADMIN_DATABASE_SSL?: string | undefined;
   ADMIN_DB_POOL_MAX?: string | undefined;
   ADMIN_DB_BREAK_GLASS?: string | undefined;
+  /**
+   * Opt-in enforcement: when exactly 'true' AND ADMIN_DATABASE_URL is unset,
+   * the mode is 'fail' (fail closed) instead of the silent 'main-db' default.
+   * Set this only in deployments that HAVE adopted the trust plane and want a
+   * missing URL to halt rather than silently fall back to the main DB.
+   */
+  AUDIT_TRUST_PLANE_REQUIRED?: string | undefined;
 }
 
-export type AdminDbModeName = 'dedicated' | 'break-glass' | 'fail';
+export type AdminDbModeName = 'dedicated' | 'break-glass' | 'main-db' | 'fail';
 
 export interface AdminDbModeDecision {
   mode: AdminDbModeName;
@@ -28,14 +51,14 @@ export interface AdminDbModeDecision {
 const isPostgresUrl = (url: string): boolean =>
   url.startsWith('postgresql://') || url.startsWith('postgres://');
 
-// Fail-closed: only the exact string 'true' arms the fallback. 'TRUE', '1',
-// ' true ', '' etc. do not — mirrors the serverEnvSchema contract from leaf 1.
-const isBreakGlassArmed = (flag: string | undefined): boolean => flag === 'true';
+// Fail-closed: only the exact string 'true' arms a flag. 'TRUE', '1',
+// ' true ', '' etc. do not — mirrors the serverEnvSchema contract.
+const isArmed = (flag: string | undefined): boolean => flag === 'true';
 
 export const resolveAdminDbMode = (env: AdminDbEnv): AdminDbModeDecision => {
   const url = env.ADMIN_DATABASE_URL;
 
-  // Empty string is treated as unset (falls through to break-glass/fail).
+  // Empty string is treated as unset (falls through to the URL-unset ladder).
   if (url !== undefined && url !== '') {
     if (!isPostgresUrl(url)) {
       return {
@@ -48,7 +71,20 @@ export const resolveAdminDbMode = (env: AdminDbEnv): AdminDbModeDecision => {
     return { mode: 'dedicated', reason: 'ADMIN_DATABASE_URL is set' };
   }
 
-  if (isBreakGlassArmed(env.ADMIN_DB_BREAK_GLASS)) {
+  // URL unset. Enforcement is opt-in and wins over both the emergency override
+  // and the silent default: an operator who declared AUDIT_TRUST_PLANE_REQUIRED
+  // wants the trust plane, so a missing URL must halt loudly.
+  if (isArmed(env.AUDIT_TRUST_PLANE_REQUIRED)) {
+    return {
+      mode: 'fail',
+      reason:
+        "AUDIT_TRUST_PLANE_REQUIRED='true' but ADMIN_DATABASE_URL is not set. " +
+        'Enforcement was requested without a dedicated Admin PG configured — set ADMIN_DATABASE_URL ' +
+        'to the trust-plane database, or unset AUDIT_TRUST_PLANE_REQUIRED to run on the main DB.',
+    };
+  }
+
+  if (isArmed(env.ADMIN_DB_BREAK_GLASS)) {
     return {
       mode: 'break-glass',
       reason:
@@ -57,10 +93,11 @@ export const resolveAdminDbMode = (env: AdminDbEnv): AdminDbModeDecision => {
   }
 
   return {
-    mode: 'fail',
+    mode: 'main-db',
     reason:
-      'ADMIN_DATABASE_URL is not set. The Admin PG (trust plane) is required in every deployment mode. ' +
-      "Set ADMIN_DATABASE_URL to the dedicated admin Postgres, or — as an emergency rollback only — set ADMIN_DB_BREAK_GLASS='true' to permit audit writes to the main DB.",
+      'ADMIN_DATABASE_URL is not set and the trust plane is not required — audit writes use the main ' +
+      'application database (the pre-trust-plane default). Set ADMIN_DATABASE_URL to adopt the dedicated ' +
+      "Admin PG, or AUDIT_TRUST_PLANE_REQUIRED='true' to fail closed when it is unconfigured.",
   };
 };
 
@@ -124,23 +161,24 @@ export const resolveAdminMigrateEnv = (env: AdminMigrateEnv): AdminDbEnv => {
 };
 
 /**
- * db:migrate:admin gate — only 'dedicated' may migrate. Break-glass degrades
- * audit WRITES to the main DB at runtime, but running admin migrations there
- * would plant the drizzle_admin journal inside the app plane, so it refuses.
+ * db:migrate:admin gate — only 'dedicated' may migrate. Break-glass and the
+ * main-db default both degrade audit WRITES to the main DB at runtime, but
+ * running admin migrations there would plant the drizzle_admin journal inside
+ * the app plane, so both refuse. 'fail' surfaces its actionable reason.
  */
 export const resolveAdminMigrateDecision = (env: AdminMigrateEnv): AdminMigrateDecision => {
   const resolvedEnv = resolveAdminMigrateEnv(env);
   const decision = resolveAdminDbMode(resolvedEnv);
-  if (decision.mode === 'break-glass') {
+  if (decision.mode === 'fail') {
+    return { ok: false, reason: decision.reason };
+  }
+  if (decision.mode === 'break-glass' || decision.mode === 'main-db') {
     return {
       ok: false,
       reason:
-        'admin migrations never run under break-glass — they target only a dedicated Admin PG. ' +
+        `admin migrations never run under ${decision.mode} — they target only a dedicated Admin PG. ` +
         'Set ADMIN_DATABASE_URL to the trust-plane database.',
     };
-  }
-  if (decision.mode === 'fail') {
-    return { ok: false, reason: decision.reason };
   }
   return { ok: true, poolConfig: resolveAdminPoolConfig(resolvedEnv) };
 };

--- a/packages/db/src/admin-db.ts
+++ b/packages/db/src/admin-db.ts
@@ -86,6 +86,11 @@ export function createAdminDbRegistry(deps: AdminDbDeps): AdminDbRegistry {
         deps.alert(breakGlassAlert(decision.reason));
         return deps.getMainDb();
       }
+      case 'main-db':
+        // Unconfigured trust plane: audit writes use the main DB — the
+        // pre-trust-plane default. SILENT: no alert, no throw. (The break-glass
+        // path is the loud, explicit variant of the same fallback.)
+        return deps.getMainDb();
       case 'fail':
         throw new Error(`adminDb init failed: ${decision.reason}`);
     }
@@ -109,6 +114,7 @@ const registry = createAdminDbRegistry({
     ADMIN_DATABASE_SSL: process.env.ADMIN_DATABASE_SSL,
     ADMIN_DB_POOL_MAX: process.env.ADMIN_DB_POOL_MAX,
     ADMIN_DB_BREAK_GLASS: process.env.ADMIN_DB_BREAK_GLASS,
+    AUDIT_TRUST_PLANE_REQUIRED: process.env.AUDIT_TRUST_PLANE_REQUIRED,
   }),
   // Break-glass only: an admin-schema-typed client over the MAIN pool — same
   // database and connections as `db`, narrow trust-plane type, no cast.

--- a/packages/lib/src/audit/__tests__/audit-db-binding.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-db-binding.test.ts
@@ -78,6 +78,27 @@ describe('resolveAuditDbBinding()', () => {
     });
   });
 
+  describe('main-db mode (unconfigured trust plane — THE incident fix)', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'main-db', reason: 'main db default' });
+    });
+
+    it('given main-db, should bind to the MAIN db client (silent legacy path)', () => {
+      const binding = resolveAuditDbBinding();
+      expect(binding.mode).toBe('main-db');
+      expect(binding.db).toBe(mockMainDb);
+    });
+
+    it('given main-db, should never touch getAdminDb — the admin-schema-typed main-pool client is shape-unsafe for main-plane reads', () => {
+      resolveAuditDbBinding();
+      expect(mockGetAdminDb).not.toHaveBeenCalled();
+    });
+
+    it('should carry the decision reason for the bind point', () => {
+      expect(resolveAuditDbBinding().reason).toBe('main db default');
+    });
+  });
+
   describe('fail mode', () => {
     beforeEach(() => {
       mockGetAdminDbMode.mockReturnValue({

--- a/packages/lib/src/audit/__tests__/security-audit-cutover.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-cutover.test.ts
@@ -287,11 +287,69 @@ describe('securityAudit default wiring cutover', () => {
     });
   });
 
-  describe('fail mode (no Admin PG, flag not armed)', () => {
+  describe('main-db mode (unconfigured trust plane — THE incident fix: silent, working)', () => {
+    beforeEach(() => {
+      mockGetAdminDbMode.mockReturnValue({ mode: 'main-db', reason: 'main db default' });
+    });
+
+    it('given logEvent, should use the advisory-lock chained append against the MAIN db (audit writes SUCCEED)', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await vi.waitFor(() => expect(state.mainInserts.length).toBeGreaterThanOrEqual(1));
+
+      expect(lockSqlSeen().length).toBeGreaterThanOrEqual(1);
+      expect(state.mainInserts.map((v) => v.eventType)).toContain('data.read');
+      // The Admin PG is never touched.
+      expect(mockGetAdminDb).not.toHaveBeenCalled();
+      expect(state.adminInserts).toHaveLength(0);
+    });
+
+    it('should NOT self-record any break-glass security event (silent operation)', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+      await vi.waitFor(() => expect(state.mainInserts.length).toBeGreaterThanOrEqual(2));
+
+      const breakGlassEvents = state.mainInserts.filter(
+        (v) =>
+          Array.isArray(v.anomalyFlags) &&
+          (v.anomalyFlags as string[]).includes('admin_db_break_glass'),
+      );
+      expect(breakGlassEvents).toHaveLength(0);
+    });
+
+    it('should NOT fire any alert through the security-audit-alerting channel', async () => {
+      const { securityAuditModule, alerting } = await loadFreshModules();
+      const handler = vi.fn();
+      alerting.setChainAlertHandler(handler);
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.write', userId: 'u' });
+      await vi.waitFor(() => expect(state.mainInserts.length).toBeGreaterThanOrEqual(2));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('should NOT log the break-glass banner (no BREAK-GLASS security error)', async () => {
+      const { securityAuditModule } = await loadFreshModules();
+
+      await securityAuditModule.securityAudit.logEvent({ eventType: 'data.read', userId: 'u' });
+      await vi.waitFor(() => expect(state.mainInserts.length).toBeGreaterThanOrEqual(1));
+
+      const banners = mockLoggers.security.error.mock.calls.filter(([msg]) =>
+        String(msg).includes('BREAK-GLASS'),
+      );
+      expect(banners).toHaveLength(0);
+    });
+  });
+
+  describe('fail mode (trust plane declared required but unconfigured)', () => {
     beforeEach(() => {
       mockGetAdminDbMode.mockReturnValue({
         mode: 'fail',
-        reason: 'ADMIN_DATABASE_URL is not set. The Admin PG (trust plane) is required.',
+        reason: "AUDIT_TRUST_PLANE_REQUIRED='true' but ADMIN_DATABASE_URL is not set.",
       });
     });
 

--- a/packages/lib/src/audit/audit-db-binding.ts
+++ b/packages/lib/src/audit/audit-db-binding.ts
@@ -8,14 +8,21 @@
  *                 lock-free ingest writer; reads (queries, chain verifier,
  *                 cron) hit the admin store.
  *   break-glass → the MAIN db client, i.e. the pre-cutover legacy path,
- *                 both writes (advisory-lock chained append) and reads.
- *                 Deliberately NOT getAdminDb()'s main-pool client: that one
- *                 is admin-schema-typed and maps emission_hash (admin
- *                 migration 0005, admin plane only), so its generated
- *                 SELECTs would 42703 against the main-plane table.
- *   fail        → throw the actionable reason. A process without a trust
- *                 plane and without the armed break-glass flag must not
- *                 write or read audit data as if nothing were wrong.
+ *                 both writes (advisory-lock chained append) and reads, with
+ *                 LOUD observability at the write bind point.
+ *   main-db     → the MAIN db client too, but SILENT — the pre-trust-plane
+ *                 default for deployments that never adopted the Admin PG.
+ *                 Identical DB target to break-glass; the difference is
+ *                 purely observability (see security-audit.ts).
+ *   fail        → throw the actionable reason. A process that DECLARED the
+ *                 trust plane required (AUDIT_TRUST_PLANE_REQUIRED) but did
+ *                 not configure it must not write or read audit data as if
+ *                 nothing were wrong.
+ *
+ * Both main-DB bindings deliberately use the plain `db` client, NOT
+ * getAdminDb()'s main-pool client: that one is admin-schema-typed and maps
+ * emission_hash (admin migration 0005, admin plane only), so its generated
+ * SELECTs would 42703 against the main-plane table.
  *
  * Break-glass OBSERVABILITY (security event + alert) is owned by the write
  * bind point in security-audit.ts — this module only decides and reports.
@@ -26,7 +33,8 @@ import { getAdminDb, getAdminDbMode, type AdminDatabase } from '@pagespace/db/ad
 
 export type AuditDbBinding =
   | { mode: 'dedicated'; reason: string; db: AdminDatabase }
-  | { mode: 'break-glass'; reason: string; db: typeof mainDb };
+  | { mode: 'break-glass'; reason: string; db: typeof mainDb }
+  | { mode: 'main-db'; reason: string; db: typeof mainDb };
 
 let cached: AuditDbBinding | null = null;
 
@@ -44,6 +52,9 @@ export function resolveAuditDbBinding(): AuditDbBinding {
       return cached;
     case 'break-glass':
       cached = { mode: 'break-glass', reason: decision.reason, db: mainDb };
+      return cached;
+    case 'main-db':
+      cached = { mode: 'main-db', reason: decision.reason, db: mainDb };
       return cached;
     case 'fail':
       throw new Error(`audit db binding failed: ${decision.reason}`);

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -379,9 +379,20 @@ function buildBreakGlassAppendPath(binding: Extract<AuditDbBinding, { mode: 'bre
 }
 
 /**
- * Lazily resolve the default append path (#890 Phase 2, leaf 5 cutover).
- * Deferred (rather than built eagerly at module load) so module load order
- * never matters and env is read after late-loaded dotenv.
+ * Silent main-DB append path (#890 prod audit-write incident fix): the legacy
+ * advisory-lock chained append against the main DB — IDENTICAL backend to
+ * break-glass, but with NO observability. This is the pre-trust-plane default
+ * for deployments that never adopted the Admin PG: audit writes simply work
+ * against the main DB, exactly as before the epic, with no alert, no security
+ * event, and no banner. (Break-glass is the loud, explicit variant.)
+ */
+function buildMainDbAppendPath(binding: Extract<AuditDbBinding, { mode: 'main-db' }>): AuditAppendPath {
+  return createSecurityAuditRepository({ db: binding.db });
+}
+
+/**
+ * Build the append path for a resolved binding. Exhaustive over the three
+ * non-fail modes (fail is handled upstream by resolveAuditDbBinding throwing).
  *
  *   dedicated   → lock-free ingest writer on the Admin PG: pure emission
  *                 hash + ONE INSERT, no advisory lock, no head read, no
@@ -389,21 +400,34 @@ function buildBreakGlassAppendPath(binding: Extract<AuditDbBinding, { mode: 'bre
  *                 chainer worker.
  *   break-glass → the legacy chained append against the main DB, with loud
  *                 observability (see buildBreakGlassAppendPath).
- *   fail        → resolveAuditDbBinding throws; logEvent rejects per event
- *                 and the audit() wrapper surfaces it as a warn log.
+ *   main-db     → the same legacy chained append against the main DB, but
+ *                 SILENT (see buildMainDbAppendPath).
+ */
+function buildAppendPath(binding: AuditDbBinding): AuditAppendPath {
+  switch (binding.mode) {
+    case 'dedicated': {
+      const writer = createAuditIngestWriter({ db: binding.db });
+      return { appendEvent: (event, opts) => writer.writeToIngest(event, opts) };
+    }
+    case 'break-glass':
+      return buildBreakGlassAppendPath(binding);
+    case 'main-db':
+      return buildMainDbAppendPath(binding);
+  }
+}
+
+/**
+ * Lazily resolve the default append path (#890 Phase 2, leaf 5 cutover).
+ * Deferred (rather than built eagerly at module load) so module load order
+ * never matters and env is read after late-loaded dotenv.
+ *
+ *   fail → resolveAuditDbBinding throws; logEvent rejects per event and the
+ *          audit() wrapper surfaces it as a warn log.
  */
 let defaultAppendPath: AuditAppendPath | null = null;
 function getDefaultAppendPath(): AuditAppendPath {
   if (!defaultAppendPath) {
-    const binding = resolveAuditDbBinding();
-    if (binding.mode === 'dedicated') {
-      const writer = createAuditIngestWriter({ db: binding.db });
-      defaultAppendPath = {
-        appendEvent: (event, opts) => writer.writeToIngest(event, opts),
-      };
-    } else {
-      defaultAppendPath = buildBreakGlassAppendPath(binding);
-    }
+    defaultAppendPath = buildAppendPath(resolveAuditDbBinding());
   }
   return defaultAppendPath;
 }

--- a/packages/lib/src/compliance/erasure/__tests__/pseudonymize-targets.test.ts
+++ b/packages/lib/src/compliance/erasure/__tests__/pseudonymize-targets.test.ts
@@ -59,6 +59,14 @@ describe('planSecurityAuditErasure (pure)', () => {
     expect(plan).toEqual({ ok: true, mode: 'break-glass', stores: ['main'] });
   });
 
+  it('given main-db mode (unconfigured default), should target only the main store like break-glass', () => {
+    const plan = planSecurityAuditErasure({
+      auditMode: 'main-db',
+      eraserMode: 'unavailable',
+    });
+    expect(plan).toEqual({ ok: true, mode: 'main-db', stores: ['main'] });
+  });
+
   it('given fail mode, should refuse loudly with the audit reason — a misconfigured trust plane never silently no-ops an erasure', () => {
     const plan = planSecurityAuditErasure({
       auditMode: 'fail',

--- a/packages/lib/src/compliance/erasure/pseudonymize-targets.ts
+++ b/packages/lib/src/compliance/erasure/pseudonymize-targets.ts
@@ -45,7 +45,7 @@ export interface SecurityAuditErasurePlanInput {
 }
 
 export type SecurityAuditErasurePlan =
-  | { ok: true; mode: 'dedicated' | 'break-glass'; stores: SecurityAuditErasureStore[] }
+  | { ok: true; mode: 'dedicated' | 'break-glass' | 'main-db'; stores: SecurityAuditErasureStore[] }
   | { ok: false; reason: string };
 
 /** Pure: which stores an erasure run must touch, or why it must refuse. */
@@ -64,6 +64,10 @@ export function planSecurityAuditErasure(
       // The whole audit surface (writes AND reads) is the main DB; there are
       // no admin-store rows the eraser identity could reach.
       return { ok: true, mode: 'break-glass', stores: ['main'] };
+    case 'main-db':
+      // Unconfigured trust plane: the audit surface is entirely the main DB,
+      // exactly like break-glass — no admin-store rows exist to erase.
+      return { ok: true, mode: 'main-db', stores: ['main'] };
     case 'dedicated':
       if (input.eraserMode === 'unavailable') {
         return {
@@ -89,7 +93,7 @@ export interface SecurityAuditErasureTarget {
 }
 
 export type ResolvedSecurityAuditErasureTargets =
-  | { ok: true; mode: 'dedicated' | 'break-glass'; targets: SecurityAuditErasureTarget[] }
+  | { ok: true; mode: 'dedicated' | 'break-glass' | 'main-db'; targets: SecurityAuditErasureTarget[] }
   | { ok: false; reason: string };
 
 /**

--- a/packages/lib/src/config/__tests__/env-validation.test.ts
+++ b/packages/lib/src/config/__tests__/env-validation.test.ts
@@ -415,21 +415,22 @@ describe('env-validation', () => {
       expect(() => validateEnv()).toThrow(/Environment validation failed/);
     });
 
-    it('given a blank ADMIN_DATABASE_URL and no flags, validateEnv should PASS at boot AND the resolved mode is main-db (#890 incident: the two must agree)', async () => {
-      // The boot half: validateEnv() (called from instrumentation.ts) must not
-      // throw for the common `ADMIN_DATABASE_URL=` blank form.
+    it('given a blank ADMIN_DATABASE_URL and no flags, validateEnv should PASS at boot (the #890 incident-fix boot gate)', () => {
+      // The boot half of the incident fix: validateEnv() (called from
+      // apps/web/src/instrumentation.ts) must NOT throw for the common
+      // `ADMIN_DATABASE_URL=` blank form — otherwise the process exits before
+      // resolveAdminDbMode ever runs. The runtime half (blank '' → the silent
+      // 'main-db' default) is pinned in packages/db's admin-db-mode.test.ts
+      // ("given an empty-string URL and no flag, should resolve main-db"); it
+      // is NOT re-imported here on purpose — pulling in @pagespace/db/admin-db
+      // would construct its module-level DATABASE_URL pool against this test's
+      // placeholder connection string and poison sibling integration tests.
       process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
       process.env.CSRF_SECRET = 'b'.repeat(32);
       process.env.ENCRYPTION_KEY = 'c'.repeat(32);
       process.env.ADMIN_DATABASE_URL = '';
 
       expect(() => validateEnv()).not.toThrow();
-
-      // The runtime half: the same blank value resolves to the silent main-db
-      // default (resolveAdminDbMode reads an env object; '' → unset). Pinning
-      // both here guarantees the boot gate and the mode decision never diverge.
-      const { resolveAdminDbMode } = await import('@pagespace/db/admin-db');
-      expect(resolveAdminDbMode({ ADMIN_DATABASE_URL: '' }).mode).toBe('main-db');
     });
   });
 

--- a/packages/lib/src/config/__tests__/env-validation.test.ts
+++ b/packages/lib/src/config/__tests__/env-validation.test.ts
@@ -243,7 +243,12 @@ describe('env-validation', () => {
       }
     });
 
-    it('given an empty-string ADMIN_DATABASE_URL, should fail validation', () => {
+    it('given an empty-string ADMIN_DATABASE_URL, should PARSE (empty is treated as unset — must not crash boot)', () => {
+      // #890 prod audit-write incident: instrumentation.ts calls validateEnv()
+      // at boot. Rejecting '' here would exit the process BEFORE
+      // resolveAdminDbMode (which maps '' → unset → the silent 'main-db'
+      // default) ever runs — defeating the incident fix for the common
+      // `ADMIN_DATABASE_URL=` blank-value form.
       const env = {
         ...baseEnv,
         ADMIN_DATABASE_URL: '',
@@ -251,11 +256,9 @@ describe('env-validation', () => {
 
       const result = serverEnvSchema.safeParse(env);
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(
-          result.error.issues.some((i) => i.path.includes('ADMIN_DATABASE_URL')),
-        ).toBe(true);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.ADMIN_DATABASE_URL).toBe('');
       }
     });
 
@@ -283,6 +286,14 @@ describe('env-validation', () => {
 
       const unset = serverEnvSchema.safeParse(baseEnv);
       expect(unset.success).toBe(true);
+    });
+
+    it('given an empty-string ADMIN_ERASER_DATABASE_URL, should PARSE (empty is treated as unset — mirrors ADMIN_DATABASE_URL, must not crash boot)', () => {
+      const result = serverEnvSchema.safeParse({
+        ...baseEnv,
+        ADMIN_ERASER_DATABASE_URL: '',
+      });
+      expect(result.success).toBe(true);
     });
 
     it('given ADMIN_DATABASE_URL unset with ADMIN_DB_BREAK_GLASS=true, should parse and expose the flag (degrade-loudly path)', () => {
@@ -402,6 +413,23 @@ describe('env-validation', () => {
       process.env.DATABASE_URL = '';
 
       expect(() => validateEnv()).toThrow(/Environment validation failed/);
+    });
+
+    it('given a blank ADMIN_DATABASE_URL and no flags, validateEnv should PASS at boot AND the resolved mode is main-db (#890 incident: the two must agree)', async () => {
+      // The boot half: validateEnv() (called from instrumentation.ts) must not
+      // throw for the common `ADMIN_DATABASE_URL=` blank form.
+      process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/db';
+      process.env.CSRF_SECRET = 'b'.repeat(32);
+      process.env.ENCRYPTION_KEY = 'c'.repeat(32);
+      process.env.ADMIN_DATABASE_URL = '';
+
+      expect(() => validateEnv()).not.toThrow();
+
+      // The runtime half: the same blank value resolves to the silent main-db
+      // default (resolveAdminDbMode reads an env object; '' → unset). Pinning
+      // both here guarantees the boot gate and the mode decision never diverge.
+      const { resolveAdminDbMode } = await import('@pagespace/db/admin-db');
+      expect(resolveAdminDbMode({ ADMIN_DATABASE_URL: '' }).mode).toBe('main-db');
     });
   });
 

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -52,6 +52,14 @@ export const serverEnvSchema = z
     // arm break-glass only on the exact value 'true' (fail-closed otherwise).
     ADMIN_DB_BREAK_GLASS: z.string().optional(),
 
+    // Opt-in trust-plane enforcement. When exactly 'true' AND ADMIN_DATABASE_URL
+    // is unset, the adminDb mode is 'fail' (fail closed) instead of the silent
+    // 'main-db' default. Set only in deployments that HAVE adopted the dedicated
+    // Admin PG and want a missing URL to halt rather than fall back to the main
+    // DB. Accept any string so a stray value never fails app-wide env
+    // validation; consumers arm it only on the exact value 'true'.
+    AUDIT_TRUST_PLANE_REQUIRED: z.string().optional(),
+
     // ClickHouse analytics tier (#890 Phase 3) — off by default. Only the
     // exact value CLICKHOUSE_ENABLED='true' turns it on (accept any string so
     // a stray value never fails app-wide env validation; the exact-match gate

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -18,9 +18,16 @@ export const serverEnvSchema = z
 
     // Admin Postgres (trust plane) — dedicated database for the tamper-evident
     // security audit chain and related admin/audit tables, isolated from the app
-    // DB in every deployment mode. Optional at the schema level: the hard
-    // fail-fast when unset (and no break-glass flag) is enforced by the adminDb
-    // client at init, not here, so non-audit code paths can still validate env.
+    // DB in every deployment mode. Optional at the schema level: the mode
+    // decision (dedicated / break-glass / main-db / fail) is owned by
+    // resolveAdminDbMode at adminDb init, not here, so non-audit code paths can
+    // still validate env. An EMPTY string is explicitly accepted (via
+    // `.or(z.literal(''))`) and treated as UNSET — resolveAdminDbMode already
+    // maps '' → unset (→ the silent 'main-db' default). Rejecting '' here would
+    // crash the process at boot (instrumentation.ts calls validateEnv) BEFORE
+    // the mode decision runs, defeating the incident fix for the common
+    // `ADMIN_DATABASE_URL=` blank-value form. A NON-empty value must still be a
+    // postgres URL.
     ADMIN_DATABASE_URL: z
       .string()
       .min(1, 'ADMIN_DATABASE_URL must not be empty when set')
@@ -28,14 +35,18 @@ export const serverEnvSchema = z
         (url) => url.startsWith('postgresql://') || url.startsWith('postgres://'),
         'ADMIN_DATABASE_URL must be a valid PostgreSQL connection string'
       )
-      .optional(),
+      .optional()
+      .or(z.literal('')),
     ADMIN_DATABASE_SSL: z.enum(['true', 'false']).optional(),
     ADMIN_DB_POOL_MAX: z.coerce.number().int().positive().optional(),
 
     // GDPR eraser identity (#890 Phase 2, leaf 6): the web pseudonymization
     // route connects to the Admin PG as admin_gdpr_eraser_user through this
     // URL. Optional at the schema level — when unset, the pseudonymize route
-    // refuses (503) via the eraser client, never at app boot.
+    // refuses (503) via the eraser client, never at app boot. An EMPTY string is
+    // accepted and treated as UNSET, mirroring ADMIN_DATABASE_URL and the eraser
+    // client (resolveAdminEraserDbMode maps '' → unavailable): a blank
+    // `ADMIN_ERASER_DATABASE_URL=` must not crash boot.
     ADMIN_ERASER_DATABASE_URL: z
       .string()
       .min(1, 'ADMIN_ERASER_DATABASE_URL must not be empty when set')
@@ -43,7 +54,8 @@ export const serverEnvSchema = z
         (url) => url.startsWith('postgresql://') || url.startsWith('postgres://'),
         'ADMIN_ERASER_DATABASE_URL must be a valid PostgreSQL connection string'
       )
-      .optional(),
+      .optional()
+      .or(z.literal('')),
 
     // Break-glass rollback ONLY: arms the fallback that permits audit writes to
     // the main DB (which must alert loudly) when the Admin PG is unavailable.


### PR DESCRIPTION
## The incident

Phases 0–2 of the DB-decomposition trust-plane epic (#890) deployed to prod. `resolveAdminDbMode` returned `'fail'` when `ADMIN_DATABASE_URL` was unset and `ADMIN_DB_BREAK_GLASS ≠ 'true'`, and `resolveAuditDbBinding` **throws** on `'fail'`. Every prod app had neither env var (the dedicated Admin PG was never provisioned), so **every audit write threw** → swallowed by the fire-and-forget `audit()` wrapper as `"[Audit] audit write failed"` → **security audit logging was silently broken in prod**.

Mitigated live by setting `ADMIN_DB_BREAK_GLASS=true` on the Fly apps — main-DB writes restored, but with a loud break-glass alert on every process (noise, and semantically wrong for a deployment that simply hasn't adopted the trust plane).

## The fix — invert the default so "unconfigured" = main-DB, silently

A **five-state** mode contract:

| `ADMIN_DATABASE_URL` | flag | mode | behavior |
|---|---|---|---|
| set, valid postgres URL | — | `dedicated` | Admin PG (unchanged) |
| set, **invalid** URL | — | `fail` | halt — positive misconfig (unchanged) |
| unset | `AUDIT_TRUST_PLANE_REQUIRED='true'` | `fail` | halt loudly — declared but unconfigured (**new flag**) |
| unset | `ADMIN_DB_BREAK_GLASS='true'` | `break-glass` | main DB + LOUD alert (unchanged) |
| unset | neither | `main-db` | main DB, **SILENT** — pre-epic default (**new default**) |

Precedence: invalid-URL `fail` > `AUDIT_TRUST_PLANE_REQUIRED` `fail` > `break-glass` > `main-db`. Both flags are fail-closed (exact `'true'` only). Edge case ruled + tested: `AUDIT_TRUST_PLANE_REQUIRED='true'` **and** break-glass armed with no URL → `fail` wins (honor the stricter declared intent).

## Changes

- **packages/db/admin-db-mode.ts** — `'main-db'` mode + `AUDIT_TRUST_PLANE_REQUIRED`; migrate gate refuses `main-db` like break-glass; doc block rewritten.
- **packages/db/admin-db.ts** — `'main-db'` returns the main db client, no alert, no throw.
- **packages/lib/audit/{audit-db-binding,security-audit}.ts** — silent `main-db` append path (legacy repository, **no** alert/event/banner); break-glass observability unchanged.
- **packages/lib/config/env-validation.ts** — `AUDIT_TRUST_PLANE_REQUIRED` (optional).
- Exhaustiveness: `pseudonymize-targets.ts` (main-db → main store) and processor `siem-pool-routing.ts` (main-db routes to main, silently).
- Docs: `infrastructure/UPGRADE.md` mode-contract table + post-merge unset-break-glass step; `.env(.onprem).example` document the new flag.

## Verification

- TDD: all 5 states + precedence edges pinned. Two HIGH-value regressions pinned: (a) neither-flag → main-db **silent write succeeds** (the incident fix); (b) URL-set-invalid still **fails**.
- `'dedicated'` / `'break-glass'` / invalid-URL `'fail'` behavior **unchanged** (regression-pinned).
- Green: `packages/db` (admin-db*), `packages/lib` (audit + config + erasure), `apps/processor` (siem) vitest; `typecheck` clean for db/lib/processor/web/admin; `db:generate` + `db:generate:admin` both no-drift. (Pre-existing base failures in realtime/web from the unrelated `terminalId→machineId` rename are not touched by this PR.)

## Post-merge prod step (after deploy)

Once deployed, drop the break-glass alert noise — with the flag gone and `ADMIN_DATABASE_URL` still unset, each app resolves to `main-db` (silent):

```bash
fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-web
fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-processor
fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-realtime
fly secrets unset ADMIN_DB_BREAK_GLASS -a pagespace-admin
```

Refs #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit data now safely defaults to the main database when a dedicated audit database is not configured.
  * Added optional trust-plane enforcement to fail fast when a dedicated audit database is required but unavailable.
  * Audit erasure operations support the default main-database mode.

* **Bug Fixes**
  * Improved handling of invalid or incomplete audit database configuration.
  * Emergency break-glass routing remains available with explicit alerting.

* **Documentation**
  * Updated environment configuration examples and upgrade guidance with the new routing behavior and configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Review follow-ups (post-initial-CI)

- **CODEX P2 (real bug, fixed):** `serverEnvSchema` validated `ADMIN_DATABASE_URL` (and `ADMIN_ERASER_DATABASE_URL`) with `z.string().min(1)`, so the common blank `ADMIN_DATABASE_URL=` form was rejected and `validateEnv()` (called at boot from `apps/web/src/instrumentation.ts`) exited the process **before** `resolveAdminDbMode` (which maps `''` → unset → `main-db`) ever ran — defeating the incident fix for the blank form. Fixed by accepting `''` via `.or(z.literal(''))` (the file's existing convention), with tests pinning that blank values parse. `ADMIN_DB_BREAK_GLASS` / `AUDIT_TRUST_PLANE_REQUIRED` / `CLICKHOUSE_*` use plain `z.string().optional()` — no `min(1)` trap.
- **CodeRabbit ×4 (docs, fixed):** `.env.example`, `.env.onprem.example`, `UPGRADE.md` now spell out the precedence ladder, clarify that "fail-closed" applies to **flag parsing only** (break-glass deliberately degrades), and warn that the post-merge `unset ADMIN_DB_BREAK_GLASS` step lands on `main-db` only while `AUDIT_TRUST_PLANE_REQUIRED` is unset.
- **Self-caught test regression (fixed):** the new combined config test imported `@pagespace/db/admin-db` while `DATABASE_URL` held a placeholder; because lib vitest runs all files in one fork, that constructed the shared module-level `db` pool against the placeholder and broke sibling billing Postgres integration tests (`password authentication failed for user "user"`). Fixed by asserting only the boot half in the lib test; the `''→main-db` half stays pinned in `packages/db/admin-db-mode.test.ts`.

All 5 review threads addressed and replied to with commit references.
