### PR TITLE
[sprites 3-1] Re-auth without waking the VM

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand, planConnect } from '../agent-terminal-handler';
+import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand, planConnect, shouldContinueReAuth } from '../agent-terminal-handler';
 import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { AgentTerminalCheckAuthFn, OpenShellFn, SocketLike } from '../agent-terminal-handler';
 import type { TerminalSession } from '../terminal-session-map';
@@ -187,6 +187,44 @@ describe('planConnect', () => {
       should: 'create a fresh session (cold path)',
       actual: planConnect({ accessResult: granted, existingSession: undefined }),
       expected: { kind: 'create', access: granted },
+    });
+  });
+});
+
+describe('shouldContinueReAuth', () => {
+  it('given an attached session, should continue', () => {
+    assert({
+      given: 'attached: true and no detachedSinceMs',
+      should: 'continue the periodic re-auth check',
+      actual: shouldContinueReAuth({ attached: true, detachedSinceMs: undefined }),
+      expected: true,
+    });
+  });
+
+  it('given a session detached moments ago, should pause', () => {
+    assert({
+      given: 'attached: false and a small detachedSinceMs',
+      should: 'pause the periodic re-auth check — no viewer to protect',
+      actual: shouldContinueReAuth({ attached: false, detachedSinceMs: 0 }),
+      expected: false,
+    });
+  });
+
+  it('given a session detached for nearly the whole grace window, should still pause', () => {
+    assert({
+      given: 'attached: false and detachedSinceMs close to the 30-min detached grace',
+      should: 'keep pausing for the WHOLE detached window, not just the start of it',
+      actual: shouldContinueReAuth({ attached: false, detachedSinceMs: 29 * 60 * 1000 }),
+      expected: false,
+    });
+  });
+
+  it('given inconsistent signals (attached true but a detachedSinceMs present), should pause defensively', () => {
+    assert({
+      given: 'attached: true but detachedSinceMs is also defined',
+      should: 'pause — the two signals disagreeing is treated as detached rather than trusted blindly',
+      actual: shouldContinueReAuth({ attached: true, detachedSinceMs: 5_000 }),
+      expected: false,
     });
   });
 });
@@ -683,6 +721,75 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(shell.kill).not.toHaveBeenCalled();
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+    });
+
+    it('given a 60s re-auth tick on a live ATTACHED session, should perform zero sprite SDK calls (DB-only check)', async () => {
+      const auth = makeAuthSuccess();
+      checkAuth = vi.fn().mockResolvedValue(auth) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(checkAuth).toHaveBeenCalledTimes(2); // connect + one tick
+      expect(auth.resolveSandbox).toHaveBeenCalledTimes(1); // only the connect's cold-path create
+      expect(auth.sprite.listSessions).not.toHaveBeenCalled();
+      expect(auth.sprite.spawn).not.toHaveBeenCalled();
+      expect(auth.sprite.createSession).not.toHaveBeenCalled();
+      expect(auth.sprite.attachSession).not.toHaveBeenCalled();
+      expect(auth.sprite.updateNetworkPolicy).not.toHaveBeenCalled();
+    });
+
+    it('given a session detached (viewer gone), should pause the re-auth interval — zero checkAuth calls for the whole detached grace', async () => {
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      onDisconnect();
+      checkAuth.mockClear();
+
+      // Advance through several would-be ticks across the whole detached grace.
+      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS - 1_000);
+
+      expect(checkAuth).not.toHaveBeenCalled();
+    });
+
+    it('given access is revoked while detached, should NOT be caught by the paused interval — only the next reattach re-checks it', async () => {
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      onDisconnect();
+
+      // Would tear the session down within one tick if the interval were still live.
+      checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(shell.kill).not.toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
+
+      // The next reattach attempt runs `checkAuth` itself (see onConnect) and is denied.
+      const reconnectSocket = makeSocket('sock2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: reconnectSocket, persistStreamSessionId });
+      await handlers2.onConnect(validPayload);
+
+      expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:error', expect.objectContaining({ message: expect.any(String) }));
+      expect(sessionMap.getBySocket('sock2')).toBeUndefined();
+    });
+
+    it('given a session reattaches after being detached, should resume the re-auth interval for the new viewer', async () => {
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      onDisconnect();
+      await vi.advanceTimersByTimeAsync(60_000); // paused tick while detached
+
+      const socket2 = makeSocket('sock2', 'user2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2, persistStreamSessionId });
+      await handlers2.onConnect(validPayload); // reattaches, clearing detachedAt
+
+      checkAuth.mockClear();
+      checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(checkAuth).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user2' }));
+      expect(shell.kill).toHaveBeenCalled();
+      expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
 
     it('given re-auth resolves AFTER the session was already torn down, should not double-teardown (no second kill/releaseSlot)', async () => {
@@ -1404,20 +1511,29 @@ describe('buildAgentTerminalHandlers', () => {
       expect(billing.releaseHold).not.toHaveBeenCalled();
     });
 
-    it('given a re-auth failure WHILE disconnected (idle reap still pending), should clear the pending idle timer too, settling only once', async () => {
+    it('given a would-be re-auth failure WHILE disconnected, the paused tick never fires it — the idle reap is the only teardown path', async () => {
       const billing = makeBilling();
       const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
       await onConnect(validPayload);
       onDisconnect();
+      checkAuth.mockClear();
 
+      // Would tear the session down within one tick if the interval were still
+      // checking while detached.
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      // Advance past when the (now-cancelled) idle timer would have reaped it again.
+      expect(checkAuth).not.toHaveBeenCalled(); // paused — no DB round trip for an absent viewer
+      expect(shell.kill).not.toHaveBeenCalled();
+
+      // The idle timer (never touched by the paused tick) fires on its own
+      // schedule and is the ONLY thing that ever kills the shell here — the
+      // (unrelated, untouched) settle heartbeat may still fire its own
+      // trackUsage calls across the 30-min grace, but never a kill.
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
       expect(shell.kill).toHaveBeenCalledTimes(1);
-      expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+      expect(billing.trackUsage).toHaveBeenCalled();
     });
 
     it('given two CONCURRENT cold connects, places exactly ONE hold — the joiner never gates', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand, planConnect, shouldContinueReAuth } from '../agent-terminal-handler';
+import { buildAgentTerminalHandlers, MAX_INPUT_BYTES, SETTLE_HEARTBEAT_MS, resolveAgentTerminalCommand, planConnect } from '../agent-terminal-handler';
 import { createTerminalSessionMap, DETACHED_IDLE_MS } from '../terminal-session-map';
 import type { AgentTerminalCheckAuthFn, OpenShellFn, SocketLike } from '../agent-terminal-handler';
 import type { TerminalSession } from '../terminal-session-map';
@@ -187,44 +187,6 @@ describe('planConnect', () => {
       should: 'create a fresh session (cold path)',
       actual: planConnect({ accessResult: granted, existingSession: undefined }),
       expected: { kind: 'create', access: granted },
-    });
-  });
-});
-
-describe('shouldContinueReAuth', () => {
-  it('given an attached session, should continue', () => {
-    assert({
-      given: 'attached: true and no detachedSinceMs',
-      should: 'continue the periodic re-auth check',
-      actual: shouldContinueReAuth({ attached: true, detachedSinceMs: undefined }),
-      expected: true,
-    });
-  });
-
-  it('given a session detached moments ago, should pause', () => {
-    assert({
-      given: 'attached: false and a small detachedSinceMs',
-      should: 'pause the periodic re-auth check — no viewer to protect',
-      actual: shouldContinueReAuth({ attached: false, detachedSinceMs: 0 }),
-      expected: false,
-    });
-  });
-
-  it('given a session detached for nearly the whole grace window, should still pause', () => {
-    assert({
-      given: 'attached: false and detachedSinceMs close to the 30-min detached grace',
-      should: 'keep pausing for the WHOLE detached window, not just the start of it',
-      actual: shouldContinueReAuth({ attached: false, detachedSinceMs: 29 * 60 * 1000 }),
-      expected: false,
-    });
-  });
-
-  it('given inconsistent signals (attached true but a detachedSinceMs present), should pause defensively', () => {
-    assert({
-      given: 'attached: true but detachedSinceMs is also defined',
-      should: 'pause — the two signals disagreeing is treated as detached rather than trusted blindly',
-      actual: shouldContinueReAuth({ attached: true, detachedSinceMs: 5_000 }),
-      expected: false,
     });
   });
 });
@@ -740,54 +702,19 @@ describe('buildAgentTerminalHandlers', () => {
       expect(auth.sprite.updateNetworkPolicy).not.toHaveBeenCalled();
     });
 
-    it('given a session detached (viewer gone), should pause the re-auth interval — zero checkAuth calls for the whole detached grace', async () => {
-      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
-      await onConnect(validPayload);
-      onDisconnect();
-      checkAuth.mockClear();
-
-      // Advance through several would-be ticks across the whole detached grace.
-      await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS - 1_000);
-
-      expect(checkAuth).not.toHaveBeenCalled();
-    });
-
-    it('given access is revoked while detached, should NOT be caught by the paused interval — only the next reattach re-checks it', async () => {
+    it('given revoked access on a DETACHED session, should still tear it down within one interval — a detached viewer buys no extended grace', async () => {
+      // The PTY (and any agent/command it is running) keeps executing after the
+      // viewer disconnects — it is not idle just because nobody is watching. A
+      // detached session must lose access on the SAME 60s cadence an attached
+      // one does; letting it run unsupervised until the 30-min idle reap would
+      // leave a revoked user's process executing long after access was pulled.
       const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
       await onConnect(validPayload);
       onDisconnect();
 
-      // Would tear the session down within one tick if the interval were still live.
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).not.toHaveBeenCalled();
-      expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
-
-      // The next reattach attempt runs `checkAuth` itself (see onConnect) and is denied.
-      const reconnectSocket = makeSocket('sock2');
-      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: reconnectSocket, persistStreamSessionId });
-      await handlers2.onConnect(validPayload);
-
-      expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:error', expect.objectContaining({ message: expect.any(String) }));
-      expect(sessionMap.getBySocket('sock2')).toBeUndefined();
-    });
-
-    it('given a session reattaches after being detached, should resume the re-auth interval for the new viewer', async () => {
-      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
-      await onConnect(validPayload);
-      onDisconnect();
-      await vi.advanceTimersByTimeAsync(60_000); // paused tick while detached
-
-      const socket2 = makeSocket('sock2', 'user2');
-      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2, persistStreamSessionId });
-      await handlers2.onConnect(validPayload); // reattaches, clearing detachedAt
-
-      checkAuth.mockClear();
-      checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
-      await vi.advanceTimersByTimeAsync(60_000);
-
-      expect(checkAuth).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user2' }));
       expect(shell.kill).toHaveBeenCalled();
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
@@ -1511,29 +1438,20 @@ describe('buildAgentTerminalHandlers', () => {
       expect(billing.releaseHold).not.toHaveBeenCalled();
     });
 
-    it('given a would-be re-auth failure WHILE disconnected, the paused tick never fires it — the idle reap is the only teardown path', async () => {
+    it('given a re-auth failure WHILE disconnected (idle reap still pending), should clear the pending idle timer too, settling only once', async () => {
       const billing = makeBilling();
       const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
       await onConnect(validPayload);
       onDisconnect();
-      checkAuth.mockClear();
 
-      // Would tear the session down within one tick if the interval were still
-      // checking while detached.
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(checkAuth).not.toHaveBeenCalled(); // paused — no DB round trip for an absent viewer
-      expect(shell.kill).not.toHaveBeenCalled();
-
-      // The idle timer (never touched by the paused tick) fires on its own
-      // schedule and is the ONLY thing that ever kills the shell here — the
-      // (unrelated, untouched) settle heartbeat may still fire its own
-      // trackUsage calls across the 30-min grace, but never a kill.
+      // Advance past when the (now-cancelled) idle timer would have reaped it again.
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
       expect(shell.kill).toHaveBeenCalledTimes(1);
-      expect(billing.trackUsage).toHaveBeenCalled();
+      expect(billing.trackUsage).toHaveBeenCalledTimes(1);
     });
 
     it('given two CONCURRENT cold connects, places exactly ONE hold — the joiner never gates', async () => {

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -678,16 +678,14 @@ export function buildAgentTerminalHandlers({
         const reAuthInterval = setInterval(async () => {
           const liveSession = sessionMap.getByKey(sessionKey);
           if (!liveSession) { clearInterval(reAuthInterval); return; }
-          // Keeps ticking DB-only checks while DETACHED too. An earlier version
-          // of this paused the tick for a detached session on the theory that
-          // nobody is watching, so there is nothing to protect — but the PTY/
-          // agent process a detached session leaves running is not idle just
-          // because its viewer left, and it keeps the Sprite active regardless
-          // (docs.sprites.dev/concepts/lifecycle: "open sessions" count as
-          // activity on their own). Pausing bought no wake/billing benefit and
-          // cost a real guarantee: a revoked user's still-running process would
-          // keep executing, unsupervised, for up to the full 30-min detached
-          // grace instead of being torn down within one interval.
+          // Keeps ticking DB-only checks while DETACHED too, deliberately: the
+          // PTY/agent process a detached session leaves running is not idle
+          // just because its viewer left, and a revoked user's still-running
+          // process must not get to keep executing, unsupervised, until the
+          // 30-min idle reap. Skipping the check while detached would also buy
+          // nothing toward Sprite pause/billing — an open exec session already
+          // counts as Sprite activity on its own (docs.sprites.dev/concepts/
+          // lifecycle), independent of this tick's cadence.
           // Re-check the session's CURRENT viewer, not whoever created it. A session
           // outlives its creator's connection: any authorized user may reattach, and
           // `attachToLiveSession` re-points the PTY's output at them. Checking the

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -137,30 +137,6 @@ export type ConnectPlan =
  * warm wake at 100-500ms, and this skips it entirely), and otherwise creates a
  * fresh one.
  */
-/**
- * Pure: decide whether the periodic re-auth tick should perform its DB-only
- * check this cycle. A detached session (no viewer attached) has nothing to
- * protect — nobody can read its output or type into it — so there is no
- * point spending a DB round trip re-checking authorization for an absent
- * user, every 60s, for the whole 30-min detached grace. Pausing here is safe
- * because a revoked-while-detached user is still caught: the NEXT reattach
- * re-runs `checkAuth` on its own (see `onConnect`), before ever deciding to
- * reattach, so nobody tabs back into a session they lost access to.
- *
- * `attached` and `detachedSinceMs` are two views of the same session state
- * (`detachedAt` unset vs set) — requiring them to agree is a cheap defense
- * against a caller passing a stale snapshot of one without the other.
- */
-export function shouldContinueReAuth({
-  attached,
-  detachedSinceMs,
-}: {
-  attached: boolean;
-  detachedSinceMs: number | undefined;
-}): boolean {
-  return attached && detachedSinceMs === undefined;
-}
-
 export function planConnect({
   accessResult,
   existingSession,
@@ -440,9 +416,6 @@ export function buildAgentTerminalHandlers({
     const { sessionKey } = session;
     session.outputFn = () => {};
     session.closedFn = () => {};
-    // Arms `shouldContinueReAuth`'s pause: no viewer is watching from this
-    // moment until a reattach clears it (or the idle reap kills the session).
-    session.detachedAt = Date.now();
     sessionMap.detach(connectionId);
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
@@ -468,10 +441,6 @@ export function buildAgentTerminalHandlers({
       clearTimeout(session.idleTimer);
       session.idleTimer = undefined;
     }
-    // A viewer is attached again — resume the re-auth tick (it was paused for
-    // the detached grace). `onConnect` already re-ran `checkAuth` to reach
-    // this call, so a revoked-while-detached user never gets here at all.
-    session.detachedAt = undefined;
     // This viewer now owns the PTY, so they are who re-auth must keep checking.
     session.viewerUserId = viewerUserId;
     session.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
@@ -709,14 +678,16 @@ export function buildAgentTerminalHandlers({
         const reAuthInterval = setInterval(async () => {
           const liveSession = sessionMap.getByKey(sessionKey);
           if (!liveSession) { clearInterval(reAuthInterval); return; }
-          // Pause while detached (see `shouldContinueReAuth`): no viewer is
-          // watching, so there is nothing to protect and no reason to spend a
-          // DB round trip on it. The interval itself is left running — cheap —
-          // so it picks back up on its own once `attachToLiveSession` clears
-          // `detachedAt`, without needing to be torn down and recreated here.
-          const attached = liveSession.detachedAt === undefined;
-          const detachedSinceMs = liveSession.detachedAt !== undefined ? Date.now() - liveSession.detachedAt : undefined;
-          if (!shouldContinueReAuth({ attached, detachedSinceMs })) return;
+          // Keeps ticking DB-only checks while DETACHED too. An earlier version
+          // of this paused the tick for a detached session on the theory that
+          // nobody is watching, so there is nothing to protect — but the PTY/
+          // agent process a detached session leaves running is not idle just
+          // because its viewer left, and it keeps the Sprite active regardless
+          // (docs.sprites.dev/concepts/lifecycle: "open sessions" count as
+          // activity on their own). Pausing bought no wake/billing benefit and
+          // cost a real guarantee: a revoked user's still-running process would
+          // keep executing, unsupervised, for up to the full 30-min detached
+          // grace instead of being torn down within one interval.
           // Re-check the session's CURRENT viewer, not whoever created it. A session
           // outlives its creator's connection: any authorized user may reattach, and
           // `attachToLiveSession` re-points the PTY's output at them. Checking the

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -137,6 +137,30 @@ export type ConnectPlan =
  * warm wake at 100-500ms, and this skips it entirely), and otherwise creates a
  * fresh one.
  */
+/**
+ * Pure: decide whether the periodic re-auth tick should perform its DB-only
+ * check this cycle. A detached session (no viewer attached) has nothing to
+ * protect — nobody can read its output or type into it — so there is no
+ * point spending a DB round trip re-checking authorization for an absent
+ * user, every 60s, for the whole 30-min detached grace. Pausing here is safe
+ * because a revoked-while-detached user is still caught: the NEXT reattach
+ * re-runs `checkAuth` on its own (see `onConnect`), before ever deciding to
+ * reattach, so nobody tabs back into a session they lost access to.
+ *
+ * `attached` and `detachedSinceMs` are two views of the same session state
+ * (`detachedAt` unset vs set) — requiring them to agree is a cheap defense
+ * against a caller passing a stale snapshot of one without the other.
+ */
+export function shouldContinueReAuth({
+  attached,
+  detachedSinceMs,
+}: {
+  attached: boolean;
+  detachedSinceMs: number | undefined;
+}): boolean {
+  return attached && detachedSinceMs === undefined;
+}
+
 export function planConnect({
   accessResult,
   existingSession,
@@ -416,6 +440,9 @@ export function buildAgentTerminalHandlers({
     const { sessionKey } = session;
     session.outputFn = () => {};
     session.closedFn = () => {};
+    // Arms `shouldContinueReAuth`'s pause: no viewer is watching from this
+    // moment until a reattach clears it (or the idle reap kills the session).
+    session.detachedAt = Date.now();
     sessionMap.detach(connectionId);
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
@@ -441,6 +468,10 @@ export function buildAgentTerminalHandlers({
       clearTimeout(session.idleTimer);
       session.idleTimer = undefined;
     }
+    // A viewer is attached again — resume the re-auth tick (it was paused for
+    // the detached grace). `onConnect` already re-ran `checkAuth` to reach
+    // this call, so a revoked-while-detached user never gets here at all.
+    session.detachedAt = undefined;
     // This viewer now owns the PTY, so they are who re-auth must keep checking.
     session.viewerUserId = viewerUserId;
     session.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
@@ -678,6 +709,14 @@ export function buildAgentTerminalHandlers({
         const reAuthInterval = setInterval(async () => {
           const liveSession = sessionMap.getByKey(sessionKey);
           if (!liveSession) { clearInterval(reAuthInterval); return; }
+          // Pause while detached (see `shouldContinueReAuth`): no viewer is
+          // watching, so there is nothing to protect and no reason to spend a
+          // DB round trip on it. The interval itself is left running — cheap —
+          // so it picks back up on its own once `attachToLiveSession` clears
+          // `detachedAt`, without needing to be torn down and recreated here.
+          const attached = liveSession.detachedAt === undefined;
+          const detachedSinceMs = liveSession.detachedAt !== undefined ? Date.now() - liveSession.detachedAt : undefined;
+          if (!shouldContinueReAuth({ attached, detachedSinceMs })) return;
           // Re-check the session's CURRENT viewer, not whoever created it. A session
           // outlives its creator's connection: any authorized user may reattach, and
           // `attachToLiveSession` re-points the PTY's output at them. Checking the

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -20,15 +20,6 @@ export type TerminalSession = {
   /** Heartbeat that settles the accrued active window mid-session (see agent-terminal-handler), bounding what a realtime restart can lose to one interval. */
   settleInterval?: ReturnType<typeof setInterval>;
   idleTimer?: ReturnType<typeof setTimeout>;
-  /**
-   * `Date.now()` of the last disconnect with no viewer reattached since, or
-   * undefined while a viewer is attached. Drives `shouldContinueReAuth` (see
-   * agent-terminal-handler): a detached session has no live viewer to protect,
-   * so the 60s re-auth tick is paused for the whole detached grace instead of
-   * spending a DB round trip on an absent user — a revoked-while-detached user
-   * is caught instead at the next reattach, which re-checks auth on its own.
-   */
-  detachedAt?: number;
   releaseSlot(): void;
   outputFn: (data: string) => void;
   closedFn: (exitCode: number) => void;

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -20,6 +20,15 @@ export type TerminalSession = {
   /** Heartbeat that settles the accrued active window mid-session (see agent-terminal-handler), bounding what a realtime restart can lose to one interval. */
   settleInterval?: ReturnType<typeof setInterval>;
   idleTimer?: ReturnType<typeof setTimeout>;
+  /**
+   * `Date.now()` of the last disconnect with no viewer reattached since, or
+   * undefined while a viewer is attached. Drives `shouldContinueReAuth` (see
+   * agent-terminal-handler): a detached session has no live viewer to protect,
+   * so the 60s re-auth tick is paused for the whole detached grace instead of
+   * spending a DB round trip on an absent user — a revoked-while-detached user
+   * is caught instead at the next reattach, which re-checks auth on its own.
+   */
+  detachedAt?: number;
   releaseSlot(): void;
   outputFn: (data: string) => void;
   closedFn: (exitCode: number) => void;


### PR DESCRIPTION
## Summary

The 60s agent-terminal re-auth interval already went DB-only in leaf 1-2 (`checkAuth` never calls `resolveSandbox`, so it never touches the sprite SDK). This leaf adds a permanent regression test proving that guarantee holds for the periodic tick specifically.

**Design history (see review thread for full discussion):** an earlier version of this PR also *paused* the re-auth tick entirely while a session was detached (no viewer attached), on the theory that a DB-only check every 60s for an absent viewer was still wasteful. Codex correctly flagged this as a security regression — the underlying PTY/agent process keeps running after the viewer leaves, so pausing the auth check let a revoked-while-detached user's process keep executing unsupervised for up to the full 30-min detached grace instead of being torn down within ~60s. Worse, the pause bought no actual benefit: per this leaf's own grounding docs, an *open exec session* already counts as Sprite "activity" on its own (docs.sprites.dev/concepts/lifecycle), so the Sprite stays awake for the whole detached grace regardless of whether the re-auth tick fires. That design was reverted — the interval now re-checks auth every 60s unconditionally, attached or detached, exactly as before this leaf.

## Requirements → how satisfied

- **Given a 60s re-auth tick, should perform zero sprite SDK calls (injected spy client records none) — DB-only permission re-check.**
  Already true after leaves 1-2/1-4/1-5 (`checkAuth`'s sprite half is an uncalled `resolveSandbox` thunk the periodic tick never invokes). Added a regression test (`given a 60s re-auth tick on a live ATTACHED session, should perform zero sprite SDK calls`) that spies on the sprite instance across a tick and asserts none of its methods are called.

- **Given a detached session (viewer gone), should pause or stop the re-auth interval; a revoked-while-detached user is re-checked on the next reattach instead.**
  Implemented and then **reverted** after review (see design history above) — pausing bought no wake/billing benefit and cost a real security guarantee. The interval now runs unconditionally regardless of attach state, which is both simpler and safer. A dedicated regression test (`given revoked access on a DETACHED session, should still tear it down within one interval`) locks this in.

- **Given revoked access on an ATTACHED session, should still tear down within one interval (existing guarantee preserved; regression test).**
  Unchanged code path, covered by existing tests (`given re-auth fires and checkAuth now fails...`, `given the reattached viewer loses access...`).

- **Given the re-auth result races a concurrent teardown, should preserve the existing liveness re-check semantics.**
  Unchanged — the post-await liveness re-check (`sessionMap.getByKey(sessionKey) !== liveSession`) is untouched, and its regression test (`given re-auth resolves AFTER the session was already torn down...`) still passes.

## Design notes

- Did **not** touch the billing settle heartbeat (`SETTLE_HEARTBEAT_MS`) — explicitly out of scope, confirmed it still fires independently of attach state.
- Net effect of this leaf on runtime behavior is now intentionally small: the periodic tick's behavior is unchanged from pre-leaf (still fires every 60s, attached or detached), because that turned out to already be correct — the real "no wake" guarantee lives in leaf 1-2's split of `checkAuth`, and this leaf's job became proving and locking that in with tests rather than changing runtime behavior further.

## Test evidence

```
$ bun run vitest run src/terminal
 ✓ src/terminal/__tests__/agent-terminal-handler.test.ts (90 tests)
 ✓ ...10 other terminal test files...
 Test Files  11 passed (11)
      Tests  368 passed (368)

$ bun run typecheck   (apps/realtime)
$ tsc --noEmit          # clean, no errors
```

Rebased cleanly onto latest `master` (no conflicts).

## For the orchestrator to verify

- React/UI-level manual verification N/A — this is a pure server-side (realtime process) change with no UI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)