### PR TITLE
[sprites 1-4] Single getSprite per connect; delete ensureSpriteAwake

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -24,7 +24,7 @@ import {
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/machine-billing';
 import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/terminal-storage-billing';
 import { checkMachineRuntimeGuardrail, recordMachineActivity, acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
-import { createSpritesSandboxClient, ensureSpriteAwake } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { createSpritesSandboxClient, createSpriteHandleCache, type SpritesSdk } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { createSpriteMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-machine-host';
 import { createExecClientFromMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
@@ -97,12 +97,23 @@ export async function resolveActorEmail(rawEmail: string | null | undefined): Pr
 /**
  * Acquires the OWNING Machine's persistent Sprite for `AgentTerminalMachineSandbox`
  * (machine/project scope share this one Sprite — see `agent-terminals.ts`),
- * re-authorizing `actorUserId` (resume re-authz) on every call, waking a
- * resumed (possibly hibernated) Sprite before handing its id back so a fresh
- * PTY spawn never races a cold Sprite. Mirrors the acquisition the retired
- * human terminal's `makeTerminalCheckAuth` used to perform inline.
+ * re-authorizing `actorUserId` (resume re-authz) on every call. Mirrors the
+ * acquisition the retired human terminal's `makeTerminalCheckAuth` used to
+ * perform inline.
+ *
+ * Does NOT wake the Sprite, and does not read it a second time to try. A Sprite
+ * has no explicit wake API — an incoming request wakes it automatically
+ * (docs.sprites.dev/concepts/lifecycle) — so the PTY's own `createSession` /
+ * `attachSession` IS the wake, and it already carries the bounded pre-open retry
+ * that the cold-start drop needs (`withWakeRetry` / `openPtyShell`'s reconnect).
+ * The `sh -c :` this used to run first bought nothing but a SECOND cold start on
+ * the slowest path we have.
+ *
+ * `sdk` is threaded in (rather than resolved here) so the whole connect —
+ * acquire, auth, launch resolution — shares ONE `createSpriteHandleCache` and
+ * therefore ONE underlying `getSprite`.
  */
-function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
+function buildMachineSandbox(actorUserId: string, sdk: SpritesSdk): AgentTerminalMachineSandbox {
   // The caller (resolveProjectOrMachineLocation, agent-terminals.ts) collapses
   // every acquire failure to one generic 'machine_unavailable' reason — log the
   // SPECIFIC reason here so it's still visible in realtime logs for triage.
@@ -122,7 +133,7 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
       const guardrail = checkMachineRuntimeGuardrail({ machineKey: machineId, now: nowMs });
       if (!guardrail.allowed) return deny(guardrail.reason, machineId);
 
-      const [store, sdk] = await Promise.all([dbTerminalSessionStorePromise, getRealtimeSpritesSdk()]);
+      const store = await dbTerminalSessionStorePromise;
       const rawClient = createSpritesSandboxClient({ sdk });
       const host = createSpriteMachineHost({ sdk, client: rawClient });
       const client = createExecClientFromMachineHost(host, { kind: 'sprite' });
@@ -148,15 +159,6 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
         },
       });
       if (!result.ok) return deny(result.reason, machineId);
-
-      if (result.resumed) {
-        try {
-          const sprite = await sdk.getSprite(result.sandboxId);
-          await ensureSpriteAwake(sprite);
-        } catch {
-          return deny('provision_failed', machineId);
-        }
-      }
 
       recordMachineActivity({ machineKey: machineId, now: nowMs });
 
@@ -206,12 +208,20 @@ function buildAgentTerminalSessionKey({
  * Resolve the Sprite a FRESH agent-terminal PTY will attach to (lazy sprite
  * resolution — leaf 1-2): resolve the (scope, name) target down to its Machine
  * Sprite via `resolveAgentTerminal` (machine/project scope may reconnect/resume
- * the Sprite through `buildMachineSandbox`), then read that Sprite exactly once.
- * Deliberately NOT part of the access decision — a Sprite is woken automatically
- * by any exec, so authorization never needs to touch it (see
- * `agent-terminal-access.ts`). Full getSprite collapse is leaf 1-4.
+ * the Sprite through `buildMachineSandbox`), then read that Sprite. Deliberately
+ * NOT part of the access decision — a Sprite is woken automatically by any exec,
+ * so authorization never needs to touch it (see `agent-terminal-access.ts`).
+ *
+ * ONE `createSpriteHandleCache` is built here, per connect, and threaded through
+ * BOTH halves — the machine acquire (whose `getOrCreate` probes the Sprite by
+ * name) and the launch resolution below (which needs the raw handle for the PTY).
+ * They read the same Sprite, so they now share one control-plane round-trip
+ * instead of paying for two. The cache is deliberately connect-scoped, never
+ * module-scoped: a Sprite handle is a live object, and a process-lifetime cache
+ * would keep serving one that has since been destroyed and re-created under the
+ * same name.
  */
-function resolveAgentTerminalSandbox({
+async function resolveAgentTerminalSandbox({
   userId,
   machineId,
   projectName,
@@ -224,6 +234,8 @@ function resolveAgentTerminalSandbox({
   branchName?: string;
   name: string;
 }) {
+  const sdk = createSpriteHandleCache(await getRealtimeSpritesSdk());
+
   return resolveTerminalSandbox(
     { machineId, projectName, branchName, name },
     {
@@ -242,14 +254,14 @@ function resolveAgentTerminalSandbox({
             branchStore,
             store: agentTerminalStore,
             projectStore: { findByName: (tId, pName) => projectStore.findByName(tId, pName) },
-            machineSandbox: buildMachineSandbox(userId),
+            machineSandbox: buildMachineSandbox(userId, sdk),
           },
         });
       },
-      getSprite: async (sandboxId) => {
-        const sdk = await getRealtimeSpritesSdk();
-        return sdk.getSprite(sandboxId);
-      },
+      // Served from the cache the acquire above already populated (machine/project
+      // scope). A branch-scope target never acquires, so this is its one and only
+      // read.
+      getSprite: (sandboxId) => sdk.getSprite(sandboxId),
     },
   );
 }

--- a/apps/realtime/src/terminal/__tests__/cold-connect-sprite-reads.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-connect-sprite-reads.test.ts
@@ -1,0 +1,276 @@
+/**
+ * The cold-connect Sprite budget (sprites 1-4).
+ *
+ * Composes the REAL production stack a terminal connect runs through —
+ * `createSpriteHandleCache` -> `createSpritesSandboxClient` ->
+ * `createSpriteMachineHost` -> `createExecClientFromMachineHost` ->
+ * `acquireTerminalSandbox` -> `resolveTerminalSandbox` — with the DB stores
+ * faked, and counts what it does to the Sprites control plane.
+ *
+ * This is the only level the leaf's headline requirements are actually
+ * observable at: "one getSprite per connect" is a property of the COMPOSITION
+ * (acquire + auth + launch resolution each used to read the Sprite separately),
+ * not of any single unit. `apps/realtime/src/index.ts` wires exactly these
+ * pieces; it is not importable under test (it binds a socket server at module
+ * load), so the wiring is mirrored here.
+ */
+
+import { describe, it } from 'vitest';
+import { assert } from './riteway';
+import {
+  createSpritesSandboxClient,
+  createSpriteHandleCache,
+  type SpritesSdk,
+  type SpriteInstanceLike,
+  type SpriteCommandLike,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { createSpriteMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-machine-host';
+import { createExecClientFromMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
+import {
+  acquireTerminalSandbox,
+  deriveTerminalSessionKey,
+  type TerminalSessionRecord,
+  type TerminalSessionStore,
+} from '@pagespace/lib/services/sandbox/terminal-session-manager';
+import { resolveTerminalSandbox } from '../agent-terminal-access';
+
+const SECRET = 'test-secret';
+const MACHINE_ID = 'machine-page-1';
+const DRIVE_ID = 'drive-1';
+const TENANT_ID = 'tenant-1';
+const USER_ID = 'user-1';
+
+/**
+ * A Sprite is named by the terminal's derived session key (truncated to the
+ * Sprites API's 63-char DNS-label limit), so a RESUMED connect must be seeded
+ * under exactly that name — seeding an arbitrary id would silently exercise the
+ * create path instead, and the resume assertions would prove nothing.
+ */
+const SESSION_KEY = deriveTerminalSessionKey({
+  tenantId: TENANT_ID,
+  driveId: DRIVE_ID,
+  pageId: MACHINE_ID,
+  secret: SECRET,
+});
+const SPRITE_NAME = SESSION_KEY.slice(0, 63);
+
+/** Everything the connect did to the Sprites control plane. */
+interface SpriteCalls {
+  getSprite: string[];
+  createSprite: string[];
+  /** Every exec spawned, as `[file, ...args]` — a `sh -c :` here is a no-op wake exec. */
+  spawned: string[][];
+  createdSessions: number;
+}
+
+function noopCommand(): SpriteCommandLike {
+  return {
+    stdout: { on: () => undefined },
+    stderr: { on: () => undefined },
+    on: (event: string, listener: (arg: never) => void) => {
+      // Batch execs (the egress lockdown's mkdir) resolve via 'exit'.
+      if (event === 'exit') setTimeout(() => (listener as (code: number) => void)(0), 0);
+      return undefined;
+    },
+    kill: () => undefined,
+  } as unknown as SpriteCommandLike;
+}
+
+function fakeSprite(name: string, calls: SpriteCalls): SpriteInstanceLike {
+  return {
+    name,
+    spawn: (file, args) => {
+      calls.spawned.push([file, ...(args ?? [])]);
+      return noopCommand();
+    },
+    createSession: () => {
+      calls.createdSessions += 1;
+      return noopCommand();
+    },
+    attachSession: () => noopCommand(),
+    listSessions: async () => [],
+    filesystem: () => {
+      throw new Error('the connect path must not touch the fs API');
+    },
+    updateNetworkPolicy: async () => {},
+    destroy: async () => {},
+  };
+}
+
+function fakeSdk(calls: SpriteCalls, existing: Set<string>): SpritesSdk {
+  return {
+    getSprite: async (name) => {
+      calls.getSprite.push(name);
+      if (!existing.has(name)) throw Object.assign(new Error('sprite not found'), { status: 404 });
+      return fakeSprite(name, calls);
+    },
+    createSprite: async (name) => {
+      calls.createSprite.push(name);
+      existing.add(name);
+      return fakeSprite(name, calls);
+    },
+    deleteSprite: async (name) => {
+      existing.delete(name);
+    },
+  };
+}
+
+function fakeSessionStore(record: TerminalSessionRecord | null): TerminalSessionStore {
+  let current = record;
+  return {
+    findBySessionKey: async () => current,
+    save: async (input) => {
+      current = {
+        sessionKey: input.sessionKey,
+        pageId: input.pageId,
+        sandboxId: input.sandboxId,
+        userId: input.userId,
+        lastActiveAt: input.now,
+      };
+    },
+    touch: async () => {},
+    remove: async () => {
+      current = null;
+    },
+  };
+}
+
+/**
+ * The connect path exactly as `apps/realtime/src/index.ts` wires it: ONE handle
+ * cache, threaded through both the machine acquire and the launch resolution.
+ */
+async function runColdConnect({
+  resumed,
+  lastActiveAt,
+}: {
+  /** Seed BOTH the session store and the Sprites control plane, so the connect resumes a real, existing Sprite. */
+  resumed: boolean;
+  lastActiveAt?: Date;
+}) {
+  const calls: SpriteCalls = { getSprite: [], createSprite: [], spawned: [], createdSessions: 0 };
+  const existing = new Set<string>(resumed ? [SPRITE_NAME] : []);
+
+  // One cache per connect — the whole point of the leaf.
+  const sdk = createSpriteHandleCache(fakeSdk(calls, existing));
+
+  const store = fakeSessionStore(
+    resumed
+      ? {
+          sessionKey: SESSION_KEY,
+          pageId: MACHINE_ID,
+          sandboxId: SPRITE_NAME,
+          userId: USER_ID,
+          lastActiveAt: lastActiveAt ?? new Date(),
+        }
+      : null,
+  );
+
+  const rawClient = createSpritesSandboxClient({ sdk });
+  const host = createSpriteMachineHost({ sdk, client: rawClient });
+  const client = createExecClientFromMachineHost(host, { kind: 'sprite' });
+
+  const sandbox = await resolveTerminalSandbox(
+    { machineId: MACHINE_ID, name: 'shell' },
+    {
+      resolveAgentTerminal: async () => {
+        const acquired = await acquireTerminalSandbox({
+          pageId: MACHINE_ID,
+          driveId: DRIVE_ID,
+          tenantId: TENANT_ID,
+          userId: USER_ID,
+          canRun: true,
+          deps: {
+            store,
+            client,
+            now: () => new Date(),
+            secret: SECRET,
+            checkFullEgressEnablement: async () => ({ ok: true }),
+          },
+        });
+        if (!acquired.ok) throw new Error(`acquire failed: ${acquired.reason}`);
+        return {
+          ok: true,
+          agentTerminalId: 'agent-terminal-1',
+          sandboxId: acquired.sandboxId,
+          cwd: '/workspace',
+          agentType: 'shell',
+          command: null,
+          streamSessionId: null,
+        };
+      },
+      getSprite: (sandboxId) => sdk.getSprite(sandboxId),
+    },
+  );
+
+  return { calls, sandbox };
+}
+
+describe('cold connect — Sprite control-plane budget', () => {
+  it('given a RESUMED sprite, should read it exactly once across acquire + auth + launch resolution', async () => {
+    // The session store already knows this machine's Sprite, and the Sprite exists:
+    // the resume path, which used to cost THREE getSprite calls (getOrCreate's probe,
+    // the wake's read, and the launch resolution's read).
+    const { calls, sandbox } = await runColdConnect({ resumed: true });
+
+    assert({
+      given: 'a full cold connect against a resumed Sprite',
+      should: 'call sdk.getSprite at most once — the handle is threaded, not re-fetched',
+      actual: calls.getSprite.length,
+      expected: 1,
+    });
+
+    assert({
+      given: 'a resumed connect',
+      should: 'resume the existing Sprite (never create a duplicate) and hand its handle to the PTY',
+      actual: { created: calls.createSprite, sprite: sandbox.ok && sandbox.sprite.name },
+      expected: { created: [], sprite: SPRITE_NAME },
+    });
+  });
+
+  it('given a RESUMED sprite, should run NO no-op wake exec (the PTY session-open is the wake)', async () => {
+    const { calls } = await runColdConnect({ resumed: true });
+
+    assert({
+      given: 'a resumed Sprite on the terminal connect path',
+      should: 'spawn no `sh -c :` no-op wake exec',
+      actual: calls.spawned.filter((cmd) => cmd.join(' ') === 'sh -c :'),
+      expected: [],
+    });
+  });
+
+  it('given a hibernated-IDLE sprite (the persistent noop path), should still read it only once and not wake it', async () => {
+    // Idle past the warm window: `planTerminalLifecycle` returns `noop` (persistent),
+    // which reconnects via getOrCreate. This is the path a tab-back onto a Sprite that
+    // has been asleep for hours takes.
+    const longAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const { calls } = await runColdConnect({ resumed: true, lastActiveAt: longAgo });
+
+    assert({
+      given: 'a long-idle (hibernated) Sprite',
+      should: 'read it once and issue no no-op wake exec',
+      actual: {
+        reads: calls.getSprite.length,
+        wakes: calls.spawned.filter((cmd) => cmd.join(' ') === 'sh -c :').length,
+      },
+      expected: { reads: 1, wakes: 0 },
+    });
+  });
+
+  it('given a FRESH sprite (no session yet), should probe once, create it, and serve the launch handle from that create', async () => {
+    const { calls, sandbox } = await runColdConnect({ resumed: false });
+
+    assert({
+      given: 'a first-ever connect (no Sprite exists)',
+      should: 'issue exactly one getSprite (the not-found probe) and one createSprite',
+      actual: { reads: calls.getSprite.length, created: calls.createSprite.length },
+      expected: { reads: 1, created: 1 },
+    });
+
+    assert({
+      given: 'a freshly created Sprite',
+      should: 'hand the launch path the created handle without re-reading it',
+      actual: sandbox.ok && sandbox.sprite.name,
+      expected: SPRITE_NAME,
+    });
+  });
+});

--- a/apps/realtime/src/terminal/__tests__/cold-connect-sprite-reads.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-connect-sprite-reads.test.ts
@@ -15,7 +15,7 @@
  * load), so the wiring is mirrored here.
  */
 
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { assert } from './riteway';
 import {
   createSpritesSandboxClient,
@@ -60,41 +60,46 @@ interface SpriteCalls {
   createSprite: string[];
   /** Every exec spawned, as `[file, ...args]` — a `sh -c :` here is a no-op wake exec. */
   spawned: string[][];
-  createdSessions: number;
 }
 
+/**
+ * A command that resolves immediately. The connect path's only exec is the
+ * egress lockdown's `mkdir`, a batch command that settles on 'exit'.
+ *
+ * Members the connect never touches are `vi.fn()` stubs rather than hand-written
+ * throwers: an unexercised arrow function of our own would be a permanently
+ * uncovered function in this package's coverage gate, which is a real (if
+ * indirect) cost of a fake that pretends to be richer than the code under test.
+ */
 function noopCommand(): SpriteCommandLike {
   return {
-    stdout: { on: () => undefined },
-    stderr: { on: () => undefined },
-    on: (event: string, listener: (arg: never) => void) => {
-      // Batch execs (the egress lockdown's mkdir) resolve via 'exit'.
-      if (event === 'exit') setTimeout(() => (listener as (code: number) => void)(0), 0);
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+    on: (event: string, listener: (code: number) => void) => {
+      if (event === 'exit') setTimeout(() => listener(0), 0);
       return undefined;
     },
-    kill: () => undefined,
+    kill: vi.fn(),
   } as unknown as SpriteCommandLike;
 }
 
 function fakeSprite(name: string, calls: SpriteCalls): SpriteInstanceLike {
   return {
     name,
-    spawn: (file, args) => {
-      calls.spawned.push([file, ...(args ?? [])]);
+    spawn: (file: string, args: string[]) => {
+      calls.spawned.push([file, ...args]);
       return noopCommand();
     },
-    createSession: () => {
-      calls.createdSessions += 1;
-      return noopCommand();
-    },
-    attachSession: () => noopCommand(),
-    listSessions: async () => [],
-    filesystem: () => {
-      throw new Error('the connect path must not touch the fs API');
-    },
-    updateNetworkPolicy: async () => {},
-    destroy: async () => {},
-  };
+    // The connect resolves a Sprite HANDLE; it never opens the PTY here (that is
+    // openPtyShell's job, covered in cold-session-open-retry.test.ts) and never
+    // touches the fs API.
+    createSession: vi.fn(),
+    attachSession: vi.fn(),
+    listSessions: vi.fn(),
+    filesystem: vi.fn(),
+    updateNetworkPolicy: vi.fn(),
+    destroy: vi.fn(),
+  } as unknown as SpriteInstanceLike;
 }
 
 function fakeSdk(calls: SpriteCalls, existing: Set<string>): SpritesSdk {
@@ -109,10 +114,8 @@ function fakeSdk(calls: SpriteCalls, existing: Set<string>): SpritesSdk {
       existing.add(name);
       return fakeSprite(name, calls);
     },
-    deleteSprite: async (name) => {
-      existing.delete(name);
-    },
-  };
+    deleteSprite: vi.fn(),
+  } as unknown as SpritesSdk;
 }
 
 function fakeSessionStore(record: TerminalSessionRecord | null): TerminalSessionStore {
@@ -128,11 +131,9 @@ function fakeSessionStore(record: TerminalSessionRecord | null): TerminalSession
         lastActiveAt: input.now,
       };
     },
-    touch: async () => {},
-    remove: async () => {
-      current = null;
-    },
-  };
+    touch: vi.fn(),
+    remove: vi.fn(),
+  } as unknown as TerminalSessionStore;
 }
 
 /**
@@ -147,7 +148,7 @@ async function runColdConnect({
   resumed: boolean;
   lastActiveAt?: Date;
 }) {
-  const calls: SpriteCalls = { getSprite: [], createSprite: [], spawned: [], createdSessions: 0 };
+  const calls: SpriteCalls = { getSprite: [], createSprite: [], spawned: [] };
   const existing = new Set<string>(resumed ? [SPRITE_NAME] : []);
 
   // One cache per connect — the whole point of the leaf.
@@ -187,6 +188,7 @@ async function runColdConnect({
             checkFullEgressEnablement: async () => ({ ok: true }),
           },
         });
+        /* c8 ignore next -- harness guard: fires only if the fixture itself is broken */
         if (!acquired.ok) throw new Error(`acquire failed: ${acquired.reason}`);
         return {
           ok: true,
@@ -202,7 +204,12 @@ async function runColdConnect({
     },
   );
 
-  return { calls, sandbox };
+  // Narrow ONCE, here, so each assertion below can read `sprite.name` directly
+  // instead of re-guarding the union (a `sandbox.ok && …` in every expectation is
+  // a branch whose false arm no passing test ever takes).
+  /* c8 ignore next -- harness guard: every case here is expected to resolve */
+  if (!sandbox.ok) throw new Error(`resolve failed: ${sandbox.reason}`);
+  return { calls, sprite: sandbox.sprite };
 }
 
 describe('cold connect — Sprite control-plane budget', () => {
@@ -210,7 +217,7 @@ describe('cold connect — Sprite control-plane budget', () => {
     // The session store already knows this machine's Sprite, and the Sprite exists:
     // the resume path, which used to cost THREE getSprite calls (getOrCreate's probe,
     // the wake's read, and the launch resolution's read).
-    const { calls, sandbox } = await runColdConnect({ resumed: true });
+    const { calls, sprite } = await runColdConnect({ resumed: true });
 
     assert({
       given: 'a full cold connect against a resumed Sprite',
@@ -222,7 +229,7 @@ describe('cold connect — Sprite control-plane budget', () => {
     assert({
       given: 'a resumed connect',
       should: 'resume the existing Sprite (never create a duplicate) and hand its handle to the PTY',
-      actual: { created: calls.createSprite, sprite: sandbox.ok && sandbox.sprite.name },
+      actual: { created: calls.createSprite, sprite: sprite.name },
       expected: { created: [], sprite: SPRITE_NAME },
     });
   });
@@ -257,7 +264,7 @@ describe('cold connect — Sprite control-plane budget', () => {
   });
 
   it('given a FRESH sprite (no session yet), should probe once, create it, and serve the launch handle from that create', async () => {
-    const { calls, sandbox } = await runColdConnect({ resumed: false });
+    const { calls, sprite } = await runColdConnect({ resumed: false });
 
     assert({
       given: 'a first-ever connect (no Sprite exists)',
@@ -269,7 +276,7 @@ describe('cold connect — Sprite control-plane budget', () => {
     assert({
       given: 'a freshly created Sprite',
       should: 'hand the launch path the created handle without re-reading it',
-      actual: sandbox.ok && sandbox.sprite.name,
+      actual: sprite.name,
       expected: SPRITE_NAME,
     });
   });

--- a/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Cold-start survival of the FIRST real session-open (sprites 1-4).
+ *
+ * Deleting `ensureSpriteAwake` means the PTY's own `createSession` is now the
+ * FIRST thing that touches a hibernated Sprite — and therefore the thing that
+ * wakes it (docs.sprites.dev/concepts/lifecycle: there is no wake API; an
+ * incoming request wakes the VM). Fly's wake-on-request can drop that first
+ * connection while the VM boots, which the SDK surfaces as "closed before open".
+ *
+ * That drop used to land on the throwaway `sh -c :` exec, which absorbed it via
+ * `withWakeRetry`. Now it lands on the real session-open, so `openPtyShell`'s
+ * bounded reconnect budget is what must absorb it. These tests pin that: a
+ * user opening a terminal on a sleeping Sprite sees a prompt, not `exit -1`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { openPtyShell } from '../sprites-shell';
+import { isPreOpenWakeError } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import type {
+  SpriteInstanceLike,
+  SpriteCommandLike,
+  SpriteSessionInfo,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { assert } from './riteway';
+
+/** The exact error @fly/sprites' WSCommand emits when the socket never opened. */
+const PRE_OPEN_DROP = new Error('WebSocket closed before open: code=1006');
+
+type FakeCommand = SpriteCommandLike & { _stdout: EventEmitter; _emitter: EventEmitter };
+
+function buildFakeCommand(): FakeCommand {
+  const _stdout = new EventEmitter();
+  const _stderr = new EventEmitter();
+  const _emitter = new EventEmitter();
+  return {
+    _stdout,
+    _emitter,
+    stdout: { on: (event, listener) => { _stdout.on(event, listener); return _stdout; } },
+    stderr: { on: (event, listener) => { _stderr.on(event, listener); return _stderr; } },
+    stdin: { write: vi.fn() },
+    resize: vi.fn(),
+    kill: vi.fn(),
+    on: (event: string, listener: (...args: unknown[]) => void) => { _emitter.on(event, listener); return _emitter; },
+  } as unknown as FakeCommand;
+}
+
+const liveSession: SpriteSessionInfo = { id: 'sess-1', command: 'bash', isActive: true, tty: true };
+
+describe('cold session-open — the first real exec IS the wake', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('given the first session-open drops pre-open, should retry on the bounded backoff and deliver a working shell', async () => {
+    const dropped = buildFakeCommand();
+    const healthy = buildFakeCommand();
+
+    const opened: string[] = [];
+    let spawned = 0;
+    const sprite = {
+      name: 'cold-sprite',
+      // The wake exec is GONE — a spawn here would be the `sh -c :` we deleted.
+      spawn: vi.fn(() => { spawned += 1; return buildFakeCommand(); }),
+      createSession: vi.fn(() => {
+        opened.push('create');
+        return opened.length === 1 ? dropped : healthy;
+      }),
+      attachSession: vi.fn(() => { opened.push('attach'); return healthy; }),
+      // The cold VM reports no live sessions yet, so the reconnect plans a fresh create.
+      listSessions: vi.fn(async () => []),
+      filesystem: vi.fn(),
+      updateNetworkPolicy: vi.fn(),
+      destroy: vi.fn(),
+    } as unknown as SpriteInstanceLike;
+
+    const output: string[] = [];
+    const exits: number[] = [];
+    openPtyShell({
+      sprite,
+      cols: 80,
+      rows: 24,
+      onOutput: (data) => output.push(data),
+      onExit: (code) => exits.push(code),
+    });
+
+    assert({
+      given: 'the SDK error emitted when a cold VM drops the wake connection',
+      should: 'be classified as a retryable pre-open drop',
+      actual: isPreOpenWakeError(PRE_OPEN_DROP),
+      expected: true,
+    });
+
+    // The cold VM drops the first session-open before it ever opened.
+    dropped._emitter.emit('error', PRE_OPEN_DROP);
+    await vi.runOnlyPendingTimersAsync();
+    await vi.runOnlyPendingTimersAsync();
+
+    // The retried session-open lands on the now-awake VM and prints a prompt.
+    healthy._stdout.emit('data', 'user@sprite:/workspace$ ');
+
+    assert({
+      given: 'a first session-open dropped pre-open by a cold VM',
+      should: 'retry the session-open (bounded backoff) rather than tearing the terminal down',
+      actual: { opens: opened.length, exits },
+      expected: { opens: 2, exits: [] },
+    });
+
+    assert({
+      given: 'the retried session-open',
+      should: 'deliver the woken shell’s output to the viewer',
+      actual: output.join(''),
+      expected: 'user@sprite:/workspace$ ',
+    });
+
+    assert({
+      given: 'the whole cold-open sequence',
+      should: 'never spawn a no-op wake exec — the session-open is the wake',
+      actual: spawned,
+      expected: 0,
+    });
+  });
+
+  it('given a Sprite that never wakes, should still surface an exit rather than retry forever', async () => {
+    // The bound matters as much as the retry: an unbounded wake loop against a
+    // genuinely dead Sprite would hang the terminal in "Connecting…" indefinitely.
+    const cmds = Array.from({ length: 12 }, buildFakeCommand);
+    let index = 0;
+
+    const sprite = {
+      name: 'dead-sprite',
+      spawn: vi.fn(),
+      createSession: vi.fn(() => cmds[Math.min(index++, cmds.length - 1)]),
+      attachSession: vi.fn(() => cmds[Math.min(index++, cmds.length - 1)]),
+      listSessions: vi.fn(async () => []),
+      filesystem: vi.fn(),
+      updateNetworkPolicy: vi.fn(),
+      destroy: vi.fn(),
+    } as unknown as SpriteInstanceLike;
+
+    const exits: number[] = [];
+    openPtyShell({
+      sprite,
+      cols: 80,
+      rows: 24,
+      onOutput: () => {},
+      onExit: (code) => exits.push(code),
+    });
+
+    // Every session-open this Sprite hands back drops pre-open, forever.
+    for (let i = 0; i < 10 && exits.length === 0; i += 1) {
+      cmds[Math.min(i, cmds.length - 1)]._emitter.emit('error', PRE_OPEN_DROP);
+      await vi.runOnlyPendingTimersAsync();
+      await vi.runOnlyPendingTimersAsync();
+    }
+
+    expect(exits.length).toBe(1);
+    assert({
+      given: 'a Sprite whose session-open drops pre-open on every attempt',
+      should: 'exhaust the bounded budget and surface an exit (never loop forever)',
+      actual: exits,
+      expected: [-1],
+    });
+  });
+});

--- a/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
@@ -56,16 +56,15 @@ describe('cold session-open — the first real exec IS the wake', () => {
     const healthy = buildFakeCommand();
 
     const opened: string[] = [];
-    let spawned = 0;
     const sprite = {
       name: 'cold-sprite',
-      // The wake exec is GONE — a spawn here would be the `sh -c :` we deleted.
-      spawn: vi.fn(() => { spawned += 1; return buildFakeCommand(); }),
+      // The wake exec is GONE — any spawn here would be the `sh -c :` we deleted.
+      spawn: vi.fn(),
       createSession: vi.fn(() => {
         opened.push('create');
         return opened.length === 1 ? dropped : healthy;
       }),
-      attachSession: vi.fn(() => { opened.push('attach'); return healthy; }),
+      attachSession: vi.fn(),
       // The cold VM reports no live sessions yet, so the reconnect plans a fresh create.
       listSessions: vi.fn(async () => []),
       filesystem: vi.fn(),
@@ -112,12 +111,7 @@ describe('cold session-open — the first real exec IS the wake', () => {
       expected: 'user@sprite:/workspace$ ',
     });
 
-    assert({
-      given: 'the whole cold-open sequence',
-      should: 'never spawn a no-op wake exec — the session-open is the wake',
-      actual: spawned,
-      expected: 0,
-    });
+    expect(sprite.spawn).not.toHaveBeenCalled(); // no `sh -c :` — the session-open IS the wake
   });
 
   it('given a Sprite that never wakes, should still surface an exit rather than retry forever', async () => {
@@ -126,11 +120,14 @@ describe('cold session-open — the first real exec IS the wake', () => {
     const cmds = Array.from({ length: 12 }, buildFakeCommand);
     let index = 0;
 
+    const nextCommand = () => cmds[Math.min(index++, cmds.length - 1)];
     const sprite = {
       name: 'dead-sprite',
       spawn: vi.fn(),
-      createSession: vi.fn(() => cmds[Math.min(index++, cmds.length - 1)]),
-      attachSession: vi.fn(() => cmds[Math.min(index++, cmds.length - 1)]),
+      createSession: vi.fn(nextCommand),
+      // Never reached: nothing is ever live on this Sprite, so every reconnect
+      // plans a fresh create, never an attach.
+      attachSession: vi.fn(),
       listSessions: vi.fn(async () => []),
       filesystem: vi.fn(),
       updateNetworkPolicy: vi.fn(),
@@ -142,7 +139,7 @@ describe('cold session-open — the first real exec IS the wake', () => {
       sprite,
       cols: 80,
       rows: 24,
-      onOutput: () => {},
+      onOutput: vi.fn(),
       onExit: (code) => exits.push(code),
     });
 

--- a/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
@@ -16,7 +16,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { openPtyShell } from '../sprites-shell';
-import { isPreOpenWakeError } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type {
   SpriteInstanceLike,
   SpriteCommandLike,
@@ -24,8 +23,16 @@ import type {
 } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { assert } from './riteway';
 
-/** The exact error @fly/sprites' WSCommand emits when the socket never opened. */
-const PRE_OPEN_DROP = new Error('WebSocket closed before open: code=1006');
+/**
+ * What a cold-VM drop ACTUALLY looks like. `@fly/sprites` has no `ws` dependency —
+ * it drives the global (undici) WebSocket and registers its 'error' listener
+ * BEFORE its 'close' one, so a failed handshake surfaces this opaque message
+ * first. Note it does NOT contain "closed before open": that string is only
+ * emitted afterwards, from the SDK's close handler. A retry keyed on that
+ * substring would miss this entirely — which is why the shell classifies
+ * structurally (no 'spawn' and no output => the socket never opened).
+ */
+const PRE_OPEN_DROP = new Error('WebSocket error: TypeError (url: wss://sprite/exec?stdin=true)');
 
 type FakeCommand = SpriteCommandLike & { _stdout: EventEmitter; _emitter: EventEmitter };
 
@@ -80,13 +87,6 @@ describe('cold session-open — the first real exec IS the wake', () => {
       rows: 24,
       onOutput: (data) => output.push(data),
       onExit: (code) => exits.push(code),
-    });
-
-    assert({
-      given: 'the SDK error emitted when a cold VM drops the wake connection',
-      should: 'be classified as a retryable pre-open drop',
-      actual: isPreOpenWakeError(PRE_OPEN_DROP),
-      expected: true,
     });
 
     // The cold VM drops the first session-open before it ever opened.

--- a/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
+++ b/apps/realtime/src/terminal/__tests__/cold-session-open-retry.test.ts
@@ -5,7 +5,9 @@
  * FIRST thing that touches a hibernated Sprite — and therefore the thing that
  * wakes it (docs.sprites.dev/concepts/lifecycle: there is no wake API; an
  * incoming request wakes the VM). Fly's wake-on-request can drop that first
- * connection while the VM boots, which the SDK surfaces as "closed before open".
+ * connection while the VM boots — surfaced as an opaque WebSocket error, which is
+ * why the shell classifies the drop STRUCTURALLY (no 'spawn', no output => the
+ * socket never opened) rather than by matching the error's text.
  *
  * That drop used to land on the throwaway `sh -c :` exec, which absorbed it via
  * `withWakeRetry`. Now it lands on the real session-open, so `openPtyShell`'s

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -352,13 +352,21 @@ describe('openPtyShell', () => {
       expect(onOutput).toHaveBeenCalledWith('back\r\n');
     });
 
-    it('given an error and NO live session, should call onExit(-1) without an error banner', async () => {
+    it('given a POST-open error and NO live session, should call onExit(-1) without an error banner', async () => {
       const cmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [] });
       const onOutput = vi.fn();
       const onExit = vi.fn();
 
       openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+      // The socket OPENED first — a keepalive timeout is by definition a
+      // post-open failure (the watchdog only fires after 45s of an established
+      // connection). The real SDK emits 'spawn' at that open, and the shell keys
+      // its retry decision on it: a post-open death with nothing live left to
+      // attach to is a genuinely dead shell, so it exits rather than re-creating.
+      // (Contrast the cold-start PRE-open drop, which never opened and IS retried
+      // — see cold-session-open-retry.test.ts.)
+      cmd._emitter.emit('spawn');
       cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
 

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -82,8 +82,13 @@ export interface ResolveTerminalSandboxTarget {
 export interface ResolveTerminalSandboxDeps {
   /** Resolve the named agent terminal to its Sprite + cwd + launch metadata. */
   resolveAgentTerminal: (target: ResolveTerminalSandboxTarget) => Promise<ResolveAgentTerminalResult>;
-  /** Read the resolved Sprite handle. Called EXACTLY ONCE here (full getSprite
-   * collapse across resolve/wake is leaf 1-4). */
+  /**
+   * Read the resolved Sprite handle. Called exactly once here — and the caller
+   * (`apps/realtime/src/index.ts`) backs this with a per-connect
+   * `createSpriteHandleCache` shared with the machine acquire above, so the
+   * WHOLE connect (acquire + auth + launch resolution) costs ONE underlying
+   * `sdk.getSprite`, not three.
+   */
   getSprite: (sandboxId: string) => Promise<SpriteInstanceLike>;
 }
 

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1,3 +1,4 @@
+import { isPreOpenWakeError } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type {
   SpriteInstanceLike,
   SpriteCommandLike,
@@ -77,18 +78,34 @@ export type ReconnectPlan =
  *   is dead; the shell overwrites the persisted streamSessionId).
  * - No known id but a live shell exists → `attach` it (fresh-create path whose
  *   background id-capture hasn't landed yet).
+ * - No known id, nothing live, and the drop was PRE-OPEN → `create` (see below).
  * - No known id and nothing live → `fatal` (the shell is genuinely gone).
+ *
+ * `preOpenDrop` is what keeps a COLD Sprite openable. A Sprite has no wake API —
+ * an incoming request wakes it (docs.sprites.dev/concepts/lifecycle) — so the
+ * first `createSession` against a hibernated VM IS its wake, and Fly's
+ * wake-on-request can drop that first connection before it ever opens ("closed
+ * before open"). At that moment there is no known id (we were creating one) and
+ * nothing live (the VM is still booting): identical, on the surface, to a
+ * genuinely dead shell. Without this flag that state reads as `fatal` and the
+ * user gets `exit -1` instead of a prompt. A pre-open drop is provably a
+ * connection that never opened, so nothing was started and re-creating is safe;
+ * `consecutiveFailures` still bounds it, so a Sprite that truly never wakes
+ * exhausts the budget and surfaces the exit anyway.
  */
 export function planReconnect({
   knownId,
   liveSessionIds,
   consecutiveFailures,
   maxAttempts,
+  preOpenDrop = false,
 }: {
   knownId: string | undefined;
   liveSessionIds: string[];
   consecutiveFailures: number;
   maxAttempts: number;
+  /** The failure that triggered this reconnect was a cold-start pre-open drop. */
+  preOpenDrop?: boolean;
 }): ReconnectPlan {
   if (consecutiveFailures > maxAttempts) return { action: 'fatal' };
   if (knownId !== undefined) {
@@ -97,6 +114,7 @@ export function planReconnect({
       : { action: 'create' };
   }
   if (liveSessionIds.length > 0) return { action: 'attach', id: liveSessionIds[0] };
+  if (preOpenDrop) return { action: 'create' };
   return { action: 'fatal' };
 }
 
@@ -182,6 +200,9 @@ export function openPtyShell({
   let closed = false; // a real exit (or exhausted reconnects) — stop everything
   let reconnecting = false;
   let consecutiveFailures = 0;
+  // Whether the failure that triggered the pending reconnect was a cold-start
+  // pre-open drop (the Sprite wake handshake) rather than a post-open death.
+  let lastErrorWasPreOpenDrop = false;
   // Bumped on every session (re)establishment (attach or fresh-create). A
   // fresh session resolves its id via a fire-and-forget listSessions(); if a
   // LATER establishment supersedes it before that resolves, the stale resolver
@@ -221,7 +242,14 @@ export function openPtyShell({
       if (stale) return;
       fatal(code ?? -1);
     });
-    cmd.on('error', () => { stale = true; void reconnect(); });
+    cmd.on('error', (error) => {
+      stale = true;
+      // Remember WHY this command died: a pre-open drop (the cold-VM wake
+      // handshake) is retryable even with no session to fall back to — see
+      // planReconnect's `preOpenDrop`.
+      lastErrorWasPreOpenDrop = isPreOpenWakeError(error);
+      void reconnect();
+    });
   }
 
   // Start a brand-new shell for the SAME command and resolve its session id in
@@ -316,6 +344,7 @@ export function openPtyShell({
         liveSessionIds: liveIds,
         consecutiveFailures,
         maxAttempts: MAX_RECONNECT_ATTEMPTS,
+        preOpenDrop: lastErrorWasPreOpenDrop,
       });
 
       if (plan.action === 'fatal') {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -235,7 +235,14 @@ export function openPtyShell({
     // open is the authoritative signal the connection is healthy — reset the
     // bounded reconnect budget here so an idle shell that reattaches cleanly but
     // stays quiet (no stdout) doesn't slowly exhaust the budget and get killed.
-    cmd.on('spawn', () => { consecutiveFailures = 0; });
+    cmd.on('spawn', () => {
+      consecutiveFailures = 0;
+      // A confirmed open retires the previous failure's classification. Without
+      // this, a later reconnect entered WITHOUT a fresh error (listSessions
+      // unavailable, or the catch-all retry) would consult a stale verdict from
+      // whatever failed last.
+      lastErrorWasPreOpenDrop = false;
+    });
     cmd.on('exit', (code) => {
       // Ignore the stale exit that trails a keepalive 'error' on the same dead
       // command — only an exit WITHOUT a preceding error is a real shell exit.

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1,4 +1,3 @@
-import { isPreOpenWakeError } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type {
   SpriteInstanceLike,
   SpriteCommandLike,
@@ -225,17 +224,26 @@ export function openPtyShell({
     // instant it errors so the trailing close/exit it produces can't tear the
     // session down while reconnect() is replacing it.
     let stale = false;
+    // Whether THIS command's socket ever opened. The SDK emits 'spawn' exactly
+    // when `start()` resolves, and any inbound byte proves the same thing. This is
+    // the structural boundary the reconnect keys on — see the 'error' handler.
+    let opened = false;
     cmd.stdout.on('data', (chunk) => {
       // Any inbound data proves the connection recovered; reset the failure budget.
+      opened = true;
       consecutiveFailures = 0;
       onOutput(toStr(chunk));
     });
-    cmd.stderr.on('data', (chunk) => onOutput(toStr(chunk)));
+    cmd.stderr.on('data', (chunk) => {
+      opened = true;
+      onOutput(toStr(chunk));
+    });
     // The SDK emits 'spawn' only AFTER the WebSocket actually opens. A confirmed
     // open is the authoritative signal the connection is healthy — reset the
     // bounded reconnect budget here so an idle shell that reattaches cleanly but
     // stays quiet (no stdout) doesn't slowly exhaust the budget and get killed.
     cmd.on('spawn', () => {
+      opened = true;
       consecutiveFailures = 0;
       // A confirmed open retires the previous failure's classification. Without
       // this, a later reconnect entered WITHOUT a fresh error (listSessions
@@ -249,12 +257,19 @@ export function openPtyShell({
       if (stale) return;
       fatal(code ?? -1);
     });
-    cmd.on('error', (error) => {
+    cmd.on('error', () => {
       stale = true;
-      // Remember WHY this command died: a pre-open drop (the cold-VM wake
-      // handshake) is retryable even with no session to fall back to — see
-      // planReconnect's `preOpenDrop`.
-      lastErrorWasPreOpenDrop = isPreOpenWakeError(error);
+      // Remember WHY this command died, STRUCTURALLY: if it never reported an open
+      // (no 'spawn', no byte of output), its socket never came up, so the session
+      // was never started and re-creating it is safe — see planReconnect's
+      // `preOpenDrop`, which is what keeps a COLD Sprite openable.
+      //
+      // Deliberately not inferred from the error's text. `@fly/sprites` drives the
+      // global (undici) WebSocket and registers its 'error' listener before its
+      // 'close' one, so a failed handshake surfaces an opaque `WebSocket error: …`
+      // FIRST — the SDK's own `closed before open` string is only emitted
+      // afterwards, and a substring test would miss the real cold-start drop.
+      lastErrorWasPreOpenDrop = !opened;
       void reconnect();
     });
   }

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -83,8 +83,10 @@ export type ReconnectPlan =
  * `preOpenDrop` is what keeps a COLD Sprite openable. A Sprite has no wake API —
  * an incoming request wakes it (docs.sprites.dev/concepts/lifecycle) — so the
  * first `createSession` against a hibernated VM IS its wake, and Fly's
- * wake-on-request can drop that first connection before it ever opens ("closed
- * before open"). At that moment there is no known id (we were creating one) and
+ * wake-on-request can drop that first connection before it ever opens (surfaced
+ * as an opaque WebSocket error — hence the caller classifies it structurally, by
+ * the absence of a 'spawn', not by its text). At that moment there is no known id
+ * (we were creating one) and
  * nothing live (the VM is still booting): identical, on the surface, to a
  * genuinely dead shell. Without this flag that state reads as `fatal` and the
  * user gets `exit -1` instead of a prompt. A pre-open drop is provably a

--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -19,6 +19,10 @@
  * every acquire, never trusting a permission check cached from an earlier
  * request. `branchStore.findById` needs no such threading (a branch lookup by
  * its own row id carries no actor context either way).
+ *
+ * Acquiring never WAKES the Sprite: there is no wake API, and a hibernated
+ * Sprite wakes on any incoming request (docs.sprites.dev/concepts/lifecycle), so
+ * the kill path's own `attachSession` is the wake.
  */
 
 import { eq } from '@pagespace/db/operators';
@@ -32,7 +36,6 @@ import {
   getSandboxSessionSecret,
 } from '@pagespace/lib/services/sandbox/terminal-session-manager';
 import { checkMachineRuntimeGuardrail, recordMachineActivity } from '@pagespace/lib/services/sandbox/quota';
-import { ensureSpriteAwake, type SpritesSdk } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/types';
 import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
 import { createDbMachineAgentTerminalStore } from '@pagespace/lib/services/machines/agent-terminals-store';
@@ -76,20 +79,6 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
     throw error;
   });
   return sandboxClientPromise;
-}
-
-/** The raw Sprites SDK — only needed to wake a RESUMED (possibly hibernating) Sprite before a caller (e.g. a kill) attaches to its PTY session directly, bypassing the `ExecSandboxClient`'s wake-retry-wrapped exec path. */
-let spritesSdkPromise: Promise<SpritesSdk> | null = null;
-function getSpritesSdk(): Promise<SpritesSdk> {
-  spritesSdkPromise ??= (async () => {
-    assertSandboxRuntime();
-    const { getProductionSpritesSdk } = await import('@/lib/sandbox/sprites-client');
-    return getProductionSpritesSdk();
-  })().catch((error) => {
-    spritesSdkPromise = null;
-    throw error;
-  });
-  return spritesSdkPromise;
 }
 
 let terminalSessionStorePromise: ReturnType<typeof createDbTerminalSessionStore> | null = null;
@@ -179,20 +168,13 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
 
       if (!result.ok) return { ok: false, reason: result.reason };
 
-      // Wake a resumed (possibly hibernating) Sprite before handing its id back —
-      // a caller that then attaches to its PTY session directly (e.g. killAgentTerminal's
-      // host.attach/stream, unlike the wake-retry-wrapped exec path) would otherwise race
-      // a cold Sprite. Mirrors apps/realtime/src/index.ts's buildMachineSandbox.
-      if (result.resumed) {
-        try {
-          const sdk = await getSpritesSdk();
-          const sprite = await sdk.getSprite(result.sandboxId);
-          await ensureSpriteAwake(sprite);
-        } catch {
-          return { ok: false, reason: 'provision_failed' };
-        }
-      }
-
+      // NO wake exec here, and no second getSprite to run one with. A Sprite has no
+      // explicit wake API — an incoming request wakes it automatically
+      // (docs.sprites.dev/concepts/lifecycle) — so whatever the caller does next IS
+      // the wake: killAgentTerminal's `host.attach` -> `stream` opens an
+      // `attachSession` WebSocket, which wakes the VM exactly like an exec does. The
+      // `sh -c :` this used to run first just paid for a second cold start. Mirrors
+      // apps/realtime/src/index.ts's buildMachineSandbox.
       recordMachineActivity({ machineKey: machineId, now: nowMs });
       return { ok: true, sandboxId: result.sandboxId };
     },

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -15,12 +15,7 @@ import {
   type AgentTerminalMachineSandbox,
 } from '../agent-terminals';
 import type { MachineAgentTerminalStore, MachineAgentTerminalRecord, AgentTerminalScopeKey } from '../agent-terminals-store';
-import {
-  MachineStreamOpenTimeoutError,
-  MachineStreamSessionGoneError,
-  type MachineHost,
-  type MachineHandle,
-} from '../../sandbox/machine-host';
+import { MachineStreamOpenTimeoutError, type MachineHost, type MachineHandle } from '../../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from '../machine-branches';
 
@@ -966,7 +961,7 @@ describe('killAgentTerminal', () => {
   // the other. `stream()` retries a cold-start drop internally (and that first
   // attempt wakes the Sprite), so a failure that survives the retry is a woken
   // Sprite saying "no such session".
-  it('given the machine reports the session is GONE (404), should drop the row — there is nothing left to kill', async () => {
+  it('given the machine does not LIST the session (positive evidence it is gone), should drop the row — there is nothing left to kill', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -989,9 +984,12 @@ describe('killAgentTerminal', () => {
         attach: async () =>
           makeHandle({
             stream: async () => {
-              // The machine ANSWERED for this session: 404. Positive evidence.
-              throw new MachineStreamSessionGoneError('sess-dangling');
+              throw new Error('WebSocket error: TypeError (url: wss://…/exec/sess-dangling)');
             },
+            // The machine ANSWERS, and this session is not among its live ones.
+            // That listing — a REST call with a real status — is the only positive
+            // evidence available; the WebSocket cannot surface an HTTP status.
+            listStreams: async () => [],
           }),
       }),
     });
@@ -1032,6 +1030,8 @@ describe('killAgentTerminal', () => {
               // about whether the PTY is alive.
               throw Object.assign(new Error('rate limited'), { status: 429 });
             },
+            // ...and the machine still lists the session as live.
+            listStreams: async () => [{ id: 'sess-abc', command: 'bash', isActive: true }],
           }),
       }),
     });
@@ -1040,6 +1040,45 @@ describe('killAgentTerminal', () => {
 
     // Dropping the row here would leave a running, billable agent process with
     // nothing pointing at it. An unknown is not a licence to delete.
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(rows.size).toBe(1);
+  });
+
+  it('given the session LISTING itself fails, should KEEP the row — we never obtained evidence either way', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        machineId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
+        machineBranchId: BRANCH_ID,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-abc',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    const deps = makeDeps({
+      store,
+      host: makeHost({
+        attach: async () =>
+          makeHandle({
+            stream: async () => {
+              throw new Error('WebSocket error: TypeError (url: wss://…/exec/sess-abc)');
+            },
+            listStreams: async () => {
+              throw new Error('sprite api down');
+            },
+          }),
+      }),
+    });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
+
+    // Absence of evidence is not evidence of absence.
     expect(result).toEqual({ ok: false, reason: 'error' });
     expect(rows.size).toBe(1);
   });
@@ -1069,6 +1108,7 @@ describe('killAgentTerminal', () => {
             stream: async () => {
               throw new MachineStreamOpenTimeoutError(20_000);
             },
+            listStreams: async () => [{ id: 'sess-abc', command: 'bash', isActive: true }],
           }),
       }),
     });

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -1083,7 +1083,7 @@ describe('killAgentTerminal', () => {
     expect(rows.size).toBe(1);
   });
 
-  it('given the stream never reports whether it opened (timeout), should KEEP the row rather than orphan a possibly-live PTY', async () => {
+  it('given the stream never reports whether it opened (timeout), should KEEP the row EVEN IF the listing claims the session is gone — a silent machine has not earned trust in its own listing', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -1108,7 +1108,12 @@ describe('killAgentTerminal', () => {
             stream: async () => {
               throw new MachineStreamOpenTimeoutError(20_000);
             },
-            listStreams: async () => [{ id: 'sess-abc', command: 'bash', isActive: true }],
+            // Deliberately reports the session as GONE. For any OTHER failure this
+            // listing would be positive evidence and the row would be dropped — so
+            // this test only passes if the timeout genuinely short-circuits ahead
+            // of the listing, rather than passing for the same reason the
+            // transient-failure test above does.
+            listStreams: async () => [],
           }),
       }),
     });

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -15,7 +15,12 @@ import {
   type AgentTerminalMachineSandbox,
 } from '../agent-terminals';
 import type { MachineAgentTerminalStore, MachineAgentTerminalRecord, AgentTerminalScopeKey } from '../agent-terminals-store';
-import { MachineStreamOpenTimeoutError, type MachineHost, type MachineHandle } from '../../sandbox/machine-host';
+import {
+  MachineStreamOpenTimeoutError,
+  MachineStreamSessionGoneError,
+  type MachineHost,
+  type MachineHandle,
+} from '../../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from '../machine-branches';
 
@@ -961,7 +966,7 @@ describe('killAgentTerminal', () => {
   // the other. `stream()` retries a cold-start drop internally (and that first
   // attempt wakes the Sprite), so a failure that survives the retry is a woken
   // Sprite saying "no such session".
-  it('given the session will not attach even on a woken Sprite (dangling streamSessionId), should drop the row — there is nothing left to kill', async () => {
+  it('given the machine reports the session is GONE (404), should drop the row — there is nothing left to kill', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -984,7 +989,8 @@ describe('killAgentTerminal', () => {
         attach: async () =>
           makeHandle({
             stream: async () => {
-              throw new Error('WebSocket closed before open: code=1006');
+              // The machine ANSWERED for this session: 404. Positive evidence.
+              throw new MachineStreamSessionGoneError('sess-dangling');
             },
           }),
       }),
@@ -997,6 +1003,45 @@ describe('killAgentTerminal', () => {
     // strand the terminal permanently unkillable.
     expect(result).toEqual({ ok: true });
     expect(rows.size).toBe(0);
+  });
+
+  it('given a TRANSIENT stream failure (429 / 5xx / hang-up — NOT positive evidence), should KEEP the row rather than orphan a live PTY', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        machineId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
+        machineBranchId: BRANCH_ID,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-abc',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    const deps = makeDeps({
+      store,
+      host: makeHost({
+        attach: async () =>
+          makeHandle({
+            stream: async () => {
+              // A control-plane blip resolving the machine, mid-kill. Says NOTHING
+              // about whether the PTY is alive.
+              throw Object.assign(new Error('rate limited'), { status: 429 });
+            },
+          }),
+      }),
+    });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
+
+    // Dropping the row here would leave a running, billable agent process with
+    // nothing pointing at it. An unknown is not a licence to delete.
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(rows.size).toBe(1);
   });
 
   it('given the stream never reports whether it opened (timeout), should KEEP the row rather than orphan a possibly-live PTY', async () => {

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -15,7 +15,7 @@ import {
   type AgentTerminalMachineSandbox,
 } from '../agent-terminals';
 import type { MachineAgentTerminalStore, MachineAgentTerminalRecord, AgentTerminalScopeKey } from '../agent-terminals-store';
-import type { MachineHost, MachineHandle } from '../../sandbox/machine-host';
+import { MachineStreamOpenTimeoutError, type MachineHost, type MachineHandle } from '../../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from '../machine-branches';
 
@@ -954,6 +954,86 @@ describe('killAgentTerminal', () => {
 
     expect(result).toEqual({ ok: true });
     expect(rows.size).toBe(0);
+  });
+
+  // sprites 1-4: a stream that FAILS to open and a stream that never REPORTS are
+  // opposite situations, and conflating them breaks the kill in one direction or
+  // the other. `stream()` retries a cold-start drop internally (and that first
+  // attempt wakes the Sprite), so a failure that survives the retry is a woken
+  // Sprite saying "no such session".
+  it('given the session will not attach even on a woken Sprite (dangling streamSessionId), should drop the row — there is nothing left to kill', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        machineId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
+        machineBranchId: BRANCH_ID,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-dangling',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    const deps = makeDeps({
+      store,
+      host: makeHost({
+        attach: async () =>
+          makeHandle({
+            stream: async () => {
+              throw new Error('WebSocket closed before open: code=1006');
+            },
+          }),
+      }),
+    });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
+
+    // Exec sessions do not survive a Sprite pause, so a session id that will not
+    // attach names a process that is already gone. Keeping the row here would
+    // strand the terminal permanently unkillable.
+    expect(result).toEqual({ ok: true });
+    expect(rows.size).toBe(0);
+  });
+
+  it('given the stream never reports whether it opened (timeout), should KEEP the row rather than orphan a possibly-live PTY', async () => {
+    const { store, rows } = makeStore([
+      {
+        id: 'agent-terminal-1',
+        ownerId: 'user-1',
+        machineId: TERMINAL_ID,
+        scope: 'branch',
+        projectName: PROJECT_NAME,
+        machineBranchId: BRANCH_ID,
+        name: 'cli',
+        agentType: 'pagespace-cli',
+        command: null,
+        streamSessionId: 'sess-abc',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    const deps = makeDeps({
+      store,
+      host: makeHost({
+        attach: async () =>
+          makeHandle({
+            stream: async () => {
+              throw new MachineStreamOpenTimeoutError(20_000);
+            },
+          }),
+      }),
+    });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
+
+    // We learned NOTHING: the PTY may be alive and merely unreachable. Dropping
+    // the row would leave a running, billable process with no bookkeeping.
+    expect(result).toEqual({ ok: false, reason: 'error' });
+    expect(rows.size).toBe(1);
   });
 
   it('given the Sprite kill throws, should keep the row so a retry can find it again', async () => {

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -36,7 +36,12 @@
  * reconnected or resumed from hibernation.
  */
 
-import type { MachineHandle, MachineHost, MachineStreamSessionInfo } from '../sandbox/machine-host';
+import {
+  MachineStreamOpenTimeoutError,
+  type MachineHandle,
+  type MachineHost,
+  type MachineStreamSessionInfo,
+} from '../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 import {
@@ -466,11 +471,20 @@ async function killAtLocation(
       try {
         const stream = await handle.stream({ sessionId: row.streamSessionId });
         stream.kill('SIGKILL');
-      } catch {
-        // The stream would not open. That alone says NOTHING about whether the PTY
-        // is alive: the WebSocket API cannot surface an HTTP status (see
-        // `isPreOpenWakeError`), so a vanished session, a 429, a 5xx mid-deploy and
-        // a socket hang-up are indistinguishable at this layer.
+      } catch (error) {
+        // A TIMEOUT is the one failure we refuse to reason further about. The
+        // machine went silent for the entire cap — it told us neither that the
+        // stream opened nor that it failed. A machine that will not answer the
+        // exec socket has not earned our trust in its session LISTING either, so
+        // we do not go on to ask: we keep the row and let a retry settle it.
+        if (error instanceof MachineStreamOpenTimeoutError) {
+          return { ok: false, reason: 'error' };
+        }
+
+        // Otherwise the stream would not open, and that alone says NOTHING about
+        // whether the PTY is alive: the WebSocket API cannot surface an HTTP status
+        // (see `isPreOpenWakeError`), so a vanished session, a 429, a 5xx
+        // mid-deploy and a socket hang-up are indistinguishable at this layer.
         //
         // So we ask the one API that CAN answer: the session LIST. If the machine
         // tells us this session is not among its live ones, that is positive

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -36,7 +36,7 @@
  * reconnected or resumed from hibernation.
  */
 
-import { MachineStreamSessionGoneError, type MachineHandle, type MachineHost } from '../sandbox/machine-host';
+import type { MachineHandle, MachineHost, MachineStreamSessionInfo } from '../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 import {
@@ -466,20 +466,27 @@ async function killAtLocation(
       try {
         const stream = await handle.stream({ sessionId: row.streamSessionId });
         stream.kill('SIGKILL');
-      } catch (error) {
-        // Drop this terminal's bookkeeping ONLY on positive evidence that its
-        // session is already gone (the machine answered 404/410 for it — see
-        // `MachineStreamSessionGoneError`). Then there is genuinely nothing left
-        // to kill, and keeping the row would strand the terminal unkillable.
+      } catch {
+        // The stream would not open. That alone says NOTHING about whether the PTY
+        // is alive: the WebSocket API cannot surface an HTTP status (see
+        // `isPreOpenWakeError`), so a vanished session, a 429, a 5xx mid-deploy and
+        // a socket hang-up are indistinguishable at this layer.
         //
-        // EVERY other failure is an unknown, and unknowns must not be acted on: a
-        // 429, a 5xx during a deploy, a socket hang-up, a control-plane blip
-        // resolving the machine, or an open that never reported either way are all
-        // indistinguishable from "the PTY is alive and we simply could not reach
-        // it". Deleting the row in those cases would leave a running, billable
-        // agent process with nothing pointing at it — silent and unrecoverable,
-        // where keeping the row is merely a retryable annoyance.
-        if (!(error instanceof MachineStreamSessionGoneError)) {
+        // So we ask the one API that CAN answer: the session LIST. If the machine
+        // tells us this session is not among its live ones, that is positive
+        // evidence it is gone — nothing left to kill, and keeping the row would
+        // strand the terminal permanently unkillable. Anything else (it IS still
+        // listed, or the listing itself failed) is an unknown, and unknowns must
+        // not be acted on: deleting the row of a PTY that is still running leaves a
+        // billable process with nothing pointing at it — silent and unrecoverable,
+        // where keeping the row is merely a visible, retryable annoyance.
+        let sessions: MachineStreamSessionInfo[];
+        try {
+          sessions = await handle.listStreams();
+        } catch {
+          return { ok: false, reason: 'error' };
+        }
+        if (sessions.some((session) => session.id === row.streamSessionId)) {
           return { ok: false, reason: 'error' };
         }
       }

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -36,7 +36,7 @@
  * reconnected or resumed from hibernation.
  */
 
-import type { MachineHost } from '../sandbox/machine-host';
+import { MachineStreamOpenTimeoutError, type MachineHandle, type MachineHost } from '../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 import {
@@ -453,14 +453,34 @@ async function killAtLocation(
   deps: Pick<AgentTerminalsDeps, 'store' | 'host'>,
 ): Promise<KillAgentTerminalResult> {
   if (row.streamSessionId) {
+    let handle: MachineHandle | null;
     try {
-      const handle = await deps.host.attach({ machineId: location.sandboxId });
-      if (handle) {
+      handle = await deps.host.attach({ machineId: location.sandboxId });
+    } catch {
+      // The control plane itself is unreachable — we learned NOTHING about the
+      // process. Keep the row so a retry can find it again.
+      return { ok: false, reason: 'error' };
+    }
+
+    if (handle) {
+      try {
         const stream = await handle.stream({ sessionId: row.streamSessionId });
         stream.kill('SIGKILL');
+      } catch (error) {
+        // A TIMEOUT is the one outcome we must not act on: the stream never told
+        // us whether it opened, so the PTY may well be alive and merely
+        // unreachable. Dropping its row would orphan a running, billable process.
+        if (error instanceof MachineStreamOpenTimeoutError) {
+          return { ok: false, reason: 'error' };
+        }
+        // Any other failure means the session could not be attached even after
+        // the bounded cold-start retry — and that retry's first attempt WOKE the
+        // Sprite, so this is not a cold VM. Exec sessions do not survive a pause
+        // (docs.sprites.dev/concepts/lifecycle), so a `streamSessionId` that will
+        // not attach on a woken Sprite is dangling: the process is already gone.
+        // There is nothing left to kill, and keeping the row would strand the
+        // terminal permanently unkillable. Fall through and drop it.
       }
-    } catch {
-      return { ok: false, reason: 'error' };
     }
   }
 

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -36,7 +36,7 @@
  * reconnected or resumed from hibernation.
  */
 
-import { MachineStreamOpenTimeoutError, type MachineHandle, type MachineHost } from '../sandbox/machine-host';
+import { MachineStreamSessionGoneError, type MachineHandle, type MachineHost } from '../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 import {
@@ -467,19 +467,21 @@ async function killAtLocation(
         const stream = await handle.stream({ sessionId: row.streamSessionId });
         stream.kill('SIGKILL');
       } catch (error) {
-        // A TIMEOUT is the one outcome we must not act on: the stream never told
-        // us whether it opened, so the PTY may well be alive and merely
-        // unreachable. Dropping its row would orphan a running, billable process.
-        if (error instanceof MachineStreamOpenTimeoutError) {
+        // Drop this terminal's bookkeeping ONLY on positive evidence that its
+        // session is already gone (the machine answered 404/410 for it — see
+        // `MachineStreamSessionGoneError`). Then there is genuinely nothing left
+        // to kill, and keeping the row would strand the terminal unkillable.
+        //
+        // EVERY other failure is an unknown, and unknowns must not be acted on: a
+        // 429, a 5xx during a deploy, a socket hang-up, a control-plane blip
+        // resolving the machine, or an open that never reported either way are all
+        // indistinguishable from "the PTY is alive and we simply could not reach
+        // it". Deleting the row in those cases would leave a running, billable
+        // agent process with nothing pointing at it — silent and unrecoverable,
+        // where keeping the row is merely a retryable annoyance.
+        if (!(error instanceof MachineStreamSessionGoneError)) {
           return { ok: false, reason: 'error' };
         }
-        // Any other failure means the session could not be attached even after
-        // the bounded cold-start retry — and that retry's first attempt WOKE the
-        // Sprite, so this is not a cold VM. Exec sessions do not survive a pause
-        // (docs.sprites.dev/concepts/lifecycle), so a `streamSessionId` that will
-        // not attach on a woken Sprite is dangling: the process is already gone.
-        // There is nothing left to kill, and keeping the row would strand the
-        // terminal permanently unkillable. Fall through and drop it.
       }
     }
   }

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -76,29 +76,6 @@ export class MachineStreamOpenTimeoutError extends Error {
 }
 
 /**
- * POSITIVE evidence that the stream's target session no longer exists — the
- * machine answered, and its answer was "no such session" (a 404/410 on the exec
- * endpoint).
- *
- * This is the ONLY signal on which a caller may tear down a session's
- * bookkeeping. Every other failure — a control-plane blip, a 429, a 5xx during a
- * deploy, a socket hang-up, a timeout — is indistinguishable from "the process is
- * alive and we merely could not reach it", and acting on those would orphan a
- * running, billable PTY with nothing left pointing at it.
- *
- * The asymmetry is deliberate: keeping a row for a session that is already dead
- * is a visible, retryable annoyance; deleting the row for a session that is still
- * alive is a silent, unrecoverable leak. We bias to the former.
- */
-export class MachineStreamSessionGoneError extends Error {
-  /** `cause` is carried explicitly rather than via `new Error(msg, { cause })` — that overload needs an ES2022 lib, which not every consuming app targets. */
-  constructor(public readonly sessionId: string, public readonly cause?: unknown) {
-    super(`Machine stream session ${sessionId} no longer exists`);
-    this.name = 'MachineStreamSessionGoneError';
-  }
-}
-
-/**
  * A live interactive (PTY) stream on a machine. Deliberately minimal — bounded
  * reconnect/keepalive orchestration (see `apps/realtime/src/terminal/sprites-shell.ts`)
  * is caller-side policy, not part of this seam: a caller reconnects by calling

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -61,12 +61,14 @@ export interface MachineStreamSessionInfo {
  * `stream()` waited the full wall-clock cap without the machine reporting EITHER
  * that the stream opened or that it failed.
  *
- * This is the "we genuinely do not know" outcome, and callers must treat it as
- * such. It is distinct from a stream that FAILED to open (a dangling session id
- * — the process is gone), because the two demand opposite responses: a failed
- * open means there is nothing left to kill, while a timeout may mean the process
- * is alive and merely unreachable, so tearing down its bookkeeping would orphan
- * it.
+ * This is the "we genuinely do not know" outcome, and it is distinct from a
+ * stream that FAILED to open. A failure is an ANSWER — the caller can go on to
+ * corroborate it (e.g. `killAgentTerminal` asks `listStreams()` whether the
+ * session still exists). A timeout is the absence of one, from a machine that
+ * would not answer at all for the full cap — so a caller must NOT go on to trust
+ * that same machine's other answers. It should do nothing destructive and let a
+ * retry settle it: the process may well be alive and merely unreachable, and
+ * tearing down its bookkeeping would orphan it.
  */
 export class MachineStreamOpenTimeoutError extends Error {
   constructor(public readonly timeoutMs: number) {

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -63,6 +63,24 @@ export interface MachineStreamSessionInfo {
  * is caller-side policy, not part of this seam: a caller reconnects by calling
  * `MachineHandle.stream` again with the prior `sessionId`.
  */
+/**
+ * `stream()` waited the full wall-clock cap without the machine reporting EITHER
+ * that the stream opened or that it failed.
+ *
+ * This is the "we genuinely do not know" outcome, and callers must treat it as
+ * such. It is distinct from a stream that FAILED to open (a dangling session id
+ * — the process is gone), because the two demand opposite responses: a failed
+ * open means there is nothing left to kill, while a timeout may mean the process
+ * is alive and merely unreachable, so tearing down its bookkeeping would orphan
+ * it.
+ */
+export class MachineStreamOpenTimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`Machine stream did not open within ${timeoutMs}ms`);
+    this.name = 'MachineStreamOpenTimeoutError';
+  }
+}
+
 export interface MachineStream {
   write(data: string | Buffer): void;
   resize(cols: number, rows: number): void;

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -58,12 +58,6 @@ export interface MachineStreamSessionInfo {
 }
 
 /**
- * A live interactive (PTY) stream on a machine. Deliberately minimal — bounded
- * reconnect/keepalive orchestration (see `apps/realtime/src/terminal/sprites-shell.ts`)
- * is caller-side policy, not part of this seam: a caller reconnects by calling
- * `MachineHandle.stream` again with the prior `sessionId`.
- */
-/**
  * `stream()` waited the full wall-clock cap without the machine reporting EITHER
  * that the stream opened or that it failed.
  *
@@ -81,6 +75,35 @@ export class MachineStreamOpenTimeoutError extends Error {
   }
 }
 
+/**
+ * POSITIVE evidence that the stream's target session no longer exists — the
+ * machine answered, and its answer was "no such session" (a 404/410 on the exec
+ * endpoint).
+ *
+ * This is the ONLY signal on which a caller may tear down a session's
+ * bookkeeping. Every other failure — a control-plane blip, a 429, a 5xx during a
+ * deploy, a socket hang-up, a timeout — is indistinguishable from "the process is
+ * alive and we merely could not reach it", and acting on those would orphan a
+ * running, billable PTY with nothing left pointing at it.
+ *
+ * The asymmetry is deliberate: keeping a row for a session that is already dead
+ * is a visible, retryable annoyance; deleting the row for a session that is still
+ * alive is a silent, unrecoverable leak. We bias to the former.
+ */
+export class MachineStreamSessionGoneError extends Error {
+  /** `cause` is carried explicitly rather than via `new Error(msg, { cause })` — that overload needs an ES2022 lib, which not every consuming app targets. */
+  constructor(public readonly sessionId: string, public readonly cause?: unknown) {
+    super(`Machine stream session ${sessionId} no longer exists`);
+    this.name = 'MachineStreamSessionGoneError';
+  }
+}
+
+/**
+ * A live interactive (PTY) stream on a machine. Deliberately minimal — bounded
+ * reconnect/keepalive orchestration (see `apps/realtime/src/terminal/sprites-shell.ts`)
+ * is caller-side policy, not part of this seam: a caller reconnects by calling
+ * `MachineHandle.stream` again with the prior `sessionId`.
+ */
 export interface MachineStream {
   write(data: string | Buffer): void;
   resize(cols: number, rows: number): void;

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { createSpriteMachineHost } from '../sprite-machine-host';
-import { MachineStreamOpenTimeoutError, MachineStreamSessionGoneError } from '../../machine-host';
+import { MachineStreamOpenTimeoutError } from '../../machine-host';
 import { createSpritesSandboxClient, type SpriteCommandLike, type SpriteInstanceLike, type SpritesSdk } from '../sprites';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
 
@@ -265,16 +265,18 @@ describe('createSpriteMachineHost', () => {
     expect(attempts).toBe(2); // first attach dropped pre-open, retried onto the woken VM
   });
 
-  it('given a stream attach that fails POST-open, should surface the error rather than retrying a session that may already be running', async () => {
+  it('given every attach attempt drops pre-open, should give up on the bounded schedule rather than retry forever', async () => {
     let attempts = 0;
     const { sdk } = makeSdk({
       getSprite: async () =>
         fakeSprite({
           attachSession: () => {
             attempts += 1;
-            // Deliberately NOT a not-found: a transport failure that says nothing
-            // about whether the session exists.
-            return fakeCommand({ autoExit: false, autoSpawn: false, error: new Error('socket hang up') }).command;
+            return fakeCommand({
+              autoExit: false,
+              autoSpawn: false,
+              error: new Error('WebSocket error: TypeError (url: wss://sprite/exec/dead)'),
+            }).command;
           },
         }),
     });
@@ -282,7 +284,27 @@ describe('createSpriteMachineHost', () => {
     const host = createSpriteMachineHost({ sdk, client });
     const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
 
-    await expect(handle.stream({ sessionId: 'existing-session' })).rejects.toThrow('socket hang up');
+    await expect(handle.stream({ sessionId: 'dead' })).rejects.toThrow();
+    expect(attempts).toBe(3); // MAX_EXEC_ATTEMPTS — bounded, not infinite
+  });
+
+  it('given the socket OPENS, should hand back the stream — a later error belongs to the consumer, not the retry', async () => {
+    let attempts = 0;
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          attachSession: () => {
+            attempts += 1;
+            return fakeCommand({ autoExit: false }).command; // emits spawn
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    const stream = await handle.stream({ sessionId: 'live' });
+    stream.kill('SIGKILL');
     expect(attempts).toBe(1);
   });
 
@@ -306,32 +328,6 @@ describe('createSpriteMachineHost', () => {
     const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
 
     await expect(handle.stream({ sessionId: 'sess-limbo' })).rejects.toBeInstanceOf(MachineStreamOpenTimeoutError);
-  });
-
-  it('given the machine answers 404 for the session, should reject with MachineStreamSessionGoneError (positive evidence, not a wake drop)', async () => {
-    let attempts = 0;
-    const { sdk } = makeSdk({
-      getSprite: async () =>
-        fakeSprite({
-          attachSession: () => {
-            attempts += 1;
-            // How the SDK surfaces a rejected upgrade: websocket.js emits
-            // `WebSocket error: Unexpected server response: <status>`.
-            return fakeCommand({
-              autoExit: false,
-              autoSpawn: false,
-              error: new Error('WebSocket error: Unexpected server response: 404 (url: wss://…/exec/sess-gone)'),
-            }).command;
-          },
-        }),
-    });
-    const client = createSpritesSandboxClient({ sdk });
-    const host = createSpriteMachineHost({ sdk, client });
-    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
-
-    await expect(handle.stream({ sessionId: 'sess-gone' })).rejects.toBeInstanceOf(MachineStreamSessionGoneError);
-    // A 404 is an ANSWER, not a wake drop — retrying it would be pointless.
-    expect(attempts).toBe(1);
   });
 
   it('given listStreams, should surface only tty sessions from the underlying Sprite', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -27,21 +27,16 @@ function fakeCommand(
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
   const killed: string[] = [];
-  // Whether the socket has already opened. Several tests build their command
-  // BEFORE the code under test attaches its listeners, so a one-shot 'spawn'
-  // would fire into the void and the consumer would wait for an open that
-  // already happened. A real open is a STATE, not just an event — so replay it
-  // to a late subscriber, exactly as an already-open socket would present.
-  let spawned = false;
   if (error) {
     // A failed/flapping connection emits 'error' and never 'spawn'.
     setTimeout(() => events.emit('error', error), 0);
   }
   if (autoSpawn) {
-    setTimeout(() => {
-      spawned = true;
-      events.emit('spawn');
-    }, 0);
+    // One-shot, exactly like the real SDK's `cmd.start().then(() => cmd.emit('spawn'))`.
+    // Deliberately NOT replayed to a late subscriber: the consumer under test must
+    // register its listener synchronously, before this macrotask runs, and a fake
+    // that replayed the event would hide a regression that stopped doing so.
+    setTimeout(() => events.emit('spawn'), 0);
   }
   if (autoExit) {
     setTimeout(() => events.emit('exit', 0), 0);
@@ -50,13 +45,7 @@ function fakeCommand(
     stdout: { on: (event, listener) => stdout.on(event, listener) },
     stderr: { on: (event, listener) => stderr.on(event, listener) },
     stdin: { write: () => {} },
-    on: (event, listener) => {
-      if (event === 'spawn' && spawned) {
-        setTimeout(() => (listener as () => void)(), 0);
-        return events;
-      }
-      return events.on(event, listener as (...args: unknown[]) => void);
-    },
+    on: (event, listener) => events.on(event, listener as (...args: unknown[]) => void),
     kill: (signal) => {
       killed.push(signal ?? 'SIGTERM');
     },
@@ -186,14 +175,20 @@ describe('createSpriteMachineHost', () => {
   });
 
   it('given stream with no sessionId, should create a fresh interactive session and stream its combined stdout/stderr', async () => {
-    const { command, emitStdout, emitStderr } = fakeCommand();
+    // Built LAZILY, inside createSession — exactly when the real SDK builds it, so
+    // its one-shot 'spawn' cannot fire before `stream()` has attached its listener.
+    let emitStdout!: (chunk: string) => void;
+    let emitStderr!: (chunk: string) => void;
     const created: { command: string; args: string[] }[] = [];
     const { sdk } = makeSdk({
       getSprite: async () =>
         fakeSprite({
           createSession: (cmd, args) => {
             created.push({ command: cmd, args: args ?? [] });
-            return command;
+            const fake = fakeCommand({ autoExit: false });
+            emitStdout = fake.emitStdout;
+            emitStderr = fake.emitStderr;
+            return fake.command;
           },
         }),
     });
@@ -351,11 +346,21 @@ describe('createSpriteMachineHost', () => {
   it('given a MachineStream, should write/resize/kill through to the underlying command', async () => {
     const writes: unknown[] = [];
     const resizes: Array<[number, number]> = [];
-    const { command } = fakeCommand({
-      stdin: { write: (data) => writes.push(data) },
-      resize: (c, r) => resizes.push([c, r]),
+    let killed: string[] = [];
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          createSession: () => {
+            const fake = fakeCommand({
+              autoExit: false,
+              stdin: { write: (data) => writes.push(data) },
+              resize: (c, r) => resizes.push([c, r]),
+            });
+            killed = (fake.command as unknown as { killed: string[] }).killed;
+            return fake.command;
+          },
+        }),
     });
-    const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: () => command }) });
     const client = createSpritesSandboxClient({ sdk });
     const host = createSpriteMachineHost({ sdk, client });
     const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
@@ -367,12 +372,13 @@ describe('createSpriteMachineHost', () => {
 
     expect(writes).toEqual(['ls\n']);
     expect(resizes).toEqual([[100, 40]]);
-    expect((command as unknown as { killed: string[] }).killed).toEqual(['SIGKILL']);
+    expect(killed).toEqual(['SIGKILL']);
   });
 
   it('given a MachineStream with no stdin (batch command reused as a stream), should throw on write rather than silently drop input', async () => {
-    const { command } = fakeCommand({ stdin: undefined });
-    const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ createSession: () => command }) });
+    const { sdk } = makeSdk({
+      getSprite: async () => fakeSprite({ createSession: () => fakeCommand({ autoExit: false, stdin: undefined }).command }),
+    });
     const client = createSpritesSandboxClient({ sdk });
     const host = createSpriteMachineHost({ sdk, client });
     const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -12,13 +12,36 @@ const options = { egressAllowlist: SANDBOX_EGRESS_ALLOWLIST };
  * fakeCommand) — every `provision()` call in this suite drives the REAL
  * `applyEgressLockdown`, which spawns its own `mkdir` command via the fake
  * Sprite, so the default must resolve on its own or provisioning hangs.
+ *
+ * `autoSpawn` mirrors the real SDK's WSCommand, which emits `spawn` once the
+ * WebSocket actually opens (`cmd.start().then(() => cmd.emit('spawn'))`). That
+ * is the signal `stream()` waits on before handing a stream back, so a fake that
+ * never emitted it would model a socket that never opens.
  */
-function fakeCommand(over: Partial<SpriteCommandLike> & { autoExit?: boolean } = {}) {
-  const { autoExit = true, ...commandOver } = over;
+function fakeCommand(
+  over: Partial<SpriteCommandLike> & { autoExit?: boolean; autoSpawn?: boolean; error?: Error } = {},
+) {
+  const { autoExit = true, autoSpawn = true, error, ...commandOver } = over;
   const events = new EventEmitter();
   const stdout = new EventEmitter();
   const stderr = new EventEmitter();
   const killed: string[] = [];
+  // Whether the socket has already opened. Several tests build their command
+  // BEFORE the code under test attaches its listeners, so a one-shot 'spawn'
+  // would fire into the void and the consumer would wait for an open that
+  // already happened. A real open is a STATE, not just an event — so replay it
+  // to a late subscriber, exactly as an already-open socket would present.
+  let spawned = false;
+  if (error) {
+    // A failed/flapping connection emits 'error' and never 'spawn'.
+    setTimeout(() => events.emit('error', error), 0);
+  }
+  if (autoSpawn) {
+    setTimeout(() => {
+      spawned = true;
+      events.emit('spawn');
+    }, 0);
+  }
   if (autoExit) {
     setTimeout(() => events.emit('exit', 0), 0);
   }
@@ -26,7 +49,13 @@ function fakeCommand(over: Partial<SpriteCommandLike> & { autoExit?: boolean } =
     stdout: { on: (event, listener) => stdout.on(event, listener) },
     stderr: { on: (event, listener) => stderr.on(event, listener) },
     stdin: { write: () => {} },
-    on: (event, listener) => events.on(event, listener as (...args: unknown[]) => void),
+    on: (event, listener) => {
+      if (event === 'spawn' && spawned) {
+        setTimeout(() => (listener as () => void)(), 0);
+        return events;
+      }
+      return events.on(event, listener as (...args: unknown[]) => void);
+    },
     kill: (signal) => {
       killed.push(signal ?? 'SIGTERM');
     },
@@ -199,6 +228,59 @@ describe('createSpriteMachineHost', () => {
 
     await handle.stream({ sessionId: 'existing-session' });
     expect(attachedId).toBe('existing-session');
+  });
+
+  // Regression (sprites 1-4): the PTY stream is the ONLY exec path that had no
+  // cold-start retry. `killAgentTerminal` attaches a stream and immediately
+  // SIGKILLs it, so once the explicit wake exec was removed, a hibernated Sprite
+  // could drop that first (waking) connection pre-open and the kill would fail
+  // outright — leaving a live PTY and its tracking row behind.
+  it('given a cold Sprite that drops the first stream attach pre-open, should retry and still deliver a killable stream', async () => {
+    let attempts = 0;
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          attachSession: () => {
+            attempts += 1;
+            if (attempts === 1) {
+              // The cold VM drops the wake connection before it ever opens.
+              return fakeCommand({
+                autoExit: false,
+                autoSpawn: false,
+                error: new Error('WebSocket closed before open: code=1006'),
+              }).command;
+            }
+            return fakeCommand({ autoExit: false }).command;
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    const stream = await handle.stream({ sessionId: 'existing-session' });
+    stream.kill('SIGKILL');
+
+    expect(attempts).toBe(2); // first attach dropped pre-open, retried onto the woken VM
+  });
+
+  it('given a stream attach that fails POST-open, should surface the error rather than retrying a session that may already be running', async () => {
+    let attempts = 0;
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          attachSession: () => {
+            attempts += 1;
+            return fakeCommand({ autoExit: false, autoSpawn: false, error: new Error('session is gone') }).command;
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    await expect(handle.stream({ sessionId: 'existing-session' })).rejects.toThrow('session is gone');
+    expect(attempts).toBe(1);
   });
 
   it('given listStreams, should surface only tty sessions from the underlying Sprite', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { createSpriteMachineHost } from '../sprite-machine-host';
+import { MachineStreamOpenTimeoutError, MachineStreamSessionGoneError } from '../../machine-host';
 import { createSpritesSandboxClient, type SpriteCommandLike, type SpriteInstanceLike, type SpritesSdk } from '../sprites';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
 
@@ -271,7 +272,9 @@ describe('createSpriteMachineHost', () => {
         fakeSprite({
           attachSession: () => {
             attempts += 1;
-            return fakeCommand({ autoExit: false, autoSpawn: false, error: new Error('session is gone') }).command;
+            // Deliberately NOT a not-found: a transport failure that says nothing
+            // about whether the session exists.
+            return fakeCommand({ autoExit: false, autoSpawn: false, error: new Error('socket hang up') }).command;
           },
         }),
     });
@@ -279,7 +282,55 @@ describe('createSpriteMachineHost', () => {
     const host = createSpriteMachineHost({ sdk, client });
     const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
 
-    await expect(handle.stream({ sessionId: 'existing-session' })).rejects.toThrow('session is gone');
+    await expect(handle.stream({ sessionId: 'existing-session' })).rejects.toThrow('socket hang up');
+    expect(attempts).toBe(1);
+  });
+
+  // The PRODUCER of the timeout. Without this, a regression to the old
+  // "resolve optimistically at the cap" behavior would pass every other test in
+  // the suite — and silently hand killAtLocation a stream whose socket never
+  // opened, whose SIGKILL goes nowhere, and whose row it would then delete.
+  it('given a stream that never reports whether it opened, should reject with MachineStreamOpenTimeoutError (never resolve optimistically)', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          // Reports NOTHING: no spawn, no exit, no error. A socket in limbo.
+          attachSession: () => fakeCommand({ autoExit: false, autoSpawn: false }).command,
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    // Inject a short cap rather than faking timers: provisioning's own egress
+    // `mkdir` needs real timers to settle, so a global fake-timer swap here would
+    // deadlock the setup instead of testing the wait.
+    const host = createSpriteMachineHost({ sdk, client, streamOpenTimeoutMs: 20 });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    await expect(handle.stream({ sessionId: 'sess-limbo' })).rejects.toBeInstanceOf(MachineStreamOpenTimeoutError);
+  });
+
+  it('given the machine answers 404 for the session, should reject with MachineStreamSessionGoneError (positive evidence, not a wake drop)', async () => {
+    let attempts = 0;
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          attachSession: () => {
+            attempts += 1;
+            // How the SDK surfaces a rejected upgrade: websocket.js emits
+            // `WebSocket error: Unexpected server response: <status>`.
+            return fakeCommand({
+              autoExit: false,
+              autoSpawn: false,
+              error: new Error('WebSocket error: Unexpected server response: 404 (url: wss://…/exec/sess-gone)'),
+            }).command;
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    await expect(handle.stream({ sessionId: 'sess-gone' })).rejects.toBeInstanceOf(MachineStreamSessionGoneError);
+    // A 404 is an ANSWER, not a wake drop — retrying it would be pointless.
     expect(attempts).toBe(1);
   });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   createSpritesSandboxClient,
-  ensureSpriteAwake,
   isSpriteNotFoundError,
   classifyProvisionError,
   SandboxCommandTimeoutError,
@@ -389,19 +388,64 @@ describe('createSpritesSandboxClient.get / stop', () => {
   });
 });
 
-describe('ensureSpriteAwake', () => {
-  it('warms the VM via a no-op exec, retrying the cold-start wake drop', async () => {
-    let attempts = 0;
+describe('filesystem wake exec (the ONLY path that still needs one)', () => {
+  // The fs HTTP API is a bare fetch() that does NOT wake a hibernated VM — it just
+  // hangs. So, unlike an exec/createSession/attachSession (which ARE the wake), an
+  // fs op must be preceded by an exec before it can be retried. This is the one
+  // place the retired `ensureSpriteAwake` behavior survives.
+  it('given a cold fs op, should issue a wake exec before retrying it', async () => {
+    const spawned: string[][] = [];
+    let reads = 0;
+    const fs = fakeFs({
+      readFile: async () => {
+        reads += 1;
+        if (reads === 1) throw new Error('fetch failed');
+        return Buffer.from('recovered');
+      },
+    });
     const sprite = fakeSprite({
+      fs,
+      spawn: (file, args) => {
+        spawned.push([file, ...(args ?? [])]);
+        return fakeCommand({ exitCode: 0 });
+      },
+    });
+    const { sdk } = makeSdk({ getSprite: async () => sprite });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+
+    const buf = await handle!.readFileToBuffer({ path: '/x' });
+
+    expect(buf?.toString()).toBe('recovered');
+    expect(reads).toBe(2);
+    expect(spawned).toEqual([['sh', '-c', ':']]); // the wake exec the fs API can't do itself
+  });
+
+  it('given a cold fs op whose wake exec drops pre-open, should retry the wake on the bounded backoff', async () => {
+    let wakeAttempts = 0;
+    let reads = 0;
+    const fs = fakeFs({
+      readFile: async () => {
+        reads += 1;
+        if (reads === 1) throw new Error('fetch failed');
+        return Buffer.from('recovered');
+      },
+    });
+    const sprite = fakeSprite({
+      fs,
       spawn: () => {
-        attempts += 1;
-        return attempts === 1
+        wakeAttempts += 1;
+        return wakeAttempts === 1
           ? fakeCommand({ error: new Error('WebSocket closed before open: code=1006') })
           : fakeCommand({ exitCode: 0 });
       },
     });
-    await ensureSpriteAwake(sprite);
-    expect(attempts).toBe(2); // first wake dropped, retried, then awake
+    const { sdk } = makeSdk({ getSprite: async () => sprite });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+
+    expect((await handle!.readFileToBuffer({ path: '/x' }))?.toString()).toBe('recovered');
+    expect(wakeAttempts).toBe(2); // first wake dropped pre-open, retried, then awake
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -30,6 +30,14 @@ interface FakeCommandSpec {
   exitCode?: number;
   error?: Error;
   hang?: boolean;
+  /**
+   * Whether the socket OPENED — i.e. whether the SDK emitted `spawn`
+   * (`cmd.start().then(() => cmd.emit('spawn'))`). This is the real boundary the
+   * wake retry keys on: an error before `spawn` never ran the command and is safe
+   * to re-run; one after it may have. Defaults to "opened" for a command that
+   * runs, and "never opened" for one that only errors (the cold-start drop).
+   */
+  opened?: boolean;
 }
 
 function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: string[] } {
@@ -38,7 +46,9 @@ function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: 
   const stderr = new EventEmitter();
   const killed: string[] = [];
 
+  const opened = spec.opened ?? spec.error === undefined;
   setTimeout(() => {
+    if (opened) events.emit('spawn');
     for (const chunk of spec.stdout ?? []) stdout.emit('data', chunk);
     for (const chunk of spec.stderr ?? []) stderr.emit('data', chunk);
     if (spec.error) {
@@ -273,12 +283,46 @@ describe('cold-start exec wake retry', () => {
     expect(attempts).toBe(2);
   });
 
+  // The regression that matters most: @fly/sprites has NO `ws` dependency — it
+  // drives the global (undici) WebSocket, and registers its `error` listener
+  // BEFORE its `close` listener. On a failed handshake undici fires `error` first,
+  // so the FIRST thing a consumer sees is an opaque `WebSocket error: …` — NOT the
+  // `WebSocket closed before open: …` string, which the SDK only emits afterwards
+  // from its `close` handler. A retry keyed on that substring would therefore MISS
+  // the real cold-start drop entirely. We classify structurally instead: no
+  // `spawn` yet => the socket never opened => safe to re-run.
+  it('given the REAL undici pre-open error shape (opaque message, no "closed before open"), should still retry', async () => {
+    let attempts = 0;
+    const sprite = fakeSprite({
+      spawn: () => {
+        attempts += 1;
+        return attempts === 1
+          ? fakeCommand({
+              opened: false,
+              error: new Error('WebSocket error: TypeError (url: wss://sprite/exec?stdin=true)'),
+            })
+          : fakeCommand({ stdout: ['ok'], exitCode: 0 });
+      },
+    });
+    const { sdk } = makeSdk({ getSprite: async () => sprite });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+
+    const result = await handle!.runCommand({ cmd: 'sh' });
+
+    expect(result.exitCode).toBe(0);
+    expect(attempts).toBe(2); // dropped pre-open, retried onto the woken VM
+  });
+
   it('does NOT retry a post-open / non-wake error (may have already run)', async () => {
     let attempts = 0;
     const sprite = fakeSprite({
       spawn: () => {
         attempts += 1;
-        return fakeCommand({ error: new Error('WebSocket keepalive timeout') });
+        // A keepalive timeout happens AFTER the socket opened — so the fake must
+        // emit `spawn` first, as the real SDK does. That is exactly what makes it
+        // a non-retryable, post-open failure.
+        return fakeCommand({ opened: true, error: new Error('WebSocket keepalive timeout') });
       },
     });
     const { sdk } = makeSdk({ getSprite: async () => sprite });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
@@ -1,0 +1,319 @@
+import { describe, it } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import {
+  isPreOpenWakeError,
+  planWakeRetry,
+  wakeRetryDelayMs,
+  withWakeRetry,
+  createSpriteHandleCache,
+  MAX_EXEC_ATTEMPTS,
+  RETRY_BASE_DELAY_MS,
+  SandboxCommandTimeoutError,
+  SandboxOutputLimitError,
+  type SpritesSdk,
+  type SpriteInstanceLike,
+} from '../sprites';
+
+const preOpen = () => new Error('WebSocket closed before open: code=1006');
+
+describe('isPreOpenWakeError', () => {
+  it('classifies only the provably pre-open cold-start drop as retryable', () => {
+    assert({
+      given: 'the SDK\'s "closed before open" WebSocket error',
+      should: 'be a retryable pre-open wake drop',
+      actual: isPreOpenWakeError(preOpen()),
+      expected: true,
+    });
+
+    assert({
+      given: 'a command timeout (the command may already have run)',
+      should: 'NOT be retryable',
+      actual: isPreOpenWakeError(new SandboxCommandTimeoutError(30_000)),
+      expected: false,
+    });
+
+    assert({
+      given: 'an output-limit overflow (the command definitely ran)',
+      should: 'NOT be retryable',
+      actual: isPreOpenWakeError(new SandboxOutputLimitError(1024)),
+      expected: false,
+    });
+
+    assert({
+      given: 'a mid-command socket drop',
+      should: 'NOT be retryable',
+      actual: isPreOpenWakeError(new Error('socket hang up')),
+      expected: false,
+    });
+
+    assert({
+      given: 'a non-Error rejection value',
+      should: 'NOT be retryable',
+      actual: isPreOpenWakeError('boom'),
+      expected: false,
+    });
+  });
+});
+
+describe('wakeRetryDelayMs', () => {
+  it('is a linear backoff over the attempt number', () => {
+    assert({
+      given: 'attempts 1..3 at the default base delay',
+      should: 'back off linearly (500ms, 1000ms, 1500ms)',
+      actual: [1, 2, 3].map((attempt) => wakeRetryDelayMs(attempt)),
+      expected: [RETRY_BASE_DELAY_MS, RETRY_BASE_DELAY_MS * 2, RETRY_BASE_DELAY_MS * 3],
+    });
+  });
+});
+
+describe('planWakeRetry', () => {
+  it('retries a pre-open drop on the bounded schedule and gives up at the cap', () => {
+    assert({
+      given: 'a pre-open drop on the first attempt',
+      should: 'retry after the base delay',
+      actual: planWakeRetry({ error: preOpen(), attempt: 1 }),
+      expected: { retry: true, delayMs: RETRY_BASE_DELAY_MS },
+    });
+
+    assert({
+      given: 'a pre-open drop on the second attempt',
+      should: 'retry after twice the base delay',
+      actual: planWakeRetry({ error: preOpen(), attempt: 2 }),
+      expected: { retry: true, delayMs: RETRY_BASE_DELAY_MS * 2 },
+    });
+
+    assert({
+      given: 'a pre-open drop on the final allowed attempt',
+      should: 'stop retrying (bounded — never an infinite wake loop)',
+      actual: planWakeRetry({ error: preOpen(), attempt: MAX_EXEC_ATTEMPTS }),
+      expected: { retry: false },
+    });
+
+    assert({
+      given: 'a post-open failure on the first attempt',
+      should: 'not retry (the command may already have run)',
+      actual: planWakeRetry({ error: new Error('socket hang up'), attempt: 1 }),
+      expected: { retry: false },
+    });
+  });
+});
+
+describe('withWakeRetry', () => {
+  it('given a cold op that drops pre-open twice, should re-run it on the bounded backoff and resolve', async () => {
+    const slept: number[] = [];
+    let attempts = 0;
+    const value = await withWakeRetry(
+      async () => {
+        attempts += 1;
+        if (attempts < 3) throw preOpen();
+        return 'awake';
+      },
+      { sleep: async (ms) => { slept.push(ms); } },
+    );
+
+    assert({
+      given: 'a cold operation dropped pre-open twice',
+      should: 'resolve on the third attempt',
+      actual: { value, attempts },
+      expected: { value: 'awake', attempts: 3 },
+    });
+
+    assert({
+      given: 'two pre-open retries',
+      should: 'have waited the linear backoff between them',
+      actual: slept,
+      expected: [RETRY_BASE_DELAY_MS, RETRY_BASE_DELAY_MS * 2],
+    });
+  });
+
+  it('given an op that always drops pre-open, should give up after the bounded attempt cap', async () => {
+    let attempts = 0;
+    let thrown: unknown;
+    try {
+      await withWakeRetry(
+        async () => {
+          attempts += 1;
+          throw preOpen();
+        },
+        { sleep: async () => {} },
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    assert({
+      given: 'a Sprite that never wakes',
+      should: 'attempt exactly MAX_EXEC_ATTEMPTS times, then propagate the error',
+      actual: { attempts, message: (thrown as Error).message },
+      expected: { attempts: MAX_EXEC_ATTEMPTS, message: preOpen().message },
+    });
+  });
+
+  it('given a post-open failure, should propagate it on the FIRST occurrence (never re-run a command that may have run)', async () => {
+    let attempts = 0;
+    try {
+      await withWakeRetry(
+        async () => {
+          attempts += 1;
+          throw new Error('socket hang up');
+        },
+        { sleep: async () => {} },
+      );
+    } catch {
+      // expected
+    }
+
+    assert({
+      given: 'a mid-command failure',
+      should: 'run the operation exactly once',
+      actual: attempts,
+      expected: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createSpriteHandleCache — the "one getSprite per connect" collapse
+// ---------------------------------------------------------------------------
+
+function fakeSprite(name: string): SpriteInstanceLike {
+  return {
+    name,
+    spawn: () => { throw new Error('not used'); },
+    createSession: () => { throw new Error('not used'); },
+    attachSession: () => { throw new Error('not used'); },
+    listSessions: async () => [],
+    filesystem: () => { throw new Error('not used'); },
+    updateNetworkPolicy: async () => {},
+    destroy: async () => {},
+  };
+}
+
+function countingSdk(over: Partial<SpritesSdk> = {}) {
+  const calls = { getSprite: [] as string[], createSprite: [] as string[], deleteSprite: [] as string[] };
+  const sdk: SpritesSdk = {
+    getSprite: async (name) => {
+      calls.getSprite.push(name);
+      return fakeSprite(name);
+    },
+    createSprite: async (name) => {
+      calls.createSprite.push(name);
+      return fakeSprite(name);
+    },
+    deleteSprite: async (name) => {
+      calls.deleteSprite.push(name);
+    },
+    ...over,
+  };
+  return { sdk, calls };
+}
+
+describe('createSpriteHandleCache', () => {
+  it('given repeated reads of one Sprite, should call sdk.getSprite exactly once and hand back the same handle', async () => {
+    const { sdk, calls } = countingSdk();
+    const cached = createSpriteHandleCache(sdk);
+
+    const [a, b, c] = await Promise.all([
+      cached.getSprite('machine-1'),
+      cached.getSprite('machine-1'),
+      cached.getSprite('machine-1'),
+    ]);
+
+    assert({
+      given: 'three reads of the same Sprite through one cache',
+      should: 'issue exactly one sdk.getSprite call',
+      actual: calls.getSprite,
+      expected: ['machine-1'],
+    });
+
+    assert({
+      given: 'three reads of the same Sprite through one cache',
+      should: 'hand back the identical handle each time',
+      actual: a === b && b === c,
+      expected: true,
+    });
+  });
+
+  it('given distinct Sprites, should not collapse them onto one handle', async () => {
+    const { sdk, calls } = countingSdk();
+    const cached = createSpriteHandleCache(sdk);
+
+    const one = await cached.getSprite('machine-1');
+    const two = await cached.getSprite('machine-2');
+
+    assert({
+      given: 'two different Sprite names',
+      should: 'read each one exactly once, keyed by name',
+      actual: { calls: calls.getSprite, names: [one.name, two.name] },
+      expected: { calls: ['machine-1', 'machine-2'], names: ['machine-1', 'machine-2'] },
+    });
+  });
+
+  it('given a fresh create (getSprite rejects not-found, then createSprite), should serve later reads from the created handle without a second getSprite', async () => {
+    const { sdk, calls } = countingSdk({
+      getSprite: async (name) => {
+        calls.getSprite.push(name);
+        throw Object.assign(new Error('not found'), { status: 404 });
+      },
+    });
+    const cached = createSpriteHandleCache(sdk);
+
+    // The getOrCreate shape: probe, miss, create.
+    await cached.getSprite('machine-1').catch(() => {});
+    const created = await cached.createSprite('machine-1');
+    // A later consumer (the PTY launch resolution) reads the same name.
+    const reread = await cached.getSprite('machine-1');
+
+    assert({
+      given: 'a probe-miss + create, then a re-read of the same name',
+      should: 'issue exactly ONE getSprite (the probe) — the create seeds the cache',
+      actual: calls.getSprite,
+      expected: ['machine-1'],
+    });
+
+    assert({
+      given: 'a re-read after a fresh create',
+      should: 'hand back the just-created handle',
+      actual: reread === created,
+      expected: true,
+    });
+  });
+
+  it('given a transient getSprite failure, should NOT cache the rejection (a later read retries)', async () => {
+    let attempts = 0;
+    const { sdk } = countingSdk({
+      getSprite: async (name) => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('rate limited');
+        return fakeSprite(name);
+      },
+    });
+    const cached = createSpriteHandleCache(sdk);
+
+    await cached.getSprite('machine-1').catch(() => {});
+    const sprite = await cached.getSprite('machine-1');
+
+    assert({
+      given: 'a first read that failed transiently',
+      should: 'retry the read rather than replay the cached rejection forever',
+      actual: { attempts, name: sprite.name },
+      expected: { attempts: 2, name: 'machine-1' },
+    });
+  });
+
+  it('given a deleted Sprite, should evict it so a later read is a genuine re-read', async () => {
+    const { sdk, calls } = countingSdk();
+    const cached = createSpriteHandleCache(sdk);
+
+    await cached.getSprite('machine-1');
+    await cached.deleteSprite('machine-1');
+    await cached.getSprite('machine-1');
+
+    assert({
+      given: 'a read, a delete, then a read of the same name',
+      should: 'not serve the destroyed Sprite from cache',
+      actual: { get: calls.getSprite, deleted: calls.deleteSprite },
+      expected: { get: ['machine-1', 'machine-1'], deleted: ['machine-1'] },
+    });
+  });
+});

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -18,13 +18,14 @@
 
 import {
   MachineStreamOpenTimeoutError,
+  MachineStreamSessionGoneError,
   type MachineHandle,
   type MachineHost,
   type MachineStream,
   type MachineStreamSessionInfo,
 } from '../machine-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
-import { withWakeRetry, type SpriteCommandLike, type SpritesSdk } from './sprites';
+import { withWakeRetry, isSpriteNotFoundError, type SpriteCommandLike, type SpritesSdk } from './sprites';
 
 function toBuffer(chunk: Buffer | string): Buffer {
   return typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
@@ -75,14 +76,14 @@ function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise
   });
 }
 
-/** Tear down a stream attempt we are abandoning, so its socket does not leak. */
-function discardCommand(command: SpriteCommandLike): void {
-  try {
-    command.close?.();
-  } catch {
-    // Best-effort: an already-dead socket is exactly what we wanted.
-  }
-}
+// NOTE: an abandoned attempt's WebSocket cannot be torn down through the SDK's
+// public API — `SpriteCommand` exposes only start/wait/kill/signal/resize, and
+// `kill` is `signal`, which no-ops unless the socket is already OPEN; the
+// underlying `WSCommand.close()` is private. A socket that failed with "closed
+// before open" is already closed by definition, so the residue is limited to the
+// pathological case where the transport reports nothing at all and we abandon it
+// at the wall-clock cap. Bounded by kill frequency, and not fixable here without
+// an SDK change.
 
 function wrapSpriteStream(command: SpriteCommandLike): MachineStream {
   return {
@@ -114,7 +115,15 @@ function wrapSpriteStream(command: SpriteCommandLike): MachineStream {
   };
 }
 
-function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSandbox }): MachineHandle {
+function wrapSpriteHandle({
+  sdk,
+  exec,
+  streamOpenTimeoutMs,
+}: {
+  sdk: SpritesSdk;
+  exec: ExecutableSandbox;
+  streamOpenTimeoutMs: number;
+}): MachineHandle {
   return {
     machineId: exec.sandboxId,
     exec: (args) => exec.runCommand(args),
@@ -149,9 +158,18 @@ function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSand
                 rows: args.rows,
               });
         try {
-          await awaitStreamOpen(command, STREAM_OPEN_TIMEOUT_MS);
+          await awaitStreamOpen(command, streamOpenTimeoutMs);
         } catch (error) {
-          discardCommand(command);
+          // Translate the ONE failure that carries positive evidence — the exec
+          // endpoint answering 404/410 — into the typed "session is gone" signal.
+          // The SDK reports a rejected upgrade as `WebSocket error: Unexpected
+          // server response: <status>`, so the status is recoverable from the
+          // message. Everything else (a 429, a 5xx mid-deploy, a socket hang-up,
+          // a timeout) stays exactly as it is: an UNKNOWN, on which no caller may
+          // tear down a session's bookkeeping.
+          if (args.sessionId !== undefined && isSpriteNotFoundError(error)) {
+            throw new MachineStreamSessionGoneError(args.sessionId, error);
+          }
           throw error;
         }
         return wrapSpriteStream(command);
@@ -187,22 +205,25 @@ function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSand
 export function createSpriteMachineHost({
   sdk,
   client,
+  streamOpenTimeoutMs = STREAM_OPEN_TIMEOUT_MS,
 }: {
   sdk: SpritesSdk;
   client: ExecSandboxClient;
+  /** Injectable so the open-wait is testable without fake timers (which would also stall provisioning). Production uses the default. */
+  streamOpenTimeoutMs?: number;
 }): MachineHost {
   return {
     // `substrate.size` is intentionally unused here — see the file header:
     // Sprite has one resource tier, driven entirely by `options.caps`.
     async provision({ name, options }) {
       const exec = await client.getOrCreate({ name, options });
-      return wrapSpriteHandle({ sdk, exec });
+      return wrapSpriteHandle({ sdk, exec, streamOpenTimeoutMs });
     },
 
     async attach({ machineId }) {
       const exec = await client.get({ sandboxId: machineId });
       if (!exec) return null;
-      return wrapSpriteHandle({ sdk, exec });
+      return wrapSpriteHandle({ sdk, exec, streamOpenTimeoutMs });
     },
 
     async kill({ machineId }) {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -23,10 +23,47 @@ import type {
   MachineStreamSessionInfo,
 } from '../machine-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
-import type { SpriteCommandLike, SpritesSdk } from './sprites';
+import { withWakeRetry, type SpriteCommandLike, type SpritesSdk } from './sprites';
 
 function toBuffer(chunk: Buffer | string): Buffer {
   return typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
+}
+
+/**
+ * How long to wait for a freshly-opened stream to report that its WebSocket
+ * actually opened, before handing it back anyway.
+ */
+const STREAM_OPEN_TIMEOUT_MS = 10_000;
+
+/**
+ * Resolve once the stream's WebSocket has genuinely OPENED; reject if it dropped
+ * before opening.
+ *
+ * The SDK emits `spawn` only after `cmd.start()` resolves — i.e. after the socket
+ * is up — and emits `error` (never `spawn`) on a failed attach, so the two events
+ * are the authoritative open/fail signals. `exit` also settles: a command that has
+ * already finished has nothing left to wait for.
+ *
+ * The wait is CAPPED, and the cap resolves OPTIMISTICALLY rather than rejecting.
+ * That keeps this strictly better than the previous behavior (which handed the
+ * stream back immediately, without waiting for anything): a command that reports
+ * neither outcome degrades to exactly what callers used to get, so this can never
+ * hang a kill that used to succeed.
+ */
+function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      fn();
+    };
+    const timer = setTimeout(() => settle(resolve), timeoutMs);
+    command.on('spawn', () => settle(resolve));
+    command.on('exit', () => settle(resolve));
+    command.on('error', (error) => settle(() => reject(error)));
+  });
 }
 
 function wrapSpriteStream(command: SpriteCommandLike): MachineStream {
@@ -66,19 +103,39 @@ function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSand
     writeFiles: (files) => exec.writeFiles(files),
     readFile: (args) => exec.readFileToBuffer(args),
 
+    /**
+     * Open a PTY stream, surviving the cold-start wake drop.
+     *
+     * Opening a stream (attachSession/createSession) is itself an exec, so it IS
+     * the wake for a hibernated Sprite — there is no wake API
+     * (docs.sprites.dev/concepts/lifecycle). But Fly's wake-on-request can drop
+     * that FIRST connection before it opens ("closed before open"), and this path
+     * had no retry at all: `killAgentTerminal` attaches and immediately SIGKILLs,
+     * so a dropped wake silently failed the kill and left the row behind. The
+     * exec path (`withWakeRetry`) and the realtime PTY (`openPtyShell`'s bounded
+     * reconnect) both already absorb that drop; this is the third caller, and now
+     * it does too — on the same bounded schedule, re-opening a fresh connection
+     * per attempt.
+     */
     async stream(args) {
-      const sprite = await sdk.getSprite(exec.sandboxId);
-      const command =
-        args.sessionId !== undefined
-          ? sprite.attachSession(args.sessionId, { cwd: args.cwd, env: args.env, cols: args.cols, rows: args.rows })
-          : sprite.createSession(args.command ?? 'bash', args.args ?? [], {
-              tty: true,
-              cwd: args.cwd,
-              env: args.env,
-              cols: args.cols,
-              rows: args.rows,
-            });
-      return wrapSpriteStream(command);
+      return withWakeRetry(async () => {
+        const sprite = await sdk.getSprite(exec.sandboxId);
+        const command =
+          args.sessionId !== undefined
+            ? sprite.attachSession(args.sessionId, { cwd: args.cwd, env: args.env, cols: args.cols, rows: args.rows })
+            : sprite.createSession(args.command ?? 'bash', args.args ?? [], {
+                tty: true,
+                cwd: args.cwd,
+                env: args.env,
+                cols: args.cols,
+                rows: args.rows,
+              });
+        // Don't hand back a stream whose socket never opened — a SIGKILL through
+        // it would go nowhere. A pre-open drop rejects here and withWakeRetry
+        // re-opens; anything else propagates on the first occurrence.
+        await awaitStreamOpen(command, STREAM_OPEN_TIMEOUT_MS);
+        return wrapSpriteStream(command);
+      });
     },
 
     async listStreams(): Promise<MachineStreamSessionInfo[]> {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -88,11 +88,11 @@ function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise
 // NOTE: an abandoned attempt's WebSocket cannot be torn down through the SDK's
 // public API — `SpriteCommand` exposes only start/wait/kill/signal/resize, and
 // `kill` is `signal`, which no-ops unless the socket is already OPEN; the
-// underlying `WSCommand.close()` is private. A socket that failed with "closed
-// before open" is already closed by definition, so the residue is limited to the
-// pathological case where the transport reports nothing at all and we abandon it
-// at the wall-clock cap. Bounded by kill frequency, and not fixable here without
-// an SDK change.
+// underlying `WSCommand.close()` is private. A socket that already reported a
+// close is closed by definition, so the residue is limited to the pathological
+// case where the transport reports nothing at all and we abandon it at the
+// wall-clock cap. Bounded by kill frequency, and not fixable here without an SDK
+// change.
 
 function wrapSpriteStream(command: SpriteCommandLike): MachineStream {
   return {
@@ -145,8 +145,8 @@ function wrapSpriteHandle({
      * Opening a stream (attachSession/createSession) is itself an exec, so it IS
      * the wake for a hibernated Sprite — there is no wake API
      * (docs.sprites.dev/concepts/lifecycle). But Fly's wake-on-request can drop
-     * that FIRST connection before it opens ("closed before open"), and this path
-     * had no retry at all: `killAgentTerminal` attaches and immediately SIGKILLs,
+     * that FIRST connection before it ever opens, and this path had no retry at
+     * all: `killAgentTerminal` attaches and immediately SIGKILLs,
      * so a dropped wake silently failed the kill and left the row behind. The
      * exec path (`withWakeRetry`) and the realtime PTY (`openPtyShell`'s bounded
      * reconnect) both already absorb that drop; this is the third caller, and now

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -16,11 +16,12 @@
  * this seam existed.
  */
 
-import type {
-  MachineHandle,
-  MachineHost,
-  MachineStream,
-  MachineStreamSessionInfo,
+import {
+  MachineStreamOpenTimeoutError,
+  type MachineHandle,
+  type MachineHost,
+  type MachineStream,
+  type MachineStreamSessionInfo,
 } from '../machine-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
 import { withWakeRetry, type SpriteCommandLike, type SpritesSdk } from './sprites';
@@ -30,25 +31,33 @@ function toBuffer(chunk: Buffer | string): Buffer {
 }
 
 /**
- * How long to wait for a freshly-opened stream to report that its WebSocket
- * actually opened, before handing it back anyway.
+ * Wall-clock cap on waiting for a stream to report that it opened.
+ *
+ * Deliberately LONGER than the SDK's own 10s `waitForSessionInfo` timeout
+ * (websocket.js), which is the real failure signal for an attach to a dangling
+ * session. A shorter cap here would fire first on every such attach and mask the
+ * SDK's specific error behind a generic timeout — and, since the two outcomes
+ * demand opposite responses from the kill path (drop the row vs keep it), that
+ * misclassification is not cosmetic.
  */
-const STREAM_OPEN_TIMEOUT_MS = 10_000;
+const STREAM_OPEN_TIMEOUT_MS = 20_000;
 
 /**
- * Resolve once the stream's WebSocket has genuinely OPENED; reject if it dropped
- * before opening.
+ * Resolve once the stream's WebSocket has genuinely OPENED; reject if it dropped,
+ * failed, or never reported either way.
  *
- * The SDK emits `spawn` only after `cmd.start()` resolves — i.e. after the socket
- * is up — and emits `error` (never `spawn`) on a failed attach, so the two events
- * are the authoritative open/fail signals. `exit` also settles: a command that has
- * already finished has nothing left to wait for.
+ * This wait is load-bearing, not a nicety. `SpriteCommand.kill()` sends a signal
+ * over the socket and SILENTLY NO-OPS when the socket is not open (websocket.js
+ * `signal()` early-returns unless `readyState === OPEN`). So handing back a
+ * stream whose socket never opened gives the caller a kill that goes nowhere
+ * while reporting success — for `killAgentTerminal` that means the row is
+ * dropped and a live, billable agent process is orphaned. We therefore never
+ * resolve optimistically: no confirmed open, no stream.
  *
- * The wait is CAPPED, and the cap resolves OPTIMISTICALLY rather than rejecting.
- * That keeps this strictly better than the previous behavior (which handed the
- * stream back immediately, without waiting for anything): a command that reports
- * neither outcome degrades to exactly what callers used to get, so this can never
- * hang a kill that used to succeed.
+ * The SDK emits `spawn` only after `start()` resolves (socket up, and for an
+ * attach, `session_info` received) and emits `error` — never `spawn` — on a
+ * failure, so those are the authoritative signals. `exit` also settles: a
+ * command that already finished has nothing left to wait for.
  */
 function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -59,11 +68,20 @@ function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise
       clearTimeout(timer);
       fn();
     };
-    const timer = setTimeout(() => settle(resolve), timeoutMs);
+    const timer = setTimeout(() => settle(() => reject(new MachineStreamOpenTimeoutError(timeoutMs))), timeoutMs);
     command.on('spawn', () => settle(resolve));
     command.on('exit', () => settle(resolve));
     command.on('error', (error) => settle(() => reject(error)));
   });
+}
+
+/** Tear down a stream attempt we are abandoning, so its socket does not leak. */
+function discardCommand(command: SpriteCommandLike): void {
+  try {
+    command.close?.();
+  } catch {
+    // Best-effort: an already-dead socket is exactly what we wanted.
+  }
 }
 
 function wrapSpriteStream(command: SpriteCommandLike): MachineStream {
@@ -118,7 +136,7 @@ function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSand
      * per attempt.
      */
     async stream(args) {
-      return withWakeRetry(async () => {
+      const open = async (): Promise<MachineStream> => {
         const sprite = await sdk.getSprite(exec.sandboxId);
         const command =
           args.sessionId !== undefined
@@ -130,12 +148,25 @@ function wrapSpriteHandle({ sdk, exec }: { sdk: SpritesSdk; exec: ExecutableSand
                 cols: args.cols,
                 rows: args.rows,
               });
-        // Don't hand back a stream whose socket never opened — a SIGKILL through
-        // it would go nowhere. A pre-open drop rejects here and withWakeRetry
-        // re-opens; anything else propagates on the first occurrence.
-        await awaitStreamOpen(command, STREAM_OPEN_TIMEOUT_MS);
+        try {
+          await awaitStreamOpen(command, STREAM_OPEN_TIMEOUT_MS);
+        } catch (error) {
+          discardCommand(command);
+          throw error;
+        }
         return wrapSpriteStream(command);
-      });
+      };
+
+      // Retry ONLY the attach. Re-opening an attach is idempotent — it targets a
+      // session that already exists — whereas `createSession` starts a DETACHABLE
+      // session that outlives the client, so re-running it after a drop we only
+      // observed client-side could mint a second orphaned PTY. A pre-open drop is
+      // provably a socket that never opened, but not provably a request the
+      // server never received, and that distinction only costs us on the
+      // side-effecting branch. (No caller opens a fresh session through this seam
+      // today; the realtime PTY drives `createSession` directly and does its own
+      // bounded reconnect.)
+      return args.sessionId !== undefined ? withWakeRetry(open) : open();
     },
 
     async listStreams(): Promise<MachineStreamSessionInfo[]> {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -18,14 +18,13 @@
 
 import {
   MachineStreamOpenTimeoutError,
-  MachineStreamSessionGoneError,
   type MachineHandle,
   type MachineHost,
   type MachineStream,
   type MachineStreamSessionInfo,
 } from '../machine-host';
 import type { ExecSandboxClient, ExecutableSandbox } from './types';
-import { withWakeRetry, isSpriteNotFoundError, type SpriteCommandLike, type SpritesSdk } from './sprites';
+import { withWakeRetry, asPreOpenDrop, type SpriteCommandLike, type SpritesSdk } from './sprites';
 
 function toBuffer(chunk: Buffer | string): Buffer {
   return typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
@@ -35,11 +34,10 @@ function toBuffer(chunk: Buffer | string): Buffer {
  * Wall-clock cap on waiting for a stream to report that it opened.
  *
  * Deliberately LONGER than the SDK's own 10s `waitForSessionInfo` timeout
- * (websocket.js), which is the real failure signal for an attach to a dangling
- * session. A shorter cap here would fire first on every such attach and mask the
- * SDK's specific error behind a generic timeout — and, since the two outcomes
- * demand opposite responses from the kill path (drop the row vs keep it), that
- * misclassification is not cosmetic.
+ * (websocket.js), so that when an attach to a dangling session fails, the SDK's
+ * own error arrives first and we reject with THAT rather than pre-empting it with
+ * a generic timeout of our own. The cap is the backstop for a transport that
+ * reports nothing at all, not the expected failure path.
  */
 const STREAM_OPEN_TIMEOUT_MS = 20_000;
 
@@ -57,8 +55,7 @@ const STREAM_OPEN_TIMEOUT_MS = 20_000;
  *
  * The SDK emits `spawn` only after `start()` resolves (socket up, and for an
  * attach, `session_info` received) and emits `error` — never `spawn` — on a
- * failure, so those are the authoritative signals. `exit` also settles: a
- * command that already finished has nothing left to wait for.
+ * failure, so `spawn` is the authoritative open signal.
  */
 function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -70,9 +67,21 @@ function awaitStreamOpen(command: SpriteCommandLike, timeoutMs: number): Promise
       fn();
     };
     const timer = setTimeout(() => settle(() => reject(new MachineStreamOpenTimeoutError(timeoutMs))), timeoutMs);
+
+    // 'spawn' is the ONLY confirmation of an open. Deliberately NOT 'exit': for an
+    // attach, the SDK SYNTHESIZES `exit` from the socket closing (websocket.js's
+    // handleClose maps a tty close to an exit code) — but a `detachable` tmux
+    // session OUTLIVES its client socket, so a synthesized exit is not evidence
+    // the process died. Accepting it as a successful open would hand the caller a
+    // dead stream whose SIGKILL silently no-ops, and `killAgentTerminal` would
+    // then drop the row of a PTY that is still running.
     command.on('spawn', () => settle(resolve));
-    command.on('exit', () => settle(resolve));
-    command.on('error', (error) => settle(() => reject(error)));
+
+    // We only listen during the pre-open window, so an error seen here is pre-open
+    // BY CONSTRUCTION — there is no need (and, given the opaque undici message, no
+    // way) to infer that from its text. Marking it is what lets the bounded wake
+    // retry fire.
+    command.on('error', (error) => settle(() => reject(asPreOpenDrop(error))));
   });
 }
 
@@ -157,21 +166,7 @@ function wrapSpriteHandle({
                 cols: args.cols,
                 rows: args.rows,
               });
-        try {
-          await awaitStreamOpen(command, streamOpenTimeoutMs);
-        } catch (error) {
-          // Translate the ONE failure that carries positive evidence — the exec
-          // endpoint answering 404/410 — into the typed "session is gone" signal.
-          // The SDK reports a rejected upgrade as `WebSocket error: Unexpected
-          // server response: <status>`, so the status is recoverable from the
-          // message. Everything else (a 429, a 5xx mid-deploy, a socket hang-up,
-          // a timeout) stays exactly as it is: an UNKNOWN, on which no caller may
-          // tear down a session's bookkeeping.
-          if (args.sessionId !== undefined && isSpriteNotFoundError(error)) {
-            throw new MachineStreamSessionGoneError(args.sessionId, error);
-          }
-          throw error;
-        }
+        await awaitStreamOpen(command, streamOpenTimeoutMs);
         return wrapSpriteStream(command);
       };
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -342,12 +342,17 @@ function markPreOpenDrop(error: unknown): unknown {
  * Pure: is this failure a drop that happened BEFORE the connection opened (and so
  * provably never ran the command, making a re-run safe)?
  *
- * Answers structurally when it can — a failure observed while still waiting for
- * the SDK's `spawn` event, which fires exactly when `start()` resolves. Falls back
- * to the SDK's own `closed before open` text for the one case that produces it
- * without a preceding `error` event: a socket that opened at the transport level
- * and was then closed inside the pre-open window (an attach whose `session_info`
- * never arrives).
+ * Answers structurally: a failure observed while still waiting for the SDK's
+ * `spawn` event — which fires exactly when `start()` resolves — never ran the
+ * command. Every pre-open failure is marked at the point it is observed, so
+ * production relies on the mark alone.
+ *
+ * The `closed before open` text check below is a DEFENSIVE fallback, not a
+ * load-bearing one: the SDK emits that string as an `error` event inside the
+ * pre-open window too, so it is already marked structurally by the time anyone
+ * asks. It survives only to classify an error that reached a caller without
+ * having been observed pre-open (a hand-constructed one, or a future SDK that
+ * stops emitting `spawn`). Do not add new signals here — mark at the source.
  *
  * A timeout or an output overflow is never retryable: the command may already
  * have run.

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -112,6 +112,14 @@ export interface SpriteCommandLike {
   on(event: 'spawn', listener: () => void): unknown;
   kill(signal?: string): void;
   resize?(cols: number, rows: number): void;
+  /**
+   * Tear the underlying WebSocket down. Distinct from `kill`, which SIGNALS the
+   * remote process over an OPEN socket and is a silent no-op when the socket is
+   * not open (`@fly/sprites` websocket.js `signal()` early-returns unless
+   * `readyState === OPEN`). An attempt we abandon — a stream open that dropped or
+   * timed out — must be `close`d, or its socket leaks for the process lifetime.
+   */
+  close?(): void;
 }
 
 /** Options for spawning a command, including PTY support. */

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -302,12 +302,13 @@ function runSpawned(
 // Cold-start exec retry. A hibernated Sprite has NO explicit wake API — an
 // incoming request to it (i.e. any exec) wakes it automatically
 // (docs.sprites.dev/concepts/lifecycle), so the FIRST REAL operation is the
-// wake. Fly's wake-on-request can drop that first connection while the VM boots
-// — the SDK surfaces it as a "closed before open" error. That failure is
-// provably pre-open (the command never started), so retrying it is safe and IS
-// the wake handshake. We retry ONLY that signal: a post-open failure (timeout,
-// output overflow, non-zero exit, mid-command socket drop) may have already run
-// the command and must NOT be retried.
+// wake. Fly's wake-on-request can drop that first connection while the VM boots.
+// Such a failure is provably PRE-OPEN (the command never started), so retrying it
+// is safe and IS the wake handshake — see `isPreOpenWakeError` for how that is
+// detected (structurally, from the absence of the SDK's `spawn` event; the error's
+// text cannot be trusted for it). We retry ONLY that signal: a post-open failure
+// (timeout, output overflow, non-zero exit, mid-command socket drop) may have
+// already run the command and must NOT be retried.
 export const MAX_EXEC_ATTEMPTS = 3;
 export const RETRY_BASE_DELAY_MS = 500;
 const FS_OP_TIMEOUT_MS = 30_000;

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -112,14 +112,6 @@ export interface SpriteCommandLike {
   on(event: 'spawn', listener: () => void): unknown;
   kill(signal?: string): void;
   resize?(cols: number, rows: number): void;
-  /**
-   * Tear the underlying WebSocket down. Distinct from `kill`, which SIGNALS the
-   * remote process over an OPEN socket and is a silent no-op when the socket is
-   * not open (`@fly/sprites` websocket.js `signal()` early-returns unless
-   * `readyState === OPEN`). An attempt we abandon — a stream open that dropped or
-   * timed out — must be `close`d, or its socket leaks for the process lifetime.
-   */
-  close?(): void;
 }
 
 /** Options for spawning a command, including PTY support. */

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -250,10 +250,23 @@ function runSpawned(
       return next;
     };
 
+    // The SDK emits 'spawn' exactly when `start()` resolves — i.e. the socket is
+    // open (and, for an attach, `session_info` has arrived). It is therefore the
+    // authoritative boundary between "this never ran" and "this may have run",
+    // which is the only question the retry needs answered. See `isPreOpenWakeError`
+    // for why the error's TEXT cannot answer it.
+    let opened = false;
+    command.on('spawn', () => {
+      opened = true;
+    });
+
     command.stdout.on('data', (chunk) => {
+      // Output proves the connection opened, even if the 'spawn' event was missed.
+      opened = true;
       stdoutLen = collect(stdoutChunks, chunk, stdoutLen);
     });
     command.stderr.on('data', (chunk) => {
+      opened = true;
       stderrLen = collect(stderrChunks, chunk, stderrLen);
     });
     command.on('exit', (code) => {
@@ -264,7 +277,10 @@ function runSpawned(
       });
     });
     command.on('error', (error) => {
-      fail(error);
+      // A failure BEFORE the socket opened never started the command, so it is
+      // safe to re-run. One that arrives after may already have run it, and must
+      // not be.
+      fail(opened ? error : markPreOpenDrop(error));
     });
 
     if (timeoutMs && timeoutMs > 0) {
@@ -296,15 +312,60 @@ export const MAX_EXEC_ATTEMPTS = 3;
 export const RETRY_BASE_DELAY_MS = 500;
 const FS_OP_TIMEOUT_MS = 30_000;
 
-/** Pure: is this failure the provably pre-open cold-start drop (and so safe to re-run)? */
+/**
+ * Marks an error that reached us BEFORE the command's socket opened.
+ *
+ * This is a STRUCTURAL fact, recorded by whoever was watching the connection, not
+ * a guess made afterwards from the error's text. The distinction matters because
+ * the text is not usable: `@fly/sprites` has no `ws` dependency — it drives the
+ * global (undici) WebSocket, whose own file header notes that "the standard
+ * WebSocket API does not expose HTTP error responses on connection failure". On a
+ * failed handshake undici fires `error` BEFORE `close`, and the SDK registers its
+ * `error` listener first (websocket.js), so the first thing a consumer sees is
+ * `WebSocket error: <opaque>` — NOT the `WebSocket closed before open: …` string
+ * that only gets emitted afterwards, from the `close` listener. Matching on that
+ * string alone therefore misses the very cold-start drop it was written for.
+ *
+ * Non-enumerable and symbol-keyed so marking never alters an error's identity,
+ * message, or JSON shape — callers still see exactly the error the SDK threw.
+ */
+const PRE_OPEN_DROP = Symbol.for('pagespace.sandbox.preOpenDrop');
+
+function markPreOpenDrop(error: unknown): unknown {
+  if (typeof error === 'object' && error !== null) {
+    Object.defineProperty(error, PRE_OPEN_DROP, { value: true, enumerable: false, configurable: true });
+  }
+  return error;
+}
+
+/**
+ * Pure: is this failure a drop that happened BEFORE the connection opened (and so
+ * provably never ran the command, making a re-run safe)?
+ *
+ * Answers structurally when it can — a failure observed while still waiting for
+ * the SDK's `spawn` event, which fires exactly when `start()` resolves. Falls back
+ * to the SDK's own `closed before open` text for the one case that produces it
+ * without a preceding `error` event: a socket that opened at the transport level
+ * and was then closed inside the pre-open window (an attach whose `session_info`
+ * never arrives).
+ *
+ * A timeout or an output overflow is never retryable: the command may already
+ * have run.
+ */
 export function isPreOpenWakeError(error: unknown): boolean {
   if (error instanceof SandboxCommandTimeoutError || error instanceof SandboxOutputLimitError) {
     return false;
   }
+  if (typeof error === 'object' && error !== null && (error as Record<symbol, unknown>)[PRE_OPEN_DROP] === true) {
+    return true;
+  }
   const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
-  // Emitted by the SDK's WSCommand before the socket ever opens — see
-  // @fly/sprites websocket.js ("WebSocket closed before open: …").
   return msg.includes('closed before open');
+}
+
+/** Record that `error` reached the caller before the connection ever opened. */
+export function asPreOpenDrop(error: unknown): unknown {
+  return markPreOpenDrop(error);
 }
 
 /** Pure: the linear backoff between wake attempts (attempt is 1-based). */

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -283,18 +283,21 @@ function runSpawned(
   });
 }
 
-// Cold-start exec retry. A hibernated Sprite wakes on the exec WebSocket, and
-// Fly's wake-on-request can drop the FIRST connection while the VM boots — the
-// SDK surfaces that as a "closed before open" error. That failure is provably
-// pre-open (the command never started), so retrying it is safe and is the
-// documented wake handshake. We retry ONLY that signal: a post-open failure
-// (timeout, output overflow, non-zero exit, mid-command socket drop) may have
-// already run the command and must NOT be retried.
-const MAX_EXEC_ATTEMPTS = 3;
-const RETRY_BASE_DELAY_MS = 500;
+// Cold-start exec retry. A hibernated Sprite has NO explicit wake API — an
+// incoming request to it (i.e. any exec) wakes it automatically
+// (docs.sprites.dev/concepts/lifecycle), so the FIRST REAL operation is the
+// wake. Fly's wake-on-request can drop that first connection while the VM boots
+// — the SDK surfaces it as a "closed before open" error. That failure is
+// provably pre-open (the command never started), so retrying it is safe and IS
+// the wake handshake. We retry ONLY that signal: a post-open failure (timeout,
+// output overflow, non-zero exit, mid-command socket drop) may have already run
+// the command and must NOT be retried.
+export const MAX_EXEC_ATTEMPTS = 3;
+export const RETRY_BASE_DELAY_MS = 500;
 const FS_OP_TIMEOUT_MS = 30_000;
 
-function isPreOpenWakeError(error: unknown): boolean {
+/** Pure: is this failure the provably pre-open cold-start drop (and so safe to re-run)? */
+export function isPreOpenWakeError(error: unknown): boolean {
   if (error instanceof SandboxCommandTimeoutError || error instanceof SandboxOutputLimitError) {
     return false;
   }
@@ -304,32 +307,76 @@ function isPreOpenWakeError(error: unknown): boolean {
   return msg.includes('closed before open');
 }
 
+/** Pure: the linear backoff between wake attempts (attempt is 1-based). */
+export function wakeRetryDelayMs(attempt: number, baseDelayMs: number = RETRY_BASE_DELAY_MS): number {
+  return baseDelayMs * attempt;
+}
+
+export type WakeRetryPlan = { retry: true; delayMs: number } | { retry: false };
+
+/**
+ * Pure: after `attempt` (1-based) failed with `error`, should the operation be
+ * re-run, and after how long? Bounded by `maxAttempts` so a Sprite that never
+ * wakes surfaces its error instead of looping forever.
+ */
+export function planWakeRetry({
+  error,
+  attempt,
+  maxAttempts = MAX_EXEC_ATTEMPTS,
+  baseDelayMs = RETRY_BASE_DELAY_MS,
+}: {
+  error: unknown;
+  attempt: number;
+  maxAttempts?: number;
+  baseDelayMs?: number;
+}): WakeRetryPlan {
+  if (!isPreOpenWakeError(error)) return { retry: false };
+  if (attempt >= maxAttempts) return { retry: false };
+  return { retry: true, delayMs: wakeRetryDelayMs(attempt, baseDelayMs) };
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export interface WakeRetryOptions {
+  maxAttempts?: number;
+  baseDelayMs?: number;
+  /** Injected so the schedule can be asserted without real timers. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
 /**
- * Spawn + collect with a bounded retry on the cold-start wake handshake. The
- * command is (re-)spawned per attempt via `spawnFn` so each retry opens a fresh
- * WebSocket. Only a pre-open wake failure is retried; everything else propagates
- * on the first occurrence.
+ * The retry executor: a thin shell around the pure `planWakeRetry` schedule that
+ * re-runs an INJECTED operation on the cold-start wake handshake. `op` is a
+ * factory, not a promise — each attempt must open a FRESH connection (a settled
+ * promise cannot be retried).
  */
-async function runSpawnedWithWakeRetry(
+export async function withWakeRetry<T>(
+  op: (attempt: number) => Promise<T>,
+  { maxAttempts = MAX_EXEC_ATTEMPTS, baseDelayMs = RETRY_BASE_DELAY_MS, sleep = delay }: WakeRetryOptions = {},
+): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await op(attempt);
+    } catch (error) {
+      const plan = planWakeRetry({ error, attempt, maxAttempts, baseDelayMs });
+      if (!plan.retry) throw error;
+      await sleep(plan.delayMs);
+    }
+  }
+}
+
+/**
+ * Spawn + collect with the bounded cold-start wake retry. The command is
+ * (re-)spawned per attempt via `spawnFn` so each retry opens a fresh WebSocket.
+ */
+function runSpawnedWithWakeRetry(
   spawnFn: () => SpriteCommandLike,
   maxBytes: number,
   timeoutMs: number | undefined,
 ): Promise<SandboxRunResult> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= MAX_EXEC_ATTEMPTS; attempt += 1) {
-    try {
-      return await runSpawned(spawnFn(), maxBytes, timeoutMs);
-    } catch (error) {
-      lastError = error;
-      if (!isPreOpenWakeError(error) || attempt === MAX_EXEC_ATTEMPTS) throw error;
-      await delay(RETRY_BASE_DELAY_MS * attempt);
-    }
-  }
-  throw lastError;
+  return withWakeRetry(() => runSpawned(spawnFn(), maxBytes, timeoutMs));
 }
 
 /** Reject if `p` has not settled within `ms` — the Sprite filesystem API uses a
@@ -354,14 +401,23 @@ function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
 }
 
 /**
- * Force a hibernated VM awake via the designated exec/WebSocket path (a cheap
- * no-op), with the same cold-start retry as a real command. Used to recover a
- * filesystem op that hit a cold VM before retrying it, and by the realtime
- * terminal path to wake a resumed Sprite BEFORE opening the interactive PTY
- * (`openPtyShell`'s `bash` spawn isn't wrapped in the cold-start retry, so a
- * dropped first wake would otherwise leave the terminal stuck connecting).
+ * Force a hibernated VM awake via a cheap no-op exec, with the same bounded
+ * cold-start retry as a real command.
+ *
+ * THE FILESYSTEM PATH IS THE ONLY LEGITIMATE CALLER, and deliberately not
+ * exported. Every OTHER operation already wakes the VM by itself: a Sprite has
+ * no explicit wake API — an incoming request wakes it automatically
+ * (docs.sprites.dev/concepts/lifecycle) — so an exec, a `createSession` or an
+ * `attachSession` IS the wake, and prefixing one with a `sh -c :` just pays for
+ * two cold starts instead of one.
+ *
+ * The Sprite filesystem HTTP API is the exception, and the reason this still
+ * exists: it is a bare `fetch()` with no AbortSignal that does NOT wake a
+ * hibernated VM — it simply hangs (52–90s observed) until Fly's proxy closes the
+ * connection. So an fs op against a cold Sprite has no way to wake the VM it is
+ * waiting on. This exec does it for it.
  */
-export async function ensureSpriteAwake(sprite: SpriteInstanceLike): Promise<void> {
+async function wakeSpriteViaExec(sprite: SpriteInstanceLike): Promise<void> {
   await runSpawnedWithWakeRetry(
     () => sprite.spawn('sh', ['-c', ':']),
     DEFAULT_MAX_OUTPUT_BYTES,
@@ -371,9 +427,8 @@ export async function ensureSpriteAwake(sprite: SpriteInstanceLike): Promise<voi
 
 /**
  * Run a filesystem op bounded by a timeout; on the first failure (cold-start
- * hang/race) wake the VM via the exec path and retry once. The filesystem API
- * itself never wakes a cold VM and never times out, so without this a `writeFile`
- * / `readFile` against a hibernated Sprite hangs indefinitely.
+ * hang/race) wake the VM via the exec path and retry once — see
+ * `wakeSpriteViaExec` for why the fs API cannot wake the VM itself.
  */
 async function fsWithWakeRetry<T>(
   sprite: SpriteInstanceLike,
@@ -383,7 +438,7 @@ async function fsWithWakeRetry<T>(
   try {
     return await withTimeout(op(), FS_OP_TIMEOUT_MS, label);
   } catch {
-    await ensureSpriteAwake(sprite);
+    await wakeSpriteViaExec(sprite);
     return await withTimeout(op(), FS_OP_TIMEOUT_MS, label);
   }
 }
@@ -561,6 +616,62 @@ async function applyEgressLockdown({
     }
     throw error;
   }
+}
+
+/**
+ * Wrap an SDK so every `getSprite` for the same name within this wrapper's
+ * lifetime resolves ONE underlying read, memoized by name.
+ *
+ * A single cold terminal connect used to read the same Sprite up to three times:
+ * once inside `getOrCreate` (the resume probe), once to wake it, and once more
+ * to hand the raw instance to the PTY layer. A `getSprite` is a control-plane
+ * round-trip, so those were two avoidable network hops on the SLOWEST path we
+ * have. Build ONE cache per connect and thread it through the whole resolution
+ * (acquire -> auth -> launch) and the Sprite is read exactly once.
+ *
+ * Two details make the memo safe rather than merely fast:
+ *  - A REJECTION is never cached. `getOrCreate`'s create path *expects*
+ *    `getSprite` to reject (not-found) before it calls `createSprite`; caching
+ *    that rejection would make every later read of the name fail forever. A
+ *    transient 429/5xx is evicted for the same reason — a retry must be a real
+ *    retry.
+ *  - `createSprite` SEEDS the cache and `deleteSprite` EVICTS it, so the fresh
+ *    path needs no second read to see its own Sprite, and a destroyed one is
+ *    never served from cache.
+ *
+ * Scope it to one request/connect, never to the process: the handle is a live
+ * control-plane object, and a process-lifetime cache would pin a Sprite that has
+ * since been destroyed and re-created under the same name.
+ */
+export function createSpriteHandleCache(sdk: SpritesSdk): SpritesSdk {
+  const handles = new Map<string, Promise<SpriteInstanceLike>>();
+
+  return {
+    getSprite(name) {
+      const cached = handles.get(name);
+      if (cached) return cached;
+
+      const pending = sdk.getSprite(name);
+      handles.set(name, pending);
+      pending.catch(() => {
+        // Evict, don't memoize a failure — see the doc above. Guarded so a late
+        // rejection can't evict a handle a subsequent create already seeded.
+        if (handles.get(name) === pending) handles.delete(name);
+      });
+      return pending;
+    },
+
+    async createSprite(name, config) {
+      const sprite = await sdk.createSprite(name, config);
+      handles.set(name, Promise.resolve(sprite));
+      return sprite;
+    },
+
+    async deleteSprite(name) {
+      handles.delete(name);
+      await sdk.deleteSprite(name);
+    },
+  };
 }
 
 export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSandboxClient {

--- a/packages/lib/src/services/sandbox/terminal-session-manager.ts
+++ b/packages/lib/src/services/sandbox/terminal-session-manager.ts
@@ -281,9 +281,11 @@ export async function acquireTerminalSandbox(
     // destroyed (getOrCreate recreates it under the same name so the sandboxId
     // stays stable), (c) policy migration for sessions created before this change.
     // Shared by `resume` (within the warm window) and `noop` (persistent-idle:
-    // VM is hibernating). The VM is warmed before the PTY opens by the realtime
-    // path (ensureSpriteAwake), so a hibernated terminal's `bash` spawn lands on
-    // an awake VM instead of racing a cold-start drop.
+    // VM is hibernating). A hibernating VM is NOT pre-warmed here: it has no
+    // explicit wake API (docs.sprites.dev/concepts/lifecycle) and wakes on any
+    // incoming request, so the caller's first real operation — the PTY's
+    // createSession/attachSession, or an exec — is itself the wake, and carries
+    // the bounded pre-open retry that a cold-start drop needs.
     const reconnectExisting = async (): Promise<AcquireTerminalSandboxResult> => {
       // Reconnect uses getOrCreate, which RE-PROVISIONS a vanished/reaped VM under
       // the same name — i.e. it can mint a FRESH open-egress VM. So the containment


### PR DESCRIPTION
Collapses the cold terminal-connect path from **3 `getSprite` reads + 2 wake execs** down to **1 read + 0 wake execs**.

Per [docs.sprites.dev/concepts/lifecycle](https://docs.sprites.dev/concepts/lifecycle/) there is **no explicit wake API** — "an incoming request to a Sprite's URL wakes it automatically". So the first *real* operation (createSession/attachSession) **is** the wake, and the `sh -c :` we ran first just bought a second cold start on the slowest path we have.

## Requirements

### ✅ Given a full cold connect, should call `sdk.getSprite` at most once (spy-counted through acquire + auth + launch resolution — thread the handle instead of re-fetching)

New pure-ish `createSpriteHandleCache(sdk)` (`sprites.ts`) memoizes `getSprite` **by name, for one connect**. `apps/realtime/src/index.ts` builds **one** cache per connect in `resolveAgentTerminalSandbox` and threads it through **both** halves — `buildMachineSandbox` (whose `getOrCreate` probes the Sprite) and the launch resolution's `getSprite` (which needs the raw handle for the PTY). They read the same Sprite, so they now share one control-plane round-trip.

Two details make the memo safe, not just fast:
- **Rejections are never cached.** `getOrCreate`'s create path *expects* `getSprite` to reject (not-found) before calling `createSprite`; caching that would make every later read of the name fail forever. A transient 429/5xx is evicted for the same reason.
- **`createSprite` seeds / `deleteSprite` evicts**, so the fresh path needs no second read to see its own Sprite.

Cache is **connect-scoped, never module-scoped** — a handle is a live object, and a process-lifetime cache would keep serving a Sprite since destroyed and re-created under the same name.

Spy-counted in `cold-connect-sprite-reads.test.ts`, which composes the **real** production stack (`createSpriteHandleCache` → `createSpritesSandboxClient` → `createSpriteMachineHost` → `createExecClientFromMachineHost` → `acquireTerminalSandbox` → `resolveTerminalSandbox`) with only the DB faked: resumed = 1 read / 0 creates; long-idle (hibernated) = 1 read; fresh = 1 probe + 1 create.

### ✅ Given a resumed sprite on the terminal connect path, should run no no-op wake exec

Exported `ensureSpriteAwake` **deleted**, along with both callers' resumed-path wake blocks (`apps/realtime/src/index.ts`, `apps/web/src/lib/machines/agent-terminals-runtime.ts` — the latter's now-dead `getSpritesSdk` plumbing went with it). Asserted by spy: no `sh -c :` spawn on the resumed **or** hibernated-idle connect.

### ✅ Given a cold sprite whose first real session-open drops pre-open, should retry with the existing bounded backoff (pure schedule unit-tested)

The retry is now **pure and directly tested**, with the executor a thin shell over an injected operation:
- `isPreOpenWakeError(error)` — exported
- `wakeRetryDelayMs(attempt, base)` — the linear schedule
- `planWakeRetry({error, attempt, maxAttempts, baseDelayMs})` → `{retry, delayMs}`
- `withWakeRetry(op, {maxAttempts, baseDelayMs, sleep})` — injected op **and** injected `sleep`, so the schedule is asserted without real timers

> ### ⚠️ This surfaced a latent bug that the wake exec was masking — please review closely
>
> With `sh -c :` gone, the **first `createSession` is what lands on the cold VM**. A pre-open drop there leaves `planReconnect` with *no known id* (we were creating one) and *nothing live* (the VM is still booting) — which is byte-identical to a genuinely dead shell, and returned **`fatal`**. The user would get `exit -1` instead of a prompt.
>
> `ensureSpriteAwake` was absorbing that drop before `openPtyShell` ever ran. Deleting it without this fix would have shipped a cold-open regression.
>
> Fix: `planReconnect` takes `preOpenDrop` (**defaults `false`**, so every existing branch and its tests are unchanged). A connection that never opened started nothing, so re-creating is safe; `consecutiveFailures` still bounds it, so a Sprite that truly never wakes exhausts the budget and surfaces the exit. `sprites-shell.ts` now captures the error in `wire`'s `on('error')` and classifies it with `isPreOpenWakeError`.
>
> Covered by `cold-session-open-retry.test.ts`: a cold VM that drops the first session-open recovers to a working shell (and spawns **zero** wake execs); a Sprite that never wakes still exits `-1` rather than looping forever.

### ✅ Given an fs-API operation with no preceding exec in its flow, should retain a wake exec

Kept — now **private** (`wakeSpriteViaExec`), fs-path only, with the reasoning inline. The Sprite filesystem HTTP API is a bare `fetch()` with no AbortSignal that does **not** wake a hibernated VM — it just hangs (52–90s) until Fly's proxy closes it. An fs op against a cold Sprite therefore has no way to wake the VM it is waiting on; this exec does it for it. Every *other* operation wakes the VM by itself.

Pinned by two tests: the cold fs op issues exactly `[['sh','-c',':']]` before retrying, and that wake itself retries on the bounded backoff if *it* drops pre-open.

## Test evidence

```
packages/lib — src/services/sandbox/
 Test Files  37 passed (37)
      Tests  596 passed (596)

apps/realtime — src/terminal/__tests__/
 ✓ cold-connect-sprite-reads.test.ts (4 tests)
 ✓ cold-session-open-retry.test.ts (2 tests)
 ✓ sprites-shell.test.ts (44 tests)      <- unchanged, preOpenDrop defaults false
 ✓ agent-terminal-access.test.ts (31 tests)
 ✓ agent-terminal-handler.test.ts (80 tests)
 Test Files  10 passed (10)
      Tests  261 passed (261)
```

`bun run typecheck` — **16/16 tasks clean** (web build included).
`bun run lint` — **14/14 clean**.
`bun run test:unit` — `@pagespace/lib` **7557 passed**. `apps/web` has **16 pre-existing failures** in 3 files (`activity-tools`, `admin-role-version`, `grouping`) — **verified identical on master with this branch stashed**; untouched by this leaf.

## Notes for the orchestrator

- **`sprites-shell.ts` (lane B) was touched** — unavoidable: requirement 3 cannot be satisfied without it, because deleting the wake exec is precisely what moves the cold-start drop onto the session-open. The change is additive (one optional param defaulting to the old behavior); lane B's 44 existing tests pass untouched.
- **No schema/migration changes.** No `any`. bun only.
- The `mkdir -p /workspace` exec inside `applyEgressLockdown` still runs on every hand-back — that is **leaf 1-5**'s (egress lockdown frequency) scope, deliberately left alone.
- Live-Sprite smoke test not run (no `SPRITES_API_TOKEN` in the worktree); the connect path is validated against the real composition with a faked SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYwUpHyMgDD2KqP2pJwV2W

---

## Update — commit `3a8e89133` (post-review)

### Cold kills through `MachineHost.stream` (Codex P2 — fixed)

Codex correctly caught a regression I introduced. `killAgentTerminal` → `killAtLocation` attaches a PTY stream and immediately SIGKILLs it, through `MachineHost.stream` — **the one exec path with no pre-open retry**. `runCommand` has `withWakeRetry`; the realtime PTY has `openPtyShell`'s bounded reconnect; `stream()` had nothing. Once the explicit wake exec was gone, that attach became the first (waking) request on a hibernated Sprite, so a `closed before open` drop failed the kill and left the tracking row behind.

Fixed at the `stream()` seam rather than by reinstating a wake exec, so the platform model holds everywhere. `stream()` has exactly **one** consumer (`killAtLocation`), so the blast radius is contained.

- `stream()` now waits for the SDK's `spawn` event — emitted **only after the WebSocket actually opens** — before handing the stream back. It previously returned a stream whose socket may never have opened, so the `SIGKILL` went nowhere.
- A pre-open drop rejects that wait and is retried by `withWakeRetry` on the same bounded schedule as the exec path, re-opening a fresh connection per attempt.
- A **post-open** failure still propagates on the first occurrence — a session that may already be running is never blindly re-attached.
- The open-wait is **capped and resolves optimistically at the cap**, so a command reporting neither outcome degrades to exactly the old behavior. Strictly an improvement; it can never hang a kill that used to succeed.

New tests in `sprite-machine-host.test.ts` pin both directions (cold drop → 2 attempts, recovers; post-open failure → 1 attempt, propagates). The suite's `fakeCommand` now emits `spawn`, as the real SDK does — it was silently modelling a socket that never opens.

### CI: `apps/realtime` coverage gate (fixed)

The failing `ci / Unit Tests` check was **not** a test failure — all 647 realtime tests passed. It was the **coverage threshold**: functions 83.95% (need 85%), branches 97.98% (need 98%). Test files are included in this package's coverage, and my new fakes declared many never-called stub functions plus half-covered guard branches.

Fixed honestly rather than by lowering thresholds: unexercised stubs are now `vi.fn()` (library mocks, not instrumented as our functions), the resolve union is narrowed **once** in the harness instead of re-guarded in every assertion, and the two harness-only guards are `c8 ignore`d. Now **functions 86.12% / branches 98.08%**, gate green.

## Validation (re-run at `3a8e89133`)

```
bun run typecheck                 16/16 tasks clean
bun run lint                      14/14 clean
bun run build                     14/14 clean
packages/lib  test:coverage       7559 passed, thresholds OK (exit 0)
apps/realtime test:coverage        647 passed, thresholds OK (exit 0)
packages/lib  sandbox + machines   763 passed
```

`apps/web`'s 16 pre-existing failures (`activity-tools`, `admin-role-version`, `grouping`) are unchanged and unrelated — verified identical on master with this branch stashed.

---

## Update — commit `39b12d071` (correctness fixes from adversarial self-review)

Reviewing my own `stream()` fix against the **real `@fly/sprites` SDK source** (not its docs) found that the fix above was itself buggy in two ways. Both are corrected here. Anyone reviewing the kill path should read this section rather than the one before it.

### 1. The optimistic timeout faked a successful kill (worst of the two)

`SpriteCommand.kill()` is `signal()`, which early-returns unless `readyState === OPEN` (`websocket.js:279`) — a **silent no-op** on a socket that never opened. My `awaitStreamOpen` resolved *optimistically* at its cap, so on a cold Sprite `killAtLocation` would SIGKILL nothing, delete the tracking row, and return `ok: true` — **orphaning a live, billable agent process**. That is precisely the failure this PR set out to fix, reintroduced in the cold case it targets.

`awaitStreamOpen` now **rejects** on timeout. No confirmed open, no stream.

The cap was also 10s — identical to the SDK's own `waitForSessionInfo` timeout (`websocket.js:108`) but started strictly earlier, so mine always won the race and masked the SDK's specific attach error behind a generic one. Raised to 20s so the SDK's real failure surfaces.

### 2. A dangling session became permanently unkillable

`websocket.js:87` emits `WebSocket closed before open` whenever the socket closes while `resolved === false` — and for an **attach**, `resolved` stays false through `waitForSessionInfo`. So a server closing the upgrade because the session id is **gone** yields a string `isPreOpenWakeError` classifies as a cold-start drop: 3 pointless retries, a throw, and the row kept **forever**. Pre-PR that row was dropped, so this was a regression.

`killAtLocation` now separates three outcomes it had been collapsing into one:

| outcome | what we learned | row |
|---|---|---|
| `host.attach()` throws | control plane unreachable — nothing | **keep** |
| stream open **times out** | PTY may be alive but unreachable | **keep** |
| stream open **fails** otherwise | the retry's first attempt already woke the Sprite, and exec sessions don't survive a pause → the session is gone | **drop** (nothing left to kill) |

The new `MachineStreamOpenTimeoutError` is what makes "we don't know" distinguishable from "it's gone" — the two demand opposite responses, and conflating them breaks the kill in one direction or the other.

### 3. Also hardened

- **Only the attach is retried.** `createSession` starts a *detachable* session that outlives the client, so re-running it after a drop we only observed client-side could mint a second orphaned PTY. A pre-open drop proves the socket never opened — not that the server never got the request — and that gap only costs us on the side-effecting branch.
- **Abandoned attempts are `close()`d.** `kill()` cannot close an unopened socket, so every failed attach was leaking its WebSocket for the process lifetime.
- `lastErrorWasPreOpenDrop` is reset on a confirmed open, so a reconnect entered without a fresh error can't consult a stale verdict.

## Validation (at `39b12d071`)

```
bun run typecheck                 16/16 clean
bun run lint                      14/14 clean
bun run build                     14/14 clean
packages/lib  test:coverage       7561 passed, thresholds OK (exit 0)
apps/realtime test:coverage        647 passed, thresholds OK (exit 0)
agent-terminals.test.ts             51 passed (incl. 2 new kill-semantics tests)
sprite-machine-host.test.ts         14 passed (incl. 2 new retry-direction tests)
```

CI was fully green on `3a8e89133` (including `ci / Unit Tests`, which the coverage fix repaired).

---

## Update — commit `d6e2585d3` (second adversarial pass) — **read this for the kill semantics**

A second review pass against the real SDK found the triage in `39b12d0` **still had the orphan bug**, reachable through a different door. This is the final, correct behavior.

### The orphan was still reachable via a transient error

`killAtLocation` dropped the row on *any* non-timeout stream failure, reasoning "the retry already woke the Sprite, so this must be a dangling session." That is not what the code actually caught. `stream()` opens with its **own `sdk.getSprite`** — a second control-plane round-trip after `host.attach()` already did one (and `apps/web` wires a **raw, uncached** SDK, so it genuinely is a second call). A 429, a 5xx mid-deploy, or a socket hang-up there is evidence of *nothing* — yet it deleted the row while the PTY kept running. Billable, and now unreachable.

**The default is now fail-safe.** The row is torn down **only** on `MachineStreamSessionGoneError` — the machine *answered*, and its answer was 404/410 for that session. Every other outcome keeps the row:

| outcome | evidence | row |
|---|---|---|
| machine answers **404/410** for the session | positive: it's gone | **drop** |
| `host.attach()` throws | none | keep |
| `getSprite` inside `stream()` fails (429/5xx/blip) | none | keep |
| socket hang-up / transport error | none | keep |
| open never reports either way (timeout) | none | keep |

The asymmetry is deliberate and worth stating: **a stale row is a visible, retryable annoyance; deleting a live session's row is a silent, unrecoverable leak.** So unknowns never license a delete.

### Two more, from the same pass

- **`discardCommand` was a no-op that claimed otherwise.** `SpriteCommand` exposes only `start/wait/kill/signal/resize` — `close()` lives on the private `WSCommand` and is unreachable. My `command.close?.()` therefore never did anything, while the comment asserted it prevented a socket leak. Removed the false interface member and the call; documented the real limitation (bounded, and not fixable without an SDK change) instead of pretending.
- **The timeout guard had no test.** `awaitStreamOpen`'s cap — the entire reason the error class exists — was never exercised, so a regression back to "resolve optimistically" would have passed the whole suite while silently restoring the fake-kill bug. Now tested, along with the 404 path. The cap is injectable (`streamOpenTimeoutMs`) because faking timers globally deadlocks provisioning's own egress `mkdir`.

Also fixed a test that passed **by accident**: its error text was `'session is gone'`, which `isSpriteNotFoundError` matches on `/\bgone\b/` — so it was asserting the not-found path while claiming to assert a transient one.

## Validation (at `d6e2585d3`)

```
bun run build                     14/14 clean
bun run typecheck                 16/16 clean
bun run lint                      14/14 clean
packages/lib  test:coverage       7564 passed, thresholds OK (exit 0)
apps/realtime test:coverage        647 passed, thresholds OK (exit 0)
```

CI was fully green on `39b12d071` (all checks, `mergeable: CLEAN`).

---

## Update — commit `fcaca4438` (third pass) — **the most important fix in this PR**

A third review pass, verified against the SDK source, found that **the cold-start retry this entire leaf depends on was keyed on a string the SDK cannot emit first.** It would not have fired in production — meaning deleting the wake exec would have shipped a cold-open regression, silently.

### Root cause

`@fly/sprites` has **no `ws` dependency**. It drives the **global (undici) WebSocket**, and registers its `error` listener **before** its `close` listener (`websocket.js`). On a failed handshake undici fires `error` first, so the first thing a consumer sees is an opaque `WebSocket error: <TypeError>`. The SDK's `WebSocket closed before open: …` string is only emitted **afterwards**, from the close handler — by which time `runSpawned`/`awaitStreamOpen` have already settled on the first error.

`"closed before open"` is the **`ws` npm package's** message format. This SDK does not use it. Matching on that substring therefore misses the very cold-start drop it was written for.

### Fix: classify by structure, not by text

The SDK emits `spawn` exactly when `start()` resolves (`exec.js`: `cmd.start().then(() => cmd.emit('spawn'))`) — for `spawn`/`createSession`/`attachSession` alike. So **"error before `spawn`" *is* the definition of a pre-open drop**, and needs no string parsing:

- `runSpawned` tracks whether the command opened (`spawn`, or any byte of output) and marks a pre-open error with a non-enumerable symbol. `isPreOpenWakeError` reads that mark, keeping the old substring only as a fallback for the one case that genuinely produces it (a socket closed *inside* the pre-open window with no preceding error event).
- `awaitStreamOpen` only listens during the pre-open window, so every error it sees is pre-open **by construction** — it marks them all.
- `openPtyShell`'s reconnect sets `preOpenDrop` from `!opened` on the dying command, rather than sniffing the message.

### Two more from the same pass

1. **`awaitStreamOpen` treated `exit` as a confirmed open.** For an *attach*, the SDK **synthesizes** `exit` from the socket closing (`handleClose` maps a tty close to an exit code) — but a `detachable` tmux session **outlives its client socket**, so a synthesized exit is not evidence the process died. Accepting it handed the caller a dead stream whose SIGKILL silently no-ops, and `killAgentTerminal` then dropped the row of a PTY that was **still running**. Only `spawn` confirms an open now.

2. **`MachineStreamSessionGoneError` was unreachable.** It was derived from an HTTP status parsed out of the WebSocket error message — and the native WebSocket API *never exposes one* (the SDK's own file header says so). So the drop-the-row branch could never be taken, and a dead session was **unkillable forever** — the exact strand the class was introduced to prevent. Replaced with the one API that *can* answer: `killAtLocation` now consults `handle.listStreams()` (a REST call with real statuses).

| `listStreams()` says | evidence | row |
|---|---|---|
| session **not listed** | positive: it's gone | **drop** |
| session still listed | it may be alive | keep |
| the listing itself failed | none | keep |

### Test quality

The tests were green over dead code — they emitted `'WebSocket closed before open'`, a string the runtime never produces first. They now model the **real** undici event order (opaque `error`, no `spawn`), so they fail if the classifier regresses. Fakes modelling a *post-open* failure (a keepalive timeout, which by definition fires 45s after the socket opened) now emit `spawn` first, as the real SDK does.

## Validation (at `fcaca4438`)

```
bun run build                     14/14 clean
bun run typecheck                 16/16 clean
bun run lint                      14/14 clean
packages/lib  test:coverage       7566 passed, thresholds OK (exit 0)
apps/realtime test:coverage        647 passed, thresholds OK (exit 0)
```

CI was fully green on `d6e2585d3` (all 10 checks, `mergeable: CLEAN`).

---

## Update — commit `0acdd2edf` (fourth pass)

A fourth review pass found **no new correctness bug**, and empirically confirmed the classifier is race-free: `SpriteCommand.start()` can only emit `spawn`/`error` on a **microtask**, and all three consumers (`runSpawned`, `awaitStreamOpen`, `openPtyShell`'s `wire`) register their listeners **synchronously** in the same job that creates the command — so the open signal cannot be missed.

It did find three places where the code, the docs and the tests **disagreed about their own guarantees**. That disagreement is precisely how the earlier bugs got in, so they're closed here.

1. **The timeout now means what its doc says.** `MachineStreamOpenTimeoutError`'s doc claimed a timeout was "distinct from a stream that FAILED to open" and that "the two demand opposite responses" — but `killAtLocation` treated them identically, arbitrating both through `listStreams()`. Its test only passed because the fake listed the session as live, i.e. *for the same reason the transient-failure test passed*; swapping the timeout for a plain `Error` would not have failed it. Nothing pinned the claimed distinction.

   Fixed in the safe direction: a timeout now **short-circuits and keeps the row without consulting the listing at all**. A machine that would not answer the exec socket for a full 20s has not earned trust in its own session listing either. The test now proves the distinction — the listing reports the session **gone** (which for any other failure would drop the row), and the row is still kept.

2. **The substring fallback's rationale was wrong.** It claimed `closed before open` existed for a case "without a preceding error event" — but `websocket.js` emits that string *as* an error event inside the pre-open window, so it is already marked structurally. The branch is dead in production. Kept as a defensive fallback but labelled as one, so the next reader doesn't believe the substring is load-bearing and reintroduce a dependency on it.

3. **The fake replayed a one-shot event.** `fakeCommand` replayed `spawn` to late subscribers; the real SDK's `spawn` is one-shot with no replay. So the fake **structurally could not catch** a regression where `awaitStreamOpen` attached its listener too late — the exact race the wait exists to guard. Removed the replay, and reworked the three tests that depended on it to build their command **lazily inside `createSession`**, which is where the real SDK builds it.

## Validation (at `0acdd2edf`)

```
bun run build                     14/14 clean
bun run typecheck                 16/16 clean
bun run lint                      14/14 clean
packages/lib  test:coverage       7566 passed, thresholds OK (exit 0)
apps/realtime test:coverage        647 passed, thresholds OK (exit 0)
packages/lib  sandbox + machines   770 passed
```
