### PR TITLE
feat(machine): Diff tab — bare MachineTree + 3-way scope toggle + per-file Monaco diffs

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -56,7 +56,12 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
         )}
         <span className="truncate font-mono text-xs">{file.path}</span>
         {file.previousPath && (
-          <span className="truncate font-mono text-xs text-muted-foreground">← {file.previousPath}</span>
+          // A COPY also carries a previousPath but is statused 'added' (see
+          // parseNameStatusZ), so name the relationship rather than showing a
+          // bare arrow that reads like a rename wearing the wrong badge.
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {file.status === 'renamed' ? 'renamed from' : 'copied from'} {file.previousPath}
+          </span>
         )}
         <span className={cn('ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium', STATUS_STYLES[file.status])}>
           {file.status}
@@ -68,15 +73,28 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
           {isLoading && <div className="px-3 py-4 text-xs text-muted-foreground">Loading diff…</div>}
           {error && <div className="px-3 py-4 text-xs text-destructive">Failed to load diff: {error.message}</div>}
           {!isLoading && !error && data && !data.notApplicable && (
-            <div className="h-[420px]">
-              <MonacoDiffEditor
-                // A missing side means the file doesn't exist there (added → no
-                // original, deleted → no modified); Monaco needs a string.
-                original={data.original ?? ''}
-                modified={data.modified ?? ''}
-                filename={file.path}
-              />
-            </div>
+            <>
+              {(data.original?.truncated || data.modified?.truncated) && (
+                // Diffing a CUT-OFF side against a whole one paints the file's
+                // entire tail as removed/added lines that never changed — so a
+                // truncated side has to be called out, never rendered as if it
+                // were the complete file.
+                <div className="border-b border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+                  This file is too large to load in full — it is cut off below, so changes near the end may be
+                  missing or shown incorrectly.
+                </div>
+              )}
+              <div className="h-[420px]">
+                <MonacoDiffEditor
+                  // A null side means the file doesn't exist there (added → no
+                  // original, deleted → no modified). Each side carries its own
+                  // content + truncated flag; Monaco needs the string.
+                  original={data.original?.content ?? ''}
+                  modified={data.modified?.content ?? ''}
+                  filename={file.path}
+                />
+              </div>
+            </>
           )}
         </div>
       )}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from 'react';
+import { useState, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -62,6 +62,9 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
     file,
     expanded,
   );
+  // Ties aria-expanded to the region it actually controls — without an id to
+  // point at, the button announces an expanded state referring to nothing.
+  const bodyId = useId();
 
   return (
     <div className="overflow-hidden rounded-md border border-border">
@@ -69,6 +72,7 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
         type="button"
         onClick={() => setExpanded((e) => !e)}
         aria-expanded={expanded}
+        aria-controls={bodyId}
         className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent/50"
       >
         {expanded ? (
@@ -91,7 +95,7 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
       </button>
 
       {expanded && (
-        <div className="border-t border-border">
+        <div id={bodyId} className="border-t border-border">
           <DiffBody path={file.path} data={data} error={error} isLoading={isLoading} />
         </div>
       )}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -54,7 +54,7 @@ interface DiffFileCardProps {
  */
 export default function DiffFileCard({ machineId, projectName, branchName, scope, file }: DiffFileCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const { data, error, isLoading } = useMachineDiffPair(
+  const { data, error } = useMachineDiffPair(
     machineId,
     projectName,
     branchName,
@@ -96,37 +96,38 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
 
       {expanded && (
         <div id={bodyId} className="border-t border-border">
-          <DiffBody path={file.path} data={data} error={error} isLoading={isLoading} />
+          <DiffBody path={file.path} data={data} error={error} />
         </div>
       )}
     </div>
   );
 }
 
-const NOTE_CLASS = 'px-3 py-4 text-xs text-muted-foreground';
+const NOTE_CLASS = 'px-3 py-4 text-xs';
 
 /** The expanded card's body — every state the pair can be in, and nothing silently blank. */
 function DiffBody({
   path,
   data,
   error,
-  isLoading,
 }: {
   path: string;
   data: MachineDiffPairResponse | undefined;
   error: Error | undefined;
-  isLoading: boolean;
 }) {
-  if (isLoading) return <div className={NOTE_CLASS}>Loading diff…</div>;
-  if (error) return <div className="px-3 py-4 text-xs text-destructive">Failed to load diff: {error.message}</div>;
-  if (!data) return <div className={NOTE_CLASS}>Loading diff…</div>;
+  const note = cn(NOTE_CLASS, 'text-muted-foreground');
+
+  if (error) return <div className={cn(NOTE_CLASS, 'text-destructive')}>Failed to load diff: {error.message}</div>;
+  // SWR only leaves `data` undefined while the request is in flight, so this IS
+  // the loading state — a separate isLoading branch said the same thing twice.
+  if (!data) return <div className={note}>Loading diff…</div>;
   if (data.notApplicable) {
     // Near-unreachable (the toggle doesn't offer a not-applicable scope), but an
     // expanded card with a blank body would be worse than saying so.
-    return <div className={NOTE_CLASS}>This scope doesn&apos;t apply on this branch.</div>;
+    return <div className={note}>This scope doesn&apos;t apply on this branch.</div>;
   }
   if (looksBinary(data.original) || looksBinary(data.modified)) {
-    return <div className={NOTE_CLASS}>Binary file — no text diff to show.</div>;
+    return <div className={note}>Binary file — no text diff to show.</div>;
   }
 
   const truncated = data.original?.truncated || data.modified?.truncated;

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -4,11 +4,23 @@ import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { useMachineDiffPair } from '@/hooks/useMachineDiff';
+import { useMachineDiffPair, type MachineDiffPairResponse } from '@/hooks/useMachineDiff';
 import type { MachineDiffFile, MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 
 // Monaco owns `window`/`document` at import time — never SSR it.
 const MonacoDiffEditor = dynamic(() => import('@/components/editors/MonacoDiffEditor'), { ssr: false });
+
+/**
+ * Git's own binary heuristic: a NUL byte inside the leading chunk. The backend
+ * UTF-8-decodes every side, so a changed `.png` would otherwise arrive as decoded
+ * mojibake and render as a side-by-side text diff of garbage. Bounded to the
+ * first 8000 chars (as git does) so this stays O(1)-ish on large files.
+ */
+const BINARY_SNIFF_CHARS = 8000;
+
+function looksBinary(side: { content: string } | null): boolean {
+  return side !== null && side.content.slice(0, BINARY_SNIFF_CHARS).includes('\u0000');
+}
 
 const STATUS_STYLES: Record<MachineDiffFile['status'], string> = {
   added: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
@@ -70,34 +82,61 @@ export default function DiffFileCard({ machineId, projectName, branchName, scope
 
       {expanded && (
         <div className="border-t border-border">
-          {isLoading && <div className="px-3 py-4 text-xs text-muted-foreground">Loading diff…</div>}
-          {error && <div className="px-3 py-4 text-xs text-destructive">Failed to load diff: {error.message}</div>}
-          {!isLoading && !error && data && !data.notApplicable && (
-            <>
-              {(data.original?.truncated || data.modified?.truncated) && (
-                // Diffing a CUT-OFF side against a whole one paints the file's
-                // entire tail as removed/added lines that never changed — so a
-                // truncated side has to be called out, never rendered as if it
-                // were the complete file.
-                <div className="border-b border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
-                  This file is too large to load in full — it is cut off below, so changes near the end may be
-                  missing or shown incorrectly.
-                </div>
-              )}
-              <div className="h-[420px]">
-                <MonacoDiffEditor
-                  // A null side means the file doesn't exist there (added → no
-                  // original, deleted → no modified). Each side carries its own
-                  // content + truncated flag; Monaco needs the string.
-                  original={data.original?.content ?? ''}
-                  modified={data.modified?.content ?? ''}
-                  filename={file.path}
-                />
-              </div>
-            </>
-          )}
+          <DiffBody path={file.path} data={data} error={error} isLoading={isLoading} />
         </div>
       )}
     </div>
+  );
+}
+
+const NOTE_CLASS = 'px-3 py-4 text-xs text-muted-foreground';
+
+/** The expanded card's body — every state the pair can be in, and nothing silently blank. */
+function DiffBody({
+  path,
+  data,
+  error,
+  isLoading,
+}: {
+  path: string;
+  data: MachineDiffPairResponse | undefined;
+  error: Error | undefined;
+  isLoading: boolean;
+}) {
+  if (isLoading) return <div className={NOTE_CLASS}>Loading diff…</div>;
+  if (error) return <div className="px-3 py-4 text-xs text-destructive">Failed to load diff: {error.message}</div>;
+  if (!data) return <div className={NOTE_CLASS}>Loading diff…</div>;
+  if (data.notApplicable) {
+    // Near-unreachable (the toggle doesn't offer a not-applicable scope), but an
+    // expanded card with a blank body would be worse than saying so.
+    return <div className={NOTE_CLASS}>This scope doesn&apos;t apply on this branch.</div>;
+  }
+  if (looksBinary(data.original) || looksBinary(data.modified)) {
+    return <div className={NOTE_CLASS}>Binary file — no text diff to show.</div>;
+  }
+
+  const truncated = data.original?.truncated || data.modified?.truncated;
+  return (
+    <>
+      {truncated && (
+        // Diffing a CUT-OFF side against a whole one paints the file's entire
+        // tail as removed/added lines that never changed — so a truncated side
+        // has to be called out, never rendered as if it were the complete file.
+        <div className="border-b border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
+          This file is too large to load in full — it is cut off below, so changes near the end may be missing or
+          shown incorrectly.
+        </div>
+      )}
+      <div className="h-[420px]">
+        <MonacoDiffEditor
+          // A null side means the file doesn't exist there (added → no original,
+          // deleted → no modified). Each side carries its own content +
+          // truncated flag; Monaco needs the string.
+          original={data.original?.content ?? ''}
+          modified={data.modified?.content ?? ''}
+          filename={path}
+        />
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from 'react';
+import dynamic from 'next/dynamic';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useMachineDiffPair } from '@/hooks/useMachineDiff';
+import type { MachineDiffFile, MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+
+// Monaco owns `window`/`document` at import time — never SSR it.
+const MonacoDiffEditor = dynamic(() => import('@/components/editors/MonacoDiffEditor'), { ssr: false });
+
+const STATUS_STYLES: Record<MachineDiffFile['status'], string> = {
+  added: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+  modified: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+  deleted: 'bg-red-500/10 text-red-600 dark:text-red-400',
+  renamed: 'bg-sky-500/10 text-sky-600 dark:text-sky-400',
+};
+
+interface DiffFileCardProps {
+  machineId: string;
+  projectName: string;
+  branchName: string;
+  scope: MachineDiffScope;
+  file: MachineDiffFile;
+}
+
+/**
+ * One changed file, collapsed to a header row until opened. Its diff pair is
+ * fetched ONLY while expanded (`useMachineDiffPair`'s `enabled`), so a scope
+ * with many changed files costs one list request, not N content requests.
+ */
+export default function DiffFileCard({ machineId, projectName, branchName, scope, file }: DiffFileCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const { data, error, isLoading } = useMachineDiffPair(
+    machineId,
+    projectName,
+    branchName,
+    scope,
+    file,
+    expanded,
+  );
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent/50"
+      >
+        {expanded ? (
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+        )}
+        <span className="truncate font-mono text-xs">{file.path}</span>
+        {file.previousPath && (
+          <span className="truncate font-mono text-xs text-muted-foreground">← {file.previousPath}</span>
+        )}
+        <span className={cn('ml-auto shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium', STATUS_STYLES[file.status])}>
+          {file.status}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="border-t border-border">
+          {isLoading && <div className="px-3 py-4 text-xs text-muted-foreground">Loading diff…</div>}
+          {error && <div className="px-3 py-4 text-xs text-destructive">Failed to load diff: {error.message}</div>}
+          {!isLoading && !error && data && !data.notApplicable && (
+            <div className="h-[420px]">
+              <MonacoDiffEditor
+                // A missing side means the file doesn't exist there (added → no
+                // original, deleted → no modified); Monaco needs a string.
+                original={data.original ?? ''}
+                modified={data.modified ?? ''}
+                filename={file.path}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -118,8 +118,9 @@ function DiffBody({
   const note = cn(NOTE_CLASS, 'text-muted-foreground');
 
   if (error) return <div className={cn(NOTE_CLASS, 'text-destructive')}>Failed to load diff: {error.message}</div>;
-  // SWR only leaves `data` undefined while the request is in flight, so this IS
-  // the loading state — a separate isLoading branch said the same thing twice.
+  // Error FIRST, then no-data-yet: SWR's isLoading is "in flight AND no data",
+  // regardless of a cached error, so checking it first would flicker
+  // Loading <-> Failed while an errored key auto-retries.
   if (!data) return <div className={note}>Loading diff…</div>;
   if (data.notApplicable) {
     // Near-unreachable (the toggle doesn't offer a not-applicable scope), but an

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffFileCard.tsx
@@ -18,6 +18,16 @@ const MonacoDiffEditor = dynamic(() => import('@/components/editors/MonacoDiffEd
  */
 const BINARY_SNIFF_CHARS = 8000;
 
+/**
+ * Monaco measures its container once at mount and installs no ResizeObserver, so
+ * without `automaticLayout` the diff keeps its original pixel width when the
+ * app's sidebar collapses or the window resizes — the modified pane gets clipped
+ * and the gutters misalign until the card is closed and reopened. `CodeViewer`
+ * sets this for the same reason. Module-level so the object identity is stable
+ * (a fresh literal each render would re-run the editor's options effect).
+ */
+const MONACO_OPTIONS = { automaticLayout: true } as const;
+
 function looksBinary(side: { content: string } | null): boolean {
   return side !== null && side.content.slice(0, BINARY_SNIFF_CHARS).includes('\u0000');
 }
@@ -135,6 +145,7 @@ function DiffBody({
           original={data.original?.content ?? ''}
           modified={data.modified?.content ?? ''}
           filename={path}
+          options={MONACO_OPTIONS}
         />
       </div>
     </>

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -51,29 +51,62 @@ const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse =
   };
 };
 
-vi.mock('@/hooks/useMachineDiff', () => ({
-  useMachineDiffFiles: (
-    _machineId: string,
-    projectName: string | null,
-    branchName: string | null,
-    scope: string | null,
-  ) => ({
-    data: projectName && branchName && scope ? filesFor(branchName, scope) : undefined,
-    error: undefined,
-    isLoading: false,
-    mutate: vi.fn(),
-  }),
-  useMachineDiffPair: () => ({
-    data: { notApplicable: false, scope: 'uncommitted', path: 'x', original: 'a', modified: 'b' },
-    error: undefined,
-    isLoading: false,
-  }),
-}));
+// The pair fixture MUST mirror the route's real wire shape — each side is
+// `{ content, truncated }`, NOT a bare string. An earlier version of this mock
+// asserted the string shape and so kept the suite green while the production
+// code handed Monaco an object; useMachineDiff.test.tsx now pins the real
+// contract against fetchWithAuth so this mock can't drift from it again.
+const pairFor = (enabled: boolean) => ({
+  data: enabled
+    ? {
+        notApplicable: false as const,
+        scope: 'uncommitted' as const,
+        path: 'src/uncommitted.ts',
+        original: { content: 'a', truncated: false },
+        modified: { content: 'b', truncated: truncatedPair },
+      }
+    : undefined,
+  error: undefined,
+  isLoading: false,
+});
+
+let truncatedPair = false;
+
+vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useMachineDiff')>();
+  return {
+    // Keep the real key predicate — the refresh path depends on it.
+    isMachineDiffKey: actual.isMachineDiffKey,
+    useMachineDiffFiles: (
+      _machineId: string,
+      projectName: string | null,
+      branchName: string | null,
+      scope: string | null,
+    ) => ({
+      data: projectName && branchName && scope ? filesFor(branchName, scope) : undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    }),
+    // Honors `enabled`, so a collapsed card genuinely fetches nothing.
+    useMachineDiffPair: (
+      _machineId: string,
+      _projectName: string | null,
+      _branchName: string | null,
+      _scope: string | null,
+      _file: unknown,
+      enabled: boolean,
+    ) => pairFor(enabled),
+  };
+});
 
 import DiffTab from './DiffTab';
 
 describe('DiffTab', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    truncatedPair = false;
+  });
 
   test('shows the empty placeholder until a branch is selected', () => {
     render(<DiffTab machineId="m1" />);
@@ -151,9 +184,24 @@ describe('DiffTab', () => {
     await waitFor(() => screen.getByTestId('monaco-diff'));
     assert({
       given: 'the changed file card clicked open',
-      should: 'mount MonacoDiffEditor with the fetched original/modified pair',
+      should: "mount MonacoDiffEditor with each side's CONTENT string, not the raw { content, truncated } side object",
       actual: screen.getByTestId('monaco-diff').textContent,
       expected: 'a→b',
+    });
+  });
+
+  test('a truncated side is called out instead of being rendered as the whole file', async () => {
+    truncatedPair = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));
+
+    await waitFor(() => screen.getByTestId('monaco-diff'));
+    assert({
+      given: 'a file whose content the sandbox cut at its output cap',
+      should: 'warn that the diff is cut off — silently diffing a truncated side paints the untouched tail as changed',
+      actual: screen.queryByText(/too large to load in full/i) !== null,
+      expected: true,
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -215,6 +215,29 @@ describe('DiffTab', () => {
     });
   });
 
+  test('clicking a scope switches the list to that scope', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await waitFor(() => screen.getByText('src/uncommitted.ts'));
+
+    await userEvent.click(screen.getByText('Committed'));
+
+    // `value` is fully controlled by `active`, so without this the toggle could
+    // render all three options while `setScope` did nothing and every other test
+    // still passed — the options are asserted everywhere, the SWITCH nowhere.
+    // The files mock names each file after its scope, so the list proves it.
+    await waitFor(() => screen.getByText('src/committed.ts'));
+    assert({
+      given: 'the Committed scope trigger clicked',
+      should: "re-fetch and render THAT scope's changed files, not the previous scope's",
+      actual: {
+        committed: screen.queryByText('src/committed.ts') !== null,
+        uncommittedGone: screen.queryByText('src/uncommitted.ts') === null,
+      },
+      expected: { committed: true, uncommittedGone: true },
+    });
+  });
+
   test('an ERRORED probe keeps the full toggle — a failed request is not a main-branch answer', async () => {
     probeErrors = true;
     render(<DiffTab machineId="m1" />);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -1,0 +1,159 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { assert } from '@/stores/__tests__/riteway';
+import type { MachineTreeNode } from '../workspace/MachineTree';
+import type { MachineDiffFilesResponse } from '@/hooks/useMachineDiff';
+import type { MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+
+// The tree is exercised by its own suite; here we only need a way to fire
+// onSelectNode with a branch node, so stub it to a pair of select buttons.
+vi.mock('../workspace/MachineTree', () => ({
+  default: ({ onSelectNode }: { onSelectNode?: (node: MachineTreeNode) => void }) => (
+    <div>
+      <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'feature' })}>
+        select-feature
+      </button>
+      <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'main' })}>
+        select-main
+      </button>
+      <button type="button" onClick={() => onSelectNode?.({ level: 'project', projectName: 'repo' })}>
+        select-project
+      </button>
+    </div>
+  ),
+}));
+
+// Monaco must never mount under jsdom; the card only needs to prove it renders.
+vi.mock('@/components/editors/MonacoDiffEditor', () => ({
+  default: ({ original, modified }: { original: string; modified: string }) => (
+    <div data-testid="monaco-diff">{`${original}→${modified}`}</div>
+  ),
+}));
+
+// The scope toggle's behaviour is driven entirely by what the files hook
+// returns for each (branch, scope) — so the mock keys off branchName + scope:
+// 'main' answers notApplicable for the non-uncommitted scopes (mirroring the
+// route), every other branch answers a real list.
+const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse => {
+  if (branchName === 'main' && scope !== 'uncommitted') {
+    return { notApplicable: true };
+  }
+  if (branchName === 'main') {
+    // Clean uncommitted tree on main — drives the explicit empty state.
+    return { notApplicable: false, scope: 'uncommitted', files: [], truncated: false };
+  }
+  return {
+    notApplicable: false,
+    scope: scope as MachineDiffScope,
+    files: [{ path: `src/${scope}.ts`, status: 'modified' }],
+    truncated: false,
+  };
+};
+
+vi.mock('@/hooks/useMachineDiff', () => ({
+  useMachineDiffFiles: (
+    _machineId: string,
+    projectName: string | null,
+    branchName: string | null,
+    scope: string | null,
+  ) => ({
+    data: projectName && branchName && scope ? filesFor(branchName, scope) : undefined,
+    error: undefined,
+    isLoading: false,
+    mutate: vi.fn(),
+  }),
+  useMachineDiffPair: () => ({
+    data: { notApplicable: false, scope: 'uncommitted', path: 'x', original: 'a', modified: 'b' },
+    error: undefined,
+    isLoading: false,
+  }),
+}));
+
+import DiffTab from './DiffTab';
+
+describe('DiffTab', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('shows the empty placeholder until a branch is selected', () => {
+    render(<DiffTab machineId="m1" />);
+    assert({
+      given: 'the Diff tab before any branch is picked',
+      should: 'prompt to select a branch and render no scope toggle',
+      actual: {
+        prompt: screen.queryByText('Select a branch to view its diff.') !== null,
+        toggle: screen.queryByText('Committed') !== null,
+      },
+      expected: { prompt: true, toggle: false },
+    });
+  });
+
+  test('a non-main branch shows all three scope options', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+
+    await waitFor(() => screen.getByText('Committed'));
+    assert({
+      given: 'a feature branch where committed/branch scopes are applicable',
+      should: 'render Uncommitted, Committed and Branch vs master in the toggle',
+      actual: {
+        uncommitted: screen.queryByText('Uncommitted') !== null,
+        committed: screen.queryByText('Committed') !== null,
+        branch: screen.queryByText('Branch vs master') !== null,
+      },
+      expected: { uncommitted: true, committed: true, branch: true },
+    });
+  });
+
+  test('the main branch collapses the toggle to Uncommitted alone (no disabled options)', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-main'));
+
+    await waitFor(() => screen.getByText('Uncommitted'));
+    assert({
+      given: 'the main branch, where the route returns notApplicable for committed/branch',
+      should: 'render ONLY the Uncommitted option — not all three with two disabled',
+      actual: {
+        uncommitted: screen.queryByText('Uncommitted') !== null,
+        committed: screen.queryByText('Committed') !== null,
+        branch: screen.queryByText('Branch vs master') !== null,
+      },
+      expected: { uncommitted: true, committed: false, branch: false },
+    });
+  });
+
+  test('a clean uncommitted tree on main shows the explicit empty state', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-main'));
+
+    await waitFor(() => screen.getByText('Uncommitted'));
+    assert({
+      given: 'main selected with no uncommitted changes',
+      should: 'name the branch in an explicit empty state, not a generic no-diff message',
+      actual: screen.queryByText('No uncommitted changes on main') !== null,
+      expected: true,
+    });
+  });
+
+  test('a changed file expands into a Monaco diff editor on click', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+
+    const fileRow = await waitFor(() => screen.getByText('src/uncommitted.ts'));
+    assert({
+      given: 'a feature branch with one changed file',
+      should: 'render the file collapsed (no editor) before it is clicked',
+      actual: screen.queryByTestId('monaco-diff') !== null,
+      expected: false,
+    });
+
+    await userEvent.click(fileRow);
+    await waitFor(() => screen.getByTestId('monaco-diff'));
+    assert({
+      given: 'the changed file card clicked open',
+      should: 'mount MonacoDiffEditor with the fetched original/modified pair',
+      actual: screen.getByTestId('monaco-diff').textContent,
+      expected: 'a→b',
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -60,7 +60,7 @@ vi.mock('@/components/editors/MonacoDiffEditor', () => ({
 }));
 
 // Per-test switches for the states the pane must not get wrong.
-let truncatedPair = false;
+let truncatedSide: 'original' | 'modified' | null = null;
 let binaryPair = false;
 let truncatedEmptyList = false;
 let probeErrors = false;
@@ -106,10 +106,14 @@ const pairFor = (enabled: boolean) => {
       notApplicable: false as const,
       scope: 'uncommitted' as const,
       path: 'src/uncommitted.ts',
+      // BOTH sides must be able to be the truncated one: a blob side is cut at
+      // 256 KB while a working-tree side gets 2 MB, so the ORIGINAL (a blob in
+      // every scope) is the likelier casualty — a sniff that only checked
+      // `modified` would miss it and paint the file's untouched tail as added.
       original: binaryPair
         ? { content: `PNG${NUL}${NUL}`, truncated: false }
-        : { content: 'a', truncated: false },
-      modified: binaryPair ? null : { content: 'b', truncated: truncatedPair },
+        : { content: 'a', truncated: truncatedSide === 'original' },
+      modified: binaryPair ? null : { content: 'b', truncated: truncatedSide === 'modified' },
     },
     error: undefined,
     isLoading: false,
@@ -196,7 +200,7 @@ const scopeOptions = () => ({
 describe('DiffTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    truncatedPair = false;
+    truncatedSide = null;
     binaryPair = false;
     truncatedEmptyList = false;
     probeErrors = false;
@@ -504,8 +508,28 @@ describe('DiffTab', () => {
     });
   });
 
-  test('a truncated side is called out instead of being rendered as the whole file', async () => {
-    truncatedPair = true;
+  test('a truncated ORIGINAL side is called out — the likelier cut, and the one that fakes added lines', async () => {
+    // The original is a git BLOB in every scope, capped at 256 KB, while a
+    // working-tree side gets 2 MB. So a 300 KB file's original is cut while its
+    // modified side is whole — and diffing them paints the file's entire untouched
+    // tail as ADDED lines. A sniff that only checked `modified` would miss exactly
+    // this, the most likely truncation in production.
+    truncatedSide = 'original';
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));
+
+    await waitFor(() => screen.getByTestId('monaco-diff'));
+    assert({
+      given: 'a file whose ORIGINAL side the sandbox cut at the 256 KB blob cap',
+      should: 'warn that the diff is cut off, rather than presenting the untouched tail as new lines',
+      actual: screen.queryByText(/too large to load in full/i) !== null,
+      expected: true,
+    });
+  });
+
+  test('a truncated MODIFIED side is called out instead of being rendered as the whole file', async () => {
+    truncatedSide = 'modified';
     render(<DiffTab machineId="m1" />);
     await userEvent.click(screen.getByText('select-feature'));
     await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -338,6 +338,35 @@ describe('DiffTab', () => {
     });
   });
 
+  test('a recovered probe drags the active scope back to Uncommitted', async () => {
+    // The one reachable path to a scope that is selected but not applicable:
+    // the probe fails transiently (so the full toggle shows), the user picks
+    // Committed, then the probe recovers and answers notApplicable — this IS the
+    // default branch. `active` must fall back to 'uncommitted' rather than leave a
+    // meaningless scope selected and render the not-applicable notice.
+    probeErrors = true;
+    const { rerender } = render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-main'));
+
+    await waitFor(() => screen.getByText('Committed'));
+    await userEvent.click(screen.getByText('Committed'));
+
+    probeErrors = false;
+    rerender(<DiffTab machineId="m1" />);
+
+    await waitFor(() => screen.getByText(/No uncommitted changes on main/i));
+    assert({
+      given: "a Committed scope selected while the probe was failing, then the probe recovering with notApplicable",
+      should: 'fall back to Uncommitted — not strand the user on a scope this branch does not have',
+      actual: {
+        fellBack: screen.queryByText(/No uncommitted changes on main/i) !== null,
+        strandedNotice: screen.queryByText(/doesn't apply on/i) !== null,
+        committedStillOffered: screen.queryByText('Committed') !== null,
+      },
+      expected: { fellBack: true, strandedNotice: false, committedStillOffered: false },
+    });
+  });
+
   test('a clean uncommitted tree on main shows the explicit empty state', async () => {
     render(<DiffTab machineId="m1" />);
     await userEvent.click(screen.getByText('select-main'));

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -41,6 +41,8 @@ let truncatedPair = false;
 let binaryPair = false;
 let truncatedEmptyList = false;
 let probeErrors = false;
+let listErrors = false;
+let pairErrors = false;
 
 // The scope toggle's behaviour is driven entirely by what the files hook returns
 // for each (branch, scope) — so the mock keys off branchName + scope: 'main'
@@ -73,21 +75,23 @@ const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse =
 //
 // The binary case deliberately nulls the MODIFIED side (a deleted binary): the
 // card must sniff EITHER side, so an `&&` across the two would leak mojibake here.
-const pairFor = (enabled: boolean) => ({
-  data: enabled
-    ? {
-        notApplicable: false as const,
-        scope: 'uncommitted' as const,
-        path: 'src/uncommitted.ts',
-        original: binaryPair
-          ? { content: `PNG${NUL}${NUL}`, truncated: false }
-          : { content: 'a', truncated: false },
-        modified: binaryPair ? null : { content: 'b', truncated: truncatedPair },
-      }
-    : undefined,
-  error: undefined,
-  isLoading: false,
-});
+const pairFor = (enabled: boolean) => {
+  if (!enabled) return { data: undefined, error: undefined, isLoading: false };
+  if (pairErrors) return { data: undefined, error: new Error('blob read failed'), isLoading: false };
+  return {
+    data: {
+      notApplicable: false as const,
+      scope: 'uncommitted' as const,
+      path: 'src/uncommitted.ts',
+      original: binaryPair
+        ? { content: `PNG${NUL}${NUL}`, truncated: false }
+        : { content: 'a', truncated: false },
+      modified: binaryPair ? null : { content: 'b', truncated: truncatedPair },
+    },
+    error: undefined,
+    isLoading: false,
+  };
+};
 
 // Spy at the CALL SITE: proves DiffFileCard threads `expanded` into the hook's
 // `enabled` gate. Asserting only "no editor while collapsed" would be satisfied by
@@ -106,8 +110,9 @@ vi.mock('swr', async (importOriginal) => {
 vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/hooks/useMachineDiff')>();
   return {
-    // Keep the real key predicate — the refresh path depends on it.
-    isMachineDiffKey: actual.isMachineDiffKey,
+    // Keep the REAL key filter — the refresh path's correctness depends on it,
+    // and a stubbed one would let a machine-agnostic predicate slip through.
+    machineDiffKeyFilter: actual.machineDiffKeyFilter,
     useMachineDiffFiles: (
       _machineId: string,
       projectName: string | null,
@@ -120,6 +125,16 @@ vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
         return {
           data: undefined,
           error: new Error('Branch machine unreachable'),
+          isLoading: false,
+          isValidating: false,
+          mutate: vi.fn(),
+        };
+      }
+      // The ACTIVE list failing (as opposed to the probe) must surface, not spin.
+      if (listErrors && scope === 'uncommitted') {
+        return {
+          data: undefined,
+          error: new Error('sandbox unreachable'),
           isLoading: false,
           isValidating: false,
           mutate: vi.fn(),
@@ -159,6 +174,8 @@ describe('DiffTab', () => {
     binaryPair = false;
     truncatedEmptyList = false;
     probeErrors = false;
+    listErrors = false;
+    pairErrors = false;
   });
 
   test('shows the empty placeholder until a branch is selected', () => {
@@ -334,17 +351,71 @@ describe('DiffTab', () => {
     // key. Refreshing via the keyed predicate is what stops an open Monaco diff
     // from serving pre-edit content forever (both hooks are revalidateOnFocus:
     // false) — so assert the predicate actually reaches a pair key.
+    //
+    // And it must be SCOPED to this branch: Machine pages stay mounted in a
+    // keep-alive LRU, so a machine-agnostic predicate would re-fire another
+    // machine's git execs (list + merge-base + every open pair) on every refresh.
     const predicate = swrMutate.mock.calls[0]?.[0] as ((key: unknown) => boolean) | undefined;
+    const key = (params: Record<string, string>) =>
+      `/api/machines/diff?${new URLSearchParams(params).toString()}`;
+    const mine = { machineId: 'm1', projectName: 'repo', branchName: 'feature' };
+
     assert({
       given: 'the Refresh button clicked',
-      should: "call SWR's global mutate with a predicate matching BOTH list and per-file pair keys",
+      should: "revalidate THIS branch's list and per-file pair keys — and nothing else's",
       actual: {
         called: swrMutate.mock.calls.length,
-        matchesList: predicate?.('/api/machines/diff?machineId=m1&scope=uncommitted'),
-        matchesPair: predicate?.('/api/machines/diff?machineId=m1&scope=uncommitted&path=src%2Fa.ts'),
-        matchesUnrelated: predicate?.('/api/machines/files?machineId=m1'),
+        myList: predicate?.(key({ ...mine, scope: 'uncommitted' })),
+        myPair: predicate?.(key({ ...mine, scope: 'uncommitted', path: 'src/a.ts', status: 'modified' })),
+        otherMachine: predicate?.(key({ ...mine, machineId: 'm2', scope: 'uncommitted' })),
+        otherBranch: predicate?.(key({ ...mine, branchName: 'other', scope: 'uncommitted' })),
+        otherProject: predicate?.(key({ ...mine, projectName: 'other-repo', scope: 'uncommitted' })),
+        unrelatedRoute: predicate?.('/api/machines/files?machineId=m1'),
       },
-      expected: { called: 1, matchesList: true, matchesPair: true, matchesUnrelated: false },
+      expected: {
+        called: 1,
+        myList: true,
+        myPair: true,
+        otherMachine: false,
+        otherBranch: false,
+        otherProject: false,
+        unrelatedRoute: false,
+      },
+    });
+  });
+
+  test('a failed changed-file list surfaces the error instead of an endless spinner', async () => {
+    listErrors = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+
+    await waitFor(() => screen.getByText(/Failed to load diff/i));
+    assert({
+      given: 'the changed-file list request failing',
+      should: 'show the real error — falling through to a permanent "Loading…" would hide a dead machine',
+      actual: {
+        error: screen.queryByText(/Failed to load diff: sandbox unreachable/i) !== null,
+        stuckLoading: screen.queryByText('Loading changed files…') !== null,
+      },
+      expected: { error: true, stuckLoading: false },
+    });
+  });
+
+  test("a failed file pair surfaces the error inside the card", async () => {
+    pairErrors = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));
+
+    await waitFor(() => screen.getByText(/Failed to load diff/i));
+    assert({
+      given: 'one file\'s diff pair failing to load',
+      should: 'show the error in that card and mount no editor',
+      actual: {
+        error: screen.queryByText(/Failed to load diff: blob read failed/i) !== null,
+        editor: screen.queryByTestId('monaco-diff') !== null,
+      },
+      expected: { error: true, editor: false },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -6,8 +6,13 @@ import type { MachineTreeNode } from '../workspace/MachineTree';
 import type { MachineDiffFilesResponse } from '@/hooks/useMachineDiff';
 import type { MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 
+// A NUL byte is how a decoded binary file gives itself away (git's own
+// heuristic). Kept as an escape, never a literal control char in the source.
+const NUL = '\u0000';
+
 // The tree is exercised by its own suite; here we only need a way to fire
-// onSelectNode with a branch node, so stub it to a pair of select buttons.
+// onSelectNode, so stub it to a set of select buttons — including a PROJECT node,
+// which DiffTab must ignore.
 vi.mock('../workspace/MachineTree', () => ({
   default: ({ onSelectNode }: { onSelectNode?: (node: MachineTreeNode) => void }) => (
     <div>
@@ -31,17 +36,26 @@ vi.mock('@/components/editors/MonacoDiffEditor', () => ({
   ),
 }));
 
-// The scope toggle's behaviour is driven entirely by what the files hook
-// returns for each (branch, scope) — so the mock keys off branchName + scope:
-// 'main' answers notApplicable for the non-uncommitted scopes (mirroring the
-// route), every other branch answers a real list.
+// Per-test switches for the states the pane must not get wrong.
+let truncatedPair = false;
+let binaryPair = false;
+let truncatedEmptyList = false;
+let probeErrors = false;
+
+// The scope toggle's behaviour is driven entirely by what the files hook returns
+// for each (branch, scope) — so the mock keys off branchName + scope: 'main'
+// answers notApplicable for the non-uncommitted scopes (mirroring the route),
+// every other branch answers a real list.
 const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse => {
-  if (branchName === 'main' && scope !== 'uncommitted') {
-    return { notApplicable: true };
-  }
+  if (branchName === 'main' && scope !== 'uncommitted') return { notApplicable: true };
   if (branchName === 'main') {
     // Clean uncommitted tree on main — drives the explicit empty state.
     return { notApplicable: false, scope: 'uncommitted', files: [], truncated: false };
+  }
+  if (truncatedEmptyList) {
+    // The sandbox output cap cut the list before its FIRST complete entry: zero
+    // files, but the diff is emphatically NOT clean.
+    return { notApplicable: false, scope: scope as MachineDiffScope, files: [], truncated: true };
   }
   return {
     notApplicable: false,
@@ -52,27 +66,35 @@ const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse =
 };
 
 // The pair fixture MUST mirror the route's real wire shape — each side is
-// `{ content, truncated }`, NOT a bare string. An earlier version of this mock
-// asserted the string shape and so kept the suite green while the production
-// code handed Monaco an object; useMachineDiff.test.tsx now pins the real
-// contract against fetchWithAuth so this mock can't drift from it again.
+// `{ content, truncated }` or null, NOT a bare string. An earlier version of this
+// mock asserted the string shape and so kept the suite green while the production
+// code handed Monaco an object; useMachineDiff.test.tsx now pins the real contract
+// against fetchWithAuth so this mock can't drift from it again.
+//
+// The binary case deliberately nulls the MODIFIED side (a deleted binary): the
+// card must sniff EITHER side, so an `&&` across the two would leak mojibake here.
 const pairFor = (enabled: boolean) => ({
   data: enabled
     ? {
         notApplicable: false as const,
         scope: 'uncommitted' as const,
         path: 'src/uncommitted.ts',
-        // A binary file's decoded content carries NUL bytes — that's how the card sniffs it.
-        original: { content: binaryPair ? 'PNG\u0000\u0000' : 'a', truncated: false },
-        modified: { content: binaryPair ? 'PNG\u0000' : 'b', truncated: truncatedPair },
+        original: binaryPair
+          ? { content: `PNG${NUL}${NUL}`, truncated: false }
+          : { content: 'a', truncated: false },
+        modified: binaryPair ? null : { content: 'b', truncated: truncatedPair },
       }
     : undefined,
   error: undefined,
   isLoading: false,
 });
 
-let truncatedPair = false;
-let binaryPair = false;
+// Spy at the CALL SITE: proves DiffFileCard threads `expanded` into the hook's
+// `enabled` gate. Asserting only "no editor while collapsed" would be satisfied by
+// the JSX guard alone — leaving a mutation to `enabled: true` free to fire a
+// content request per file on list render (the N-fetch regression the design
+// forbids) with a green suite.
+const useMachineDiffPairSpy = vi.fn(pairFor);
 
 // SWR's global mutate — the refresh path calls it with a key predicate.
 const swrMutate = vi.fn();
@@ -91,13 +113,26 @@ vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
       projectName: string | null,
       branchName: string | null,
       scope: string | null,
-    ) => ({
-      data: projectName && branchName && scope ? filesFor(branchName, scope) : undefined,
-      error: undefined,
-      isLoading: false,
-      mutate: vi.fn(),
-    }),
-    // Honors `enabled`, so a collapsed card genuinely fetches nothing.
+    ) => {
+      // A failed PROBE (machine stopped, transient git failure) must never be
+      // mistaken for the main branch's notApplicable answer.
+      if (probeErrors && scope === 'committed') {
+        return {
+          data: undefined,
+          error: new Error('Branch machine unreachable'),
+          isLoading: false,
+          isValidating: false,
+          mutate: vi.fn(),
+        };
+      }
+      return {
+        data: projectName && branchName && scope ? filesFor(branchName, scope) : undefined,
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: vi.fn(),
+      };
+    },
     useMachineDiffPair: (
       _machineId: string,
       _projectName: string | null,
@@ -105,17 +140,25 @@ vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
       _scope: string | null,
       _file: unknown,
       enabled: boolean,
-    ) => pairFor(enabled),
+    ) => useMachineDiffPairSpy(enabled),
   };
 });
 
 import DiffTab from './DiffTab';
+
+const scopeOptions = () => ({
+  uncommitted: screen.queryByText('Uncommitted') !== null,
+  committed: screen.queryByText('Committed') !== null,
+  branch: screen.queryByText('Branch vs default') !== null,
+});
 
 describe('DiffTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     truncatedPair = false;
     binaryPair = false;
+    truncatedEmptyList = false;
+    probeErrors = false;
   });
 
   test('shows the empty placeholder until a branch is selected', () => {
@@ -131,6 +174,21 @@ describe('DiffTab', () => {
     });
   });
 
+  test('selecting a PROJECT node does not open a diff — only a branch identifies a checkout', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-project'));
+
+    assert({
+      given: 'a project node reported by the tree',
+      should: 'ignore it and keep prompting for a branch — a project has no single checkout to diff',
+      actual: {
+        prompt: screen.queryByText('Select a branch to view its diff.') !== null,
+        toggle: screen.queryByText('Uncommitted') !== null,
+      },
+      expected: { prompt: true, toggle: false },
+    });
+  });
+
   test('a non-main branch shows all three scope options', async () => {
     render(<DiffTab machineId="m1" />);
     await userEvent.click(screen.getByText('select-feature'));
@@ -138,12 +196,8 @@ describe('DiffTab', () => {
     await waitFor(() => screen.getByText('Committed'));
     assert({
       given: 'a feature branch where committed/branch scopes are applicable',
-      should: 'render Uncommitted, Committed and Branch vs master in the toggle',
-      actual: {
-        uncommitted: screen.queryByText('Uncommitted') !== null,
-        committed: screen.queryByText('Committed') !== null,
-        branch: screen.queryByText('Branch vs master') !== null,
-      },
+      should: 'render all three scope options',
+      actual: scopeOptions(),
       expected: { uncommitted: true, committed: true, branch: true },
     });
   });
@@ -156,12 +210,22 @@ describe('DiffTab', () => {
     assert({
       given: 'the main branch, where the route returns notApplicable for committed/branch',
       should: 'render ONLY the Uncommitted option — not all three with two disabled',
-      actual: {
-        uncommitted: screen.queryByText('Uncommitted') !== null,
-        committed: screen.queryByText('Committed') !== null,
-        branch: screen.queryByText('Branch vs master') !== null,
-      },
+      actual: scopeOptions(),
       expected: { uncommitted: true, committed: false, branch: false },
+    });
+  });
+
+  test('an ERRORED probe keeps the full toggle — a failed request is not a main-branch answer', async () => {
+    probeErrors = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+
+    await waitFor(() => screen.getByText('Uncommitted'));
+    assert({
+      given: 'the applicability probe failing (machine stopped / transient git failure)',
+      should: 'keep all three scopes offered — collapsing here would silently hide real scopes on a flake',
+      actual: scopeOptions(),
+      expected: { uncommitted: true, committed: true, branch: true },
     });
   });
 
@@ -175,6 +239,39 @@ describe('DiffTab', () => {
       should: 'name the branch in an explicit empty state, not a generic no-diff message',
       actual: screen.queryByText('No uncommitted changes on main') !== null,
       expected: true,
+    });
+  });
+
+  test('an empty-but-TRUNCATED list is not reported as a clean tree', async () => {
+    truncatedEmptyList = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+
+    await waitFor(() => screen.getByText('Uncommitted'));
+    assert({
+      given: 'a file list cut by the output cap before its first complete entry (files: [], truncated: true)',
+      should: 'warn that the diff was cut — never claim "no changes" on partial data',
+      actual: {
+        warned: screen.queryByText(/too large to list in full/i) !== null,
+        falselyClean: screen.queryByText(/^No uncommitted changes$/i) !== null,
+      },
+      expected: { warned: true, falselyClean: false },
+    });
+  });
+
+  test('a collapsed card fetches nothing — the pair hook is called with enabled=false', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await waitFor(() => screen.getByText('src/uncommitted.ts'));
+
+    assert({
+      given: 'a changed-file list rendered with every card collapsed',
+      should: 'gate the pair hook off, so a 200-file scope costs ZERO content requests until a card is opened',
+      actual: {
+        everCalled: useMachineDiffPairSpy.mock.calls.length > 0,
+        everEnabled: useMachineDiffPairSpy.mock.calls.some(([enabled]) => enabled === true),
+      },
+      expected: { everCalled: true, everEnabled: false },
     });
   });
 
@@ -195,22 +292,25 @@ describe('DiffTab', () => {
     assert({
       given: 'the changed file card clicked open',
       should: "mount MonacoDiffEditor with each side's CONTENT string, not the raw { content, truncated } side object",
-      actual: screen.getByTestId('monaco-diff').textContent,
-      expected: 'a→b',
+      actual: {
+        rendered: screen.getByTestId('monaco-diff').textContent,
+        enabledOnExpand: useMachineDiffPairSpy.mock.calls.some(([enabled]) => enabled === true),
+      },
+      expected: { rendered: 'a→b', enabledOnExpand: true },
     });
   });
 
-  test('Refresh revalidates the expanded cards\' pair keys, not just the file lists', async () => {
+  test("Refresh revalidates the expanded cards' pair keys, not just the file lists", async () => {
     render(<DiffTab machineId="m1" />);
     await userEvent.click(screen.getByText('select-feature'));
     await waitFor(() => screen.getByText('src/uncommitted.ts'));
 
     await userEvent.click(screen.getByTitle('Refresh diff'));
 
-    // The pane owns only the two LIST keys; every expanded card holds its own
-    // pair key. Refreshing via the keyed predicate is what stops an open Monaco
-    // diff from serving pre-edit content forever (both hooks are
-    // revalidateOnFocus: false) — so assert the predicate reaches a pair key.
+    // The pane owns only the two LIST keys; every expanded card holds its own pair
+    // key. Refreshing via the keyed predicate is what stops an open Monaco diff
+    // from serving pre-edit content forever (both hooks are revalidateOnFocus:
+    // false) — so assert the predicate actually reaches a pair key.
     const predicate = swrMutate.mock.calls[0]?.[0] as ((key: unknown) => boolean) | undefined;
     assert({
       given: 'the Refresh button clicked',
@@ -231,8 +331,11 @@ describe('DiffTab', () => {
     await userEvent.click(screen.getByText('select-feature'));
     await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));
 
+    // Only the ORIGINAL side is binary here (a deleted binary has no modified
+    // side), so a card that sniffed `original && modified` would fall through and
+    // render garbage.
     assert({
-      given: 'a changed binary file (its decoded content carries NUL bytes)',
+      given: 'a changed binary file whose decoded content carries NUL bytes on one side only',
       should: 'say it is binary and mount no diff editor — a text diff of decoded bytes is garbage',
       actual: {
         note: screen.queryByText(/binary file/i) !== null,

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -62,8 +62,9 @@ const pairFor = (enabled: boolean) => ({
         notApplicable: false as const,
         scope: 'uncommitted' as const,
         path: 'src/uncommitted.ts',
-        original: { content: 'a', truncated: false },
-        modified: { content: 'b', truncated: truncatedPair },
+        // A binary file's decoded content carries NUL bytes — that's how the card sniffs it.
+        original: { content: binaryPair ? 'PNG\u0000\u0000' : 'a', truncated: false },
+        modified: { content: binaryPair ? 'PNG\u0000' : 'b', truncated: truncatedPair },
       }
     : undefined,
   error: undefined,
@@ -71,6 +72,14 @@ const pairFor = (enabled: boolean) => ({
 });
 
 let truncatedPair = false;
+let binaryPair = false;
+
+// SWR's global mutate — the refresh path calls it with a key predicate.
+const swrMutate = vi.fn();
+vi.mock('swr', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('swr')>();
+  return { ...actual, useSWRConfig: () => ({ mutate: swrMutate }) };
+});
 
 vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/hooks/useMachineDiff')>();
@@ -106,6 +115,7 @@ describe('DiffTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     truncatedPair = false;
+    binaryPair = false;
   });
 
   test('shows the empty placeholder until a branch is selected', () => {
@@ -187,6 +197,48 @@ describe('DiffTab', () => {
       should: "mount MonacoDiffEditor with each side's CONTENT string, not the raw { content, truncated } side object",
       actual: screen.getByTestId('monaco-diff').textContent,
       expected: 'a→b',
+    });
+  });
+
+  test('Refresh revalidates the expanded cards\' pair keys, not just the file lists', async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await waitFor(() => screen.getByText('src/uncommitted.ts'));
+
+    await userEvent.click(screen.getByTitle('Refresh diff'));
+
+    // The pane owns only the two LIST keys; every expanded card holds its own
+    // pair key. Refreshing via the keyed predicate is what stops an open Monaco
+    // diff from serving pre-edit content forever (both hooks are
+    // revalidateOnFocus: false) — so assert the predicate reaches a pair key.
+    const predicate = swrMutate.mock.calls[0]?.[0] as ((key: unknown) => boolean) | undefined;
+    assert({
+      given: 'the Refresh button clicked',
+      should: "call SWR's global mutate with a predicate matching BOTH list and per-file pair keys",
+      actual: {
+        called: swrMutate.mock.calls.length,
+        matchesList: predicate?.('/api/machines/diff?machineId=m1&scope=uncommitted'),
+        matchesPair: predicate?.('/api/machines/diff?machineId=m1&scope=uncommitted&path=src%2Fa.ts'),
+        matchesUnrelated: predicate?.('/api/machines/files?machineId=m1'),
+      },
+      expected: { called: 1, matchesList: true, matchesPair: true, matchesUnrelated: false },
+    });
+  });
+
+  test('a binary file is named as such instead of rendering decoded mojibake', async () => {
+    binaryPair = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await userEvent.click(await waitFor(() => screen.getByText('src/uncommitted.ts')));
+
+    assert({
+      given: 'a changed binary file (its decoded content carries NUL bytes)',
+      should: 'say it is binary and mount no diff editor — a text diff of decoded bytes is garbage',
+      actual: {
+        note: screen.queryByText(/binary file/i) !== null,
+        editor: screen.queryByTestId('monaco-diff') !== null,
+      },
+      expected: { note: true, editor: false },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -66,6 +66,7 @@ let truncatedEmptyList = false;
 let probeErrors = false;
 let listErrors = false;
 let pairErrors = false;
+let samePathAcrossScopes = false;
 
 // The scope toggle's behaviour is driven entirely by what the files hook returns
 // for each (branch, scope) — so the mock keys off branchName + scope: 'main'
@@ -85,7 +86,12 @@ const filesFor = (branchName: string, scope: string): MachineDiffFilesResponse =
   return {
     notApplicable: false,
     scope: scope as MachineDiffScope,
-    files: [{ path: `src/${scope}.ts`, status: 'modified' }],
+    // Normally each scope names its file after itself so tests can tell them
+    // apart. When a path exists in BOTH scopes (the realistic case — committed and
+    // branch are both merge-base-derived and overlap heavily), a card's React key
+    // no longer changes across a scope switch, which is what makes the per-scope
+    // TabsContent keying observable.
+    files: [{ path: samePathAcrossScopes ? 'src/shared.ts' : `src/${scope}.ts`, status: 'modified' }],
     truncated: false,
   };
 };
@@ -206,6 +212,7 @@ describe('DiffTab', () => {
     probeErrors = false;
     listErrors = false;
     pairErrors = false;
+    samePathAcrossScopes = false;
   });
 
   test('shows the empty placeholder until a branch is selected', () => {
@@ -321,6 +328,51 @@ describe('DiffTab', () => {
         uncommittedGone: screen.queryByText('src/uncommitted.ts') === null,
       },
       expected: { committed: true, uncommittedGone: true },
+    });
+  });
+
+  test("every scope trigger's aria-controls resolves to a real tabpanel", async () => {
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await waitFor(() => screen.getByText('Committed'));
+
+    // Radix hands TabsContent's children to Presence AS A FUNCTION, which
+    // force-mounts — so an INACTIVE panel's <div> is still in the DOM (only its
+    // children are gated). Rendering one panel instead of one-per-scope therefore
+    // leaves the two inactive triggers pointing at ids that exist nowhere: a
+    // dangling IDREF, which is exactly what the Tabs wrapper exists to prevent.
+    const dangling = screen
+      .getAllByRole('tab')
+      .map((tab) => tab.getAttribute('aria-controls'))
+      .filter((id) => id === null || document.getElementById(id) === null);
+
+    assert({
+      given: 'the three scope triggers',
+      should: 'each control a tabpanel that actually exists in the DOM',
+      actual: { tabs: screen.getAllByRole('tab').length, dangling: dangling.length },
+      expected: { tabs: 3, dangling: 0 },
+    });
+  });
+
+  test('switching scope collapses an open card even when the same file exists in both scopes', async () => {
+    // The per-scope TabsContent `key` gives each scope its own subtree, so a scope
+    // switch UNMOUNTS the old panel. Without it, a card whose path appears in both
+    // lists keeps its React key, stays expanded, and immediately refetches its pair
+    // under the new scope — an extra sandbox git exec per open card, every switch.
+    samePathAcrossScopes = true;
+    render(<DiffTab machineId="m1" />);
+    await userEvent.click(screen.getByText('select-feature'));
+    await userEvent.click(await waitFor(() => screen.getByText('src/shared.ts')));
+    await waitFor(() => screen.getByTestId('monaco-diff'));
+
+    await userEvent.click(screen.getByText('Committed'));
+    await waitFor(() => screen.getByText('src/shared.ts'));
+
+    assert({
+      given: 'an expanded card for a file present in both the uncommitted and committed scopes',
+      should: 'collapse it on the scope switch — not carry it open into the new scope and refetch',
+      actual: screen.queryByTestId('monaco-diff') !== null,
+      expected: false,
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.test.tsx
@@ -13,20 +13,43 @@ const NUL = '\u0000';
 // The tree is exercised by its own suite; here we only need a way to fire
 // onSelectNode, so stub it to a set of select buttons — including a PROJECT node,
 // which DiffTab must ignore.
+//
+// The stub CAPTURES the props it receives. Dropping `isNodeSelectable` or
+// `selectedNode` from DiffTab's <MachineTree> would otherwise leave the suite
+// green while, in the real app, every Machine/Project label became a dead button
+// (a select handler wins over expand-on-label-click) and the selected branch lost
+// its highlight.
+const treeProps: {
+  isNodeSelectable?: (node: MachineTreeNode) => boolean;
+  selectedNode?: MachineTreeNode | null;
+} = {};
+
 vi.mock('../workspace/MachineTree', () => ({
-  default: ({ onSelectNode }: { onSelectNode?: (node: MachineTreeNode) => void }) => (
-    <div>
-      <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'feature' })}>
-        select-feature
-      </button>
-      <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'main' })}>
-        select-main
-      </button>
-      <button type="button" onClick={() => onSelectNode?.({ level: 'project', projectName: 'repo' })}>
-        select-project
-      </button>
-    </div>
-  ),
+  default: ({
+    onSelectNode,
+    isNodeSelectable,
+    selectedNode,
+  }: {
+    onSelectNode?: (node: MachineTreeNode) => void;
+    isNodeSelectable?: (node: MachineTreeNode) => boolean;
+    selectedNode?: MachineTreeNode | null;
+  }) => {
+    treeProps.isNodeSelectable = isNodeSelectable;
+    treeProps.selectedNode = selectedNode;
+    return (
+      <div>
+        <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'feature' })}>
+          select-feature
+        </button>
+        <button type="button" onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'main' })}>
+          select-main
+        </button>
+        <button type="button" onClick={() => onSelectNode?.({ level: 'project', projectName: 'repo' })}>
+          select-project
+        </button>
+      </div>
+    );
+  },
 }));
 
 // Monaco must never mount under jsdom; the card only needs to prove it renders.
@@ -110,9 +133,11 @@ vi.mock('swr', async (importOriginal) => {
 vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/hooks/useMachineDiff')>();
   return {
-    // Keep the REAL key filter — the refresh path's correctness depends on it,
-    // and a stubbed one would let a machine-agnostic predicate slip through.
+    // Keep the REAL key builders and filter — the refresh path's correctness
+    // depends on them agreeing, and stubs would let a mismatch slip through.
     machineDiffKeyFilter: actual.machineDiffKeyFilter,
+    machineDiffListKey: actual.machineDiffListKey,
+    machineDiffPairKey: actual.machineDiffPairKey,
     useMachineDiffFiles: (
       _machineId: string,
       projectName: string | null,
@@ -160,6 +185,7 @@ vi.mock('@/hooks/useMachineDiff', async (importOriginal) => {
 });
 
 import DiffTab from './DiffTab';
+import { machineDiffListKey, machineDiffPairKey } from '@/hooks/useMachineDiff';
 
 const scopeOptions = () => ({
   uncommitted: screen.queryByText('Uncommitted') !== null,
@@ -188,6 +214,45 @@ describe('DiffTab', () => {
         toggle: screen.queryByText('Committed') !== null,
       },
       expected: { prompt: true, toggle: false },
+    });
+  });
+
+  test('the tree is told that ONLY branch rows are selectable', () => {
+    render(<DiffTab machineId="m1" />);
+
+    // Load-bearing: a row WITH a select handler uses it instead of
+    // expand-on-label-click, and DiffTab's handler ignores non-branch nodes — so
+    // marking Machine/Project selectable turns their labels into dead buttons.
+    assert({
+      given: 'the Diff tab rendering the shared tree',
+      should: 'pass isNodeSelectable so Machine/Project rows keep expand-on-label-click',
+      actual: {
+        wired: typeof treeProps.isNodeSelectable === 'function',
+        branch: treeProps.isNodeSelectable?.({ level: 'branch', projectName: 'repo', branchName: 'x' }),
+        project: treeProps.isNodeSelectable?.({ level: 'project', projectName: 'repo' }),
+        machine: treeProps.isNodeSelectable?.({ level: 'machine' }),
+      },
+      expected: { wired: true, branch: true, project: false, machine: false },
+    });
+  });
+
+  test('the tree is told which branch is selected, so the sidebar can show it', async () => {
+    render(<DiffTab machineId="m1" />);
+    assert({
+      given: 'no branch picked yet',
+      should: 'report no selection',
+      actual: treeProps.selectedNode ?? null,
+      expected: null,
+    });
+
+    await userEvent.click(screen.getByText('select-feature'));
+    await waitFor(() => screen.getByText('Uncommitted'));
+
+    assert({
+      given: 'a branch selected',
+      should: 'thread that branch back to the tree as selectedNode — otherwise nothing shows which branch is being diffed',
+      actual: treeProps.selectedNode,
+      expected: { level: 'branch', projectName: 'repo', branchName: 'feature' },
     });
   });
 
@@ -356,20 +421,20 @@ describe('DiffTab', () => {
     // keep-alive LRU, so a machine-agnostic predicate would re-fire another
     // machine's git execs (list + merge-base + every open pair) on every refresh.
     const predicate = swrMutate.mock.calls[0]?.[0] as ((key: unknown) => boolean) | undefined;
-    const key = (params: Record<string, string>) =>
-      `/api/machines/diff?${new URLSearchParams(params).toString()}`;
-    const mine = { machineId: 'm1', projectName: 'repo', branchName: 'feature' };
+    // Real keys from the real builders, so a param reorder can't leave this green
+    // while Refresh silently matches nothing in the app.
+    const f = { path: 'src/a.ts', status: 'modified' as const };
 
     assert({
       given: 'the Refresh button clicked',
       should: "revalidate THIS branch's list and per-file pair keys — and nothing else's",
       actual: {
         called: swrMutate.mock.calls.length,
-        myList: predicate?.(key({ ...mine, scope: 'uncommitted' })),
-        myPair: predicate?.(key({ ...mine, scope: 'uncommitted', path: 'src/a.ts', status: 'modified' })),
-        otherMachine: predicate?.(key({ ...mine, machineId: 'm2', scope: 'uncommitted' })),
-        otherBranch: predicate?.(key({ ...mine, branchName: 'other', scope: 'uncommitted' })),
-        otherProject: predicate?.(key({ ...mine, projectName: 'other-repo', scope: 'uncommitted' })),
+        myList: predicate?.(machineDiffListKey('m1', 'repo', 'feature', 'uncommitted')),
+        myPair: predicate?.(machineDiffPairKey('m1', 'repo', 'feature', 'uncommitted', f)),
+        otherMachine: predicate?.(machineDiffListKey('m2', 'repo', 'feature', 'uncommitted')),
+        otherBranch: predicate?.(machineDiffListKey('m1', 'repo', 'other', 'uncommitted')),
+        otherProject: predicate?.(machineDiffListKey('m1', 'other-repo', 'feature', 'uncommitted')),
         unrelatedRoute: predicate?.('/api/machines/files?machineId=m1'),
       },
       expected: {

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useCallback, useState } from 'react';
+import { useSWRConfig } from 'swr';
 import { GitCompare, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useMachineDiffFiles } from '@/hooks/useMachineDiff';
+import { useMachineDiffFiles, isMachineDiffKey } from '@/hooks/useMachineDiff';
 import { isMachineDiffScope, type MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
 import DiffFileCard from './DiffFileCard';
@@ -19,6 +20,20 @@ const SCOPE_LABELS: Record<MachineDiffScope, string> = {
 interface SelectedBranch {
   projectName: string;
   branchName: string;
+}
+
+/**
+ * The empty state for a clean scope. The main-branch case names the branch
+ * explicitly ("No uncommitted changes on main") — on the default branch
+ * Uncommitted is the ONLY scope, so an unqualified "no changes" would leave the
+ * user wondering what happened to the other two.
+ */
+function emptyMessage(scope: MachineDiffScope, branchName: string, scopesApplicable: boolean): string {
+  if (scope === 'uncommitted') {
+    return scopesApplicable ? 'No uncommitted changes' : `No uncommitted changes on ${branchName}`;
+  }
+  if (scope === 'committed') return `No commits on ${branchName} yet`;
+  return `${branchName} is identical to the default branch`;
 }
 
 /**
@@ -97,10 +112,15 @@ function BranchDiffPane({
   const active: MachineDiffScope = scopesApplicable ? scope : 'uncommitted';
   const list = useMachineDiffFiles(machineId, projectName, branchName, active);
 
+  // Revalidate the WHOLE diff surface, not just the two lists this pane holds:
+  // every expanded card owns a separate pair key, and refreshing only the lists
+  // would leave an open Monaco diff showing pre-edit content indefinitely (the
+  // pair hook sets revalidateOnFocus: false, so nothing else would ever refetch
+  // it). The keyed predicate catches lists and pairs alike.
+  const { mutate } = useSWRConfig();
   const refresh = useCallback(() => {
-    void committed.mutate();
-    void list.mutate();
-  }, [committed, list]);
+    void mutate(isMachineDiffKey);
+  }, [mutate]);
 
   const availableScopes: MachineDiffScope[] = scopesApplicable
     ? ['uncommitted', 'committed', 'branch']
@@ -140,14 +160,21 @@ function BranchDiffPane({
       </div>
 
       <ScrollArea className="min-h-0 flex-1">
-        <DiffFileList
-          machineId={machineId}
-          projectName={projectName}
-          branchName={branchName}
-          scope={active}
-          scopesApplicable={scopesApplicable}
-          list={list}
-        />
+        {/* Hold the list until the probe answers: rendering it first would show
+            a generic "No uncommitted changes" that then flips to the
+            main-branch-specific copy once applicability is known. */}
+        {!probeResolved ? (
+          <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>
+        ) : (
+          <DiffFileList
+            machineId={machineId}
+            projectName={projectName}
+            branchName={branchName}
+            scope={active}
+            scopesApplicable={scopesApplicable}
+            list={list}
+          />
+        )}
       </ScrollArea>
     </div>
   );
@@ -176,19 +203,23 @@ function DiffFileList({
   if (error) {
     return <div className="p-4 text-sm text-destructive">Failed to load diff: {error.message}</div>;
   }
-  if (!data || data.notApplicable) {
-    // Only reachable if the active scope is itself not applicable — which the
-    // toggle already prevents; render nothing rather than an empty-diff lie.
-    return null;
+  if (!data) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>;
   }
-  if (data.files.length === 0) {
+  if (data.notApplicable) {
+    // The toggle normally prevents this (a not-applicable scope isn't offered),
+    // but say so explicitly rather than render a blank pane — a transiently
+    // failed probe can leave the full toggle up on a main branch, and an empty
+    // white pane would read as "no changes", which is a different claim.
     return (
       <div className="p-4 text-sm text-muted-foreground">
-        {scope === 'uncommitted' && !scopesApplicable
-          ? `No uncommitted changes on ${branchName}`
-          : `No ${SCOPE_LABELS[scope].toLowerCase()} changes`}
+        This scope doesn&apos;t apply on <span className="font-mono">{branchName}</span> — it is the repository&apos;s
+        default branch, so there is nothing to compare it against.
       </div>
     );
+  }
+  if (data.files.length === 0) {
+    return <div className="p-4 text-sm text-muted-foreground">{emptyMessage(scope, branchName, scopesApplicable)}</div>;
   }
 
   return (

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -177,6 +177,7 @@ function BranchDiffPane({
             onClick={refresh}
             disabled={refreshing}
             title="Refresh diff"
+            aria-label="Refresh diff"
           >
             {/* Without this the click has no visible effect until the sandbox
                 answers — SWR keeps the stale data and only flips isValidating. */}
@@ -267,7 +268,11 @@ function DiffFileList({
       )}
       {data.files.map((file) => (
         <DiffFileCard
-          key={`${file.status}:${file.previousPath ?? ''}:${file.path}`}
+          // Keyed by IDENTITY (path + rename source), deliberately not by status:
+          // a refresh that flips a file modified -> deleted would otherwise change
+          // its key, remount the card, and silently collapse it under the user.
+          // Status is already a prop, so it still re-renders in place.
+          key={`${file.previousPath ?? ''}:${file.path}`}
           machineId={machineId}
           projectName={projectName}
           branchName={branchName}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -45,10 +45,14 @@ function emptyMessage(scope: MachineDiffScope, branchName: string, scopesApplica
 
 /**
  * The Machine page's Diff tab: the shared {@link MachineTree} in BARE mode as an
- * inner sidebar (no session leaves — the Project/Branch rows themselves are the
- * diff target), beside a 3-way scope toggle over the selected branch's changed
- * files. Each file expands into its own `MonacoDiffEditor`, so a 200-file branch
- * renders 200 cheap header rows and zero editors until one is opened.
+ * inner sidebar (no session leaves), beside a 3-way scope toggle over the
+ * selected branch's changed files. Each file expands into its own
+ * `MonacoDiffEditor`, so a 200-file branch renders 200 cheap header rows and zero
+ * editors until one is opened.
+ *
+ * BRANCH rows are the diff target — a Machine or Project spans many checkouts and
+ * has no single working tree to compare, so those rows stay pure navigation
+ * (see `isNodeSelectable`).
  */
 export default function DiffTab({ machineId }: { machineId: string }) {
   const [selected, setSelected] = useState<SelectedBranch | null>(null);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -5,7 +5,8 @@ import { useSWRConfig } from 'swr';
 import { GitCompare, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 import { useMachineDiffFiles, isMachineDiffKey } from '@/hooks/useMachineDiff';
 import { isMachineDiffScope, type MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
@@ -14,7 +15,13 @@ import DiffFileCard from './DiffFileCard';
 const SCOPE_LABELS: Record<MachineDiffScope, string> = {
   uncommitted: 'Uncommitted',
   committed: 'Committed',
-  branch: 'Branch vs master',
+  // "vs default", not "vs master": the server diffs against `origin/HEAD` — the
+  // remote's ACTUAL default branch — precisely so the scope is correct whether a
+  // repo's default is master, main, or anything else (see machine-diff-scope.ts,
+  // which refuses to hardcode the literal). Labeling it "vs master" would name a
+  // branch that doesn't exist on a main-default repo, and would contradict this
+  // file's own empty state ("identical to the default branch").
+  branch: 'Branch vs default',
 };
 
 interface SelectedBranch {
@@ -130,8 +137,21 @@ function BranchDiffPane({
     ? ['uncommitted', 'committed', 'branch']
     : ['uncommitted'];
 
+  const refreshing = list.isValidating || committed.isValidating;
+
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    // Tabs wraps the triggers AND the panel on purpose: a Radix TabsTrigger emits
+    // aria-controls pointing at its TabsContent, so a TabsList with no TabsContent
+    // would leave every tab referencing an element id that exists nowhere in the
+    // DOM (a tablist owning no tabpanel — invalid ARIA, and a screen reader
+    // announces a panel the user can never reach).
+    <Tabs
+      value={active}
+      onValueChange={(value) => {
+        if (isMachineDiffScope(value)) setScope(value);
+      }}
+      className="flex h-full min-h-0 flex-col gap-0"
+    >
       <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
         <div className="flex min-w-0 items-center gap-2">
           <span className="truncate font-mono text-xs text-muted-foreground">
@@ -142,45 +162,53 @@ function BranchDiffPane({
           {!probeResolved ? (
             <span className="text-xs text-muted-foreground">Loading scopes…</span>
           ) : (
-            <Tabs
-              value={active}
-              onValueChange={(value) => {
-                if (isMachineDiffScope(value)) setScope(value);
-              }}
-            >
-              <TabsList>
-                {availableScopes.map((option) => (
-                  <TabsTrigger key={option} value={option}>
-                    {SCOPE_LABELS[option]}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
+            <TabsList>
+              {availableScopes.map((option) => (
+                <TabsTrigger key={option} value={option}>
+                  {SCOPE_LABELS[option]}
+                </TabsTrigger>
+              ))}
+            </TabsList>
           )}
-          <Button variant="ghost" size="icon" className="size-8" onClick={refresh} title="Refresh diff">
-            <RefreshCw className="size-3.5" />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            onClick={refresh}
+            disabled={refreshing}
+            title="Refresh diff"
+          >
+            {/* Without this the click has no visible effect until the sandbox
+                answers — SWR keeps the stale data and only flips isValidating. */}
+            <RefreshCw className={cn('size-3.5', refreshing && 'animate-spin')} />
           </Button>
         </div>
       </div>
 
-      <ScrollArea className="min-h-0 flex-1">
-        {/* Hold the list until the probe answers: rendering it first would show
-            a generic "No uncommitted changes" that then flips to the
-            main-branch-specific copy once applicability is known. */}
-        {!probeResolved ? (
-          <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>
-        ) : (
-          <DiffFileList
-            machineId={machineId}
-            projectName={projectName}
-            branchName={branchName}
-            scope={active}
-            scopesApplicable={scopesApplicable}
-            list={list}
-          />
-        )}
-      </ScrollArea>
-    </div>
+      {/* Hold the list until the probe answers: rendering it first would show a
+          generic "No uncommitted changes" that then flips to the main-branch
+          copy once applicability is known. */}
+      {!probeResolved ? (
+        <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>
+      ) : (
+        availableScopes.map((option) => (
+          // Radix renders only the ACTIVE scope's content, so this is one list,
+          // not three — it just gives each trigger a real panel to control.
+          <TabsContent key={option} value={option} className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <DiffFileList
+                machineId={machineId}
+                projectName={projectName}
+                branchName={branchName}
+                scope={active}
+                scopesApplicable={scopesApplicable}
+                list={list}
+              />
+            </ScrollArea>
+          </TabsContent>
+        ))
+      )}
+    </Tabs>
   );
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
-import { useMachineDiffFiles, machineDiffKeyFilter } from '@/hooks/useMachineDiff';
+import { useMachineDiffFiles, machineDiffKeyFilter, type MachineDiffFilesResponse } from '@/hooks/useMachineDiff';
 import { isMachineDiffScope, type MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
 import DiffFileCard from './DiffFileCard';
@@ -212,22 +212,23 @@ function BranchDiffPane({
       {!probeResolved ? (
         <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>
       ) : (
-        availableScopes.map((option) => (
-          // Radix renders only the ACTIVE scope's content, so this is one list,
-          // not three — it just gives each trigger a real panel to control.
-          <TabsContent key={option} value={option} className="min-h-0 flex-1">
-            <ScrollArea className="h-full">
-              <DiffFileList
-                machineId={machineId}
-                projectName={projectName}
-                branchName={branchName}
-                scope={active}
-                scopesApplicable={scopesApplicable}
-                list={list}
-              />
-            </ScrollArea>
-          </TabsContent>
-        ))
+        // ONE panel, for the active scope. Radix unmounts inactive TabsContent, so
+        // rendering one per scope produced identical DOM. It exists to give the
+        // active trigger a real tabpanel to control — the whole reason Tabs wraps
+        // the list rather than just the triggers.
+        <TabsContent value={active} className="min-h-0 flex-1">
+          <ScrollArea className="h-full">
+            <DiffFileList
+              machineId={machineId}
+              projectName={projectName}
+              branchName={branchName}
+              scope={active}
+              scopesApplicable={scopesApplicable}
+              data={list.data}
+              error={list.error}
+            />
+          </ScrollArea>
+        </TabsContent>
       )}
     </Tabs>
   );
@@ -239,23 +240,23 @@ function DiffFileList({
   branchName,
   scope,
   scopesApplicable,
-  list,
+  data,
+  error,
 }: {
   machineId: string;
   projectName: string;
   branchName: string;
   scope: MachineDiffScope;
   scopesApplicable: boolean;
-  list: ReturnType<typeof useMachineDiffFiles>;
+  data: MachineDiffFilesResponse | undefined;
+  error: Error | undefined;
 }) {
-  const { data, error, isLoading } = list;
-
-  if (isLoading) {
-    return <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>;
-  }
   if (error) {
     return <div className="p-4 text-sm text-destructive">Failed to load diff: {error.message}</div>;
   }
+  // SWR only leaves `data` undefined while the FIRST request is in flight — a
+  // refresh keeps the previous data and flips isValidating instead — so this IS
+  // the loading state, and a separate isLoading branch said the same thing twice.
   if (!data) {
     return <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>;
   }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -101,7 +101,9 @@ export default function DiffTab({ machineId }: { machineId: string }) {
           <BranchDiffPane
             // Remounting per branch resets the scope selection and expanded
             // cards, so a stale scope can never carry across a branch switch.
-            key={`${selected.projectName}/${selected.branchName}`}
+            // NUL-joined: branch names contain '/', so a '/' separator could let
+            // two different (project, branch) pairs collide on one key.
+            key={`${selected.projectName}\u0000${selected.branchName}`}
             machineId={machineId}
             projectName={selected.projectName}
             branchName={selected.branchName}
@@ -289,8 +291,9 @@ function DiffFileList({
           // Keyed by IDENTITY (path + rename source), deliberately not by status:
           // a refresh that flips a file modified -> deleted would otherwise change
           // its key, remount the card, and silently collapse it under the user.
-          // Status is already a prop, so it still re-renders in place.
-          key={`${file.previousPath ?? ''}:${file.path}`}
+          // Status is already a prop, so it still re-renders in place. NUL-joined
+          // because a path may legally contain ':'.
+          key={`${file.previousPath ?? ''}\u0000${file.path}`}
           machineId={machineId}
           projectName={projectName}
           branchName={branchName}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -222,10 +222,11 @@ function BranchDiffPane({
         //     panel, the two inactive triggers point at ids present nowhere in the
         //     DOM — the exact dangling-IDREF violation the Tabs wrapper above
         //     exists to avoid.
-        //  2. `key={option}` gives each scope its own subtree, so switching scope
-        //     UNMOUNTS the old panel. Without it an expanded card whose path exists
-        //     in both scopes stays open across the switch and immediately refetches
-        //     its pair — an extra sandbox git exec per open card, every switch.
+        //  2. one panel PER SCOPE means switching scope unmounts the old panel's
+        //     children (Presence gates them on `present`). Collapsed to a single
+        //     panel, an expanded card whose path exists in both scopes stays open
+        //     across the switch and immediately refetches its pair — an extra
+        //     sandbox git exec per open card, every switch.
         //
         // Radix renders only the ACTIVE panel's children, so this is still one
         // rendered list, not three.
@@ -269,9 +270,15 @@ function DiffFileList({
   if (error) {
     return <div className="p-4 text-sm text-destructive">Failed to load diff: {error.message}</div>;
   }
-  // SWR only leaves `data` undefined while the FIRST request is in flight — a
-  // refresh keeps the previous data and flips isValidating instead — so this IS
-  // the loading state, and a separate isLoading branch said the same thing twice.
+  // Error FIRST, then no-data-yet. SWR reads data/error from the CURRENT key's
+  // cache entry, so on a scope switch `data` is immediately undefined and the
+  // previous scope's diff can never leak — this is the loading state, and a
+  // separate isLoading branch said the same thing twice.
+  //
+  // The order also matters on a retry: SWR's isLoading is "in flight AND no data",
+  // regardless of a cached error, so an errored key that auto-retries would flicker
+  // Loading <-> Failed if isLoading were checked first. Holding the error steady and
+  // signalling the retry through the spinning Refresh icon is the honest reading.
   if (!data) {
     return <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>;
   }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -1,13 +1,213 @@
 "use client";
 
-import ComingSoonTab from './ComingSoonTab';
+import { useCallback, useState } from 'react';
+import { GitCompare, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useMachineDiffFiles } from '@/hooks/useMachineDiff';
+import { isMachineDiffScope, type MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
+import DiffFileCard from './DiffFileCard';
+
+const SCOPE_LABELS: Record<MachineDiffScope, string> = {
+  uncommitted: 'Uncommitted',
+  committed: 'Committed',
+  branch: 'Branch vs master',
+};
+
+interface SelectedBranch {
+  projectName: string;
+  branchName: string;
+}
 
 /**
- * PLACEHOLDER — the real Diff tab (per-branch working-tree diff viewer) is
- * built by a sibling follow-up PR (spec `lmnkz43dpczplbz4d2xuinob`). The
- * `{ machineId }` prop signature and file location are locked in here so that
- * agent only fills in the body (replacing the shared ComingSoonTab placeholder).
+ * The Machine page's Diff tab: the shared {@link MachineTree} in BARE mode as an
+ * inner sidebar (no session leaves — the Project/Branch rows themselves are the
+ * diff target), beside a 3-way scope toggle over the selected branch's changed
+ * files. Each file expands into its own `MonacoDiffEditor`, so a 200-file branch
+ * renders 200 cheap header rows and zero editors until one is opened.
  */
 export default function DiffTab({ machineId }: { machineId: string }) {
-  return <ComingSoonTab machineId={machineId} label="Diff" />;
+  const [selected, setSelected] = useState<SelectedBranch | null>(null);
+
+  const onSelectNode = useCallback((node: MachineTreeNode) => {
+    // Only a branch identifies a checkout to diff; Machine/Project rows are
+    // navigation-only here (clicking them still expands via TreeRow).
+    if (node.level !== 'branch') return;
+    setSelected({ projectName: node.projectName, branchName: node.branchName });
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0">
+      <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-background">
+        <div className="flex items-center justify-between border-b border-border px-3 py-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Branches</span>
+        </div>
+        <ScrollArea className="flex-1">
+          <MachineTree machineId={machineId} onSelectNode={onSelectNode} />
+        </ScrollArea>
+      </aside>
+      <div className="min-w-0 flex-1">
+        {selected === null ? (
+          <div className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center text-sm text-muted-foreground">
+            <GitCompare className="size-5" />
+            <span>Select a branch to view its diff.</span>
+          </div>
+        ) : (
+          <BranchDiffPane
+            // Remounting per branch resets the scope selection and expanded
+            // cards, so a stale scope can never carry across a branch switch.
+            key={`${selected.projectName}/${selected.branchName}`}
+            machineId={machineId}
+            projectName={selected.projectName}
+            branchName={selected.branchName}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** The scope toggle + changed-file list for ONE selected branch. */
+function BranchDiffPane({
+  machineId,
+  projectName,
+  branchName,
+}: {
+  machineId: string;
+  projectName: string;
+  branchName: string;
+}) {
+  const [scope, setScope] = useState<MachineDiffScope>('uncommitted');
+
+  // The 'committed' list doubles as the main-branch PROBE: on the repo's main
+  // branch the route answers `{ notApplicable: true }` for both non-uncommitted
+  // scopes (it can't merge-base a branch with itself), which is how we learn the
+  // toggle must collapse to Uncommitted alone — never by string-matching the
+  // branch name here, and never by inferring it from an empty file list. When
+  // the scope IS applicable this same response is the committed scope's list, so
+  // SWR serves it from cache on select rather than refetching.
+  const committed = useMachineDiffFiles(machineId, projectName, branchName, 'committed');
+  const probeResolved = committed.data !== undefined || committed.error !== undefined;
+  // An errored probe (machine stopped, git failure) is NOT a main-branch answer,
+  // so the full toggle stays available and the error surfaces on the list below.
+  const scopesApplicable = committed.data?.notApplicable !== true;
+
+  const active: MachineDiffScope = scopesApplicable ? scope : 'uncommitted';
+  const list = useMachineDiffFiles(machineId, projectName, branchName, active);
+
+  const refresh = useCallback(() => {
+    void committed.mutate();
+    void list.mutate();
+  }, [committed, list]);
+
+  const availableScopes: MachineDiffScope[] = scopesApplicable
+    ? ['uncommitted', 'committed', 'branch']
+    : ['uncommitted'];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {projectName}/{branchName}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {!probeResolved ? (
+            <span className="text-xs text-muted-foreground">Loading scopes…</span>
+          ) : (
+            <Tabs
+              value={active}
+              onValueChange={(value) => {
+                if (isMachineDiffScope(value)) setScope(value);
+              }}
+            >
+              <TabsList>
+                {availableScopes.map((option) => (
+                  <TabsTrigger key={option} value={option}>
+                    {SCOPE_LABELS[option]}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          )}
+          <Button variant="ghost" size="icon" className="size-8" onClick={refresh} title="Refresh diff">
+            <RefreshCw className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <DiffFileList
+          machineId={machineId}
+          projectName={projectName}
+          branchName={branchName}
+          scope={active}
+          scopesApplicable={scopesApplicable}
+          list={list}
+        />
+      </ScrollArea>
+    </div>
+  );
+}
+
+function DiffFileList({
+  machineId,
+  projectName,
+  branchName,
+  scope,
+  scopesApplicable,
+  list,
+}: {
+  machineId: string;
+  projectName: string;
+  branchName: string;
+  scope: MachineDiffScope;
+  scopesApplicable: boolean;
+  list: ReturnType<typeof useMachineDiffFiles>;
+}) {
+  const { data, error, isLoading } = list;
+
+  if (isLoading) {
+    return <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>;
+  }
+  if (error) {
+    return <div className="p-4 text-sm text-destructive">Failed to load diff: {error.message}</div>;
+  }
+  if (!data || data.notApplicable) {
+    // Only reachable if the active scope is itself not applicable — which the
+    // toggle already prevents; render nothing rather than an empty-diff lie.
+    return null;
+  }
+  if (data.files.length === 0) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">
+        {scope === 'uncommitted' && !scopesApplicable
+          ? `No uncommitted changes on ${branchName}`
+          : `No ${SCOPE_LABELS[scope].toLowerCase()} changes`}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 p-3">
+      {data.truncated && (
+        <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+          This diff is too large to list in full — some changed files are not shown.
+        </div>
+      )}
+      {data.files.map((file) => (
+        <DiffFileCard
+          key={`${file.status}:${file.previousPath ?? ''}:${file.path}`}
+          machineId={machineId}
+          projectName={projectName}
+          branchName={branchName}
+          scope={scope}
+          file={file}
+        />
+      ))}
+    </div>
+  );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -46,9 +46,13 @@ function emptyMessage(scope: MachineDiffScope, branchName: string, scopesApplica
 export default function DiffTab({ machineId }: { machineId: string }) {
   const [selected, setSelected] = useState<SelectedBranch | null>(null);
 
+  // Only a branch identifies a checkout to diff. Machine/Project rows are
+  // navigation-only, so they must NOT be marked selectable — a row with a select
+  // handler uses it INSTEAD of expand-on-label-click, which would leave those
+  // labels as dead buttons that swallow the click and do nothing.
+  const isNodeSelectable = useCallback((node: MachineTreeNode) => node.level === 'branch', []);
+
   const onSelectNode = useCallback((node: MachineTreeNode) => {
-    // Only a branch identifies a checkout to diff; Machine/Project rows are
-    // navigation-only here (clicking them still expands via TreeRow).
     if (node.level !== 'branch') return;
     setSelected({ projectName: node.projectName, branchName: node.branchName });
   }, []);
@@ -60,7 +64,7 @@ export default function DiffTab({ machineId }: { machineId: string }) {
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Branches</span>
         </div>
         <ScrollArea className="flex-1">
-          <MachineTree machineId={machineId} onSelectNode={onSelectNode} />
+          <MachineTree machineId={machineId} onSelectNode={onSelectNode} isNodeSelectable={isNodeSelectable} />
         </ScrollArea>
       </aside>
       <div className="min-w-0 flex-1">
@@ -218,14 +222,18 @@ function DiffFileList({
       </div>
     );
   }
-  if (data.files.length === 0) {
+  // `truncated` is checked BEFORE the empty state: a list cut at the output cap
+  // before its first complete entry comes back as `{ files: [], truncated: true }`,
+  // and reporting that as "no changes" would be the one place this pane claims a
+  // clean tree on partial data.
+  if (data.files.length === 0 && !data.truncated) {
     return <div className="p-4 text-sm text-muted-foreground">{emptyMessage(scope, branchName, scopesApplicable)}</div>;
   }
 
   return (
     <div className="flex flex-col gap-2 p-3">
       {data.truncated && (
-        <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <div className="rounded-md border border-border bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
           This diff is too large to list in full — some changed files are not shown.
         </div>
       )}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -212,23 +212,38 @@ function BranchDiffPane({
       {!probeResolved ? (
         <div className="p-4 text-sm text-muted-foreground">Loading changed files…</div>
       ) : (
-        // ONE panel, for the active scope. Radix unmounts inactive TabsContent, so
-        // rendering one per scope produced identical DOM. It exists to give the
-        // active trigger a real tabpanel to control — the whole reason Tabs wraps
-        // the list rather than just the triggers.
-        <TabsContent value={active} className="min-h-0 flex-1">
-          <ScrollArea className="h-full">
-            <DiffFileList
-              machineId={machineId}
-              projectName={projectName}
-              branchName={branchName}
-              scope={active}
-              scopesApplicable={scopesApplicable}
-              data={list.data}
-              error={list.error}
-            />
-          </ScrollArea>
-        </TabsContent>
+        // ONE PANEL PER SCOPE, and this is NOT redundant — a simplification pass
+        // collapsed it to a single `<TabsContent value={active}>` on the premise
+        // that Radix unmounts inactive panels. It does not: Tabs hands `children`
+        // to Presence AS A FUNCTION, which force-mounts, so the panel <div> always
+        // renders (only its children are gated). Two things depend on that:
+        //
+        //  1. every trigger's `aria-controls` resolves to a real element. With one
+        //     panel, the two inactive triggers point at ids present nowhere in the
+        //     DOM — the exact dangling-IDREF violation the Tabs wrapper above
+        //     exists to avoid.
+        //  2. `key={option}` gives each scope its own subtree, so switching scope
+        //     UNMOUNTS the old panel. Without it an expanded card whose path exists
+        //     in both scopes stays open across the switch and immediately refetches
+        //     its pair — an extra sandbox git exec per open card, every switch.
+        //
+        // Radix renders only the ACTIVE panel's children, so this is still one
+        // rendered list, not three.
+        availableScopes.map((option) => (
+          <TabsContent key={option} value={option} className="min-h-0 flex-1">
+            <ScrollArea className="h-full">
+              <DiffFileList
+                machineId={machineId}
+                projectName={projectName}
+                branchName={branchName}
+                scope={active}
+                scopesApplicable={scopesApplicable}
+                data={list.data}
+                error={list.error}
+              />
+            </ScrollArea>
+          </TabsContent>
+        ))
       )}
     </Tabs>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -79,7 +79,16 @@ export default function DiffTab({ machineId }: { machineId: string }) {
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Branches</span>
         </div>
         <ScrollArea className="flex-1">
-          <MachineTree machineId={machineId} onSelectNode={onSelectNode} isNodeSelectable={isNodeSelectable} />
+          <MachineTree
+            machineId={machineId}
+            onSelectNode={onSelectNode}
+            isNodeSelectable={isNodeSelectable}
+            // Without this the tree gives no sign of which branch is being
+            // diffed — the only clue would be the path in the pane header.
+            selectedNode={
+              selected ? { level: 'branch', projectName: selected.projectName, branchName: selected.branchName } : null
+            }
+          />
         </ScrollArea>
       </aside>
       <div className="min-w-0 flex-1">

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/tabs/DiffTab.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
-import { useMachineDiffFiles, isMachineDiffKey } from '@/hooks/useMachineDiff';
+import { useMachineDiffFiles, machineDiffKeyFilter } from '@/hooks/useMachineDiff';
 import { isMachineDiffScope, type MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
 import DiffFileCard from './DiffFileCard';
@@ -39,7 +39,11 @@ function emptyMessage(scope: MachineDiffScope, branchName: string, scopesApplica
   if (scope === 'uncommitted') {
     return scopesApplicable ? 'No uncommitted changes' : `No uncommitted changes on ${branchName}`;
   }
-  if (scope === 'committed') return `No commits on ${branchName} yet`;
+  // "No committed CHANGES", not "no commits": this scope measures the
+  // merge-base..HEAD diff, and a branch whose commits cancel out (a change plus
+  // its revert, or empty/merge commits) has commits but an empty diff. Say what
+  // was actually measured.
+  if (scope === 'committed') return `No committed changes on ${branchName}`;
   return `${branchName} is identical to the default branch`;
 }
 
@@ -127,15 +131,16 @@ function BranchDiffPane({
   const active: MachineDiffScope = scopesApplicable ? scope : 'uncommitted';
   const list = useMachineDiffFiles(machineId, projectName, branchName, active);
 
-  // Revalidate the WHOLE diff surface, not just the two lists this pane holds:
-  // every expanded card owns a separate pair key, and refreshing only the lists
-  // would leave an open Monaco diff showing pre-edit content indefinitely (the
-  // pair hook sets revalidateOnFocus: false, so nothing else would ever refetch
-  // it). The keyed predicate catches lists and pairs alike.
+  // Revalidate every key of THIS branch's diff — not just the two lists this pane
+  // holds, because each expanded card owns a separate pair key and refreshing only
+  // the lists would leave an open Monaco diff serving pre-edit content forever
+  // (the pair hook sets revalidateOnFocus: false, so nothing else would refetch
+  // it). Scoped to the branch, so refreshing here can't re-fire the git execs of
+  // another Machine page that's merely kept mounted in the keep-alive LRU.
   const { mutate } = useSWRConfig();
   const refresh = useCallback(() => {
-    void mutate(isMachineDiffKey);
-  }, [mutate]);
+    void mutate(machineDiffKeyFilter(machineId, projectName, branchName));
+  }, [mutate, machineId, projectName, branchName]);
 
   const availableScopes: MachineDiffScope[] = scopesApplicable
     ? ['uncommitted', 'committed', 'branch']

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -31,8 +31,16 @@ const cannedFetch = () =>
   vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
     const url = String(args[0]);
     if (url.includes('/api/machines/projects')) {
+      // TWO projects, each with an identically-named branch: nearly every repo has
+      // a 'main', so a node-identity check that ignored projectName would highlight
+      // the 'main' row under EVERY project while only one is being diffed.
       return new Response(
-        JSON.stringify({ projects: [{ name: 'my-repo', repoUrl: 'https://github.com/org/my-repo.git', path: '/repo', createdAt: '2026-01-01' }] }),
+        JSON.stringify({
+          projects: [
+            { name: 'my-repo', repoUrl: 'https://github.com/org/my-repo.git', path: '/repo', createdAt: '2026-01-01' },
+            { name: 'other-repo', repoUrl: 'https://github.com/org/other-repo.git', path: '/other', createdAt: '2026-01-01' },
+          ],
+        }),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     }
@@ -133,25 +141,50 @@ describe('MachineTree', () => {
     });
   });
 
-  test('the selected node is highlighted and marked aria-current', async () => {
+  /** The row's LABEL button — the interactive element, which is where aria-current has to live. */
+  const labelButtonIn = (row: HTMLElement) => within(row).getAllByRole('button')[row.querySelector('[data-testid="expand-chevron"]') ? 1 : 0];
+
+  test('the selected branch is marked aria-current — under ITS project only', async () => {
+    // Both projects have a 'main'. Only my-repo/main is selected, so a
+    // node-identity check that ignored projectName would light up both.
     renderTree({
       onSelectNode: vi.fn(),
+      isNodeSelectable: (node: MachineTreeNode) => node.level === 'branch',
       selectedNode: { level: 'branch', projectName: 'my-repo', branchName: 'main' },
     });
 
     await expandRowFor('my-repo');
-    const branchRow = (await waitFor(() => screen.getByText('main'))).closest('.group') as HTMLElement;
-    const projectRow = screen.getByText('my-repo').closest('.group') as HTMLElement;
+    await expandRowFor('other-repo');
+    const mainRows = await waitFor(() => {
+      const rows = screen.getAllByText('main');
+      if (rows.length < 2) throw new Error('waiting for both projects to list their branches');
+      return rows;
+    });
 
-    // Without this the Diff tab gives no sign of which branch it is diffing.
+    // aria-current must be on the interactive label button: the row wrapper has no
+    // role and isn't focusable, so AT never reaches it.
+    const current = mainRows.map((label) => {
+      const row = label.closest('.group') as HTMLElement;
+      return labelButtonIn(row).getAttribute('aria-current');
+    });
+
     assert({
-      given: 'a selectedNode naming one branch',
-      should: 'mark THAT row current (and not its siblings/ancestors)',
-      actual: {
-        branch: branchRow.getAttribute('aria-current'),
-        project: projectRow.getAttribute('aria-current'),
-      },
-      expected: { branch: 'true', project: null },
+      given: "two projects that each have a 'main' branch, with only my-repo/main selected",
+      should: 'mark exactly ONE of them current — the one under the selected project',
+      actual: { currentCount: current.filter((c) => c === 'true').length, total: current.length },
+      expected: { currentCount: 1, total: 2 },
+    });
+  });
+
+  test('no selectedNode leaves every row uncurrent (the Terminal tab has no persistent selection)', async () => {
+    renderTree();
+
+    const projectRow = (await waitFor(() => screen.getByText('my-repo'))).closest('.group') as HTMLElement;
+    assert({
+      given: 'a tree rendered without selectedNode',
+      should: 'mark nothing current',
+      actual: labelButtonIn(projectRow).getAttribute('aria-current'),
+      expected: null,
     });
   });
 
@@ -207,14 +240,17 @@ describe('MachineTree', () => {
     renderTree();
 
     await expandRowFor('my-repo');
-    await waitFor(() => screen.getByText('main'));
+    const branchLabel = await waitFor(() => screen.getAllByText('main')[0]);
+    const branchRow = branchLabel.closest('.group') as HTMLElement;
 
-    // Machine and Project rows each have a chevron; a bare branch row (no renderNodeChildren) should not add a third.
+    // Asserted on the BRANCH ROW itself rather than by counting chevrons across the
+    // whole tree — a global count silently depends on how many projects the fixture
+    // happens to have.
     assert({
       given: 'no renderNodeChildren slot passed',
-      should: 'not offer an expand/collapse control on branch rows (they render as flat, selectable leaves)',
-      actual: screen.getAllByTestId('expand-chevron').length,
-      expected: 2,
+      should: 'not offer an expand/collapse control on the branch row (it renders as a flat, selectable leaf)',
+      actual: within(branchRow).queryByTestId('expand-chevron'),
+      expected: null,
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -133,6 +133,28 @@ describe('MachineTree', () => {
     });
   });
 
+  test('the selected node is highlighted and marked aria-current', async () => {
+    renderTree({
+      onSelectNode: vi.fn(),
+      selectedNode: { level: 'branch', projectName: 'my-repo', branchName: 'main' },
+    });
+
+    await expandRowFor('my-repo');
+    const branchRow = (await waitFor(() => screen.getByText('main'))).closest('.group') as HTMLElement;
+    const projectRow = screen.getByText('my-repo').closest('.group') as HTMLElement;
+
+    // Without this the Diff tab gives no sign of which branch it is diffing.
+    assert({
+      given: 'a selectedNode naming one branch',
+      should: 'mark THAT row current (and not its siblings/ancestors)',
+      actual: {
+        branch: branchRow.getAttribute('aria-current'),
+        project: projectRow.getAttribute('aria-current'),
+      },
+      expected: { branch: 'true', project: null },
+    });
+  });
+
   test('a node included by isNodeSelectable still selects (and does not expand)', async () => {
     const onSelectNode = vi.fn();
     renderTree({ onSelectNode, isNodeSelectable: (node: MachineTreeNode) => node.level === 'branch' });

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -45,10 +45,20 @@ const cannedFetch = () =>
       );
     }
     if (url.includes('/api/machines/branches')) {
-      return new Response(
-        JSON.stringify({ branches: [{ branchName: 'main', createdAt: '2026-01-01' }] }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      );
+      // my-repo carries TWO branches so node identity is pinned on BOTH axes: the
+      // two projects (above) cover the projectName half, these cover branchName.
+      // Without a second branch here, an identity check that ignored branchName
+      // would highlight every branch under the selected project at once.
+      const branches = url.includes('projectName=my-repo')
+        ? [
+            { branchName: 'main', createdAt: '2026-01-01' },
+            { branchName: 'feat/x', createdAt: '2026-01-01' },
+          ]
+        : [{ branchName: 'main', createdAt: '2026-01-01' }];
+      return new Response(JSON.stringify({ branches }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
     return new Response('{}', { status: 200 });
   });
@@ -173,6 +183,31 @@ describe('MachineTree', () => {
       should: 'mark exactly ONE of them current — the one under the selected project',
       actual: { currentCount: current.filter((c) => c === 'true').length, total: current.length },
       expected: { currentCount: 1, total: 2 },
+    });
+  });
+
+  test('a SIBLING branch in the same project is not marked current', async () => {
+    // The other half of node identity: my-repo has both 'main' and 'feat/x'.
+    // Selecting one must not light up the other, or the sidebar claims two
+    // branches are being diffed while the pane shows one.
+    renderTree({
+      onSelectNode: vi.fn(),
+      isNodeSelectable: (node: MachineTreeNode) => node.level === 'branch',
+      selectedNode: { level: 'branch', projectName: 'my-repo', branchName: 'feat/x' },
+    });
+
+    await expandRowFor('my-repo');
+    const selectedRow = (await waitFor(() => screen.getByText('feat/x'))).closest('.group') as HTMLElement;
+    const siblingRow = screen.getAllByText('main')[0].closest('.group') as HTMLElement;
+
+    assert({
+      given: "one project holding two branches, with only feat/x selected",
+      should: 'mark feat/x current and leave its sibling main uncurrent',
+      actual: {
+        selected: labelButtonIn(selectedRow).getAttribute('aria-current'),
+        sibling: labelButtonIn(siblingRow).getAttribute('aria-current'),
+      },
+      expected: { selected: 'true', sibling: null },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.test.tsx
@@ -113,6 +113,42 @@ describe('MachineTree', () => {
     });
   });
 
+  test('a node excluded by isNodeSelectable keeps expand-on-label-click instead of becoming a dead button', async () => {
+    // The Diff tab selects BRANCHES only. Without this opt-in, passing
+    // onSelectNode would attach a select handler to every row — and since a
+    // select handler is used INSTEAD of expand-on-label-click, the Machine and
+    // Project labels would swallow the click and do nothing at all.
+    const onSelectNode = vi.fn();
+    renderTree({ onSelectNode, isNodeSelectable: (node: MachineTreeNode) => node.level === 'branch' });
+
+    const projectRow = await waitFor(() => screen.getByText('my-repo'));
+    await userEvent.click(projectRow);
+
+    const branchRow = await waitFor(() => screen.getByText('main'));
+    assert({
+      given: 'onSelectNode with only branch nodes marked selectable, and a project label clicked',
+      should: 'expand the project (not select it) — the label must stay live',
+      actual: { expanded: branchRow.textContent, selected: onSelectNode.mock.calls.length },
+      expected: { expanded: 'main', selected: 0 },
+    });
+  });
+
+  test('a node included by isNodeSelectable still selects (and does not expand)', async () => {
+    const onSelectNode = vi.fn();
+    renderTree({ onSelectNode, isNodeSelectable: (node: MachineTreeNode) => node.level === 'branch' });
+
+    await expandRowFor('my-repo');
+    const branchRow = await waitFor(() => screen.getByText('main'));
+    await userEvent.click(branchRow);
+
+    assert({
+      given: 'a selectable branch row clicked',
+      should: 'report the branch node to onSelectNode',
+      actual: onSelectNode.mock.calls[0]?.[0],
+      expected: { level: 'branch', projectName: 'my-repo', branchName: 'main' },
+    });
+  });
+
   test('with no onSelectNode, clicking a node label toggles its expansion (row-click affordance)', async () => {
     // The Terminal tab renders MachineTree without onSelectNode; the label must
     // still expand the row on click (like the old Navigator), not be a dead button.

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -135,10 +135,13 @@ function TreeRow({
   return (
     <div
       className={cn(
-        'group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50',
-        selected && 'bg-accent',
+        'group flex items-center gap-1 rounded-sm py-1 pr-1',
+        // Hover must not fight the selected state: bg-accent and hover:bg-accent/50
+        // are different variant groups, so twMerge keeps both and the hover rule
+        // wins — pointing at the selected row would LIGHTEN it, making it read as
+        // less selected than its unhovered siblings.
+        selected ? 'bg-accent' : 'hover:bg-accent/50',
       )}
-      aria-current={selected ? 'true' : undefined}
     >
       {onToggleExpand ? (
         <button
@@ -157,6 +160,10 @@ function TreeRow({
         type="button"
         onClick={onLabelClick}
         disabled={!onLabelClick}
+        // aria-current belongs on the INTERACTIVE element, not the row wrapper: the
+        // wrapper has no role and isn't focusable, so a screen-reader user never
+        // reaches it and the selection would be conveyed by background colour alone.
+        aria-current={selected ? 'true' : undefined}
         className={cn('flex flex-1 items-center gap-1 text-left', !onLabelClick && 'cursor-default')}
       >
         {icon}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -66,18 +66,29 @@ interface MachineTreeProps {
    * normal expand-on-label-click affordance.
    */
   isNodeSelectable?: (node: MachineTreeNode) => boolean;
+  /** The currently-selected node, highlighted and marked `aria-current`. Omit for trees where selection isn't a persistent state (e.g. the Terminal tab, whose clicks open panes rather than select a row). */
+  selectedNode?: MachineTreeNode | null;
   /** Renders caller-owned content under a node when it's expanded (e.g. session-terminal rows). Branch nodes are only expandable when this is provided — otherwise they render as a flat, non-expandable row. */
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
 }
 
+/** Do two tree nodes address the same thing? */
+export function isSameMachineTreeNode(a: MachineTreeNode | null | undefined, b: MachineTreeNode | null | undefined): boolean {
+  if (!a || !b || a.level !== b.level) return false;
+  if (a.level === 'machine') return true;
+  if (a.level === 'project') return b.level === 'project' && a.projectName === b.projectName;
+  return b.level === 'branch' && a.projectName === b.projectName && a.branchName === b.branchName;
+}
+
 /** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */
-export default function MachineTree({ machineId, onSelectNode, isNodeSelectable, renderNodeChildren }: MachineTreeProps) {
+export default function MachineTree({ machineId, onSelectNode, isNodeSelectable, selectedNode, renderNodeChildren }: MachineTreeProps) {
   return (
     <div className="p-1 text-sm">
       <MachineNode
         machineId={machineId}
         onSelectNode={onSelectNode}
         isNodeSelectable={isNodeSelectable}
+        selectedNode={selectedNode}
         renderNodeChildren={renderNodeChildren}
       />
     </div>
@@ -99,6 +110,7 @@ function TreeRow({
   expanded,
   onToggleExpand,
   onSelect,
+  selected,
   icon,
   label,
   labelClassName,
@@ -108,6 +120,7 @@ function TreeRow({
   expanded?: boolean;
   onToggleExpand?(): void;
   onSelect?(): void;
+  selected?: boolean;
   icon: ReactNode;
   label: string;
   labelClassName?: string;
@@ -120,7 +133,13 @@ function TreeRow({
   // stays decoupled from expansion for callers that use it.
   const onLabelClick = onSelect ?? onToggleExpand;
   return (
-    <div className="group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50">
+    <div
+      className={cn(
+        'group flex items-center gap-1 rounded-sm py-1 pr-1 hover:bg-accent/50',
+        selected && 'bg-accent',
+      )}
+      aria-current={selected ? 'true' : undefined}
+    >
       {onToggleExpand ? (
         <button
           type="button"
@@ -151,10 +170,11 @@ function TreeRow({
 interface TreeLevelProps {
   onSelectNode?: (node: MachineTreeNode) => void;
   isNodeSelectable?: (node: MachineTreeNode) => boolean;
+  selectedNode?: MachineTreeNode | null;
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
 }
 
-function MachineNode({ machineId, onSelectNode, isNodeSelectable, renderNodeChildren }: TreeLevelProps & { machineId: string }) {
+function MachineNode({ machineId, onSelectNode, isNodeSelectable, selectedNode, renderNodeChildren }: TreeLevelProps & { machineId: string }) {
   const [expanded, setExpanded] = useState(true);
   const node: MachineTreeNode = { level: 'machine' };
   const { projects, isLoading: projectsLoading, addProject, removeProject } = useMachineProjects(expanded ? machineId : null);
@@ -165,6 +185,7 @@ function MachineNode({ machineId, onSelectNode, isNodeSelectable, renderNodeChil
         expanded={expanded}
         onToggleExpand={() => setExpanded((e) => !e)}
         onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
+        selected={isSameMachineTreeNode(node, selectedNode)}
         icon={<Cpu className="size-3.5 shrink-0" />}
         label="Machine"
         labelClassName="font-medium"
@@ -192,6 +213,7 @@ function MachineNode({ machineId, onSelectNode, isNodeSelectable, renderNodeChil
               projectName={project.name}
               onSelectNode={onSelectNode}
               isNodeSelectable={isNodeSelectable}
+              selectedNode={selectedNode}
               renderNodeChildren={renderNodeChildren}
               onRemoveProject={() => removeProject(project.name)}
             />
@@ -207,6 +229,7 @@ function ProjectNode({
   projectName,
   onSelectNode,
   isNodeSelectable,
+  selectedNode,
   renderNodeChildren,
   onRemoveProject,
 }: TreeLevelProps & {
@@ -225,6 +248,7 @@ function ProjectNode({
         expanded={expanded}
         onToggleExpand={() => setExpanded((e) => !e)}
         onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
+        selected={isSameMachineTreeNode(node, selectedNode)}
         icon={<FolderGit2 className="size-3.5 shrink-0" />}
         label={projectName}
         labelClassName="font-medium"
@@ -256,6 +280,7 @@ function ProjectNode({
               branchName={branch.branchName}
               onSelectNode={onSelectNode}
               isNodeSelectable={isNodeSelectable}
+              selectedNode={selectedNode}
               renderNodeChildren={renderNodeChildren}
               onRemoveBranch={() => removeBranch(branch.branchName)}
             />
@@ -271,6 +296,7 @@ function BranchNode({
   branchName,
   onSelectNode,
   isNodeSelectable,
+  selectedNode,
   renderNodeChildren,
   onRemoveBranch,
 }: TreeLevelProps & {
@@ -289,6 +315,7 @@ function BranchNode({
         expanded={expandable ? expanded : undefined}
         onToggleExpand={expandable ? () => setExpanded((e) => !e) : undefined}
         onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
+        selected={isSameMachineTreeNode(node, selectedNode)}
         icon={<GitBranch className="size-3.5 shrink-0" />}
         label={branchName}
         onRemove={() => setConfirmingRemove(true)}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -72,12 +72,28 @@ interface MachineTreeProps {
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
 }
 
+/**
+ * The node's identity as a string. A `switch` over `level`, so a fourth level can't
+ * be added without the compiler pointing here — the pairwise comparison this
+ * replaced needed a second `b.level === …` check on every branch purely to
+ * re-narrow the type, which read like a real (and confusing) extra condition.
+ * NUL-joined for the same reason the Diff tab's React keys are: these names can
+ * contain '/' and ':'.
+ */
+function nodeKey(node: MachineTreeNode): string {
+  switch (node.level) {
+    case 'machine':
+      return 'machine';
+    case 'project':
+      return `project\u0000${node.projectName}`;
+    case 'branch':
+      return `branch\u0000${node.projectName}\u0000${node.branchName}`;
+  }
+}
+
 /** Do two tree nodes address the same thing? */
 export function isSameMachineTreeNode(a: MachineTreeNode | null | undefined, b: MachineTreeNode | null | undefined): boolean {
-  if (!a || !b || a.level !== b.level) return false;
-  if (a.level === 'machine') return true;
-  if (a.level === 'project') return b.level === 'project' && a.projectName === b.projectName;
-  return b.level === 'branch' && a.projectName === b.projectName && a.branchName === b.branchName;
+  return a != null && b != null && nodeKey(a) === nodeKey(b);
 }
 
 /** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/workspace/MachineTree.tsx
@@ -55,17 +55,44 @@ interface MachineTreeProps {
   machineId: string;
   /** Called when a Machine/Project/Branch row is clicked. Omit if the tree itself isn't selectable (e.g. selection lives on injected leaf content instead). */
   onSelectNode?: (node: MachineTreeNode) => void;
+  /**
+   * Which nodes `onSelectNode` actually applies to. Default: all of them.
+   *
+   * A row with a select handler uses it INSTEAD of expand-on-label-click (the
+   * two are deliberately decoupled — selecting a row must never flip its
+   * disclosure state). So a caller that only means one level — the Diff tab
+   * selects branches, nothing else — would otherwise turn every Machine/Project
+   * label into a dead button. Returning false here leaves that row with the
+   * normal expand-on-label-click affordance.
+   */
+  isNodeSelectable?: (node: MachineTreeNode) => boolean;
   /** Renders caller-owned content under a node when it's expanded (e.g. session-terminal rows). Branch nodes are only expandable when this is provided — otherwise they render as a flat, non-expandable row. */
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
 }
 
 /** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */
-export default function MachineTree({ machineId, onSelectNode, renderNodeChildren }: MachineTreeProps) {
+export default function MachineTree({ machineId, onSelectNode, isNodeSelectable, renderNodeChildren }: MachineTreeProps) {
   return (
     <div className="p-1 text-sm">
-      <MachineNode machineId={machineId} onSelectNode={onSelectNode} renderNodeChildren={renderNodeChildren} />
+      <MachineNode
+        machineId={machineId}
+        onSelectNode={onSelectNode}
+        isNodeSelectable={isNodeSelectable}
+        renderNodeChildren={renderNodeChildren}
+      />
     </div>
   );
+}
+
+/** The row's select handler, or undefined when this node isn't selectable — in which case its label falls back to expand/collapse. */
+function selectHandlerFor(
+  node: MachineTreeNode,
+  onSelectNode?: (node: MachineTreeNode) => void,
+  isNodeSelectable?: (node: MachineTreeNode) => boolean,
+): (() => void) | undefined {
+  if (!onSelectNode) return undefined;
+  if (isNodeSelectable && !isNodeSelectable(node)) return undefined;
+  return () => onSelectNode(node);
 }
 
 function TreeRow({
@@ -123,10 +150,11 @@ function TreeRow({
 
 interface TreeLevelProps {
   onSelectNode?: (node: MachineTreeNode) => void;
+  isNodeSelectable?: (node: MachineTreeNode) => boolean;
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
 }
 
-function MachineNode({ machineId, onSelectNode, renderNodeChildren }: TreeLevelProps & { machineId: string }) {
+function MachineNode({ machineId, onSelectNode, isNodeSelectable, renderNodeChildren }: TreeLevelProps & { machineId: string }) {
   const [expanded, setExpanded] = useState(true);
   const node: MachineTreeNode = { level: 'machine' };
   const { projects, isLoading: projectsLoading, addProject, removeProject } = useMachineProjects(expanded ? machineId : null);
@@ -136,7 +164,7 @@ function MachineNode({ machineId, onSelectNode, renderNodeChildren }: TreeLevelP
       <TreeRow
         expanded={expanded}
         onToggleExpand={() => setExpanded((e) => !e)}
-        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
         icon={<Cpu className="size-3.5 shrink-0" />}
         label="Machine"
         labelClassName="font-medium"
@@ -163,6 +191,7 @@ function MachineNode({ machineId, onSelectNode, renderNodeChildren }: TreeLevelP
               machineId={machineId}
               projectName={project.name}
               onSelectNode={onSelectNode}
+              isNodeSelectable={isNodeSelectable}
               renderNodeChildren={renderNodeChildren}
               onRemoveProject={() => removeProject(project.name)}
             />
@@ -177,6 +206,7 @@ function ProjectNode({
   machineId,
   projectName,
   onSelectNode,
+  isNodeSelectable,
   renderNodeChildren,
   onRemoveProject,
 }: TreeLevelProps & {
@@ -194,7 +224,7 @@ function ProjectNode({
       <TreeRow
         expanded={expanded}
         onToggleExpand={() => setExpanded((e) => !e)}
-        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
         icon={<FolderGit2 className="size-3.5 shrink-0" />}
         label={projectName}
         labelClassName="font-medium"
@@ -225,6 +255,7 @@ function ProjectNode({
               projectName={projectName}
               branchName={branch.branchName}
               onSelectNode={onSelectNode}
+              isNodeSelectable={isNodeSelectable}
               renderNodeChildren={renderNodeChildren}
               onRemoveBranch={() => removeBranch(branch.branchName)}
             />
@@ -239,6 +270,7 @@ function BranchNode({
   projectName,
   branchName,
   onSelectNode,
+  isNodeSelectable,
   renderNodeChildren,
   onRemoveBranch,
 }: TreeLevelProps & {
@@ -256,7 +288,7 @@ function BranchNode({
       <TreeRow
         expanded={expandable ? expanded : undefined}
         onToggleExpand={expandable ? () => setExpanded((e) => !e) : undefined}
-        onSelect={onSelectNode ? () => onSelectNode(node) : undefined}
+        onSelect={selectHandlerFor(node, onSelectNode, isNodeSelectable)}
         icon={<GitBranch className="size-3.5 shrink-0" />}
         label={branchName}
         onRemove={() => setConfirmingRemove(true)}

--- a/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
 }));
 
-import { useMachineDiffFiles, useMachineDiffPair, isMachineDiffKey } from '../useMachineDiff';
+import { useMachineDiffFiles, useMachineDiffPair, machineDiffKeyFilter } from '../useMachineDiff';
 
 const ok = (body: unknown) => ({ ok: true, json: async () => body });
 
@@ -190,18 +190,57 @@ describe('useMachineDiffPair', () => {
   });
 });
 
-describe('isMachineDiffKey', () => {
-  test('matches list and pair keys, and nothing else', () => {
+describe('machineDiffKeyFilter', () => {
+  const key = (params: Record<string, string>) =>
+    `/api/machines/diff?${new URLSearchParams(params).toString()}`;
+
+  test("matches every key of ONE branch's diff — its lists and its open file pairs", () => {
+    const matches = machineDiffKeyFilter('m1', 'repo', 'feat/x');
+
     assert({
-      given: 'SWR keys from across the app',
-      should: 'match only this surface\'s keys, so a refresh revalidates lists AND open file pairs but not unrelated caches',
+      given: "the refresh filter for one branch, and that branch's own SWR keys",
+      should: 'match its scope lists AND its per-file pair keys — an open card owns a separate key that must revalidate too',
       actual: {
-        list: isMachineDiffKey('/api/machines/diff?machineId=m1&scope=uncommitted'),
-        pair: isMachineDiffKey('/api/machines/diff?machineId=m1&scope=uncommitted&path=src%2Fa.ts'),
-        otherRoute: isMachineDiffKey('/api/machines/files?machineId=m1'),
-        nonString: isMachineDiffKey(null),
+        uncommittedList: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'uncommitted' })),
+        committedList: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'committed' })),
+        pair: matches(
+          key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'branch', path: 'src/a.ts', status: 'modified' }),
+        ),
       },
-      expected: { list: true, pair: true, otherRoute: false, nonString: false },
+      expected: { uncommittedList: true, committedList: true, pair: true },
+    });
+  });
+
+  test('does NOT match another machine, project, or branch', () => {
+    const matches = machineDiffKeyFilter('m1', 'repo', 'feat/x');
+
+    // Machine pages stay mounted in a keep-alive LRU, so a machine-agnostic filter
+    // would re-fire a hidden machine's git execs (list + merge-base + every open
+    // pair) on every refresh — against a machine the user isn't even looking at.
+    assert({
+      given: 'SWR keys belonging to other machines/projects/branches, and unrelated routes',
+      should: 'reject them all — a refresh must never trigger sandbox git on a machine the user is not viewing',
+      actual: {
+        otherMachine: matches(key({ machineId: 'm2', projectName: 'repo', branchName: 'feat/x', scope: 'uncommitted' })),
+        otherProject: matches(key({ machineId: 'm1', projectName: 'other', branchName: 'feat/x', scope: 'uncommitted' })),
+        otherBranch: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/y', scope: 'uncommitted' })),
+        otherRoute: matches('/api/machines/files?machineId=m1'),
+        nonString: matches(null),
+      },
+      expected: { otherMachine: false, otherProject: false, otherBranch: false, otherRoute: false, nonString: false },
+    });
+  });
+
+  test('a branch name that PREFIXES another does not match it', () => {
+    const matches = machineDiffKeyFilter('m1', 'repo', 'feat');
+
+    // The filter is a string prefix test, so the trailing '&' after branchName is
+    // load-bearing: without it, the filter for 'feat' would also swallow 'feature'.
+    assert({
+      given: "the filter for branch 'feat' and a key for branch 'feature'",
+      should: "not match — 'feat' must not swallow 'feature'",
+      actual: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feature', scope: 'uncommitted' })),
+      expected: false,
     });
   });
 });

--- a/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
@@ -1,0 +1,207 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import type { ReactNode } from 'react';
+import { assert } from '@/stores/__tests__/riteway';
+
+const fetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
+}));
+
+import { useMachineDiffFiles, useMachineDiffPair, isMachineDiffKey } from '../useMachineDiff';
+
+const ok = (body: unknown) => ({ ok: true, json: async () => body });
+
+/** Fresh SWR cache per test, else a key hit in one test satisfies the next. */
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+/** The URL the hook actually requested, as parsed params. */
+const requestedParams = (): URLSearchParams =>
+  new URL(fetchWithAuth.mock.calls[0][0] as string, 'https://x').searchParams;
+
+describe('useMachineDiffFiles', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('does not fetch until a branch and scope are selected', () => {
+    renderHook(() => useMachineDiffFiles('m1', null, null, null), { wrapper });
+
+    assert({
+      given: 'no branch selected yet',
+      should: 'issue no request — the tab fetches on-demand, never eagerly',
+      actual: fetchWithAuth.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('requests the changed-file list for the selected branch and scope', async () => {
+    fetchWithAuth.mockResolvedValue(
+      ok({ notApplicable: false, scope: 'branch', files: [{ path: 'src/a.ts', status: 'modified' }], truncated: false }),
+    );
+
+    const { result } = renderHook(() => useMachineDiffFiles('m1', 'repo', 'feat/x', 'branch'), { wrapper });
+    await waitFor(() => assert({ given: 'a resolved fetch', should: 'have data', actual: result.current.data !== undefined, expected: true }));
+
+    assert({
+      given: 'a branch + scope selected',
+      should: 'GET the diff route with machineId/projectName/branchName/scope, and surface the file list',
+      actual: {
+        params: Object.fromEntries(requestedParams()),
+        files: result.current.data && !result.current.data.notApplicable ? result.current.data.files : null,
+      },
+      expected: {
+        params: { machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'branch' },
+        files: [{ path: 'src/a.ts', status: 'modified' }],
+      },
+    });
+  });
+
+  test('surfaces the route\'s explicit notApplicable answer rather than flattening it to empty', async () => {
+    fetchWithAuth.mockResolvedValue(ok({ notApplicable: true }));
+
+    const { result } = renderHook(() => useMachineDiffFiles('m1', 'repo', 'main', 'committed'), { wrapper });
+    await waitFor(() => assert({ given: 'a resolved fetch', should: 'have data', actual: result.current.data !== undefined, expected: true }));
+
+    assert({
+      given: 'the main branch, where committed/branch scopes are meaningless',
+      should: 'pass notApplicable through — the toggle depends on this flag, not on an empty file list',
+      actual: result.current.data,
+      expected: { notApplicable: true },
+    });
+  });
+
+  test('raises the route error message', async () => {
+    fetchWithAuth.mockResolvedValue({ ok: false, json: async () => ({ error: 'Branch machine not_found' }) });
+
+    const { result } = renderHook(() => useMachineDiffFiles('m1', 'repo', 'feat/x', 'uncommitted'), { wrapper });
+    await waitFor(() => assert({ given: 'a failed fetch', should: 'have error', actual: result.current.error !== undefined, expected: true }));
+
+    assert({
+      given: 'the route returning a non-2xx with an error body',
+      should: 'throw that message so the UI shows the real failure, not an empty diff',
+      actual: result.current.error?.message,
+      expected: 'Branch machine not_found',
+    });
+  });
+});
+
+describe('useMachineDiffPair', () => {
+  const file = { path: 'src/a.ts', status: 'modified' as const };
+
+  beforeEach(() => vi.clearAllMocks());
+
+  test('does not fetch while the card is collapsed', () => {
+    renderHook(() => useMachineDiffPair('m1', 'repo', 'feat/x', 'uncommitted', file, false), { wrapper });
+
+    assert({
+      given: 'a collapsed file card (enabled=false)',
+      should: 'issue no request — a 200-file scope must cost zero content fetches until a card is opened',
+      actual: fetchWithAuth.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('returns each side as { content, truncated } — the shape the route actually ships', async () => {
+    fetchWithAuth.mockResolvedValue(
+      ok({
+        notApplicable: false,
+        scope: 'uncommitted',
+        path: 'src/a.ts',
+        original: { content: 'old', truncated: false },
+        modified: { content: 'new', truncated: true },
+      }),
+    );
+
+    const { result } = renderHook(() => useMachineDiffPair('m1', 'repo', 'feat/x', 'uncommitted', file, true), { wrapper });
+    await waitFor(() => assert({ given: 'a resolved fetch', should: 'have data', actual: result.current.data !== undefined, expected: true }));
+
+    assert({
+      given: 'the per-file pair form of the diff route',
+      should: 'keep each side\'s content AND its truncated flag — a bare string would drop the cut-off warning',
+      actual: result.current.data,
+      expected: {
+        notApplicable: false,
+        scope: 'uncommitted',
+        path: 'src/a.ts',
+        original: { content: 'old', truncated: false },
+        modified: { content: 'new', truncated: true },
+      },
+    });
+  });
+
+  test('passes null sides through for an added file (no original)', async () => {
+    fetchWithAuth.mockResolvedValue(
+      ok({ notApplicable: false, scope: 'uncommitted', path: 'new.ts', original: null, modified: { content: 'brand new', truncated: false } }),
+    );
+    const added = { path: 'new.ts', status: 'added' as const };
+
+    const { result } = renderHook(() => useMachineDiffPair('m1', 'repo', 'feat/x', 'uncommitted', added, true), { wrapper });
+    await waitFor(() => assert({ given: 'a resolved fetch', should: 'have data', actual: result.current.data !== undefined, expected: true }));
+
+    assert({
+      given: 'an added file, which has no original side',
+      should: 'keep the null side as null so the renderer diffs against an empty original',
+      actual: result.current.data && !result.current.data.notApplicable ? result.current.data.original : 'missing',
+      expected: null,
+    });
+  });
+
+  test('threads status and previousPath so a rename reads its pre-rename original', async () => {
+    fetchWithAuth.mockResolvedValue(
+      ok({ notApplicable: false, scope: 'branch', path: 'src/new.ts', original: { content: 'a', truncated: false }, modified: { content: 'b', truncated: false } }),
+    );
+    const renamed = { path: 'src/new.ts', status: 'renamed' as const, previousPath: 'src/old.ts' };
+
+    renderHook(() => useMachineDiffPair('m1', 'repo', 'feat/x', 'branch', renamed, true), { wrapper });
+    await waitFor(() => assert({ given: 'a fired fetch', should: 'have been called', actual: fetchWithAuth.mock.calls.length, expected: 1 }));
+
+    assert({
+      given: 'a renamed file from the changed-file list',
+      should: 'send path, status and previousPath — without previousPath the route resolves no original and mis-shows the rename as an add',
+      actual: Object.fromEntries(requestedParams()),
+      expected: {
+        machineId: 'm1',
+        projectName: 'repo',
+        branchName: 'feat/x',
+        scope: 'branch',
+        path: 'src/new.ts',
+        status: 'renamed',
+        previousPath: 'src/old.ts',
+      },
+    });
+  });
+
+  test('omits previousPath for a file that has none', async () => {
+    fetchWithAuth.mockResolvedValue(
+      ok({ notApplicable: false, scope: 'uncommitted', path: 'src/a.ts', original: null, modified: null }),
+    );
+
+    renderHook(() => useMachineDiffPair('m1', 'repo', 'feat/x', 'uncommitted', file, true), { wrapper });
+    await waitFor(() => assert({ given: 'a fired fetch', should: 'have been called', actual: fetchWithAuth.mock.calls.length, expected: 1 }));
+
+    assert({
+      given: 'a plain modified file',
+      should: 'not send an empty previousPath param',
+      actual: requestedParams().has('previousPath'),
+      expected: false,
+    });
+  });
+});
+
+describe('isMachineDiffKey', () => {
+  test('matches list and pair keys, and nothing else', () => {
+    assert({
+      given: 'SWR keys from across the app',
+      should: 'match only this surface\'s keys, so a refresh revalidates lists AND open file pairs but not unrelated caches',
+      actual: {
+        list: isMachineDiffKey('/api/machines/diff?machineId=m1&scope=uncommitted'),
+        pair: isMachineDiffKey('/api/machines/diff?machineId=m1&scope=uncommitted&path=src%2Fa.ts'),
+        otherRoute: isMachineDiffKey('/api/machines/files?machineId=m1'),
+        nonString: isMachineDiffKey(null),
+      },
+      expected: { list: true, pair: true, otherRoute: false, nonString: false },
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
+++ b/apps/web/src/hooks/__tests__/useMachineDiff.test.tsx
@@ -9,7 +9,13 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
 }));
 
-import { useMachineDiffFiles, useMachineDiffPair, machineDiffKeyFilter } from '../useMachineDiff';
+import {
+  useMachineDiffFiles,
+  useMachineDiffPair,
+  machineDiffKeyFilter,
+  machineDiffListKey,
+  machineDiffPairKey,
+} from '../useMachineDiff';
 
 const ok = (body: unknown) => ({ ok: true, json: async () => body });
 
@@ -191,23 +197,27 @@ describe('useMachineDiffPair', () => {
 });
 
 describe('machineDiffKeyFilter', () => {
-  const key = (params: Record<string, string>) =>
-    `/api/machines/diff?${new URLSearchParams(params).toString()}`;
+  const file = { path: 'src/a.ts', status: 'modified' as const };
 
-  test("matches every key of ONE branch's diff — its lists and its open file pairs", () => {
+  test("matches the REAL keys the hooks build for one branch — lists and open file pairs", () => {
     const matches = machineDiffKeyFilter('m1', 'repo', 'feat/x');
 
+    // Built with the SAME exported builders the hooks use, not hand-written
+    // look-alikes: the filter is a string-prefix test, so its correctness is
+    // coupled to the key's param ORDER. A hand-rolled expectation would keep
+    // passing after a reorder while Refresh silently matched nothing in the app.
     assert({
-      given: "the refresh filter for one branch, and that branch's own SWR keys",
+      given: "the refresh filter for one branch, and the actual keys the hooks produce for it",
       should: 'match its scope lists AND its per-file pair keys — an open card owns a separate key that must revalidate too',
       actual: {
-        uncommittedList: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'uncommitted' })),
-        committedList: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'committed' })),
-        pair: matches(
-          key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/x', scope: 'branch', path: 'src/a.ts', status: 'modified' }),
+        uncommittedList: matches(machineDiffListKey('m1', 'repo', 'feat/x', 'uncommitted')),
+        committedList: matches(machineDiffListKey('m1', 'repo', 'feat/x', 'committed')),
+        pair: matches(machineDiffPairKey('m1', 'repo', 'feat/x', 'branch', file)),
+        renamedPair: matches(
+          machineDiffPairKey('m1', 'repo', 'feat/x', 'branch', { ...file, status: 'renamed', previousPath: 'src/old.ts' }),
         ),
       },
-      expected: { uncommittedList: true, committedList: true, pair: true },
+      expected: { uncommittedList: true, committedList: true, pair: true, renamedPair: true },
     });
   });
 
@@ -221,26 +231,48 @@ describe('machineDiffKeyFilter', () => {
       given: 'SWR keys belonging to other machines/projects/branches, and unrelated routes',
       should: 'reject them all — a refresh must never trigger sandbox git on a machine the user is not viewing',
       actual: {
-        otherMachine: matches(key({ machineId: 'm2', projectName: 'repo', branchName: 'feat/x', scope: 'uncommitted' })),
-        otherProject: matches(key({ machineId: 'm1', projectName: 'other', branchName: 'feat/x', scope: 'uncommitted' })),
-        otherBranch: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feat/y', scope: 'uncommitted' })),
+        otherMachine: matches(machineDiffListKey('m2', 'repo', 'feat/x', 'uncommitted')),
+        otherProject: matches(machineDiffListKey('m1', 'other', 'feat/x', 'uncommitted')),
+        otherBranch: matches(machineDiffListKey('m1', 'repo', 'feat/y', 'uncommitted')),
+        otherMachinePair: matches(machineDiffPairKey('m2', 'repo', 'feat/x', 'uncommitted', file)),
         otherRoute: matches('/api/machines/files?machineId=m1'),
         nonString: matches(null),
       },
-      expected: { otherMachine: false, otherProject: false, otherBranch: false, otherRoute: false, nonString: false },
+      expected: {
+        otherMachine: false,
+        otherProject: false,
+        otherBranch: false,
+        otherMachinePair: false,
+        otherRoute: false,
+        nonString: false,
+      },
     });
   });
 
   test('a branch name that PREFIXES another does not match it', () => {
-    const matches = machineDiffKeyFilter('m1', 'repo', 'feat');
-
     // The filter is a string prefix test, so the trailing '&' after branchName is
     // load-bearing: without it, the filter for 'feat' would also swallow 'feature'.
     assert({
-      given: "the filter for branch 'feat' and a key for branch 'feature'",
+      given: "the filter for branch 'feat' and a real key for branch 'feature'",
       should: "not match — 'feat' must not swallow 'feature'",
-      actual: matches(key({ machineId: 'm1', projectName: 'repo', branchName: 'feature', scope: 'uncommitted' })),
+      actual: machineDiffKeyFilter('m1', 'repo', 'feat')(machineDiffListKey('m1', 'repo', 'feature', 'uncommitted')),
       expected: false,
+    });
+  });
+
+  test('a branch name containing & or = cannot forge the key boundary', () => {
+    // URLSearchParams percent-encodes them, so a value can never look like a
+    // delimiter and cross-match another branch's keys.
+    const matches = machineDiffKeyFilter('m1', 'repo', 'feat&branchName=other');
+
+    assert({
+      given: 'a branch name carrying the key format\'s own delimiters',
+      should: 'still match only its own keys, and not the branch it tries to impersonate',
+      actual: {
+        own: matches(machineDiffListKey('m1', 'repo', 'feat&branchName=other', 'uncommitted')),
+        impersonated: matches(machineDiffListKey('m1', 'repo', 'other', 'uncommitted')),
+      },
+      expected: { own: true, impersonated: false },
     });
   });
 });

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -23,9 +23,22 @@ export type MachineDiffFilesResponse =
     };
 
 /**
+ * One SIDE of a file's diff. NOT a bare string: the route ships the content
+ * together with its own `truncated` flag, because each side has its own cap — a
+ * git-blob side is cut at `runGitInSandbox`'s 256 KB stdout limit, a
+ * working-tree side at 2 MB (see `machine-diff.ts`). A truncated side matters to
+ * the UI: diffing a cut-off original against a whole modified paints the file's
+ * entire tail as removed lines that were never removed, so the flag has to reach
+ * the renderer rather than be dropped here.
+ */
+export interface MachineDiffSide {
+  content: string;
+  truncated: boolean;
+}
+
+/**
  * One file's original/modified pair for a scope. A side is `null` when the file
- * doesn't exist there (an added file's original, a deleted file's modified);
- * the caller coerces null to '' before handing it to Monaco.
+ * doesn't exist there (an added file's original, a deleted file's modified).
  */
 export type MachineDiffPairResponse =
   | { notApplicable: true }
@@ -33,9 +46,23 @@ export type MachineDiffPairResponse =
       notApplicable: false;
       scope: MachineDiffScope;
       path: string;
-      original: string | null;
-      modified: string | null;
+      original: MachineDiffSide | null;
+      modified: MachineDiffSide | null;
     };
+
+/**
+ * Every diff SWR key (lists AND per-file pairs) starts with this, so a refresh
+ * can invalidate the whole surface with one keyed predicate — the expanded
+ * cards' pair keys are separate SWR entries the pane doesn't own, and revalidating
+ * only the lists would leave an open card serving pre-edit content forever
+ * (both hooks set `revalidateOnFocus: false`).
+ */
+export const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';
+
+/** True for any SWR key belonging to this surface — pass to SWR's global `mutate`. */
+export function isMachineDiffKey(key: unknown): boolean {
+  return typeof key === 'string' && key.startsWith(MACHINE_DIFF_KEY_PREFIX);
+}
 
 const fetcher = <T>(url: string): Promise<T> =>
   fetchWithAuth(url).then(async (res) => {
@@ -59,10 +86,8 @@ export function useMachineDiffFiles(
 ) {
   const key =
     projectName && branchName && scope
-      ? `/api/machines/diff?machineId=${encodeURIComponent(machineId)}` +
-        `&projectName=${encodeURIComponent(projectName)}` +
-        `&branchName=${encodeURIComponent(branchName)}` +
-        `&scope=${scope}`
+      ? MACHINE_DIFF_KEY_PREFIX +
+        new URLSearchParams({ machineId, projectName, branchName, scope }).toString()
       : null;
 
   const { data, error, isLoading, mutate } = useSWR<MachineDiffFilesResponse>(key, fetcher, {
@@ -98,8 +123,11 @@ export function useMachineDiffPair(
             path: file.path,
             status: file.status,
           });
+          // The rename SOURCE, so the route reads the 'original' side from the
+          // pre-rename location instead of missing at the new path and
+          // mis-showing the rename as an add.
           if (file.previousPath) params.set('previousPath', file.previousPath);
-          return `/api/machines/diff?${params.toString()}`;
+          return MACHINE_DIFF_KEY_PREFIX + params.toString();
         })()
       : null;
 

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -95,11 +95,13 @@ export function useMachineDiffFiles(
         new URLSearchParams({ machineId, projectName, branchName, scope }).toString()
       : null;
 
-  const { data, error, isLoading, mutate } = useSWR<MachineDiffFilesResponse>(key, fetcher, {
+  const { data, error, isLoading, isValidating, mutate } = useSWR<MachineDiffFilesResponse>(key, fetcher, {
     revalidateOnFocus: false,
   });
 
-  return { data, error: error as Error | undefined, isLoading, mutate };
+  // `isValidating` (not `isLoading`) is what a refresh flips: the list already
+  // has data, so SWR keeps serving it and only marks the refetch in flight.
+  return { data, error: error as Error | undefined, isLoading, isValidating, mutate };
 }
 
 /**

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -55,13 +55,53 @@ export type MachineDiffPairResponse =
       modified: MachineDiffSide | null;
     };
 
+const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';
+
 /**
- * Every diff SWR key (lists AND per-file pairs) starts with this. Both builders
- * below emit `machineId`, `projectName`, `branchName` first and in that order, so
- * a key for one branch is exactly `<prefix><those three>&…` — which is what makes
- * the scoped filter below a simple, exact string test.
+ * The params identifying WHICH branch's diff a key addresses. Every key — list and
+ * pair alike — starts with exactly these three, in this order.
+ *
+ * This is a single shared builder ON PURPOSE. `machineDiffKeyFilter` matches keys
+ * by string prefix, so its correctness depends on that ordering; if the list and
+ * pair hooks each spelled their own `URLSearchParams` literal, reordering one of
+ * them would silently stop Refresh from matching it — the button would revalidate
+ * nothing, with no spinner and no error, and present a stale diff as fresh. Routing
+ * every key through one function makes that drift impossible rather than merely
+ * unlikely.
  */
-export const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';
+function branchScopedParams(machineId: string, projectName: string, branchName: string): URLSearchParams {
+  return new URLSearchParams({ machineId, projectName, branchName });
+}
+
+/** SWR key for one branch+scope's changed-file list. */
+export function machineDiffListKey(
+  machineId: string,
+  projectName: string,
+  branchName: string,
+  scope: MachineDiffScope,
+): string {
+  const params = branchScopedParams(machineId, projectName, branchName);
+  params.set('scope', scope);
+  return MACHINE_DIFF_KEY_PREFIX + params.toString();
+}
+
+/** SWR key for ONE file's diff pair within a branch+scope. */
+export function machineDiffPairKey(
+  machineId: string,
+  projectName: string,
+  branchName: string,
+  scope: MachineDiffScope,
+  file: MachineDiffFile,
+): string {
+  const params = branchScopedParams(machineId, projectName, branchName);
+  params.set('scope', scope);
+  params.set('path', file.path);
+  params.set('status', file.status);
+  // The rename SOURCE, so the route reads the 'original' side from the pre-rename
+  // location instead of missing at the new path and mis-showing the rename as an add.
+  if (file.previousPath) params.set('previousPath', file.previousPath);
+  return MACHINE_DIFF_KEY_PREFIX + params.toString();
+}
 
 /**
  * An SWR `mutate` filter matching every key of ONE branch's diff — its scope
@@ -79,16 +119,18 @@ export const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';
  * refreshing only the lists would leave an open card serving pre-edit content
  * forever (both hooks set `revalidateOnFocus: false`) — hence a filter rather than
  * two `mutate()` calls.
+ *
+ * The trailing '&' is a real boundary, not decoration: without it the filter for
+ * branch 'feat' would also swallow 'feature'. A value can never forge that
+ * delimiter, because `URLSearchParams` percent-encodes any literal '&' or '=' it
+ * contains.
  */
 export function machineDiffKeyFilter(
   machineId: string,
   projectName: string,
   branchName: string,
 ): (key: unknown) => boolean {
-  const branchPrefix =
-    MACHINE_DIFF_KEY_PREFIX +
-    new URLSearchParams({ machineId, projectName, branchName }).toString() +
-    '&';
+  const branchPrefix = MACHINE_DIFF_KEY_PREFIX + branchScopedParams(machineId, projectName, branchName).toString() + '&';
   return (key: unknown): boolean => typeof key === 'string' && key.startsWith(branchPrefix);
 }
 
@@ -113,10 +155,7 @@ export function useMachineDiffFiles(
   scope: MachineDiffScope | null,
 ) {
   const key =
-    projectName && branchName && scope
-      ? MACHINE_DIFF_KEY_PREFIX +
-        new URLSearchParams({ machineId, projectName, branchName, scope }).toString()
-      : null;
+    projectName && branchName && scope ? machineDiffListKey(machineId, projectName, branchName, scope) : null;
 
   const { data, error, isLoading, isValidating, mutate } = useSWR<MachineDiffFilesResponse>(key, fetcher, {
     revalidateOnFocus: false,
@@ -144,21 +183,7 @@ export function useMachineDiffPair(
 ) {
   const key =
     enabled && projectName && branchName && scope && file
-      ? (() => {
-          const params = new URLSearchParams({
-            machineId,
-            projectName,
-            branchName,
-            scope,
-            path: file.path,
-            status: file.status,
-          });
-          // The rename SOURCE, so the route reads the 'original' side from the
-          // pre-rename location instead of missing at the new path and
-          // mis-showing the rename as an add.
-          if (file.previousPath) params.set('previousPath', file.previousPath);
-          return MACHINE_DIFF_KEY_PREFIX + params.toString();
-        })()
+      ? machineDiffPairKey(machineId, projectName, branchName, scope, file)
       : null;
 
   const { data, error, isLoading } = useSWR<MachineDiffPairResponse>(key, fetcher, {

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { MachineDiffFile, MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+
+/**
+ * The Diff tab's changed-file list for one branch + scope, or the explicit
+ * `{ notApplicable: true }` the route returns for the 'committed'/'branch'
+ * scopes on the repo's main branch. Consumers detect the main-branch case from
+ * this flag — never by string-matching the branch name. `mergeBase` is present
+ * for the committed/branch scopes; the client doesn't need it (the pair form
+ * below re-derives both sides server-side), so it's typed loosely.
+ */
+export type MachineDiffFilesResponse =
+  | { notApplicable: true }
+  | {
+      notApplicable: false;
+      scope: MachineDiffScope;
+      files: MachineDiffFile[];
+      truncated: boolean;
+      mergeBase?: string | null;
+    };
+
+/**
+ * One file's original/modified pair for a scope. A side is `null` when the file
+ * doesn't exist there (an added file's original, a deleted file's modified);
+ * the caller coerces null to '' before handing it to Monaco.
+ */
+export type MachineDiffPairResponse =
+  | { notApplicable: true }
+  | {
+      notApplicable: false;
+      scope: MachineDiffScope;
+      path: string;
+      original: string | null;
+      modified: string | null;
+    };
+
+const fetcher = <T>(url: string): Promise<T> =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to load diff');
+    }
+    return res.json() as Promise<T>;
+  });
+
+/**
+ * Fetch the changed-file list for a branch + scope. Inert (no request) until a
+ * branch is selected AND a scope is set — the tab drives fetching on-demand
+ * (branch-select / scope-change / refresh), never eagerly.
+ */
+export function useMachineDiffFiles(
+  machineId: string,
+  projectName: string | null,
+  branchName: string | null,
+  scope: MachineDiffScope | null,
+) {
+  const key =
+    projectName && branchName && scope
+      ? `/api/machines/diff?machineId=${encodeURIComponent(machineId)}` +
+        `&projectName=${encodeURIComponent(projectName)}` +
+        `&branchName=${encodeURIComponent(branchName)}` +
+        `&scope=${scope}`
+      : null;
+
+  const { data, error, isLoading, mutate } = useSWR<MachineDiffFilesResponse>(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  return { data, error: error as Error | undefined, isLoading, mutate };
+}
+
+/**
+ * Fetch one file's diff pair, but only while `enabled` (i.e. the file card is
+ * expanded) — so a scope with 100 changed files issues 0 content requests until
+ * the user opens a card. `previousPath`/`status` are threaded so a rename's
+ * original resolves to its pre-rename location and a deletion's modified side is
+ * forced null (see the diff route's per-file contract).
+ */
+export function useMachineDiffPair(
+  machineId: string,
+  projectName: string | null,
+  branchName: string | null,
+  scope: MachineDiffScope | null,
+  file: MachineDiffFile | null,
+  enabled: boolean,
+) {
+  const key =
+    enabled && projectName && branchName && scope && file
+      ? (() => {
+          const params = new URLSearchParams({
+            machineId,
+            projectName,
+            branchName,
+            scope,
+            path: file.path,
+            status: file.status,
+          });
+          if (file.previousPath) params.set('previousPath', file.previousPath);
+          return `/api/machines/diff?${params.toString()}`;
+        })()
+      : null;
+
+  const { data, error, isLoading } = useSWR<MachineDiffPairResponse>(key, fetcher, {
+    revalidateOnFocus: false,
+  });
+
+  return { data, error: error as Error | undefined, isLoading };
+}

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -24,26 +24,23 @@ export type MachineDiffFilesResponse =
     };
 
 /**
- * One SIDE of a file's diff — `{ content, truncated }`, NOT a bare string.
+ * One file's original/modified pair for a scope.
  *
- * This ALIASES the server's own return type rather than re-declaring the shape,
- * on purpose: the first cut of this hook hand-copied a `string | null` side, the
- * fetcher's `as Promise<T>` cast laundered it past the compiler, and every file
- * expansion handed Monaco an object. Aliasing the source of truth means a future
- * server-side change to a side's shape breaks THIS file at typecheck instead of
- * silently at runtime. (`import type` is erased at build — no server code or
- * node dependency reaches the client bundle.)
+ * Each SIDE is the server's own `MachineDiffSideContent` — `{ content, truncated }`,
+ * NOT a bare string — imported rather than re-declared ON PURPOSE. The first cut of
+ * this hook hand-copied a `string | null` side, the fetcher's `as Promise<T>` cast
+ * laundered it past the compiler, and every file expansion handed Monaco an object.
+ * Importing the source of truth means a future server-side change to a side's shape
+ * breaks THIS file at typecheck instead of silently at runtime. (`import type` is
+ * erased at build — no server code or node dependency reaches the client bundle.)
  *
  * The `truncated` flag has to survive to the renderer: a git-blob side is cut at
- * `runGitInSandbox`'s 256 KB stdout cap and a working-tree side at 2 MB, and
- * diffing a cut-off side against a whole one paints the file's untouched tail as
+ * `runGitInSandbox`'s 256 KB stdout cap and a working-tree side at 2 MB, and diffing
+ * a cut-off side against a whole one paints the file's untouched tail as
  * removed/added lines.
- */
-export type MachineDiffSide = MachineDiffSideContent;
-
-/**
- * One file's original/modified pair for a scope. A side is `null` when the file
- * doesn't exist there (an added file's original, a deleted file's modified).
+ *
+ * A side is `null` when the file doesn't exist there (an added file's original, a
+ * deleted file's modified).
  */
 export type MachineDiffPairResponse =
   | { notApplicable: true }
@@ -51,8 +48,8 @@ export type MachineDiffPairResponse =
       notApplicable: false;
       scope: MachineDiffScope;
       path: string;
-      original: MachineDiffSide | null;
-      modified: MachineDiffSide | null;
+      original: MachineDiffSideContent | null;
+      modified: MachineDiffSideContent | null;
     };
 
 const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -56,17 +56,40 @@ export type MachineDiffPairResponse =
     };
 
 /**
- * Every diff SWR key (lists AND per-file pairs) starts with this, so a refresh
- * can invalidate the whole surface with one keyed predicate — the expanded
- * cards' pair keys are separate SWR entries the pane doesn't own, and revalidating
- * only the lists would leave an open card serving pre-edit content forever
- * (both hooks set `revalidateOnFocus: false`).
+ * Every diff SWR key (lists AND per-file pairs) starts with this. Both builders
+ * below emit `machineId`, `projectName`, `branchName` first and in that order, so
+ * a key for one branch is exactly `<prefix><those three>&…` — which is what makes
+ * the scoped filter below a simple, exact string test.
  */
 export const MACHINE_DIFF_KEY_PREFIX = '/api/machines/diff?';
 
-/** True for any SWR key belonging to this surface — pass to SWR's global `mutate`. */
-export function isMachineDiffKey(key: unknown): boolean {
-  return typeof key === 'string' && key.startsWith(MACHINE_DIFF_KEY_PREFIX);
+/**
+ * An SWR `mutate` filter matching every key of ONE branch's diff — its scope
+ * lists AND its expanded cards' per-file pairs.
+ *
+ * Scoped to the branch ON PURPOSE. A bare `/api/machines/diff?` prefix test would
+ * also match OTHER machines' keys, and those are not hypothetical: Machine pages
+ * are kept mounted across navigation in a bounded LRU (`TerminalKeepAliveHost`,
+ * CSS-hidden, not unmounted), so a hidden Machine page's Diff tab still holds live
+ * SWR subscriptions. Refreshing machine B would then re-fire machine A's list, its
+ * merge-base probe, and every pair it had open — real sandbox `git` execs, billed,
+ * against an unrelated and possibly stopped machine.
+ *
+ * The expanded cards' pair keys are separate SWR entries the pane doesn't own, so
+ * refreshing only the lists would leave an open card serving pre-edit content
+ * forever (both hooks set `revalidateOnFocus: false`) — hence a filter rather than
+ * two `mutate()` calls.
+ */
+export function machineDiffKeyFilter(
+  machineId: string,
+  projectName: string,
+  branchName: string,
+): (key: unknown) => boolean {
+  const branchPrefix =
+    MACHINE_DIFF_KEY_PREFIX +
+    new URLSearchParams({ machineId, projectName, branchName }).toString() +
+    '&';
+  return (key: unknown): boolean => typeof key === 'string' && key.startsWith(branchPrefix);
 }
 
 const fetcher = <T>(url: string): Promise<T> =>

--- a/apps/web/src/hooks/useMachineDiff.ts
+++ b/apps/web/src/hooks/useMachineDiff.ts
@@ -3,6 +3,7 @@
 import useSWR from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import type { MachineDiffFile, MachineDiffScope } from '@pagespace/lib/services/sandbox/machine-diff-scope';
+import type { MachineDiffSideContent } from '@pagespace/lib/services/sandbox/machine-diff';
 
 /**
  * The Diff tab's changed-file list for one branch + scope, or the explicit
@@ -23,18 +24,22 @@ export type MachineDiffFilesResponse =
     };
 
 /**
- * One SIDE of a file's diff. NOT a bare string: the route ships the content
- * together with its own `truncated` flag, because each side has its own cap — a
- * git-blob side is cut at `runGitInSandbox`'s 256 KB stdout limit, a
- * working-tree side at 2 MB (see `machine-diff.ts`). A truncated side matters to
- * the UI: diffing a cut-off original against a whole modified paints the file's
- * entire tail as removed lines that were never removed, so the flag has to reach
- * the renderer rather than be dropped here.
+ * One SIDE of a file's diff — `{ content, truncated }`, NOT a bare string.
+ *
+ * This ALIASES the server's own return type rather than re-declaring the shape,
+ * on purpose: the first cut of this hook hand-copied a `string | null` side, the
+ * fetcher's `as Promise<T>` cast laundered it past the compiler, and every file
+ * expansion handed Monaco an object. Aliasing the source of truth means a future
+ * server-side change to a side's shape breaks THIS file at typecheck instead of
+ * silently at runtime. (`import type` is erased at build — no server code or
+ * node dependency reaches the client bundle.)
+ *
+ * The `truncated` flag has to survive to the renderer: a git-blob side is cut at
+ * `runGitInSandbox`'s 256 KB stdout cap and a working-tree side at 2 MB, and
+ * diffing a cut-off side against a whole one paints the file's untouched tail as
+ * removed/added lines.
  */
-export interface MachineDiffSide {
-  content: string;
-  truncated: boolean;
-}
+export type MachineDiffSide = MachineDiffSideContent;
 
 /**
  * One file's original/modified pair for a scope. A side is `null` when the file


### PR DESCRIPTION
Phase 3 of the Machine page rebuild (Terminal — GA Release epic). Fills in the placeholder `DiffTab` left by the 4-tab shell (#1999). Spec: task page `o4qkoxr3tcbxsy26cvwq5kyg`.

## What it does

**Inner sidebar** — the shared `MachineTree` in **bare mode** (no session leaves). **Branch** rows are the diff target; a Machine or Project spans many checkouts and has no single working tree to compare, so those rows stay pure navigation. The selected branch is highlighted and `aria-current`.

**Main pane** — a 3-way scope toggle (Uncommitted / Committed / Branch vs default) on shadcn `Tabs`, over the changed-file list. Each file is its own card expanding into a `MonacoDiffEditor` — not one giant diff.

## The main-branch edge case

On the repo's main branch the `committed`/`branch` scopes are meaningless (a merge-base with itself), and `/api/machines/diff` says so with an explicit `{ notApplicable: true }`. The toggle **collapses to `Uncommitted` alone** — not three options with two disabled — driven by the route's flag, *not* by string-matching the branch name (grep the new files for `main`/`master`: only a comment) and *not* by inferring from empty data. When Uncommitted is itself clean: `No uncommitted changes on main`.

The `committed` list doubles as that probe: when the scopes *are* applicable, that same response *is* the Committed list, so SWR serves it from cache on select. An **errored** probe is deliberately not treated as a main-branch answer — a transient git failure must not silently hide two real scopes.

## Fetching

- Nothing fetched until a branch is selected.
- A card fetches its pair only **while expanded** — a 200-file branch costs one list request and zero editors until a file is opened.
- `previousPath`/`status` threaded per the route's contract: a rename resolves its `original` from the pre-rename location; a deletion's `modified` is forced null.
- Refresh revalidates **this branch's** lists *and* its open cards' pair keys — and nothing else's.

## One deliberate deviation from the spec's wording

The spec labels the third scope "Branch vs master"; it ships as **"Branch vs default"**. The server diffs against `origin/HEAD` — the remote's *actual* default — and `machine-diff-scope.ts` explicitly refuses to hardcode the `master` literal. "vs master" would name a branch that doesn't exist on a `main`-default repo, and would contradict this file's own empty state. Happy to revert if you'd rather match the spec text exactly.

## How this was converged — ten adversarial passes

Each pass found something the previous ones missed. The bugs worth knowing about:

1. **Blocker.** The route ships each side as `{ content, truncated }`, **not** a string. The hook typed it `string | null` and `res.json() as Promise<T>` laundered it past the compiler — every file expansion would have handed Monaco an object and rendered `[object Object]`. The suite was green only because the test mocked the hook with the same fictional shape. **Codex independently flagged this as P1** (thread below). The type now *aliases the server's own* `MachineDiffSideContent`.
2. Machine/Project sidebar rows were **dead buttons** (a select handler wins over expand-on-label-click). Fixed with an `isNodeSelectable` opt-in.
3. The scope toggle had **invalid ARIA**; Monaco **never relaid out** on resize.
4. **The scope switch itself was untested** — no-op'ing `setScope` left clicking "Committed" doing nothing while every test passed.
5. **Refresh re-fired *other machines'* sandbox git execs.** The key filter matched the route prefix alone, and `TerminalKeepAliveHost` keeps Machine pages *mounted* in a bounded LRU — so refreshing machine B revalidated machine A's list, its merge-base probe, and every open pair. Now scoped to `machineId+projectName+branchName`.
6. All diff SWR keys now flow through **one shared builder** (the prefix filter's correctness silently depended on three separate `URLSearchParams` literals agreeing on param order). `aria-current` was also on a non-interactive `<div>` — it never reached assistive tech.
7. Node identity and the truncated-**original** side were unpinned (the original is a blob, capped at 256 KB vs 2 MB — so it's the *likelier* truncation).
8. Clean (29 mutations, 22 killed, every survivor verified a non-defect).
9. **A simplification pass talked me into a regression, and the next pass caught it.** It claimed Radix unmounts inactive `TabsContent`, so the per-scope panels were redundant. **False** — Radix's `Presence` force-mounts when children is a function, so the panel div always renders and only its children are gated. Collapsing to one panel would have (a) left the two inactive triggers' `aria-controls` dangling and (b) stopped the scope switch from unmounting the panel, so a card open on a file present in both scopes would stay open and refetch — an extra sandbox git exec per open card, per switch. Reverted, with two regression tests that fail against the collapsed version. The other five simplifications were verified and kept.
10. Clean.

## Places the UI could have silently lied — all closed and mutation-pinned

- A **truncated side** diffed against a whole one paints the file's untouched tail as removed/added lines → warned (either side).
- A **truncated file list** cut to zero entries claimed "no changes" → `truncated` checked before the empty state.
- **Binary files** rendered as decoded mojibake → named as binary (git's NUL heuristic), sniffing *either* side.
- `notApplicable` and both **error** paths render explicitly rather than an endless spinner or a blank pane.

## Verification

- `tsc --noEmit` for `apps/web` — **exit 0**. CI green.
- `next lint` on every touched file — clean.
- **74/74 tests pass**, incl. 12 hook tests running the *real* hook against a mocked `fetchWithAuth`.
- **Mutation-tested throughout.** Every guard was deliberately broken, confirmed to fail exactly the intended test, and restored — including after the refactor.
- Full `apps/web` suite also run locally; the only failures are 4 files outside this diff needing a local Postgres role. CI's DB-backed run is green.

## Files (7)

| File | |
|---|---|
| `hooks/useMachineDiff.ts` | new — list + pair hooks, shared key builders, scoped refresh filter |
| `.../tabs/DiffTab.tsx` | body filled in (export name + `{ machineId }` signature unchanged) |
| `.../tabs/DiffFileCard.tsx` | new — collapsible per-file card |
| `.../workspace/MachineTree.tsx` | **shared** — adds optional `isNodeSelectable` + `selectedNode`; `TerminalTab` passes neither and is behaviorally unchanged |
| 3 test files | |

`ComingSoonTab.tsx` untouched (Code/Settings still import it).

## Known, accepted

- Removing the branch you're diffing leaves the pane on a dead branch; it shows an honest `Branch machine not_found`, not a wrong diff.
- Selecting a branch costs one extra git run (the applicability probe) — inherent to the spec's "no client-side inference" mandate; its response doubles as the Committed list.
- A changed binary still ships its bytes before being identified as binary. Cheaper to sniff server-side in `readMachineDiffPair` — a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfCchLKcuhRXeVrEh2uQcj