### PR TITLE
fix(mobile): always show hover-revealed controls on every touch device

### DIFF
--- a/apps/web/src/app/__tests__/touch-reveal-rules.test.ts
+++ b/apps/web/src/app/__tests__/touch-reveal-rules.test.ts
@@ -1,0 +1,176 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+
+/**
+ * The touch-reveal rules in globals.css are blunt attribute-substring selectors.
+ * Everything else about this feature is unit-tested, but until now the selectors
+ * themselves were only ever verified by reading the compiled CSS — nothing failed
+ * if they stopped matching the controls they exist to reveal, or started matching
+ * something they must not touch.
+ *
+ * This reads the SELECTORS OUT OF globals.css (rather than restating them, which
+ * would only test a copy of itself) and runs them against the real class strings
+ * from the components, so the CSS and the markup are pinned to each other.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const GLOBALS_CSS = resolve(here, '../globals.css');
+
+/** Selectors of every unlayered rule keyed on the coarse-pointer stamp. */
+let revealSelector: string;
+let displaySelectors: string[];
+
+beforeAll(() => {
+  const css = readFileSync(GLOBALS_CSS, 'utf8');
+
+  // Rule bodies are `:where([data-pointer='coarse']) <selector> { ... }`. Capture
+  // the FULL selector including the `:where()` ancestor — dropping it would leave
+  // the desktop assertion below testing nothing, since every rule would match
+  // regardless of whether <html> carries the stamp.
+  const rules = [...css.matchAll(/(:where\(\[data-pointer='coarse'\]\)[^{]+)\{([^}]+)\}/g)].map(
+    (m) => ({ selector: m[1].replace(/\s+/g, ' ').trim(), body: m[2] }),
+  );
+
+  const reveal = rules.filter((r) => r.body.includes('opacity: 1'));
+  expect(reveal, 'globals.css should contain exactly one opacity reveal rule').toHaveLength(1);
+  revealSelector = reveal[0].selector;
+
+  displaySelectors = rules.filter((r) => r.body.includes('display:')).map((r) => r.selector);
+  expect(displaySelectors.length, 'globals.css should contain display reveal rules').toBeGreaterThan(0);
+});
+
+/** Does an element with this class list get revealed on a coarse-pointer device? */
+function isRevealed(className: string, attrs: Record<string, string> = {}): boolean {
+  document.documentElement.setAttribute('data-pointer', 'coarse');
+  const el = document.createElement('div');
+  el.className = className;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return document.querySelectorAll(revealSelector).length === 1;
+}
+
+function isDisplayRevealed(className: string, attrs: Record<string, string> = {}): boolean {
+  document.documentElement.setAttribute('data-pointer', 'coarse');
+  const el = document.createElement('div');
+  el.className = className;
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.appendChild(el);
+  return displaySelectors.some((s) => document.querySelectorAll(s).length === 1);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.removeAttribute('data-pointer');
+});
+
+describe('touch reveal rules — controls that MUST become visible', () => {
+  // Class strings copied verbatim from the components they belong to.
+  const REVEALED: Array<[string, string]> = [
+    [
+      'MessageActionButtons — AI chat retry/edit/copy/delete (the headline bug)',
+      'flex items-center space-x-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity',
+    ],
+    [
+      'ui/sidebar SidebarMenuAction — page-tree row actions (md: viewport gate)',
+      'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+    ],
+    [
+      'TerminalPanes — the md: gate master re-introduced in #2006',
+      'absolute right-1.5 top-1.5 z-10 flex items-center opacity-100 transition-opacity focus-within:opacity-100 md:opacity-0 md:group-hover/pane:opacity-100',
+    ],
+    [
+      'MessageHoverToolbar — named group + pointer-events-none',
+      'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 pointer-events-none group-hover/msg:pointer-events-auto',
+    ],
+    [
+      'TabItem close button',
+      'ml-1 rounded-sm p-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100',
+    ],
+    [
+      'prompt-input remove-attachment button',
+      'absolute inset-0 size-5 rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100',
+    ],
+    [
+      'SidebarActivityTab sub-item — sm: gate + named group',
+      'h-5 w-5 sm:opacity-0 sm:group-hover/item:opacity-100 transition-opacity flex-shrink-0',
+    ],
+  ];
+
+  it.each(REVEALED)('reveals %s', (_name, className) => {
+    expect(isRevealed(className)).toBe(true);
+  });
+
+  it('does nothing at all on a desktop device (no data-pointer stamp)', () => {
+    const el = document.createElement('div');
+    el.className = 'flex items-center sm:opacity-0 sm:group-hover:opacity-100';
+    document.body.appendChild(el);
+    // No data-pointer on <html> — the ancestor condition fails, so no rule can match.
+    expect(document.querySelectorAll(revealSelector)).toHaveLength(0);
+  });
+});
+
+describe('touch reveal rules — decoration that MUST STAY hidden', () => {
+  const OPTED_OUT: Array<[string, string]> = [
+    [
+      'FeedbackDialog screenshot scrim (would black out the preview)',
+      'absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity',
+    ],
+    [
+      'resizable drag seam',
+      'h-full w-px bg-sidebar-border transition-opacity group-hover:opacity-100 group-data-[separator=active]:opacity-100 opacity-0',
+    ],
+    [
+      'ChannelView message timestamp',
+      'absolute inset-y-0 right-2 flex items-center opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums',
+    ],
+    [
+      'StatusConfigManager slug hint',
+      'text-xs text-muted-foreground ml-auto opacity-0 group-hover:opacity-100',
+    ],
+  ];
+
+  it.each(OPTED_OUT)('keeps %s hidden via data-hover-only', (_name, className) => {
+    expect(isRevealed(className, { 'data-hover-only': '' })).toBe(false);
+    // ...and would otherwise have been revealed, so the opt-out is load-bearing.
+    expect(isRevealed(className)).toBe(true);
+  });
+
+  it('never pins a hover FADE-OUT visible — it would cover the content beneath it', () => {
+    // prompt-input.tsx: the attachment thumbnail that fades out to expose its
+    // remove button. Forcing opacity:1 here would be an inversion.
+    expect(
+      isRevealed('absolute inset-0 flex size-5 rounded bg-background transition-opacity group-hover:opacity-0'),
+    ).toBe(false);
+  });
+
+  it('still excludes a fade-out that later grows an :opacity-100 variant (the landmine)', () => {
+    // This is the case the `:not([class*='group-hover:opacity-0'])` guard exists for.
+    // Without it, adding focus-within:opacity-100 to a scrim pins the scrim VISIBLE.
+    expect(
+      isRevealed('absolute inset-0 bg-black/50 transition-opacity group-hover:opacity-0 focus-within:opacity-100'),
+    ).toBe(false);
+  });
+});
+
+describe('touch reveal rules — display-based reveals', () => {
+  it('reveals a hidden group-hover:flex control', () => {
+    expect(isDisplayRevealed('hidden group-hover:flex items-center gap-1')).toBe(true);
+  });
+
+  it('keeps TabItem’s Cmd+N shortcut hint hidden — it is a keyboard affordance', () => {
+    expect(
+      isDisplayRevealed('text-[10px] text-white/70 flex-shrink-0 hidden group-hover:inline', {
+        'data-hover-only': '',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not let group-hover:flex-row masquerade as a display reveal', () => {
+    // Exact-token (`~=`) matching, not substring: a flex-DIRECTION change on hover
+    // must not be forced to `display: flex` on touch.
+    expect(isDisplayRevealed('flex group-hover:flex-row items-center')).toBe(false);
+  });
+});

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -627,7 +627,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className={cn("flex-1 min-w-0", !isFirst && "touch:pr-28")}>
+                  <div className={cn("flex-1 min-w-0", !isFirst && "[@media(hover:none)]:pr-28 touch:pr-28")}>
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -621,13 +621,13 @@ export default function InboxDMPage() {
                     </Avatar>
                   ) : (
                     <div className="h-10 w-10 flex-shrink-0 relative" aria-hidden>
-                      <span className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
+                      <span data-hover-only="" className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
                         {new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                       </span>
                     </div>
                   )}
 
-                  <div className={cn("flex-1 min-w-0", !isFirst && "[@media(hover:none)]:pr-28")}>
+                  <div className={cn("flex-1 min-w-0", !isFirst && "touch:pr-28")}>
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,10 +55,30 @@ svg.lucide {
   opacity: 0;
 }
 
-/* Display-based reveal (`hidden group-hover:inline`), not opacity-based. */
-:where([data-pointer='coarse'])
-  [class*='group-hover:inline']:not([data-hover-only]) {
+/* Display-based reveals (`hidden group-hover:inline`), not opacity-based. Only
+   `inline` is in use today; the others are the natural forms for the next such
+   control, covered now so it can't silently re-break.
+
+   These match the exact class token (`~=`), NOT a substring. Substring matching
+   is correct for the opacity rules above — it is what catches `sm:` and
+   named-group variants — but here it would make `group-hover:flex` also match
+   `group-hover:flex-row` and force `display: flex` on an element that only asked
+   to change its flex-direction. For a display reveal there is nothing to catch:
+   the token is written out in full. */
+:where([data-pointer='coarse']) [class~='group-hover:inline']:not([data-hover-only]) {
   display: inline;
+}
+:where([data-pointer='coarse']) [class~='group-hover:inline-flex']:not([data-hover-only]) {
+  display: inline-flex;
+}
+:where([data-pointer='coarse']) [class~='group-hover:flex']:not([data-hover-only]) {
+  display: flex;
+}
+:where([data-pointer='coarse']) [class~='group-hover:block']:not([data-hover-only]) {
+  display: block;
+}
+:where([data-pointer='coarse']) [class~='group-hover:grid']:not([data-hover-only]) {
+  display: grid;
 }
 
 @theme inline {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,8 +7,58 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Touch devices are stamped with data-pointer="coarse" on <html> pre-paint by
+   the inline script in layout.tsx (see lib/pointer-capability.ts). Use `touch:`
+   for any new code that needs a touch-only rule. */
+@custom-variant touch (&:where([data-pointer='coarse'] *));
+
 svg.lucide {
   stroke-width: 1.5;
+}
+
+/* ---------------------------------------------------------------------------
+   Hover-revealed controls on touch devices.
+
+   There is no hover on a touchscreen, so every `opacity-0 group-hover:opacity-100`
+   affordance (message retry/edit/copy, page-tree row actions, tab close buttons,
+   version-history and activity actions, …) is unreachable. Worse, the `sm:`/`md:`
+   -prefixed variants consult no pointer signal at all, so they break in iPad
+   Safari too — an iPad is wide enough to match `sm:`, but never hovers.
+
+   These rules are UNLAYERED (Tailwind utilities live in `@layer utilities`), so
+   they win without `!important` — same trick as `svg.lucide` above.
+
+   Attribute-substring matching is required: a plain `.group-hover\:opacity-100`
+   selector would miss both the named-group variants (`group-hover/msg:`,
+   `group-hover/pane:`, `group-hover/item:`, `group-hover/menu-item:`) and the
+   `sm:`/`md:`-prefixed forms.
+
+   `data-hover-only` opts an element out — for decoration (scrims, drag seams,
+   timestamps) as opposed to affordances.
+   --------------------------------------------------------------------------- */
+
+/* Reveal pair: a resting `opacity-0` that a group-hover restores to full.
+   `pointer-events: auto` is required — MessageHoverToolbar and prompt-input pair
+   their `opacity-0` with `pointer-events-none`, so opacity alone would leave the
+   buttons visible but dead. */
+:where([data-pointer='coarse'])
+  [class*='opacity-0'][class*='group-hover'][class*=':opacity-100']:not([data-hover-only]) {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* The other half of a reveal pair: an element that fades OUT on hover to expose
+   the control underneath (the attachment thumbnail under its remove button).
+   Pin it to the hover state too, rather than letting the rule above invert it. */
+:where([data-pointer='coarse'])
+  [class*='group-hover:opacity-0']:not([class*=':opacity-100']):not([data-hover-only]) {
+  opacity: 0;
+}
+
+/* Display-based reveal (`hidden group-hover:inline`), not opacity-based. */
+:where([data-pointer='coarse'])
+  [class*='group-hover:inline']:not([data-hover-only]) {
+  display: inline;
 }
 
 @theme inline {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,9 +55,15 @@ svg.lucide {
   pointer-events: auto;
 }
 
-/* Display-based reveals (`hidden group-hover:inline`), not opacity-based. Only
-   `inline` is in use today; the others are the natural forms for the next such
-   control, covered now so it can't silently re-break.
+/* Display-based reveals (`hidden group-hover:flex`), not opacity-based.
+
+   These have ZERO live matches today, and that is deliberate rather than an
+   oversight: the repo's only `hidden group-hover:inline` is TabItem's Cmd+N
+   shortcut hint, which is a keyboard affordance and is opted out. The rules stay
+   as the standing policy, so the next display-based control — `hidden
+   group-hover:flex` is the idiomatic way to hide a button row — is revealed on
+   touch instead of silently disappearing, which is the entire bug class this file
+   exists to close.
 
    These match the exact class token (`~=`), NOT a substring. Substring matching
    is correct for the opacity rules above — it is what catches `sm:` and

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -40,19 +40,19 @@ svg.lucide {
 /* Reveal pair: a resting `opacity-0` that a group-hover restores to full.
    `pointer-events: auto` is required — MessageHoverToolbar and prompt-input pair
    their `opacity-0` with `pointer-events-none`, so opacity alone would leave the
-   buttons visible but dead. */
+   buttons visible but dead.
+
+   The `group-hover:opacity-0` exclusion matters: an element that fades OUT on
+   hover (to expose a control beneath it) also carries the `opacity-0` substring.
+   Without the guard, adding any `:opacity-100` variant to such an element — a
+   `focus-within:opacity-100`, say — would drag it into this rule and pin the
+   fade-out permanently VISIBLE, hiding whatever it covers. We reveal controls;
+   we do not simulate a whole hover state. Elements that fade out are simply left
+   alone, at their natural resting opacity. */
 :where([data-pointer='coarse'])
-  [class*='opacity-0'][class*='group-hover'][class*=':opacity-100']:not([data-hover-only]) {
+  [class*='opacity-0'][class*='group-hover'][class*=':opacity-100']:not([class*='group-hover:opacity-0']):not([data-hover-only]) {
   opacity: 1;
   pointer-events: auto;
-}
-
-/* The other half of a reveal pair: an element that fades OUT on hover to expose
-   the control underneath (the attachment thumbnail under its remove button).
-   Pin it to the hover state too, rather than letting the rule above invert it. */
-:where([data-pointer='coarse'])
-  [class*='group-hover:opacity-0']:not([class*=':opacity-100']):not([data-hover-only]) {
-  opacity: 0;
 }
 
 /* Display-based reveals (`hidden group-hover:inline`), not opacity-based. Only

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import ClientTrackingProvider from "@/components/providers/ClientTrackingProvide
 import ConsentProvider from "@/components/providers/ConsentProvider";
 import { Toaster } from "@/components/ui/sonner";
 import { getRequestNonce } from "@/lib/request-nonce";
+import { POINTER_CAPABILITY_SCRIPT } from "@/lib/pointer-capability";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -99,6 +100,15 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        {/* Stamp data-pointer="coarse" on <html> before first paint so the
+            unlayered touch rules in globals.css apply without a flash of hidden
+            controls. Emitted only client-side: the server renders no attribute,
+            so desktop SSR output is unchanged. <html> carries
+            suppressHydrationWarning, so the pre-paint mutation is free. */}
+        <script
+          nonce={nonce}
+          dangerouslySetInnerHTML={{ __html: POINTER_CAPABILITY_SCRIPT }}
+        />
         {/* Set webpack nonce for dynamically loaded chunks (next/dynamic) */}
         <script
           nonce={nonce}

--- a/apps/web/src/components/ai/ui/prompt-input.tsx
+++ b/apps/web/src/components/ai/ui/prompt-input.tsx
@@ -326,9 +326,13 @@ export function PromptInputAttachment({
             </div>
             <Button
               aria-label="Remove attachment"
-              // On touch the button is pinned visible (globals.css) while the
-              // thumbnail beneath it stays visible too — there is no hover to fade
-              // it out — so give the ✕ a backdrop to stay legible over an image.
+              // On touch this button is pinned visible (globals.css) and there is no
+              // hover to fade the thumbnail out from under it, so the ✕ needs a
+              // backdrop or it is unreadable over a dark image. At a 20px chip there
+              // is no room for both: the backdrop largely occludes the thumbnail.
+              // That is the right trade — the filename beside it identifies the
+              // attachment, and a legible remove control matters more than a 20px
+              // preview.
               className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 touch:bg-background/80 [&>svg]:size-2.5"
               onClick={(e) => {
                 e.stopPropagation();

--- a/apps/web/src/components/ai/ui/prompt-input.tsx
+++ b/apps/web/src/components/ai/ui/prompt-input.tsx
@@ -326,7 +326,10 @@ export function PromptInputAttachment({
             </div>
             <Button
               aria-label="Remove attachment"
-              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 [&>svg]:size-2.5"
+              // On touch the button is pinned visible (globals.css) while the
+              // thumbnail beneath it stays visible too — there is no hover to fade
+              // it out — so give the ✕ a backdrop to stay legible over an image.
+              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 touch:bg-background/80 [&>svg]:size-2.5"
               onClick={(e) => {
                 e.stopPropagation();
                 attachments.remove(data.id);

--- a/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, type MouseEvent } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, ExternalLink, Folder, MoreHorizontal, Star } from "lucide-react";
 import { useTabsStore } from "@/stores/useTabsStore";
+import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { shouldOpenInNewTab } from "@/lib/tabs/tab-navigation-utils";
 import {
   Collapsible,
@@ -148,6 +149,7 @@ interface FavoriteItemProps {
 
 function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove, hideTabActions }: FavoriteItemProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const isTouchDevice = useTouchDevice();
 
   const title =
     favorite.itemType === "drive"
@@ -202,7 +204,7 @@ function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove, hideTabA
             size="icon"
             className={cn(
               "absolute right-1 h-6 w-6 transition-opacity",
-              isHovered ? "opacity-100" : "opacity-0"
+              isTouchDevice || isHovered ? "opacity-100" : "opacity-0"
             )}
             onClick={(e) => e.stopPropagation()}
           >

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -416,7 +416,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
               <div
                 className={cn(
                   "flex items-center ml-2 transition-opacity duration-200",
-                  isHovered ? "opacity-100" : "opacity-0"
+                  isTouchDevice || isHovered ? "opacity-100" : "opacity-0"
                 )}
               >
                 <button

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -702,12 +702,12 @@ function ChannelView({ page }: ChannelViewProps) {
                               </Avatar>
                             ) : (
                               <div className="size-8 shrink-0 relative" aria-hidden>
-                                <span className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
+                                <span data-hover-only="" className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
                                   {new Date(m.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                                 </span>
                               </div>
                             )}
-                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "[@media(hover:none)]:pr-28")}>
+                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "touch:pr-28")}>
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -707,7 +707,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "touch:pr-28")}>
+                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "[@media(hover:none)]:pr-28 touch:pr-28")}>
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/StatusConfigManager.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/StatusConfigManager.tsx
@@ -234,7 +234,8 @@ export function StatusConfigManager({
                     ) : (
                       <>
                         <Badge className={cn('text-xs', config.color)}>{config.name}</Badge>
-                        <span className="text-xs text-muted-foreground ml-auto opacity-0 group-hover:opacity-100">
+                        {/* Metadata hint, not a control — keep it hover-only. */}
+                        <span data-hover-only="" className="text-xs text-muted-foreground ml-auto opacity-0 group-hover:opacity-100">
                           {config.slug}
                         </span>
                         <DropdownMenu>

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -781,7 +781,7 @@ export function ThreadPanel({
                   {author.image && <AvatarImage src={author.image} />}
                   <AvatarFallback>{initial}</AvatarFallback>
                 </Avatar>
-                <div className={cn("min-w-0 flex-1", "touch:pr-28")}>
+                <div className={cn("min-w-0 flex-1", "[@media(hover:none)]:pr-28 touch:pr-28")}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold">{author.name}</span>
                     <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -781,7 +781,7 @@ export function ThreadPanel({
                   {author.image && <AvatarImage src={author.image} />}
                   <AvatarFallback>{initial}</AvatarFallback>
                 </Avatar>
-                <div className={cn("min-w-0 flex-1", "[@media(hover:none)]:pr-28")}>
+                <div className={cn("min-w-0 flex-1", "touch:pr-28")}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold">{author.name}</span>
                     <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -18,6 +18,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { CustomScrollArea } from "@/components/ui/custom-scroll-area";
 import { useDriveStore, type Drive } from "@/hooks/useDrive";
 import { useFavorites, useFavoritesSync } from "@/hooks/useFavorites";
+import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { fetchWithAuth } from "@/lib/auth/auth-fetch";
 import CreateDriveDialog from "@/components/layout/left-sidebar/CreateDriveDialog";
 import { cn } from "@/lib/utils";
@@ -287,6 +288,7 @@ function DriveMenuItem({
   onToggleFavorite,
 }: DriveMenuItemProps) {
   const [isHovered, setIsHovered] = useState(false);
+  const isTouchDevice = useTouchDevice();
 
   return (
     <DropdownMenuItem
@@ -304,7 +306,7 @@ function DriveMenuItem({
         onClick={onToggleFavorite}
         className={cn(
           "h-6 w-6 flex items-center justify-center rounded-sm transition-opacity",
-          isHovered || isFavorite ? "opacity-100" : "opacity-0",
+          isTouchDevice || isHovered || isFavorite ? "opacity-100" : "opacity-0",
           "hover:bg-accent"
         )}
       >

--- a/apps/web/src/components/layout/tabs/TabItem.tsx
+++ b/apps/web/src/components/layout/tabs/TabItem.tsx
@@ -181,7 +181,10 @@ export const TabItem = memo(function TabItem({
               title="Unsaved changes"
             />
           ) : shortcutNumber && !tab.isPinned ? (
-            <span className="text-[10px] text-white/70 flex-shrink-0 hidden group-hover:inline">
+            // The Cmd/Ctrl+N shortcut hint — a keyboard affordance, so it stays
+            // hover-only. Revealing it on touch would pin a stray digit into every
+            // tab, next to the close button this same mechanism already surfaces.
+            <span data-hover-only="" className="text-[10px] text-white/70 flex-shrink-0 hidden group-hover:inline">
               {shortcutNumber}
             </span>
           ) : null}

--- a/apps/web/src/components/shared/FeedbackDialog.tsx
+++ b/apps/web/src/components/shared/FeedbackDialog.tsx
@@ -316,10 +316,17 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
                   <button
                     type="button"
                     onClick={() => removeFile(af.id)}
-                    // A full-bleed black scrim — pinning it visible on touch would
-                    // permanently black out the screenshot preview.
+                    // Opted out of the blanket reveal: this is a full-bleed black
+                    // scrim, and pinning it visible would black out the screenshot
+                    // preview on every phone.
+                    //
+                    // But leaving it at opacity-0 is not good enough either — a
+                    // `<button>` still takes taps, so on touch this was an invisible
+                    // full-bleed destructive target: tap your screenshot to inspect
+                    // it, silently delete it instead. On touch it becomes a real
+                    // corner delete badge; on desktop the hover scrim is unchanged.
                     data-hover-only=""
-                    className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                    className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center touch:inset-auto touch:top-1 touch:right-1 touch:size-6 touch:rounded-full touch:bg-black/60 touch:opacity-100"
                   >
                     <X className="w-4 h-4 text-white" />
                   </button>

--- a/apps/web/src/components/shared/FeedbackDialog.tsx
+++ b/apps/web/src/components/shared/FeedbackDialog.tsx
@@ -316,6 +316,9 @@ export function FeedbackDialog({ isOpen, onClose }: FeedbackDialogProps) {
                   <button
                     type="button"
                     onClick={() => removeFile(af.id)}
+                    // A full-bleed black scrim — pinning it visible on touch would
+                    // permanently black out the screenshot preview.
+                    data-hover-only=""
                     className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
                   >
                     <X className="w-4 h-4 text-white" />

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -83,10 +83,13 @@ export function MessageHoverToolbar({
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.
-        // Touch / no-hover devices: always visible so message actions remain reachable.
+        // Touch devices: always visible so message actions remain reachable. This used
+        // to key off `[@media(hover:none)]`, which is dead on a desktop-class iPad —
+        // it reports `hover: hover`. `touch:` keys off the JS-stamped data-pointer
+        // attribute instead (see lib/pointer-capability.ts).
         'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
         'pointer-events-none group-hover/msg:pointer-events-auto focus-within:pointer-events-auto',
-        '[@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto',
+        'touch:opacity-100 touch:pointer-events-auto',
         'transition-opacity',
         pickerOpen && 'opacity-100 pointer-events-auto',
         className,

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -83,12 +83,17 @@ export function MessageHoverToolbar({
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.
-        // Touch devices: always visible so message actions remain reachable. This used
-        // to key off `[@media(hover:none)]`, which is dead on a desktop-class iPad —
-        // it reports `hover: hover`. `touch:` keys off the JS-stamped data-pointer
-        // attribute instead (see lib/pointer-capability.ts).
+        // Touch devices: always visible so message actions remain reachable.
+        //
+        // Both gates are kept on purpose. `[@media(hover:none)]` catches iPhone and
+        // Android with zero JS, but is dead on a desktop-class iPad, which reports
+        // `hover: hover`. `touch:` catches that iPad, but depends on the inline script
+        // in layout.tsx having stamped data-pointer (see lib/pointer-capability.ts).
+        // Together they degrade gracefully: if the script never runs, every device the
+        // media query already covered still works.
         'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
         'pointer-events-none group-hover/msg:pointer-events-auto focus-within:pointer-events-auto',
+        '[@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto',
         'touch:opacity-100 touch:pointer-events-auto',
         'transition-opacity',
         pickerOpen && 'opacity-100 pointer-events-auto',

--- a/apps/web/src/components/ui/resizable.tsx
+++ b/apps/web/src/components/ui/resizable.tsx
@@ -50,6 +50,8 @@ function ResizableHandle({
           handles both orientations — a fixed absolute/translate line was
           hardcoded vertical and broke for orientation="vertical" groups. */}
       <div
+        // Decoration, not an affordance — the seam must not be pinned visible on touch.
+        data-hover-only=""
         className={cn(
           "h-full w-px bg-sidebar-border transition-opacity duration-150",
           "group-aria-[orientation=horizontal]:h-px group-aria-[orientation=horizontal]:w-full",

--- a/apps/web/src/hooks/__tests__/useTouchDevice.test.ts
+++ b/apps/web/src/hooks/__tests__/useTouchDevice.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useTouchDevice } from '../useTouchDevice';
+
+/**
+ * Pins the hook to `detectCoarsePointer`. Without this, reverting `getSnapshot`
+ * to a bare `matchMedia('(pointer: coarse)')` check — the obvious-looking
+ * simplification — passes every other test in the suite while silently
+ * re-breaking every JS-hover affordance on a desktop-class iPad.
+ */
+vi.mock('@/lib/pointer-capability', () => ({
+  detectCoarsePointer: vi.fn(() => false),
+}));
+
+const { detectCoarsePointer } = await import('@/lib/pointer-capability');
+const detectMock = vi.mocked(detectCoarsePointer);
+
+afterEach(() => {
+  detectMock.mockReset();
+});
+
+describe('useTouchDevice', () => {
+  it('reports touch when detectCoarsePointer says so', () => {
+    detectMock.mockReturnValue(true);
+    const { result } = renderHook(() => useTouchDevice());
+    expect(result.current).toBe(true);
+  });
+
+  it('reports no touch when detectCoarsePointer says so', () => {
+    detectMock.mockReturnValue(false);
+    const { result } = renderHook(() => useTouchDevice());
+    expect(result.current).toBe(false);
+  });
+
+  it('does not decide on its own — the verdict comes from detectCoarsePointer', () => {
+    // jsdom's matchMedia stub always reports `matches: false` (see test/setup.ts).
+    // A hook that consulted the media query directly could never return true here.
+    detectMock.mockReturnValue(true);
+    const { result } = renderHook(() => useTouchDevice());
+
+    expect(detectMock).toHaveBeenCalled();
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/useTouchDevice.ts
+++ b/apps/web/src/hooks/useTouchDevice.ts
@@ -2,9 +2,14 @@
 
 import { useSyncExternalStore } from "react";
 
+import { detectCoarsePointer } from "@/lib/pointer-capability";
+
 /**
  * Detects if the current device is a touch device.
- * Uses coarse pointer detection which is more reliable than touch event checks.
+ *
+ * Delegates to `detectCoarsePointer()` — `(pointer: coarse)` alone is not enough,
+ * because a desktop-class iPad (the Capacitor app's default content mode, and
+ * iPad Safari's "Request Desktop Site") reports `pointer: fine`.
  */
 
 const TOUCH_QUERY = "(pointer: coarse)";
@@ -32,12 +37,7 @@ const subscribe = (callback: () => void) => {
   };
 };
 
-const getSnapshot = () => {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return window.matchMedia(TOUCH_QUERY).matches;
-};
+const getSnapshot = () => detectCoarsePointer();
 
 const getServerSnapshot = () => false;
 

--- a/apps/web/src/lib/__tests__/pointer-capability.test.ts
+++ b/apps/web/src/lib/__tests__/pointer-capability.test.ts
@@ -135,9 +135,36 @@ describe('POINTER_CAPABILITY_SCRIPT', () => {
     expect(evalScript({ coarse: false, maxTouchPoints: 0, userAgent: UA.macOS })).toEqual({});
   });
 
-  it('agrees with detectCoarsePointer on the iPhone', () => {
-    expect(evalScript({ coarse: true, maxTouchPoints: 5, userAgent: UA.iPhone })).toEqual({
-      'data-pointer': 'coarse',
+  /**
+   * The script is a hand-minified copy of `detectCoarsePointer` — it has to be,
+   * because it runs before any bundle loads. That duplication is the one real
+   * maintenance hazard in this module, so pin the two together: every device in
+   * the matrix must produce the same verdict from both implementations. Change
+   * one without the other and this fails.
+   */
+  describe('parity with detectCoarsePointer', () => {
+    const DEVICES: Array<{ name: string; device: DeviceShape }> = [
+      { name: 'iPhone', device: { coarse: true, maxTouchPoints: 5, userAgent: UA.iPhone } },
+      { name: 'iPad, mobile content mode', device: { coarse: true, maxTouchPoints: 5, userAgent: UA.mobileIPad } },
+      { name: 'iPad, desktop-class', device: { coarse: false, maxTouchPoints: 5, userAgent: UA.desktopClassIPad } },
+      {
+        name: 'iPad, desktop-class, Capacitor native',
+        device: { coarse: false, maxTouchPoints: 5, userAgent: UA.desktopClassIPad, capacitorNative: true },
+      },
+      { name: 'macOS', device: { coarse: false, maxTouchPoints: 0, userAgent: UA.macOS } },
+      {
+        name: 'macOS with a non-native Capacitor shim',
+        device: { coarse: false, maxTouchPoints: 0, userAgent: UA.macOS, capacitorNative: false },
+      },
+      { name: 'Windows desktop', device: { coarse: false, maxTouchPoints: 0, userAgent: UA.windows } },
+      { name: 'Windows touchscreen laptop', device: { coarse: false, maxTouchPoints: 10, userAgent: UA.windows } },
+    ];
+
+    it.each(DEVICES)('agrees on $name', ({ device }) => {
+      const stamped = evalScript(device)['data-pointer'] === 'coarse';
+
+      stubDevice(device);
+      expect(stamped).toBe(detectCoarsePointer());
     });
   });
 });

--- a/apps/web/src/lib/__tests__/pointer-capability.test.ts
+++ b/apps/web/src/lib/__tests__/pointer-capability.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { detectCoarsePointer, POINTER_CAPABILITY_SCRIPT } from '../pointer-capability';
+
+/** Real-world user-agent strings, verbatim. */
+const UA = {
+  /** iPadOS with `preferredContentMode: 'recommended'` — reports as a Mac. */
+  desktopClassIPad:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+  /** iPad Safari in mobile content mode. */
+  mobileIPad:
+    'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  iPhone:
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  /** Genuine macOS — UA is indistinguishable from a desktop-class iPad. */
+  macOS:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  windows:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+};
+
+interface DeviceShape {
+  coarse: boolean;
+  maxTouchPoints: number;
+  userAgent: string;
+  capacitorNative?: boolean;
+}
+
+function stubDevice({ coarse, maxTouchPoints, userAgent, capacitorNative }: DeviceShape) {
+  vi.stubGlobal('window', {
+    matchMedia: (query: string) => ({ matches: query === '(pointer: coarse)' && coarse }),
+    ...(capacitorNative === undefined
+      ? {}
+      : { Capacitor: { isNativePlatform: () => capacitorNative } }),
+  });
+  vi.stubGlobal('navigator', { maxTouchPoints, userAgent });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('detectCoarsePointer', () => {
+  it('returns false during SSR, when there is no window', () => {
+    vi.stubGlobal('window', undefined);
+    expect(detectCoarsePointer()).toBe(false);
+  });
+
+  it('detects the Capacitor native shell even when it reports a fine pointer', () => {
+    // The iOS app runs desktop-class by default: pointer is `fine`, hover is `hover`.
+    stubDevice({
+      coarse: false,
+      maxTouchPoints: 5,
+      userAgent: UA.desktopClassIPad,
+      capacitorNative: true,
+    });
+    expect(detectCoarsePointer()).toBe(true);
+  });
+
+  it('does not treat a non-native Capacitor shim as touch on desktop', () => {
+    stubDevice({
+      coarse: false,
+      maxTouchPoints: 0,
+      userAgent: UA.macOS,
+      capacitorNative: false,
+    });
+    expect(detectCoarsePointer()).toBe(false);
+  });
+
+  it('detects a plain coarse pointer (iPhone)', () => {
+    stubDevice({ coarse: true, maxTouchPoints: 5, userAgent: UA.iPhone });
+    expect(detectCoarsePointer()).toBe(true);
+  });
+
+  it('detects an iPad in mobile content mode via the coarse-pointer query', () => {
+    stubDevice({ coarse: true, maxTouchPoints: 5, userAgent: UA.mobileIPad });
+    expect(detectCoarsePointer()).toBe(true);
+  });
+
+  it('detects a desktop-class iPad in Safari — the case every media query misses', () => {
+    // Reports `pointer: fine` and a Macintosh UA. maxTouchPoints is the only tell.
+    stubDevice({ coarse: false, maxTouchPoints: 5, userAgent: UA.desktopClassIPad });
+    expect(detectCoarsePointer()).toBe(true);
+  });
+
+  it('returns false on real macOS, which has the same UA but no touch points', () => {
+    stubDevice({ coarse: false, maxTouchPoints: 0, userAgent: UA.macOS });
+    expect(detectCoarsePointer()).toBe(false);
+  });
+
+  it('returns false on a touchscreen Windows laptop, which must keep hover behaviour', () => {
+    // Deliberately out of scope: a fine pointer is present, so hover works.
+    stubDevice({ coarse: false, maxTouchPoints: 10, userAgent: UA.windows });
+    expect(detectCoarsePointer()).toBe(false);
+  });
+
+  it('tolerates a missing matchMedia', () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('navigator', { maxTouchPoints: 0, userAgent: UA.macOS });
+    expect(detectCoarsePointer()).toBe(false);
+  });
+});
+
+describe('POINTER_CAPABILITY_SCRIPT', () => {
+  const evalScript = (device: DeviceShape) => {
+    const html: Record<string, string> = {};
+    const win = {
+      Capacitor:
+        device.capacitorNative === undefined
+          ? undefined
+          : { isNativePlatform: () => device.capacitorNative },
+      matchMedia: (query: string) => ({
+        matches: query === '(pointer: coarse)' && device.coarse,
+      }),
+    };
+    const nav = { maxTouchPoints: device.maxTouchPoints, userAgent: device.userAgent };
+    const doc = {
+      documentElement: {
+        setAttribute: (name: string, value: string) => {
+          html[name] = value;
+        },
+      },
+    };
+    new Function('window', 'navigator', 'document', POINTER_CAPABILITY_SCRIPT)(win, nav, doc);
+    return html;
+  };
+
+  it('stamps data-pointer="coarse" on a desktop-class iPad', () => {
+    expect(evalScript({ coarse: false, maxTouchPoints: 5, userAgent: UA.desktopClassIPad })).toEqual(
+      { 'data-pointer': 'coarse' },
+    );
+  });
+
+  it('stamps nothing on real macOS — desktop markup is untouched', () => {
+    expect(evalScript({ coarse: false, maxTouchPoints: 0, userAgent: UA.macOS })).toEqual({});
+  });
+
+  it('agrees with detectCoarsePointer on the iPhone', () => {
+    expect(evalScript({ coarse: true, maxTouchPoints: 5, userAgent: UA.iPhone })).toEqual({
+      'data-pointer': 'coarse',
+    });
+  });
+});

--- a/apps/web/src/lib/pointer-capability.ts
+++ b/apps/web/src/lib/pointer-capability.ts
@@ -15,27 +15,20 @@
  * laptops and change desktop rendering.
  */
 
-interface CapacitorGlobal {
-  isNativePlatform?: () => boolean;
-}
-
-type WindowWithCapacitor = Window & { Capacitor?: CapacitorGlobal };
+import { isCapacitorApp } from './capacitor-bridge';
 
 export function detectCoarsePointer(): boolean {
   if (typeof window === 'undefined') return false;
 
   // 1. Capacitor native shell — true regardless of content mode.
-  const capacitor = (window as WindowWithCapacitor).Capacitor;
-  if (capacitor?.isNativePlatform?.()) return true;
+  if (isCapacitorApp()) return true;
 
   // 2. Standard coarse pointer — iPhone, Android, iPad in mobile content mode.
   if (window.matchMedia?.('(pointer: coarse)').matches) return true;
 
   // 3. Desktop-class iPad: reports `pointer: fine` but still has multi-touch.
   //    Real macOS has maxTouchPoints === 0, so it never matches.
-  const nav = typeof navigator === 'undefined' ? undefined : navigator;
-  if (!nav) return false;
-  return (nav.maxTouchPoints ?? 0) > 1 && /iPad|Macintosh|iPhone/.test(nav.userAgent);
+  return (navigator.maxTouchPoints ?? 0) > 1 && /iPad|Macintosh|iPhone/.test(navigator.userAgent);
 }
 
 /**

--- a/apps/web/src/lib/pointer-capability.ts
+++ b/apps/web/src/lib/pointer-capability.ts
@@ -4,8 +4,14 @@
  * Why not `@media (hover: none)` / `(pointer: coarse)` alone?
  * The iOS app sets `ios.preferredContentMode: 'recommended'`, which gives the
  * iPad desktop-class browsing: it reports `hover: hover` and `pointer: fine`.
- * A CSS-only gate is therefore dead on the exact device that needs it — see the
- * previously-dead `[@media(hover:none)]` rule this module replaces.
+ * A CSS-only gate is therefore dead on the exact device that needs it — the
+ * `[@media(hover:none)]` rule in MessageHoverToolbar had been silently inert on
+ * that iPad for exactly this reason.
+ *
+ * This module does not *replace* those media queries — it backstops them. They
+ * still cover iPhone and Android with zero JS; this covers the one device they
+ * cannot see. Both gates ship together so that if this script never runs,
+ * everything the media query already handled keeps working.
  *
  * `navigator.maxTouchPoints` is the only reliable tell: iPadOS reports 5 even in
  * desktop-class mode, while real macOS reports 0. The repo already trusts this
@@ -32,8 +38,11 @@ export function detectCoarsePointer(): boolean {
 }
 
 /**
- * The pre-paint inline script stamped into <body> by the root layout. Kept here
- * (rather than inline in layout.tsx) so the logic and its unit tests live
- * together. Must stay behaviourally identical to `detectCoarsePointer`.
+ * The pre-paint inline script stamped into <body> by the root layout. It has to
+ * be a hand-minified copy of `detectCoarsePointer` — it runs before any bundle
+ * loads — which makes it the one real maintenance hazard here. It is kept in this
+ * file, beside the function it mirrors, and a parity test in
+ * `__tests__/pointer-capability.test.ts` asserts the two agree on every device in
+ * the matrix. Change one without the other and that test fails.
  */
 export const POINTER_CAPABILITY_SCRIPT = `(function(){try{var C=window.Capacitor;var t=(C&&C.isNativePlatform&&C.isNativePlatform())||(window.matchMedia&&window.matchMedia('(pointer: coarse)').matches)||((navigator.maxTouchPoints||0)>1&&/iPad|Macintosh|iPhone/.test(navigator.userAgent));if(t){document.documentElement.setAttribute('data-pointer','coarse');}}catch(e){}})();`;

--- a/apps/web/src/lib/pointer-capability.ts
+++ b/apps/web/src/lib/pointer-capability.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical touch/coarse-pointer detection.
+ *
+ * Why not `@media (hover: none)` / `(pointer: coarse)` alone?
+ * The iOS app sets `ios.preferredContentMode: 'recommended'`, which gives the
+ * iPad desktop-class browsing: it reports `hover: hover` and `pointer: fine`.
+ * A CSS-only gate is therefore dead on the exact device that needs it — see the
+ * previously-dead `[@media(hover:none)]` rule this module replaces.
+ *
+ * `navigator.maxTouchPoints` is the only reliable tell: iPadOS reports 5 even in
+ * desktop-class mode, while real macOS reports 0. The repo already trusts this
+ * escape hatch in `useEnterToSend.ts`.
+ *
+ * Deliberately NOT `(any-pointer: coarse)` — that would flip touchscreen Windows
+ * laptops and change desktop rendering.
+ */
+
+interface CapacitorGlobal {
+  isNativePlatform?: () => boolean;
+}
+
+type WindowWithCapacitor = Window & { Capacitor?: CapacitorGlobal };
+
+export function detectCoarsePointer(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  // 1. Capacitor native shell — true regardless of content mode.
+  const capacitor = (window as WindowWithCapacitor).Capacitor;
+  if (capacitor?.isNativePlatform?.()) return true;
+
+  // 2. Standard coarse pointer — iPhone, Android, iPad in mobile content mode.
+  if (window.matchMedia?.('(pointer: coarse)').matches) return true;
+
+  // 3. Desktop-class iPad: reports `pointer: fine` but still has multi-touch.
+  //    Real macOS has maxTouchPoints === 0, so it never matches.
+  const nav = typeof navigator === 'undefined' ? undefined : navigator;
+  if (!nav) return false;
+  return (nav.maxTouchPoints ?? 0) > 1 && /iPad|Macintosh|iPhone/.test(nav.userAgent);
+}
+
+/**
+ * The pre-paint inline script stamped into <body> by the root layout. Kept here
+ * (rather than inline in layout.tsx) so the logic and its unit tests live
+ * together. Must stay behaviourally identical to `detectCoarsePointer`.
+ */
+export const POINTER_CAPABILITY_SCRIPT = `(function(){try{var C=window.Capacitor;var t=(C&&C.isNativePlatform&&C.isNativePlatform())||(window.matchMedia&&window.matchMedia('(pointer: coarse)').matches)||((navigator.maxTouchPoints||0)>1&&/iPad|Macintosh|iPhone/.test(navigator.userAgent));if(t){document.documentElement.setAttribute('data-pointer','coarse');}}catch(e){}})();`;


### PR DESCRIPTION
On iPad — **both the Capacitor app and iPad Safari** — every hover-revealed control was unreachable. There is no hover on a touchscreen, so AI chat message actions (retry / edit / copy / delete), page-tree row actions, sidebar affordances, tab close buttons, and version-history / activity actions were invisible, and those features were effectively gone.

This makes **any touch device — iPhone or iPad, native app or mobile browser — always show them. Desktop is completely unchanged.**

## Why the obvious fix (`@media (hover: none)`) is wrong

The iOS app sets `ios.preferredContentMode: 'recommended'` (`apps/ios/capacitor.config.ts`), which gives the iPad **desktop-class** browsing: it reports **`hover: hover`** and **`pointer: fine`**. A CSS-only hover/pointer gate is therefore dead on the exact device in the bug report.

We don't have to take that on faith — **the codebase already contained a dead one.** `MessageHoverToolbar.tsx:89` had `[@media(hover:none)]:opacity-100`, a touch hatch written for precisely this purpose, which never fires on a desktop-class iPad. This PR retargets it rather than deleting it.

`(pointer: coarse)` alone fails for the same reason. `(any-pointer: coarse)` was rejected too — it would flip touchscreen Windows laptops and change desktop rendering, which is out of scope.

So detection is **JS-based, keyed on `navigator.maxTouchPoints`**: iPadOS reports **5** even in desktop-class mode, while real macOS reports **0**. This is the same escape hatch the repo already trusts at `useEnterToSend.ts:26-29`.

Note this also means **`preferredContentMode: 'mobile'` would not have fixed it** — the `sm:`/`md:` gates below consult no pointer signal at all, and it could never reach iPad Safari.

## The three independent gates

A single naive fix catches only one of them.

**Gate 1 — viewport-width gates.** This was the user's #1 complaint and the least obvious bug. `MessageActionButtons.tsx:26` was `sm:opacity-0 sm:group-hover:opacity-100`. This is Tailwind v4, so `sm:` = `min-width: 640px`. An iPhone in portrait (~390px) **never matches**, so the buttons are permanently visible — which is exactly why iPhone "just works" today. **Every** iPad matches (≥744px, 1024px+ desktop-class), so they collapse to `opacity-0` behind a hover that will never arrive. This gate consults no pointer/hover/touch signal whatsoever, which is why it broke iPad Safari too.

**Gate 2 — bare `group-hover:` with no touch hatch (~30 sites).** Tailwind v4 wraps hover variants in `@media (hover: hover)`, but the base `opacity-0` always applies.

**Gate 3 — JS `isHovered` state**, gated on `useTouchDevice()`, whose only signal was `(pointer: coarse)`.

## The mechanism

1. **`apps/web/src/lib/pointer-capability.ts`** (new) — one canonical, pure, SSR-safe `detectCoarsePointer()`: Capacitor-native (any content mode) **OR** `matchMedia('(pointer: coarse)')` **OR** (`maxTouchPoints > 1` AND an `/iPad|Macintosh|iPhone/` UA). Unit-tested per branch, including desktop-class iPad and a real-macOS negative.
2. **`apps/web/src/app/layout.tsx`** — a nonce'd inline script, first child of `<body>` next to the existing `__webpack_nonce__` script, stamps `data-pointer="coarse"` on `<html>` **before first paint**, so there is no flash of hidden controls. `<html>` already carries `suppressHydrationWarning`.
3. **`apps/web/src/app/globals.css`** — three **unlayered** rules (unlayered beats `@layer utilities` with no `!important`; same trick as the existing `svg.lucide` override) driven off that attribute, plus a `@custom-variant touch` so new code has a first-class idiom.

The selectors use **attribute-substring matching**, which is what catches both the **named-group** variants (`group-hover/msg:`, `group-hover/pane:`, `group-hover/item:`, `group-hover/menu-item:`) and the **`sm:`/`md:`-prefixed** forms. A plain `.group-hover\:opacity-100` selector would have missed the user's #1 complaint entirely.

`pointer-events: auto` is **required**, not cosmetic: `MessageHoverToolbar.tsx:88` and `prompt-input.tsx:329` pair their `opacity-0` with `pointer-events-none`. Opacity alone would leave the buttons visible but **dead**, which is arguably worse than hidden.

## Call-site inventory

All 41 hiding sites found by `grep -rn 'group-hover' apps/web/src`. The diagnosis predicted ~36; the extra sites are noted below. They reconcile as:

| | Count |
|---|---|
| Revealed by the blanket CSS | **33** (9 viewport-gated + 24 bare `group-hover:`) |
| Opted out with `data-hover-only` (decoration) | **6** |
| Fade-out, left at its natural opacity | **1** |
| Not matched — colour change, nothing hidden | **1** |
| **Total** | **41** |

Plus **4** JS-hover sites and **4** dead-media-query sites, below.

### Gate 1 — viewport-width gated (9) — all covered by CSS

| Site | Shape | What it hides |
|---|---|---|
| `ai/shared/chat/MessageActionButtons.tsx:26` | `sm:opacity-0 sm:group-hover:opacity-100` | **AI chat retry / edit / copy / delete** |
| `ui/sidebar.tsx:569` | `md:opacity-0` + `group-hover/menu-item:opacity-100` | sidebar + page-tree row actions |
| `right-sidebar/ai-assistant/SidebarActivityTab.tsx:505` | `sm:opacity-0 sm:group-hover:` | activity action |
| `right-sidebar/ai-assistant/SidebarActivityTab.tsx:582` | `sm:opacity-0 sm:group-hover:` | activity action |
| `right-sidebar/ai-assistant/SidebarActivityTab.tsx:636` | `sm:opacity-0 sm:group-hover/item:` | activity sub-item action |
| `version-history/VersionHistoryItem.tsx:173` | `sm:opacity-0 sm:group-hover:` | version restore |
| `activity/ActivityItem.tsx:147` | `sm:opacity-0 sm:group-hover:` | activity action |
| `activity/ActivityGroupItem.tsx:137` | `sm:opacity-0 sm:group-hover:` | activity action |
| `.../terminal/workspace/TerminalPanes.tsx:215` | `md:opacity-0` + `md:group-hover/pane:opacity-100` | terminal pane controls — see note below |

> **This bug class is still being written.** I rebased onto master and picked up #2006 ("Phase 4 — narrow-viewport pass"), which *rewrote* `TerminalPanes` into `opacity-100 … md:opacity-0 md:group-hover/pane:opacity-100`. That is a brand-new instance of Gate 1: it fixes narrow viewports and leaves **every iPad** (which is ≥`md`) hiding its terminal pane controls behind a hover that never arrives — the identical mistake, made independently, while this PR was open. The blanket rule catches it with no extra work, which is the main argument for a blanket rule over 41 hand-edits.

### Gate 2 — bare `group-hover:` (24) — all covered by CSS

| Site | Note |
|---|---|
| `layout/tabs/TabItem.tsx:201` | tab close button |
| `.../terminal/workspace/RemoveButton.tsx:15` | *(beyond the diagnosis inventory)* |
| `shared/MessageHoverToolbar.tsx:87` | `group-hover/msg:` + `pointer-events-none` — needs `pointer-events: auto` |
| `notifications/NotificationItem.tsx:166` | |
| `inbox/DMCenterList.tsx:208` | disclosure chevron |
| `inbox/ChannelsCenterList.tsx:229` | disclosure chevron |
| `tasks/TaskKanbanComponents.tsx:138` | |
| `.../task-list/TaskKanbanView.tsx:176` | drag handle |
| `.../task-list/TaskKanbanView.tsx:225` | |
| `.../task-list/StatusConfigManager.tsx:242` | status dropdown |
| `ai/ui/queue.tsx:129` | *(beyond the diagnosis inventory)* |
| `ai/ui/message.tsx:370` | remove attachment *(beyond inventory)* |
| `ai/ui/message.tsx:398` | remove attachment *(beyond inventory)* |
| `ai/ui/prompt-input.tsx:329` | `group-hover:pointer-events-auto` — needs `pointer-events: auto` |
| `.../tool-calls/ActivityRenderer.tsx:194` | |
| `.../tool-calls/AgentListRenderer.tsx:113` | |
| `.../tool-calls/PageTreeRenderer.tsx:113` | |
| `.../tool-calls/SearchResultsRenderer.tsx:127` | |
| `.../tool-calls/AgentConfigRenderer.tsx:73` | |
| `.../tool-calls/WebSearchRenderer.tsx:133` | |
| `.../tool-calls/ActionResultRenderer.tsx:189` | |
| `.../tool-calls/DriveListRenderer.tsx:117` | |
| `.../tool-calls/calendar/CalendarEventRenderer.tsx:101` | |
| `.../tool-calls/workflow/WorkflowCard.tsx:118` | "Open agent" hint |

### Opted out with `data-hover-only` (6) — decoration, not affordances

Shipping these **together with** the blanket rule is mandatory, or we'd introduce an **iPhone regression** — pinning genuinely-hover-only chrome permanently on-screen where it is fine today.

| Site | Why |
|---|---|
| `shared/FeedbackDialog.tsx:321` | a `bg-black/50` **scrim over the screenshot preview** — would permanently black out the screenshot on every phone. (Still tappable to remove: it was never `pointer-events-none`.) |
| `ui/resizable.tsx:54` | drag seam |
| `.../channel/ChannelView.tsx:705` | message timestamp |
| `dashboard/dms/[conversationId]/page.tsx:624` | message timestamp |
| `.../task-list/StatusConfigManager.tsx:238` | status **slug** — metadata hint, not a control *(beyond the diagnosis inventory)* |
| `layout/tabs/TabItem.tsx:184` | the **Cmd/Ctrl+N shortcut number**. Caught by adversarial review: it is a *keyboard* affordance, and there is no keyboard on a phone. Revealing it pinned a stray digit into every tab. *(beyond the diagnosis inventory — the diagnosis explicitly listed this as a site to reveal)* |

### Fade-outs are left alone, not pinned (deviation from the diagnosis)

The diagnosis prescribed a second rule forcing `group-hover:opacity-0` elements (the prompt-input attachment thumbnail) to `opacity: 0` on touch. Shipping that pins the *faded* state permanently, so an iPhone user attaching an image would see a bare ✕ where their thumbnail renders fine today — a regression on a device that was never broken.

**We reveal controls; we do not simulate a whole hover state.** So that rule is gone. Fade-out elements keep their natural resting opacity and the control they were hiding sits on top of them, rather than the element being force-hidden by a global rule.

For this one element the *visible* outcome is admittedly similar — at a 20px chip there is no room for both a legible ✕ and a readable thumbnail, so the ✕ gets a `touch:` backdrop that largely occludes it (the filename beside it identifies the attachment). The difference is architectural and it matters: the behaviour is now local and explicit on the one element that needs it, instead of a global rule that force-hid *every* fade-out on the page and carried the landmine below.

Rule 1 grew a `:not([class*='group-hover:opacity-0'])` guard to make this safe, which also closes a landmine: adding any `:opacity-100` variant to a fade-out element (a `focus-within:opacity-100`, say) would otherwise have dragged it into rule 1 and pinned a **scrim permanently visible over the content it covers**.

### Deliberately revealed, though arguably decoration

Called out so it reads as a decision, not an oversight. These become permanently visible on touch: the disclosure `ChevronRight` on inbox rows (`DMCenterList.tsx:208`, `ChannelsCenterList.tsx:229`), the `ExternalLink` icon on the ten tool-call renderer rows, and the "Open agent" hint on `WorkflowCard.tsx:118`. Each one signals *this row opens something* — which is the standard iOS disclosure convention and the only tappability cue left once hover is gone. Happy to opt any of them out on request.

### Not matched, no action (1)

`ai/ui/inline-citation.tsx:53` — `group-hover:bg-accent` is a colour change with no `opacity-0`, so no selector matches it. Correct: nothing is hidden.

### Gate 3 — JS `isHovered` (4 + 2 fixed transitively)

| Site | Fix |
|---|---|
| `hooks/useTouchDevice.ts:10` | now delegates to `detectCoarsePointer()` (keeps the `useSyncExternalStore` shape) |
| `.../page-tree/PageTreeItem.tsx:419` | `isTouchDevice \|\| isHovered ? …` |
| `left-sidebar/FavoritesSection.tsx:205` | `isTouchDevice \|\| isHovered ? …` |
| `navbar/DriveSwitcher.tsx:307` | `isTouchDevice \|\| isHovered ? …` |
| `left-sidebar/DriveList.tsx:97` | **already correct** (`isTouchDevice \|\| isHovered`) — repaired by the `useTouchDevice` change alone |
| `hooks/useChatPullToRefresh.ts:62` | **revived** — chat pull-to-refresh was dead on desktop-class iPad for the same reason |

### The dead `[@media(hover:none)]` rules (4) — **augmented**, not replaced

My first pass swapped these to `touch:`. That was wrong, and self-review caught it: the media query is dead *only on a desktop-class iPad*. On iPhone and Android it works with **zero JS**. Replacing it traded a no-JS floor for nothing.

So both gates now ship together. `[@media(hover:none)]` covers every no-hover device without JS; `touch:` adds the one device the media query cannot see. If the inline script never runs, everything the media query already handled still works.

**The spacing hacks matter**: without them the now-visible toolbar overlaps message text.

| Site | Change |
|---|---|
| `shared/MessageHoverToolbar.tsx:89` | keeps `[@media(hover:none)]:opacity-100 …:pointer-events-auto`, **adds** `touch:opacity-100 touch:pointer-events-auto` |
| `.../channel/ChannelView.tsx:710` | keeps `[@media(hover:none)]:pr-28`, **adds** `touch:pr-28` |
| `.../thread/ThreadPanel.tsx:784` | keeps `[@media(hover:none)]:pr-28`, **adds** `touch:pr-28` |
| `dashboard/dms/[conversationId]/page.tsx:630` | keeps `[@media(hover:none)]:pr-28`, **adds** `touch:pr-28` |

## Desktop is provably unchanged

- **No attribute is ever emitted server-side.** `grep -rn 'data-pointer' apps/web/src` returns exactly three hits: two comments and the inline-script string. **No JSX anywhere sets it**, so SSR `<html>` markup is byte-identical to today for every UA.
- **The script is a no-op on desktop.** A unit test asserts real macOS (`maxTouchPoints: 0`, Macintosh UA) stamps nothing, and that a touchscreen Windows laptop stamps nothing either.
- **Every new CSS rule is descendant-scoped to `[data-pointer='coarse']`.** With no attribute, none of them can match — so hover behaviour on a mouse-driven browser is untouched by construction.
- Verified against the **real compiled CSS** from `bun run build`, not just the source: all three override rules are present with **zero enclosing at-rule blocks** (i.e. genuinely unlayered, so they beat `@layer utilities` without `!important`), and Tailwind generated `.touch\:opacity-100`, `.touch\:pointer-events-auto`, `.touch\:pr-28` as `:where([data-pointer=coarse] *)`.

## The CSS contract is tested, not just asserted

The selectors doing the actual work are blunt attribute-substring rules, and nothing used to fail if they stopped matching the controls they exist to reveal — or started matching decoration they must not touch. `app/__tests__/touch-reveal-rules.test.ts` now reads the selectors **out of `globals.css`** (rather than restating them, which would only test a copy of itself) and runs them in jsdom against the real class strings from the components. It pins the controls that must be revealed, the decoration that must stay hidden (asserting each opt-out is *load-bearing* — revealed without `data-hover-only`, hidden with it), the fade-out landmine, exact-token display matching, and that a desktop device with no stamp matches nothing at all.

I verified it can fail rather than assuming it would: dropping the `group-hover:opacity-0` guard, making the display rules substring-matched, and removing the `data-hover-only` opt-out each break it (1, 1 and 5 tests). Writing it also caught a bug in its own harness — the first draft stripped the `:where()` ancestor out of the extracted selector, which made the desktop assertion vacuous.

## Two guards, both mutation-tested

The module has one genuine maintenance hazard: `POINTER_CAPABILITY_SCRIPT` is a hand-minified copy of `detectCoarsePointer()`, and it has to be, because it runs before any bundle loads. Two tests pin the things that would otherwise rot silently — and I verified each **actually fails** when the regression it guards is introduced, rather than trusting that it would:

- **Parity matrix** — all eight device shapes must get the same verdict from the script and the function. Desyncing the script's `maxTouchPoints` threshold fails 2 tests.
- **`useTouchDevice` delegation** — reverting `getSnapshot` to a bare `matchMedia('(pointer: coarse)')` (the obvious-looking simplification, and `TOUCH_QUERY` is still sitting in the file) previously passed the entire suite while silently re-breaking every JS-hover site on desktop-class iPad. It now fails 2 tests.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` (apps/web) | **exit 0**, clean |
| `next lint --dir src` | **no errors** — only pre-existing warnings, none in touched files |
| `next build` | **succeeded**; compiled CSS inspected to confirm the rules and the `touch:` variant |
| `vitest run` (new tests) | **41/41 passed** — 19 `pointer-capability`, 3 `useTouchDevice`, 17 `touch-reveal-rules` (CSS contract), 2 layout |
| `vitest run src/lib src/hooks` | 5314 passed, **16 failed in 3 files** |

The 16 failures are **pre-existing and unrelated** — I re-ran those three files against a clean stashed tree and got the **identical 16 failures**. They are DB-dependent (`role "test" does not exist`) in `auth/admin-role-version`, `ai/tools/activity-tools`, and `messages/grouping`. Nothing in them touches hover or pointer code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTxhiZAxjv9jcbVS8wJeUc
