### PR TITLE
[sprites 6-4] Move gh config off /tmp onto the persistent disk

### DIFF
--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   runGitInSandbox,
+  buildGitToolEnv,
+  GH_CONFIG_DIR,
   type GitSandboxRunDeps,
 } from '../git-tool-runners';
 import type { SandboxActorContext } from '../tool-runners';
 import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
 import { SANDBOX_ROOT } from '../sandbox-paths';
+import { assert } from './riteway';
 
 const NOW = new Date('2026-06-01T12:00:00.000Z');
 
@@ -166,10 +169,12 @@ describe('runGitInSandbox', () => {
     expect(runCommandCalls[0].env).toMatchObject({ GIT_CONFIG_NOSYSTEM: '1' });
   });
 
-  it('always injects GH_CONFIG_DIR=/tmp/gh-config', async () => {
+  it('always injects GH_CONFIG_DIR pointed at the persistent sandbox disk (not /tmp)', async () => {
     const { deps, runCommandCalls } = makeDepsWithSpy();
     await runGitInSandbox({ cmd: 'gh', args: ['auth', 'status'], ctx: makeCtx(), deps });
-    expect(runCommandCalls[0].env).toMatchObject({ GH_CONFIG_DIR: '/tmp/gh-config' });
+    expect(runCommandCalls[0].env).toMatchObject({ GH_CONFIG_DIR });
+    expect(runCommandCalls[0].env?.GH_CONFIG_DIR).toMatch(new RegExp(`^${SANDBOX_ROOT}/`));
+    expect(runCommandCalls[0].env?.GH_CONFIG_DIR).not.toContain('/tmp');
   });
 
   it('returns success result with stdout, stderr, exitCode, truncated', async () => {
@@ -249,5 +254,97 @@ describe('runGitInSandbox — injection seam (screenOutput, fail-open)', () => {
     const { deps } = makeDeps({ reconnect: async () => sandbox });
     const result = await runGitInSandbox({ cmd: 'git', args: ['log'], ctx: makeCtx(), deps });
     if (result.success) expect(result.stdout).toBe('plain');
+  });
+});
+
+describe('buildGitToolEnv (pure)', () => {
+  const base = { NODE_ENV: 'test' };
+
+  it('given the tool env, should point GH_CONFIG_DIR under the persistent SANDBOX_ROOT', () => {
+    const env = buildGitToolEnv({ baseEnv: base, token: 'ghp_x' });
+    assert({
+      given: 'a git/gh tool env',
+      should: 'root GH_CONFIG_DIR at the persistent sandbox disk',
+      actual: env.GH_CONFIG_DIR.startsWith(`${SANDBOX_ROOT}/`),
+      expected: true,
+    });
+  });
+
+  it('given any token state, should never reference /tmp in any env value', () => {
+    const withToken = buildGitToolEnv({ baseEnv: base, token: 'ghp_x' });
+    const withoutToken = buildGitToolEnv({ baseEnv: base, token: null });
+    const referencesTmp = (env: Record<string, string>) =>
+      Object.values(env).some((v) => v.includes('/tmp'));
+    assert({
+      given: 'the tool env with and without a token',
+      should: 'contain no /tmp path in any value',
+      actual: referencesTmp(withToken) || referencesTmp(withoutToken),
+      expected: false,
+    });
+  });
+
+  it('given the GH_CONFIG_DIR path, should sit outside the repo working dir', () => {
+    assert({
+      given: 'the persistent gh config dir',
+      should: 'not live under the agent repo dir where git operations run',
+      actual: GH_CONFIG_DIR.startsWith(`${SANDBOX_ROOT}/repo`),
+      expected: false,
+    });
+  });
+
+  it('given a token, should inject GH_TOKEN, GITHUB_TOKEN and the credential helper', () => {
+    const env = buildGitToolEnv({ baseEnv: base, token: 'ghp_abc' });
+    assert({
+      given: 'a resolved GitHub token',
+      should: 'expose both token env vars plus the one-shot credential-helper config',
+      actual: {
+        GH_TOKEN: env.GH_TOKEN,
+        GITHUB_TOKEN: env.GITHUB_TOKEN,
+        GIT_CONFIG_COUNT: env.GIT_CONFIG_COUNT,
+        GIT_CONFIG_KEY_0: env.GIT_CONFIG_KEY_0,
+        hasHelper: typeof env.GIT_CONFIG_VALUE_0 === 'string',
+      },
+      expected: {
+        GH_TOKEN: 'ghp_abc',
+        GITHUB_TOKEN: 'ghp_abc',
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'credential.helper',
+        hasHelper: true,
+      },
+    });
+  });
+
+  it('given no token, should omit token env vars but keep the pause-proof config dir', () => {
+    const env = buildGitToolEnv({ baseEnv: base, token: null });
+    assert({
+      given: 'a null token',
+      should: 'omit token vars yet still root GH_CONFIG_DIR on the persistent disk',
+      actual: {
+        hasGhToken: 'GH_TOKEN' in env,
+        hasGithubToken: 'GITHUB_TOKEN' in env,
+        hasHelper: 'GIT_CONFIG_VALUE_0' in env,
+        ghConfigDir: env.GH_CONFIG_DIR,
+      },
+      expected: {
+        hasGhToken: false,
+        hasGithubToken: false,
+        hasHelper: false,
+        ghConfigDir: GH_CONFIG_DIR,
+      },
+    });
+  });
+
+  it('given a base env, should preserve base vars and the always-on git safety flags', () => {
+    const env = buildGitToolEnv({ baseEnv: base, token: null });
+    assert({
+      given: 'a base sandbox env',
+      should: 'carry base vars through alongside the git safety flags',
+      actual: {
+        NODE_ENV: env.NODE_ENV,
+        GIT_TERMINAL_PROMPT: env.GIT_TERMINAL_PROMPT,
+        GIT_CONFIG_NOSYSTEM: env.GIT_CONFIG_NOSYSTEM,
+      },
+      expected: { NODE_ENV: 'test', GIT_TERMINAL_PROMPT: '0', GIT_CONFIG_NOSYSTEM: '1' },
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -169,12 +169,14 @@ describe('runGitInSandbox', () => {
     expect(runCommandCalls[0].env).toMatchObject({ GIT_CONFIG_NOSYSTEM: '1' });
   });
 
-  it('always injects GH_CONFIG_DIR pointed at the persistent sandbox disk (not /tmp)', async () => {
+  it('always injects GH_CONFIG_DIR pointed at the persistent disk, not /tmp', async () => {
     const { deps, runCommandCalls } = makeDepsWithSpy();
     await runGitInSandbox({ cmd: 'gh', args: ['auth', 'status'], ctx: makeCtx(), deps });
     expect(runCommandCalls[0].env).toMatchObject({ GH_CONFIG_DIR });
-    expect(runCommandCalls[0].env?.GH_CONFIG_DIR).toMatch(new RegExp(`^${SANDBOX_ROOT}/`));
     expect(runCommandCalls[0].env?.GH_CONFIG_DIR).not.toContain('/tmp');
+    // Must NOT live under the workspace root — git_clone/git_init default their
+    // destination there, and a non-empty /workspace breaks a no-path clone.
+    expect(runCommandCalls[0].env?.GH_CONFIG_DIR?.startsWith(`${SANDBOX_ROOT}/`)).toBe(false);
   });
 
   it('returns success result with stdout, stderr, exitCode, truncated', async () => {
@@ -260,12 +262,12 @@ describe('runGitInSandbox — injection seam (screenOutput, fail-open)', () => {
 describe('buildGitToolEnv (pure)', () => {
   const base = { NODE_ENV: 'test' };
 
-  it('given the tool env, should point GH_CONFIG_DIR under the persistent SANDBOX_ROOT', () => {
+  it('given the tool env, should root GH_CONFIG_DIR at an absolute persistent path (not /tmp)', () => {
     const env = buildGitToolEnv({ baseEnv: base, token: 'ghp_x' });
     assert({
       given: 'a git/gh tool env',
-      should: 'root GH_CONFIG_DIR at the persistent sandbox disk',
-      actual: env.GH_CONFIG_DIR.startsWith(`${SANDBOX_ROOT}/`),
+      should: 'root GH_CONFIG_DIR at an absolute, non-ephemeral disk path',
+      actual: env.GH_CONFIG_DIR.startsWith('/') && !env.GH_CONFIG_DIR.includes('/tmp'),
       expected: true,
     });
   });
@@ -283,11 +285,19 @@ describe('buildGitToolEnv (pure)', () => {
     });
   });
 
-  it('given the GH_CONFIG_DIR path, should sit outside the repo working dir', () => {
+  it('given the GH_CONFIG_DIR path, should sit entirely outside the workspace root', () => {
+    // git_clone / git_init default their destination to SANDBOX_ROOT itself, so
+    // ANY path under /workspace (not just /workspace/repo) would collide: a
+    // non-empty /workspace breaks a no-path clone. The config dir must be fully
+    // outside the workspace root. (Widen to string — the literal constants are
+    // provably disjoint, which would otherwise trip TS's unintentional-compare
+    // check.)
+    const dir: string = GH_CONFIG_DIR;
+    const root: string = SANDBOX_ROOT;
     assert({
       given: 'the persistent gh config dir',
-      should: 'not live under the agent repo dir where git operations run',
-      actual: GH_CONFIG_DIR.startsWith(`${SANDBOX_ROOT}/repo`),
+      should: 'be neither the workspace root nor nested under it',
+      actual: dir === root || dir.startsWith(`${root}/`),
       expected: false,
     });
   });

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -16,15 +16,23 @@ const GITHUB_CREDENTIAL_HELPER =
 /**
  * Where `gh` keeps its durable config (hosts.yml, prefs, cached auth state).
  *
- * MUST live on the persistent sandbox disk under SANDBOX_ROOT — NOT `/tmp`,
- * which the Sprites platform wipes on ANY pause
- * (https://docs.sprites.dev/concepts/lifecycle/ — "Lost on any pause: /tmp
- * scratch files"). Durable state belongs on the persistent disk
- * (https://docs.sprites.dev/working-with-sprites/). Deliberately kept at the
- * sandbox root, outside `${SANDBOX_ROOT}/repo` and agent project dirs where
- * git/gh operations run, so it can never collide with a checked-out repo.
+ * MUST live on the persistent disk — NOT `/tmp`, which the Sprites platform
+ * wipes on ANY pause (https://docs.sprites.dev/concepts/lifecycle/ — "disk
+ * persists, memory does not"; `/tmp` is scratch). The ENTIRE Sprite filesystem
+ * is durable, so any non-`/tmp` path survives pause/wake.
+ *
+ * It must ALSO sit OUTSIDE the sandbox workspace root (SANDBOX_ROOT =
+ * `/workspace`). The agent git tools default `git_clone` / `git_init` to
+ * SANDBOX_ROOT itself when no `path` is given
+ * (apps/web/src/lib/ai/tools/sandbox-git-tools.ts) — so a config dir anywhere
+ * under `/workspace` would make the root non-empty and break a no-path clone
+ * (git refuses a non-empty destination) or get swept into a `git init` +
+ * `git add .`. We therefore anchor it in the Sprite user's persistent home
+ * (`/home/sprite`, per https://docs.sprites.dev/working-with-sprites/), which
+ * is durable, writable by the running `sprite` user, gh auto-creates it on
+ * first write, and it is never a git destination.
  */
-export const GH_CONFIG_DIR = `${SANDBOX_ROOT}/.gh-config`;
+export const GH_CONFIG_DIR = '/home/sprite/.gh-config';
 
 /**
  * Pure builder for the environment passed to a single in-sprite git/gh

--- a/packages/lib/src/services/sandbox/git-tool-runners.ts
+++ b/packages/lib/src/services/sandbox/git-tool-runners.ts
@@ -14,6 +14,57 @@ const GITHUB_CREDENTIAL_HELPER =
   '!f() { test "$1" = get || exit 0; echo username=x-access-token; echo password=$GITHUB_TOKEN; }; f';
 
 /**
+ * Where `gh` keeps its durable config (hosts.yml, prefs, cached auth state).
+ *
+ * MUST live on the persistent sandbox disk under SANDBOX_ROOT — NOT `/tmp`,
+ * which the Sprites platform wipes on ANY pause
+ * (https://docs.sprites.dev/concepts/lifecycle/ — "Lost on any pause: /tmp
+ * scratch files"). Durable state belongs on the persistent disk
+ * (https://docs.sprites.dev/working-with-sprites/). Deliberately kept at the
+ * sandbox root, outside `${SANDBOX_ROOT}/repo` and agent project dirs where
+ * git/gh operations run, so it can never collide with a checked-out repo.
+ */
+export const GH_CONFIG_DIR = `${SANDBOX_ROOT}/.gh-config`;
+
+/**
+ * Pure builder for the environment passed to a single in-sprite git/gh
+ * invocation.
+ *
+ * Given the base sandbox env and (optionally) a resolved GitHub token, returns
+ * the full env map. Invariants:
+ * - GH_CONFIG_DIR is rooted on the persistent disk so gh config survives
+ *   pause/wake; no value references `/tmp`.
+ * - GIT_TERMINAL_PROMPT/GIT_CONFIG_NOSYSTEM are always set.
+ * - Token vars (GH_TOKEN, GITHUB_TOKEN) and the one-shot credential-helper git
+ *   config are added ONLY when a token is present. The token is injected per
+ *   command (never persisted to the config dir), which keeps auth pause-proof
+ *   by construction.
+ */
+export function buildGitToolEnv({
+  baseEnv,
+  token,
+}: {
+  baseEnv: Record<string, string>;
+  token: string | null;
+}): Record<string, string> {
+  return {
+    ...baseEnv,
+    GIT_TERMINAL_PROMPT: '0',
+    GIT_CONFIG_NOSYSTEM: '1',
+    GH_CONFIG_DIR,
+    ...(token
+      ? {
+          GH_TOKEN: token,
+          GITHUB_TOKEN: token,
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'credential.helper',
+          GIT_CONFIG_VALUE_0: GITHUB_CREDENTIAL_HELPER,
+        }
+      : {}),
+  };
+}
+
+/**
  * Runs a git or gh command inside a sandbox.
  *
  * Security invariants:
@@ -24,7 +75,8 @@ const GITHUB_CREDENTIAL_HELPER =
  * - Git receives the token through a one-shot credential helper configured via
  *   env-only git config, so HTTPS remotes work without putting the token in argv.
  * - GIT_CONFIG_NOSYSTEM prevents system gitconfig credential caching.
- * - GH_CONFIG_DIR isolates gh config from the persistent sandbox home dir.
+ * - GH_CONFIG_DIR points at the persistent sandbox disk (not /tmp, which is
+ *   wiped on any pause) so gh config survives pause/wake — see GH_CONFIG_DIR.
  * - GIT_TERMINAL_PROMPT=0 prevents git from blocking on a credential prompt.
  */
 export async function runGitInSandbox({
@@ -104,21 +156,7 @@ export async function runGitInSandbox({
         cmd,
         args,
         cwd: resolvedCwd,
-        env: {
-          ...deps.buildEnv(),
-          GIT_TERMINAL_PROMPT: '0',
-          GIT_CONFIG_NOSYSTEM: '1',
-          GH_CONFIG_DIR: '/tmp/gh-config',
-          ...(token
-            ? {
-                GH_TOKEN: token,
-                GITHUB_TOKEN: token,
-                GIT_CONFIG_COUNT: '1',
-                GIT_CONFIG_KEY_0: 'credential.helper',
-                GIT_CONFIG_VALUE_0: GITHUB_CREDENTIAL_HELPER,
-              }
-            : {}),
-        },
+        env: buildGitToolEnv({ baseEnv: deps.buildEnv(), token }),
         timeoutMs: SANDBOX_TIMEOUT_MS,
         maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
       });


### PR DESCRIPTION
## Why

Every in-sprite `git`/`gh` invocation set `GH_CONFIG_DIR=/tmp/gh-config`. Per the [Sprites lifecycle docs](https://docs.sprites.dev/concepts/lifecycle/), `/tmp` is scratch — wiped on any pause; the rest of the filesystem is durable ("disk persists, memory does not"). It works today only because the GitHub token is re-injected per command; the moment anything expects gh state (hosts config, prefs, cached auth) to persist, it silently won't. Durable state belongs on the persistent disk.

## What changed

- `GH_CONFIG_DIR` now points at `/home/sprite/.gh-config` — the Sprite user's **persistent home**, fully **outside** the workspace root. It's durable across pause/wake, writable by the running `sprite` user, auto-created by gh on first write, and never a git destination.
- Extracted the tool-runner env construction into a **pure builder** `buildGitToolEnv({baseEnv, token}) -> Record<string,string>`, unit-tested without mocks.
- Token injection strategy is unchanged (per-command env, pause-proof by construction) — out of scope per the leaf.

### Why not `${SANDBOX_ROOT}/.gh-config`?
The leaf spec originally suggested a path under `/workspace`, but Codex review ([P2](https://github.com/2witstudios/PageSpace/pull/1997#discussion_r3563285646)) correctly flagged that the agent git tools default `git_clone`/`git_init` destinations to `SANDBOX_ROOT` **itself** when no `path` is given (`resolveDestinationPath(undefined) → SANDBOX_ROOT`). A config dir anywhere under `/workspace` makes the root non-empty and breaks a no-path `git clone <url> /workspace` (git refuses a non-empty destination), and a no-path `git init` + `git add .` would sweep `.gh-config` into the repo. The fix moves config out of the workspace entirely.

## Requirements satisfied

- [x] **Given git/gh tool-runner env, should point GH_CONFIG_DIR at a persistent path (pure builder test).** New `buildGitToolEnv` exported from `git-tool-runners.ts`; `GH_CONFIG_DIR = '/home/sprite/.gh-config'`. Pure tests assert it's absolute, non-`/tmp`, and fully outside `${SANDBOX_ROOT}/`, and that **no env value references `/tmp`** (with and without a token).
- [x] **Given a pause/wake cycle, should retain gh config.** No live-sprite integration harness exists in-repo, so this is covered structurally (config on the durable filesystem, outside `/tmp`) plus the manual verification below.
- [x] **Given the /tmp sweep, should relocate every in-sprite /tmp write.** Swept `packages/lib/src/services/sandbox`, `.../services/machines`, `apps/realtime/src/terminal`. The **only** real in-sprite `/tmp` write was this `GH_CONFIG_DIR`. Remaining `/tmp` hits are non-writes: `machine-git-blob.ts` comments describing a `git show --output=/tmp/x` rejection case, and test fixtures — both excluded per spec.

## Manual verification (pause/wake persistence)

Against a live Sprite (no automated harness in-repo):
1. `gh config set -h github.com git_protocol ssh` (writes `$GH_CONFIG_DIR/hosts.yml`).
2. Force the sprite idle → pause.
3. Wake via any exec, then `gh config get -h github.com git_protocol` → expect `ssh` (previously blank, because `/tmp` was wiped).
4. Additionally: `git clone https://github.com/owner/repo.git` (no path) still succeeds — `/workspace` is empty, gh config lives under `/home/sprite`.

## Test evidence

```
 ✓ src/services/sandbox/__tests__/git-tool-runners.test.ts (22 tests) 5ms
 Test Files  1 passed (1)
      Tests  22 passed (22)
```

`bun run typecheck` — `@pagespace/lib` clean (the only real errors surfaced during iteration were fixed; remaining full-run noise is stale `.next/types` worktree artifacts that CI regenerates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)