### PR TITLE
[sprites 2-5] Discard redundant replay on transparent reconnect (agent-TUI repaint fix)

### DIFF
--- a/apps/realtime/src/terminal/__tests__/replay-dedupe.test.ts
+++ b/apps/realtime/src/terminal/__tests__/replay-dedupe.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   EMPTY_SEEN,
   MAX_ANCHOR_BYTES,
+  MAX_DISCARDABLE_GIVEUP_BYTES,
   MAX_MATCH_CANDIDATES,
   MAX_PENDING_BYTES,
   MAX_SEEN_BYTES,
@@ -740,26 +741,53 @@ describe('buffering an unalignable replay (pure)', () => {
  * The give-up TERMINAL ACTION — what a caller does with an unaligned replay's bytes once
  * `planReplayEmission`/`flushReplay` have already decided they cannot be placed. Detection is
  * unchanged (both still hand back the whole burst); this is the decision built on top of it.
+ *
+ * The server session keeps running while the client is disconnected — only the socket died —
+ * so an unaligned burst on a transparent reconnect can legitimately contain output the shell
+ * produced DURING the reconnect gap, not just a stale redraw of what the viewer already saw
+ * (see the function's own doc). `burstBytes` bounds how much of that risk this leaf accepts:
+ * small (redraw-shaped) bursts are discarded, large (active-output-shaped) ones are still shown.
  */
 describe('resolveGiveUpAction (pure)', () => {
   assert({
-    given: 'a transparent in-place attach reconnect (the viewer never left)',
-    should: 'discard the burst — every byte it could carry has already been shown, live',
-    actual: resolveGiveUpAction({ attachKind: 'transparent-attach' }),
+    given: 'a SMALL burst on a transparent in-place attach reconnect (the viewer never left)',
+    should: 'discard it — small enough to be a plausible redraw of what is already on screen',
+    actual: resolveGiveUpAction({ attachKind: 'transparent-attach', burstBytes: 100 }),
     expected: 'discard',
   });
 
   assert({
-    given: 'a fresh session create (the old one is gone, nothing of it is on screen)',
-    should: 'emit the burst verbatim — today\'s baseline give-up behavior',
-    actual: resolveGiveUpAction({ attachKind: 'fresh' }),
+    given: 'a burst EXACTLY at the discardable bound, on a transparent attach reconnect',
+    should: 'still discard it — the bound is inclusive',
+    actual: resolveGiveUpAction({ attachKind: 'transparent-attach', burstBytes: MAX_DISCARDABLE_GIVEUP_BYTES }),
+    expected: 'discard',
+  });
+
+  assert({
+    given: 'a burst ONE BYTE over the discardable bound, on a transparent attach reconnect',
+    should: 'emit it — too large to plausibly be a mere redraw; treat it as real output',
+    actual: resolveGiveUpAction({ attachKind: 'transparent-attach', burstBytes: MAX_DISCARDABLE_GIVEUP_BYTES + 1 }),
     expected: 'emit',
   });
 
   assert({
-    given: 'a fresh-viewer attach (a cold connect, or this shell\'s very first wire())',
+    given: 'a LARGE burst on a transparent in-place attach reconnect (e.g. a build, a log flood)',
+    should: 'emit it — the "silently lose build/log output" case must still be shown, not dropped',
+    actual: resolveGiveUpAction({ attachKind: 'transparent-attach', burstBytes: 4 * 1024 * 1024 }),
+    expected: 'emit',
+  });
+
+  assert({
+    given: 'a fresh session create (the old one is gone, nothing of it is on screen), any burst size',
+    should: 'emit the burst verbatim — today\'s baseline give-up behavior, regardless of size',
+    actual: resolveGiveUpAction({ attachKind: 'fresh', burstBytes: 10 }),
+    expected: 'emit',
+  });
+
+  assert({
+    given: 'a fresh-viewer attach (a cold connect, or this shell\'s very first wire()), any burst size',
     should: 'emit the burst verbatim — discard is scoped to transparent reconnects only',
-    actual: resolveGiveUpAction({ attachKind: 'fresh' }),
+    actual: resolveGiveUpAction({ attachKind: 'fresh', burstBytes: 10 * 1024 * 1024 }),
     expected: 'emit',
   });
 });

--- a/apps/realtime/src/terminal/__tests__/replay-dedupe.test.ts
+++ b/apps/realtime/src/terminal/__tests__/replay-dedupe.test.ts
@@ -13,6 +13,7 @@ import {
   planReplayEmission,
   rememberDelivered,
   resetFoldCount,
+  resolveGiveUpAction,
 } from '../replay-dedupe';
 
 // riteway-style assertion (given/should/actual/expected) on top of vitest. There IS a
@@ -732,5 +733,33 @@ describe('buffering an unalignable replay (pure)', () => {
 
     expect(state.pending.length).toBeGreaterThan(MAX_ANCHOR_BYTES); // still searching, still holding
     expect(foldCount()).toBe(0); // warm: the window ROLLS. 100 frames, zero re-folds.
+  });
+});
+
+/**
+ * The give-up TERMINAL ACTION — what a caller does with an unaligned replay's bytes once
+ * `planReplayEmission`/`flushReplay` have already decided they cannot be placed. Detection is
+ * unchanged (both still hand back the whole burst); this is the decision built on top of it.
+ */
+describe('resolveGiveUpAction (pure)', () => {
+  assert({
+    given: 'a transparent in-place attach reconnect (the viewer never left)',
+    should: 'discard the burst — every byte it could carry has already been shown, live',
+    actual: resolveGiveUpAction({ attachKind: 'transparent-attach' }),
+    expected: 'discard',
+  });
+
+  assert({
+    given: 'a fresh session create (the old one is gone, nothing of it is on screen)',
+    should: 'emit the burst verbatim — today\'s baseline give-up behavior',
+    actual: resolveGiveUpAction({ attachKind: 'fresh' }),
+    expected: 'emit',
+  });
+
+  assert({
+    given: 'a fresh-viewer attach (a cold connect, or this shell\'s very first wire())',
+    should: 'emit the burst verbatim — discard is scoped to transparent reconnects only',
+    actual: resolveGiveUpAction({ attachKind: 'fresh' }),
+    expected: 'emit',
   });
 });

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1080,7 +1080,14 @@ describe('openPtyShell', () => {
       expect(outputs(onOutput)).toEqual([BANNER, BANNER]);
     });
 
-    it('given a replay it cannot align (the server buffer trimmed past what we forwarded), emits it rather than losing it', async () => {
+    it('given a replay on a TRANSPARENT reconnect that cannot align, discards it rather than reprinting (leaf 2-5)', async () => {
+      // 2-4's baseline (superseded by this leaf, for exactly this shape): "duplicating a
+      // redraw is survivable; swallowing the session's output is not" — so an unaligned
+      // replay went out verbatim. That is right for a FRESH session, and wrong for an
+      // in-place reconnect: the viewer has been continuously attached the whole time, so
+      // whatever this attach's replay carries, it has already been shown — see
+      // `resolveGiveUpAction`. Discarding it is what stops a repainting agent TUI from
+      // restacking itself on every ~45s keepalive cycle.
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
@@ -1097,10 +1104,33 @@ describe('openPtyShell', () => {
 
       // Held back while the boundary might still turn up...
       expect(outputs(onOutput)).toEqual([BANNER]);
-      // ...then released. Duplicating a redraw is survivable; swallowing the
-      // session's output is not.
+      // ...then the window closes, gives up, and — on THIS attach kind — discards rather
+      // than reprints. No new output reaches the client.
       await vi.advanceTimersByTimeAsync(1000);
-      expect(outputs(onOutput)).toEqual([BANNER, 'output we never forwarded\r\n']);
+      expect(outputs(onOutput)).toEqual([BANNER]);
+    });
+
+    it('given genuinely-new output AFTER a discarded give-up on the SAME reconnect, still forwards it', async () => {
+      // Discard must not swallow live output that arrives once the window has already
+      // closed and resolved — only the unaligned BURST itself is dropped.
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onOutput = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      cmd._emitter.emit('spawn');
+      cmd._stdout.emit('data', BANNER);
+
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+      attachCmd._stdout.emit('data', 'output we never forwarded\r\n');
+      await vi.advanceTimersByTimeAsync(1000); // the window closes and discards it
+
+      attachCmd._stdout.emit('data', 'genuinely live output\r\n');
+
+      expect(outputs(onOutput)).toEqual([BANNER, 'genuinely live output\r\n']);
     });
 
     it('given the handler\'s scrollback sink on the other end, appends the banner ONCE across repeated reconnects', async () => {
@@ -1188,10 +1218,11 @@ describe('openPtyShell', () => {
       expect(outputs(onOutput).join('')).toBe(afterRecovery); // recovered, and stayed recovered
     });
 
-    it('given an unalignable replay whose window closes, REPORTS it', async () => {
-      // The terminal is reprinting its scrollback rather than deduping, and an operator can
-      // only see that if we say so. This path had no test: deleting the report left the whole
-      // suite green.
+    it('given an unalignable replay whose window closes, REPORTS it (and says it was discarded)', async () => {
+      // The terminal is discarding its replay burst rather than deduping it, and an operator
+      // can only see that if we say so. This path had no test: deleting the report left the
+      // whole suite green. The `outcome` field is what leaf 2-5 added to that report — see
+      // `resolveGiveUpAction` — so the cadence stays distinguishable from a plain reprint.
       const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
@@ -1208,18 +1239,20 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(2000); // settle, then the window deadline
 
       const reported = warn.mock.calls.filter(
-        ([, meta]) => (meta as { cause?: string } | undefined)?.cause === 'window-closed',
+        ([, meta]) => (meta as { cause?: string; outcome?: string } | undefined)?.cause === 'window-closed',
       );
       warn.mockRestore(); // before the assertion: a failing expect must not leak the spy
       expect(reported.length).toBeGreaterThan(0);
+      expect((reported[0][1] as { outcome?: string }).outcome).toBe('discarded');
     });
 
-    it('given a replay that overflows the byte cap, REPORTS it (the one give-up that never reaches the window close)', async () => {
+    it('given a replay that overflows the byte cap, REPORTS it (and says it was discarded)', async () => {
       // A ring bigger than MAX_PENDING_BYTES is the cause that does not heal: the anchor sits
-      // at a replay's END, so the cap trips before it ever arrives, and the scrollback reprints
-      // on every reconnect until the cap is raised past the ring. It is also the give-up that
-      // resolves inside the pure core — `closeReplayWindow`, and its log, never run. If it did
-      // not report here, the failure the cap exists to catch would be the only silent one.
+      // at a replay's END, so the cap trips before it ever arrives, and the scrollback would
+      // reprint (or now, discard) on every reconnect until the cap is raised past the ring. It
+      // is also the give-up that resolves inside the pure core — `closeReplayWindow`, and its
+      // log, never run. If it did not report here, the failure the cap exists to catch would
+      // be the only silent one.
       const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
@@ -1239,20 +1272,20 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(2000);
 
       const reported = warn.mock.calls.filter(
-        ([, meta]) => (meta as { cause?: string } | undefined)?.cause === 'pending-cap',
+        ([, meta]) => (meta as { cause?: string; outcome?: string } | undefined)?.cause === 'pending-cap',
       );
       warn.mockRestore(); // before the assertion: a failing expect must not leak the spy
       expect(reported.length).toBeGreaterThan(0); // it says so, instead of failing silently
+      expect((reported[0][1] as { outcome?: string }).outcome).toBe('discarded');
     });
 
-    it('given a replay that overflows the byte cap, emits it and leaves a usable history', async () => {
+    it('given a replay that overflows the byte cap on a transparent reconnect, discards it and leaves a usable history', async () => {
       // The other give-up path: the replay never aligns and grows past MAX_PENDING_BYTES, so
-      // the pure core emits it verbatim rather than the window timer. (Whether that emission
-      // 'restarts' or 'appends' the history is unobservable HERE by construction — it is
-      // larger than the whole history, so the retention trim evicts the past either way. The
-      // flag itself is asserted at the source, in replay-dedupe.test.ts.) What this pins is
-      // what the shell must guarantee: the bytes reach the user, and the history that comes
-      // out the other side still dedupes.
+      // the pure core resolves inside `planReplayEmission` rather than the window timer. 2-4's
+      // baseline emitted it verbatim; leaf 2-5 discards it on THIS attach kind (see
+      // `resolveGiveUpAction`) — same as the window-closed give-up, just triggered by the byte
+      // cap instead of a timer. What this pins is what the shell must still guarantee: the
+      // history that comes out the other side still dedupes.
       const cmd = buildFakeCommand();
       const attach1 = buildFakeCommand();
       const attach2 = buildFakeCommand();
@@ -1272,16 +1305,17 @@ describe('openPtyShell', () => {
       const flood = `unalignable ${Array.from({ length: 220_000 }, (_, i) => `line ${i} of the flood\r\n`).join('')}`;
       attach1._stdout.emit('data', flood);
       await vi.advanceTimersByTimeAsync(2000);
-      expect(outputs(onOutput).join('')).toContain('unalignable'); // emitted, not swallowed
+      expect(outputs(onOutput).join('')).not.toContain('unalignable'); // discarded, not shown
 
       const afterOverflow = outputs(onOutput).join('');
 
-      // The history restarted from those bytes, so replaying them again dedupes. Note this
-      // fake delivers the whole flood in ONE frame, and the anchor search runs before the
-      // overflow check — so it is found. A real over-cap ring arrives in many frames and
-      // overflows first, and THAT reprints on every cycle: which is why the cap has to exceed
-      // the server's ring (see MAX_PENDING_BYTES). What this pins is the recovery, not a
-      // claim that an over-cap ring heals.
+      // The history restarted from those bytes even though they were never shown (see
+      // `recordHistory`), so replaying them again dedupes. Note this fake delivers the whole
+      // flood in ONE frame, and the anchor search runs before the overflow check — so it is
+      // found. A real over-cap ring arrives in many frames and overflows first, and THAT
+      // reprints (silently, since it is discarded) on every cycle: which is why the cap has to
+      // exceed the server's ring (see MAX_PENDING_BYTES). What this pins is the recovery, not
+      // a claim that an over-cap ring heals.
       attach1._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
       attach2._stdout.emit('data', flood);
@@ -1290,11 +1324,38 @@ describe('openPtyShell', () => {
       expect(outputs(onOutput).join('')).toBe(afterOverflow); // nothing reprinted
     });
 
-    it('given a CHATTY shell across the reconnect, emits within the replay window instead of stalling to the byte cap', async () => {
+    it('given a pending-cap give-up on a transparent reconnect, discards the overflow but still forwards output that arrives right after', async () => {
+      // The pending-cap give-up resolves SYNCHRONOUSLY inside the chunk that pushed it over —
+      // unlike the window-closed give-up, there is no timer in between. Discard must not
+      // swallow whatever the SAME command sends next, once the replay state is resolved.
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onOutput = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      cmd._emitter.emit('spawn');
+      cmd._stdout.emit('data', BANNER);
+
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+
+      const flood = `unalignable ${Array.from({ length: 220_000 }, (_, i) => `line ${i} of the flood\r\n`).join('')}`;
+      attachCmd._stdout.emit('data', flood); // overflows MAX_PENDING_BYTES in one chunk
+      expect(outputs(onOutput).join('')).toBe(BANNER); // discarded synchronously
+
+      attachCmd._stdout.emit('data', 'genuinely live output\r\n'); // same command, after resolution
+      expect(outputs(onOutput).join('')).toBe(`${BANNER}genuinely live output\r\n`);
+    });
+
+    it('given a CHATTY shell across the reconnect, discards the held burst on its deadline but keeps forwarding afterward', async () => {
       // The quiet-gap timer alone is not a bound: a build or a repainting TUI
       // never goes quiet, so every chunk would re-arm it and the terminal would
       // sit dead all the way to MAX_PENDING_BYTES. The hard window is what makes the worst
-      // case a redraw rather than a multi-megabyte stall.
+      // case a bounded discard rather than a multi-megabyte stall — and once it closes
+      // (attachKind is a transparent reconnect here, so the burst is discarded, not shown),
+      // output resumes flowing normally: discard must not swallow POST-window live output.
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
@@ -1315,18 +1376,24 @@ describe('openPtyShell', () => {
         await vi.advanceTimersByTimeAsync(100); // < REPLAY_SETTLE_MS every time
       }
 
-      // The window closed on its deadline and the output flowed.
+      // The window closed on its deadline (discarding whatever it had held) and later
+      // chunks — arriving after resolution — flowed through as ordinary live output.
       const seen = outputs(onOutput).join('');
-      expect(seen).toContain('build step 0\r\n');
-      expect(seen).toContain('build step 19\r\n');
+      expect(seen).not.toContain('build step 0\r\n'); // inside the discarded burst
+      expect(seen).toContain('build step 19\r\n'); // arrived after the window resolved
     });
 
-    it('given an unalignable replay whose anchor RECURS in live output moments later, swallows nothing', async () => {
-      // The loss path, at the shell level and INSIDE the replay window (a repaint
-      // arriving after the window closes can't reach the search at all). A long
-      // session, a replay the ring has trimmed past, and a TUI that repaints the
-      // exact bytes the client last saw. An unanchored match lands past the true
-      // boundary and drops the output in front of it — output nobody has ever seen.
+    it('given an unalignable replay whose anchor RECURS in live output moments later, refuses the false match and reports the give-up', async () => {
+      // The corroboration guard (replay-dedupe.test.ts) still refuses to WRONGLY suppress
+      // here: an unanchored match landing past the true boundary would silently drop output
+      // nobody has ever seen, with no report — the one failure mode this module can never
+      // accept. What changes under leaf 2-5 is what happens to the correctly-identified
+      // give-up that results: on a TRANSPARENT reconnect it is now discarded rather than
+      // reprinted (a DELIBERATE, REPORTED tradeoff — see `resolveGiveUpAction`), not silently
+      // dropped by a wrong match. The distinction that matters is wrong-suppression (silent,
+      // unbounded, never acceptable) vs. a reported give-up discard (bounded, observable,
+      // the accepted cost of not repainting an idle agent TUI).
+      const warn = vi.spyOn(loggers.realtime, 'warn');
       const line = (p: string, n: number) =>
         Array.from({ length: n }, (_, i) => `${p} ${i}\r\n`).join('');
       const cmd = buildFakeCommand();
@@ -1344,26 +1411,35 @@ describe('openPtyShell', () => {
       cmd._stdout.emit('data', history + tail);
       const delivered = outputs(onOutput).join('');
       const repaint = delivered.slice(-8 * 1024); // exactly the bytes the anchor holds
+      const beforeReconnect = outputs(onOutput).join('');
 
       cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
 
-      // The replay the client has never seen (the ring trimmed past our anchor)...
+      // Content the client has never seen (the ring trimmed past our anchor)...
       attachCmd._stdout.emit('data', 'work the client never saw\r\n');
       await vi.advanceTimersByTimeAsync(50); // still well inside the replay window
       // ...immediately followed by a repaint of the anchor's exact bytes.
       attachCmd._stdout.emit('data', `${repaint}after repaint\r\n`);
       await vi.advanceTimersByTimeAsync(2000);
 
-      const shown = outputs(onOutput).join('');
-      expect(shown).toContain('work the client never saw\r\n'); // NOT swallowed
-      expect(shown).toContain('after repaint\r\n');
+      expect(outputs(onOutput).join('')).toBe(beforeReconnect); // discarded, not shown
+      const reported = warn.mock.calls.filter(
+        ([, meta]) => (meta as { outcome?: string } | undefined)?.outcome === 'discarded',
+      );
+      warn.mockRestore();
+      expect(reported.length).toBeGreaterThan(0); // ...but never silently
     });
 
-    it('given the socket dies while replay bytes are buffered and the reconnect CREATES a fresh session, still delivers them', async () => {
-      // Those bytes exist nowhere else: a fresh session has no scrollback to replay
-      // them from, and nothing appended them to the app-side buffer. Dropping them
-      // loses the dying shell's last words for good.
+    it('given the socket dies while replay bytes are buffered and the reconnect CREATES a fresh session, discards the buffered burst but still reports it', async () => {
+      // 2-4's baseline here was "still delivers them" — those bytes exist nowhere else, so
+      // losing them loses the dying shell's last words for good. Leaf 2-5 accepts that risk
+      // DELIBERATELY, uniformly, for every give-up on a transparent-attach reconnect (see
+      // `resolveGiveUpAction`) — whether the window closes on a timer, on this socket dying
+      // mid-buffer, or (as here) right before a fresh session replaces it. What must still
+      // hold: the discard is REPORTED, not silent, and the fresh session that follows is
+      // unaffected (its own history starts clean via `launchFreshSession`).
+      const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const freshCmd = buildFakeCommand();
@@ -1385,7 +1461,16 @@ describe('openPtyShell', () => {
       attachCmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(1000);
 
-      expect(outputs(onOutput).join('')).toContain('segfault: dumping core\r\n');
+      expect(outputs(onOutput).join('')).toBe(BANNER); // discarded, not shown
+      const discarded = warn.mock.calls.filter(
+        ([, meta]) => (meta as { outcome?: string } | undefined)?.outcome === 'discarded',
+      );
+      warn.mockRestore();
+      expect(discarded.length).toBeGreaterThan(0); // ...but not silently
+
+      // The fresh session's own output still flows normally.
+      freshCmd._stdout.emit('data', 'fresh prompt\r\n');
+      expect(outputs(onOutput).join('')).toBe(`${BANNER}fresh prompt\r\n`);
     });
 
     it('given a drain that arrives BEFORE the replay, delivers it exactly once (the replay recognises it)', async () => {
@@ -1660,12 +1745,15 @@ describe('openPtyShell', () => {
       expect(shown).toBe(`${BANNER}X$ `);
     });
 
-    it('given an UNALIGNABLE replay, the drain still arrives and the history still recovers', async () => {
-      // The give-up path: the ring could not be aligned, so it is re-emitted verbatim —
-      // duplicating what the client already had, drain included. That is the accepted cost.
-      // What must NOT happen is the history keeping that duplicate: an unaligned flush
-      // RESTARTS the history with the replayed bytes (which are themselves a contiguous run
-      // of the stream), so the next cycle dedupes normally instead of reprinting forever.
+    it('given an UNALIGNABLE replay, the drain still arrives (unaffected) and the history still recovers', async () => {
+      // The give-up path: the ring could not be aligned. 2-4's baseline re-emitted it
+      // verbatim; on a transparent reconnect, leaf 2-5 discards it instead (see
+      // `resolveGiveUpAction`) — but the DRAIN is a completely separate path (a stale
+      // command's own last bytes, delivered via ordinary `deliver`, never a give-up), so it
+      // is untouched by this change. What must still NOT happen is the history keeping a
+      // duplicate: an unaligned flush RESTARTS the history with the replayed bytes (which
+      // are themselves a contiguous run of the stream, discarded or not), so the next cycle
+      // dedupes normally instead of reprinting forever.
       const cmd = buildFakeCommand();
       const attach1 = buildFakeCommand();
       const attach2 = buildFakeCommand();
@@ -1686,8 +1774,8 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(2000);
 
       const afterFlush = outputs(onOutput).join('');
-      expect(afterFlush).toContain('X'); // the drain reached the user
-      expect(afterFlush).toContain('unalignable scrollback X'); // and so did the ring
+      expect(afterFlush).toContain('X'); // the drain reached the user, unaffected by the discard
+      expect(afterFlush).not.toContain('unalignable scrollback X'); // the ring was discarded
 
       // The history restarted from the replayed bytes, so the NEXT cycle dedupes cleanly.
       attach1._emitter.emit('error', new Error('WebSocket keepalive timeout'));
@@ -2058,9 +2146,12 @@ describe('openPtyShell', () => {
       expect(outputs(onOutput).join('')).toBe(afterCreate); // nothing reprinted
     });
 
-    it('given a quiet gap shorter than the hard deadline, closes the window on the gap', async () => {
+    it('given a quiet gap shorter than the hard deadline, gives up (and discards) on the gap', async () => {
       // REPLAY_SETTLE_MS must work on its own: an unalignable replay that goes quiet is
-      // released promptly, not held until the 1s deadline.
+      // resolved promptly, not held until the 1s deadline. The bytes are discarded on this
+      // attach kind (leaf 2-5), so the timing is pinned via the WARN the give-up must still
+      // emit, at the gap rather than the later deadline.
+      const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
@@ -2076,7 +2167,12 @@ describe('openPtyShell', () => {
       attachCmd._stdout.emit('data', 'unalignable\r\n');
 
       await vi.advanceTimersByTimeAsync(600); // past the 500ms gap, well short of the 1s deadline
-      expect(outputs(onOutput).join('')).toContain('unalignable\r\n');
+      const reported = warn.mock.calls.filter(
+        ([, meta]) => (meta as { cause?: string } | undefined)?.cause === 'window-closed',
+      );
+      warn.mockRestore();
+      expect(reported.length).toBeGreaterThan(0); // closed already, on the gap
+      expect(outputs(onOutput).join('')).toBe(BANNER); // discarded, not shown
     });
 
     it('given stderr that floods past the queue cap while a replay is held, releases it rather than buffering without limit', async () => {
@@ -2219,12 +2315,14 @@ describe('openPtyShell', () => {
       expect(outputs(onOutput)).toEqual([BANNER]);
     });
 
-    it('given a socket that dies holding a replay, flushes it THEN — not on a timer after its successor is live', async () => {
+    it('given a socket that dies holding a replay, gives up THEN — not on a timer after its successor is live', async () => {
       // The error handler closes the window (and cancels its timers) before marking the
       // command stale. Without that, a DEAD command's settle timer fires ~500ms later — after
-      // its successor has already snapshotted — and its verbatim flush restarts the SHARED
-      // history behind the live command's back: a reprint, out of order, from a socket that
-      // no longer exists.
+      // its successor has already snapshotted — and its flush restarts the SHARED history
+      // behind the live command's back: a give-up, out of order, from a socket that no longer
+      // exists. The give-up's bytes are discarded on this attach kind (leaf 2-5), so the
+      // timing is pinned via the WARN it must still emit, immediately and not on a later timer.
+      const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attach1 = buildFakeCommand();
       const attach2 = buildFakeCommand();
@@ -2243,8 +2341,12 @@ describe('openPtyShell', () => {
       attach1._stdout.emit('data', 'held and unalignable\r\n'); // held by attach1's window
       attach1._emitter.emit('error', new Error('WebSocket keepalive timeout')); // dies holding it
 
-      // Flushed by the error handler, at once — not by a timer belonging to a dead socket.
-      expect(outputs(onOutput).join('')).toContain('held and unalignable\r\n');
+      // Given up by the error handler, at once — not by a timer belonging to a dead socket.
+      expect(outputs(onOutput).join('')).toBe(BANNER); // discarded, not shown
+      const reported = warn.mock.calls.filter(
+        ([, meta]) => (meta as { cause?: string } | undefined)?.cause === 'window-closed',
+      );
+      expect(reported.length).toBeGreaterThan(0);
 
       // And its successor's history is intact: an ordinary idle cycle still dedupes.
       await vi.advanceTimersByTimeAsync(500);
@@ -2252,10 +2354,17 @@ describe('openPtyShell', () => {
       attach2._stdout.emit('data', 'held and unalignable\r\n'); // the ring, replayed
       await vi.advanceTimersByTimeAsync(2000);
 
+      warn.mockRestore();
       expect(outputs(onOutput).join('')).toBe(beforeReplay); // suppressed, not reprinted
     });
 
-    it('given a shell that exits while replay bytes are still buffered, flushes them before the exit', async () => {
+    it('given a shell that exits while replay bytes are still buffered, gives up (discarding them) before the exit', async () => {
+      // 2-4's baseline showed 'goodbye\r\n' — the shell's genuine last words. Leaf 2-5
+      // discards it instead, the same as every other give-up on a transparent attach
+      // reconnect (see `resolveGiveUpAction`): the ordering invariant this test exists to
+      // pin — the window resolves BEFORE `fatal()`/`onExit` fires, not after — holds
+      // regardless of whether the resolution shows or discards its bytes.
+      const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
@@ -2272,7 +2381,12 @@ describe('openPtyShell', () => {
       attachCmd._stdout.emit('data', 'goodbye\r\n'); // unalignable, so buffered
       attachCmd._emitter.emit('exit', 0);
 
-      expect(outputs(onOutput)).toEqual([BANNER, 'goodbye\r\n']);
+      expect(outputs(onOutput)).toEqual([BANNER]); // discarded, not shown
+      const reported = warn.mock.calls.filter(
+        ([, meta]) => (meta as { cause?: string } | undefined)?.cause === 'window-closed',
+      );
+      warn.mockRestore();
+      expect(reported.length).toBeGreaterThan(0); // the give-up still happened, and was reported
       expect(onExit).toHaveBeenCalledWith(0);
     });
   });

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1246,13 +1246,18 @@ describe('openPtyShell', () => {
       expect((reported[0][1] as { outcome?: string }).outcome).toBe('discarded');
     });
 
-    it('given a replay that overflows the byte cap, REPORTS it (and says it was discarded)', async () => {
+    it('given a replay that overflows the byte cap, REPORTS it (and says it was shown, not discarded)', async () => {
       // A ring bigger than MAX_PENDING_BYTES is the cause that does not heal: the anchor sits
       // at a replay's END, so the cap trips before it ever arrives, and the scrollback would
-      // reprint (or now, discard) on every reconnect until the cap is raised past the ring. It
-      // is also the give-up that resolves inside the pure core — `closeReplayWindow`, and its
-      // log, never run. If it did not report here, the failure the cap exists to catch would
-      // be the only silent one.
+      // reprint on every reconnect until the cap is raised past the ring. It is also the
+      // give-up that resolves inside the pure core — `closeReplayWindow`, and its log, never
+      // run. If it did not report here, the failure the cap exists to catch would be the only
+      // silent one.
+      //
+      // `outcome` is 'reprinted' here, not 'discarded': a burst this large (megabytes) is far
+      // past `MAX_DISCARDABLE_GIVEUP_BYTES` — see `resolveGiveUpAction` — so leaf 2-5's discard
+      // never applies to it. A give-up this size is the shape of real, active output (a build,
+      // a verbose command), which must still reach the user, not the shape of a stale redraw.
       const warn = vi.spyOn(loggers.realtime, 'warn');
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
@@ -1276,16 +1281,18 @@ describe('openPtyShell', () => {
       );
       warn.mockRestore(); // before the assertion: a failing expect must not leak the spy
       expect(reported.length).toBeGreaterThan(0); // it says so, instead of failing silently
-      expect((reported[0][1] as { outcome?: string }).outcome).toBe('discarded');
+      expect((reported[0][1] as { outcome?: string }).outcome).toBe('reprinted');
     });
 
-    it('given a replay that overflows the byte cap on a transparent reconnect, discards it and leaves a usable history', async () => {
+    it('given a replay that overflows the byte cap on a transparent reconnect, STILL shows it (too large to be a mere redraw) and leaves a usable history', async () => {
       // The other give-up path: the replay never aligns and grows past MAX_PENDING_BYTES, so
-      // the pure core resolves inside `planReplayEmission` rather than the window timer. 2-4's
-      // baseline emitted it verbatim; leaf 2-5 discards it on THIS attach kind (see
-      // `resolveGiveUpAction`) — same as the window-closed give-up, just triggered by the byte
-      // cap instead of a timer. What this pins is what the shell must still guarantee: the
-      // history that comes out the other side still dedupes.
+      // the pure core resolves inside `planReplayEmission` rather than the window timer.
+      // Unlike a SMALL give-up, this one is NOT discarded even on a transparent reconnect: a
+      // multi-megabyte burst is far past what a mere screen redraw could produce, so
+      // `resolveGiveUpAction` treats it as real, active output (a build, a verbose command)
+      // and shows it — the exact "silently lose build/log output" case a P1 review flagged
+      // against a blanket discard. What this pins is what the shell must still guarantee: the
+      // bytes reach the user, and the history that comes out the other side still dedupes.
       const cmd = buildFakeCommand();
       const attach1 = buildFakeCommand();
       const attach2 = buildFakeCommand();
@@ -1305,29 +1312,30 @@ describe('openPtyShell', () => {
       const flood = `unalignable ${Array.from({ length: 220_000 }, (_, i) => `line ${i} of the flood\r\n`).join('')}`;
       attach1._stdout.emit('data', flood);
       await vi.advanceTimersByTimeAsync(2000);
-      expect(outputs(onOutput).join('')).not.toContain('unalignable'); // discarded, not shown
+      expect(outputs(onOutput).join('')).toContain('unalignable'); // shown, not swallowed
 
       const afterOverflow = outputs(onOutput).join('');
 
-      // The history restarted from those bytes even though they were never shown (see
-      // `recordHistory`), so replaying them again dedupes. Note this fake delivers the whole
-      // flood in ONE frame, and the anchor search runs before the overflow check — so it is
-      // found. A real over-cap ring arrives in many frames and overflows first, and THAT
-      // reprints (silently, since it is discarded) on every cycle: which is why the cap has to
-      // exceed the server's ring (see MAX_PENDING_BYTES). What this pins is the recovery, not
-      // a claim that an over-cap ring heals.
+      // The history restarted from those bytes, so replaying them again dedupes. Note this
+      // fake delivers the whole flood in ONE frame, and the anchor search runs before the
+      // overflow check — so it is found. A real over-cap ring arrives in many frames and
+      // overflows first, and THAT reprints on every cycle: which is why the cap has to exceed
+      // the server's ring (see MAX_PENDING_BYTES). What this pins is the recovery, not a claim
+      // that an over-cap ring heals.
       attach1._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
       attach2._stdout.emit('data', flood);
       await vi.advanceTimersByTimeAsync(2000);
 
-      expect(outputs(onOutput).join('')).toBe(afterOverflow); // nothing reprinted
+      expect(outputs(onOutput).join('')).toBe(afterOverflow); // nothing reprinted a SECOND time
     });
 
-    it('given a pending-cap give-up on a transparent reconnect, discards the overflow but still forwards output that arrives right after', async () => {
+    it('given a pending-cap give-up on a transparent reconnect, still shows it (too large to discard) and keeps forwarding what arrives right after', async () => {
       // The pending-cap give-up resolves SYNCHRONOUSLY inside the chunk that pushed it over —
-      // unlike the window-closed give-up, there is no timer in between. Discard must not
-      // swallow whatever the SAME command sends next, once the replay state is resolved.
+      // unlike the window-closed give-up, there is no timer in between. A burst this size is
+      // always past `MAX_DISCARDABLE_GIVEUP_BYTES`, so it is shown (see the test above); what
+      // this test pins is that showing it does not somehow re-enter dedupe state and swallow
+      // whatever the SAME command sends next, once the replay has resolved.
       const cmd = buildFakeCommand();
       const attachCmd = buildFakeCommand();
       const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
@@ -1343,10 +1351,10 @@ describe('openPtyShell', () => {
 
       const flood = `unalignable ${Array.from({ length: 220_000 }, (_, i) => `line ${i} of the flood\r\n`).join('')}`;
       attachCmd._stdout.emit('data', flood); // overflows MAX_PENDING_BYTES in one chunk
-      expect(outputs(onOutput).join('')).toBe(BANNER); // discarded synchronously
+      expect(outputs(onOutput).join('')).toBe(`${BANNER}${flood}`); // shown synchronously
 
       attachCmd._stdout.emit('data', 'genuinely live output\r\n'); // same command, after resolution
-      expect(outputs(onOutput).join('')).toBe(`${BANNER}genuinely live output\r\n`);
+      expect(outputs(onOutput).join('')).toBe(`${BANNER}${flood}genuinely live output\r\n`);
     });
 
     it('given a CHATTY shell across the reconnect, discards the held burst on its deadline but keeps forwarding afterward', async () => {
@@ -1383,17 +1391,15 @@ describe('openPtyShell', () => {
       expect(seen).toContain('build step 19\r\n'); // arrived after the window resolved
     });
 
-    it('given an unalignable replay whose anchor RECURS in live output moments later, refuses the false match and reports the give-up', async () => {
+    it('given an unalignable replay whose anchor RECURS in live output moments later, swallows nothing (burst too large to discard)', async () => {
       // The corroboration guard (replay-dedupe.test.ts) still refuses to WRONGLY suppress
       // here: an unanchored match landing past the true boundary would silently drop output
       // nobody has ever seen, with no report — the one failure mode this module can never
-      // accept. What changes under leaf 2-5 is what happens to the correctly-identified
-      // give-up that results: on a TRANSPARENT reconnect it is now discarded rather than
-      // reprinted (a DELIBERATE, REPORTED tradeoff — see `resolveGiveUpAction`), not silently
-      // dropped by a wrong match. The distinction that matters is wrong-suppression (silent,
-      // unbounded, never acceptable) vs. a reported give-up discard (bounded, observable,
-      // the accepted cost of not repainting an idle agent TUI).
-      const warn = vi.spyOn(loggers.realtime, 'warn');
+      // accept. The resulting give-up is ~8.2 KiB (the never-seen line plus a full
+      // anchor-sized repaint) — just OVER `MAX_DISCARDABLE_GIVEUP_BYTES` (8 KiB) — so leaf
+      // 2-5's size bound keeps it on the SHOW side: it is too large to plausibly be a mere
+      // redraw, so it is shown rather than risk it being the "output the client never saw"
+      // it explicitly is here.
       const line = (p: string, n: number) =>
         Array.from({ length: n }, (_, i) => `${p} ${i}\r\n`).join('');
       const cmd = buildFakeCommand();
@@ -1411,16 +1417,46 @@ describe('openPtyShell', () => {
       cmd._stdout.emit('data', history + tail);
       const delivered = outputs(onOutput).join('');
       const repaint = delivered.slice(-8 * 1024); // exactly the bytes the anchor holds
-      const beforeReconnect = outputs(onOutput).join('');
 
       cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
 
-      // Content the client has never seen (the ring trimmed past our anchor)...
+      // The replay the client has never seen (the ring trimmed past our anchor)...
       attachCmd._stdout.emit('data', 'work the client never saw\r\n');
       await vi.advanceTimersByTimeAsync(50); // still well inside the replay window
       // ...immediately followed by a repaint of the anchor's exact bytes.
       attachCmd._stdout.emit('data', `${repaint}after repaint\r\n`);
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const shown = outputs(onOutput).join('');
+      expect(shown).toContain('work the client never saw\r\n'); // NOT swallowed
+      expect(shown).toContain('after repaint\r\n');
+    });
+
+    it('given an unalignable replay whose anchor RECURS in live output, but the burst is SMALL, discards it (the residual risk leaf 2-5 accepts)', async () => {
+      // The flip side of the test above, pinned deliberately: a false-match-refused give-up
+      // that stays under `MAX_DISCARDABLE_GIVEUP_BYTES` IS discarded, even though — as far as
+      // this module can prove — it might contain a short line of genuinely new output rather
+      // than a redraw. This is the residual risk documented on `resolveGiveUpAction`: no
+      // byte-level heuristic can fully distinguish the two for a SHORT burst, and the size
+      // bound only protects the large-loss end of that risk. Reported via WARN either way, so
+      // the tradeoff stays observable rather than silent.
+      const warn = vi.spyOn(loggers.realtime, 'warn');
+      const cmd = buildFakeCommand();
+      const attachCmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+      const onOutput = vi.fn();
+
+      openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      cmd._emitter.emit('spawn');
+      cmd._stdout.emit('data', BANNER);
+      const beforeReconnect = outputs(onOutput).join('');
+
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(500);
+      // A short line the client never saw — well under the discardable bound.
+      attachCmd._stdout.emit('data', 'a short new line\r\n');
       await vi.advanceTimersByTimeAsync(2000);
 
       expect(outputs(onOutput).join('')).toBe(beforeReconnect); // discarded, not shown

--- a/apps/realtime/src/terminal/replay-dedupe.ts
+++ b/apps/realtime/src/terminal/replay-dedupe.ts
@@ -585,6 +585,20 @@ export function planReplayEmission({
 export type AttachKind = 'transparent-attach' | 'fresh';
 
 /**
+ * The largest give-up burst leaf 2-5 will discard rather than show, on a transparent attach.
+ * Set to `MAX_ANCHOR_BYTES` deliberately, not a fresh magic number: this module's own docs
+ * already treat that bound as "about the size of an idle terminal's whole history" — "the
+ * shape the 45s watchdog cycles on" (see `anchorOf`, and the corroboration doc's "NO history
+ * at all behind the match" case). A give-up burst that fits under it is consistent with "a TUI
+ * redrew what's already roughly on screen"; a burst LARGER than it has grown past anything a
+ * mere redraw explains.
+ *
+ * This is a size heuristic, not a proof — see `resolveGiveUpAction`'s doc for what it does and
+ * does not guarantee.
+ */
+export const MAX_DISCARDABLE_GIVEUP_BYTES = MAX_ANCHOR_BYTES;
+
+/**
  * A give-up's TERMINAL ACTION: show the unaligned bytes (today's baseline — see the give-up
  * doc above, "duplication is survivable"), or drop them.
  *
@@ -593,17 +607,43 @@ export type AttachKind = 'transparent-attach' | 'fresh';
  * `attachSession`'s own `{cols,rows}`) violates byte-equality on almost every ~45s keepalive
  * cycle, so "reprint rather than risk losing a byte" becomes "repaint on top of itself every
  * 45s" for exactly the terminals that need the dedupe most. On THAT reconnect the viewer has
- * been continuously attached, so nothing is actually at risk: the replay is redundant, not
- * unverifiable, and can be dropped outright.
+ * been continuously attached, so a SMALL give-up is very likely pure redraw noise and can be
+ * dropped outright.
+ *
+ * "Very likely," not "provably" — and that gap is real, not glossed over. The server session
+ * keeps running while the client is disconnected (sessions survive client drops; only the
+ * SOCKET died), so the replay a reattach carries is "history the client already saw" PLUS
+ * "whatever the shell produced during the gap," concatenated, with no marker between them —
+ * see the module header's "cannot tell a replay from an EXACT reproduction." An unaligned
+ * give-up therefore CAN legitimately contain new output (a build line, a crash message) that
+ * arrived during the reconnect gap, and discarding loses it for good.
+ *
+ * `burstBytes` is the mitigation, not a fix for that: a mere redraw is bounded by roughly what
+ * is already on screen (`MAX_DISCARDABLE_GIVEUP_BYTES`), while active new output — a build, a
+ * verbose command, exactly the "silently lose build/log output" case a reattach-timing gap can
+ * produce — accumulates without that bound and is shown, not dropped, once the burst outgrows
+ * it. This closes the large-loss end of the risk (megabytes of real output are never silently
+ * eaten) without pretending to close the small end (a short message racing the reconnect,
+ * indistinguishable byte-for-byte from a short redraw, can still be discarded). That residual
+ * is the same shape this module already accepts elsewhere: "violently periodic output... where
+ * the dropped bytes are indistinguishable from their neighbours anyway" — bounded and
+ * understood, not eliminated.
  *
  * Detection is unchanged — `planReplayEmission`/`flushReplay` still decide alignment purely
- * from bytes, with no notion of where the attach came from. This is the decision layered on
- * top of a give-up they already produced, so the caller can still record the bytes as history
- * (a give-up is itself a contiguous run of the stream — see `deliver`'s `restart` doc) without
- * being forced to also show them.
+ * from bytes, with no notion of where the attach came from or how large the burst is. This is
+ * the decision layered on top of a give-up they already produced, so the caller can still
+ * record the bytes as history (a give-up is itself a contiguous run of the stream — see
+ * `deliver`'s `restart` doc) without being forced to also show them.
  */
-export function resolveGiveUpAction({ attachKind }: { attachKind: AttachKind }): 'emit' | 'discard' {
-  return attachKind === 'transparent-attach' ? 'discard' : 'emit';
+export function resolveGiveUpAction({
+  attachKind,
+  burstBytes,
+}: {
+  attachKind: AttachKind;
+  burstBytes: number;
+}): 'emit' | 'discard' {
+  if (attachKind !== 'transparent-attach') return 'emit';
+  return burstBytes <= MAX_DISCARDABLE_GIVEUP_BYTES ? 'discard' : 'emit';
 }
 
 export function flushReplay(state: ReplayState): ReplayEmission {

--- a/apps/realtime/src/terminal/replay-dedupe.ts
+++ b/apps/realtime/src/terminal/replay-dedupe.ts
@@ -606,17 +606,27 @@ export const MAX_DISCARDABLE_GIVEUP_BYTES = MAX_ANCHOR_BYTES;
  * AGENT terminal (a repainting TUI status line, a `SIGWINCH`-triggered redraw off
  * `attachSession`'s own `{cols,rows}`) violates byte-equality on almost every ~45s keepalive
  * cycle, so "reprint rather than risk losing a byte" becomes "repaint on top of itself every
- * 45s" for exactly the terminals that need the dedupe most. On THAT reconnect the viewer has
- * been continuously attached, so a SMALL give-up is very likely pure redraw noise and can be
+ * 45s" for exactly the terminals that need the dedupe most. On THAT reconnect the caller has
+ * already delivered every byte this module knows about — via whatever single sink is downstream
+ * of this module's output (see the caller's own doc: in `sprites-shell.ts` that sink is one
+ * `onOutput` call feeding BOTH the live viewer and the app-level scrollback buffer any FUTURE
+ * viewer catches up from) — so a SMALL give-up is very likely pure redraw noise and can be
  * dropped outright.
  *
  * "Very likely," not "provably" — and that gap is real, not glossed over. The server session
  * keeps running while the client is disconnected (sessions survive client drops; only the
- * SOCKET died), so the replay a reattach carries is "history the client already saw" PLUS
+ * SOCKET died), so the replay a reattach carries is "history already delivered downstream" PLUS
  * "whatever the shell produced during the gap," concatenated, with no marker between them —
  * see the module header's "cannot tell a replay from an EXACT reproduction." An unaligned
  * give-up therefore CAN legitimately contain new output (a build line, a crash message) that
- * arrived during the reconnect gap, and discarding loses it for good.
+ * arrived during the reconnect gap.
+ *
+ * And discarding loses it TOTALLY, not just from the one connection that happened to trigger
+ * the reconnect: a discard skips the caller's sink outright (see `sprites-shell.ts`'s
+ * `recordHistory` vs `deliver`), so the bytes reach neither whoever is watching live right now
+ * NOR any later viewer who joins fresh and catches up from whatever that sink also feeds (e.g.
+ * an app-level scrollback buffer). There is no narrower "just this viewer already saw it"
+ * reading available here — a discard is gone from the system, for every consumer, for good.
  *
  * `burstBytes` is the mitigation, not a fix for that: a mere redraw is bounded by roughly what
  * is already on screen (`MAX_DISCARDABLE_GIVEUP_BYTES`), while active new output — a build, a
@@ -624,16 +634,17 @@ export const MAX_DISCARDABLE_GIVEUP_BYTES = MAX_ANCHOR_BYTES;
  * produce — accumulates without that bound and is shown, not dropped, once the burst outgrows
  * it. This closes the large-loss end of the risk (megabytes of real output are never silently
  * eaten) without pretending to close the small end (a short message racing the reconnect,
- * indistinguishable byte-for-byte from a short redraw, can still be discarded). That residual
- * is the same shape this module already accepts elsewhere: "violently periodic output... where
- * the dropped bytes are indistinguishable from their neighbours anyway" — bounded and
- * understood, not eliminated.
+ * indistinguishable byte-for-byte from a short redraw, can still be discarded — and that loss is
+ * total, per the paragraph above, not partial). That residual is the same shape this module
+ * already accepts elsewhere: "violently periodic output... where the dropped bytes are
+ * indistinguishable from their neighbours anyway" — bounded and understood, not eliminated.
  *
  * Detection is unchanged — `planReplayEmission`/`flushReplay` still decide alignment purely
- * from bytes, with no notion of where the attach came from or how large the burst is. This is
- * the decision layered on top of a give-up they already produced, so the caller can still
- * record the bytes as history (a give-up is itself a contiguous run of the stream — see
- * `deliver`'s `restart` doc) without being forced to also show them.
+ * from bytes, with no notion of where the attach came from, how large the burst is, or how many
+ * downstream consumers exist. This is the decision layered on top of a give-up they already
+ * produced, so the caller can still record the bytes as history (a give-up is itself a
+ * contiguous run of the stream — see `deliver`'s `restart` doc) without being forced to also
+ * show them.
  */
 export function resolveGiveUpAction({
   attachKind,

--- a/apps/realtime/src/terminal/replay-dedupe.ts
+++ b/apps/realtime/src/terminal/replay-dedupe.ts
@@ -569,6 +569,43 @@ export function planReplayEmission({
  * replayed one, and trimming it would delete output the client never saw. An
  * unalignable replay costs a redraw. That is the whole trade.
  */
+/**
+ * Where a `wire()`'d command's replay comes from — the axis `resolveGiveUpAction` decides on.
+ *
+ * - `'transparent-attach'`: an in-place RECONNECT's attach to the session the client was
+ *   already watching (an idle-shell keepalive drop, an optimistic reattach when `listSessions`
+ *   is unavailable). The viewer never left — every byte a replay on this attach could carry has
+ *   already been shown, live, so a give-up here is pure duplication.
+ * - `'fresh'`: everything else. A shell's very FIRST `wire()` (a fresh viewer opening the
+ *   terminal, or a caller reattaching after ITS OWN restart) and a reconnect that CREATES a
+ *   new session (the old one is gone; nothing of its output is on the client's screen) both
+ *   want a give-up's bytes shown — there is no continuously-watching viewer to have already
+ *   seen them.
+ */
+export type AttachKind = 'transparent-attach' | 'fresh';
+
+/**
+ * A give-up's TERMINAL ACTION: show the unaligned bytes (today's baseline — see the give-up
+ * doc above, "duplication is survivable"), or drop them.
+ *
+ * That baseline is right for a fresh session and wrong for a transparent reconnect: an idle
+ * AGENT terminal (a repainting TUI status line, a `SIGWINCH`-triggered redraw off
+ * `attachSession`'s own `{cols,rows}`) violates byte-equality on almost every ~45s keepalive
+ * cycle, so "reprint rather than risk losing a byte" becomes "repaint on top of itself every
+ * 45s" for exactly the terminals that need the dedupe most. On THAT reconnect the viewer has
+ * been continuously attached, so nothing is actually at risk: the replay is redundant, not
+ * unverifiable, and can be dropped outright.
+ *
+ * Detection is unchanged — `planReplayEmission`/`flushReplay` still decide alignment purely
+ * from bytes, with no notion of where the attach came from. This is the decision layered on
+ * top of a give-up they already produced, so the caller can still record the bytes as history
+ * (a give-up is itself a contiguous run of the stream — see `deliver`'s `restart` doc) without
+ * being forced to also show them.
+ */
+export function resolveGiveUpAction({ attachKind }: { attachKind: AttachKind }): 'emit' | 'discard' {
+  return attachKind === 'transparent-attach' ? 'discard' : 'emit';
+}
+
 export function flushReplay(state: ReplayState): ReplayEmission {
   // Nothing held is not a give-up. A window can close over an attach that never received a
   // byte — a socket that died before it opened — and calling THAT a give-up would report a

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -13,6 +13,8 @@ import {
   materializeSeen,
   planReplayEmission,
   rememberDelivered,
+  resolveGiveUpAction,
+  type AttachKind,
   type GiveUpCause,
   type ReplayState,
   type SeenTail,
@@ -314,7 +316,7 @@ export function openPtyShell({
     onExit(exitCode);
   }
 
-  function wire(cmd: SpriteCommandLike): void {
+  function wire(cmd: SpriteCommandLike, attachKind: AttachKind): void {
     // Per-command staleness. A keepalive timeout in the SDK emits 'error' and
     // then closes the socket, which makes the SAME dead command also emit a
     // spurious 'exit' (code 0 or 1). A genuine shell exit (user typed `exit`)
@@ -369,10 +371,14 @@ export function openPtyShell({
      * latched permanently by one blip. Replacing the history with the replayed bytes
      * restores the invariant, because a replay IS a contiguous run of that stream.
      */
-    const deliver = (bytes: Buffer, mode: 'append' | 'restart' = 'append') => {
+    const recordHistory = (bytes: Buffer, mode: 'append' | 'restart') => {
       if (bytes.length === 0) return;
       if (mode === 'restart') seenTail = EMPTY_SEEN;
       seenTail = rememberDelivered(seenTail, bytes);
+    };
+    const deliver = (bytes: Buffer, mode: 'append' | 'restart' = 'append') => {
+      if (bytes.length === 0) return;
+      recordHistory(bytes, mode);
       onOutput(bytes.toString('utf8'));
     };
     // Bytes that arrived while a replay was being held, and that must not be deduped:
@@ -429,7 +435,7 @@ export function openPtyShell({
      *   its scrollback", not as "raise the cap" — a ring over the cap is the diagnosis only if
      *   the shell was quiet, and neither field here can tell you that.
      */
-    const reportUnaligned = (cause: GiveUpCause, bytes: number) => {
+    const reportUnaligned = (cause: GiveUpCause, bytes: number, action: 'emit' | 'discard') => {
       // WARN, not info: this is the whole safety net under two constants that bracket a
       // server value nobody has measured, and `.env.example` tells operators to run
       // production at LOG_LEVEL=warn. At info, the one signal that this feature has
@@ -438,7 +444,26 @@ export function openPtyShell({
         cause,
         unalignedBytes: bytes,
         seenBytes: seenTail.bytes,
+        outcome: action === 'discard' ? 'discarded' : 'reprinted',
       });
+    };
+
+    /**
+     * A give-up's terminal action, resolved by `attachKind` (see `resolveGiveUpAction`): shown
+     * (today's baseline — a fresh session, or this shell's first attach), or discarded (a
+     * transparent in-place reconnect, where the viewer has already been shown every byte the
+     * replay could carry, so reprinting it is pure noise, not a safety margin).
+     *
+     * Either way the history RESTARTS to these bytes: a give-up's bytes ARE a contiguous run
+     * of the stream regardless of whether they are shown, and recording them (via
+     * `recordHistory`, not `deliver`, on the discard path) is what keeps the NEXT reconnect's
+     * dedupe working instead of latching an empty-then-broken history.
+     */
+    const settleGiveUp = (emit: Buffer, cause: GiveUpCause) => {
+      const action = resolveGiveUpAction({ attachKind });
+      reportUnaligned(cause, emit.length, action);
+      if (action === 'discard') recordHistory(emit, 'restart');
+      else deliver(emit, 'restart');
     };
 
     /** Close the replay window: hand over whatever we were still holding. */
@@ -447,9 +472,8 @@ export function openPtyShell({
       if (closed) return;
       const { emit, state, history, giveUp } = flushReplay(replay);
       replay = state;
-      if (giveUp !== undefined) reportUnaligned(giveUp, emit.length);
-      // A give-up RESTARTS the history rather than extending it — see `deliver`.
-      deliver(emit, history);
+      if (giveUp !== undefined) settleGiveUp(emit, giveUp);
+      else deliver(emit, history);
       releaseOutOfBand();
     };
 
@@ -515,13 +539,12 @@ export function openPtyShell({
 
       const { emit, state, history, giveUp } = planReplayEmission({ seen, chunk: toBuf(chunk), state: replay });
       replay = state;
-      // A give-up re-emits bytes the history may already hold, so it RESTARTS that history
-      // instead of extending it (see `deliver`). It also has to be REPORTED here: the byte-cap
-      // give-up resolves the window inside the pure core, so `closeReplayWindow` — and its log
-      // — never runs. Without this the one failure the cap exists to catch would be the only
-      // one that happens silently.
-      if (giveUp !== undefined) reportUnaligned(giveUp, emit.length);
-      deliver(emit, history);
+      // A give-up has to be SETTLED here rather than just delivered: the byte-cap give-up
+      // resolves the window inside the pure core, so `closeReplayWindow` — and its report —
+      // never runs. Without this the one failure the cap exists to catch would be the only one
+      // that happens silently. `settleGiveUp` also decides show-vs-discard by `attachKind`.
+      if (giveUp !== undefined) settleGiveUp(emit, giveUp);
+      else deliver(emit, history);
       if (replay.resolved) { cancelTimers(); releaseOutOfBand(); return; }
       // Boundary still unknown. Hold these bytes — but bound the hold twice over: on the
       // next quiet gap, and on a deadline a chatty shell cannot push out by talking.
@@ -724,7 +747,9 @@ export function openPtyShell({
           sessionGeneration += 1;
           wiredBinding = { id: currentSessionId };
           current = sprite.attachSession(currentSessionId, { cols: lastCols, rows: lastRows });
-          wire(current);
+          // A transparent in-place reconnect: the viewer never left, so a give-up on THIS
+          // attach's replay is discarded rather than shown — see `resolveGiveUpAction`.
+          wire(current, 'transparent-attach');
           reconnecting = false;
           return;
         }
@@ -739,9 +764,11 @@ export function openPtyShell({
         // Either the known id is dead (Sprite paused then cold-woke) or we never
         // learned one. Start a fresh shell transparently; its own session_info
         // frame names it, overwriting any dangling streamSessionId, so the user
-        // sees a new prompt rather than exit -1.
+        // sees a new prompt rather than exit -1. `launchFreshSession` already clears
+        // `seenTail`, so there is nothing a give-up here could be redundant WITH —
+        // 'fresh' keeps it shown, matching a brand-new shell's own scrollback.
         launchFreshSession();
-        wire(current);
+        wire(current, 'fresh');
         reconnecting = false;
         return;
       }
@@ -749,7 +776,9 @@ export function openPtyShell({
       wiredBinding = { id: plan.id };
       currentSessionId = plan.id;
       current = sprite.attachSession(plan.id, { cols: lastCols, rows: lastRows });
-      wire(current);
+      // Same reasoning as the optimistic-reattach branch above: the viewer has been
+      // continuously attached, so this reconnect's give-up (if any) is discarded.
+      wire(current, 'transparent-attach');
       reconnecting = false;
     } catch {
       reconnecting = false;
@@ -769,7 +798,11 @@ export function openPtyShell({
   } else {
     launchFreshSession();
   }
-  wire(current);
+  // This shell's FIRST wire(), whether attaching to a persisted session or creating fresh: a
+  // fresh-viewer attach, not a transparent reconnect — nothing has been shown yet in this
+  // process (`seenTail` starts empty), so there is nothing a give-up could be redundant with.
+  // Discard is scoped to reconnects INSIDE this shell's own lifetime — see `resolveGiveUpAction`.
+  wire(current, 'fresh');
 
   return {
     write: (data) => { if (!closed) current.stdin?.write(data); },

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -449,10 +449,11 @@ export function openPtyShell({
     };
 
     /**
-     * A give-up's terminal action, resolved by `attachKind` (see `resolveGiveUpAction`): shown
-     * (today's baseline — a fresh session, or this shell's first attach), or discarded (a
-     * transparent in-place reconnect, where the viewer has already been shown every byte the
-     * replay could carry, so reprinting it is pure noise, not a safety margin).
+     * A give-up's terminal action, resolved by `attachKind` AND burst size (see
+     * `resolveGiveUpAction`): shown (today's baseline — a fresh session, this shell's first
+     * attach, or a burst too large to plausibly be a mere redraw), or discarded (a small give-up
+     * on a transparent in-place reconnect, where the viewer has already been shown every byte a
+     * redraw-sized replay could carry).
      *
      * Either way the history RESTARTS to these bytes: a give-up's bytes ARE a contiguous run
      * of the stream regardless of whether they are shown, and recording them (via
@@ -460,7 +461,7 @@ export function openPtyShell({
      * dedupe working instead of latching an empty-then-broken history.
      */
     const settleGiveUp = (emit: Buffer, cause: GiveUpCause) => {
-      const action = resolveGiveUpAction({ attachKind });
+      const action = resolveGiveUpAction({ attachKind, burstBytes: emit.length });
       reportUnaligned(cause, emit.length, action);
       if (action === 'discard') recordHistory(emit, 'restart');
       else deliver(emit, 'restart');

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -748,8 +748,8 @@ export function openPtyShell({
           sessionGeneration += 1;
           wiredBinding = { id: currentSessionId };
           current = sprite.attachSession(currentSessionId, { cols: lastCols, rows: lastRows });
-          // A transparent in-place reconnect: the viewer never left, so a give-up on THIS
-          // attach's replay is discarded rather than shown — see `resolveGiveUpAction`.
+          // A transparent in-place reconnect: the viewer never left, so a SMALL give-up on
+          // THIS attach's replay is discarded rather than shown — see `resolveGiveUpAction`.
           wire(current, 'transparent-attach');
           reconnecting = false;
           return;
@@ -778,7 +778,7 @@ export function openPtyShell({
       currentSessionId = plan.id;
       current = sprite.attachSession(plan.id, { cols: lastCols, rows: lastRows });
       // Same reasoning as the optimistic-reattach branch above: the viewer has been
-      // continuously attached, so this reconnect's give-up (if any) is discarded.
+      // continuously attached, so a SMALL give-up on this reconnect (if any) is discarded.
       wire(current, 'transparent-attach');
       reconnecting = false;
     } catch {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -16,6 +16,7 @@ import {
   resolveGiveUpAction,
   type AttachKind,
   type GiveUpCause,
+  type ReplayEmission,
   type ReplayState,
   type SeenTail,
 } from './replay-dedupe';
@@ -452,8 +453,14 @@ export function openPtyShell({
      * A give-up's terminal action, resolved by `attachKind` AND burst size (see
      * `resolveGiveUpAction`): shown (today's baseline — a fresh session, this shell's first
      * attach, or a burst too large to plausibly be a mere redraw), or discarded (a small give-up
-     * on a transparent in-place reconnect, where the viewer has already been shown every byte a
-     * redraw-sized replay could carry).
+     * on a transparent in-place reconnect).
+     *
+     * Discarding means these bytes never reach `onOutput` at all — not "shown to someone else
+     * instead." `onOutput` is the ONE sink this shell has (the caller wires it to both the live
+     * viewer and whatever app-level scrollback buffer a later viewer catches up from — see
+     * `agent-terminal-handler.ts`'s `attachToLiveSession`), so a discard is total loss from every
+     * consumer of it, not just the connection whose reconnect triggered the give-up. That is the
+     * bet `resolveGiveUpAction`'s size bound is deliberately scoped around — see its own doc.
      *
      * Either way the history RESTARTS to these bytes: a give-up's bytes ARE a contiguous run
      * of the stream regardless of whether they are shown, and recording them (via
@@ -467,14 +474,25 @@ export function openPtyShell({
       else deliver(emit, 'restart');
     };
 
+    /**
+     * The dispatch every `ReplayEmission` (from either `planReplayEmission` or `flushReplay`)
+     * goes through: a give-up is SETTLED (shown or discarded, by `settleGiveUp`); anything else
+     * — the aligned/suppress-nothing case, and the "nothing to dedupe" pass-through — is just
+     * delivered. Shared by both call sites (the live `stdout` handler and `closeReplayWindow`)
+     * so the two can't drift out of sync on what counts as a give-up.
+     */
+    const resolveEmission = ({ emit, history, giveUp }: Pick<ReplayEmission, 'emit' | 'history' | 'giveUp'>) => {
+      if (giveUp !== undefined) settleGiveUp(emit, giveUp);
+      else deliver(emit, history);
+    };
+
     /** Close the replay window: hand over whatever we were still holding. */
     const closeReplayWindow = () => {
       cancelTimers();
       if (closed) return;
       const { emit, state, history, giveUp } = flushReplay(replay);
       replay = state;
-      if (giveUp !== undefined) settleGiveUp(emit, giveUp);
-      else deliver(emit, history);
+      resolveEmission({ emit, history, giveUp });
       releaseOutOfBand();
     };
 
@@ -543,9 +561,9 @@ export function openPtyShell({
       // A give-up has to be SETTLED here rather than just delivered: the byte-cap give-up
       // resolves the window inside the pure core, so `closeReplayWindow` — and its report —
       // never runs. Without this the one failure the cap exists to catch would be the only one
-      // that happens silently. `settleGiveUp` also decides show-vs-discard by `attachKind`.
-      if (giveUp !== undefined) settleGiveUp(emit, giveUp);
-      else deliver(emit, history);
+      // that happens silently. `settleGiveUp` (via `resolveEmission`) also decides
+      // show-vs-discard by `attachKind` and burst size.
+      resolveEmission({ emit, history, giveUp });
       if (replay.resolved) { cancelTimers(); releaseOutOfBand(); return; }
       // Boundary still unknown. Hold these bytes — but bound the hold twice over: on the
       // next quiet gap, and on a deadline a chatty shell cannot push out by talking.


### PR DESCRIPTION
## Summary

Leaf 2-4 (#2013) suppresses scrollback replay on the ~45s keepalive reconnect by byte-matching the replayed bytes against delivered history (`seenTail`) — but when it can't align, it deliberately re-emits the replay **verbatim** ("reprint rather than risk losing a byte"). An idle AGENT terminal violates byte-equality every cycle (a repainting TUI — claude/codex status line / shell line-editor — redraws with cursor-relative escapes that render identically but aren't byte-equal; and each `attachSession(id,{cols,rows})` re-sends dimensions → SIGWINCH → a live redraw whose bytes differ from the replayed copy). Result: the terminal **repaints on top of itself every ~45s while idle**, cleared only by a resize.

This is the residual of 2-4's design tradeoff, and it is wrong for agent TUIs — on a TRANSPARENT in-place reconnect the viewer has been continuously attached and has already seen every byte, so a *small* unaligned replay is almost certainly redundant and should be **discarded, not reprinted**.

## Requirements satisfied

- **Transparent `attach` reconnect, unaligned replay → discard (emit nothing).** New pure `resolveGiveUpAction({attachKind, burstBytes})` in `replay-dedupe.ts` resolves `'discard'` for `attachKind: 'transparent-attach'` **when the give-up burst is small** (see "Review fix" below). Wired into both give-up sites in `sprites-shell.ts` (`planReplayEmission`'s byte-cap give-up, and `flushReplay`'s window-closed give-up) via a shared `settleGiveUp` helper.
- **Genuinely-new bytes arriving AFTER the replay window on the same reconnect still forward.** A resolved give-up (discarded or shown) still resolves the replay state, so subsequent chunks hit the normal pass-through path. Covered by dedicated tests on both give-up sites.
- **Fresh `create` reconnect / fresh-viewer attach keep today's behavior.** `AttachKind` is `'fresh'` for: this shell's very first `wire()` call (whether attach-to-persisted-session or create), and any reconnect that calls `launchFreshSession()`. `resolveGiveUpAction({attachKind:'fresh', ...})` → always `'emit'`, regardless of burst size.
- **Aligned (byte-identical) replay case unchanged.** `resolveGiveUpAction` is only consulted when `giveUp !== undefined`; the aligned/suppress-nothing path never produces a `giveUp`, so it's untouched. Pre-existing "idle watchdog reconnect replays nothing" test still passes unmodified.
- **WARN log still fires, now noting `discarded` vs `reprinted`.** `reportUnaligned` gained an `outcome` field.

## Review fix: bounded discard, not blanket discard

[Codex flagged (P1)](https://github.com/2witstudios/PageSpace/pull/2024#discussion_r3567055502) that a give-up burst on a transparent reconnect is **not provably** "bytes the viewer already saw": the sprite session survives client disconnects (only the socket died), so the shell can keep producing genuinely new stdout during the reconnect gap — concatenated into the same unaligned burst with no marker separating old from new. A blanket discard could silently eat active build/log output, not just redundant repaint noise.

Fix (pushed after the initial review): `resolveGiveUpAction` now also takes `burstBytes` and only discards when the burst is **≤ `MAX_DISCARDABLE_GIVEUP_BYTES`** (`= MAX_ANCHOR_BYTES`, 8 KiB — reusing this module's own existing bound for "about the size of an idle terminal's whole history / a full redraw," not a new magic number). A burst larger than that is the shape of active output (a build, a verbose command), not a stale redraw, and is **shown**, matching 2-4's original baseline. The byte-cap give-up is always multi-megabyte, so it now **always** resolves to `'emit'` under this bound — the discard path only ever applies to the window-closed give-up, and only when it's small.

This is a size heuristic, not a proof, and the doc comments say so explicitly: it closes the *large*-loss end of the risk (a build's real output is never silently swallowed) without pretending to close the *small* end (a short message racing the reconnect is still indistinguishable byte-for-byte from a short redraw, and remains a residual, bounded, and now explicitly-tested risk — `given an unalignable replay whose anchor RECURS in live output, but the burst is SMALL, discards it`). No purely byte-level heuristic can fully close that without a terminal emulator parsing escape sequences, which is out of scope for this leaf.

## Self-review pass (proactive, post-review-fix)

Ran a parallel multi-angle self-review after the Codex fix above. Two non-blocking findings, both addressed:

- **Duplication**: the 2-line give-up dispatch (`if (giveUp !== undefined) settleGiveUp(...) else deliver(...)`) was repeated verbatim at both give-up call sites. Extracted into a shared `resolveEmission()` closure so they can't drift out of sync.
- **Doc precision**: the `resolveGiveUpAction`/`settleGiveUp` doc comments framed the discard risk in terms of "the viewer" (singular), as if referring only to the connection whose exec-layer reconnect triggered the give-up. Traced `onOutput` through `agent-terminal-handler.ts` and confirmed it's the single sink feeding BOTH the live viewer (`TerminalSession.outputFn`, a single-slot field) AND the app-level `session.scrollback` buffer any later viewer catches up from via `attachToLiveSession`. A discard is therefore **total** loss from every consumer, not "duplicated but still shown to the one who already had it." Tightened both doc comments to say so explicitly. No functional change — there's no coherent fix that shows discarded bytes to a hypothetical future joiner without also replaying them to the currently-attached viewer, which would reintroduce the repaint bug this leaf exists to remove. The size bound already scopes this total-loss risk to small, redraw-shaped bursts.

## Design notes

- Detection (`planReplayEmission` / `flushReplay`) is **unchanged** — this leaf only adds a decision layered on top of a give-up they already produce, per the leaf spec's "the change is to the give-up TERMINAL ACTION, not the detection."
- A discarded give-up still **restarts the history** (`recordHistory`, extracted from `deliver`) — the give-up's bytes are themselves a contiguous run of the stream whether shown or not, so recording them (without displaying them) is what keeps the *next* reconnect's dedupe working instead of latching a broken/empty history.
- Noted but out of scope (per leaf spec, and DISTINCT from the discard-is-total-loss point above): the app-side `session.scrollback` re-emit via `agent-terminal:ready` (RANK 3 latent double-mount stack) is a separate small fix, not touched here.

## Test plan

- [x] `bun run typecheck` (via `tsc --noEmit`) clean
- [x] `replay-dedupe.test.ts`: 51 tests green (matrix coverage for `resolveGiveUpAction`'s attachKind × burstBytes decision, including the boundary at/over `MAX_DISCARDABLE_GIVEUP_BYTES`)
- [x] `sprites-shell.test.ts`: 98 tests green (give-up tests split by burst size: small bursts discard, large bursts — byte-cap overflow, an 8.2 KiB anchor-recurrence repro — still show)
- [x] Full realtime app suite: `bun run test` → **763 passed**, 0 failed
- [x] `eslint` clean on all 4 changed files

```
 Test Files  22 passed (22)
      Tests  763 passed (763)
```

## For the orchestrator to verify

- Confirm no concurrent 2-3 (kill endpoint) or 3-2 (detached reconnect churn) agent was touching `sprites-shell.ts` during this run (guardrail note in the leaf spec) — checked at time of writing, no such PR is open.
- The residual small-burst risk described above ("Review fix" section) is a deliberate, bounded, and documented tradeoff, now also documented as TOTAL (not partial) loss per the self-review pass — flagging for visibility in case a future leaf wants to close it further (e.g. a real terminal-emulator diff), but it is not expected to block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UsgDS4ZSKj2iW4cMgjhByq

