### PR TITLE
[sprites 6-2] Destroy semantics: user intent only

### DIFF
--- a/apps/web/src/lib/machines/machine-settings-runtime.ts
+++ b/apps/web/src/lib/machines/machine-settings-runtime.ts
@@ -14,9 +14,10 @@
  * `pageRepository.trash`.
  *
  * `createMachineSpriteTeardown` tears down ALL the compute a Machine spawned:
- * each branch's OWN Sprite (tracked in `machine_branches`, which — unlike the
- * Machine's own session — has no idle reaper, so a delete that skipped them would
- * leak microVMs), then the Machine's own persistent Sprite (resolved the same way
+ * each branch's OWN Sprite (tracked only in `machine_branches` — a Sprite that
+ * goes idle simply hibernates on its own, it is never destroyed automatically,
+ * so a Machine delete that skipped these would leak live microVMs), then the
+ * Machine's own persistent Sprite (resolved the same way
  * the shell/session layer does: derive the `machine_sessions` key from (tenant,
  * drive, page), look up its `sandboxId`, kill through the `MachineHost` seam).
  * Everything runs inside `teardown()` so any host error surfaces AFTER the page is
@@ -168,10 +169,11 @@ export function createDbMachineSettingsStore(): MachineSettingsStore {
 }
 
 /**
- * Tears down all the Sprites a Machine spawned. See the module doc: branch Sprites
- * (no idle reaper) are killed best-effort first, then the Machine's own Sprite
- * whose kill governs `spriteTornDown`; the tracking-row removal is best-effort so a
- * post-kill DB error can't falsely report the Sprite as still alive.
+ * Tears down all the Sprites a Machine spawned. See the module doc: branch
+ * Sprites (never destroyed automatically — only hibernated on idle) are killed
+ * best-effort first, then the Machine's own Sprite whose kill governs
+ * `spriteTornDown`; the tracking-row removal is best-effort so a post-kill DB
+ * error can't falsely report the Sprite as still alive.
  */
 export function createMachineSpriteTeardown(): MachineSpriteTeardown {
   return {

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -383,9 +383,9 @@ export async function killBranch({
   try {
     await host.kill({ machineId: existing.sandboxId });
   } catch {
-    // Sprite may still be running — keep the tracking row so a retry (or the
-    // idle reaper) can still find and reclaim it. An untracked-but-live
-    // Sprite would otherwise be an unkillable orphan.
+    // Sprite may still be running — keep the tracking row so a retry can still
+    // find and kill it later. There is no reaper: an untracked-but-live Sprite
+    // would otherwise be an unkillable orphan.
     return { ok: false, reason: 'error' };
   }
 

--- a/packages/lib/src/services/sandbox/egress-lockdown.ts
+++ b/packages/lib/src/services/sandbox/egress-lockdown.ts
@@ -35,9 +35,11 @@
  *    it is always locked down before it is usable. The caller links the session
  *    only AFTER `getOrCreate` resolves, so a crash between `createSprite` and
  *    lockdown leaves no session row pointing at an unlocked Sprite: the next
- *    attempt sees no link and re-provisions (and the Sprite is destroyed on
- *    lockdown failure anyway). That ordering — not re-application — is what
- *    closes the old crash window.
+ *    attempt sees no link and re-provisions against the SAME retained Sprite — a
+ *    lockdown failure no longer destroys it (see `sprites.ts`'s
+ *    `planProvisionFailure`). That ordering — not re-application, and not
+ *    destruction — is what closes the old crash window: an unlocked Sprite is
+ *    never reachable from a session row, whether or not it is ever destroyed.
  *  - **token mismatch** — a different policy, or a different Sprite instance.
  *  - **unknown** — no recorded token (a session that predates the record, or one
  *    whose write was lost), or a platform that did not report the Sprite's id at

--- a/packages/lib/src/services/sandbox/machine-session-manager.ts
+++ b/packages/lib/src/services/sandbox/machine-session-manager.ts
@@ -39,11 +39,19 @@ export interface SandboxGetOrCreateArgs {
  * The provider-agnostic slice of the sandbox client this layer drives, injected
  * so this lifecycle owns no execution path (the Fly Sprites driver implements
  * it). `getOrCreate` auto-resumes by `name` (the session key); `get` reconnects
- * to a known id (null if it has vanished); `stop` tears down.
+ * to a known id (null if it has vanished); `stop` DESTROYS — see its own doc.
  */
 export interface SandboxClient {
   getOrCreate(args: SandboxGetOrCreateArgs): Promise<SandboxHandle>;
   get(args: { sandboxId: string }): Promise<SandboxHandle | null>;
+  /**
+   * Irreversible DESTROY — files, installed packages, and checkpoints are gone,
+   * with no undo (docs.sprites.dev/working-with-sprites). Call this ONLY for
+   * genuine teardown intent (a Machine/branch delete, or cleaning up a Sprite
+   * this process just failed to link to a session row) — NEVER as idle/billing
+   * cleanup. A paused sandbox already stops compute billing on its own and costs
+   * only bytes-written storage, so idleness alone is never a reason to call this.
+   */
   stop(args: { sandboxId: string }): Promise<void>;
 }
 
@@ -416,7 +424,9 @@ export async function acquireMachineSession(
       case 'teardown': {
         const stopped = await safeStop(deps.client, plan.sandboxId);
         if (!stopped) {
-          // VM may still be running — keep the link so the idle reaper can reclaim it.
+          // VM may still be running — keep the link so a later attempt (or an
+          // explicit retry) can still find it and finish the teardown. There is
+          // no separate reaper; nothing reclaims this but a future call here.
           return { ok: false, reason: 'error' };
         }
         await safeRemove(deps.store, key);

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -4,6 +4,7 @@ import {
   createSpritesSandboxClient,
   isSpriteNotFoundError,
   classifyProvisionError,
+  planProvisionFailure,
   readSessionInfoId,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
@@ -394,7 +395,7 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     expect(handle.egressPolicyToken).toBeUndefined();
   });
 
-  it('given the egress lockdown fails, should destroy the Sprite and reject (never hand back open egress)', async () => {
+  it('given a FRESH create whose lockdown fails (transient flake), should retain the Sprite and reject WITHOUT destroying it', async () => {
     let destroyed: string | null = null;
     const sprite = fakeSprite({
       name: 'k',
@@ -415,7 +416,90 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     const error = await client.getOrCreate({ name: 'k', options }).then(() => null, (e) => e);
     expect(error).toBeInstanceOf(SandboxProvisionError);
     expect(String((error as SandboxProvisionError).providerCause)).toContain('policy api down');
-    expect(destroyed).toBe('k');
+    // A cold-start flake must never throw away a reusable VM — the next acquire
+    // under the same name retries against this SAME retained Sprite.
+    expect(destroyed).toBeNull();
+  });
+
+  it('given a FRESH create whose lockdown failed and was retained, the next acquire under the same name should retry against it and succeed', async () => {
+    let policyCalls = 0;
+    let spriteExists = false;
+    const created: string[] = [];
+    const deleted: string[] = [];
+    const sprite = fakeSprite({
+      name: 'k',
+      updateNetworkPolicy: async () => {
+        policyCalls += 1;
+        if (policyCalls === 1) throw new Error('policy api down');
+      },
+    });
+    const sdk: SpritesSdk = {
+      getSprite: async () => {
+        if (!spriteExists) throw new Error('not found');
+        return sprite;
+      },
+      createSprite: async (name) => {
+        created.push(name);
+        spriteExists = true;
+        return sprite;
+      },
+      deleteSprite: async (name) => {
+        deleted.push(name);
+        spriteExists = false;
+      },
+    };
+    const client = createSpritesSandboxClient({ sdk });
+
+    // First acquire: fresh create, lockdown fails, retained (not destroyed).
+    const firstError = await client.getOrCreate({ name: 'k', options }).then(() => null, (e) => e);
+    expect(firstError).toBeInstanceOf(SandboxProvisionError);
+    expect(created).toEqual(['k']);
+    expect(deleted).toEqual([]);
+
+    // Second acquire, same name: the Sprite still exists (retained), so this
+    // resolves via resume (not a second create) and the lockdown succeeds.
+    const handle = await client.getOrCreate({ name: 'k', options });
+    expect(handle.sandboxId).toBe('k');
+    expect(created).toEqual(['k']); // still only ONE create across both acquires
+    expect(deleted).toEqual([]); // never destroyed
+    expect(policyCalls).toBe(2); // retried, and this time it landed
+  });
+});
+
+describe('planProvisionFailure (pure)', () => {
+  assert({
+    given: 'a fresh Sprite failing its first lockdown attempt',
+    should: 'retain the VM and refuse the hand-back rather than destroy a reusable Sprite',
+    actual: planProvisionFailure({ fresh: true, attempt: 1, maxAttempts: 3 }),
+    expected: 'retain-and-refuse',
+  });
+
+  assert({
+    given: 'a fresh Sprite still short of its attempt ceiling',
+    should: 'keep retaining it',
+    actual: planProvisionFailure({ fresh: true, attempt: 2, maxAttempts: 3 }),
+    expected: 'retain-and-refuse',
+  });
+
+  assert({
+    given: 'a fresh Sprite that has exhausted every allotted attempt',
+    should: 'treat it as genuinely unusable and destroy it',
+    actual: planProvisionFailure({ fresh: true, attempt: 3, maxAttempts: 3 }),
+    expected: 'destroy',
+  });
+
+  assert({
+    given: 'a fresh Sprite past its ceiling',
+    should: 'still destroy — never loop forever provisioning against a broken VM',
+    actual: planProvisionFailure({ fresh: true, attempt: 5, maxAttempts: 3 }),
+    expected: 'destroy',
+  });
+
+  assert({
+    given: 'a RESUMED Sprite (not fresh) failing its lockdown, no matter the attempt count',
+    should: 'never destroy a warm session this caller does not own the lifecycle of',
+    actual: planProvisionFailure({ fresh: false, attempt: 10, maxAttempts: 3 }),
+    expected: 'retain-and-refuse',
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -425,6 +425,39 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     expect(destroyed).toBeNull();
   });
 
+  it('given a FRESH create whose mkdir fails but whose policy already landed, should retry ONLY the mkdir — never re-push an already-confirmed policy', async () => {
+    let policyCalls = 0;
+    let mkdirAttempts = 0;
+    const sprite = fakeSprite({
+      name: 'k',
+      updateNetworkPolicy: async () => {
+        policyCalls += 1;
+      },
+      spawn: () => {
+        mkdirAttempts += 1;
+        // A POST-open failure (opened: true) so the inner exec-level wake retry
+        // does NOT swallow it — it must propagate out to applyEgressLockdown's
+        // own OUTER retry loop, which is what this test exercises.
+        return mkdirAttempts === 1
+          ? fakeCommand({ opened: true, error: new Error('mkdir transport dropped mid-command') })
+          : fakeCommand({ exitCode: 0 });
+      },
+    });
+    const sdk: SpritesSdk = {
+      getSprite: async () => {
+        throw new Error('not found');
+      },
+      createSprite: async () => sprite,
+      deleteSprite: async () => {},
+    };
+    const client = createSpritesSandboxClient({ sdk, sleep: async () => {} });
+    const handle = await client.getOrCreate({ name: 'k', options });
+    expect(handle.sandboxId).toBe('k');
+    // The policy call succeeded on its very first (and only) attempt — a later
+    // retry of the failed mkdir step must not re-push it.
+    expect(policyCalls).toBe(1);
+  });
+
   it('given a FRESH create whose lockdown fails PERSISTENTLY, should exhaust its bounded retry budget and THEN destroy it (never poisoned forever)', async () => {
     let destroyed: string | null = null;
     let policyCalls = 0;

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -395,11 +395,43 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     expect(handle.egressPolicyToken).toBeUndefined();
   });
 
-  it('given a FRESH create whose lockdown fails (transient flake), should retain the Sprite and reject WITHOUT destroying it', async () => {
+  it('given a FRESH create whose lockdown fails ONCE (transient flake), should retry inline against the SAME Sprite and succeed without destroying it', async () => {
     let destroyed: string | null = null;
+    let policyCalls = 0;
     const sprite = fakeSprite({
       name: 'k',
       updateNetworkPolicy: async () => {
+        policyCalls += 1;
+        if (policyCalls === 1) throw new Error('policy api down');
+      },
+    });
+    const sdk: SpritesSdk = {
+      getSprite: async () => {
+        throw new Error('not found');
+      },
+      createSprite: async () => sprite,
+      deleteSprite: async (name) => {
+        destroyed = name;
+      },
+    };
+    // Real backoff would be fine (a couple hundred ms), but injecting a no-op
+    // sleep keeps this test instant.
+    const client = createSpritesSandboxClient({ sdk, sleep: async () => {} });
+    const handle = await client.getOrCreate({ name: 'k', options });
+    // A cold-start flake must never throw away a reusable VM: it retries the
+    // SAME Sprite inline (within this one acquire) and hands it back.
+    expect(handle.sandboxId).toBe('k');
+    expect(policyCalls).toBe(2);
+    expect(destroyed).toBeNull();
+  });
+
+  it('given a FRESH create whose lockdown fails PERSISTENTLY, should exhaust its bounded retry budget and THEN destroy it (never poisoned forever)', async () => {
+    let destroyed: string | null = null;
+    let policyCalls = 0;
+    const sprite = fakeSprite({
+      name: 'k',
+      updateNetworkPolicy: async () => {
+        policyCalls += 1;
         throw new Error('policy api down');
       },
     });
@@ -412,57 +444,60 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
         destroyed = name;
       },
     };
-    const client = createSpritesSandboxClient({ sdk });
+    const client = createSpritesSandboxClient({ sdk, sleep: async () => {} });
     const error = await client.getOrCreate({ name: 'k', options }).then(() => null, (e) => e);
     expect(error).toBeInstanceOf(SandboxProvisionError);
     expect(String((error as SandboxProvisionError).providerCause)).toContain('policy api down');
-    // A cold-start flake must never throw away a reusable VM — the next acquire
-    // under the same name retries against this SAME retained Sprite.
-    expect(destroyed).toBeNull();
+    // A genuinely broken fresh VM must not poison the session key forever with
+    // no persisted row to act on: it gets every bounded attempt, then is
+    // destroyed so the next acquire provisions a clean replacement.
+    expect(policyCalls).toBe(3);
+    expect(destroyed).toBe('k');
   });
 
-  it('given a FRESH create whose lockdown failed and was retained, the next acquire under the same name should retry against it and succeed', async () => {
+  it('given a fresh Sprite destroyed after exhausting its retry budget, the next acquire under the same name should provision a clean replacement and succeed', async () => {
+    let created = 0;
     let policyCalls = 0;
     let spriteExists = false;
-    const created: string[] = [];
     const deleted: string[] = [];
-    const sprite = fakeSprite({
-      name: 'k',
-      updateNetworkPolicy: async () => {
-        policyCalls += 1;
-        if (policyCalls === 1) throw new Error('policy api down');
-      },
-    });
+    const makeSprite = () =>
+      fakeSprite({
+        name: 'k',
+        updateNetworkPolicy: async () => {
+          policyCalls += 1;
+          // Only the FIRST Sprite instance is broken; its replacement works.
+          if (created === 1) throw new Error('policy api down');
+        },
+      });
     const sdk: SpritesSdk = {
       getSprite: async () => {
         if (!spriteExists) throw new Error('not found');
-        return sprite;
+        return makeSprite();
       },
       createSprite: async (name) => {
-        created.push(name);
+        created += 1;
         spriteExists = true;
-        return sprite;
+        return makeSprite();
       },
       deleteSprite: async (name) => {
         deleted.push(name);
         spriteExists = false;
       },
     };
-    const client = createSpritesSandboxClient({ sdk });
+    const client = createSpritesSandboxClient({ sdk, sleep: async () => {} });
 
-    // First acquire: fresh create, lockdown fails, retained (not destroyed).
+    // First acquire: fresh create, lockdown persistently fails, exhausted and destroyed.
     const firstError = await client.getOrCreate({ name: 'k', options }).then(() => null, (e) => e);
     expect(firstError).toBeInstanceOf(SandboxProvisionError);
-    expect(created).toEqual(['k']);
-    expect(deleted).toEqual([]);
+    expect(created).toBe(1);
+    expect(deleted).toEqual(['k']);
 
-    // Second acquire, same name: the Sprite still exists (retained), so this
-    // resolves via resume (not a second create) and the lockdown succeeds.
+    // Second acquire, same name: the broken Sprite is gone, so this is a genuine
+    // fresh create of a NEW (working) instance.
     const handle = await client.getOrCreate({ name: 'k', options });
     expect(handle.sandboxId).toBe('k');
-    expect(created).toEqual(['k']); // still only ONE create across both acquires
-    expect(deleted).toEqual([]); // never destroyed
-    expect(policyCalls).toBe(2); // retried, and this time it landed
+    expect(created).toBe(2);
+    expect(deleted).toEqual(['k']); // never re-destroyed
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -20,12 +20,15 @@
  *    `../egress-lockdown.ts`. The crash window the old unconditional re-apply
  *    defended (a crash between `createSprite` and its lockdown) is closed by
  *    ORDERING instead: the caller links the session only after `getOrCreate`
- *    resolves, so an unlocked Sprite is never reachable from a session row. A
- *    lockdown failure — FRESH or RESUMED — never destroys the Sprite: it RETAINS
- *    it and refuses the hand-back, so the next `getOrCreate` under the same name
- *    retries against that same VM instead of paying to provision a new one (see
- *    `planProvisionFailure`). The call still rejects so no command runs without a
- *    confirmed policy.
+ *    resolves, so an unlocked Sprite is never reachable from a session row —
+ *    whether or not it is ever destroyed. A lockdown failure RETAINS and retries
+ *    the Sprite inline (with backoff) rather than destroying it on the first
+ *    flake; a RESUMED Sprite is never destroyed no matter how many failures (it
+ *    already has a session row a user can act on), while a FRESH one that
+ *    exhausts its bounded retry budget IS destroyed, so a genuinely broken VM
+ *    doesn't poison its session key forever with no persisted row to act on —
+ *    see `planProvisionFailure`. The call always rejects on a failure so no
+ *    command runs without a confirmed policy.
  *  - **Caps** — RAM / vCPUs / storage / region come from the resolved policy
  *    (`SpriteConfig`), set explicitly per Sprite rather than relying on the quota
  *    defaults.
@@ -809,12 +812,17 @@ export type ProvisionFailurePlan = 'retain-and-refuse' | 'destroy';
  * `maxAttempts`), is it still worth RETAINING (retry the SAME VM again), or has
  * it proven genuinely unusable and earned a DESTROY?
  *
- * A RESUMED Sprite (`fresh: false`) is never destroyed here, no matter how many
+ * A RESUMED Sprite (`fresh: false`) is NEVER destroyed here, no matter how many
  * attempts: this caller does not own its lifecycle, and a warm session with a
  * flaky lockdown is still cheaper to keep retrying than to throw away (sprites
  * are meant to be created once and reused — docs.sprites.dev/working-with-sprites).
- * It already has a persisted session row a user can act on, so there is no
- * "poisoned with no way out" risk in leaving it to retry indefinitely.
+ * It already has a persisted session row a user (or a future operator tool) can
+ * act on, so there is no "poisoned with no way out" risk in leaving it to retry
+ * indefinitely — this IS a deliberate asymmetry with the fresh case below, not
+ * an oversight: a resumed Sprite that stays permanently broken degrades to "this
+ * one Machine/branch needs a human to delete and re-provision it," which is a
+ * known, acceptable outcome, never a silent resource leak (see
+ * `applyEgressLockdown`'s doc for the loop that enforces this).
  *
  * A FRESH Sprite is different: on its VERY FIRST successful `getOrCreate`
  * (fresh create, no session row yet — see `provisionFreshMachine`), a
@@ -858,10 +866,52 @@ const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
  * The retry loop is what keeps a FRESH Sprite from being poisoned forever by a
  * transient flake without ALSO being destroyed the instant a genuinely broken
  * one fails: `planProvisionFailure` decides, on each failure, whether this was
- * merely attempt N of a bounded budget (retry again) or the last chance (destroy
- * — see its doc). A RESUMED Sprite's caller passes `maxAttempts: 1`, so its
- * first failure is immediately judged 'retain-and-refuse' by `fresh: false`
- * and never retried inline — it already has a session row to fall back on.
+ * merely attempt N of a bounded budget (retry again) or the last chance
+ * (destroy — see its doc). Only the step that actually failed is retried: once
+ * `updateNetworkPolicy` lands, it is not re-pushed on a later attempt whose
+ * `mkdir` alone failed — needless repeat control-plane calls would otherwise
+ * risk tripping the policy API's own rate limiting on an already-healthy step.
+ *
+ * A RESUMED Sprite's caller passes `maxAttempts: 1`, so its first failure hits
+ * the loop's ceiling immediately: `planProvisionFailure` never returns
+ * 'destroy' for `fresh: false` (see its doc), so the explicit
+ * `attempt >= maxAttempts` check below — not `planProvisionFailure` — is what
+ * actually bounds THAT case. Do not delete it as "redundant": for a fresh
+ * Sprite it is provably unreachable (planProvisionFailure already returns
+ * 'destroy' at that same boundary), but for a resumed one it is the only thing
+ * standing between a single failed attempt and an infinite retry loop.
+ *
+ * This deliberately does NOT reuse the file's `withWakeRetry` executor above:
+ * that one retries ONLY a structurally-detected pre-open wake-drop and never
+ * destroys anything, while this one retries any lockdown failure and destroys
+ * on exhaustion — different enough plans that sharing one generic executor
+ * would need threading a plan callback through `withWakeRetry` for a single
+ * caller, more indirection than the duplication it would save.
+ *
+ * Nested retry note: the `mkdir` step below goes through
+ * `runSpawnedWithWakeRetry`, which has its OWN bounded wake-drop retry
+ * (`MAX_EXEC_ATTEMPTS`, each capped at the 30s passed here). In the
+ * vanishingly rare worst case where a Sprite hits pre-open wake-drops on every
+ * inner attempt AND every outer attempt, the two bounds compound
+ * (`maxAttempts` × `MAX_EXEC_ATTEMPTS` × 30s, plus backoff) — several minutes,
+ * not the ~90s a glance at `maxAttempts` alone suggests. This is accepted: it
+ * requires a VM that is broken in a very specific, narrow way, this driver
+ * runs inside long-lived Fly services (not a hard-timeout serverless
+ * function), and the alternative — a shorter per-attempt timeout — risks
+ * misjudging a merely slow-to-wake but healthy cold boot as "unusable" (the
+ * exact failure mode this leaf exists to fix).
+ *
+ * Residual risk (accepted, out of scope): if the PROCESS itself is killed
+ * mid-loop (a Fly Machine restart/OOM, not a request timeout — see above),
+ * a fresh Sprite that hasn't yet exhausted its budget survives undestroyed. The
+ * NEXT `getOrCreate` for that name then finds it via `sdk.getSprite` (success,
+ * not not-found), so `fresh` becomes `false` and it is treated as a RESUMED
+ * Sprite from then on — retained and refused forever if still broken, same as
+ * any other persistently-broken resumed Sprite (see `planProvisionFailure`'s
+ * doc on that asymmetry). Closing this fully would need a durable,
+ * cross-acquire attempt counter (e.g. persisted on the session row) — that is
+ * the same class of work as the reaper this leaf explicitly declines to build.
+ *
  * Either way the error still propagates so the caller refuses to hand back a
  * Sprite without a confirmed policy.
  */
@@ -882,9 +932,13 @@ async function applyEgressLockdown({
   baseDelayMs?: number;
   sleep?: (ms: number) => Promise<void>;
 }): Promise<void> {
-  for (let attempt = 1; ; attempt += 1) {
+  let policyApplied = false;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     try {
-      await sprite.updateNetworkPolicy(policy);
+      if (!policyApplied) {
+        await sprite.updateNetworkPolicy(policy);
+        policyApplied = true;
+      }
       // Use spawn + runSpawned (30 s wall-clock) to create the workspace dir
       // instead of filesystem().mkdir(). The filesystem API uses a bare fetch()
       // with no AbortSignal — it hangs for 52–90 s when the Sprite VM is
@@ -904,7 +958,10 @@ async function applyEgressLockdown({
         }
         throw error;
       }
-      if (attempt >= maxAttempts) throw error; // matches planProvisionFailure's own ceiling; defensive only
+      // Reached for a RESUMED Sprite once its (single-attempt) budget is spent
+      // — see this function's doc on why this check, not planProvisionFailure,
+      // is what bounds that case.
+      if (attempt >= maxAttempts) throw error;
       await sleep(wakeRetryDelayMs(attempt, baseDelayMs));
     }
   }

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -805,23 +805,27 @@ export function classifyProvisionError(error: unknown): SandboxProvisionError {
 export type ProvisionFailurePlan = 'retain-and-refuse' | 'destroy';
 
 /**
- * Pure: after a Sprite fails its `attempt`-th lockdown, is it still worth
- * RETAINING (so the next `getOrCreate` under the same name retries against this
- * SAME VM instead of paying to provision a new one), or has it proven genuinely
- * unusable and earned a DESTROY?
+ * Pure: after a Sprite fails its `attempt`-th lockdown (of at most
+ * `maxAttempts`), is it still worth RETAINING (retry the SAME VM again), or has
+ * it proven genuinely unusable and earned a DESTROY?
  *
  * A RESUMED Sprite (`fresh: false`) is never destroyed here, no matter how many
  * attempts: this caller does not own its lifecycle, and a warm session with a
  * flaky lockdown is still cheaper to keep retrying than to throw away (sprites
  * are meant to be created once and reused — docs.sprites.dev/working-with-sprites).
+ * It already has a persisted session row a user can act on, so there is no
+ * "poisoned with no way out" risk in leaving it to retry indefinitely.
  *
- * `attempt`/`maxAttempts` model a bounded retry budget for a caller that tracks
- * failed lockdown attempts ACROSS separate acquires (e.g. a counter persisted on
- * the session row). `applyEgressLockdown` below has no such counter today — every
- * real call passes `attempt: 1` against a `maxAttempts` greater than one, so a
- * genuine transient flake (a cold-start mkdir/network hiccup) always retains.
- * The `destroy` branch is fully exercised in tests and stands ready for a future
- * caller that supplies a real, persisted attempt count.
+ * A FRESH Sprite is different: on its VERY FIRST successful `getOrCreate`
+ * (fresh create, no session row yet — see `provisionFreshMachine`), a
+ * persistently broken VM (filesystem corruption, a policy API that rejects
+ * THIS instance specifically) would otherwise poison the session key forever —
+ * no row is ever saved for the caller to find and tear down. So `attempt` here
+ * is a BOUNDED retry budget `applyEgressLockdown` exhausts WITHIN one
+ * `getOrCreate` call (see its bounded-retry loop): fewer than `maxAttempts`
+ * failures retains and retries once more with backoff; reaching `maxAttempts`
+ * means the VM has had every reasonable chance and is destroyed so the next
+ * acquire provisions a clean one instead of retrying forever against a broken VM.
  */
 export function planProvisionFailure({
   fresh,
@@ -836,51 +840,73 @@ export function planProvisionFailure({
   return attempt >= maxAttempts ? 'destroy' : 'retain-and-refuse';
 }
 
-// No caller yet persists a failed-lockdown attempt count across separate
-// acquires, so every real call to `applyEgressLockdown` is "attempt 1" against
-// this ceiling — which `planProvisionFailure` always resolves to
-// 'retain-and-refuse'. Kept > 1 so a transient flake is never destroyed; see
-// `planProvisionFailure`'s doc for the future caller this budget is reserved for.
+// A FRESH Sprite gets this many lockdown attempts (with backoff) inside ONE
+// `getOrCreate` call before it is judged genuinely unusable and destroyed — see
+// `planProvisionFailure`. A RESUMED Sprite gets exactly one attempt (it already
+// has a session row a user can act on, so there is no urgency to retry inline —
+// see `applyEgressLockdown`'s call site).
 const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
 
-// Apply the deny-by-default egress policy and ensure the sandbox root exists.
-// Called only when the policy is NOT already known-good on this Sprite (fresh
-// create, hash mismatch, or unknown recorded state — see `shouldApplyPolicy`), so
-// a Sprite is never returned with open/unknown egress and a warm resume pays no
-// redundant control-plane round-trip. A lockdown failure NEVER destroys the
-// Sprite on a transient flake — see `planProvisionFailure` — it only destroys a
-// genuinely exhausted, unusable one. Either way the error still propagates so
-// the caller refuses to hand back a Sprite without a confirmed policy.
+/**
+ * Apply the deny-by-default egress policy and ensure the sandbox root exists,
+ * retrying a FAILED lockdown up to `maxAttempts` times (with backoff) before
+ * giving up. Called only when the policy is NOT already known-good on this
+ * Sprite (fresh create, hash mismatch, or unknown recorded state — see
+ * `shouldApplyPolicy`), so a Sprite is never returned with open/unknown egress
+ * and a warm resume pays no redundant control-plane round-trip.
+ *
+ * The retry loop is what keeps a FRESH Sprite from being poisoned forever by a
+ * transient flake without ALSO being destroyed the instant a genuinely broken
+ * one fails: `planProvisionFailure` decides, on each failure, whether this was
+ * merely attempt N of a bounded budget (retry again) or the last chance (destroy
+ * — see its doc). A RESUMED Sprite's caller passes `maxAttempts: 1`, so its
+ * first failure is immediately judged 'retain-and-refuse' by `fresh: false`
+ * and never retried inline — it already has a session row to fall back on.
+ * Either way the error still propagates so the caller refuses to hand back a
+ * Sprite without a confirmed policy.
+ */
 async function applyEgressLockdown({
   sdk,
   sprite,
   policy,
   fresh,
+  maxAttempts,
+  baseDelayMs = RETRY_BASE_DELAY_MS,
+  sleep = delay,
 }: {
   sdk: SpritesSdk;
   sprite: SpriteInstanceLike;
   policy: NetworkPolicy;
   fresh: boolean;
+  maxAttempts: number;
+  baseDelayMs?: number;
+  sleep?: (ms: number) => Promise<void>;
 }): Promise<void> {
-  try {
-    await sprite.updateNetworkPolicy(policy);
-    // Use spawn + runSpawned (30 s wall-clock) to create the workspace dir instead
-    // of filesystem().mkdir(). The filesystem API uses a bare fetch() with no
-    // AbortSignal — it hangs for 52–90 s when the Sprite VM is cold-booting and
-    // Fly's proxy eventually closes the connection. spawn() connects via WebSocket
-    // which is the designated wake-up path; runSpawned enforces the timeout and
-    // SIGKILLs if the Sprite never becomes ready.
-    await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, 30_000);
-  } catch (error) {
-    const plan = planProvisionFailure({ fresh, attempt: 1, maxAttempts: PROVISION_LOCKDOWN_MAX_ATTEMPTS });
-    if (plan === 'destroy') {
-      try {
-        await sdk.deleteSprite(sprite.name);
-      } catch {
-        // Best-effort cleanup of a Sprite we refuse to hand back.
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      await sprite.updateNetworkPolicy(policy);
+      // Use spawn + runSpawned (30 s wall-clock) to create the workspace dir
+      // instead of filesystem().mkdir(). The filesystem API uses a bare fetch()
+      // with no AbortSignal — it hangs for 52–90 s when the Sprite VM is
+      // cold-booting and Fly's proxy eventually closes the connection. spawn()
+      // connects via WebSocket, which is the designated wake-up path;
+      // runSpawned enforces the timeout and SIGKILLs if the Sprite never
+      // becomes ready.
+      await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, 30_000);
+      return;
+    } catch (error) {
+      const plan = planProvisionFailure({ fresh, attempt, maxAttempts });
+      if (plan === 'destroy') {
+        try {
+          await sdk.deleteSprite(sprite.name);
+        } catch {
+          // Best-effort cleanup of a Sprite we refuse to hand back.
+        }
+        throw error;
       }
+      if (attempt >= maxAttempts) throw error; // matches planProvisionFailure's own ceiling; defensive only
+      await sleep(wakeRetryDelayMs(attempt, baseDelayMs));
     }
-    throw error;
   }
 }
 
@@ -940,7 +966,15 @@ export function createSpriteHandleCache(sdk: SpritesSdk): SpritesSdk {
   };
 }
 
-export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSandboxClient {
+export function createSpritesSandboxClient({
+  sdk,
+  // Injectable so a test can exercise the bounded lockdown-retry backoff
+  // without real wall-clock waits. Production uses the real timer.
+  sleep = delay,
+}: {
+  sdk: SpritesSdk;
+  sleep?: (ms: number) => Promise<void>;
+}): ExecSandboxClient {
   return {
     async getOrCreate({ name, options, appliedEgressToken }) {
       // Resume by name when the Sprite already exists; create fresh ONLY on a
@@ -978,7 +1012,17 @@ export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSa
         });
         const desiredToken = egressLockdownToken({ spriteId: sprite.id, policyHash: hashPolicy(policy) });
         if (shouldApplyPolicy({ fresh, appliedToken: appliedEgressToken, desiredToken })) {
-          await applyEgressLockdown({ sdk, sprite, policy, fresh });
+          // A FRESH Sprite gets a bounded retry budget (see planProvisionFailure)
+          // before it is judged unusable; a RESUMED one gets exactly one attempt
+          // — it already has a session row a user can act on if this keeps failing.
+          await applyEgressLockdown({
+            sdk,
+            sprite,
+            policy,
+            fresh,
+            maxAttempts: fresh ? PROVISION_LOCKDOWN_MAX_ATTEMPTS : 1,
+            sleep,
+          });
         }
         // wrap sets sandboxId = sprite.name = spriteName (truncated). The token is
         // now CONFIRMED for this VM (freshly applied, or already proven) — the

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -20,10 +20,11 @@
  *    `../egress-lockdown.ts`. The crash window the old unconditional re-apply
  *    defended (a crash between `createSprite` and its lockdown) is closed by
  *    ORDERING instead: the caller links the session only after `getOrCreate`
- *    resolves, so an unlocked Sprite is never reachable from a session row. On a
- *    FRESH Sprite a lockdown failure destroys it and rejects; on a RESUMED one we
- *    never destroy a warm session we don't own the lifecycle of, but we still
- *    refuse to hand it back — the call rejects so no command runs without a
+ *    resolves, so an unlocked Sprite is never reachable from a session row. A
+ *    lockdown failure — FRESH or RESUMED — never destroys the Sprite: it RETAINS
+ *    it and refuses the hand-back, so the next `getOrCreate` under the same name
+ *    retries against that same VM instead of paying to provision a new one (see
+ *    `planProvisionFailure`). The call still rejects so no command runs without a
  *    confirmed policy.
  *  - **Caps** — RAM / vCPUs / storage / region come from the resolved policy
  *    (`SpriteConfig`), set explicitly per Sprite rather than relying on the quota
@@ -32,8 +33,13 @@
  *    `buildSandboxEnv`; this driver injects none. v1 brokers no outbound
  *    credentials (a Fly Tokenizer proxy is the future path, out of scope).
  *
- * `stop` DESTROYS the Sprite (not a checkpoint) so there is no orphaned/idle
- * billing.
+ * `stop` is a USER-INITIATED, irreversible DESTROY — files, installed packages,
+ * and checkpoints are all gone with no undo (docs.sprites.dev/working-with-sprites).
+ * Call it only for genuine teardown intent (a Machine/branch delete, or cleaning
+ * up a Sprite this process just failed to link to a session row) — never as
+ * idle/billing cleanup: a paused Sprite already stops compute billing on its own
+ * and costs only bytes-written storage, so idleness alone is never a reason to
+ * destroy one (docs.sprites.dev/concepts/lifecycle).
  *
  * The SDK's promise-based `exec`/`execFile` expose neither a per-command timeout
  * nor a handle to abort a running command, so the run is driven through `spawn`
@@ -42,8 +48,9 @@
  * the SDK's own `execFile` stream collection (stdout/stderr `data` listeners,
  * `maxBuffer` cap, `exit` event) and add a HARD wall-clock timer that SIGKILLs
  * the command on expiry. The command, not the Sprite, is killed — the warm
- * conversation session survives a single slow run and the idle reaper reclaims
- * an abandoned VM.
+ * conversation session survives a single slow run; if the conversation goes
+ * quiet afterward, the Sprite simply hibernates on its own (the platform's idle
+ * pause), never destructively reclaimed.
  *
  * The SDK is injected (`sdk`) so the mapping — create/resume, policy lockdown,
  * exit/stdout/stderr surfacing, hard-timeout SIGKILL, get→null on a vanished
@@ -349,7 +356,9 @@ function runSpawned(
         try {
           command.kill('SIGKILL');
         } catch {
-          // Best-effort kill; the wall-clock timer / idle reaper still bound it.
+          // Best-effort kill; if the signal is dropped, the run's own wall-clock
+          // timeout (when set) or the Sprite's own idle hibernation is the
+          // eventual backstop — there is no separate reaper.
         }
         fail(new SandboxOutputLimitError(maxBuffer));
         return len;
@@ -399,7 +408,8 @@ function runSpawned(
         try {
           command.kill('SIGKILL');
         } catch {
-          // Best-effort; an unkillable command is reclaimed by the idle reaper.
+          // Best-effort; if SIGKILL is dropped, the Sprite's own idle
+          // hibernation is the eventual backstop — there is no separate reaper.
         }
         fail(new SandboxCommandTimeoutError(timeoutMs));
       }, timeoutMs);
@@ -791,25 +801,66 @@ export function classifyProvisionError(error: unknown): SandboxProvisionError {
   return new SandboxProvisionError('unavailable', retryAfterSeconds, error);
 }
 
+/** The outcome of a failed lockdown attempt: keep the VM around, or give up on it. */
+export type ProvisionFailurePlan = 'retain-and-refuse' | 'destroy';
+
+/**
+ * Pure: after a Sprite fails its `attempt`-th lockdown, is it still worth
+ * RETAINING (so the next `getOrCreate` under the same name retries against this
+ * SAME VM instead of paying to provision a new one), or has it proven genuinely
+ * unusable and earned a DESTROY?
+ *
+ * A RESUMED Sprite (`fresh: false`) is never destroyed here, no matter how many
+ * attempts: this caller does not own its lifecycle, and a warm session with a
+ * flaky lockdown is still cheaper to keep retrying than to throw away (sprites
+ * are meant to be created once and reused — docs.sprites.dev/working-with-sprites).
+ *
+ * `attempt`/`maxAttempts` model a bounded retry budget for a caller that tracks
+ * failed lockdown attempts ACROSS separate acquires (e.g. a counter persisted on
+ * the session row). `applyEgressLockdown` below has no such counter today — every
+ * real call passes `attempt: 1` against a `maxAttempts` greater than one, so a
+ * genuine transient flake (a cold-start mkdir/network hiccup) always retains.
+ * The `destroy` branch is fully exercised in tests and stands ready for a future
+ * caller that supplies a real, persisted attempt count.
+ */
+export function planProvisionFailure({
+  fresh,
+  attempt,
+  maxAttempts,
+}: {
+  fresh: boolean;
+  attempt: number;
+  maxAttempts: number;
+}): ProvisionFailurePlan {
+  if (!fresh) return 'retain-and-refuse';
+  return attempt >= maxAttempts ? 'destroy' : 'retain-and-refuse';
+}
+
+// No caller yet persists a failed-lockdown attempt count across separate
+// acquires, so every real call to `applyEgressLockdown` is "attempt 1" against
+// this ceiling — which `planProvisionFailure` always resolves to
+// 'retain-and-refuse'. Kept > 1 so a transient flake is never destroyed; see
+// `planProvisionFailure`'s doc for the future caller this budget is reserved for.
+const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
+
 // Apply the deny-by-default egress policy and ensure the sandbox root exists.
 // Called only when the policy is NOT already known-good on this Sprite (fresh
 // create, hash mismatch, or unknown recorded state — see `shouldApplyPolicy`), so
 // a Sprite is never returned with open/unknown egress and a warm resume pays no
-// redundant control-plane round-trip. When `destroyOnFailure` is set (a FRESH
-// create), a lockdown failure destroys the just-created Sprite before
-// propagating; on a resumed Sprite we never destroy a warm session, but the error
-// still propagates so the caller refuses to hand back a Sprite without a
-// confirmed policy.
+// redundant control-plane round-trip. A lockdown failure NEVER destroys the
+// Sprite on a transient flake — see `planProvisionFailure` — it only destroys a
+// genuinely exhausted, unusable one. Either way the error still propagates so
+// the caller refuses to hand back a Sprite without a confirmed policy.
 async function applyEgressLockdown({
   sdk,
   sprite,
   policy,
-  destroyOnFailure,
+  fresh,
 }: {
   sdk: SpritesSdk;
   sprite: SpriteInstanceLike;
   policy: NetworkPolicy;
-  destroyOnFailure: boolean;
+  fresh: boolean;
 }): Promise<void> {
   try {
     await sprite.updateNetworkPolicy(policy);
@@ -821,7 +872,8 @@ async function applyEgressLockdown({
     // SIGKILLs if the Sprite never becomes ready.
     await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, 30_000);
   } catch (error) {
-    if (destroyOnFailure) {
+    const plan = planProvisionFailure({ fresh, attempt: 1, maxAttempts: PROVISION_LOCKDOWN_MAX_ATTEMPTS });
+    if (plan === 'destroy') {
       try {
         await sdk.deleteSprite(sprite.name);
       } catch {
@@ -926,7 +978,7 @@ export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSa
         });
         const desiredToken = egressLockdownToken({ spriteId: sprite.id, policyHash: hashPolicy(policy) });
         if (shouldApplyPolicy({ fresh, appliedToken: appliedEgressToken, desiredToken })) {
-          await applyEgressLockdown({ sdk, sprite, policy, destroyOnFailure: fresh });
+          await applyEgressLockdown({ sdk, sprite, policy, fresh });
         }
         // wrap sets sandboxId = sprite.name = spriteName (truncated). The token is
         // now CONFIRMED for this VM (freshly applied, or already proven) — the
@@ -956,7 +1008,8 @@ export function createSpritesSandboxClient({ sdk }: { sdk: SpritesSdk }): ExecSa
     },
 
     async stop({ sandboxId }) {
-      // DESTROY, not checkpoint — no orphaned/idle billing.
+      // Irreversible DESTROY, never a checkpoint — see the file header. Callers
+      // must only invoke this for genuine teardown intent, never idle cleanup.
       await sdk.deleteSprite(sandboxId);
     },
   };


### PR DESCRIPTION
## Summary

`stop()`/`deleteSprite` is irreversible (files, installed packages, checkpoints
all gone — docs.sprites.dev/working-with-sprites) and a paused sprite already
stops compute billing on its own, costing only bytes-written storage
(docs.sprites.dev/concepts/lifecycle). So the old rationale — destroy to avoid
"orphaned/idle billing" — was never accurate, and its worst consequence was
destroying a **fresh** sprite over a transient lockdown/mkdir flake during
provisioning, throwing away a reusable VM on a cold-start blip.

This PR makes destroy semantics reflect actual user intent.

## Requirements → how satisfied

- **Teardown primitive documented/named as user-initiated DESTROY, "no
  orphaned/idle billing" rationale removed.**
  Kept the `stop` name (documenting contractually, per the leaf's "or document
  contractually" option, rather than a 16-file rename across `apps/web`,
  `apps/realtime`, and multiple test suites that sit outside this leaf's file
  region). Rewrote the doc on `sprites.ts`'s file header, its `stop()`
  implementation, and `SandboxClient.stop` in `machine-session-manager.ts`:
  each now states this is an irreversible DESTROY, for genuine teardown intent
  only (machine delete, branch kill, orphan-on-save-failure) — never
  idle/billing cleanup.

- **Transient lockdown/mkdir failure on a fresh create refuses the hand-back
  WITHOUT deleting the sprite; the next acquire retries against the retained
  VM.**
  Added the pure decision `planProvisionFailure({fresh, attempt, maxAttempts})
  -> 'retain-and-refuse' | 'destroy'` (`sprites.ts`). `applyEgressLockdown` now
  retries a FRESH Sprite's lockdown INLINE (with backoff), up to
  `PROVISION_LOCKDOWN_MAX_ATTEMPTS` (3) attempts, within the same `getOrCreate`
  call, before `planProvisionFailure`'s `destroy` branch actually fires:
  - A one-off transient flake now recovers and succeeds inline — no user-visible
    failure at all.
  - A persistently broken fresh VM (filesystem corruption, a policy API that
    consistently rejects that specific instance) exhausts its bounded retry
    budget and IS destroyed within that same call, so the next acquire under
    the same name provisions a clean replacement — the session key is never
    poisoned forever with no persisted row to act on. *(This closes a gap a
    reviewer flagged after the first push — see "Review feedback addressed"
    below.)*
  - A RESUMED Sprite is unchanged: exactly one attempt, never destroyed (it
    already has a session row a user can act on if its lockdown keeps failing).
  `createSpritesSandboxClient` takes an optional `sleep` override so tests can
  skip the real backoff wait.

- **Crash-window safety preserved.**
  No change to the ordering invariant: the caller still links the session only
  AFTER `getOrCreate` resolves, so an unlocked Sprite is never reachable from a
  session row — updated the stale doc in `egress-lockdown.ts` that claimed "the
  Sprite is destroyed on lockdown failure anyway" (no longer true) to describe
  the current retain/bounded-retry behavior instead.

- **Phantom "idle reaper" comments removed/reworded.**
  Reworded in `sprites.ts` (file header ×2, both SIGKILL-fallback comments),
  `machine-session-manager.ts` (teardown-retry comment), `machine-branches.ts`
  (kill-retry comment), and `machine-settings-runtime.ts` (module doc + teardown
  doc) to describe reality: pause-on-idle is the platform's own job, not a
  code-level reclaimer; any future storage-cost-based reclaimer is out of scope.
  (Left `lifecycle.ts:83`'s "durable idle reaper" comment alone — that's the
  separate Agent Code Execution conversation-sandbox lifecycle, not in this
  leaf's context/file region.)

## Review feedback addressed

- **Codex** ([thread](https://github.com/2witstudios/PageSpace/pull/2021#discussion_r3566817718)):
  flagged that the first version of this PR evaluated every real lockdown
  failure as `attempt: 1`, so a genuinely broken fresh Sprite would be retained
  forever with no persisted session row for a user to act on ("poisoned" key).
  Fixed in 3e5626da4 — see the bounded-retry design above and the two new
  tests (`given a FRESH create whose lockdown fails ONCE...` /
  `...fails PERSISTENTLY...`).

## Out of scope (per leaf spec)
- Building any reaper.
- Checkpoint-on-destroy (a possible future safety net) — noted as a follow-up,
  not built here.

## Test plan
- [x] `bun run test` (from `packages/lib`) — full suite: 7623 passed, 6 skipped
  (348 files), including the `planProvisionFailure` matrix and the new
  bounded-retry / destroy-after-exhaustion integration tests.
- [x] `bun run typecheck` (monorepo, via turbo) — clean, exit 0.
- [x] No `any` types added.
- [x] Verified no merge conflicts with `master` (`git merge-tree` dry run —
  clean; only 2 unrelated commits ahead on master, neither touching these files).

Depends on 1-4/1-5 landing first (same file region in `sprites.ts`) — this PR
was branched from current master.

https://claude.ai/code/session_01LAFHBEZ2gFCvXKNxbU7W9m