### PR TITLE
[sprites 6-5] Egress policy semantics: `defaults` is an allowlist, not a deny

### DIFF
--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -432,4 +432,17 @@ describe('sanitizeEgressAllowlist', () => {
       expected: ['*.githubusercontent.com', '*.pkg.dev', '*.npmjs.org'],
     });
   });
+
+  it('drops bare single-label TLD wildcards uniformly (no per-TLD asymmetry)', () => {
+    // `*.com`/`*.dev`/`*.io` have a single-label base, which HOSTNAME_RE rejects
+    // before the internal-zone check — so all are dropped as invalid, whether or
+    // not a Fly internal zone happens to sit under that TLD. Only a MULTI-label
+    // wildcard reaches the ancestor-overlap rule (see the ancestor test above).
+    assert({
+      given: 'bare single-label TLD wildcards, with and without an internal zone under them',
+      should: 'drop all of them uniformly (a multi-label base is required)',
+      actual: sanitizeEgressAllowlist(['*.dev', '*.io', '*.com']),
+      expected: [],
+    });
+  });
 });

--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -8,7 +8,6 @@ import {
 import type { PolicyRule } from '@fly/sprites';
 
 const hasInclude = (rules: PolicyRule[]): boolean => rules.some((r) => r.include !== undefined);
-const domains = (rules: PolicyRule[]): (string | undefined)[] => rules.map((r) => r.domain);
 
 describe('buildSpriteNetworkPolicy — allowlist mode', () => {
   it('empty allowlist is pure deny-all', () => {
@@ -399,12 +398,38 @@ describe('sanitizeEgressAllowlist', () => {
   });
 
   it('keeps public hosts that merely share a parent domain with an internal zone', () => {
-    // Only the exact internal zones are blocked; a sibling public host is fine.
+    // A non-wildcard sibling host only matches itself, so it cannot reach the
+    // internal zone and is fine.
     assert({
-      given: 'a public host that shares a parent domain but is not an internal zone',
+      given: 'a public non-wildcard host that shares a parent domain but is not an internal zone',
       should: 'keep it',
       actual: sanitizeEgressAllowlist(['other.tigrisfiles.io', 'notinternal.com']),
       expected: ['other.tigrisfiles.io', 'notinternal.com'],
+    });
+  });
+
+  it('drops ANCESTOR wildcards that would match into an internal zone', () => {
+    // A wildcard `*.base` matches subdomains of `base`; if an internal zone is a
+    // subdomain of `base`, the allow overlaps the internal surface (same
+    // wildcard tier as the deny, which the docs do not tie-break) and must go.
+    assert({
+      given: 'wildcard entries whose base is an ancestor of an internal zone',
+      should: 'drop every one so no allow can reach the internal object-storage surface',
+      actual: sanitizeEgressAllowlist([
+        '*.tigrisfiles.io', // ancestor of t3.tigrisfiles.io
+        '*.tigris.dev', // ancestor of fly.storage.tigris.dev
+        '*.storage.tigris.dev', // ancestor of fly.storage.tigris.dev
+      ]),
+      expected: [],
+    });
+  });
+
+  it('keeps legit subdomain wildcards that do not overlap any internal zone', () => {
+    assert({
+      given: 'subdomain wildcards for public hosts with no internal zone beneath them',
+      should: 'keep them',
+      actual: sanitizeEgressAllowlist(['*.githubusercontent.com', '*.pkg.dev', '*.npmjs.org']),
+      expected: ['*.githubusercontent.com', '*.pkg.dev', '*.npmjs.org'],
     });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -158,6 +158,38 @@ describe('buildSpriteNetworkPolicy — allowlist mode', () => {
       expected: buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org'] }),
     });
   });
+
+  it('never emits an allow rule for an internal-surface host (no specificity bypass)', () => {
+    // An exact/more-specific ALLOW would beat the wildcard internal deny under the
+    // documented precedence, so a caller-supplied internal host must be dropped.
+    const { rules } = buildSpriteNetworkPolicy({
+      egressAllowlist: [
+        'foo.internal',
+        'evil.flycast',
+        'sub.fly.storage.tigris.dev',
+        't3.tigrisfiles.io',
+        '*.internal',
+        'registry.npmjs.org',
+      ],
+    });
+    assert({
+      given: 'an allowlist mixing internal-surface hosts with a legit registry',
+      should: 'allow only the legit host and never allow any internal-surface host',
+      actual: rules.filter((r) => r.action === 'allow'),
+      expected: [{ domain: 'registry.npmjs.org', action: 'allow' }],
+    });
+  });
+
+  it('collapses to pure deny-all when the allowlist is only internal-surface hosts', () => {
+    assert({
+      given: 'an allowlist of only internal-surface hosts',
+      should: 'drop them all and collapse to pure deny-all',
+      actual: buildSpriteNetworkPolicy({
+        egressAllowlist: ['foo.internal', '_api.internal', '*.flycast', 'fly.storage.tigris.dev'],
+      }),
+      expected: { rules: [{ domain: '*', action: 'deny' }] },
+    });
+  });
 });
 
 describe('buildSpriteNetworkPolicy — open mode', () => {
@@ -342,6 +374,37 @@ describe('sanitizeEgressAllowlist', () => {
       should: 'dedupe after canonicalization',
       actual: sanitizeEgressAllowlist(['Example.com', 'example.com', '*.Example.com', '*.example.com']),
       expected: ['example.com', '*.example.com'],
+    });
+  });
+
+  it('drops entries that target the internal surface (exact, subdomain, or wildcard)', () => {
+    assert({
+      given: 'allowlist entries inside the internal-surface zones',
+      should: 'drop every one so no allow can beat the wildcard internal deny',
+      actual: sanitizeEgressAllowlist([
+        'foo.internal',
+        '_api.internal',
+        '*.internal',
+        'flycast',
+        'evil.flycast',
+        '*.flycast',
+        'fly.storage.tigris.dev',
+        'sub.fly.storage.tigris.dev',
+        '*.fly.storage.tigris.dev',
+        't3.tigrisfiles.io',
+        'x.t3.tigrisfiles.io',
+      ]),
+      expected: [],
+    });
+  });
+
+  it('keeps public hosts that merely share a parent domain with an internal zone', () => {
+    // Only the exact internal zones are blocked; a sibling public host is fine.
+    assert({
+      given: 'a public host that shares a parent domain but is not an internal zone',
+      should: 'keep it',
+      actual: sanitizeEgressAllowlist(['other.tigrisfiles.io', 'notinternal.com']),
+      expected: ['other.tigrisfiles.io', 'notinternal.com'],
     });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -1,191 +1,345 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it } from 'vitest';
+import { assert } from './riteway';
 import {
   buildSpriteNetworkPolicy,
   sanitizeEgressAllowlist,
   buildInternalSurfaceDenyRules,
 } from '../egress';
+import type { PolicyRule } from '@fly/sprites';
 
-describe('buildSpriteNetworkPolicy', () => {
-  it('given an empty allowlist, should be pure deny-all (default-deny egress)', () => {
-    expect(buildSpriteNetworkPolicy({ egressAllowlist: [] })).toEqual({
-      rules: [{ domain: '*', action: 'deny' }],
+const hasInclude = (rules: PolicyRule[]): boolean => rules.some((r) => r.include !== undefined);
+const domains = (rules: PolicyRule[]): (string | undefined)[] => rules.map((r) => r.domain);
+
+describe('buildSpriteNetworkPolicy — allowlist mode', () => {
+  it('empty allowlist is pure deny-all', () => {
+    assert({
+      given: 'an empty allowlist',
+      should: 'be a pure deny-all policy (default-deny egress)',
+      actual: buildSpriteNetworkPolicy({ egressAllowlist: [] }),
+      expected: { rules: [{ domain: '*', action: 'deny' }] },
     });
   });
 
-  it('given no input, should default to deny-all', () => {
-    expect(buildSpriteNetworkPolicy()).toEqual({ rules: [{ domain: '*', action: 'deny' }] });
+  it('no input defaults to deny-all', () => {
+    assert({
+      given: 'no input',
+      should: 'default to deny-all',
+      actual: buildSpriteNetworkPolicy(),
+      expected: { rules: [{ domain: '*', action: 'deny' }] },
+    });
   });
 
-  it('given registry hosts, should allow them and terminate with a deny-all catch-all', () => {
+  it('empty allowlist does not lean on the defaults preset', () => {
+    assert({
+      given: 'an empty allowlist',
+      should: 'not emit the include:defaults preset (pure deny-all, no preset semantics)',
+      actual: hasInclude(buildSpriteNetworkPolicy({ egressAllowlist: [] }).rules),
+      expected: false,
+    });
+  });
+
+  it('widened allowlist allows the hosts and terminates in deny-all', () => {
     const { rules } = buildSpriteNetworkPolicy({
       egressAllowlist: ['registry.npmjs.org', 'pypi.org'],
     });
-    expect(rules).toContainEqual({ domain: 'registry.npmjs.org', action: 'allow' });
-    expect(rules).toContainEqual({ domain: 'pypi.org', action: 'allow' });
-    // Catch-all deny must be the final rule.
-    expect(rules[rules.length - 1]).toEqual({ domain: '*', action: 'deny' });
-  });
-
-  it('given a widened allowlist, should include the SDK internal-blocking defaults BEFORE any allow', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['registry.npmjs.org'] });
-    const includeIdx = rules.findIndex((r) => r.include === 'defaults');
-    const allowIdx = rules.findIndex((r) => r.domain === 'registry.npmjs.org');
-    // The internal surface is denied via the maintained `defaults` preset, placed
-    // first so a later `*` allow could never reach it.
-    expect(includeIdx).toBe(0);
-    expect(includeIdx).toBeLessThan(allowIdx);
-    expect(rules[0]).toEqual({ include: 'defaults' });
-    // Still terminates in default-deny.
-    expect(rules[rules.length - 1]).toEqual({ domain: '*', action: 'deny' });
-  });
-
-  it('given an empty allowlist, should NOT include the defaults preset (pure deny-all, no preset semantics)', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: [] });
-    expect(rules.some((r) => r.include === 'defaults')).toBe(false);
-    expect(rules).toEqual([{ domain: '*', action: 'deny' }]);
-  });
-
-  it('given duplicate/empty hosts, should dedupe and drop blanks', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org', 'pypi.org', ''] });
-    const allows = rules.filter((r) => r.action === 'allow');
-    expect(allows).toEqual([{ domain: 'pypi.org', action: 'allow' }]);
-  });
-
-  it('given a wildcard "*" entry, should drop it so it cannot short-circuit the terminating deny', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['*', 'registry.npmjs.org'] });
-    expect(rules.some((r) => r.action === 'allow' && r.domain === '*')).toBe(false);
-    expect(rules).toContainEqual({ domain: 'registry.npmjs.org', action: 'allow' });
-    expect(rules[rules.length - 1]).toEqual({ domain: '*', action: 'deny' });
-  });
-
-  it('given an allowlist of only invalid entries, should collapse to pure deny-all', () => {
-    const { rules } = buildSpriteNetworkPolicy({
-      egressAllowlist: ['*', '10.0.0.1', '::1', 'https://evil.com', 'host:443', 'a/b'],
+    assert({
+      given: 'registry hosts',
+      should: 'emit an allow rule for each host',
+      actual: rules.filter((r) => r.action === 'allow'),
+      expected: [
+        { domain: 'registry.npmjs.org', action: 'allow' },
+        { domain: 'pypi.org', action: 'allow' },
+      ],
     });
-    expect(rules).toEqual([{ domain: '*', action: 'deny' }]);
+    assert({
+      given: 'registry hosts',
+      should: 'terminate with a deny-all catch-all as the final rule',
+      actual: rules[rules.length - 1],
+      expected: { domain: '*', action: 'deny' },
+    });
+  });
+
+  it('widened allowlist protects the internal surface via EXPLICIT denies, not include:defaults', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['registry.npmjs.org'] });
+    assert({
+      given: 'a widened allowlist',
+      should: 'never emit the include:defaults preset (it is an allowlist convenience, not a deny)',
+      actual: hasInclude(rules),
+      expected: false,
+    });
+    assert({
+      given: 'a widened allowlist',
+      should: 'emit the explicit internal-surface deny rules',
+      actual: buildInternalSurfaceDenyRules().every((deny) =>
+        rules.some((r) => r.domain === deny.domain && r.action === 'deny'),
+      ),
+      expected: true,
+    });
+  });
+
+  it('widened allowlist orders the internal denies BEFORE any allow', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['registry.npmjs.org'] });
+    const lastInternalDenyIdx = rules.reduce(
+      (acc, r, i) => (r.action === 'deny' && r.domain !== '*' ? i : acc),
+      -1,
+    );
+    const firstAllowIdx = rules.findIndex((r) => r.action === 'allow');
+    assert({
+      given: 'a widened allowlist',
+      should: 'place every explicit internal deny ahead of the first allow',
+      actual: lastInternalDenyIdx >= 0 && lastInternalDenyIdx < firstAllowIdx,
+      expected: true,
+    });
+  });
+
+  it('dedupes and drops blank hosts', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org', 'pypi.org', ''] });
+    assert({
+      given: 'duplicate and empty hosts',
+      should: 'dedupe and drop blanks',
+      actual: rules.filter((r) => r.action === 'allow'),
+      expected: [{ domain: 'pypi.org', action: 'allow' }],
+    });
+  });
+
+  it('drops a bare "*" so it cannot allow-all past the terminating deny', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['*', 'registry.npmjs.org'] });
+    assert({
+      given: 'a bare global-wildcard "*" allow entry',
+      should: 'drop it (the global wildcard would defeat deny-by-default)',
+      actual: rules.some((r) => r.action === 'allow' && r.domain === '*'),
+      expected: false,
+    });
+    assert({
+      given: 'a bare "*" alongside a real host',
+      should: 'still allow the real host and terminate in deny-all',
+      actual: {
+        allowsHost: rules.some((r) => r.domain === 'registry.npmjs.org' && r.action === 'allow'),
+        terminatingDeny: rules[rules.length - 1],
+      },
+      expected: {
+        allowsHost: true,
+        terminatingDeny: { domain: '*', action: 'deny' },
+      },
+    });
+  });
+
+  it('an allowlist of only invalid entries collapses to pure deny-all', () => {
+    assert({
+      given: 'an allowlist of only invalid entries',
+      should: 'collapse to pure deny-all',
+      actual: buildSpriteNetworkPolicy({
+        egressAllowlist: ['*', '10.0.0.1', '::1', 'https://evil.com', 'host:443', 'a/b'],
+      }),
+      expected: { rules: [{ domain: '*', action: 'deny' }] },
+    });
+  });
+
+  it('accepts and emits a subdomain-wildcard allow entry', () => {
+    const { rules } = buildSpriteNetworkPolicy({
+      egressAllowlist: ['*.githubusercontent.com', 'github.com'],
+    });
+    assert({
+      given: 'a subdomain-wildcard allow entry',
+      should: 'emit it verbatim as an allow rule (per the documented grammar)',
+      actual: rules.filter((r) => r.action === 'allow'),
+      expected: [
+        { domain: '*.githubusercontent.com', action: 'allow' },
+        { domain: 'github.com', action: 'allow' },
+      ],
+    });
+  });
+
+  it('explicit egressMode: allowlist behaves identically to the default path', () => {
+    assert({
+      given: 'egressMode: allowlist explicitly',
+      should: 'behave identically to the default (no-mode) path',
+      actual: buildSpriteNetworkPolicy({ egressMode: 'allowlist', egressAllowlist: ['pypi.org'] }),
+      expected: buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org'] }),
+    });
   });
 });
 
 describe('buildSpriteNetworkPolicy — open mode', () => {
-  it('given egressMode: open, should deny the explicit internal surface, then defaults, then allow-all (no terminating deny)', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
-    expect(rules).toEqual([
-      ...buildInternalSurfaceDenyRules(),
-      { include: 'defaults' },
-      { domain: '*', action: 'allow' },
-    ]);
+  it('emits internal denies then a single allow-all, with no defaults preset', () => {
+    assert({
+      given: 'egressMode: open',
+      should: 'be [explicit internal denies, allow-all] — no include:defaults, no terminating deny',
+      actual: buildSpriteNetworkPolicy({ egressMode: 'open' }),
+      expected: {
+        rules: [...buildInternalSurfaceDenyRules(), { domain: '*', action: 'allow' }],
+      },
+    });
   });
 
-  it('given egressMode: open, the explicit internal denies must come BEFORE the allow-all (first-match-wins)', () => {
+  it('does NOT duplicate include:defaults alongside the global allow-all', () => {
+    assert({
+      given: 'egressMode: open (which already emits a global {domain:"*",action:"allow"})',
+      should: 'not also emit the redundant include:defaults preset',
+      actual: hasInclude(buildSpriteNetworkPolicy({ egressMode: 'open' }).rules),
+      expected: false,
+    });
+  });
+
+  it('orders the explicit internal denies before the allow-all', () => {
     const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
     const allowAllIdx = rules.findIndex((r) => r.domain === '*' && r.action === 'allow');
     const lastInternalDenyIdx = rules.reduce(
       (acc, r, i) => (r.action === 'deny' && r.domain !== '*' ? i : acc),
       -1,
     );
-    expect(lastInternalDenyIdx).toBeGreaterThanOrEqual(0);
-    expect(lastInternalDenyIdx).toBeLessThan(allowAllIdx);
-  });
-
-  it('given egressMode: open, should NOT lean solely on the include:defaults preset — explicit _api.internal deny present', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
-    expect(rules.some((r) => r.domain === '_api.internal' && r.action === 'deny')).toBe(true);
-  });
-
-  it('given egressMode: open, should include an allow-all domain rule', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
-    expect(rules.some((r) => r.domain === '*' && r.action === 'allow')).toBe(true);
-  });
-
-  it('given egressMode: open, must NOT contain a terminating deny-all rule', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
-    expect(rules.some((r) => r.domain === '*' && r.action === 'deny')).toBe(false);
-  });
-
-  it('given egressMode: open with an egressAllowlist, should ignore the allowlist (allowlist is irrelevant in open mode)', () => {
-    const { rules } = buildSpriteNetworkPolicy({
-      egressMode: 'open',
-      egressAllowlist: ['registry.npmjs.org'],
+    assert({
+      given: 'egressMode: open',
+      should: 'place every explicit internal deny before the allow-all',
+      actual: lastInternalDenyIdx >= 0 && lastInternalDenyIdx < allowAllIdx,
+      expected: true,
     });
-    expect(rules).toEqual([
-      ...buildInternalSurfaceDenyRules(),
-      { include: 'defaults' },
-      { domain: '*', action: 'allow' },
-    ]);
   });
 
-  it('given egressMode: allowlist (explicit), should behave identically to the default (no-mode) path', () => {
-    const withMode = buildSpriteNetworkPolicy({ egressMode: 'allowlist', egressAllowlist: ['pypi.org'] });
-    const withoutMode = buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org'] });
-    expect(withMode).toEqual(withoutMode);
+  it('keeps an explicit _api.internal deny (does not lean on any preset)', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
+    assert({
+      given: 'egressMode: open',
+      should: 'keep an explicit _api.internal deny',
+      actual: rules.some((r) => r.domain === '_api.internal' && r.action === 'deny'),
+      expected: true,
+    });
   });
 
-  it('given egressMode: allowlist and empty allowlist, should be pure deny-all (no change from default)', () => {
-    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'allowlist', egressAllowlist: [] });
-    expect(rules).toEqual([{ domain: '*', action: 'deny' }]);
+  it('contains a global allow-all and no terminating deny-all', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressMode: 'open' });
+    assert({
+      given: 'egressMode: open',
+      should: 'include a global allow-all and NOT a terminating deny-all',
+      actual: {
+        allowAll: rules.some((r) => r.domain === '*' && r.action === 'allow'),
+        denyAll: rules.some((r) => r.domain === '*' && r.action === 'deny'),
+      },
+      expected: { allowAll: true, denyAll: false },
+    });
+  });
+
+  it('ignores any egressAllowlist in open mode', () => {
+    assert({
+      given: 'egressMode: open with an egressAllowlist',
+      should: 'ignore the allowlist entirely',
+      actual: buildSpriteNetworkPolicy({
+        egressMode: 'open',
+        egressAllowlist: ['registry.npmjs.org'],
+      }),
+      expected: {
+        rules: [...buildInternalSurfaceDenyRules(), { domain: '*', action: 'allow' }],
+      },
+    });
   });
 });
 
 describe('buildInternalSurfaceDenyRules', () => {
-  it('given no input, should emit explicit deny rules for the Fly internal surface', () => {
-    const rules = buildInternalSurfaceDenyRules();
-    const denied = rules.map((r) => r.domain);
-    expect(denied).toContain('_api.internal');
-    expect(denied).toContain('*.internal');
-    expect(denied).toContain('*.flycast');
-    // Tigris / object-storage surface.
-    expect(denied.some((d) => d?.includes('tigris'))).toBe(true);
-  });
-
-  it('should deny EXACT apex hostnames as well as wildcard children (apex must not fall through if wildcards do not match it)', () => {
+  it('emits deny rules for the Fly internal surface', () => {
     const denied = buildInternalSurfaceDenyRules().map((r) => r.domain);
-    // Exact apex hosts — a wildcard like `*.flycast` may not match `flycast` itself.
-    expect(denied).toContain('flycast');
-    expect(denied).toContain('fly.storage.tigris.dev');
-    expect(denied).toContain('t3.tigrisfiles.io');
+    assert({
+      given: 'no input',
+      should: 'deny the core internal-surface names',
+      actual: {
+        api: denied.includes('_api.internal'),
+        internal: denied.includes('*.internal'),
+        flycast: denied.includes('*.flycast'),
+        tigris: denied.some((d) => d?.includes('tigris')),
+      },
+      expected: { api: true, internal: true, flycast: true, tigris: true },
+    });
   });
 
-  it('every rule should be a deny (this builder never allows)', () => {
-    expect(buildInternalSurfaceDenyRules().every((r) => r.action === 'deny')).toBe(true);
+  it('denies exact apex hostnames as well as wildcard children', () => {
+    const denied = buildInternalSurfaceDenyRules().map((r) => r.domain);
+    assert({
+      given: 'apex hosts a subdomain wildcard would not match',
+      should: 'deny the exact apex hostnames too',
+      actual: {
+        flycast: denied.includes('flycast'),
+        tigrisApex: denied.includes('fly.storage.tigris.dev'),
+        tigrisFiles: denied.includes('t3.tigrisfiles.io'),
+      },
+      expected: { flycast: true, tigrisApex: true, tigrisFiles: true },
+    });
   });
 
-  it('does NOT depend on the SDK include:defaults preset (explicit denies, belt-and-suspenders)', () => {
-    expect(buildInternalSurfaceDenyRules().some((r) => 'include' in r)).toBe(false);
+  it('every emitted rule is a deny', () => {
+    assert({
+      given: 'the internal-surface deny builder',
+      should: 'only ever emit deny rules',
+      actual: buildInternalSurfaceDenyRules().every((r) => r.action === 'deny'),
+      expected: true,
+    });
   });
 
-  it('returns a fresh, clone-safe array each call (no shared mutation)', () => {
+  it('does not depend on the include:defaults preset', () => {
+    assert({
+      given: 'the internal-surface deny builder',
+      should: 'never emit an include rule (explicit denies only)',
+      actual: buildInternalSurfaceDenyRules().some((r) => r.include !== undefined),
+      expected: false,
+    });
+  });
+
+  it('returns a fresh, clone-safe array each call', () => {
     const a = buildInternalSurfaceDenyRules();
-    const b = buildInternalSurfaceDenyRules();
-    expect(a).not.toBe(b);
     a.push({ domain: 'evil.test', action: 'allow' });
-    expect(buildInternalSurfaceDenyRules().some((r) => r.domain === 'evil.test')).toBe(false);
+    assert({
+      given: 'a mutated returned array',
+      should: 'not affect a fresh build (no shared mutation)',
+      actual: buildInternalSurfaceDenyRules().some((r) => r.domain === 'evil.test'),
+      expected: false,
+    });
   });
 });
 
 describe('sanitizeEgressAllowlist', () => {
   it('keeps literal hostnames, trimmed and lowercased', () => {
-    expect(sanitizeEgressAllowlist([' Registry.NPMJS.org ', 'pypi.org'])).toEqual([
-      'registry.npmjs.org',
-      'pypi.org',
-    ]);
+    assert({
+      given: 'literal hostnames with surrounding space and mixed case',
+      should: 'keep them trimmed and lowercased',
+      actual: sanitizeEgressAllowlist([' Registry.NPMJS.org ', 'pypi.org']),
+      expected: ['registry.npmjs.org', 'pypi.org'],
+    });
   });
 
-  it('drops wildcards, IP literals, and non-host strings', () => {
-    expect(
-      sanitizeEgressAllowlist([
+  it('keeps subdomain-wildcard hostnames per the documented grammar', () => {
+    assert({
+      given: 'subdomain-wildcard hostnames',
+      should: 'keep them (trimmed, lowercased)',
+      actual: sanitizeEgressAllowlist([' *.GithubUserContent.com ', '*.pkg.dev']),
+      expected: ['*.githubusercontent.com', '*.pkg.dev'],
+    });
+  });
+
+  it('drops the bare global wildcard, IP literals, and non-host strings', () => {
+    assert({
+      given: 'a bare "*", IP literals, and non-host strings',
+      should: 'drop all of them',
+      actual: sanitizeEgressAllowlist([
         '*',
         '1.2.3.4',
         '2001:db8::1',
         'https://example.com',
         'example.com/path',
         'example.com:8080',
+        '*.',
+        '*.*',
+        '*.1.2.3.4',
         '',
         '   ',
       ]),
-    ).toEqual([]);
+      expected: [],
+    });
   });
 
   it('dedupes after canonicalization', () => {
-    expect(sanitizeEgressAllowlist(['Example.com', 'example.com'])).toEqual(['example.com']);
+    assert({
+      given: 'the same host in different case',
+      should: 'dedupe after canonicalization',
+      actual: sanitizeEgressAllowlist(['Example.com', 'example.com', '*.Example.com', '*.example.com']),
+      expected: ['example.com', '*.example.com'],
+    });
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -236,29 +236,31 @@ describe('buildSpriteNetworkPolicy — open mode', () => {
 
 describe('buildInternalSurfaceDenyRules', () => {
   it('emits deny rules for the Fly internal surface', () => {
-    const denied = buildInternalSurfaceDenyRules().map((r) => r.domain);
+    // Exact-membership set over our own built rules (not URL substring matching).
+    const denied = new Set(buildInternalSurfaceDenyRules().map((r) => r.domain));
     assert({
       given: 'no input',
       should: 'deny the core internal-surface names',
       actual: {
-        api: denied.includes('_api.internal'),
-        internal: denied.includes('*.internal'),
-        flycast: denied.includes('*.flycast'),
-        tigris: denied.some((d) => d?.includes('tigris')),
+        api: denied.has('_api.internal'),
+        internal: denied.has('*.internal'),
+        flycast: denied.has('*.flycast'),
+        tigris: denied.has('fly.storage.tigris.dev') && denied.has('t3.tigrisfiles.io'),
       },
       expected: { api: true, internal: true, flycast: true, tigris: true },
     });
   });
 
   it('denies exact apex hostnames as well as wildcard children', () => {
-    const denied = buildInternalSurfaceDenyRules().map((r) => r.domain);
+    // Exact-membership set over our own built rules (not URL substring matching).
+    const denied = new Set(buildInternalSurfaceDenyRules().map((r) => r.domain));
     assert({
       given: 'apex hosts a subdomain wildcard would not match',
       should: 'deny the exact apex hostnames too',
       actual: {
-        flycast: denied.includes('flycast'),
-        tigrisApex: denied.includes('fly.storage.tigris.dev'),
-        tigrisFiles: denied.includes('t3.tigrisfiles.io'),
+        flycast: denied.has('flycast'),
+        tigrisApex: denied.has('fly.storage.tigris.dev'),
+        tigrisFiles: denied.has('t3.tigrisfiles.io'),
       },
       expected: { flycast: true, tigrisApex: true, tigrisFiles: true },
     });

--- a/packages/lib/src/services/sandbox/egress.ts
+++ b/packages/lib/src/services/sandbox/egress.ts
@@ -82,17 +82,31 @@ const INTERNAL_SURFACE_DENY_DOMAINS: readonly string[] = Object.freeze([
 // The internal-surface DNS zones a caller must never be able to ALLOW. Derived
 // from the deny list (leading `*.` stripped, deduped) so the two stay in
 // lockstep — a future deny addition automatically extends this filter. Needed
-// because the internal denies are wildcards/apexes: a caller-supplied MORE
-// specific allow (e.g. `foo.internal` beats `*.internal`) would win under the
-// documented precedence ("an exact match beats a subdomain wildcard") and reopen
-// the surface. So `sanitizeEgressAllowlist` drops any entry inside these zones.
+// because the internal denies are wildcards/apexes: a caller-supplied allow that
+// overlaps one would win (or, wildcard-vs-wildcard, MIGHT win — the docs only
+// rank exact > subdomain wildcard > global, not two wildcards) and reopen the
+// surface. So `sanitizeEgressAllowlist` drops any entry that overlaps a zone.
 const INTERNAL_SURFACE_ZONES: readonly string[] = Object.freeze(
   Array.from(new Set(INTERNAL_SURFACE_DENY_DOMAINS.map((d) => d.replace(/^\*\./, '')))),
 );
 
-/** True when `host` is one of the internal zones or a subdomain of one. */
-function targetsInternalSurface(host: string): boolean {
-  return INTERNAL_SURFACE_ZONES.some((zone) => host === zone || host.endsWith(`.${zone}`));
+/**
+ * True when an allowlist entry would overlap the internal surface. `base` is the
+ * entry with any leading `*.` stripped; `isWildcard` says whether the original
+ * entry was a `*.`-subdomain wildcard. Two overlap directions:
+ *  - the entry IS an internal zone or a subdomain of one (e.g. `foo.internal`
+ *    beats `*.internal`; `*.internal` itself; `t3.tigrisfiles.io`); OR
+ *  - the entry is a WILDCARD whose base is an ANCESTOR of a zone (e.g.
+ *    `*.tigrisfiles.io` matches `<bucket>.t3.tigrisfiles.io`), so the allow could
+ *    reach into the internal surface.
+ * A non-wildcard entry only matches itself, so only the first direction applies.
+ */
+function targetsInternalSurface(base: string, isWildcard: boolean): boolean {
+  return INTERNAL_SURFACE_ZONES.some((zone) => {
+    if (base === zone || base.endsWith(`.${zone}`)) return true; // entry is/descends a zone
+    if (isWildcard && zone.endsWith(`.${base}`)) return true; // wildcard ancestor of a zone
+    return false;
+  });
 }
 
 /**
@@ -137,11 +151,12 @@ export function sanitizeEgressAllowlist(egressAllowlist: readonly string[] = [])
     if (entry.length === 0 || entry === '*') continue;
     // The label validated is the entry itself, or — for a subdomain wildcard —
     // the base host after the `*.` prefix.
-    const base = entry.startsWith(WILDCARD_PREFIX) ? entry.slice(WILDCARD_PREFIX.length) : entry;
+    const isWildcard = entry.startsWith(WILDCARD_PREFIX);
+    const base = isWildcard ? entry.slice(WILDCARD_PREFIX.length) : entry;
     if (base.length === 0) continue; // bare `*.`
     if (isIP(base) !== 0) continue; // reject IPv4/IPv6 literals (incl. `*.1.2.3.4`)
     if (!HOSTNAME_RE.test(base)) continue; // reject URLs, schemes, host:port, paths, `*.*`
-    if (targetsInternalSurface(base)) continue; // never allow the internal surface
+    if (targetsInternalSurface(base, isWildcard)) continue; // never allow the internal surface
     if (seen.has(entry)) continue;
     seen.add(entry);
     hosts.push(entry);
@@ -178,7 +193,9 @@ export function buildSpriteNetworkPolicy({
       // Internal surface denied via EXPLICIT deny rules — defense in depth on top
       // of allowlist sanitization and the platform's own IP/private-range blocks.
       // Not `{ include: 'defaults' }`: that preset only pre-allows common dev
-      // domains, it denies nothing.
+      // domains, it denies nothing. Allowlist mode is therefore a PURE explicit
+      // allowlist — dev registries (GitHub/npm/PyPI/…) are NOT auto-allowed here;
+      // a caller that wants them must list them (or use `egressMode: 'open'`).
       ...buildInternalSurfaceDenyRules(),
       ...hosts.map((domain): PolicyRule => ({ domain, action: 'allow' })),
       { ...DENY_ALL },

--- a/packages/lib/src/services/sandbox/egress.ts
+++ b/packages/lib/src/services/sandbox/egress.ts
@@ -79,6 +79,22 @@ const INTERNAL_SURFACE_DENY_DOMAINS: readonly string[] = Object.freeze([
   '*.t3.tigrisfiles.io', // Tigris public object-storage subdomains
 ]);
 
+// The internal-surface DNS zones a caller must never be able to ALLOW. Derived
+// from the deny list (leading `*.` stripped, deduped) so the two stay in
+// lockstep — a future deny addition automatically extends this filter. Needed
+// because the internal denies are wildcards/apexes: a caller-supplied MORE
+// specific allow (e.g. `foo.internal` beats `*.internal`) would win under the
+// documented precedence ("an exact match beats a subdomain wildcard") and reopen
+// the surface. So `sanitizeEgressAllowlist` drops any entry inside these zones.
+const INTERNAL_SURFACE_ZONES: readonly string[] = Object.freeze(
+  Array.from(new Set(INTERNAL_SURFACE_DENY_DOMAINS.map((d) => d.replace(/^\*\./, '')))),
+);
+
+/** True when `host` is one of the internal zones or a subdomain of one. */
+function targetsInternalSurface(host: string): boolean {
+  return INTERNAL_SURFACE_ZONES.some((zone) => host === zone || host.endsWith(`.${zone}`));
+}
+
 /**
  * Explicit deny rules for the Fly internal surface. Returns a FRESH array of
  * fresh rule objects on every call (clone-safe — a caller cannot mutate a shared
@@ -109,7 +125,9 @@ const WILDCARD_PREFIX = '*.';
  * literal (Sprites `domain` rules are DNS-pattern only — IPs are not matched, so
  * an IP "allow" is a silent no-op that misleads; the platform blocks raw IPs on
  * its own), or any non-host string (URL, scheme, path, `host:port`) is dropped
- * rather than passed through.
+ * rather than passed through. Entries inside the internal-surface zones are also
+ * dropped so a caller can never emit an allow that beats the wildcard internal
+ * deny under the documented precedence.
  */
 export function sanitizeEgressAllowlist(egressAllowlist: readonly string[] = []): string[] {
   const seen = new Set<string>();
@@ -123,6 +141,7 @@ export function sanitizeEgressAllowlist(egressAllowlist: readonly string[] = [])
     if (base.length === 0) continue; // bare `*.`
     if (isIP(base) !== 0) continue; // reject IPv4/IPv6 literals (incl. `*.1.2.3.4`)
     if (!HOSTNAME_RE.test(base)) continue; // reject URLs, schemes, host:port, paths, `*.*`
+    if (targetsInternalSurface(base)) continue; // never allow the internal surface
     if (seen.has(entry)) continue;
     seen.add(entry);
     hosts.push(entry);

--- a/packages/lib/src/services/sandbox/egress.ts
+++ b/packages/lib/src/services/sandbox/egress.ts
@@ -100,6 +100,14 @@ const INTERNAL_SURFACE_ZONES: readonly string[] = Object.freeze(
  *    `*.tigrisfiles.io` matches `<bucket>.t3.tigrisfiles.io`), so the allow could
  *    reach into the internal surface.
  * A non-wildcard entry only matches itself, so only the first direction applies.
+ *
+ * Fail-closed by design. A bare single-label TLD wildcard (`*.dev`, `*.com`,
+ * `*.io`) never even reaches this check — HOSTNAME_RE requires a multi-label
+ * base, so those are dropped as invalid, uniformly (no per-TLD asymmetry). What
+ * this ancestor rule adds is dropping a MULTI-label wildcard that reaches an
+ * internal zone (e.g. `*.tigris.dev` matches `fly.storage.tigris.dev`). The
+ * builder stays pure, so a dropped entry is not logged here; surfacing drops to
+ * an operator is a shell-side concern for whenever a caller populates the list.
  */
 function targetsInternalSurface(base: string, isWildcard: boolean): boolean {
   return INTERNAL_SURFACE_ZONES.some((zone) => {

--- a/packages/lib/src/services/sandbox/egress.ts
+++ b/packages/lib/src/services/sandbox/egress.ts
@@ -2,39 +2,50 @@
  * Sprite egress network policy construction (pure).
  *
  * Maps a policy's `egressAllowlist` (or `egressMode: 'open'`) to a Fly Sprites
- * L3 `NetworkPolicy` — an ordered, domain-matched rule list applied to the Sprite
- * via the authenticated policy API.
+ * L3 `NetworkPolicy` — a domain-matched rule list applied to the Sprite via the
+ * authenticated policy API. The platform resolves rule precedence by
+ * SPECIFICITY, not array order: per docs.sprites.dev/concepts/networking,
+ * "More specific rules win: an exact match beats a subdomain wildcard, which
+ * beats the global wildcard." We still emit rules in a readable order (denies
+ * ahead of the broad allow), but correctness rests on specificity, not position.
  *
  * Two modes:
- *  - `'allowlist'` (default): deny-by-default. The policy ends in a terminating
- *    `{ domain: '*', action: 'deny' }` catch-all. v1 ships an empty allowlist,
- *    so the policy is pure deny-all — no outbound at all.
- *  - `'open'`: allow all public internet. Returns `[INCLUDE_DEFAULTS, allow-*]`.
- *    Used exclusively by the human terminal (admin-gated, isolated Sprite) where
- *    the tight allowlist would block coding CLIs that need their provider hosts.
+ *  - `'allowlist'` (default): deny-by-default. The policy ends in a global
+ *    `{ domain: '*', action: 'deny' }` catch-all; each allowed host is a more
+ *    specific rule that beats it. v1 ships an empty allowlist, so the policy is a
+ *    pure deny-all — no outbound at all.
+ *  - `'open'`: allow all public internet via a global `{ domain: '*', action:
+ *    'allow' }`. Used exclusively by the human terminal (admin-gated, isolated
+ *    Sprite) where the tight allowlist would block coding CLIs that need their
+ *    provider hosts.
  *
  * Allowlist entries are sanitized first (`sanitizeEgressAllowlist`): trimmed,
- * lowercased, and restricted to literal DNS hostnames. A wildcard `'*'`, an IP
- * literal, or any non-host string (URL, scheme, `host:port`, path) is DROPPED —
- * `'*'` would otherwise emit an allow-all rule that short-circuits the
- * terminating deny under first-match-wins ordering, and an IP "allow" is a
- * silent no-op (Sprites `domain` rules match DNS patterns, never IP literals).
+ * lowercased, and restricted to literal DNS hostnames and `*.`-prefixed
+ * subdomain wildcards. A bare wildcard `'*'`, an IP literal, or any non-host
+ * string (URL, scheme, `host:port`, path) is DROPPED — a bare `'*'` allow is the
+ * global wildcard and would allow everything past the terminating deny, and an
+ * IP "allow" is a silent no-op (Sprites `domain` rules match DNS patterns, never
+ * IP literals).
  *
- * Internal-target blocking is the SDK's `{ include: 'defaults' }` preset — the
- * only lever the Sprites policy API exposes for the internal surface (6PN
- * `*.internal`, the `_api.internal` metadata endpoint, Flycast, Tigris). We
- * prepend it BEFORE any allow whenever the allowlist is deliberately widened for
- * an external registry, so the internal surface is denied first regardless of
- * later rules. The empty-allowlist (v1) case stays a pure deny-all and does not
- * lean on the preset's semantics at all.
+ * Internal-surface protection is EXPLICIT deny rules
+ * (`buildInternalSurfaceDenyRules`) plus the platform's own guarantees — NOT the
+ * `{ include: 'defaults' }` preset, which the docs describe purely as an
+ * allowlist convenience: it "pulls
+ * in the common development domains, GitHub, npm, PyPI, Docker Hub, and the major
+ * AI APIs among them, so package installs and model calls work without listing
+ * every host yourself." `defaults` allows hosts; it denies nothing. Our internal
+ * denies are exact/subdomain-wildcard rules, so by the specificity precedence
+ * above they beat a global `{ domain: '*' }` allow regardless of position.
  *
- * KNOWN LIMITATION — domain rules cannot block IP-LITERAL egress: a policy keyed
- * on `domain` only matches name-resolved traffic, so a Sprite dialing a raw
- * `fdaa::…`/`169.254.169.254` address bypasses it. The IP-level 6PN (`fdaa::/8`)
- * / metadata isolation is therefore a DEPLOYMENT concern — a Sprite is meant to
- * sit on a separate `fdf::` prefix with no 6PN route and no `*.internal`
- * resolution. That empirical 6PN/metadata gate (G1) lives in the enablement
- * checklist, verified before exposure, NOT in this domain-rule builder.
+ * The platform also blocks IP-level egress on its own: "Private IPs are always
+ * blocked, so a Sprite can't reach into private network ranges," and "Raw IP
+ * connections are blocked unless the IP was resolved from an allowed domain. You
+ * can't route around the allowlist by dialing an address directly." A `domain`
+ * rule cannot match an IP literal, but it does not have to — the platform gate
+ * covers that surface. The dedicated 6PN/metadata containment topology (a Sprite
+ * on a separate `fdf::` prefix with no 6PN route and no `*.internal` resolution)
+ * is a DEPLOYMENT concern verified in the enablement checklist (G1) before
+ * exposure, NOT this domain-rule builder; see `containment.ts`.
  *
  * The allow map is built from a frozen, deduped copy of the input so a caller
  * cannot mutate the shared policy array through the returned object.
@@ -43,20 +54,20 @@
 import { isIP } from 'node:net';
 import type { NetworkPolicy, PolicyRule } from '@fly/sprites';
 
-// The SDK's curated internal-blocking preset (mutually exclusive with `domain`).
-// This is the maintained replacement for a hand-rolled `*.internal` / Tigris /
-// Flycast deny list — the SDK owns keeping it complete.
-const INCLUDE_DEFAULTS: PolicyRule = Object.freeze({ include: 'defaults' });
-
 const DENY_ALL: PolicyRule = Object.freeze({ domain: '*', action: 'deny' });
 
-// The Fly internal surface we deny EXPLICITLY rather than trusting the SDK's
-// `{ include: 'defaults' }` preset — no Sprites doc states that preset blocks the
-// internal surface (it is documented only as an *allowlist* of LLM-friendly
-// destinations), so under full egress we must not assume it does. These are
-// belt-and-suspenders DNS-layer denies; they cannot block IP-literal/6PN egress
-// (a domain rule only matches name-resolved traffic), which is why the real
-// boundary is verified containment (see `containment.ts`), not these rules.
+const ALLOW_ALL: PolicyRule = Object.freeze({ domain: '*', action: 'allow' });
+
+// The Fly internal surface we deny EXPLICITLY. These are defense-in-depth
+// DNS-layer denies: each is an exact host or a `*.`-subdomain wildcard, both of
+// which are more specific than a global `{ domain: '*' }` rule, so per the
+// documented precedence ("an exact match beats a subdomain wildcard, which beats
+// the global wildcard") they win over an open-mode allow-all. They are redundant
+// with the platform's own guarantees ("Private IPs are always blocked"; "Raw IP
+// connections are blocked unless the IP was resolved from an allowed domain") for
+// the IP surface, but a name-resolved dial of e.g. `_api.internal` is exactly
+// what these DNS-layer rules cover. They are NOT a substitute for verified
+// containment (see `containment.ts`) — that remains the real boundary.
 const INTERNAL_SURFACE_DENY_DOMAINS: readonly string[] = Object.freeze([
   '_api.internal', // Fly Machines API over 6PN
   '*.internal', // 6PN app/private-network names
@@ -69,11 +80,12 @@ const INTERNAL_SURFACE_DENY_DOMAINS: readonly string[] = Object.freeze([
 ]);
 
 /**
- * Explicit deny rules for the Fly internal surface, independent of the SDK
- * `{ include: 'defaults' }` preset. Returns a FRESH array of fresh rule objects on
- * every call (clone-safe — a caller cannot mutate a shared policy). Ordered so the
- * internal surface is denied first when composed ahead of any allow under
- * first-match-wins.
+ * Explicit deny rules for the Fly internal surface. Returns a FRESH array of
+ * fresh rule objects on every call (clone-safe — a caller cannot mutate a shared
+ * policy). Every entry is an exact host or `*.`-subdomain wildcard, so by the
+ * documented specificity precedence it beats a global `{ domain: '*' }` allow
+ * regardless of position; we still compose them ahead of any broad allow for
+ * readability.
  */
 export function buildInternalSurfaceDenyRules(): PolicyRule[] {
   return INTERNAL_SURFACE_DENY_DOMAINS.map((domain): PolicyRule => ({ domain, action: 'deny' }));
@@ -85,25 +97,35 @@ export function buildInternalSurfaceDenyRules(): PolicyRule[] {
 const HOSTNAME_RE =
   /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
+const WILDCARD_PREFIX = '*.';
+
 /**
- * Canonicalize and validate an egress allowlist into the literal hostnames safe
- * to emit as Sprites `domain` allow rules. Fail-closed: a wildcard `'*'` (which
- * would short-circuit the terminating deny under first-match-wins ordering), an
- * IP literal (Sprites `domain` rules are DNS-pattern only — IPs are not matched,
- * so an IP "allow" is a silent no-op that misleads), or any non-host string
- * (URL, scheme, path, `host:port`) is dropped rather than passed through.
+ * Canonicalize and validate an egress allowlist into the domain patterns safe to
+ * emit as Sprites `domain` allow rules: literal hostnames and `*.`-prefixed
+ * subdomain wildcards (e.g. `*.githubusercontent.com`), the two forms the
+ * documented grammar and precedence support ("an exact match beats a subdomain
+ * wildcard, which beats the global wildcard"). Fail-closed: a bare wildcard `'*'`
+ * (the global wildcard — an allow-all that would defeat deny-by-default), an IP
+ * literal (Sprites `domain` rules are DNS-pattern only — IPs are not matched, so
+ * an IP "allow" is a silent no-op that misleads; the platform blocks raw IPs on
+ * its own), or any non-host string (URL, scheme, path, `host:port`) is dropped
+ * rather than passed through.
  */
 export function sanitizeEgressAllowlist(egressAllowlist: readonly string[] = []): string[] {
   const seen = new Set<string>();
   const hosts: string[] = [];
   for (const raw of egressAllowlist) {
-    const host = raw.trim().toLowerCase();
-    if (host.length === 0 || host === '*') continue;
-    if (isIP(host) !== 0) continue; // reject IPv4/IPv6 literals
-    if (!HOSTNAME_RE.test(host)) continue; // reject URLs, schemes, host:port, paths
-    if (seen.has(host)) continue;
-    seen.add(host);
-    hosts.push(host);
+    const entry = raw.trim().toLowerCase();
+    if (entry.length === 0 || entry === '*') continue;
+    // The label validated is the entry itself, or — for a subdomain wildcard —
+    // the base host after the `*.` prefix.
+    const base = entry.startsWith(WILDCARD_PREFIX) ? entry.slice(WILDCARD_PREFIX.length) : entry;
+    if (base.length === 0) continue; // bare `*.`
+    if (isIP(base) !== 0) continue; // reject IPv4/IPv6 literals (incl. `*.1.2.3.4`)
+    if (!HOSTNAME_RE.test(base)) continue; // reject URLs, schemes, host:port, paths, `*.*`
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    hosts.push(entry);
   }
   return hosts;
 }
@@ -115,34 +137,30 @@ export function buildSpriteNetworkPolicy({
   egressAllowlist?: readonly string[];
   egressMode?: 'allowlist' | 'open';
 } = {}): NetworkPolicy {
-  // Open mode: allow all public internet, but deny the Fly internal surface FIRST
-  // under first-match-wins. We emit our OWN explicit internal denies
-  // (`buildInternalSurfaceDenyRules`) rather than trusting the SDK's
-  // `{ include: 'defaults' }` preset — no Sprites doc states that preset blocks the
-  // internal surface — then keep the preset too (belt-and-suspenders), then the
-  // catch-all allow. The allow-all is emitted directly — NOT routed through
-  // sanitizeEgressAllowlist, which intentionally strips '*'.
+  // Open mode: allow all public internet with a single global allow-all. The
+  // explicit internal denies are more specific than that global wildcard, so per
+  // the documented precedence they win and the internal surface stays blocked. We
+  // do NOT also emit `{ include: 'defaults' }` here: it only pre-allows common
+  // dev domains, all of which the allow-all already covers, so it would be pure
+  // redundancy.
   if (egressMode === 'open') {
     return {
-      rules: [
-        ...buildInternalSurfaceDenyRules(),
-        { ...INCLUDE_DEFAULTS },
-        { domain: '*', action: 'allow' },
-      ],
+      rules: [...buildInternalSurfaceDenyRules(), { ...ALLOW_ALL }],
     };
   }
 
   const hosts = sanitizeEgressAllowlist(egressAllowlist);
   if (hosts.length === 0) {
-    // Default-deny: no outbound at all. Pure deny-all — no preset semantics.
+    // Default-deny: no outbound at all. Pure deny-all.
     return { rules: [{ ...DENY_ALL }] };
   }
   return {
     rules: [
-      // Internal surface denied first, via the SDK preset — defence in depth on
-      // top of the allowlist sanitization, so a widened allowlist can never reach
-      // the internal surface regardless of later rules.
-      { ...INCLUDE_DEFAULTS },
+      // Internal surface denied via EXPLICIT deny rules — defense in depth on top
+      // of allowlist sanitization and the platform's own IP/private-range blocks.
+      // Not `{ include: 'defaults' }`: that preset only pre-allows common dev
+      // domains, it denies nothing.
+      ...buildInternalSurfaceDenyRules(),
       ...hosts.map((domain): PolicyRule => ({ domain, action: 'allow' })),
       { ...DENY_ALL },
     ],


### PR DESCRIPTION
## 🔒 SECURITY REVIEW REQUESTED — containment code

This leaf corrects egress-policy semantics in `packages/lib/src/services/sandbox/egress.ts`. It does **not** weaken effective isolation: the explicit internal-surface deny list is **kept**, and the correction removes only a *mistaken reliance* on `{include:'defaults'}` as a deny mechanism plus one redundant include. Please verify the specificity-precedence reasoning below.

## Why
`{"include":"defaults"}` was treated as internal-surface DENY protection. Per [docs.sprites.dev/concepts/networking](https://docs.sprites.dev/concepts/networking/) it is only an **allowlist convenience** — it *"pulls in the common development domains, GitHub, npm, PyPI, Docker Hub, and the major AI APIs"*. It allows hosts; it denies nothing. The docs also guarantee the platform blocks *"Private IPs … always"* and *"Raw IP connections … unless the IP was resolved from an allowed domain"*, and that precedence is by specificity: *"an exact match beats a subdomain wildcard, which beats the global wildcard."*

## Requirements → how satisfied

**1. Allowlist mode must not depend on `{include:'defaults'}` for deny semantics; explicit denies kept, present & correctly ordered.**
- Widened-allowlist path now emits `...buildInternalSurfaceDenyRules()` (explicit exact/`*.`-wildcard denies) instead of `{include:'defaults'}`, followed by the allowed hosts, then the terminating `{domain:'*',action:'deny'}`.
- Comments cite the platform guarantees and the specificity precedence (exact/subdomain denies beat the global-wildcard allow regardless of position).
- Tests: `widened allowlist protects the internal surface via EXPLICIT denies, not include:defaults`; `widened allowlist orders the internal denies BEFORE any allow`; `no include rule emitted`.

**2. Open mode must not duplicate `defaults` alongside a global `{domain:'*',action:'allow'}`.**
- Open mode is now exactly `[...buildInternalSurfaceDenyRules(), {domain:'*',action:'allow'}]` — the redundant `{include:'defaults'}` is gone (the allow-all already covers every dev domain it pre-allowed).
- Tests: `does NOT duplicate include:defaults alongside the global allow-all`; `emits internal denies then a single allow-all, with no defaults preset`.

**3. Subdomain-wildcard allow entry (e.g. `*.githubusercontent.com`) accepted & emitted per the documented grammar.**
- `sanitizeEgressAllowlist` now accepts `*.`-prefixed entries (validating the base host with the existing `HOSTNAME_RE` + `isIP` guards), still dropping bare `*`, IP literals, `*.`, `*.*`, `*.1.2.3.4`, URLs, `host:port`, and paths.
- Tests: `keeps subdomain-wildcard hostnames per the documented grammar`; `accepts and emits a subdomain-wildcard allow entry`; expanded drop/dedupe cases.

**4. Every comment describing `defaults`/the platform matches the docs verbatim; no comment claims `defaults` denies.**
- Header, `INCLUDE_DEFAULTS` removal, `INTERNAL_SURFACE_DENY_DOMAINS`, `buildInternalSurfaceDenyRules`, `sanitizeEgressAllowlist`, and both mode branches now quote the docs and attribute enforcement to specificity, not "first-match-wins." The unused `INCLUDE_DEFAULTS` constant was removed.

## Out of scope (per leaf)
- Removing the explicit deny list (needs live-sprite verification + separate security review). **Recorded as follow-up** — the live check was **not** run in this leaf.
- Containment / 6PN deployment topology (`containment.ts`, enablement checklist G1).

## Test evidence

`bun run test:unit` (egress + neighbours), `bun run typecheck`, `eslint` all green:

```
✓ src/services/sandbox/__tests__/egress.test.ts (26 tests) 7ms
✓ src/services/sandbox/__tests__/network-options.test.ts (6 tests) 1ms
 Test Files  2 passed (2)   Tests  32 passed (32)

# full sandbox suite
 Test Files  33 passed (33)   Tests  521 passed (521)

# typecheck
$ tsc --noEmit   → exit 0

# eslint egress.ts → 0 errors
```

TDD followed: rewrote colocated tests in riteway `assert({given,should,actual,expected})` style first (8 failed RED), then implemented (all GREEN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvzBweZKfBG3jQfZAiESAT

---

## Review-driven updates (post-open)

**Codex P2 — reject internal domains before emitting allow rules (`6202dae21`).**
Because allow entries now accept exact hosts and `*.`-subdomain wildcards, a caller widening the allowlist with an internal name (e.g. `foo.internal`, exact) would be *more specific* than the `*.internal` wildcard deny and win under the documented precedence, reopening the internal surface. `sanitizeEgressAllowlist` now drops any entry inside the internal-surface zones (derived from `INTERNAL_SURFACE_DENY_DOMAINS` with `*.` stripped + deduped, so filter and deny list stay in lockstep). Sibling public hosts (e.g. `other.tigrisfiles.io`) are still allowed. New tests cover exact/subdomain/wildcard internal entries and the full-collapse-to-deny-all case. **This strengthens isolation** relative to the original PR.

**CodeQL false positive — Set.has over array membership (`ddd4c6a9e`).**
`js/incomplete-url-substring-sanitization` flagged `denied.includes('t3.tigrisfiles.io')` in a test. It was `Array.prototype.includes` (exact membership over our own built rule domains), not URL substring matching. Rewrote the two assertions to use a `Set` with exact `.has()` checks — clearer, and clears the alert.

Updated test count: **30 egress tests green; full sandbox suite 525/525; typecheck + eslint clean.**

**High-effort review hardening — reject ancestor wildcards overlapping the internal surface (`8def12296`).**
A workflow-backed high-effort review flagged that accepting `*.`-subdomain wildcards opened a containment gap: `targetsInternalSurface` only dropped entries that ARE/DESCEND from an internal zone, so an *ancestor* wildcard like `*.tigrisfiles.io` survived and would match `<bucket>.t3.tigrisfiles.io` — same wildcard tier as the deny, which the docs don't tie-break. Now also rejects any wildcard whose base is an ancestor of an internal zone, while keeping legit public wildcards (`*.githubusercontent.com`, `*.pkg.dev`) and non-wildcard siblings. Also removed a dead test helper and documented that allowlist mode is a *pure* explicit allowlist (no implicit dev-registry auto-allow via `defaults` — deliberate). Tests: 32 egress green; full sandbox suite 527/527; typecheck + eslint clean.

**Second high-effort re-review + clarification (`47d03ab14`).**
Re-ran the workflow-backed high-effort review on the post-fix diff. Both correctness finders returned **zero** candidates — no bypass in the two-direction `targetsInternalSurface` logic. One consistency finding (broad TLD wildcards dropped asymmetrically) was investigated and found to rest on a false premise: bare single-label TLD wildcards (`*.com`, `*.dev`, `*.io`) are all dropped uniformly by `HOSTNAME_RE` (which requires a multi-label base) *before* the internal-zone check — there is no per-TLD asymmetry. Corrected the comment and added a test locking that behavior in.

### Final validation
- Local: **33 egress tests, 528/528 full sandbox suite, `tsc --noEmit` clean, eslint clean.**
- CI: **all checks green** (CodeQL, CodeQL Security Analysis, Security Test Suite, Static Security Analysis, Lint & TypeScript, Unit Tests, etc.).
- Mergeable: **CLEAN**, 0 commits behind `master`, zero conflicts.

### Reviewer notes
- 🔒 Security-sensitive containment code — the explicit internal-surface deny list is intentionally retained (out of scope to remove; needs live-sprite verification + separate security review).
- The one open review thread (Codex P2) was fixed during automated convergence and is **intentionally left open for your verification** rather than auto-resolved.
