### PR TITLE
[sprites 1-3] onConnect: in-memory reattach before sprite resolution

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -43,6 +43,7 @@ import { createDbMachineAgentTerminalStore } from '@pagespace/lib/services/machi
 import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/machine-projects-store';
 import {
   resolveAgentTerminal,
+  resolveAgentTerminalRow,
   type AgentTerminalMachineSandbox,
   type AgentTerminalMachineSandboxResult,
 } from '@pagespace/lib/services/machines/agent-terminals';
@@ -284,6 +285,28 @@ const makeAgentTerminalCheckAuth = buildAgentTerminalCheckAuth({
   acquireSlot: ({ userId, tier }) => acquireCodeExecutionSlot({ userId, tier }),
   releaseSlot: (userId) => releaseCodeExecutionSlot({ userId }),
   resolveSandbox: (target) => resolveAgentTerminalSandbox(target),
+  // DB-only existence check for the (scope, name) target — no Sprite is resolved
+  // or woken, so the reattach fast path and the 60s re-auth tick can both afford
+  // to run it. It is what keeps a deleted project/branch/agent-terminal row from
+  // going unnoticed now that the sandbox resolution is lazy.
+  resolveTerminalRow: async ({ machineId, projectName, branchName, name }) => {
+    const [branchStore, agentTerminalStore, projectStore] = await Promise.all([
+      dbMachineBranchStorePromise,
+      dbMachineAgentTerminalStorePromise,
+      dbMachineProjectStorePromise,
+    ]);
+    return resolveAgentTerminalRow({
+      machineId,
+      projectName,
+      branchName,
+      name,
+      deps: {
+        branchStore,
+        store: agentTerminalStore,
+        projectStore: { findByName: (tId, pName) => projectStore.findByName(tId, pName) },
+      },
+    });
+  },
   // Write code execution audit record (agent terminal PTY session open) — this
   // launches an arbitrary pluggable agent binary (the resolved command, or a
   // per-terminal command override) inside the Sprite.

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -444,7 +444,19 @@ describe('buildAgentTerminalCheckAuth', () => {
     assert({
       given: 'an authorized connect whose caller must create a fresh PTY',
       should: 'resolve the agent terminal, sprite, cwd and launch spec',
-      actual: sandbox,
+      actual: sandbox.ok
+        ? {
+            ok: sandbox.ok,
+            agentTerminalId: sandbox.agentTerminalId,
+            sandboxId: sandbox.sandboxId,
+            cwd: sandbox.cwd,
+            sprite: sandbox.sprite,
+            command: sandbox.command,
+            args: sandbox.args,
+            commandOverride: sandbox.commandOverride,
+            streamSessionId: sandbox.streamSessionId,
+          }
+        : sandbox,
       expected: {
         ok: true,
         agentTerminalId: 'at-1',
@@ -476,6 +488,9 @@ describe('buildAgentTerminalCheckAuth', () => {
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
     const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    // The tier is only consulted where the slot is actually reserved — the
+    // create path — so drive the thunk to observe it.
+    if (result.ok) await result.resolveSandbox();
 
     assert({
       given: 'an authorized connect whose user row is missing',
@@ -485,18 +500,67 @@ describe('buildAgentTerminalCheckAuth', () => {
     });
   });
 
-  it('denies with concurrency_limit and reads no Sprite when the slot is exhausted', async () => {
+  it('denies with concurrency_limit and reads no Sprite when the slot is exhausted on the CREATE path', async () => {
     const sandbox = sandboxSpy(async () => resolvedOk);
     const { deps } = buildDeps({ acquireSlot: () => false, resolveSandbox: sandbox.fn });
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
-    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const result = auth.ok ? await auth.resolveSandbox() : auth;
 
     assert({
-      given: 'an exhausted concurrency slot',
+      given: 'an exhausted concurrency slot on a connect that must create a fresh PTY',
       should: 'deny with concurrency_limit without resolving a Sprite',
       actual: { result, spriteCalls: sandbox.getSpriteCalls.length },
       expected: { result: { ok: false, reason: 'concurrency_limit' }, spriteCalls: 0 },
+    });
+  });
+
+  it('AUTHORIZES a connect whose concurrency slots are all consumed, so long as the caller does not create a PTY', async () => {
+    // The regression this guards: the slot used to be reserved by the access
+    // check itself. A free-tier user (limit 1) whose ONE live session already
+    // held the only slot therefore could not (a) tab back to that session — the
+    // reattach's access check was denied `concurrency_limit` — nor (b) survive
+    // the 60s re-auth tick, which read the same denial as a REVOKED
+    // authorization and tore the live session down. Neither path starts a PTY,
+    // so neither may depend on a free slot.
+    let acquires = 0;
+    const { deps } = buildDeps({
+      acquireSlot: () => {
+        acquires += 1;
+        return false; // every slot is taken — by this user's own live session
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+
+    assert({
+      given: 'a reattach/re-auth check by a user with no free concurrency slot',
+      should: 'still authorize, and never even attempt to reserve a slot',
+      actual: { ok: auth.ok, sessionKey: auth.ok ? auth.sessionKey : null, acquires },
+      expected: { ok: true, sessionKey: 'session-key-1', acquires: 0 },
+    });
+  });
+
+  it('surfaces releaseSlot on the RESOLVED sandbox (the only path that reserves one)', async () => {
+    let releases = 0;
+    const { deps } = buildDeps({
+      releaseSlot: () => {
+        releases += 1;
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const sandbox = auth.ok ? await auth.resolveSandbox() : auth;
+    if (sandbox.ok) sandbox.releaseSlot();
+
+    assert({
+      given: 'a successfully resolved sandbox whose caller releases the slot it reserved',
+      should: 'expose releaseSlot on the sandbox result and release exactly the one slot taken',
+      actual: { hasRelease: sandbox.ok ? typeof sandbox.releaseSlot : null, releases },
+      expected: { hasRelease: 'function', releases: 1 },
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -253,7 +253,7 @@ function sandboxSpy(resolve: () => Promise<ResolveAgentTerminalResult>): Sandbox
   return spy;
 }
 
-type DepCalls = { getPageDriveId: number; canRunCode: number; getDriveAndUser: number };
+type DepCalls = { getPageDriveId: number; canRunCode: number; getDriveAndUser: number; resolveTerminalRow: number };
 
 /** Default deps whose read functions COUNT their own invocations, so a
  * short-circuit test can assert "this table was never queried" via `calls`
@@ -263,7 +263,7 @@ function buildDeps(overrides: Partial<AgentTerminalCheckAuthDeps> = {}): {
   deps: AgentTerminalCheckAuthDeps;
   calls: DepCalls;
 } {
-  const calls: DepCalls = { getPageDriveId: 0, canRunCode: 0, getDriveAndUser: 0 };
+  const calls: DepCalls = { getPageDriveId: 0, canRunCode: 0, getDriveAndUser: 0, resolveTerminalRow: 0 };
   const base: AgentTerminalCheckAuthDeps = {
     getAccessLevel: async () => ({ canEdit: true }),
     getPageDriveId: async () => {
@@ -292,6 +292,10 @@ function buildDeps(overrides: Partial<AgentTerminalCheckAuthDeps> = {}): {
       streamSessionId: null,
       sprite: fakeSprite,
     }),
+    resolveTerminalRow: async () => {
+      calls.resolveTerminalRow += 1;
+      return { ok: true };
+    },
     writeAudit: () => {},
     buildSessionKey: () => 'session-key-1',
     logDenied: () => {},
@@ -624,6 +628,71 @@ describe('buildAgentTerminalCheckAuth', () => {
       should: 'release the slot and propagate the original error (unchanged socket surface)',
       actual: { releases, thrown },
       expected: { releases: 1, thrown: boom },
+    });
+  });
+
+  it('DENIES when the terminal\'s scope row is gone, WITHOUT resolving a Sprite (so the 60s re-auth tick still notices a deleted project)', async () => {
+    // The regression this guards: with the sandbox resolution made lazy, the only
+    // thing that ever noticed a deleted project/branch/agent-terminal row was the
+    // resolve the re-auth tick no longer performs. A project deleted out from
+    // under a LIVE terminal would leave its PTY running against a scope that no
+    // longer exists. The existence check is DB-only, so re-auth can afford it —
+    // and it must never be answered by waking a Sprite.
+    const sandbox = sandboxSpy(async () => resolvedOk);
+    const denials: string[] = [];
+    const { deps } = buildDeps({
+      resolveSandbox: sandbox.fn,
+      resolveTerminalRow: async () => ({ ok: false, reason: 'project_not_found' }),
+      logDenied: (reason) => {
+        denials.push(reason);
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', projectName: 'gone', name: 'shell' });
+
+    assert({
+      given: 'a live terminal whose project row has been deleted',
+      should: 'deny with project_not_found from the ACCESS half, touching no Sprite',
+      actual: { result, denials, sandboxCalls: sandbox.calls, spriteCalls: sandbox.getSpriteCalls.length },
+      expected: {
+        result: { ok: false, reason: 'project_not_found' },
+        denials: ['project_not_found'],
+        sandboxCalls: 0,
+        spriteCalls: 0,
+      },
+    });
+  });
+
+  it('DENIES when the agent-terminal row itself is gone, without resolving a Sprite', async () => {
+    const sandbox = sandboxSpy(async () => resolvedOk);
+    const { deps } = buildDeps({
+      resolveSandbox: sandbox.fn,
+      resolveTerminalRow: async () => ({ ok: false, reason: 'not_found' }),
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'ghost' });
+
+    assert({
+      given: 'an agent-terminal row that no longer exists',
+      should: 'deny with not_found from the access half, touching no Sprite',
+      actual: { result, spriteCalls: sandbox.getSpriteCalls.length },
+      expected: { result: { ok: false, reason: 'not_found' }, spriteCalls: 0 },
+    });
+  });
+
+  it('checks the target row existence only AFTER the read-only access gates (a stranger learns nothing about which terminals exist)', async () => {
+    const { deps, calls } = buildDeps({ getAccessLevel: async () => ({ canEdit: false }) });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+
+    assert({
+      given: 'a user without edit access on the owning machine',
+      should: 'deny on access alone, without probing whether the named terminal exists',
+      actual: { result, rowLookups: calls.resolveTerminalRow },
+      expected: { result: { ok: false, reason: 'no_edit_access' }, rowLookups: 0 },
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -348,13 +348,43 @@ describe('buildAgentTerminalCheckAuth', () => {
     });
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
-    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'ghost' });
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'ghost' });
+    const result = auth.ok ? await auth.resolveSandbox() : auth;
 
     assert({
       given: 'a read-only sandbox resolution denial (not_found) after the slot was reserved',
       should: 'release the slot, log the denial, and return the reason',
       actual: { result, releases, denials },
       expected: { result: { ok: false, reason: 'not_found' }, releases: 1, denials: [{ reason: 'not_found' }] },
+    });
+  });
+
+  it('performs ZERO sandbox resolution and writes NO audit row when the caller never resolves the sandbox (the reattach path)', async () => {
+    const sandbox = sandboxSpy(async () => resolvedOk);
+    const audits: string[] = [];
+    const { deps } = buildDeps({
+      resolveSandbox: sandbox.fn,
+      writeAudit: ({ command }) => {
+        audits.push(command);
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    // Exactly what onConnect does when it finds a live in-memory session: it
+    // authorizes, takes the sessionKey, and never calls resolveSandbox.
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+
+    assert({
+      given: 'an authorized connect whose caller reattaches instead of creating',
+      should: 'authorize with a session key while touching no Sprite and writing no audit row',
+      actual: {
+        ok: auth.ok,
+        sessionKey: auth.ok ? auth.sessionKey : null,
+        sandboxCalls: sandbox.calls,
+        spriteCalls: sandbox.getSpriteCalls.length,
+        audits,
+      },
+      expected: { ok: true, sessionKey: 'session-key-1', sandboxCalls: 0, spriteCalls: 0, audits: [] },
     });
   });
 
@@ -388,7 +418,7 @@ describe('buildAgentTerminalCheckAuth', () => {
     });
   });
 
-  it('returns a fully-populated authorization on the happy path', async () => {
+  it('returns the access verdict (session key + payer) on the happy path', async () => {
     const { deps } = buildDeps();
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
@@ -396,34 +426,35 @@ describe('buildAgentTerminalCheckAuth', () => {
 
     assert({
       given: 'a fully-authorized connect',
-      should: 'return ok with the sandbox, session key and payer',
+      should: 'return ok with the session key and payer, plus a sandbox resolver to call lazily',
       actual: result.ok
-        ? {
-            ok: result.ok,
-            agentTerminalId: result.agentTerminalId,
-            sandboxId: result.sandboxId,
-            cwd: result.cwd,
-            sessionKey: result.sessionKey,
-            command: result.command,
-            args: result.args,
-            commandOverride: result.commandOverride,
-            streamSessionId: result.streamSessionId,
-            payerId: result.payerId,
-            sprite: result.sprite,
-          }
+        ? { ok: result.ok, sessionKey: result.sessionKey, payerId: result.payerId, resolver: typeof result.resolveSandbox }
         : result,
+      expected: { ok: true, sessionKey: 'session-key-1', payerId: 'payer-1', resolver: 'function' },
+    });
+  });
+
+  it('resolves the full sandbox (sprite + launch spec) when the cold path calls resolveSandbox', async () => {
+    const { deps } = buildDeps();
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const sandbox = auth.ok ? await auth.resolveSandbox() : auth;
+
+    assert({
+      given: 'an authorized connect whose caller must create a fresh PTY',
+      should: 'resolve the agent terminal, sprite, cwd and launch spec',
+      actual: sandbox,
       expected: {
         ok: true,
         agentTerminalId: 'at-1',
         sandboxId: 'sbx-1',
         cwd: '/home/machine',
-        sessionKey: 'session-key-1',
+        sprite: fakeSprite,
         command: 'shell',
         args: [],
         commandOverride: null,
         streamSessionId: null,
-        payerId: 'payer-1',
-        sprite: fakeSprite,
       },
     });
   });
@@ -487,7 +518,8 @@ describe('buildAgentTerminalCheckAuth', () => {
     });
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
-    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+    const result = auth.ok ? await auth.resolveSandbox() : auth;
 
     assert({
       given: 'a vanished-Sprite (provision_failed) sandbox result after the slot was reserved',
@@ -517,7 +549,8 @@ describe('buildAgentTerminalCheckAuth', () => {
 
     let thrown: unknown;
     try {
-      await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+      const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'shell' });
+      if (auth.ok) await auth.resolveSandbox();
     } catch (error) {
       thrown = error;
     }
@@ -550,7 +583,8 @@ describe('buildAgentTerminalCheckAuth', () => {
     });
     const checkAuth = buildAgentTerminalCheckAuth(deps);
 
-    await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'runner' });
+    const auth = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'runner' });
+    if (auth.ok) await auth.resolveSandbox();
 
     assert({
       given: 'a resolved terminal with a command override',

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -490,6 +490,71 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getBySocket('attacker-sock')).toBeUndefined();
     });
 
+    it('given two CONCURRENT cold connects for the same key, should keep ONE PTY — killing the loser and returning its slot', async () => {
+      // The genuinely racy double-mount: connect #2 arrives while connect #1 is
+      // still seconds deep in its cold resolveSandbox, so BOTH see an empty
+      // sessionMap and both open a PTY. Without a guard, setNew silently
+      // overwrites — orphaning the winner's PTY (nothing can reach it to kill it)
+      // and stranding its concurrency slot for the life of the process.
+      const authA = makeAuthSuccess();
+      const authB = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await Promise.all([
+        onConnect({ ...validPayload, connectionId: 'pane-a' }),
+        onConnect({ ...validPayload, connectionId: 'pane-b' }),
+      ]);
+
+      // Both genuinely raced down the cold path...
+      expect(openShell).toHaveBeenCalledTimes(2);
+      // ...but exactly one session survives under the shared key.
+      const survivor = sessionMap.getByKey('branch1:agent:cli');
+      expect(survivor).toBeDefined();
+      expect(survivor?.command).toBe(shellA);
+
+      // The loser's PTY is killed and its slot handed straight back — no orphan,
+      // no permanently-leaked concurrency capacity.
+      expect(shellB.kill).toHaveBeenCalled();
+      expect(authB.releaseSlot).toHaveBeenCalledTimes(1);
+
+      // The winner is untouched and still holds the one slot it reserved.
+      expect(shellA.kill).not.toHaveBeenCalled();
+      expect(authA.releaseSlot).not.toHaveBeenCalled();
+
+      // The loser's pane still gets a working terminal — it joined the winner.
+      expect(sessionMap.getBySocket('pane-b')).toBe(survivor);
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ connectionId: 'pane-b', scrollback: expect.any(String) }));
+    });
+
+    it('given a lost cold-race whose orphaned PTY exits later, should NOT evict the winner from the session map', async () => {
+      const authA = makeAuthSuccess();
+      const authB = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await Promise.all([
+        onConnect({ ...validPayload, connectionId: 'pane-a' }),
+        onConnect({ ...validPayload, connectionId: 'pane-b' }),
+      ]);
+
+      // The discarded PTY's kill lands asynchronously: its onExit fires AFTER the
+      // winner already owns the key. A blind deleteByKey here would evict the
+      // live winner and strand a running PTY.
+      const loserOnExit = openShell.mock.calls[1][0].onExit as (exitCode: number) => void;
+      loserOnExit(0);
+
+      expect(sessionMap.getByKey('branch1:agent:cli')?.command).toBe(shellA);
+      // ...and the loser's slot is still only returned once, not twice.
+      expect(authB.releaseSlot).toHaveBeenCalledTimes(1);
+    });
+
     it('given two connects for the same key (double-mount remount), should not double-create — the second reattaches via getByKey', async () => {
       // A StrictMode/HMR double-mount fires connect twice for the same
       // (scope, name). Once the first has established the session (setNew), the

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -490,18 +490,15 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getBySocket('attacker-sock')).toBeUndefined();
     });
 
-    it('given two CONCURRENT cold connects for the same key, should keep ONE PTY — killing the loser and returning its slot', async () => {
+    it('given two CONCURRENT cold connects for the same key, should open exactly ONE PTY — the second joins the first', async () => {
       // The genuinely racy double-mount: connect #2 arrives while connect #1 is
-      // still seconds deep in its cold resolveSandbox, so BOTH see an empty
-      // sessionMap and both open a PTY. Without a guard, setNew silently
-      // overwrites — orphaning the winner's PTY (nothing can reach it to kill it)
-      // and stranding its concurrency slot for the life of the process.
+      // still seconds deep in its cold resolveSandbox. Opening a second PTY here
+      // is not merely wasteful — when both attach to the SAME persisted Sprite exec
+      // session, discarding one would SIGKILL the process the other is attached to.
+      // So the key is claimed before the first await and #2 joins #1 instead.
       const authA = makeAuthSuccess();
       const authB = makeAuthSuccess();
       checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
-      const shellA = makeShell();
-      const shellB = makeShell();
-      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
       const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
 
       await Promise.all([
@@ -509,34 +506,29 @@ describe('buildAgentTerminalHandlers', () => {
         onConnect({ ...validPayload, connectionId: 'pane-b' }),
       ]);
 
-      // Both genuinely raced down the cold path...
-      expect(openShell).toHaveBeenCalledTimes(2);
-      // ...but exactly one session survives under the shared key.
-      const survivor = sessionMap.getByKey('branch1:agent:cli');
-      expect(survivor).toBeDefined();
-      expect(survivor?.command).toBe(shellA);
-
-      // The loser's PTY is killed and its slot handed straight back — no orphan,
-      // no permanently-leaked concurrency capacity.
-      expect(shellB.kill).toHaveBeenCalled();
-      expect(authB.releaseSlot).toHaveBeenCalledTimes(1);
-
-      // The winner is untouched and still holds the one slot it reserved.
-      expect(shellA.kill).not.toHaveBeenCalled();
+      // Exactly one PTY — the loser never opened one, so there is none to kill.
+      expect(openShell).toHaveBeenCalledTimes(1);
+      // The loser never even resolved a sandbox, so it reserved no slot and no hold.
+      expect(authB.resolveSandbox).not.toHaveBeenCalled();
+      expect(authB.releaseSlot).not.toHaveBeenCalled();
       expect(authA.releaseSlot).not.toHaveBeenCalled();
 
-      // The loser's pane still gets a working terminal — it joined the winner.
-      expect(sessionMap.getBySocket('pane-b')).toBe(survivor);
+      // Both panes end up on the one live session.
+      const session = sessionMap.getByKey('branch1:agent:cli');
+      expect(session).toBeDefined();
+      expect(sessionMap.getBySocket('pane-b')).toBe(session);
       expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ connectionId: 'pane-b', scrollback: expect.any(String) }));
     });
 
-    it('given a lost cold-race whose orphaned PTY exits later, should NOT evict the winner from the session map', async () => {
-      const authA = makeAuthSuccess();
-      const authB = makeAuthSuccess();
-      checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
-      const shellA = makeShell();
-      const shellB = makeShell();
-      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+    it('given a CONCURRENT connect while a cold create is attaching to a PERSISTED Sprite session, should never kill that session', async () => {
+      // The destructive case: both connects resolve the SAME streamSessionId, so
+      // openPtyShell would attachSession() to one shared server-side exec session.
+      // A "discard the duplicate" strategy would SIGKILL the very process the
+      // survivor is attached to. Serializing means the second never opens one.
+      checkAuth = vi
+        .fn()
+        .mockResolvedValueOnce(makeAuthSuccess({ streamSessionId: 'sess-shared' }))
+        .mockResolvedValueOnce(makeAuthSuccess({ streamSessionId: 'sess-shared' })) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
       const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
 
       await Promise.all([
@@ -544,15 +536,50 @@ describe('buildAgentTerminalHandlers', () => {
         onConnect({ ...validPayload, connectionId: 'pane-b' }),
       ]);
 
-      // The discarded PTY's kill lands asynchronously: its onExit fires AFTER the
-      // winner already owns the key. A blind deleteByKey here would evict the
-      // live winner and strand a running PTY.
-      const loserOnExit = openShell.mock.calls[1][0].onExit as (exitCode: number) => void;
-      loserOnExit(0);
+      expect(openShell).toHaveBeenCalledTimes(1);
+      expect(openShell).toHaveBeenCalledWith(expect.objectContaining({ sessionId: 'sess-shared' }));
+      // Nothing was killed — the shared Sprite session survives for the live viewer.
+      expect(shell.kill).not.toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')?.command).toBe(shell);
+    });
 
-      expect(sessionMap.getByKey('branch1:agent:cli')?.command).toBe(shellA);
-      // ...and the loser's slot is still only returned once, not twice.
-      expect(authB.releaseSlot).toHaveBeenCalledTimes(1);
+    it('given an in-flight cold create that FAILS, should let a queued connect create the session itself (no wedged key)', async () => {
+      const failing = makeAuthSuccess();
+      failing.resolveSandbox = vi.fn(async () => ({ ok: false as const, reason: 'provision_failed' }));
+      const succeeding = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValueOnce(failing).mockResolvedValueOnce(succeeding) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await Promise.all([
+        onConnect({ ...validPayload, connectionId: 'pane-a' }),
+        onConnect({ ...validPayload, connectionId: 'pane-b' }),
+      ]);
+
+      // The failed create released its claim, so the queued connect went on to
+      // create the session rather than joining a session that never existed.
+      expect(succeeding.resolveSandbox).toHaveBeenCalledTimes(1);
+      expect(openShell).toHaveBeenCalledTimes(1);
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+    });
+
+    it('given a fresh session where a SIBLING terminal opened a tty in the same window, should persist nothing rather than the sibling\'s id', async () => {
+      // One Sprite hosts every agent terminal on the machine. Two new tty sessions
+      // in the diff is ambiguous — guessing would point THIS terminal's next cold
+      // connect at another terminal's PTY.
+      const auth = makeAuthSuccess({ streamSessionId: null });
+      auth.sprite.listSessions = vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { id: 'sess-ours', command: 'pagespace-cli', isActive: true, tty: true },
+          { id: 'sess-sibling', command: 'claude', isActive: true, tty: true },
+        ]);
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(persistStreamSessionId).not.toHaveBeenCalled();
     });
 
     it('given two connects for the same key (double-mount remount), should not double-create — the second reattaches via getByKey', async () => {
@@ -611,6 +638,47 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(shell.kill).not.toHaveBeenCalled(); // natural exit — the stale re-auth must not kill
       expect(auth.releaseSlot).toHaveBeenCalledTimes(1); // slot not double-released
+    });
+
+    it('given a session reattached by a DIFFERENT user, should re-auth the CURRENT viewer, not the creator', async () => {
+      // A session outlives its creator's connection. If re-auth kept checking the
+      // creator — who of course remains authorized — a viewer who reattached and
+      // then had their access revoked would keep receiving PTY output, and could
+      // keep typing, indefinitely.
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload); // user1 creates
+
+      // user2 reattaches on their own socket.
+      const socket2 = makeSocket('sock2', 'user2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2, persistStreamSessionId });
+      await handlers2.onConnect(validPayload);
+      expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ viewerUserId: 'user2' });
+
+      checkAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      // The tick must ask about user2 — the one actually driving the PTY.
+      expect(checkAuth).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user2' }));
+      expect(checkAuth).not.toHaveBeenCalledWith(expect.objectContaining({ userId: 'user1' }));
+    });
+
+    it('given the reattached viewer loses access, should tear the session down at the next re-auth tick', async () => {
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload); // user1 creates
+
+      const socket2 = makeSocket('sock2', 'user2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2, persistStreamSessionId });
+      await handlers2.onConnect(validPayload); // user2 takes over the PTY
+
+      // user2's access is revoked; user1 would still pass.
+      checkAuth.mockImplementation(async ({ userId }: { userId: string }) =>
+        userId === 'user2' ? { ok: false, reason: 'permission_revoked' } : makeAuthSuccess(),
+      );
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(shell.kill).toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
+      expect(socket2.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock2' });
     });
 
     it('given re-auth fires and checkAuth now fails, should kill shell, remove session, and emit agent-terminal:closed with exitCode -2', async () => {
@@ -1076,17 +1144,13 @@ describe('buildAgentTerminalHandlers', () => {
       expect(billing.trackUsage).toHaveBeenCalledTimes(1);
     });
 
-    it('given a lost cold-connect race, RELEASES the duplicate\'s hold rather than settling it (even after its onExit lands)', async () => {
-      // The discarded PTY is killed the instant it opened — it ran no billable
-      // window. Its hold must be handed back, and the onExit that follows the
-      // kill must NOT then settle that same (already-released) hold.
+    it('given two CONCURRENT cold connects, places exactly ONE hold — the joiner never gates', async () => {
+      // Serializing the key means the second connect never resolves a sandbox, so
+      // it never gates and never places a hold there is nobody left to settle.
       const billing = makeBilling();
       const authA = makeAuthSuccess();
       const authB = makeAuthSuccess();
       checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
-      const shellA = makeShell();
-      const shellB = makeShell();
-      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
       const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
 
       await Promise.all([
@@ -1094,18 +1158,26 @@ describe('buildAgentTerminalHandlers', () => {
         onConnect({ ...validPayload, connectionId: 'pane-b' }),
       ]);
 
-      // Two cold paths raced, so two holds were placed; the loser's is released.
-      expect(billing.gate).toHaveBeenCalledTimes(2);
-      expect(billing.releaseHold).toHaveBeenCalledTimes(1);
+      expect(billing.gate).toHaveBeenCalledTimes(1);
+      expect(billing.releaseHold).not.toHaveBeenCalled();
       expect(billing.trackUsage).not.toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ holdId: 'hold-1' });
+    });
 
-      // The kill's onExit lands afterwards — it must not settle the released hold.
-      const loserOnExit = openShell.mock.calls[1][0].onExit as (exitCode: number) => void;
-      loserOnExit(0);
-      expect(billing.trackUsage).not.toHaveBeenCalled();
+    it('given the billing gate THROWS after the slot was reserved, releases the slot rather than leaking it forever', async () => {
+      // `activeByUser` is a process-lifetime counter. A gate that throws with the
+      // slot still held would lock a free-tier user (limit 1) out of agent terminals
+      // on this replica until the process restarts.
+      const auth = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const billing = makeBilling({ gate: vi.fn().mockRejectedValue(new Error('billing db blip')) });
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
 
-      // The winner is still live and still billable.
-      expect(sessionMap.getByKey('branch1:agent:cli')?.command).toBe(shellA);
+      await expect(onConnect(validPayload)).rejects.toThrow('billing db blip');
+
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
+      expect(openShell).not.toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
 
     it('reattaching to a live session does NOT place a second hold', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -877,6 +877,20 @@ describe('buildAgentTerminalHandlers', () => {
       expect(shell.kill).not.toHaveBeenCalled();
     });
 
+    it('given the idle timeout elapses, should HAND BACK the concurrency slot as well as killing the shell', async () => {
+      // The reaped session held a slot for its whole detached grace; the reap must
+      // return it, or a user's tier capacity bleeds away one abandoned tab at a time.
+      const auth = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      onDisconnect();
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
+
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
+      expect(shell.kill).toHaveBeenCalled();
+    });
+
     it('given the idle timeout elapses, should kill the shell and drop the session', async () => {
       const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
       await onConnect(validPayload);
@@ -1097,6 +1111,86 @@ describe('buildAgentTerminalHandlers', () => {
         expect(call.holdId).toBeUndefined();
         expect(call.activeSeconds).toBeCloseTo(5, 0);
       });
+
+      it('given a settle that rejects with a NON-Error value, wraps it and keeps the session alive (fail-open)', async () => {
+        const billing = makeBilling({ trackUsage: vi.fn().mockRejectedValue('db string blip') });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        // The non-Error rejection is coerced (never thrown), so the PTY survives.
+        expect(shell.kill).not.toHaveBeenCalled();
+        expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ holdId: 'hold-1' });
+      });
+
+      it('given the re-hold gate rejects with a NON-Error value at a heartbeat, keeps the session alive (fail-open)', async () => {
+        const billing = makeBilling({
+          gate: vi.fn().mockResolvedValueOnce({ allowed: true, holdId: 'hold-1' }).mockRejectedValue('gate string blip'),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        // Settle succeeded; only the re-hold failed (and with a non-Error) — session stays alive.
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+        expect(shell.kill).not.toHaveBeenCalled();
+        expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+      });
+
+      it('given the session was already removed when a heartbeat fires, clears its interval without settling', async () => {
+        const billing = makeBilling();
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        // Session vanished (e.g. reaped elsewhere) before the heartbeat tick.
+        sessionMap.deleteByKey('branch1:agent:cli');
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+        // No settle attempted for a gone session, and the interval stopped firing.
+        expect(billing.trackUsage).not.toHaveBeenCalled();
+      });
+
+      it('given a settle still in flight when the next heartbeat fires, skips the overlapping run', async () => {
+        let resolveSettle: () => void = () => {};
+        const billing = makeBilling({
+          trackUsage: vi
+            .fn()
+            .mockImplementationOnce(() => new Promise<void>((resolve) => { resolveSettle = () => resolve(undefined); }))
+            .mockResolvedValue(undefined),
+        });
+        const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+        await onConnect(validPayload);
+
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // first heartbeat: settle hangs
+        await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // second heartbeat: still settling → skipped
+
+        // Only the first settle is in flight; the overlapping tick did not start a second.
+        expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+
+        resolveSettle();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+      });
+    });
+
+    it('given two teardown paths fire for one session, hands the concurrency slot back exactly ONCE (idempotent release)', async () => {
+      // The slot is a bare counter — a second release would hand back capacity the
+      // connect never held, letting the user exceed their tier. A re-auth teardown
+      // releases it; a late onExit for the same (now killed) PTY must be a no-op.
+      const auth = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing: makeBilling() });
+      await onConnect(validPayload);
+      const onExitArg = openShell.mock.calls[0][0].onExit as (exitCode: number) => void;
+
+      checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
+      await vi.advanceTimersByTimeAsync(60_000); // re-auth teardown → release #1
+      onExitArg(0); // the killed PTY's exit lands later → release #2 attempt, must no-op
+
+      expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
     });
 
     it('given the shell exits naturally WHILE disconnected (idle reap still pending), should cancel the pending reap so it never double-settles', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -31,10 +31,11 @@ function makeSprite(sessions: Array<{ id: string; command: string; isActive: boo
 
 /**
  * A successful two-phase checkAuth result: the cheap DB-only access verdict,
- * plus the LAZY `resolveSandbox` thunk the cold path calls to resolve the
- * Sprite. `sprite` is re-surfaced at the top level purely so tests can spy on
- * it (it is the very same object the thunk hands back) — a reattach must leave
- * every one of its methods, and the thunk itself, untouched.
+ * plus the LAZY `resolveSandbox` thunk the cold path calls to reserve the
+ * concurrency slot and resolve the Sprite. `sprite` and `releaseSlot` are
+ * re-surfaced at the top level purely so tests can spy on them (they are the
+ * very same objects the thunk hands back) — a reattach must leave the sprite's
+ * methods, the slot, and the thunk itself untouched.
  */
 function makeAuthSuccess(over: Partial<{
   sessionKey: string;
@@ -47,6 +48,7 @@ function makeAuthSuccess(over: Partial<{
   payerId: string;
 }> = {}) {
   const sprite = makeSprite(over.sessions ?? []);
+  const releaseSlot = vi.fn();
   const sandbox = {
     ok: true as const,
     agentTerminalId: 'agent-terminal-1',
@@ -57,14 +59,15 @@ function makeAuthSuccess(over: Partial<{
     args: over.args ?? [],
     commandOverride: over.commandOverride ?? null,
     streamSessionId: over.streamSessionId ?? null,
+    releaseSlot,
   };
   return {
     ok: true as const,
     sessionKey: over.sessionKey ?? 'branch1:agent:cli',
     payerId: over.payerId ?? 'owner-1',
-    releaseSlot: vi.fn(),
     resolveSandbox: vi.fn(async () => sandbox),
     sprite,
+    releaseSlot,
   };
 }
 
@@ -123,32 +126,34 @@ describe('resolveAgentTerminalCommand', () => {
 });
 
 describe('planConnect', () => {
-  const liveSession = {} as TerminalSession;
+  const liveSession = { sessionKey: 'branch1:agent:cli' } as TerminalSession;
+  const granted = makeAuthSuccess();
+  const denied = { ok: false as const, reason: 'no_edit_access' };
 
   it('given access denied, should deny regardless of an existing session', () => {
     assert({
       given: 'a denied access verdict with a live in-memory session',
       should: 'deny (auth still gates the fast path — never reattach)',
-      actual: planConnect({ accessAllowed: false, existingSession: liveSession }),
-      expected: 'deny',
+      actual: planConnect({ accessResult: denied, existingSession: liveSession }),
+      expected: { kind: 'deny', reason: 'no_edit_access' },
     });
   });
 
-  it('given access denied and no session, should deny', () => {
+  it('given access denied and no session, should deny with the verdict reason', () => {
     assert({
       given: 'a denied access verdict and no live session',
-      should: 'deny',
-      actual: planConnect({ accessAllowed: false, existingSession: undefined }),
-      expected: 'deny',
+      should: 'deny, surfacing the verdict reason',
+      actual: planConnect({ accessResult: denied, existingSession: undefined }),
+      expected: { kind: 'deny', reason: 'no_edit_access' },
     });
   });
 
-  it('given access allowed and a live session, should reattach', () => {
+  it('given access allowed and a live session, should reattach carrying that session', () => {
     assert({
       given: 'an allowed access verdict and a live in-memory session',
-      should: 'reattach to the live session',
-      actual: planConnect({ accessAllowed: true, existingSession: liveSession }),
-      expected: 'reattach',
+      should: 'reattach, carrying the live session and the granted access',
+      actual: planConnect({ accessResult: granted, existingSession: liveSession }),
+      expected: { kind: 'reattach', access: granted, session: liveSession },
     });
   });
 
@@ -156,8 +161,8 @@ describe('planConnect', () => {
     assert({
       given: 'an allowed access verdict and no live session',
       should: 'create a fresh session (cold path)',
-      actual: planConnect({ accessAllowed: true, existingSession: undefined }),
-      expected: 'create',
+      actual: planConnect({ accessResult: granted, existingSession: undefined }),
+      expected: { kind: 'create', access: granted },
     });
   });
 });
@@ -449,7 +454,10 @@ describe('buildAgentTerminalHandlers', () => {
       expect(reattachAuth.sprite.attachSession).not.toHaveBeenCalled();
       expect(reattachAuth.sprite.updateNetworkPolicy).not.toHaveBeenCalled();
       expect(openShell).toHaveBeenCalledTimes(1);
-      expect(reattachAuth.releaseSlot).toHaveBeenCalledTimes(1);
+      // No slot was reserved for the reattach (resolveSandbox is what reserves
+      // one), so there is nothing to release — releasing here would decrement
+      // the LIVE session's own reservation.
+      expect(reattachAuth.releaseSlot).not.toHaveBeenCalled();
       expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ scrollback: expect.any(String) }));
     });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand } from '../agent-terminal-handler';
+import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand, planConnect } from '../agent-terminal-handler';
 import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { AgentTerminalCheckAuthFn, OpenShellFn, SocketLike } from '../agent-terminal-handler';
+import type { TerminalSession } from '../terminal-session-map';
 import type { PtyShell } from '../sprites-shell';
+import { assert } from './riteway';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 
@@ -27,6 +29,13 @@ function makeSprite(sessions: Array<{ id: string; command: string; isActive: boo
   };
 }
 
+/**
+ * A successful two-phase checkAuth result: the cheap DB-only access verdict,
+ * plus the LAZY `resolveSandbox` thunk the cold path calls to resolve the
+ * Sprite. `sprite` is re-surfaced at the top level purely so tests can spy on
+ * it (it is the very same object the thunk hands back) — a reattach must leave
+ * every one of its methods, and the thunk itself, untouched.
+ */
 function makeAuthSuccess(over: Partial<{
   sessionKey: string;
   streamSessionId: string | null;
@@ -37,19 +46,25 @@ function makeAuthSuccess(over: Partial<{
   cwd: string;
   payerId: string;
 }> = {}) {
-  return {
+  const sprite = makeSprite(over.sessions ?? []);
+  const sandbox = {
     ok: true as const,
     agentTerminalId: 'agent-terminal-1',
     sandboxId: 'sbx1',
     cwd: over.cwd ?? BRANCH_REPO_PATH,
-    sessionKey: over.sessionKey ?? 'branch1:agent:cli',
-    sprite: makeSprite(over.sessions ?? []),
-    releaseSlot: vi.fn(),
+    sprite,
     command: over.command ?? 'pagespace-cli',
     args: over.args ?? [],
     commandOverride: over.commandOverride ?? null,
     streamSessionId: over.streamSessionId ?? null,
+  };
+  return {
+    ok: true as const,
+    sessionKey: over.sessionKey ?? 'branch1:agent:cli',
     payerId: over.payerId ?? 'owner-1',
+    releaseSlot: vi.fn(),
+    resolveSandbox: vi.fn(async () => sandbox),
+    sprite,
   };
 }
 
@@ -103,6 +118,46 @@ describe('resolveAgentTerminalCommand', () => {
     expect(resolveAgentTerminalCommand({ command: 'pagespace-cli', args: [], commandOverride: 'htop' })).toEqual({
       command: '/bin/zsh',
       args: ['-c', 'htop'],
+    });
+  });
+});
+
+describe('planConnect', () => {
+  const liveSession = {} as TerminalSession;
+
+  it('given access denied, should deny regardless of an existing session', () => {
+    assert({
+      given: 'a denied access verdict with a live in-memory session',
+      should: 'deny (auth still gates the fast path — never reattach)',
+      actual: planConnect({ accessAllowed: false, existingSession: liveSession }),
+      expected: 'deny',
+    });
+  });
+
+  it('given access denied and no session, should deny', () => {
+    assert({
+      given: 'a denied access verdict and no live session',
+      should: 'deny',
+      actual: planConnect({ accessAllowed: false, existingSession: undefined }),
+      expected: 'deny',
+    });
+  });
+
+  it('given access allowed and a live session, should reattach', () => {
+    assert({
+      given: 'an allowed access verdict and a live in-memory session',
+      should: 'reattach to the live session',
+      actual: planConnect({ accessAllowed: true, existingSession: liveSession }),
+      expected: 'reattach',
+    });
+  });
+
+  it('given access allowed and no session, should create', () => {
+    assert({
+      given: 'an allowed access verdict and no live session',
+      should: 'create a fresh session (cold path)',
+      actual: planConnect({ accessAllowed: true, existingSession: undefined }),
+      expected: 'create',
     });
   });
 });
@@ -372,6 +427,76 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(openShell).toHaveBeenCalledTimes(1);
       expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ scrollback: expect.any(String) }));
+    });
+
+    it('given a live in-memory session, should reattach after the access check with ZERO sprite SDK calls and without resolving the sandbox', async () => {
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The reconnect gets a fresh auth result whose sprite is a dedicated spy —
+      // the tab-back fast path must not touch it, nor its resolveSandbox thunk.
+      const reattachAuth = makeAuthSuccess();
+      checkAuth.mockResolvedValueOnce(reattachAuth);
+      const reconnectSocket = makeSocket('sock2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: reconnectSocket, persistStreamSessionId });
+      await handlers2.onConnect(validPayload);
+
+      expect(reattachAuth.resolveSandbox).not.toHaveBeenCalled();
+      expect(reattachAuth.sprite.listSessions).not.toHaveBeenCalled();
+      expect(reattachAuth.sprite.spawn).not.toHaveBeenCalled();
+      expect(reattachAuth.sprite.createSession).not.toHaveBeenCalled();
+      expect(reattachAuth.sprite.attachSession).not.toHaveBeenCalled();
+      expect(reattachAuth.sprite.updateNetworkPolicy).not.toHaveBeenCalled();
+      expect(openShell).toHaveBeenCalledTimes(1);
+      expect(reattachAuth.releaseSlot).toHaveBeenCalledTimes(1);
+      expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ scrollback: expect.any(String) }));
+    });
+
+    it('given no live session, should follow the cold path and resolve the sandbox', async () => {
+      const auth = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+
+      expect(auth.resolveSandbox).toHaveBeenCalledTimes(1);
+      expect(openShell).toHaveBeenCalledTimes(1);
+      expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', { connectionId: 'sock1' });
+    });
+
+    it('given a denied user with a live session, should refuse and NOT reattach (auth gates the fast path)', async () => {
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // A different, now-unauthorized user tabs back to the same (scope, name).
+      checkAuth.mockResolvedValueOnce({ ok: false, reason: 'permission_revoked' });
+      const attackerSocket = makeSocket('attacker-sock', 'user2');
+      const attacker = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: attackerSocket, persistStreamSessionId });
+      await attacker.onConnect(validPayload);
+
+      expect(attackerSocket.emit).toHaveBeenCalledWith('agent-terminal:error', expect.objectContaining({ message: expect.any(String) }));
+      expect(attackerSocket.emit).not.toHaveBeenCalledWith('agent-terminal:ready', expect.anything());
+      // The victim's live session is untouched and still owned by the original socket.
+      expect(sessionMap.getBySocket('sock1')).toBeDefined();
+      expect(sessionMap.getBySocket('attacker-sock')).toBeUndefined();
+    });
+
+    it('given two connects for the same key (double-mount remount), should not double-create — the second reattaches via getByKey', async () => {
+      // A StrictMode/HMR double-mount fires connect twice for the same
+      // (scope, name). Once the first has established the session (setNew), the
+      // second must find it via getByKey and reattach rather than open a second
+      // PTY — the existing setNew/getByKey identity is what prevents a duplicate.
+      checkAuth = vi.fn().mockResolvedValue(makeAuthSuccess({ sessionKey: 'branch1:agent:cli' })) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+
+      await onConnect({ ...validPayload, connectionId: 'pane-a' });
+      await onConnect({ ...validPayload, connectionId: 'pane-b' });
+
+      expect(openShell).toHaveBeenCalledTimes(1);
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+      // The second connect reattached the shared session onto pane-b.
+      expect(sessionMap.getBySocket('pane-b')).toMatchObject({ sessionKey: 'branch1:agent:cli' });
     });
 
     it('given a successful connect, should set up a re-auth interval on the session', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -1076,6 +1076,38 @@ describe('buildAgentTerminalHandlers', () => {
       expect(billing.trackUsage).toHaveBeenCalledTimes(1);
     });
 
+    it('given a lost cold-connect race, RELEASES the duplicate\'s hold rather than settling it (even after its onExit lands)', async () => {
+      // The discarded PTY is killed the instant it opened — it ran no billable
+      // window. Its hold must be handed back, and the onExit that follows the
+      // kill must NOT then settle that same (already-released) hold.
+      const billing = makeBilling();
+      const authA = makeAuthSuccess();
+      const authB = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValueOnce(authA).mockResolvedValueOnce(authB) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const shellA = makeShell();
+      const shellB = makeShell();
+      openShell = vi.fn().mockReturnValueOnce(shellA).mockReturnValueOnce(shellB) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+
+      await Promise.all([
+        onConnect({ ...validPayload, connectionId: 'pane-a' }),
+        onConnect({ ...validPayload, connectionId: 'pane-b' }),
+      ]);
+
+      // Two cold paths raced, so two holds were placed; the loser's is released.
+      expect(billing.gate).toHaveBeenCalledTimes(2);
+      expect(billing.releaseHold).toHaveBeenCalledTimes(1);
+      expect(billing.trackUsage).not.toHaveBeenCalled();
+
+      // The kill's onExit lands afterwards — it must not settle the released hold.
+      const loserOnExit = openShell.mock.calls[1][0].onExit as (exitCode: number) => void;
+      loserOnExit(0);
+      expect(billing.trackUsage).not.toHaveBeenCalled();
+
+      // The winner is still live and still billable.
+      expect(sessionMap.getByKey('branch1:agent:cli')?.command).toBe(shellA);
+    });
+
     it('reattaching to a live session does NOT place a second hold', async () => {
       const billing = makeBilling();
       const { onConnect: connect1 } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });

--- a/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
@@ -136,6 +136,68 @@ describe('createTerminalSessionMap', () => {
   });
 });
 
+describe('cold-create serialization (trackCreate / pendingCreate)', () => {
+  it('given no create in flight, pendingCreate should report nothing', () => {
+    const map = createTerminalSessionMap();
+    expect(map.pendingCreate('k1')).toBeUndefined();
+  });
+
+  it('given a tracked create, pendingCreate should hand it back so a concurrent connect can join it', () => {
+    const map = createTerminalSessionMap();
+    const create = new Promise<void>(() => {}); // never settles during this test
+    map.trackCreate('k1', create);
+
+    expect(map.pendingCreate('k1')).toBe(create);
+    // Claims are per-key — an unrelated terminal is never blocked by this one.
+    expect(map.pendingCreate('k2')).toBeUndefined();
+  });
+
+  it('given the tracked create RESOLVES, should drop the claim so the key is connectable again', async () => {
+    const map = createTerminalSessionMap();
+    let finish!: () => void;
+    map.trackCreate('k1', new Promise<void>((resolve) => { finish = resolve; }));
+    expect(map.pendingCreate('k1')).toBeDefined();
+
+    finish();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(map.pendingCreate('k1')).toBeUndefined();
+  });
+
+  it('given the tracked create REJECTS, should still drop the claim (a failed create must not wedge the key forever)', async () => {
+    const map = createTerminalSessionMap();
+    let fail!: (e: Error) => void;
+    map.trackCreate('k1', new Promise<void>((_, reject) => { fail = reject; }));
+
+    fail(new Error('provision failed'));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(map.pendingCreate('k1')).toBeUndefined();
+  });
+
+  it('given a SECOND create claims the key while the first is still settling, should not let the first revoke the second\'s claim', async () => {
+    const map = createTerminalSessionMap();
+    let finishFirst!: () => void;
+    const first = new Promise<void>((resolve) => { finishFirst = resolve; });
+    map.trackCreate('k1', first);
+
+    // A later create takes the key over (the first failed and its retry queued).
+    const second = new Promise<void>(() => {});
+    map.trackCreate('k1', second);
+
+    finishFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The stale first create's settle must not clear the SECOND's claim, or a
+    // third connect would race the create that is genuinely still in flight.
+    expect(map.pendingCreate('k1')).toBe(second);
+  });
+});
+
 describe('appendScrollback', () => {
   it('given small chunks, should accumulate them in order', () => {
     const session = { scrollback: [] as string[], scrollbackBytes: 0 };

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -204,19 +204,10 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
       return { ok: false, reason: readOnly.reason };
     }
 
-    // Decrypt the actor email BEFORE reserving the slot (a decrypt throw here
+    // Decrypt the actor email BEFORE anything is reserved (a decrypt throw here
     // must not leak a reserved slot — same ordering the fused checkAuth had).
     const tier = (userRow?.subscriptionTier ?? 'free') as SubscriptionTier;
     const actorEmail = await deps.resolveActorEmail(userRow?.email);
-
-    // Read-only gates passed -> reserve the concurrency slot. Failing to reserve
-    // IS the concurrency_limit denial (the pure decision's final gate, exercised
-    // in its unit tests); nothing to release, since acquireSlot reserved nothing.
-    if (!deps.acquireSlot({ userId, tier })) {
-      deps.logDenied('concurrency_limit', { userId, machineId });
-      return { ok: false, reason: 'concurrency_limit' };
-    }
-    const releaseSlot = () => deps.releaseSlot(userId);
 
     return {
       ok: true,
@@ -225,23 +216,50 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
       // before deciding whether any sandbox work is warranted at all.
       sessionKey: deps.buildSessionKey({ terminalId: machineId, projectName, branchName, name }),
       payerId: readOnly.payerId,
-      releaseSlot,
 
       /**
        * Resolve/read the Sprite for a FRESH PTY — called by the cold path only.
        *
-       * Owns slot release on its own failure paths (as the fused checkAuth did):
-       * a deny releases and logs before returning; a REJECT (a DB error inside
-       * resolveAgentTerminal, a failed store/SDK lookup) releases before the
-       * rejection propagates, so a transient failure can never permanently
-       * consume the user's concurrency capacity. Re-throws so the socket surface
-       * is unchanged (the PTY bridge's onConnect .catch emits the generic error).
+       * RESERVES the concurrency slot, because the slot exists to bound how many
+       * PTYs a user has RUNNING — and only this path starts one. Reserving it in
+       * the access half instead (as the fused checkAuth did) made a slot a
+       * precondition for merely *asking* whether you may attach, which is wrong
+       * in two ways that both bite the common case:
        *
-       * The audit row is written HERE rather than in the access half, because
-       * it records a session actually being launched — a reattach to an already
+       *   - A free-tier user (limit 1) with one live session could never reattach
+       *     to it: their own session holds the only slot, so the tab-back's
+       *     access check failed to acquire a second one and was denied
+       *     `concurrency_limit`.
+       *   - The 60s re-auth tick calls checkAuth on a LIVE session. It too failed
+       *     to acquire a slot at the limit, read that as a lost authorization,
+       *     and tore the session down — killing a free-tier PTY ~60s after it
+       *     opened.
+       *
+       * Neither path starts a PTY, so neither needs a slot. Now they take none,
+       * and `releaseSlot` is surfaced on the SUCCESS result only — there is no
+       * slot to release unless this thunk actually reserved one.
+       *
+       * Owns slot release on its own failure paths: a deny releases and logs
+       * before returning; a REJECT (a DB error inside resolveAgentTerminal, a
+       * failed store/SDK lookup) releases before the rejection propagates, so a
+       * transient failure can never permanently consume the user's concurrency
+       * capacity. Re-throws so the socket surface is unchanged (the PTY bridge's
+       * onConnect .catch emits the generic error).
+       *
+       * The audit row is written HERE rather than in the access half, because it
+       * records a session actually being launched — a reattach to an already
        * running PTY launches nothing and must not write one.
        */
       resolveSandbox: async () => {
+        // The pure decision's final gate (`slotAcquired`), enforced at the only
+        // point a slot is genuinely needed. Nothing to release on failure —
+        // acquireSlot reserved nothing.
+        if (!deps.acquireSlot({ userId, tier })) {
+          deps.logDenied('concurrency_limit', { userId, machineId });
+          return { ok: false, reason: 'concurrency_limit' };
+        }
+        const releaseSlot = () => deps.releaseSlot(userId);
+
         let sandbox: ResolveTerminalSandboxResult;
         try {
           sandbox = await deps.resolveSandbox({ userId, machineId, projectName, branchName, name });
@@ -276,6 +294,7 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
           args: sandbox.args,
           commandOverride: sandbox.commandOverride,
           streamSessionId: sandbox.streamSessionId,
+          releaseSlot,
         };
       },
     };

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -165,8 +165,15 @@ export interface AgentTerminalCheckAuthDeps {
 /**
  * Compose the two halves into the `AgentTerminalCheckAuthFn` the realtime PTY
  * bridge consumes. The access half (gather inputs -> `decideAgentTerminalAccess`)
- * runs first and touches no Sprite; only once it allows AND a concurrency slot
- * is reserved does `resolveSandbox` resolve/read the Sprite for the fresh PTY.
+ * runs first and touches no Sprite; the sprite half is handed back UNCALLED, as
+ * a `resolveSandbox` thunk.
+ *
+ * Returning the sprite half lazily (rather than awaiting it here) is what lets
+ * `onConnect` reattach a live in-memory session — a tab-back inside the 30-min
+ * detached grace — on the strength of the access verdict alone (leaf 1-3): it
+ * simply never calls the thunk, so no Sprite is resolved or woken and no audit
+ * row is written for a session that already exists. Only the cold, create path
+ * calls it.
  */
 export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): AgentTerminalCheckAuthFn {
   return async ({ userId, machineId, projectName, branchName, name }) => {
@@ -211,50 +218,66 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
     }
     const releaseSlot = () => deps.releaseSlot(userId);
 
-    // Only NOW — a fresh PTY must be created — resolve/read the Sprite. If this
-    // REJECTS (a DB error inside resolveAgentTerminal, a failed store/SDK
-    // lookup) rather than returning a deny, the reserved slot must still be
-    // released before the rejection propagates — otherwise a transient failure
-    // permanently consumes the user's concurrency capacity. Re-throw so the
-    // socket surface is unchanged (the PTY bridge's onConnect .catch emits the
-    // generic error).
-    let sandbox: ResolveTerminalSandboxResult;
-    try {
-      sandbox = await deps.resolveSandbox({ userId, machineId, projectName, branchName, name });
-    } catch (error) {
-      releaseSlot();
-      throw error;
-    }
-    if (!sandbox.ok) {
-      releaseSlot();
-      if (sandbox.reason === 'provision_failed') {
-        deps.logSandboxLookupFailed({ userId, sandboxId: sandbox.sandboxId });
-      } else {
-        deps.logDenied(sandbox.reason, { userId, machineId, projectName, branchName, name });
-      }
-      return { ok: false, reason: sandbox.reason };
-    }
-
-    deps.writeAudit({
-      userId,
-      actorEmail,
-      driveId: readOnly.driveId,
-      command: sandbox.commandOverride ?? sandbox.command,
-    });
-
     return {
       ok: true,
-      agentTerminalId: sandbox.agentTerminalId,
-      sandboxId: sandbox.sandboxId,
-      cwd: sandbox.cwd,
+      // Derived from the (scope, name) target alone — no Sprite needed (leaf
+      // 1-1), which is precisely what lets the caller look up a live session
+      // before deciding whether any sandbox work is warranted at all.
       sessionKey: deps.buildSessionKey({ terminalId: machineId, projectName, branchName, name }),
-      sprite: sandbox.sprite,
-      releaseSlot,
-      command: sandbox.command,
-      args: sandbox.args,
-      commandOverride: sandbox.commandOverride,
-      streamSessionId: sandbox.streamSessionId,
       payerId: readOnly.payerId,
+      releaseSlot,
+
+      /**
+       * Resolve/read the Sprite for a FRESH PTY — called by the cold path only.
+       *
+       * Owns slot release on its own failure paths (as the fused checkAuth did):
+       * a deny releases and logs before returning; a REJECT (a DB error inside
+       * resolveAgentTerminal, a failed store/SDK lookup) releases before the
+       * rejection propagates, so a transient failure can never permanently
+       * consume the user's concurrency capacity. Re-throws so the socket surface
+       * is unchanged (the PTY bridge's onConnect .catch emits the generic error).
+       *
+       * The audit row is written HERE rather than in the access half, because
+       * it records a session actually being launched — a reattach to an already
+       * running PTY launches nothing and must not write one.
+       */
+      resolveSandbox: async () => {
+        let sandbox: ResolveTerminalSandboxResult;
+        try {
+          sandbox = await deps.resolveSandbox({ userId, machineId, projectName, branchName, name });
+        } catch (error) {
+          releaseSlot();
+          throw error;
+        }
+        if (!sandbox.ok) {
+          releaseSlot();
+          if (sandbox.reason === 'provision_failed') {
+            deps.logSandboxLookupFailed({ userId, sandboxId: sandbox.sandboxId });
+          } else {
+            deps.logDenied(sandbox.reason, { userId, machineId, projectName, branchName, name });
+          }
+          return { ok: false, reason: sandbox.reason };
+        }
+
+        deps.writeAudit({
+          userId,
+          actorEmail,
+          driveId: readOnly.driveId,
+          command: sandbox.commandOverride ?? sandbox.command,
+        });
+
+        return {
+          ok: true,
+          agentTerminalId: sandbox.agentTerminalId,
+          sandboxId: sandbox.sandboxId,
+          cwd: sandbox.cwd,
+          sprite: sandbox.sprite,
+          command: sandbox.command,
+          args: sandbox.args,
+          commandOverride: sandbox.commandOverride,
+          streamSessionId: sandbox.streamSessionId,
+        };
+      },
     };
   };
 }

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -156,6 +156,14 @@ export interface AgentTerminalCheckAuthDeps {
   acquireSlot: (args: { userId: string; tier: SubscriptionTier }) => boolean;
   releaseSlot: (userId: string) => void;
   resolveSandbox: (target: ResolveTerminalSandboxTarget & { userId: string }) => Promise<ResolveTerminalSandboxResult>;
+  /**
+   * DB-only existence check for the (scope, name) target — resolves the branch/
+   * project scope rows and the agent-terminal row itself, touching NO Sprite.
+   * Part of the ACCESS half precisely because it is cheap: authorization must
+   * keep noticing that a terminal's project/branch/row was deleted, and the 60s
+   * re-auth tick (which never resolves a sandbox) is the only thing that will.
+   */
+  resolveTerminalRow: (target: ResolveTerminalSandboxTarget) => Promise<{ ok: true } | { ok: false; reason: string }>;
   writeAudit: (input: { userId: string; actorEmail: string; driveId: string; command: string }) => void;
   buildSessionKey: (args: { terminalId: string; projectName?: string; branchName?: string; name: string }) => string;
   logDenied: (reason: string, context: Record<string, unknown>) => void;
@@ -202,6 +210,23 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
     if (!readOnly.allow) {
       deps.logDenied(readOnly.reason, { userId, machineId });
       return { ok: false, reason: readOnly.reason };
+    }
+
+    // The TARGET must still exist, not just the machine page. A DB-only check —
+    // it resolves the branch/project scope rows and the agent-terminal row, and
+    // wakes no Sprite — so it belongs in the access half even though the fused
+    // checkAuth only ever learned this as a side effect of resolving the sandbox.
+    //
+    // Keeping it here is load-bearing: the 60s re-auth tick calls ONLY this half.
+    // If the existence check lived behind the lazy sandbox thunk, deleting a
+    // terminal's project (or branch, or the row itself) would stop being noticed
+    // by re-auth at all, and the orphaned PTY would keep running against a scope
+    // that no longer exists. The fused check caught that — at the cost of waking
+    // the Sprite every 60 seconds, which is exactly what this epic is removing.
+    const terminalRow = await deps.resolveTerminalRow({ machineId, projectName, branchName, name });
+    if (!terminalRow.ok) {
+      deps.logDenied(terminalRow.reason, { userId, machineId, projectName, branchName, name });
+      return { ok: false, reason: terminalRow.reason };
     }
 
     // Decrypt the actor email BEFORE anything is reserved (a decrypt throw here

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -192,12 +192,25 @@ export const MAX_INPUT_BYTES = 4096;
  */
 export const SETTLE_HEARTBEAT_MS = 10 * 60 * 1000;
 
-/** Discover the NEWLY created session's id by diffing the Sprite's session list against a snapshot taken before it was launched. Best-effort — an ambiguous or failed lookup just means the next reconnect falls back to a fresh session, exactly like a vanished session already does. */
+/**
+ * Discover the NEWLY created session's id by diffing the Sprite's session list
+ * against a snapshot taken before it was launched. Best-effort — an ambiguous or
+ * failed lookup just means the next reconnect falls back to a fresh session,
+ * exactly like a vanished session already does.
+ *
+ * ABSTAINS when more than one new tty session appeared. One Sprite hosts every
+ * agent terminal on its machine, so a sibling terminal launching its own shell in
+ * the same window is indistinguishable from ours — and guessing wrong persists
+ * the SIBLING's id as this terminal's `streamSessionId`, pointing its next cold
+ * connect at another terminal's PTY. `newTtySessionId` in `sprites-shell.ts`
+ * already gets this right; this is the same rule.
+ */
 async function discoverNewSessionId(sprite: SpriteInstanceLike, before: { id: string }[]): Promise<string | undefined> {
   try {
     const beforeIds = new Set(before.map((s) => s.id));
     const after = await sprite.listSessions();
-    return after.find((s) => s.tty && !beforeIds.has(s.id))?.id;
+    const created = after.filter((s) => s.tty && !beforeIds.has(s.id));
+    return created.length === 1 ? created[0].id : undefined;
   } catch {
     return undefined;
   }
@@ -443,11 +456,13 @@ export function buildAgentTerminalHandlers({
    * and a cold-path racer that lost a double-mount (see `onConnect`) — both are
    * "someone else's PTY is already live under this key; join it".
    */
-  function attachToLiveSession(session: TerminalSession, sessionKey: string, connectionId: string) {
+  function attachToLiveSession(session: TerminalSession, sessionKey: string, connectionId: string, viewerUserId: string) {
     if (session.idleTimer !== undefined) {
       clearTimeout(session.idleTimer);
       session.idleTimer = undefined;
     }
+    // This viewer now owns the PTY, so they are who re-auth must keep checking.
+    session.viewerUserId = viewerUserId;
     session.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
     session.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
     sessionMap.reattach(sessionKey, connectionId);
@@ -490,12 +505,42 @@ export function buildAgentTerminalHandlers({
         // No slot to release: reattaching starts no PTY, so the access check
         // reserved none. The live session still holds the one it was created
         // with, and keeps it until it is torn down or reaped.
-        attachToLiveSession(plan.session, sessionKey, connectionId);
+        attachToLiveSession(plan.session, sessionKey, connectionId, userId);
         return;
       }
 
-      // The cold path. ONLY now is a concurrency slot reserved and the Sprite
-      // resolved: a reattach above returned without ever calling this.
+      // The cold path — slow (it resolves, and may wake, a Sprite), which makes it
+      // exactly the window a double-mount's second connect lands in. Join a create
+      // already in flight for this key rather than starting a second one: opening
+      // a second PTY here is not merely wasteful, it is destructive. Both connects
+      // would attach to the SAME persisted Sprite exec session, so discarding the
+      // duplicate afterwards would SIGKILL the process the survivor is attached to.
+      //
+      // Loop rather than check once: if the create we waited on FAILED, another
+      // connect may already have claimed the key behind it.
+      for (;;) {
+        const inFlight = sessionMap.pendingCreate(sessionKey);
+        if (inFlight === undefined) break;
+        await inFlight.catch(() => {});
+        const created = sessionMap.getByKey(sessionKey);
+        if (created !== undefined) {
+          attachToLiveSession(created, sessionKey, connectionId, userId);
+          return;
+        }
+        // That create failed and installed nothing — see if another is in flight,
+        // otherwise fall through and create it ourselves.
+      }
+
+      // Claim the key BEFORE the first await, so a connect that arrives while we
+      // are resolving joins us instead of racing us. There is no await between the
+      // loop's exit and this claim, so the claim is atomic w.r.t. the event loop.
+      // The claim is released by the `finally` below, on every exit from the cold
+      // path — success, denial, or throw.
+      let finishCreate!: () => void;
+      sessionMap.trackCreate(sessionKey, new Promise<void>((resolve) => { finishCreate = resolve; }));
+      try {
+      // ONLY now is a concurrency slot reserved and the Sprite resolved: a
+      // reattach above returned without ever calling this.
       const sandbox = await plan.access.resolveSandbox();
       if (!sandbox.ok) {
         // resolveSandbox released the slot (if it had reserved one) and logged.
@@ -522,7 +567,19 @@ export function buildAgentTerminalHandlers({
       // hold for the same still-open session.
       let holdId: string | undefined;
       if (billing) {
-        const gateResult = await billing.gate({ payerId: plan.access.payerId });
+        // The slot is already reserved, and nothing owns it yet — no session
+        // exists to release it on teardown. A gate that THROWS (a billing/DB blip)
+        // would otherwise propagate straight out of onConnect with the slot still
+        // held, and `activeByUser` is a process-lifetime counter: one transient
+        // failure would lock a free-tier user (limit 1) out of agent terminals on
+        // this replica until the process restarts.
+        let gateResult: Awaited<ReturnType<SandboxBillingDeps['gate']>>;
+        try {
+          gateResult = await billing.gate({ payerId: plan.access.payerId });
+        } catch (error) {
+          releaseSlot();
+          throw error;
+        }
         if (!gateResult.allowed) {
           releaseSlot();
           socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.', connectionId });
@@ -547,6 +604,7 @@ export function buildAgentTerminalHandlers({
         command: null as unknown as PtyShell,
         sandboxId,
         sessionKey,
+        viewerUserId: userId,
         sessionId: sandbox.streamSessionId ?? undefined,
         releaseSlot,
         payerId: plan.access.payerId,
@@ -608,36 +666,6 @@ export function buildAgentTerminalHandlers({
       }
 
       session.command = shell;
-
-      // Did we LOSE a double-mount race? Another cold connect for this same key
-      // (a StrictMode/HMR remount firing while we were seconds deep in
-      // resolveSandbox — the window is widest on exactly this slow path) may have
-      // finished and claimed the key while we were awaiting. `setNew` would
-      // silently overwrite it, orphaning the winner's PTY where nothing can ever
-      // reach it to kill it and permanently stranding its concurrency slot.
-      //
-      // Discard OUR duplicate and join the winner instead — from the client's
-      // side this is indistinguishable from an ordinary reattach.
-      const winner = sessionMap.getByKey(sessionKey);
-      if (winner !== undefined) {
-        session.outputFn = () => {};
-        session.closedFn = () => {};
-        // Billing: this PTY is killed the instant it opened, so its window is the
-        // openShell-throw case, not a session that ran — RELEASE the hold rather
-        // than settling it. Clearing connectedAt/holdId first is what makes that
-        // stick: killing the shell fires onExit asynchronously, and
-        // endAgentTerminalSession would otherwise settle the very hold released
-        // here (double-handling it) against a window that never happened.
-        session.connectedAt = undefined;
-        session.holdId = undefined;
-        shell.kill();
-        releaseSlot();
-        if (holdId) void billing?.releaseHold(holdId).catch(() => {});
-        loggers.realtime.info('Agent terminal duplicate cold connect discarded (lost double-mount race)', { sessionKey, sandboxId });
-        attachToLiveSession(winner, sessionKey, connectionId);
-        return;
-      }
-
       sessionMap.setNew(sessionKey, connectionId, session);
       activeConnectionIds.add(connectionId);
 
@@ -674,7 +702,13 @@ export function buildAgentTerminalHandlers({
       const reAuthInterval = setInterval(async () => {
         const liveSession = sessionMap.getByKey(sessionKey);
         if (!liveSession) { clearInterval(reAuthInterval); return; }
-        const result = await checkAuth({ userId, machineId, projectName, branchName, name });
+        // Re-check the session's CURRENT viewer, not whoever created it. A session
+        // outlives its creator's connection: any authorized user may reattach, and
+        // `attachToLiveSession` re-points the PTY's output at them. Checking the
+        // creator would leave a reattached viewer whose access was revoked
+        // mid-session still receiving output and still able to type, because the
+        // long-gone creator is of course still authorized.
+        const result = await checkAuth({ userId: liveSession.viewerUserId, machineId, projectName, branchName, name });
         // Re-check liveness after the await: another actor (heartbeat insolvency,
         // PTY exit, idle reap) may have torn the session down while checkAuth ran —
         // acting on the stale reference would double kill/closedFn.
@@ -690,6 +724,11 @@ export function buildAgentTerminalHandlers({
       session.reAuthInterval = reAuthInterval;
 
       socket.emit('agent-terminal:ready', { connectionId });
+      } finally {
+        // Release the key claim on EVERY exit from the cold path — success, denial
+        // or throw — so a failed create never wedges the key against future connects.
+        finishCreate();
+      }
     },
 
     onInput(payload: unknown) {

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -539,191 +539,191 @@ export function buildAgentTerminalHandlers({
       let finishCreate!: () => void;
       sessionMap.trackCreate(sessionKey, new Promise<void>((resolve) => { finishCreate = resolve; }));
       try {
-      // ONLY now is a concurrency slot reserved and the Sprite resolved: a
-      // reattach above returned without ever calling this.
-      const sandbox = await plan.access.resolveSandbox();
-      if (!sandbox.ok) {
-        // resolveSandbox released the slot (if it had reserved one) and logged.
-        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${sandbox.reason}`, connectionId });
-        return;
-      }
-      // Every teardown path below can race another (a PTY exit landing while the
-      // idle reap is pending, a lost double-mount whose onExit fires later), and
-      // the slot is a bare counter — releasing it twice silently hands back
-      // capacity this connect never held, letting the user exceed their tier.
-      // Collapse them: the slot goes back exactly once, whoever gets there first.
-      let slotReleased = false;
-      const releaseSlot = () => {
-        if (slotReleased) return;
-        slotReleased = true;
-        sandbox.releaseSlot();
-      };
-
-      // Terminal Epic 3 metering: place a flat-estimate hold for this NEW
-      // machine-active window BEFORE opening the shell (hibernated/idle time
-      // between sessions is free). Settled at session end — see
-      // endAgentTerminalSession. Deliberately NOT in checkAuth: that also runs
-      // on every periodic re-auth tick below, which must never place a second
-      // hold for the same still-open session.
-      let holdId: string | undefined;
-      if (billing) {
-        // The slot is already reserved, and nothing owns it yet — no session
-        // exists to release it on teardown. A gate that THROWS (a billing/DB blip)
-        // would otherwise propagate straight out of onConnect with the slot still
-        // held, and `activeByUser` is a process-lifetime counter: one transient
-        // failure would lock a free-tier user (limit 1) out of agent terminals on
-        // this replica until the process restarts.
-        let gateResult: Awaited<ReturnType<SandboxBillingDeps['gate']>>;
-        try {
-          gateResult = await billing.gate({ payerId: plan.access.payerId });
-        } catch (error) {
-          releaseSlot();
-          throw error;
-        }
-        if (!gateResult.allowed) {
-          releaseSlot();
-          socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.', connectionId });
+        // ONLY now is a concurrency slot reserved and the Sprite resolved: a
+        // reattach above returned without ever calling this.
+        const sandbox = await plan.access.resolveSandbox();
+        if (!sandbox.ok) {
+          // resolveSandbox released the slot (if it had reserved one) and logged.
+          socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${sandbox.reason}`, connectionId });
           return;
         }
-        holdId = gateResult.holdId;
-      }
-      const connectedAt = Date.now();
+        // Every teardown path below can race another (a PTY exit landing while the
+        // idle reap is pending, a lost double-mount whose onExit fires later), and
+        // the slot is a bare counter — releasing it twice silently hands back
+        // capacity this connect never held, letting the user exceed their tier.
+        // Collapse them: the slot goes back exactly once, whoever gets there first.
+        let slotReleased = false;
+        const releaseSlot = () => {
+          if (slotReleased) return;
+          slotReleased = true;
+          sandbox.releaseSlot();
+        };
 
-      const { sandboxId, sprite } = sandbox;
-
-      let sessionsBeforeLaunch: { id: string }[] = [];
-      if (sandbox.streamSessionId === null) {
-        try {
-          sessionsBeforeLaunch = await sprite.listSessions();
-        } catch {
-          sessionsBeforeLaunch = [];
+        // Terminal Epic 3 metering: place a flat-estimate hold for this NEW
+        // machine-active window BEFORE opening the shell (hibernated/idle time
+        // between sessions is free). Settled at session end — see
+        // endAgentTerminalSession. Deliberately NOT in checkAuth: that also runs
+        // on every periodic re-auth tick below, which must never place a second
+        // hold for the same still-open session.
+        let holdId: string | undefined;
+        if (billing) {
+          // The slot is already reserved, and nothing owns it yet — no session
+          // exists to release it on teardown. A gate that THROWS (a billing/DB blip)
+          // would otherwise propagate straight out of onConnect with the slot still
+          // held, and `activeByUser` is a process-lifetime counter: one transient
+          // failure would lock a free-tier user (limit 1) out of agent terminals on
+          // this replica until the process restarts.
+          let gateResult: Awaited<ReturnType<SandboxBillingDeps['gate']>>;
+          try {
+            gateResult = await billing.gate({ payerId: plan.access.payerId });
+          } catch (error) {
+            releaseSlot();
+            throw error;
+          }
+          if (!gateResult.allowed) {
+            releaseSlot();
+            socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.', connectionId });
+            return;
+          }
+          holdId = gateResult.holdId;
         }
-      }
+        const connectedAt = Date.now();
 
-      const session: TerminalSession = {
-        command: null as unknown as PtyShell,
-        sandboxId,
-        sessionKey,
-        viewerUserId: userId,
-        sessionId: sandbox.streamSessionId ?? undefined,
-        releaseSlot,
-        payerId: plan.access.payerId,
-        holdId,
-        connectedAt,
-        pageId: machineId,
-        outputFn: (data) => socket.emit('agent-terminal:output', { data, connectionId }),
-        closedFn: (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId }),
-        scrollback: [],
-        scrollbackBytes: 0,
-        reAuthInterval: undefined,
-        idleTimer: undefined,
-      };
+        const { sandboxId, sprite } = sandbox;
 
-      const launch = resolveAgentTerminalCommand({
-        command: sandbox.command,
-        args: sandbox.args,
-        commandOverride: sandbox.commandOverride,
-      });
+        let sessionsBeforeLaunch: { id: string }[] = [];
+        if (sandbox.streamSessionId === null) {
+          try {
+            sessionsBeforeLaunch = await sprite.listSessions();
+          } catch {
+            sessionsBeforeLaunch = [];
+          }
+        }
 
-      let shell: PtyShell;
-      try {
-        shell = openShell({
-          sprite,
-          cols: clampedCols,
-          rows: clampedRows,
+        const session: TerminalSession = {
+          command: null as unknown as PtyShell,
+          sandboxId,
+          sessionKey,
+          viewerUserId: userId,
           sessionId: sandbox.streamSessionId ?? undefined,
-          command: launch.command,
-          args: launch.args,
-          cwd: sandbox.cwd,
-          onOutput: (data) => {
-            appendScrollback(session, data);
-            session.outputFn(data);
-          },
-          onExit: (exitCode) => {
-            session.releaseSlot();
-            loggers.realtime.info('Agent terminal session closed', { exitCode, sandboxId, sessionKey });
-            session.closedFn(exitCode);
-            // Clears all of the session's timers (re-auth, settle heartbeat, idle).
-            endAgentTerminalSession(billing, sessionMap, session, sessionKey);
-          },
-          // The fresh-session fallback fired: the persisted streamSessionId was
-          // dangling (Sprite paused then cold-woke), so overwrite it with the new
-          // live session's id — otherwise the NEXT reconnect targets the dead id.
-          onSessionId: (sessionId) => {
+          releaseSlot,
+          payerId: plan.access.payerId,
+          holdId,
+          connectedAt,
+          pageId: machineId,
+          outputFn: (data) => socket.emit('agent-terminal:output', { data, connectionId }),
+          closedFn: (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId }),
+          scrollback: [],
+          scrollbackBytes: 0,
+          reAuthInterval: undefined,
+          idleTimer: undefined,
+        };
+
+        const launch = resolveAgentTerminalCommand({
+          command: sandbox.command,
+          args: sandbox.args,
+          commandOverride: sandbox.commandOverride,
+        });
+
+        let shell: PtyShell;
+        try {
+          shell = openShell({
+            sprite,
+            cols: clampedCols,
+            rows: clampedRows,
+            sessionId: sandbox.streamSessionId ?? undefined,
+            command: launch.command,
+            args: launch.args,
+            cwd: sandbox.cwd,
+            onOutput: (data) => {
+              appendScrollback(session, data);
+              session.outputFn(data);
+            },
+            onExit: (exitCode) => {
+              session.releaseSlot();
+              loggers.realtime.info('Agent terminal session closed', { exitCode, sandboxId, sessionKey });
+              session.closedFn(exitCode);
+              // Clears all of the session's timers (re-auth, settle heartbeat, idle).
+              endAgentTerminalSession(billing, sessionMap, session, sessionKey);
+            },
+            // The fresh-session fallback fired: the persisted streamSessionId was
+            // dangling (Sprite paused then cold-woke), so overwrite it with the new
+            // live session's id — otherwise the NEXT reconnect targets the dead id.
+            onSessionId: (sessionId) => {
+              session.sessionId = sessionId;
+              void persistStreamSessionId({ agentTerminalId: sandbox.agentTerminalId, sessionId }).catch((error) => {
+                loggers.realtime.error('Failed to persist reconnect session id', error instanceof Error ? error : new Error(String(error)), {
+                  sessionKey,
+                });
+              });
+            },
+          });
+        } catch {
+          releaseSlot();
+          if (holdId) void billing?.releaseHold(holdId).catch(() => {});
+          socket.emit('agent-terminal:error', { message: 'Failed to open agent terminal session', connectionId });
+          return;
+        }
+
+        session.command = shell;
+        sessionMap.setNew(sessionKey, connectionId, session);
+        activeConnectionIds.add(connectionId);
+
+        if (sandbox.streamSessionId === null) {
+          void discoverNewSessionId(sprite, sessionsBeforeLaunch).then((sessionId) => {
+            if (sessionId === undefined) return;
             session.sessionId = sessionId;
             void persistStreamSessionId({ agentTerminalId: sandbox.agentTerminalId, sessionId }).catch((error) => {
-              loggers.realtime.error('Failed to persist reconnect session id', error instanceof Error ? error : new Error(String(error)), {
+              loggers.realtime.error('Failed to persist agent terminal session id', error instanceof Error ? error : new Error(String(error)), {
                 sessionKey,
               });
             });
-          },
-        });
-      } catch {
-        releaseSlot();
-        if (holdId) void billing?.releaseHold(holdId).catch(() => {});
-        socket.emit('agent-terminal:error', { message: 'Failed to open agent terminal session', connectionId });
-        return;
-      }
-
-      session.command = shell;
-      sessionMap.setNew(sessionKey, connectionId, session);
-      activeConnectionIds.add(connectionId);
-
-      if (sandbox.streamSessionId === null) {
-        void discoverNewSessionId(sprite, sessionsBeforeLaunch).then((sessionId) => {
-          if (sessionId === undefined) return;
-          session.sessionId = sessionId;
-          void persistStreamSessionId({ agentTerminalId: sandbox.agentTerminalId, sessionId }).catch((error) => {
-            loggers.realtime.error('Failed to persist agent terminal session id', error instanceof Error ? error : new Error(String(error)), {
-              sessionKey,
-            });
           });
-        });
-      }
-
-      // Heartbeat settle (see SETTLE_HEARTBEAT_MS): bill the accrued window and
-      // re-hold on an interval so a realtime restart loses at most one interval
-      // of runtime, not the whole session. A gate DENIAL (payer out of credits)
-      // tears the session down exactly like a failed re-auth below.
-      if (billing) {
-        session.settleInterval = startSettleHeartbeat(billing, sessionMap, session, sessionKey);
-      }
-
-      // Periodically re-check authorization while the session is alive.
-      // Routes closed notification through closedFn so it reaches the current socket.
-      //
-      // This re-check reserves NOTHING: it never calls `resolveSandbox`, so it
-      // takes no concurrency slot and has none to hand back. That is load-bearing,
-      // not incidental — while the slot lived in the access check, this tick
-      // competed with the very session it was checking. A free-tier user (limit 1)
-      // whose one live session already held the only slot failed to acquire a
-      // second, the tick read that `concurrency_limit` as a REVOKED authorization,
-      // and tore the session down ~60s after it opened.
-      const reAuthInterval = setInterval(async () => {
-        const liveSession = sessionMap.getByKey(sessionKey);
-        if (!liveSession) { clearInterval(reAuthInterval); return; }
-        // Re-check the session's CURRENT viewer, not whoever created it. A session
-        // outlives its creator's connection: any authorized user may reattach, and
-        // `attachToLiveSession` re-points the PTY's output at them. Checking the
-        // creator would leave a reattached viewer whose access was revoked
-        // mid-session still receiving output and still able to type, because the
-        // long-gone creator is of course still authorized.
-        const result = await checkAuth({ userId: liveSession.viewerUserId, machineId, projectName, branchName, name });
-        // Re-check liveness after the await: another actor (heartbeat insolvency,
-        // PTY exit, idle reap) may have torn the session down while checkAuth ran —
-        // acting on the stale reference would double kill/closedFn.
-        if (sessionMap.getByKey(sessionKey) !== liveSession) {
-          clearInterval(reAuthInterval);
-          return;
         }
-        if (!result.ok) {
-          teardownAgentTerminalSession(billing, sessionMap, liveSession, sessionKey, -2);
+
+        // Heartbeat settle (see SETTLE_HEARTBEAT_MS): bill the accrued window and
+        // re-hold on an interval so a realtime restart loses at most one interval
+        // of runtime, not the whole session. A gate DENIAL (payer out of credits)
+        // tears the session down exactly like a failed re-auth below.
+        if (billing) {
+          session.settleInterval = startSettleHeartbeat(billing, sessionMap, session, sessionKey);
         }
-      }, 60_000);
 
-      session.reAuthInterval = reAuthInterval;
+        // Periodically re-check authorization while the session is alive.
+        // Routes closed notification through closedFn so it reaches the current socket.
+        //
+        // This re-check reserves NOTHING: it never calls `resolveSandbox`, so it
+        // takes no concurrency slot and has none to hand back. That is load-bearing,
+        // not incidental — while the slot lived in the access check, this tick
+        // competed with the very session it was checking. A free-tier user (limit 1)
+        // whose one live session already held the only slot failed to acquire a
+        // second, the tick read that `concurrency_limit` as a REVOKED authorization,
+        // and tore the session down ~60s after it opened.
+        const reAuthInterval = setInterval(async () => {
+          const liveSession = sessionMap.getByKey(sessionKey);
+          if (!liveSession) { clearInterval(reAuthInterval); return; }
+          // Re-check the session's CURRENT viewer, not whoever created it. A session
+          // outlives its creator's connection: any authorized user may reattach, and
+          // `attachToLiveSession` re-points the PTY's output at them. Checking the
+          // creator would leave a reattached viewer whose access was revoked
+          // mid-session still receiving output and still able to type, because the
+          // long-gone creator is of course still authorized.
+          const result = await checkAuth({ userId: liveSession.viewerUserId, machineId, projectName, branchName, name });
+          // Re-check liveness after the await: another actor (heartbeat insolvency,
+          // PTY exit, idle reap) may have torn the session down while checkAuth ran —
+          // acting on the stale reference would double kill/closedFn.
+          if (sessionMap.getByKey(sessionKey) !== liveSession) {
+            clearInterval(reAuthInterval);
+            return;
+          }
+          if (!result.ok) {
+            teardownAgentTerminalSession(billing, sessionMap, liveSession, sessionKey, -2);
+          }
+        }, 60_000);
 
-      socket.emit('agent-terminal:ready', { connectionId });
+        session.reAuthInterval = reAuthInterval;
+
+        socket.emit('agent-terminal:ready', { connectionId });
       } finally {
         // Release the key claim on EVERY exit from the cold path — success, denial
         // or throw — so a failed create never wedges the key against future connects.

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -64,15 +64,24 @@ export type AgentTerminalSandboxResult =
       commandOverride: string | null;
       /** The Sprite exec-session id this agent terminal was last known to run under, if any. */
       streamSessionId: string | null;
+      /**
+       * Releases the concurrency slot this resolution reserved for the PTY it is
+       * about to start. Present ONLY here, on the success result, because this
+       * is the only path that reserves one — a reattach starts no PTY, takes no
+       * slot, and so has nothing to release.
+       */
+      releaseSlot: () => void;
     }
   | { ok: false; reason: string };
 
 /**
  * The CHEAP half of a connect: a DB-only authorization verdict (leaf 1-2) plus
  * the session key, which derives from the (scope, name) target alone (leaf 1-1).
- * Nothing here has touched — let alone woken — a Sprite, which is what lets
- * `onConnect` look up a live in-memory session and reattach to it before any
- * sandbox work happens at all.
+ * Nothing here has touched — let alone woken — a Sprite, and nothing here has
+ * reserved a concurrency slot. That is what lets `onConnect` look up a live
+ * in-memory session and reattach to it before any sandbox work happens at all,
+ * and what lets the 60s re-auth tick re-check a LIVE session's authorization
+ * without competing with that very session for its own slot.
  */
 export type AgentTerminalCheckAuthResult =
   | {
@@ -80,13 +89,13 @@ export type AgentTerminalCheckAuthResult =
       sessionKey: string;
       /** The machine's resolved payer — metering attribution (Terminal Epic 3), present regardless of whether `billing` is wired. */
       payerId: string;
-      releaseSlot: () => void;
       /**
-       * Resolve the Sprite for a FRESH PTY — called ONLY on the create path.
-       * Owns the reserved concurrency slot's release on its OWN failure paths:
-       * a denial releases the slot (and logs) before returning `ok: false`, and
-       * a rejection releases it before propagating. On success the slot stays
-       * reserved and the caller owns it.
+       * Reserve the concurrency slot and resolve the Sprite for a FRESH PTY —
+       * called ONLY on the create path. Owns the slot's release on its OWN
+       * failure paths: a denial releases it (and logs) before returning
+       * `ok: false`, and a rejection releases it before propagating. On success
+       * the slot stays reserved and the caller owns it via the returned
+       * `releaseSlot`.
        */
       resolveSandbox: () => Promise<AgentTerminalSandboxResult>;
     }
@@ -100,8 +109,19 @@ export type AgentTerminalCheckAuthFn = (args: {
   name: string;
 }) => Promise<AgentTerminalCheckAuthResult>;
 
-/** The three ways a connect can go, once the access verdict and the live-session lookup are both in hand. */
-export type ConnectPlan = 'reattach' | 'create' | 'deny';
+/** An authorized connect — the `ok` arm of a check-auth result. */
+export type AgentTerminalAccessGranted = Extract<AgentTerminalCheckAuthResult, { ok: true }>;
+
+/**
+ * The three ways a connect can go, once the access verdict and the live-session
+ * lookup are both in hand. Each arm carries exactly the (already-narrowed) data
+ * its branch of the handler needs, so the shell executes the plan without
+ * re-deriving or re-checking any part of the decision.
+ */
+export type ConnectPlan =
+  | { kind: 'deny'; reason: string }
+  | { kind: 'reattach'; access: AgentTerminalAccessGranted; session: TerminalSession }
+  | { kind: 'create'; access: AgentTerminalAccessGranted };
 
 /**
  * Pure: decide the connect path from the (cheap, DB-only) access verdict and
@@ -110,19 +130,21 @@ export type ConnectPlan = 'reattach' | 'create' | 'deny';
  * A denied verdict ALWAYS denies — the presence of a live session must never
  * shortcut authorization, or a user who just lost access could tab back into a
  * PTY that outlived their permission. An allowed verdict reattaches to a live
- * session when there is one (the fast path: no sprite resolution, no wake exec,
- * no audit write — docs.sprites.dev/concepts/lifecycle puts even a warm wake at
- * 100-500ms, and this skips it entirely), and otherwise creates a fresh one.
+ * session when there is one (the fast path: no slot, no sprite resolution, no
+ * wake exec, no audit write — docs.sprites.dev/concepts/lifecycle puts even a
+ * warm wake at 100-500ms, and this skips it entirely), and otherwise creates a
+ * fresh one.
  */
 export function planConnect({
-  accessAllowed,
+  accessResult,
   existingSession,
 }: {
-  accessAllowed: boolean;
+  accessResult: AgentTerminalCheckAuthResult;
   existingSession: TerminalSession | undefined;
 }): ConnectPlan {
-  if (!accessAllowed) return 'deny';
-  return existingSession !== undefined ? 'reattach' : 'create';
+  if (!accessResult.ok) return { kind: 'deny', reason: accessResult.reason };
+  if (existingSession !== undefined) return { kind: 'reattach', access: accessResult, session: existingSession };
+  return { kind: 'create', access: accessResult };
 }
 
 export type OpenShellFn = (args: OpenPtyShellArgs) => PtyShell;
@@ -418,50 +440,50 @@ export function buildAgentTerminalHandlers({
 
       const userId = socket.data.user?.id ?? '';
 
-      // The access check is DB-only (leaf 1-2) and the session key derives from
-      // the (scope, name) target without the Sprite (leaf 1-1) — so the live
-      // in-memory session lookup happens HERE, before anything has resolved,
-      // woken or written policy to a Sprite. A tab-back inside the detached
-      // grace window is therefore decided on the strength of the access check
-      // alone: milliseconds, not the seconds a sandbox resolution costs.
-      const authResult = await checkAuth({ userId, machineId, projectName, branchName, name });
-      const existingSession = authResult.ok ? sessionMap.getByKey(authResult.sessionKey) : undefined;
-      const plan = planConnect({ accessAllowed: authResult.ok, existingSession });
+      // The access check is DB-only (leaf 1-2), reserves no concurrency slot, and
+      // the session key derives from the (scope, name) target without the Sprite
+      // (leaf 1-1) — so the live in-memory session lookup happens HERE, before
+      // anything has resolved, woken or written policy to a Sprite. A tab-back
+      // inside the detached grace window is therefore decided on the strength of
+      // the access check alone: milliseconds, not the seconds a sandbox
+      // resolution costs.
+      const accessResult = await checkAuth({ userId, machineId, projectName, branchName, name });
+      const existingSession = accessResult.ok ? sessionMap.getByKey(accessResult.sessionKey) : undefined;
+      const plan = planConnect({ accessResult, existingSession });
 
-      if (!authResult.ok) {
-        // plan === 'deny'. Note the lookup above never even ran for a denied
-        // user, so a live session can't be reattached to by someone who has
-        // lost access — auth gates the fast path.
-        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${authResult.reason}`, connectionId });
+      if (plan.kind === 'deny') {
+        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${plan.reason}`, connectionId });
         return;
       }
 
-      const { sessionKey } = authResult;
+      const { sessionKey } = plan.access;
 
-      if (plan === 'reattach' && existingSession !== undefined) {
-        if (existingSession.idleTimer !== undefined) {
-          clearTimeout(existingSession.idleTimer);
-          existingSession.idleTimer = undefined;
+      if (plan.kind === 'reattach') {
+        const { session: liveSession } = plan;
+        if (liveSession.idleTimer !== undefined) {
+          clearTimeout(liveSession.idleTimer);
+          liveSession.idleTimer = undefined;
         }
-        existingSession.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
-        existingSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
+        liveSession.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
+        liveSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
         sessionMap.reattach(sessionKey, connectionId);
         activeConnectionIds.add(connectionId);
-        // The live session already holds the slot it was created with; this
-        // connect's transient reservation is handed straight back.
-        authResult.releaseSlot();
-        socket.emit('agent-terminal:ready', { scrollback: existingSession.scrollback.join(''), connectionId });
+        // No slot to release: reattaching starts no PTY, so the access check
+        // reserved none. The live session still holds the one it was created
+        // with, and keeps it until it is torn down or reaped.
+        socket.emit('agent-terminal:ready', { scrollback: liveSession.scrollback.join(''), connectionId });
         return;
       }
 
-      // plan === 'create' — the cold path. ONLY now is the Sprite resolved: a
-      // reattach above returned without ever calling this.
-      const sandbox = await authResult.resolveSandbox();
+      // The cold path. ONLY now is a concurrency slot reserved and the Sprite
+      // resolved: a reattach above returned without ever calling this.
+      const sandbox = await plan.access.resolveSandbox();
       if (!sandbox.ok) {
-        // resolveSandbox released the reserved slot and logged the reason.
+        // resolveSandbox released the slot (if it had reserved one) and logged.
         socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${sandbox.reason}`, connectionId });
         return;
       }
+      const { releaseSlot } = sandbox;
 
       // Terminal Epic 3 metering: place a flat-estimate hold for this NEW
       // machine-active window BEFORE opening the shell (hibernated/idle time
@@ -471,9 +493,9 @@ export function buildAgentTerminalHandlers({
       // hold for the same still-open session.
       let holdId: string | undefined;
       if (billing) {
-        const gateResult = await billing.gate({ payerId: authResult.payerId });
+        const gateResult = await billing.gate({ payerId: plan.access.payerId });
         if (!gateResult.allowed) {
-          authResult.releaseSlot();
+          releaseSlot();
           socket.emit('agent-terminal:error', { message: 'Insufficient credits to open an agent terminal session.', connectionId });
           return;
         }
@@ -497,8 +519,8 @@ export function buildAgentTerminalHandlers({
         sandboxId,
         sessionKey,
         sessionId: sandbox.streamSessionId ?? undefined,
-        releaseSlot: authResult.releaseSlot,
-        payerId: authResult.payerId,
+        releaseSlot,
+        payerId: plan.access.payerId,
         holdId,
         connectedAt,
         pageId: machineId,
@@ -550,7 +572,7 @@ export function buildAgentTerminalHandlers({
           },
         });
       } catch {
-        authResult.releaseSlot();
+        releaseSlot();
         if (holdId) void billing?.releaseHold(holdId).catch(() => {});
         socket.emit('agent-terminal:error', { message: 'Failed to open agent terminal session', connectionId });
         return;
@@ -582,22 +604,27 @@ export function buildAgentTerminalHandlers({
 
       // Periodically re-check authorization while the session is alive.
       // Routes closed notification through closedFn so it reaches the current socket.
+      //
+      // This re-check reserves NOTHING: it never calls `resolveSandbox`, so it
+      // takes no concurrency slot and has none to hand back. That is load-bearing,
+      // not incidental — while the slot lived in the access check, this tick
+      // competed with the very session it was checking. A free-tier user (limit 1)
+      // whose one live session already held the only slot failed to acquire a
+      // second, the tick read that `concurrency_limit` as a REVOKED authorization,
+      // and tore the session down ~60s after it opened.
       const reAuthInterval = setInterval(async () => {
         const liveSession = sessionMap.getByKey(sessionKey);
         if (!liveSession) { clearInterval(reAuthInterval); return; }
         const result = await checkAuth({ userId, machineId, projectName, branchName, name });
         // Re-check liveness after the await: another actor (heartbeat insolvency,
         // PTY exit, idle reap) may have torn the session down while checkAuth ran —
-        // acting on the stale reference would double releaseSlot/kill/closedFn.
+        // acting on the stale reference would double kill/closedFn.
         if (sessionMap.getByKey(sessionKey) !== liveSession) {
-          if (result.ok) result.releaseSlot();
           clearInterval(reAuthInterval);
           return;
         }
         if (!result.ok) {
           teardownAgentTerminalSession(billing, sessionMap, liveSession, sessionKey, -2);
-        } else {
-          result.releaseSlot();
         }
       }, 60_000);
 

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -241,7 +241,13 @@ function endAgentTerminalSession(
   session: TerminalSession,
   sessionKey: string,
 ): void {
-  sessionMap.deleteByKey(sessionKey);
+  // Only evict the key if THIS session is still the one under it. A session that
+  // never made it into the map (a cold-path racer that lost — see onConnect), or
+  // one already replaced, must not delete the live session that now holds its
+  // key: that would orphan a running PTY nothing can reach.
+  if (sessionMap.getByKey(sessionKey) === session) {
+    sessionMap.deleteByKey(sessionKey);
+  }
   // This is the one funnel every teardown path goes through, so it owns clearing
   // ALL of the session's timers — a caller that forgets one can't leak a firing
   // interval against a dead session.
@@ -427,6 +433,28 @@ export function buildAgentTerminalHandlers({
     }, DETACHED_IDLE_MS);
   }
 
+  /**
+   * Bind an ALREADY-RUNNING session to this connection and hand the viewer its
+   * buffered scrollback: cancel any pending idle reap, re-point the session's
+   * output/closed callbacks at this socket+pane, and take over its socket
+   * mapping. Reserves nothing and touches no Sprite.
+   *
+   * Two paths land here: the tab-back fast path (`planConnect` -> 'reattach'),
+   * and a cold-path racer that lost a double-mount (see `onConnect`) — both are
+   * "someone else's PTY is already live under this key; join it".
+   */
+  function attachToLiveSession(session: TerminalSession, sessionKey: string, connectionId: string) {
+    if (session.idleTimer !== undefined) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = undefined;
+    }
+    session.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
+    session.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
+    sessionMap.reattach(sessionKey, connectionId);
+    activeConnectionIds.add(connectionId);
+    socket.emit('agent-terminal:ready', { scrollback: session.scrollback.join(''), connectionId });
+  }
+
   return {
     async onConnect(payload: unknown) {
       const validation = validateAgentTerminalConnectPayload(payload);
@@ -459,19 +487,10 @@ export function buildAgentTerminalHandlers({
       const { sessionKey } = plan.access;
 
       if (plan.kind === 'reattach') {
-        const { session: liveSession } = plan;
-        if (liveSession.idleTimer !== undefined) {
-          clearTimeout(liveSession.idleTimer);
-          liveSession.idleTimer = undefined;
-        }
-        liveSession.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
-        liveSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
-        sessionMap.reattach(sessionKey, connectionId);
-        activeConnectionIds.add(connectionId);
         // No slot to release: reattaching starts no PTY, so the access check
         // reserved none. The live session still holds the one it was created
         // with, and keeps it until it is torn down or reaped.
-        socket.emit('agent-terminal:ready', { scrollback: liveSession.scrollback.join(''), connectionId });
+        attachToLiveSession(plan.session, sessionKey, connectionId);
         return;
       }
 
@@ -483,7 +502,17 @@ export function buildAgentTerminalHandlers({
         socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${sandbox.reason}`, connectionId });
         return;
       }
-      const { releaseSlot } = sandbox;
+      // Every teardown path below can race another (a PTY exit landing while the
+      // idle reap is pending, a lost double-mount whose onExit fires later), and
+      // the slot is a bare counter — releasing it twice silently hands back
+      // capacity this connect never held, letting the user exceed their tier.
+      // Collapse them: the slot goes back exactly once, whoever gets there first.
+      let slotReleased = false;
+      const releaseSlot = () => {
+        if (slotReleased) return;
+        slotReleased = true;
+        sandbox.releaseSlot();
+      };
 
       // Terminal Epic 3 metering: place a flat-estimate hold for this NEW
       // machine-active window BEFORE opening the shell (hibernated/idle time
@@ -579,6 +608,28 @@ export function buildAgentTerminalHandlers({
       }
 
       session.command = shell;
+
+      // Did we LOSE a double-mount race? Another cold connect for this same key
+      // (a StrictMode/HMR remount firing while we were seconds deep in
+      // resolveSandbox — the window is widest on exactly this slow path) may have
+      // finished and claimed the key while we were awaiting. `setNew` would
+      // silently overwrite it, orphaning the winner's PTY where nothing can ever
+      // reach it to kill it and permanently stranding its concurrency slot.
+      //
+      // Discard OUR duplicate and join the winner instead — from the client's
+      // side this is indistinguishable from an ordinary reattach.
+      const winner = sessionMap.getByKey(sessionKey);
+      if (winner !== undefined) {
+        session.outputFn = () => {};
+        session.closedFn = () => {};
+        shell.kill();
+        releaseSlot();
+        if (holdId) void billing?.releaseHold(holdId).catch(() => {});
+        loggers.realtime.info('Agent terminal duplicate cold connect discarded (lost double-mount race)', { sessionKey, sandboxId });
+        attachToLiveSession(winner, sessionKey, connectionId);
+        return;
+      }
+
       sessionMap.setNew(sessionKey, connectionId, session);
       activeConnectionIds.add(connectionId);
 

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -622,6 +622,14 @@ export function buildAgentTerminalHandlers({
       if (winner !== undefined) {
         session.outputFn = () => {};
         session.closedFn = () => {};
+        // Billing: this PTY is killed the instant it opened, so its window is the
+        // openShell-throw case, not a session that ran — RELEASE the hold rather
+        // than settling it. Clearing connectedAt/holdId first is what makes that
+        // stick: killing the shell fires onExit asynchronously, and
+        // endAgentTerminalSession would otherwise settle the very hold released
+        // here (double-handling it) against a window that never happened.
+        session.connectedAt = undefined;
+        session.holdId = undefined;
         shell.kill();
         releaseSlot();
         if (holdId) void billing?.releaseHold(holdId).catch(() => {});

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -24,9 +24,17 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
  * Sprite can now host MULTIPLE tty sessions at once, "any tty session" is no
  * longer unambiguous — so this bridge persists the Sprite's own exec-session
  * id back to `machine_agent_terminals.streamSessionId` (via
- * `persistStreamSessionId`) the first time it discovers one, and `checkAuth`
- * hands that id back on the next connect so THIS specific session is
- * reattached, not just any one.
+ * `persistStreamSessionId`) the first time it discovers one, and the sandbox
+ * resolution hands that id back on the next COLD connect so THIS specific
+ * session is reattached, not just any one.
+ *
+ * A restart is the only time that costs anything, though: while this process is
+ * up, the session stays in `sessionMap` for the whole 30-min detached grace, so
+ * a tab-back is served by `planConnect`'s reattach path — the access check, the
+ * in-memory lookup, and `agent-terminal:ready` with the buffered scrollback. No
+ * sandbox is resolved, no Sprite is woken and no audit row is written, because
+ * `checkAuth` hands the sprite half back as an UNCALLED `resolveSandbox` thunk
+ * (see `agent-terminal-access.ts`) that only the cold path invokes.
  *
  * `billing` (Terminal Epic 3) meters this PTY session's active-runtime cost
  * against the machine's payer — the same hold/gate/settle seam the retired
@@ -36,16 +44,19 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
  * -> unmetered (no hold, no settle).
  */
 
-export type AgentTerminalCheckAuthResult =
+/**
+ * The Sprite and launch metadata a FRESH PTY needs. Produced lazily, by
+ * `AgentTerminalCheckAuthResult.resolveSandbox`, and therefore ONLY on the cold
+ * (create) path — reattaching to a live in-memory session never resolves it.
+ */
+export type AgentTerminalSandboxResult =
   | {
       ok: true;
       agentTerminalId: string;
       sandboxId: string;
       /** The resolved working directory for a FRESH session — machine's SANDBOX_ROOT, a project's clone path, or a branch's repo checkout. */
       cwd: string;
-      sessionKey: string;
       sprite: SpriteInstanceLike;
-      releaseSlot: () => void;
       /** The agentType's resolved launch command — the literal sentinel `'shell'` when unresolved to an actual shell binary yet (see `resolveAgentTerminalCommand`). */
       command: string;
       args: string[];
@@ -53,8 +64,31 @@ export type AgentTerminalCheckAuthResult =
       commandOverride: string | null;
       /** The Sprite exec-session id this agent terminal was last known to run under, if any. */
       streamSessionId: string | null;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * The CHEAP half of a connect: a DB-only authorization verdict (leaf 1-2) plus
+ * the session key, which derives from the (scope, name) target alone (leaf 1-1).
+ * Nothing here has touched — let alone woken — a Sprite, which is what lets
+ * `onConnect` look up a live in-memory session and reattach to it before any
+ * sandbox work happens at all.
+ */
+export type AgentTerminalCheckAuthResult =
+  | {
+      ok: true;
+      sessionKey: string;
       /** The machine's resolved payer — metering attribution (Terminal Epic 3), present regardless of whether `billing` is wired. */
       payerId: string;
+      releaseSlot: () => void;
+      /**
+       * Resolve the Sprite for a FRESH PTY — called ONLY on the create path.
+       * Owns the reserved concurrency slot's release on its OWN failure paths:
+       * a denial releases the slot (and logs) before returning `ok: false`, and
+       * a rejection releases it before propagating. On success the slot stays
+       * reserved and the caller owns it.
+       */
+      resolveSandbox: () => Promise<AgentTerminalSandboxResult>;
     }
   | { ok: false; reason: string };
 
@@ -65,6 +99,31 @@ export type AgentTerminalCheckAuthFn = (args: {
   branchName?: string;
   name: string;
 }) => Promise<AgentTerminalCheckAuthResult>;
+
+/** The three ways a connect can go, once the access verdict and the live-session lookup are both in hand. */
+export type ConnectPlan = 'reattach' | 'create' | 'deny';
+
+/**
+ * Pure: decide the connect path from the (cheap, DB-only) access verdict and
+ * whether a live in-memory session already exists for this session key.
+ *
+ * A denied verdict ALWAYS denies — the presence of a live session must never
+ * shortcut authorization, or a user who just lost access could tab back into a
+ * PTY that outlived their permission. An allowed verdict reattaches to a live
+ * session when there is one (the fast path: no sprite resolution, no wake exec,
+ * no audit write — docs.sprites.dev/concepts/lifecycle puts even a warm wake at
+ * 100-500ms, and this skips it entirely), and otherwise creates a fresh one.
+ */
+export function planConnect({
+  accessAllowed,
+  existingSession,
+}: {
+  accessAllowed: boolean;
+  existingSession: TerminalSession | undefined;
+}): ConnectPlan {
+  if (!accessAllowed) return 'deny';
+  return existingSession !== undefined ? 'reattach' : 'create';
+}
 
 export type OpenShellFn = (args: OpenPtyShellArgs) => PtyShell;
 
@@ -358,16 +417,28 @@ export function buildAgentTerminalHandlers({
       const { cols: clampedCols, rows: clampedRows } = clampTerminalDimensions({ cols, rows });
 
       const userId = socket.data.user?.id ?? '';
+
+      // The access check is DB-only (leaf 1-2) and the session key derives from
+      // the (scope, name) target without the Sprite (leaf 1-1) — so the live
+      // in-memory session lookup happens HERE, before anything has resolved,
+      // woken or written policy to a Sprite. A tab-back inside the detached
+      // grace window is therefore decided on the strength of the access check
+      // alone: milliseconds, not the seconds a sandbox resolution costs.
       const authResult = await checkAuth({ userId, machineId, projectName, branchName, name });
+      const existingSession = authResult.ok ? sessionMap.getByKey(authResult.sessionKey) : undefined;
+      const plan = planConnect({ accessAllowed: authResult.ok, existingSession });
+
       if (!authResult.ok) {
+        // plan === 'deny'. Note the lookup above never even ran for a denied
+        // user, so a live session can't be reattached to by someone who has
+        // lost access — auth gates the fast path.
         socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${authResult.reason}`, connectionId });
         return;
       }
 
       const { sessionKey } = authResult;
 
-      const existingSession = sessionMap.getByKey(sessionKey);
-      if (existingSession) {
+      if (plan === 'reattach' && existingSession !== undefined) {
         if (existingSession.idleTimer !== undefined) {
           clearTimeout(existingSession.idleTimer);
           existingSession.idleTimer = undefined;
@@ -376,8 +447,19 @@ export function buildAgentTerminalHandlers({
         existingSession.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
         sessionMap.reattach(sessionKey, connectionId);
         activeConnectionIds.add(connectionId);
+        // The live session already holds the slot it was created with; this
+        // connect's transient reservation is handed straight back.
         authResult.releaseSlot();
         socket.emit('agent-terminal:ready', { scrollback: existingSession.scrollback.join(''), connectionId });
+        return;
+      }
+
+      // plan === 'create' — the cold path. ONLY now is the Sprite resolved: a
+      // reattach above returned without ever calling this.
+      const sandbox = await authResult.resolveSandbox();
+      if (!sandbox.ok) {
+        // resolveSandbox released the reserved slot and logged the reason.
+        socket.emit('agent-terminal:error', { message: `Agent terminal access denied: ${sandbox.reason}`, connectionId });
         return;
       }
 
@@ -399,10 +481,10 @@ export function buildAgentTerminalHandlers({
       }
       const connectedAt = Date.now();
 
-      const { sandboxId, sprite } = authResult;
+      const { sandboxId, sprite } = sandbox;
 
       let sessionsBeforeLaunch: { id: string }[] = [];
-      if (authResult.streamSessionId === null) {
+      if (sandbox.streamSessionId === null) {
         try {
           sessionsBeforeLaunch = await sprite.listSessions();
         } catch {
@@ -414,7 +496,7 @@ export function buildAgentTerminalHandlers({
         command: null as unknown as PtyShell,
         sandboxId,
         sessionKey,
-        sessionId: authResult.streamSessionId ?? undefined,
+        sessionId: sandbox.streamSessionId ?? undefined,
         releaseSlot: authResult.releaseSlot,
         payerId: authResult.payerId,
         holdId,
@@ -429,9 +511,9 @@ export function buildAgentTerminalHandlers({
       };
 
       const launch = resolveAgentTerminalCommand({
-        command: authResult.command,
-        args: authResult.args,
-        commandOverride: authResult.commandOverride,
+        command: sandbox.command,
+        args: sandbox.args,
+        commandOverride: sandbox.commandOverride,
       });
 
       let shell: PtyShell;
@@ -440,10 +522,10 @@ export function buildAgentTerminalHandlers({
           sprite,
           cols: clampedCols,
           rows: clampedRows,
-          sessionId: authResult.streamSessionId ?? undefined,
+          sessionId: sandbox.streamSessionId ?? undefined,
           command: launch.command,
           args: launch.args,
-          cwd: authResult.cwd,
+          cwd: sandbox.cwd,
           onOutput: (data) => {
             appendScrollback(session, data);
             session.outputFn(data);
@@ -460,7 +542,7 @@ export function buildAgentTerminalHandlers({
           // live session's id — otherwise the NEXT reconnect targets the dead id.
           onSessionId: (sessionId) => {
             session.sessionId = sessionId;
-            void persistStreamSessionId({ agentTerminalId: authResult.agentTerminalId, sessionId }).catch((error) => {
+            void persistStreamSessionId({ agentTerminalId: sandbox.agentTerminalId, sessionId }).catch((error) => {
               loggers.realtime.error('Failed to persist reconnect session id', error instanceof Error ? error : new Error(String(error)), {
                 sessionKey,
               });
@@ -478,11 +560,11 @@ export function buildAgentTerminalHandlers({
       sessionMap.setNew(sessionKey, connectionId, session);
       activeConnectionIds.add(connectionId);
 
-      if (authResult.streamSessionId === null) {
+      if (sandbox.streamSessionId === null) {
         void discoverNewSessionId(sprite, sessionsBeforeLaunch).then((sessionId) => {
           if (sessionId === undefined) return;
           session.sessionId = sessionId;
-          void persistStreamSessionId({ agentTerminalId: authResult.agentTerminalId, sessionId }).catch((error) => {
+          void persistStreamSessionId({ agentTerminalId: sandbox.agentTerminalId, sessionId }).catch((error) => {
             loggers.realtime.error('Failed to persist agent terminal session id', error instanceof Error ? error : new Error(String(error)), {
               sessionKey,
             });

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -254,10 +254,12 @@ function endAgentTerminalSession(
   session: TerminalSession,
   sessionKey: string,
 ): void {
-  // Only evict the key if THIS session is still the one under it. A session that
-  // never made it into the map (a cold-path racer that lost — see onConnect), or
-  // one already replaced, must not delete the live session that now holds its
-  // key: that would orphan a running PTY nothing can reach.
+  // Defensive: only evict the key if THIS session is still the one under it, so a
+  // teardown can never delete a DIFFERENT session that now holds the key and
+  // orphan its running PTY. Per-key create serialization (see onConnect) already
+  // guarantees one session per key at a time, so today `getByKey` is always this
+  // session or already-absent; this guard just keeps that invariant from being a
+  // silent precondition of correctness here.
   if (sessionMap.getByKey(sessionKey) === session) {
     sessionMap.deleteByKey(sessionKey);
   }

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -7,6 +7,13 @@ export type TerminalSession = {
   command: PtyShell;
   sandboxId: string;
   sessionKey: string;
+  /**
+   * The user CURRENTLY attached to this session — the creator, or whoever last
+   * reattached. A session outlives its creator's connection, so this is the
+   * identity the 60s re-auth tick must re-check: checking the creator would leave
+   * a reattached viewer whose access was revoked still driving the PTY.
+   */
+  viewerUserId: string;
   /** Detachable exec session id on the Sprite, used to reattach after a WS drop. */
   sessionId?: string;
   reAuthInterval?: ReturnType<typeof setInterval>;
@@ -49,13 +56,50 @@ export type TerminalSessionMap = {
   reattach(sessionKey: string, newSocketId: string): void;
   detach(socketId: string): void;
   deleteByKey(sessionKey: string): void;
+  /**
+   * The cold create already in flight for this key, if any — see `trackCreate`.
+   */
+  pendingCreate(sessionKey: string): Promise<void> | undefined;
+  /**
+   * Claim this key for a cold create that is about to run, so a concurrent
+   * connect for the SAME key joins it instead of opening a second PTY.
+   *
+   * A cold create is slow (it resolves, and may wake, a Sprite), and a
+   * double-mount fires its second connect straight into that window. Both would
+   * otherwise see an empty map, both open a PTY, and `setNew` would silently
+   * overwrite one — orphaning a live PTY that nothing can reach to kill and
+   * stranding its concurrency slot for the life of the process. Worse, when the
+   * two attach to the same PERSISTED Sprite exec session, killing the duplicate
+   * would SIGKILL the process the survivor is attached to.
+   *
+   * Serializing at the key is what makes all of that unrepresentable: exactly one
+   * cold create per key runs at a time, so a second PTY is never opened at all.
+   * The claim is released when `create` settles (or when `setNew` installs the
+   * session), whichever happens first.
+   */
+  trackCreate(sessionKey: string, create: Promise<void>): void;
 };
 
 export function createTerminalSessionMap(): TerminalSessionMap {
   const bySocket = new Map<string, string>();        // socketId → sessionKey
   const byKey = new Map<string, TerminalSession>();  // sessionKey → session
+  const creating = new Map<string, Promise<void>>(); // sessionKey → in-flight cold create
 
   return {
+    pendingCreate(sessionKey) {
+      return creating.get(sessionKey);
+    },
+    trackCreate(sessionKey, create) {
+      creating.set(sessionKey, create);
+      // Drop the claim once this create settles — but only if it is still OURS,
+      // so a later create for the same key can't have its claim revoked by an
+      // earlier one finishing late.
+      void create
+        .catch(() => {})
+        .finally(() => {
+          if (creating.get(sessionKey) === create) creating.delete(sessionKey);
+        });
+    },
     getBySocket(socketId) {
       const key = bySocket.get(socketId);
       return key !== undefined ? byKey.get(key) : undefined;

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -3,6 +3,7 @@ import {
   planSpawnAgentTerminal,
   spawnAgentTerminal,
   resolveAgentTerminal,
+  resolveAgentTerminalRow,
   resolveAgentTerminalById,
   killAgentTerminal,
   killAgentTerminalById,
@@ -432,6 +433,67 @@ describe('spawnAgentTerminal — machine scope', () => {
       deps,
     });
     expect(result).toMatchObject({ ok: true, resumed: false });
+  });
+});
+
+describe('resolveAgentTerminalRow', () => {
+  // The whole point of this resolver: it answers "does this target still exist?"
+  // with DB reads alone. Passing `machineSandbox: undefined` throughout is the
+  // proof — the function cannot wake, resume or reconnect a Sprite because it is
+  // never handed one. That is what lets the 60s re-auth tick and the reattach
+  // fast path run it without paying for a Sprite wake.
+  it('given a machine-scoped terminal, should resolve the row WITHOUT any machineSandbox', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, machineSandbox: undefined });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true, agentTerminalId: expect.any(String), agentType: 'pagespace-cli' });
+  });
+
+  it('given a project-scoped terminal whose project row is GONE, should deny project_not_found without a Sprite', async () => {
+    const deps = makeDeps({ projectStore: makeProjectLookup(), machineSandbox: undefined });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given a branch-scoped terminal whose branch row is GONE, should deny branch_not_found without a Sprite', async () => {
+    const deps = makeDeps({ branchStore: makeBranchLookup(), machineSandbox: undefined });
+
+    const result = await resolveAgentTerminalRow({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'cli',
+      deps,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+  });
+
+  it('given a name that was never spawned, should deny not_found without a Sprite', async () => {
+    const deps = makeDeps({ machineSandbox: undefined });
+
+    const result = await resolveAgentTerminalRow({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'ghost',
+      deps,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('given a branch name with no project, should reject the target as invalid without a Sprite', async () => {
+    const deps = makeDeps({ machineSandbox: undefined });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, branchName: BRANCH_NAME, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_target' });
   });
 });
 

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -336,6 +336,46 @@ function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId:
   };
 }
 
+export type ResolveAgentTerminalRowResult =
+  | { ok: true; agentTerminalId: string; agentType: AgentRuntimeType }
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+
+export type ResolveAgentTerminalRowDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store'>;
+
+/**
+ * Does this (scope, name) target still EXIST? A purely relational existence
+ * check — `resolveScopeKey` (branch/project row lookups) plus the agent-terminal
+ * row itself — that resolves NO Sprite and wakes nothing.
+ *
+ * Split out of `resolveAgentTerminal` because that function fuses two very
+ * differently-priced questions: "does this row exist" (a couple of indexed
+ * reads) and "where does its Sprite live" (which, for machine/project scope,
+ * goes through `machineSandbox.acquire` and can RECONNECT OR RESUME a
+ * hibernated Sprite). Callers that only need to re-validate a target — the
+ * realtime bridge's 60s re-auth tick, and its reattach path — must ask the
+ * cheap question alone: asking the expensive one on a timer is what kept idle
+ * Sprites awake, and asking it on a tab-back is what made tab-backs slow.
+ *
+ * `agentType` is validated here (an unrecognized one reads as `not_found`,
+ * matching `toResolveResult`) so a corrupt row is caught by the existence check
+ * rather than surviving to the launch path.
+ */
+export async function resolveAgentTerminalRow({
+  machineId,
+  projectName,
+  branchName,
+  name,
+  deps,
+}: AgentTerminalTarget & { deps: ResolveAgentTerminalRowDeps }): Promise<ResolveAgentTerminalRowResult> {
+  const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
+
+  const row = await deps.store.findByName(scope.scopeKey, name);
+  if (!row) return { ok: false, reason: 'not_found' };
+  if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
+  return { ok: true, agentTerminalId: row.id, agentType: row.agentType };
+}
+
 /**
  * Resolve a named agent terminal down to what the realtime PTY bridge needs
  * to open (or reattach) its stream: which Sprite (`sandboxId`), which working


### PR DESCRIPTION
## Why

Tab-back to an open terminal was slow for a reason that had nothing to do with the platform. `onConnect` ran the **entire** fused `checkAuth` chain — resolve the agent-terminal row → `getSprite` → write a code-execution audit row → reserve a concurrency slot — and only *then* looked in `sessionMap` to discover that a live in-memory session was sitting right there, ready to reattach.

[docs.sprites.dev/concepts/lifecycle](https://docs.sprites.dev/concepts/lifecycle/) puts a warm wake at 100–500ms and a cold one at 1–2s. That is the platform floor; everything we stacked above it on a tab-back was our own orchestration overhead.

## What changed

`checkAuth` no longer resolves the Sprite (or reserves a slot) eagerly. It returns the cheap, DB-only access verdict (`sessionKey`, `payerId`) plus an **uncalled** `resolveSandbox()` thunk. `onConnect` runs the access check, looks up the live session (the key derives without a Sprite, per 1-1), and a pure `planConnect({ accessResult, existingSession })` returns a discriminated `deny | reattach | create` plan carrying the narrowed payload each branch needs. Only the cold path invokes the thunk.

The audit row moved into `resolveSandbox` with it — it records a PTY actually being launched, and a reattach launches nothing.

- `apps/realtime/src/terminal/agent-terminal-handler.ts` — `planConnect` (pure), split `AgentTerminalCheckAuthResult` / `AgentTerminalSandboxResult`, reordered `onConnect`.
- `apps/realtime/src/terminal/agent-terminal-access.ts` — `buildAgentTerminalCheckAuth` returns the lazy thunk, which owns slot reservation + release.

`AgentTerminalCheckAuthDeps` is unchanged, so the `index.ts` wiring needed no edits.

## 🐛 A severe pre-existing bug this surfaced (please read)

Reviewing the reorder turned up a bug that the reorder would otherwise have shipped on top of. `acquireCodeExecutionSlot` (`packages/lib/src/services/sandbox/quota.ts`) is a **per-user counter** — `free: 1`, `pro: 2`, `founder: 3`, `business: 5` — and `checkAuth` reserved a slot on **every** call, including calls that start no PTY:

1. **Reattach was impossible at the limit.** A free-tier user with one live session already holds the only slot. The tab-back's access check tried to acquire a *second*, failed, and was denied `concurrency_limit`. The fast path this PR exists to build was unreachable for the most common tier.
2. **Live sessions were killed after 60s.** The re-auth tick also calls `checkAuth`. At the limit it too failed to acquire a slot — and the tick reads any denial as a *revoked authorization*, so it called `teardownAgentTerminalSession`. **A free-tier PTY died ~60 seconds after opening.**

Both are pre-existing on `master`; they are masked in production only because `CODE_EXECUTION_ENABLED` is off. My handler tests missed them because they mock `checkAuth` — the bug lives in the real composition.

**The fix falls out of the same lazy split**: a slot bounds how many PTYs a user has *running*, so it is reserved inside `resolveSandbox` (the only path that starts one), and `releaseSlot` is surfaced on the sandbox **success** result — there is no slot to release unless one was actually reserved. Reattach takes none; re-auth reserves nothing and hands nothing back. Regression tests are at the access layer where the real slot logic lives.

## 🐛 Second bug: concurrent cold connects (double-mount)

The leaf requires that a double-mount not double-create. The *sequential* remount was already safe (connect #2 finds the session via `getByKey`). The genuinely **concurrent** race was not — and this PR **widens its window**, because the cold path is exactly where a connect now spends seconds inside `resolveSandbox`.

My first fix was to let both open a PTY and then discard the loser. **An adversarial review pass found that this was destructive**, and I replaced it. Recording it here because the reason is subtle and worth a reviewer's attention:

> `openPtyShell` with a non-null `sessionId` calls `sprite.attachSession(id)` — it connects to a **server-side** exec session — and `PtyShell.kill()` is `SIGKILL` on the *process*, not a local socket close. So whenever a `streamSessionId` is persisted (any warm reattach after a realtime restart), both racers attach to the **same remote session**, and killing the duplicate SIGKILLs the very process the survivor is attached to. It turned a recoverable orphan into a *guaranteed terminal kill*, on exactly the path it was meant to protect.

**The fix in place: serialize at the key, so a second PTY is never opened at all.** A cold connect claims the key *before its first await*; a concurrent connect for that key awaits the in-flight create and joins its session.

- `TerminalSessionMap` gains `trackCreate` / `pendingCreate`.
- The claim is released on **every** exit from the cold path — success, denial, or throw — so a failed create cannot wedge the key. The joiner loops, in case another create queued behind a failure.
- No `await` sits between the join-loop's exit and the claim, so it is atomic w.r.t. the event loop and needs no lock.

This dissolves the class rather than patching it: no duplicate PTY → no kill; no double slot; no double hold; no ambiguous session-id discovery.

## 🐛 Fourth/fifth/sixth: found by the same adversarial pass

- **Concurrency slot leaked when `billing.gate` throws.** The slot was reserved but no session owned it yet, so a rejection escaped `onConnect` with the slot still held. `activeByUser` is a *process-lifetime* counter — one transient billing/DB blip permanently locked a free-tier user (limit 1) out of terminals on that replica until restart. Now released before rethrowing.
- **`discoverNewSessionId` took the FIRST new tty session.** One Sprite hosts *every* agent terminal on its machine, so a sibling terminal launching in the same window is indistinguishable from ours — persisting the sibling's id points this terminal's next cold connect at another terminal's PTY. Now abstains unless exactly one appeared (the rule `sprites-shell.ts`'s `newTtySessionId` already applies).
- **Re-auth checked the CREATOR's userId forever.** A session outlives its creator's connection, and any authorized user may reattach. A viewer whose access was revoked mid-session kept receiving output and could keep typing — because the long-gone creator still passed the check. Sessions now carry `viewerUserId`, set on create and on every reattach, and the tick re-checks whoever is actually driving the PTY.

## 🐛 Third bug: re-auth stopped noticing a deleted scope (review catch — codex P2)

Making the sandbox resolution lazy *also* made the **(scope, name) existence check** lazy — because the fused `checkAuth` only ever learned "this terminal still exists" as a **side effect** of resolving its sandbox. The 60s re-auth tick calls only the access half, so after the split it stopped noticing that a terminal's project, branch, or own row had been deleted: the orphaned PTY kept running against a scope that no longer existed.

Restoring the check naively would have re-broken the epic. `resolveAgentTerminal` fuses two very differently-priced questions:

- **cheap** — does the row exist? (`resolveScopeKey` + `store.findByName`: a couple of indexed reads, no Sprite)
- **expensive** — where does its Sprite live? (`machineSandbox.acquire`, which for machine/project scope can **reconnect or resume a hibernated Sprite**)

Calling it from the access half would wake the Sprite on every re-auth tick *and* every tab-back. So I split the question, not just the call site:

- **New `resolveAgentTerminalRow`** (`packages/lib/src/services/machines/agent-terminals.ts`) — DB-only. Its tests pass `machineSandbox: undefined` throughout, which is the proof it *cannot* wake a Sprite: it is never handed one.
- The **access half** runs it eagerly, **after** the read-only access gates — so a user without edit rights still learns nothing about which terminals exist.
- The **Sprite wake/read stays lazy**, so reattach still performs zero Sprite SDK calls.

## Requirements

| Requirement | How it is satisfied |
|---|---|
| Live detached session + allowed user → `agent-terminal:ready` (with scrollback) after the access check, **ZERO sprite SDK calls** | Reattach returns before `resolveSandbox()` is ever called. Test spies on the thunk **and** every sprite method (`listSessions`/`spawn`/`createSession`/`attachSession`/`updateNetworkPolicy`) and asserts none fired — plus that no slot was taken. |
| No live session → cold path unchanged (resolve sandbox → billing gate → `openShell`) | Create path calls the thunk, then gates, then opens. All pre-existing handler tests (launch command, cwd, session-id discovery/persistence, billing holds, heartbeat settle, re-auth teardown) pass untouched. |
| Denied user + live session → refuse, **not** reattach | `planConnect` returns `{ kind: 'deny' }` for a denied verdict regardless of `existingSession` (pure test). In the shell a denied verdict never reaches the lookup. Handler test: an unauthorized socket gets `agent-terminal:error`, never `:ready`, and the victim's session stays bound to its original socket. |
| Two connects for the same key (double-mount) → no double-create | Regression test: the second connect finds the session via `getByKey` and reattaches — `openShell` called exactly once. `setNew`/`getByKey` semantics preserved, no new locking. |

## Tests

TDD: `planConnect` is pure and tested with **no mocks** (riteway `assert({given, should, actual, expected})`); the handler is tested with an injected spy sprite client and a real `createTerminalSessionMap`.

```
apps/realtime  (all)   19 files / 641 tests pass · branch coverage 98.02% (gate 98%)
packages/lib  (machines) 8 files / 165 tests pass
```

`tsc --noEmit` clean, eslint clean. No `any`.

## Notes for reviewers

- **A reattach no longer writes a code-execution audit row.** Intended ("no policy writes" in the leaf spec) — the row asserts a PTY was launched, and a reattach launches none. The cold path still audits (test-covered). Flag it if compliance expects a row per *connect* rather than per *launch*.
- Side benefit of the split: the 60s re-auth tick no longer resolves or wakes the Sprite. It calls `checkAuth` and never touches the thunk.
- Untouched, as scoped out: the cold-path wake hack (1-4) and frontend keep-alive (4-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnFmynYiN6bmrtibxdzLDJ




