### PR TITLE
[sprites 5-2] Checkpoint before destructive agent operations

### DIFF
--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -82,4 +82,14 @@ export interface ToolExecutionContext {
   // same turn see the new active machine. Undefined means "not yet
   // switched" — callers fall back to the configured machines[0].
   activeMachine?: MachineRef;
+
+  // Sprites Platform Alignment 5-2: a stable id for THIS agent turn (one
+  // streamText run), lazily stamped once by `resolveSandboxActorContext`
+  // (apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts) the first time a
+  // sandbox tool call reads this context, then reused by every later bash
+  // call in the same run — same mutate-in-place pattern as `activeMachine`
+  // above. Threads into `SandboxActorContext.turnId`, which gates the
+  // pre-batch checkpoint's "at most once per turn" throttle
+  // (`checkpoint-policy.ts`). Undefined until first stamped.
+  turnId?: string;
 }

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -150,6 +150,50 @@ describe('resolveSandboxActorContext', () => {
       expect(result.tenantId).toBe('tenant-from-drive');
     });
   });
+
+  describe('turnId stamping (Sprites Platform Alignment 5-2)', () => {
+    // Deliberately fresh, standalone context objects per test (not the shared
+    // module-level `baseGlobalContext`, which sibling tests above mutate
+    // in-place via stamping — reusing it here would leak a turnId across
+    // tests and defeat the very thing being asserted).
+    function freshGlobalContext(): ToolExecutionContext {
+      return { userId: 'u1', conversationId: 'conv-1', chatSource: { type: 'global' } };
+    }
+
+    it('stamps a turnId onto the resolved ctx when the raw context has none yet', async () => {
+      const resolve = createResolveSandboxActorContext(makeDeps());
+      const result = await resolve(freshGlobalContext());
+      expect('error' in result).toBe(false);
+      if ('error' in result) return;
+      expect(result.turnId).toBeTruthy();
+    });
+
+    it('reuses the SAME turnId across multiple tool calls sharing one context object (one streamText run)', async () => {
+      const resolve = createResolveSandboxActorContext(makeDeps());
+      const sharedContext = freshGlobalContext();
+
+      const first = await resolve(sharedContext);
+      const second = await resolve(sharedContext);
+
+      expect('error' in first).toBe(false);
+      expect('error' in second).toBe(false);
+      if ('error' in first || 'error' in second) return;
+      expect(first.turnId).toBe(second.turnId);
+      // The stamp is visible on the raw context too — later non-sandbox code
+      // paths reading it (or a second resolve call) see the same value.
+      expect(sharedContext.turnId).toBe(first.turnId);
+    });
+
+    it('mints a DIFFERENT turnId for a different context object (a new streamText run)', async () => {
+      const resolve = createResolveSandboxActorContext(makeDeps());
+      const first = await resolve(freshGlobalContext());
+      const second = await resolve(freshGlobalContext());
+      expect('error' in first).toBe(false);
+      expect('error' in second).toBe(false);
+      if ('error' in first || 'error' in second) return;
+      expect(first.turnId).not.toBe(second.turnId);
+    });
+  });
 });
 
 function makeMachineDirectoryDeps(

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -36,6 +36,7 @@ function fakeRunDeps(): SandboxRunDeps {
       runCommand: async () => ({ exitCode: 0, stdout: 'hi', stderr: '' }),
       writeFiles: async () => {},
       readFileToBuffer: async () => Buffer.from('data'),
+      createCheckpoint: async () => {},
     }),
     quota: {
       acquireSlot: () => true,
@@ -148,6 +149,7 @@ describe('createSandboxTools', () => {
         wrote = true;
       },
       readFileToBuffer: async () => Buffer.from(''),
+      createCheckpoint: async () => {},
     });
     const tools = createSandboxTools({
       runDeps,
@@ -229,6 +231,7 @@ describe('createSandboxTools', () => {
         wrote = true;
       },
       readFileToBuffer: async () => Buffer.from('data'),
+      createCheckpoint: async () => {},
     });
     const tools = createSandboxTools({
       runDeps,

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -35,6 +35,11 @@ import { acquireMachineSandbox } from '@pagespace/lib/services/sandbox/machine-s
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/machine-billing';
 import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
 import { lookupPageOwnerId } from '@pagespace/lib/billing/machine-payer';
+import {
+  isCheckpointBeforeAgentBatchEnabled,
+  getCheckpointState,
+  recordCheckpoint,
+} from '@pagespace/lib/services/sandbox/checkpoint-policy';
 import type { ExecSandboxClient } from '@pagespace/lib/services/sandbox/sandbox-client/types';
 import {
   acquireCodeExecutionSlot,
@@ -187,6 +192,17 @@ export function buildRealSandboxRunDeps(): SandboxRunDeps {
         handle: { exec: (args) => sandbox.runCommand(args) },
         pageId,
       }),
+    // Sprites Platform Alignment 5-2: checkpoint the sandbox filesystem before
+    // an agent bash batch runs (fail-open, at most once per turn — see
+    // checkpoint-policy.ts). State is in-process, keyed by sandboxId; a
+    // process restart simply re-checkpoints on the next batch, which is
+    // harmless (COW, ~300ms).
+    checkpoint: {
+      isEnabled: isCheckpointBeforeAgentBatchEnabled,
+      getState: getCheckpointState,
+      recordCheckpoint,
+      createCheckpoint: ({ sandbox, comment }) => sandbox.createCheckpoint(comment),
+    },
   };
 }
 
@@ -194,6 +210,21 @@ const VALID_TIERS: ReadonlySet<string> = new Set(['free', 'pro', 'founder', 'bus
 
 function toTier(value: string | null | undefined): SubscriptionTier {
   return value && VALID_TIERS.has(value) ? (value as SubscriptionTier) : 'free';
+}
+
+/**
+ * Lazily stamp a stable turn id onto `context` the first time it's read, then
+ * return it. `context` is the SAME object reference for every tool call
+ * within one streamText run (see `ToolExecutionContext.activeMachine`'s doc —
+ * same guarantee, same mutate-in-place pattern), so this stamps once per
+ * agent turn and every later bash call in the run sees the value already set.
+ * Undefined `context` (no tool-execution context at all) stays undefined —
+ * there is nothing to stamp onto.
+ */
+function stampTurnId(context: ToolExecutionContext | undefined): string | undefined {
+  if (!context) return undefined;
+  context.turnId ??= crypto.randomUUID();
+  return context.turnId;
 }
 
 /**
@@ -241,6 +272,7 @@ export function createResolveSandboxActorContext(
     if (!userId) return { error: 'Code execution requires an authenticated user.' };
     if (!conversationId) return { error: 'Code execution requires a conversation.' };
 
+    const turnId = stampTurnId(context);
     const chatSourceType = context?.chatSource?.type;
     const driveId =
       context?.locationContext?.currentDrive?.id ??
@@ -278,6 +310,7 @@ export function createResolveSandboxActorContext(
         aiProvider: context?.aiProvider,
         aiModel: context?.aiModel,
         tier: toTier(actorRow?.subscriptionTier),
+        turnId,
       };
     }
 
@@ -303,6 +336,7 @@ export function createResolveSandboxActorContext(
       aiProvider: context?.aiProvider,
       aiModel: context?.aiModel,
       tier: toTier(actorRow?.subscriptionTier),
+      turnId,
     };
   };
 }

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -288,46 +288,20 @@ export function createResolveSandboxActorContext(
       return { error: 'Code execution requires an active drive.' };
     }
 
-    // driveId present for both page AI and global AI: resolve tenantId from the
-    // drive's owning account. Both surfaces share identical resolution logic here.
-    if (driveId) {
-      const [drive, actorRow, actorInfo] = await Promise.all([
-        deps.findDrive(driveId),
-        deps.findUser(userId),
-        deps.getActorInfo(userId),
-      ]);
-      if (!drive) return { error: 'Code execution requires an active drive.' };
-
-      return {
-        userId,
-        tenantId: drive.ownerId,
-        driveId,
-        conversationId,
-        requestOrigin: context?.requestOrigin,
-        agentPageId: context?.chatSource?.agentPageId ?? context?.parentAgentId,
-        actorEmail: actorInfo.actorEmail,
-        actorDisplayName: actorInfo.actorDisplayName,
-        aiProvider: context?.aiProvider,
-        aiModel: context?.aiModel,
-        tier: toTier(actorRow?.subscriptionTier),
-        turnId,
-      };
-    }
-
-    // Global AI without a drive: user is their own isolation boundary.
-    // tenantId = userId keeps the session key and quota scopes user-owned.
-    // Side-effect: the tenant quota bucket becomes code-exec:tenant:<userId>,
-    // a second user-keyed window alongside code-exec:user:<userId>. This
-    // over-counts conservatively (only tightens budget) and is acceptable while
-    // the feature is admin-gated. Revisit if tenant-scope quota semantics matter.
-    const [actorRow, actorInfo] = await Promise.all([
+    // One parallel fetch covers both branches below: `findDrive` only runs a
+    // real query when driveId is present (an immediately-resolved undefined
+    // otherwise), so this preserves the original concurrency — findDrive,
+    // findUser, and getActorInfo all in flight together — without duplicating
+    // the actor lookup + result-object construction per branch.
+    const [drive, actorRow, actorInfo] = await Promise.all([
+      driveId ? deps.findDrive(driveId) : Promise.resolve(undefined),
       deps.findUser(userId),
       deps.getActorInfo(userId),
     ]);
+    if (driveId && !drive) return { error: 'Code execution requires an active drive.' };
 
-    return {
+    const base = {
       userId,
-      tenantId: userId,
       conversationId,
       requestOrigin: context?.requestOrigin,
       agentPageId: context?.chatSource?.agentPageId ?? context?.parentAgentId,
@@ -338,6 +312,20 @@ export function createResolveSandboxActorContext(
       tier: toTier(actorRow?.subscriptionTier),
       turnId,
     };
+
+    // driveId present for both page AI and global AI: tenantId is the drive's
+    // owning account. Both surfaces share identical resolution logic here.
+    if (driveId) {
+      return { ...base, tenantId: drive!.ownerId, driveId };
+    }
+
+    // Global AI without a drive: user is their own isolation boundary.
+    // tenantId = userId keeps the session key and quota scopes user-owned.
+    // Side-effect: the tenant quota bucket becomes code-exec:tenant:<userId>,
+    // a second user-keyed window alongside code-exec:user:<userId>. This
+    // over-counts conservatively (only tightens budget) and is acceptable while
+    // the feature is admin-gated. Revisit if tenant-scope quota semantics matter.
+    return { ...base, tenantId: userId };
   };
 }
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -422,6 +422,11 @@
       "import": "./dist/services/sandbox/can-run-code.js",
       "require": "./dist/services/sandbox/can-run-code.js"
     },
+    "./services/sandbox/checkpoint-policy": {
+      "types": "./dist/services/sandbox/checkpoint-policy.d.ts",
+      "import": "./dist/services/sandbox/checkpoint-policy.js",
+      "require": "./dist/services/sandbox/checkpoint-policy.js"
+    },
     "./services/sandbox/execution-policy": {
       "types": "./dist/services/sandbox/execution-policy.d.ts",
       "import": "./dist/services/sandbox/execution-policy.js",
@@ -1674,6 +1679,9 @@
       ],
       "services/sandbox/can-run-code": [
         "./dist/services/sandbox/can-run-code.d.ts"
+      ],
+      "services/sandbox/checkpoint-policy": [
+        "./dist/services/sandbox/checkpoint-policy.d.ts"
       ],
       "services/sandbox/execution-policy": [
         "./dist/services/sandbox/execution-policy.d.ts"

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -134,6 +134,7 @@ function makeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
     exec: async () => ({ success: true, exitCode: 0, stdout: '', stderr: '' }),
     writeFiles: async () => {},
     readFile: async () => null,
+    createCheckpoint: async () => {},
     stream: async () => ({
       write: () => {},
       resize: () => {},

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -115,6 +115,7 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
         const content = state.files.get(path);
         return content === undefined ? null : Buffer.from(content);
       },
+      createCheckpoint: async () => {},
       stream: async () => {
         throw new Error('not used by machine-branches');
       },

--- a/packages/lib/src/services/machines/__tests__/machine-projects.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-projects.test.ts
@@ -65,6 +65,7 @@ function makeSandbox(runCommandImpl?: (opts: Parameters<ExecutableSandbox['runCo
       throw new Error('writeFiles should never be called by clone/remove — no persisted credentials');
     },
     readFileToBuffer: async () => null,
+    createCheckpoint: async () => {},
   };
   return { sandbox, runCommandCalls };
 }
@@ -250,6 +251,7 @@ describe('addProject', () => {
       },
       writeFiles: async () => {},
       readFileToBuffer: async () => null,
+      createCheckpoint: async () => {},
     };
     const { deps, store } = makeDeps({ reconnect: async () => sandbox });
     const result = await addProject({

--- a/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
@@ -4,7 +4,6 @@ import {
   shouldCheckpoint,
   checkpointComment,
   resolveCheckpointFlag,
-  CHECKPOINT_MIN_INTERVAL_MS,
   getCheckpointState,
   recordCheckpoint,
   resetCheckpointState,
@@ -19,25 +18,21 @@ describe('shouldCheckpoint (pure)', () => {
       should: 'checkpoint',
       actual: shouldCheckpoint({
         flagEnabled: true,
-        lastCheckpointAt: null,
         turnId: 'turn-1',
         lastCheckpointTurnId: null,
-        now: NOW,
       }),
       expected: true,
     });
   });
 
-  it('never checkpoints when the flag is off, regardless of turn/throttle state', () => {
+  it('never checkpoints when the flag is off, regardless of turn state', () => {
     assert({
       given: 'flag off but otherwise a fresh turn',
       should: 'not checkpoint',
       actual: shouldCheckpoint({
         flagEnabled: false,
-        lastCheckpointAt: null,
         turnId: 'turn-1',
         lastCheckpointTurnId: null,
-        now: NOW,
       }),
       expected: false,
     });
@@ -49,55 +44,30 @@ describe('shouldCheckpoint (pure)', () => {
       should: 'skip a second checkpoint for a later batch in the same turn',
       actual: shouldCheckpoint({
         flagEnabled: true,
-        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS * 10),
         turnId: 'turn-1',
         lastCheckpointTurnId: 'turn-1',
-        now: NOW,
       }),
       expected: false,
     });
   });
 
-  it('checkpoints again for a NEW turn once the throttle window has elapsed', () => {
+  // Regression test for a P2 finding on PR #2025 (chatgpt-codex-connector):
+  // an earlier revision suppressed a NEW turn's first checkpoint if it fell
+  // within a time-based throttle window of a PRIOR, different turn's
+  // checkpoint. That silently defeated the safety net: two legitimate turns
+  // close together would leave only the older turn's restore point on
+  // record, so a restore after the newer turn's destructive work would
+  // discard the newer turn's real work too. A different turnId must ALWAYS
+  // checkpoint, no matter how recently the previous (different) turn's
+  // checkpoint was taken.
+  it('checkpoints a NEW turn immediately, even moments after a different turn was checkpointed', () => {
     assert({
-      given: 'a new turnId and a last checkpoint well outside the throttle window',
-      should: 'checkpoint',
+      given: 'a different turnId than the last checkpoint, taken 1ms ago',
+      should: 'checkpoint anyway — a new turn is never suppressed by how recent the prior one was',
       actual: shouldCheckpoint({
         flagEnabled: true,
-        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS - 1),
         turnId: 'turn-2',
         lastCheckpointTurnId: 'turn-1',
-        now: NOW,
-      }),
-      expected: true,
-    });
-  });
-
-  it('throttles across rapid batches even when the turnId changed (safety net)', () => {
-    assert({
-      given: 'a new turnId but the last checkpoint was inside the throttle window',
-      should: 'skip (throttled)',
-      actual: shouldCheckpoint({
-        flagEnabled: true,
-        lastCheckpointAt: new Date(NOW.getTime() - 1_000),
-        turnId: 'turn-2',
-        lastCheckpointTurnId: 'turn-1',
-        now: NOW,
-      }),
-      expected: false,
-    });
-  });
-
-  it('checkpoints exactly at the throttle boundary (>= throttle, not >)', () => {
-    assert({
-      given: 'a last checkpoint exactly CHECKPOINT_MIN_INTERVAL_MS ago',
-      should: 'checkpoint',
-      actual: shouldCheckpoint({
-        flagEnabled: true,
-        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS),
-        turnId: 'turn-2',
-        lastCheckpointTurnId: 'turn-1',
-        now: NOW,
       }),
       expected: true,
     });

--- a/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { assert } from './riteway';
+import {
+  shouldCheckpoint,
+  checkpointComment,
+  resolveCheckpointFlag,
+  CHECKPOINT_MIN_INTERVAL_MS,
+  getCheckpointState,
+  recordCheckpoint,
+  resetCheckpointState,
+} from '../checkpoint-policy';
+
+const NOW = new Date('2026-07-12T12:00:00.000Z');
+
+describe('shouldCheckpoint (pure)', () => {
+  it('creates a checkpoint on the first batch of a turn when the flag is on', () => {
+    assert({
+      given: 'flag on, never checkpointed before, a fresh turn',
+      should: 'checkpoint',
+      actual: shouldCheckpoint({
+        flagEnabled: true,
+        lastCheckpointAt: null,
+        turnId: 'turn-1',
+        lastCheckpointTurnId: null,
+        now: NOW,
+      }),
+      expected: true,
+    });
+  });
+
+  it('never checkpoints when the flag is off, regardless of turn/throttle state', () => {
+    assert({
+      given: 'flag off but otherwise a fresh turn',
+      should: 'not checkpoint',
+      actual: shouldCheckpoint({
+        flagEnabled: false,
+        lastCheckpointAt: null,
+        turnId: 'turn-1',
+        lastCheckpointTurnId: null,
+        now: NOW,
+      }),
+      expected: false,
+    });
+  });
+
+  it('does not checkpoint again within the SAME turn (at most once per agent turn)', () => {
+    assert({
+      given: 'a turn that already produced a checkpoint',
+      should: 'skip a second checkpoint for a later batch in the same turn',
+      actual: shouldCheckpoint({
+        flagEnabled: true,
+        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS * 10),
+        turnId: 'turn-1',
+        lastCheckpointTurnId: 'turn-1',
+        now: NOW,
+      }),
+      expected: false,
+    });
+  });
+
+  it('checkpoints again for a NEW turn once the throttle window has elapsed', () => {
+    assert({
+      given: 'a new turnId and a last checkpoint well outside the throttle window',
+      should: 'checkpoint',
+      actual: shouldCheckpoint({
+        flagEnabled: true,
+        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS - 1),
+        turnId: 'turn-2',
+        lastCheckpointTurnId: 'turn-1',
+        now: NOW,
+      }),
+      expected: true,
+    });
+  });
+
+  it('throttles across rapid batches even when the turnId changed (safety net)', () => {
+    assert({
+      given: 'a new turnId but the last checkpoint was inside the throttle window',
+      should: 'skip (throttled)',
+      actual: shouldCheckpoint({
+        flagEnabled: true,
+        lastCheckpointAt: new Date(NOW.getTime() - 1_000),
+        turnId: 'turn-2',
+        lastCheckpointTurnId: 'turn-1',
+        now: NOW,
+      }),
+      expected: false,
+    });
+  });
+
+  it('checkpoints exactly at the throttle boundary (>= throttle, not >)', () => {
+    assert({
+      given: 'a last checkpoint exactly CHECKPOINT_MIN_INTERVAL_MS ago',
+      should: 'checkpoint',
+      actual: shouldCheckpoint({
+        flagEnabled: true,
+        lastCheckpointAt: new Date(NOW.getTime() - CHECKPOINT_MIN_INTERVAL_MS),
+        turnId: 'turn-2',
+        lastCheckpointTurnId: 'turn-1',
+        now: NOW,
+      }),
+      expected: true,
+    });
+  });
+});
+
+describe('resolveCheckpointFlag (pure)', () => {
+  it('is ON by default outside production', () => {
+    assert({
+      given: 'no explicit env value, nodeEnv "development"',
+      should: 'default ON',
+      actual: resolveCheckpointFlag({ rawEnvValue: undefined, nodeEnv: 'development' }),
+      expected: true,
+    });
+  });
+
+  it('is ON by default in test', () => {
+    assert({
+      given: 'no explicit env value, nodeEnv "test"',
+      should: 'default ON',
+      actual: resolveCheckpointFlag({ rawEnvValue: undefined, nodeEnv: 'test' }),
+      expected: true,
+    });
+  });
+
+  it('is OFF by default in production (prod default deferred to PR discussion)', () => {
+    assert({
+      given: 'no explicit env value, nodeEnv "production"',
+      should: 'default OFF',
+      actual: resolveCheckpointFlag({ rawEnvValue: undefined, nodeEnv: 'production' }),
+      expected: false,
+    });
+  });
+
+  it('an explicit "true" always wins, even in production', () => {
+    assert({
+      given: 'rawEnvValue "true", nodeEnv "production"',
+      should: 'be ON',
+      actual: resolveCheckpointFlag({ rawEnvValue: 'true', nodeEnv: 'production' }),
+      expected: true,
+    });
+  });
+
+  it('an explicit "false" always wins, even outside production', () => {
+    assert({
+      given: 'rawEnvValue "false", nodeEnv "development"',
+      should: 'be OFF',
+      actual: resolveCheckpointFlag({ rawEnvValue: 'false', nodeEnv: 'development' }),
+      expected: false,
+    });
+  });
+
+  it('an unrecognized raw value falls back to the NODE_ENV default', () => {
+    assert({
+      given: 'rawEnvValue "yes" (not the literal "true"), nodeEnv "production"',
+      should: 'fall back to the production default (OFF)',
+      actual: resolveCheckpointFlag({ rawEnvValue: 'yes', nodeEnv: 'production' }),
+      expected: false,
+    });
+  });
+});
+
+describe('checkpointComment (pure)', () => {
+  it('tags the checkpoint with a recognizable, turn-scoped comment', () => {
+    assert({
+      given: 'turnId "abc123"',
+      should: 'produce the pagespace-pre-agent-<turnId> comment',
+      actual: checkpointComment('abc123'),
+      expected: 'pagespace-pre-agent-abc123',
+    });
+  });
+});
+
+describe('checkpoint state (in-process, per sandbox)', () => {
+  it('reports null state for a sandbox that has never been checkpointed', () => {
+    resetCheckpointState();
+    assert({
+      given: 'an unknown sandboxId',
+      should: 'return null lastCheckpointAt/lastCheckpointTurnId',
+      actual: getCheckpointState('sbx-never-seen'),
+      expected: { lastCheckpointAt: null, lastCheckpointTurnId: null },
+    });
+  });
+
+  it('remembers the last recorded checkpoint per sandboxId', () => {
+    resetCheckpointState();
+    recordCheckpoint('sbx-1', { lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-1' });
+    expect(getCheckpointState('sbx-1')).toEqual({ lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-1' });
+    // A different sandbox is unaffected.
+    expect(getCheckpointState('sbx-2')).toEqual({ lastCheckpointAt: null, lastCheckpointTurnId: null });
+  });
+
+  it('resetCheckpointState clears all recorded state (test-only seam)', () => {
+    recordCheckpoint('sbx-1', { lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-1' });
+    resetCheckpointState();
+    expect(getCheckpointState('sbx-1')).toEqual({ lastCheckpointAt: null, lastCheckpointTurnId: null });
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/checkpoint-policy.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { assert } from './riteway';
 import {
   shouldCheckpoint,
@@ -7,6 +7,7 @@ import {
   getCheckpointState,
   recordCheckpoint,
   resetCheckpointState,
+  coalesceCheckpointAttempt,
 } from '../checkpoint-policy';
 
 const NOW = new Date('2026-07-12T12:00:00.000Z');
@@ -164,5 +165,111 @@ describe('checkpoint state (in-process, per sandbox)', () => {
     recordCheckpoint('sbx-1', { lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-1' });
     resetCheckpointState();
     expect(getCheckpointState('sbx-1')).toEqual({ lastCheckpointAt: null, lastCheckpointTurnId: null });
+  });
+
+  // Efficiency finding from code review: this in-process Map has no
+  // symmetric acquire/release, so it needs an opportunistic sweep (mirroring
+  // quota.ts's machineActivityByKey) or it grows by one entry per distinct
+  // sandboxId ever seen for the life of the process.
+  it('opportunistically evicts entries older than the TTL when a later checkpoint is recorded', () => {
+    resetCheckpointState();
+    const longAgo = new Date(NOW.getTime() - 25 * 60 * 60 * 1000); // 25h ago, past the 24h TTL
+    recordCheckpoint('sbx-stale', { lastCheckpointAt: longAgo, lastCheckpointTurnId: 'turn-old' });
+    // A fresh checkpoint on a DIFFERENT sandbox is the natural sweep trigger.
+    recordCheckpoint('sbx-fresh', { lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-new' });
+
+    expect(getCheckpointState('sbx-stale')).toEqual({ lastCheckpointAt: null, lastCheckpointTurnId: null });
+    expect(getCheckpointState('sbx-fresh')).toEqual({ lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-new' });
+  });
+
+  it('does not evict an entry still within the TTL', () => {
+    resetCheckpointState();
+    const recent = new Date(NOW.getTime() - 60 * 60 * 1000); // 1h ago, well within the 24h TTL
+    recordCheckpoint('sbx-recent', { lastCheckpointAt: recent, lastCheckpointTurnId: 'turn-a' });
+    recordCheckpoint('sbx-other', { lastCheckpointAt: NOW, lastCheckpointTurnId: 'turn-b' });
+
+    expect(getCheckpointState('sbx-recent')).toEqual({ lastCheckpointAt: recent, lastCheckpointTurnId: 'turn-a' });
+  });
+});
+
+describe('coalesceCheckpointAttempt', () => {
+  it('runs the attempt and resolves when there is no concurrent attempt in flight', async () => {
+    resetCheckpointState();
+    let calls = 0;
+    await coalesceCheckpointAttempt('sbx-1', async () => {
+      calls += 1;
+    });
+    expect(calls).toBe(1);
+  });
+
+  // Regression test for a P2 finding on PR #2025 (2 independent review
+  // agents): the AI SDK can execute multiple tool calls from one agent step
+  // concurrently. Without coalescing, two callers checkpointing the SAME
+  // sandbox at "the same time" would each start their own attempt.
+  it('given two concurrent callers for the SAME sandbox, runs the attempt only once and both resolve together', async () => {
+    resetCheckpointState();
+    let starts = 0;
+    let releaseAttempt: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseAttempt = resolve;
+    });
+    const attempt = async () => {
+      starts += 1;
+      await gate;
+    };
+
+    const first = coalesceCheckpointAttempt('sbx-1', attempt);
+    const second = coalesceCheckpointAttempt('sbx-1', attempt);
+
+    expect(starts).toBe(1); // the second caller reused the first's in-flight promise
+    releaseAttempt?.();
+    await Promise.all([first, second]);
+  });
+
+  it('given two DIFFERENT sandboxes, runs independent attempts for each', async () => {
+    resetCheckpointState();
+    const starts: string[] = [];
+    await Promise.all([
+      coalesceCheckpointAttempt('sbx-1', async () => {
+        starts.push('sbx-1');
+      }),
+      coalesceCheckpointAttempt('sbx-2', async () => {
+        starts.push('sbx-2');
+      }),
+    ]);
+    expect(starts.sort()).toEqual(['sbx-1', 'sbx-2']);
+  });
+
+  it('removes the in-flight entry once the attempt settles, so a LATER (non-overlapping) call starts fresh', async () => {
+    resetCheckpointState();
+    let calls = 0;
+    await coalesceCheckpointAttempt('sbx-1', async () => {
+      calls += 1;
+    });
+    await coalesceCheckpointAttempt('sbx-1', async () => {
+      calls += 1;
+    });
+    expect(calls).toBe(2);
+  });
+
+  it('propagates the attempt\'s rejection to every coalesced caller, and still cleans up the in-flight entry', async () => {
+    resetCheckpointState();
+    const failingAttempt = vi.fn(async () => {
+      throw new Error('checkpoint failed');
+    });
+
+    const first = coalesceCheckpointAttempt('sbx-1', failingAttempt);
+    const second = coalesceCheckpointAttempt('sbx-1', failingAttempt);
+
+    await expect(first).rejects.toThrow('checkpoint failed');
+    await expect(second).rejects.toThrow('checkpoint failed');
+    expect(failingAttempt).toHaveBeenCalledTimes(1); // still coalesced onto one attempt
+
+    // Cleaned up: a later call starts a fresh attempt rather than reusing the dead one.
+    let calls = 0;
+    await coalesceCheckpointAttempt('sbx-1', async () => {
+      calls += 1;
+    });
+    expect(calls).toBe(1);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/git-tool-runners.test.ts
@@ -37,6 +37,7 @@ function makeSandbox(over: Partial<ExecutableSandbox> = {}): {
     },
     writeFiles: async () => {},
     readFileToBuffer: async () => Buffer.from(''),
+    createCheckpoint: async () => {},
     ...over,
   };
   return { sandbox, runCommandCalls };
@@ -73,6 +74,7 @@ function makeDepsWithSpy(token: string | null = 'ghp_test_token') {
     },
     writeFiles: async () => {},
     readFileToBuffer: async () => Buffer.from(''),
+    createCheckpoint: async () => {},
   };
   const slots = { acquired: 0, released: 0 };
   const deps: GitSandboxRunDeps = {
@@ -225,6 +227,7 @@ describe('runGitInSandbox', () => {
       runCommand: async () => { throw new Error('run failed'); },
       writeFiles: async () => {},
       readFileToBuffer: async () => null,
+      createCheckpoint: async () => {},
     });
     const result = await runGitInSandbox({ cmd: 'git', args: ['status'], ctx: makeCtx(), deps });
     expect(result).toMatchObject({ success: false });

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -39,6 +39,7 @@ function makeDeps(runCommand: (args: RunCommandArgs) => Promise<SandboxRunResult
     },
     writeFiles: async () => {},
     readFileToBuffer: async () => Buffer.from(''),
+    createCheckpoint: async () => {},
   };
   const deps: GitSandboxRunDeps = {
     isEnabled: () => true,

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -77,6 +77,7 @@ function makeHandle(files: Record<string, string>): { handle: MachineHandle; rea
       const content = files[path];
       return content === undefined ? null : Buffer.from(content, 'utf8');
     },
+    createCheckpoint: async () => {},
     stream: async () => {
       throw new Error('not used');
     },

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -17,6 +17,7 @@ function makeHandle(overrides: {
     exec: overrides.exec ?? (async () => ({ exitCode: 0, stdout: '', stderr: '' })),
     readFile: overrides.readFile ?? (async () => null),
     writeFiles: async () => {},
+    createCheckpoint: async () => {},
     stream: async () => {
       throw new Error('stream() is not used by the fs primitives');
     },

--- a/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-git-blob.test.ts
@@ -34,6 +34,7 @@ function makeDeps(runCommand: (args: RunCommandArgs) => Promise<SandboxRunResult
     },
     writeFiles: async () => {},
     readFileToBuffer: async () => Buffer.from(''),
+    createCheckpoint: async () => {},
   };
   const deps: GitSandboxRunDeps = {
     isEnabled: () => true,

--- a/packages/lib/src/services/sandbox/__tests__/persistent-machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/persistent-machine-fs.test.ts
@@ -99,6 +99,7 @@ function makeSpriteWorld() {
         const content = fs.get(path);
         return content === undefined ? null : Buffer.from(content, 'utf8');
       },
+      createCheckpoint: async () => {},
     };
   }
 

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -603,7 +603,7 @@ describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 
     expect(created).toHaveLength(1);
   });
 
-  it('given a NEW turn well after the throttle window, should checkpoint again', async () => {
+  it('given a NEW turn well after the first, should checkpoint again', async () => {
     const { checkpoint, created } = makeCheckpointDeps();
     const { deps: deps1 } = makeDeps({ checkpoint, now: () => new Date('2026-07-12T12:00:00.000Z') });
     await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps: deps1 });
@@ -613,6 +613,30 @@ describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 
 
     expect(created).toHaveLength(2);
     expect(created[1]).toEqual({ sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-2' });
+  });
+
+  // Regression test for a P2 finding on PR #2025 (chatgpt-codex-connector): an
+  // earlier revision's pure policy suppressed a NEW turn's checkpoint if it
+  // fell within a time-based throttle window of a prior, DIFFERENT turn's
+  // checkpoint — so two legitimate turns close together (an ordinary rapid
+  // back-and-forth) would leave only the older turn's restore point on
+  // record, silently discarding the newer turn's real work on a later
+  // restore. Exercised here through the full runBashInSandbox path, not just
+  // the pure function, with `now` identical across both turns (the most
+  // adversarial case for a time-based throttle).
+  it('given a NEW turn moments after a different turn was checkpointed, should still checkpoint (no cross-turn interval suppression)', async () => {
+    const { checkpoint, created } = makeCheckpointDeps();
+    const sameInstant = () => new Date('2026-07-12T12:00:00.000Z');
+    const { deps: deps1 } = makeDeps({ checkpoint, now: sameInstant });
+    await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps: deps1 });
+
+    const { deps: deps2 } = makeDeps({ checkpoint, now: sameInstant });
+    await runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-2' }), deps: deps2 });
+
+    expect(created).toEqual([
+      { sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-1' },
+      { sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-2' },
+    ]);
   });
 
   it('given checkpoint creation throws, should proceed with the batch (fail-open) and log', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -32,6 +32,7 @@ function makeSandbox(over: Partial<ExecutableSandbox> = {}): ExecutableSandbox {
     runCommand: async (): Promise<SandboxRunResult> => ({ exitCode: 0, stdout: 'ok', stderr: '' }),
     writeFiles: async () => {},
     readFileToBuffer: async () => Buffer.from('file-contents'),
+    createCheckpoint: async () => {},
     ...over,
   };
 }
@@ -532,6 +533,131 @@ describe('runBashInSandbox', () => {
     });
     await runBashInSandbox({ command: 'echo hi', timeoutMs: 0, ctx: makeCtx(), deps });
     expect(seenTimeout).toBe(1);
+  });
+});
+
+describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 5-2)', () => {
+  function makeCheckpointDeps(over: Partial<NonNullable<SandboxRunDeps['checkpoint']>> = {}) {
+    const state = new Map<string, { lastCheckpointAt: Date | null; lastCheckpointTurnId: string | null }>();
+    const created: Array<{ sandboxId: string; comment: string }> = [];
+    const checkpoint: NonNullable<SandboxRunDeps['checkpoint']> = {
+      isEnabled: () => true,
+      getState: (sandboxId) => state.get(sandboxId) ?? { lastCheckpointAt: null, lastCheckpointTurnId: null },
+      recordCheckpoint: (sandboxId, s) => {
+        state.set(sandboxId, s);
+      },
+      createCheckpoint: async ({ sandbox, comment }) => {
+        created.push({ sandboxId: sandbox.sandboxId, comment });
+      },
+      ...over,
+    };
+    return { checkpoint, created, state };
+  }
+
+  it('given the flag on and a turnId, should checkpoint before the command runs, tagged with the turn', async () => {
+    const order: string[] = [];
+    const { checkpoint, created } = makeCheckpointDeps({
+      createCheckpoint: async ({ sandbox, comment }) => {
+        order.push('checkpoint');
+        created.push({ sandboxId: sandbox.sandboxId, comment });
+      },
+    });
+    const { deps } = makeDeps({
+      checkpoint,
+      reconnect: async () =>
+        makeSandbox({
+          runCommand: async () => {
+            order.push('run');
+            return { exitCode: 0, stdout: 'ok', stderr: '' };
+          },
+        }),
+    });
+    const result = await runBashInSandbox({ command: 'rm -rf /workspace', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(result).toMatchObject({ success: true });
+    expect(created).toEqual([{ sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-1' }]);
+    expect(order).toEqual(['checkpoint', 'run']);
+  });
+
+  it('given the flag off, should never call createCheckpoint', async () => {
+    const { checkpoint, created } = makeCheckpointDeps({ isEnabled: () => false });
+    const { deps } = makeDeps({ checkpoint });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(result).toMatchObject({ success: true });
+    expect(created).toEqual([]);
+  });
+
+  it('given no turnId on ctx, should skip checkpointing entirely (no turn boundary to key the throttle on)', async () => {
+    const { checkpoint, created } = makeCheckpointDeps();
+    const { deps } = makeDeps({ checkpoint });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: undefined }), deps });
+    expect(result).toMatchObject({ success: true });
+    expect(created).toEqual([]);
+  });
+
+  it('given repeated batches within the SAME turn, should checkpoint at most once', async () => {
+    const { checkpoint, created } = makeCheckpointDeps();
+    const { deps } = makeDeps({ checkpoint });
+    await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    await runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    await runBashInSandbox({ command: 'echo three', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(created).toHaveLength(1);
+  });
+
+  it('given a NEW turn well after the throttle window, should checkpoint again', async () => {
+    const { checkpoint, created } = makeCheckpointDeps();
+    const { deps: deps1 } = makeDeps({ checkpoint, now: () => new Date('2026-07-12T12:00:00.000Z') });
+    await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps: deps1 });
+
+    const { deps: deps2 } = makeDeps({ checkpoint, now: () => new Date('2026-07-12T12:05:00.000Z') });
+    await runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-2' }), deps: deps2 });
+
+    expect(created).toHaveLength(2);
+    expect(created[1]).toEqual({ sandboxId: 'sbx-1', comment: 'pagespace-pre-agent-turn-2' });
+  });
+
+  it('given checkpoint creation throws, should proceed with the batch (fail-open) and log', async () => {
+    const { checkpoint, created } = makeCheckpointDeps({
+      createCheckpoint: async () => {
+        throw new Error('checkpoint API unavailable');
+      },
+    });
+    const warnings: Array<[string, Record<string, unknown> | undefined]> = [];
+    const { deps } = makeDeps({
+      checkpoint,
+      logger: {
+        error: () => {},
+        warn: (message, metadata) => {
+          warnings.push([message, metadata]);
+        },
+      },
+    });
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(result).toMatchObject({ success: true, stdout: 'ok' });
+    expect(created).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0][0]).toMatch(/checkpoint/i);
+  });
+
+  it('given no checkpoint dep configured, should run normally (seam fully optional)', async () => {
+    const { deps } = makeDeps();
+    const result = await runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(result).toMatchObject({ success: true });
+  });
+
+  it('does not record a checkpoint when the SDK call itself fails (a later batch in the same turn may retry)', async () => {
+    let attempts = 0;
+    const { checkpoint, created } = makeCheckpointDeps({
+      createCheckpoint: async ({ sandbox, comment }) => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('transient failure');
+        created.push({ sandboxId: sandbox.sandboxId, comment });
+      },
+    });
+    const { deps } = makeDeps({ checkpoint, logger: { error: () => {}, warn: () => {} } });
+    await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    await runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    expect(attempts).toBe(2);
+    expect(created).toHaveLength(1);
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -5,6 +5,7 @@ import {
   readSandboxFile,
   editSandboxFile,
   MAX_WRITE_BYTES,
+  CHECKPOINT_TIMEOUT_MS,
   type SandboxActorContext,
   type SandboxRunDeps,
 } from '../tool-runners';
@@ -681,6 +682,76 @@ describe('runBashInSandbox — pre-batch checkpoint (Sprites Platform Alignment 
     await runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps });
     await runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-1' }), deps });
     expect(attempts).toBe(2);
+    expect(created).toHaveLength(1);
+  });
+
+  // Regression test for a P2 finding on PR #2025 (chatgpt-codex-connector): a
+  // checkpoint call that never settles must never block the batch — the
+  // fail-open guarantee documented on maybeCheckpointBeforeBatch would
+  // otherwise be violated by an indefinitely hung checkpoint stream.
+  it('given a checkpoint call that never settles, still proceeds with the batch after CHECKPOINT_TIMEOUT_MS (fail-open)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { checkpoint, created } = makeCheckpointDeps({
+        createCheckpoint: () => new Promise(() => {}), // never resolves
+      });
+      const warnings: Array<[string, Record<string, unknown> | undefined]> = [];
+      const { deps } = makeDeps({
+        checkpoint,
+        logger: {
+          error: () => {},
+          warn: (message, metadata) => {
+            warnings.push([message, metadata]);
+          },
+        },
+      });
+
+      const resultPromise = runBashInSandbox({ command: 'echo hi', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+      const assertion = expect(resultPromise).resolves.toMatchObject({ success: true, stdout: 'ok' });
+      await vi.advanceTimersByTimeAsync(CHECKPOINT_TIMEOUT_MS);
+      await assertion;
+
+      expect(created).toEqual([]);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0][0]).toMatch(/checkpoint/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Regression test for a P2 finding on PR #2025 (2 independent review
+  // agents): the AI SDK can execute multiple tool calls from one agent step
+  // concurrently, so two bash calls in the SAME turn must still checkpoint
+  // at most once even when dispatched together (Promise.all), not just when
+  // dispatched sequentially (already covered above).
+  it('given two bash calls in the SAME turn dispatched concurrently, still checkpoints at most once', async () => {
+    let createCalls = 0;
+    let releaseCheckpoint: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      releaseCheckpoint = resolve;
+    });
+    const { checkpoint, created } = makeCheckpointDeps({
+      createCheckpoint: async ({ sandbox, comment }) => {
+        createCalls += 1;
+        await gate; // hold both concurrent callers here until released together
+        created.push({ sandboxId: sandbox.sandboxId, comment });
+      },
+    });
+    const { deps } = makeDeps({ checkpoint });
+
+    const first = runBashInSandbox({ command: 'echo one', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+    const second = runBashInSandbox({ command: 'echo two', ctx: makeCtx({ turnId: 'turn-1' }), deps });
+
+    // Give both calls a chance to reach (and coalesce on) the checkpoint attempt.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(createCalls).toBe(1); // coalesced — not 2, even though both calls raced past the throttle check
+
+    releaseCheckpoint?.();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toMatchObject({ success: true });
+    expect(secondResult).toMatchObject({ success: true });
     expect(created).toHaveLength(1);
   });
 });

--- a/packages/lib/src/services/sandbox/checkpoint-policy.ts
+++ b/packages/lib/src/services/sandbox/checkpoint-policy.ts
@@ -24,25 +24,6 @@ export function checkpointComment(turnId: string): string {
   return `${CHECKPOINT_COMMENT_PREFIX}${turnId}`;
 }
 
-/** Parse a non-negative integer env override; fall back on absence/garbage (mirrors machine-storage-measure.ts). */
-function envInt(name: string, fallback: number): number {
-  const raw = process.env[name]?.trim();
-  if (raw === undefined || raw === '' || !/^\d+$/.test(raw)) return fallback;
-  return Number.parseInt(raw, 10);
-}
-
-/**
- * Safety-net floor between two pre-batch checkpoints on the SAME sandbox, even
- * across DIFFERENT turns. The primary gate is "at most once per turn" (the
- * `turnId` comparison below); this additionally bounds checkpoint frequency if
- * turns are somehow generated in a tight loop (a caller bug, or a future turn
- * boundary that turns out to be finer-grained than intended) — a checkpoint is
- * cheap (~300ms, COW) but not free, and this keeps a runaway loop from hammering
- * the checkpoint API. Env-tunable; default well under any real agent turn's
- * cadence.
- */
-export const CHECKPOINT_MIN_INTERVAL_MS = envInt('SANDBOX_CHECKPOINT_MIN_INTERVAL_MS', 30_000);
-
 /**
  * Pure: resolve the checkpoint-before-agent-batch flag from its raw env value
  * + NODE_ENV. Explicit 'true'/'false' always wins. Unset defaults ON outside
@@ -74,13 +55,10 @@ export function isCheckpointBeforeAgentBatchEnabled(): boolean {
 export interface ShouldCheckpointInput {
   /** The feature flag, re-checked fresh per batch. */
   flagEnabled: boolean;
-  /** When this sandbox was last checkpointed by this policy, or null if never. */
-  lastCheckpointAt: Date | null;
   /** Stable id for the CURRENT agent turn (one streamText run). */
   turnId: string;
   /** The turnId the last checkpoint was taken for, or null if never checkpointed. */
   lastCheckpointTurnId: string | null;
-  now: Date;
 }
 
 /**
@@ -89,23 +67,26 @@ export interface ShouldCheckpointInput {
  * - Flag off → never.
  * - Same turnId as the last checkpoint → never (at most once per agent turn;
  *   repeated tool batches within one turn must not pile up checkpoints).
- * - Otherwise → yes, UNLESS the last checkpoint (for a different, presumably
- *   fast-preceding turn) is still inside `CHECKPOINT_MIN_INTERVAL_MS` — the
- *   throttle safety net documented above.
+ * - A DIFFERENT turnId → always yes. There is deliberately NO additional
+ *   time-based throttle here: an earlier revision added one (a floor between
+ *   checkpoints regardless of turn, meant as a backstop against a hypothetical
+ *   caller bug that regenerates turnId too eagerly) — but since this function
+ *   only ever remembers the SINGLE most recent turnId, a turnId that differs
+ *   from it is BY DEFINITION a turn that has never been checkpointed. Skipping
+ *   it because a prior, different turn was checkpointed moments ago silently
+ *   drops the very safety net this exists for: two legitimate turns close
+ *   together (an ordinary rapid back-and-forth) would leave only the OLDER
+ *   turn's checkpoint on record, so a later restore would discard the newer
+ *   turn's real work along with whatever it was trying to undo. Do not
+ *   reintroduce a cross-turn interval gate without solving that.
  */
 export function shouldCheckpoint({
   flagEnabled,
-  lastCheckpointAt,
   turnId,
   lastCheckpointTurnId,
-  now,
 }: ShouldCheckpointInput): boolean {
   if (!flagEnabled) return false;
-  if (lastCheckpointTurnId === turnId) return false;
-  if (lastCheckpointAt !== null && now.getTime() - lastCheckpointAt.getTime() < CHECKPOINT_MIN_INTERVAL_MS) {
-    return false;
-  }
-  return true;
+  return turnId !== lastCheckpointTurnId;
 }
 
 export interface CheckpointState {

--- a/packages/lib/src/services/sandbox/checkpoint-policy.ts
+++ b/packages/lib/src/services/sandbox/checkpoint-policy.ts
@@ -1,0 +1,143 @@
+/**
+ * Checkpoint-before-agent-batch policy (Sprites Platform Alignment 5-2).
+ *
+ * Checkpoints are ~300ms copy-on-write filesystem snapshots
+ * (docs.sprites.dev/concepts/checkpoints), designed for exactly this: a safety
+ * net before destructive, unattended agent bash batches. `sprites.ts`'s own
+ * `spawnWithSelfHealingCwd` doc already worries that "an agent that `rm -rf`s
+ * /workspace would otherwise brick every later command" — a checkpoint turns
+ * that from a bricked machine into a restore (restore itself is a separate,
+ * manual/admin action; this leaf only creates the safety net, never uses it).
+ *
+ * Pure core (this file): the throttle decision and the checkpoint's tagged
+ * comment. IO — the actual SDK call, and where the per-sandbox bookkeeping is
+ * read/written — lives in the shell (`tool-runners.ts`'s `SandboxCheckpointDeps`
+ * seam, wired to the in-process state below by default).
+ */
+
+/** Recognizable prefix for a pre-batch checkpoint's comment, so a human browsing
+ *  `sprite checkpoint list` can tell an agent-safety checkpoint from a manual one. */
+const CHECKPOINT_COMMENT_PREFIX = 'pagespace-pre-agent-';
+
+/** Pure: the tagged comment for a pre-batch checkpoint taken during `turnId`. */
+export function checkpointComment(turnId: string): string {
+  return `${CHECKPOINT_COMMENT_PREFIX}${turnId}`;
+}
+
+/** Parse a non-negative integer env override; fall back on absence/garbage (mirrors machine-storage-measure.ts). */
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (raw === undefined || raw === '' || !/^\d+$/.test(raw)) return fallback;
+  return Number.parseInt(raw, 10);
+}
+
+/**
+ * Safety-net floor between two pre-batch checkpoints on the SAME sandbox, even
+ * across DIFFERENT turns. The primary gate is "at most once per turn" (the
+ * `turnId` comparison below); this additionally bounds checkpoint frequency if
+ * turns are somehow generated in a tight loop (a caller bug, or a future turn
+ * boundary that turns out to be finer-grained than intended) — a checkpoint is
+ * cheap (~300ms, COW) but not free, and this keeps a runaway loop from hammering
+ * the checkpoint API. Env-tunable; default well under any real agent turn's
+ * cadence.
+ */
+export const CHECKPOINT_MIN_INTERVAL_MS = envInt('SANDBOX_CHECKPOINT_MIN_INTERVAL_MS', 30_000);
+
+/**
+ * Pure: resolve the checkpoint-before-agent-batch flag from its raw env value
+ * + NODE_ENV. Explicit 'true'/'false' always wins. Unset defaults ON outside
+ * production (dev/test/staging get the safety net by default) and OFF in
+ * production — the leaf spec explicitly defers the production default to PR
+ * discussion; flip `SANDBOX_CHECKPOINT_BEFORE_AGENT_BATCH=true` to enable it
+ * in prod once that's decided, with no code change needed.
+ */
+export function resolveCheckpointFlag({
+  rawEnvValue,
+  nodeEnv,
+}: {
+  rawEnvValue: string | undefined;
+  nodeEnv: string | undefined;
+}): boolean {
+  if (rawEnvValue === 'true') return true;
+  if (rawEnvValue === 'false') return false;
+  return nodeEnv !== 'production';
+}
+
+/** The real flag read, wired to `process.env`. */
+export function isCheckpointBeforeAgentBatchEnabled(): boolean {
+  return resolveCheckpointFlag({
+    rawEnvValue: process.env.SANDBOX_CHECKPOINT_BEFORE_AGENT_BATCH,
+    nodeEnv: process.env.NODE_ENV,
+  });
+}
+
+export interface ShouldCheckpointInput {
+  /** The feature flag, re-checked fresh per batch. */
+  flagEnabled: boolean;
+  /** When this sandbox was last checkpointed by this policy, or null if never. */
+  lastCheckpointAt: Date | null;
+  /** Stable id for the CURRENT agent turn (one streamText run). */
+  turnId: string;
+  /** The turnId the last checkpoint was taken for, or null if never checkpointed. */
+  lastCheckpointTurnId: string | null;
+  now: Date;
+}
+
+/**
+ * Pure: should a pre-batch checkpoint be taken right now?
+ *
+ * - Flag off → never.
+ * - Same turnId as the last checkpoint → never (at most once per agent turn;
+ *   repeated tool batches within one turn must not pile up checkpoints).
+ * - Otherwise → yes, UNLESS the last checkpoint (for a different, presumably
+ *   fast-preceding turn) is still inside `CHECKPOINT_MIN_INTERVAL_MS` — the
+ *   throttle safety net documented above.
+ */
+export function shouldCheckpoint({
+  flagEnabled,
+  lastCheckpointAt,
+  turnId,
+  lastCheckpointTurnId,
+  now,
+}: ShouldCheckpointInput): boolean {
+  if (!flagEnabled) return false;
+  if (lastCheckpointTurnId === turnId) return false;
+  if (lastCheckpointAt !== null && now.getTime() - lastCheckpointAt.getTime() < CHECKPOINT_MIN_INTERVAL_MS) {
+    return false;
+  }
+  return true;
+}
+
+export interface CheckpointState {
+  lastCheckpointAt: Date | null;
+  lastCheckpointTurnId: string | null;
+}
+
+const EMPTY_STATE: CheckpointState = { lastCheckpointAt: null, lastCheckpointTurnId: null };
+
+/**
+ * In-process, per-sandbox checkpoint bookkeeping — mirrors `quota.ts`'s
+ * `machineActivityByKey`: a plain Map, no persistence, no reaper. This is
+ * intentionally NOT the platform's own checkpoint list (which the leaf
+ * explicitly declines to reap — see the leaf spec's "rely on platform
+ * auto-pruning" requirement); it only tracks enough to enforce the
+ * at-most-once-per-turn throttle above. Scoped to the process lifetime: a
+ * restart simply re-checkpoints on the next batch, which is harmless (COW,
+ * ~300ms) and strictly safer than under-checkpointing.
+ */
+const stateBySandboxId = new Map<string, CheckpointState>();
+
+/** Read the last-checkpoint bookkeeping for `sandboxId`, or the empty state if never recorded. */
+export function getCheckpointState(sandboxId: string): CheckpointState {
+  return stateBySandboxId.get(sandboxId) ?? EMPTY_STATE;
+}
+
+/** Record that `sandboxId` was just checkpointed for `lastCheckpointTurnId` at `lastCheckpointAt`. */
+export function recordCheckpoint(sandboxId: string, state: CheckpointState): void {
+  stateBySandboxId.set(sandboxId, state);
+}
+
+/** Clear all recorded checkpoint state. Test-only seam. */
+export function resetCheckpointState(): void {
+  stateBySandboxId.clear();
+}

--- a/packages/lib/src/services/sandbox/checkpoint-policy.ts
+++ b/packages/lib/src/services/sandbox/checkpoint-policy.ts
@@ -9,10 +9,13 @@
  * that from a bricked machine into a restore (restore itself is a separate,
  * manual/admin action; this leaf only creates the safety net, never uses it).
  *
- * Pure core (this file): the throttle decision and the checkpoint's tagged
- * comment. IO — the actual SDK call, and where the per-sandbox bookkeeping is
- * read/written — lives in the shell (`tool-runners.ts`'s `SandboxCheckpointDeps`
- * seam, wired to the in-process state below by default).
+ * Pure core (this file): the throttle decision (`shouldCheckpoint`) and the
+ * checkpoint's tagged comment (`checkpointComment`). The rest of this file is
+ * in-process, stateful bookkeeping (the per-sandbox state map + the
+ * concurrent-attempt coalescing below it) — still no IO of its own, but not
+ * pure either. The actual SDK call lives in the shell
+ * (`tool-runners.ts`'s `SandboxCheckpointDeps` seam, wired to the state below
+ * by default).
  */
 
 /** Recognizable prefix for a pre-batch checkpoint's comment, so a human browsing
@@ -97,16 +100,44 @@ export interface CheckpointState {
 const EMPTY_STATE: CheckpointState = { lastCheckpointAt: null, lastCheckpointTurnId: null };
 
 /**
- * In-process, per-sandbox checkpoint bookkeeping — mirrors `quota.ts`'s
- * `machineActivityByKey`: a plain Map, no persistence, no reaper. This is
- * intentionally NOT the platform's own checkpoint list (which the leaf
- * explicitly declines to reap — see the leaf spec's "rely on platform
- * auto-pruning" requirement); it only tracks enough to enforce the
+ * In-process, per-sandbox checkpoint bookkeeping — a plain Map, no
+ * persistence. This is intentionally NOT the platform's own checkpoint list
+ * (which the leaf explicitly declines to reap — see the leaf spec's "rely on
+ * platform auto-pruning" requirement); it only tracks enough to enforce the
  * at-most-once-per-turn throttle above. Scoped to the process lifetime: a
  * restart simply re-checkpoints on the next batch, which is harmless (COW,
  * ~300ms) and strictly safer than under-checkpointing.
  */
 const stateBySandboxId = new Map<string, CheckpointState>();
+
+/**
+ * How long a sandbox's checkpoint bookkeeping may sit unused before an
+ * opportunistic sweep reclaims it — mirrors `quota.ts`'s
+ * `evictStaleMachineActivity`/`MACHINE_ACTIVITY_GRACE_MS` pattern (this map
+ * has no symmetric acquire/release either, so eviction has to be
+ * opportunistic). Sandboxes are long-lived and reused across many turns, so
+ * this is deliberately generous — the only failure mode of evicting too
+ * early is one harmless redundant checkpoint on the next batch (same
+ * "re-checkpointing after a restart is safe" property documented above),
+ * never a missed one.
+ */
+const CHECKPOINT_STATE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Opportunistic sweep: drop any entry whose last checkpoint is older than
+ * `CHECKPOINT_STATE_TTL_MS`, so the map is bounded by recently-active
+ * sandboxes rather than every sandbox ever checkpointed in this process's
+ * lifetime. Run from `recordCheckpoint`, using ITS `now` as the reference
+ * instant — every real checkpoint is a natural opportunity to reclaim other
+ * long-idle entries.
+ */
+function evictStaleCheckpointState(now: Date): void {
+  for (const [sandboxId, state] of stateBySandboxId) {
+    if (state.lastCheckpointAt !== null && now.getTime() - state.lastCheckpointAt.getTime() > CHECKPOINT_STATE_TTL_MS) {
+      stateBySandboxId.delete(sandboxId);
+    }
+  }
+}
 
 /** Read the last-checkpoint bookkeeping for `sandboxId`, or the empty state if never recorded. */
 export function getCheckpointState(sandboxId: string): CheckpointState {
@@ -115,10 +146,43 @@ export function getCheckpointState(sandboxId: string): CheckpointState {
 
 /** Record that `sandboxId` was just checkpointed for `lastCheckpointTurnId` at `lastCheckpointAt`. */
 export function recordCheckpoint(sandboxId: string, state: CheckpointState): void {
+  if (state.lastCheckpointAt !== null) evictStaleCheckpointState(state.lastCheckpointAt);
   stateBySandboxId.set(sandboxId, state);
 }
 
-/** Clear all recorded checkpoint state. Test-only seam. */
+const inFlightBySandboxId = new Map<string, Promise<void>>();
+
+/**
+ * Coalesce concurrent checkpoint attempts for the SAME sandbox onto a single
+ * in-flight promise.
+ *
+ * The AI SDK can execute multiple tool calls from one agent step
+ * concurrently, so two bash calls in the same turn can both pass
+ * `shouldCheckpoint`'s synchronous check before either finishes its
+ * checkpoint — without this, both would independently call the checkpoint
+ * SDK, producing two checkpoints for one turn (a real regression found in
+ * review on PR #2025). `attempt`'s registration in `inFlightBySandboxId`
+ * happens SYNCHRONOUSLY relative to the caller (no `await` before the
+ * `.set()` below), so whichever concurrent caller's synchronous call stack
+ * reaches this function first always wins the registration, and every other
+ * concurrent caller for the same sandbox reuses that SAME promise instead of
+ * starting a redundant attempt — closing the check-then-act race regardless
+ * of exact timing between callers. The entry is removed once `attempt`
+ * settles (success OR failure), so the next, non-overlapping attempt starts
+ * fresh rather than being permanently coalesced onto a long-dead promise.
+ */
+export function coalesceCheckpointAttempt(sandboxId: string, attempt: () => Promise<void>): Promise<void> {
+  const existing = inFlightBySandboxId.get(sandboxId);
+  if (existing) return existing;
+  const promise = attempt().finally(() => {
+    if (inFlightBySandboxId.get(sandboxId) === promise) inFlightBySandboxId.delete(sandboxId);
+  });
+  inFlightBySandboxId.set(sandboxId, promise);
+  return promise;
+}
+
+/** Clear all recorded checkpoint state (including in-flight coalescing). Test-only seam. */
 export function resetCheckpointState(): void {
   stateBySandboxId.clear();
+  inFlightBySandboxId.clear();
 }

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -108,12 +108,15 @@ export interface MachineHandle {
   listStreams(): Promise<MachineStreamSessionInfo[]>;
   /**
    * Create a filesystem checkpoint tagged with `comment` (Sprites Platform
-   * Alignment 5-2). Optional — not every future backend need support it; the
-   * Sprite backend always does (see `sprite-machine-host.ts`). Callers that
-   * need it unconditionally go through `ExecutableSandbox.createCheckpoint`
-   * (`sandbox-client/types.ts`), which is always present.
+   * Alignment 5-2) — see `sprite-machine-host.ts` for the (today, only)
+   * implementation. Required: `MachineHost` has exactly one backend
+   * (Sprite) as of this writing, so an optional-with-runtime-fallback here
+   * would be a guard against a hypothetical future backend that does not
+   * exist yet — code review on PR #2025 flagged that as premature
+   * abstraction. Add it back as optional only when a second backend that
+   * genuinely cannot support checkpoints is introduced.
    */
-  createCheckpoint?(comment: string): Promise<void>;
+  createCheckpoint(comment: string): Promise<void>;
 }
 
 /**

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -106,6 +106,14 @@ export interface MachineHandle {
   readFile(args: { path: string }): Promise<Buffer | null>;
   stream(args: MachineStreamOptions): Promise<MachineStream>;
   listStreams(): Promise<MachineStreamSessionInfo[]>;
+  /**
+   * Create a filesystem checkpoint tagged with `comment` (Sprites Platform
+   * Alignment 5-2). Optional — not every future backend need support it; the
+   * Sprite backend always does (see `sprite-machine-host.ts`). Callers that
+   * need it unconditionally go through `ExecutableSandbox.createCheckpoint`
+   * (`sandbox-client/types.ts`), which is always present.
+   */
+  createCheckpoint?(comment: string): Promise<void>;
 }
 
 /**

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/machine-host-adapter.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/machine-host-adapter.test.ts
@@ -12,6 +12,7 @@ function fakeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
     exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
     writeFiles: async () => {},
     readFile: async () => null,
+    createCheckpoint: async () => {},
     stream: async () => {
       throw new Error('not used by this adapter');
     },
@@ -108,5 +109,22 @@ describe('createExecClientFromMachineHost', () => {
     expect(seen.writeFiles).toEqual([[{ path: '/a', content: 'x' }]]);
     expect(seen.readFile).toEqual([{ path: '/a' }]);
     expect(buf?.toString('utf8')).toBe('contents');
+  });
+
+  it('given the adapted handle, should delegate createCheckpoint to the underlying handle', async () => {
+    const seen: Array<string> = [];
+    const { host } = makeHost({
+      provision: async () =>
+        fakeHandle({
+          createCheckpoint: async (comment) => {
+            seen.push(comment);
+          },
+        }),
+    });
+    const client = createExecClientFromMachineHost(host, substrate);
+    const handle = await client.getOrCreate({ name: 'k', options });
+
+    await handle.createCheckpoint('pagespace-pre-agent-turn-1');
+    expect(seen).toEqual(['pagespace-pre-agent-turn-1']);
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -77,7 +77,7 @@ function fakeSprite(over: Partial<SpriteInstanceLike> = {}): SpriteInstanceLike 
     listSessions: async () => [],
     filesystem: () => ({ readFile: async () => Buffer.from(''), writeFile: async () => {}, mkdir: async () => {} }),
     updateNetworkPolicy: async () => {},
-    createCheckpoint: async () => ({ processAll: async () => {} }),
+    createCheckpoint: async () => ({ processAll: async () => {}, close: () => {} }),
     destroy: async () => {},
     ...over,
   };

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -77,6 +77,7 @@ function fakeSprite(over: Partial<SpriteInstanceLike> = {}): SpriteInstanceLike 
     listSessions: async () => [],
     filesystem: () => ({ readFile: async () => Buffer.from(''), writeFile: async () => {}, mkdir: async () => {} }),
     updateNetworkPolicy: async () => {},
+    createCheckpoint: async () => ({ processAll: async () => {} }),
     destroy: async () => {},
     ...over,
   };

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import {
   createSpritesSandboxClient,
@@ -101,16 +101,26 @@ function fakeFs(over: Partial<SpriteFsLike> = {}): SpriteFsLike {
   };
 }
 
-/** A fake checkpoint stream: replays `messages` through `processAll`, in order. */
+/**
+ * A fake checkpoint stream: replays `messages` through `processAll`, in
+ * order. `processAll` never resolves when `hang: true` (simulates a stalled
+ * SDK stream); `close` is a spy so a test can assert it was called on
+ * timeout.
+ */
 function fakeCheckpointStream(
   messages: Array<{ type: string; data?: string; error?: string }> = [{ type: 'info', data: 'done' }],
-): SpriteCheckpointStreamLike {
+  options: { hang?: boolean } = {},
+): SpriteCheckpointStreamLike & { close: ReturnType<typeof vi.fn> } {
   return {
     processAll: async (handler) => {
+      if (options.hang) {
+        await new Promise(() => {}); // never resolves
+      }
       for (const message of messages) {
         await handler(message);
       }
     },
+    close: vi.fn(),
   };
 }
 
@@ -1127,6 +1137,52 @@ describe('ExecutableSandbox.createCheckpoint', () => {
     const client = createSpritesSandboxClient({ sdk });
     const handle = await client.get({ sandboxId: 'k' });
     await expect(handle!.createCheckpoint('c')).rejects.toThrow('sprite unreachable');
+  });
+
+  // Regression test for a P2 finding on PR #2025 (chatgpt-codex-connector): the
+  // SDK exposes no timeout for createCheckpoint or the stream it returns, so a
+  // stalled connection would otherwise hang this call — and therefore the
+  // caller's whole fail-open checkpoint attempt (tool-runners.ts) — forever.
+  it('given a stream that never settles, rejects after CHECKPOINT_TIMEOUT_MS and closes the stream', async () => {
+    vi.useFakeTimers();
+    try {
+      const hungStream = fakeCheckpointStream(undefined, { hang: true });
+      const { sdk } = makeSdk({
+        getSprite: async () => fakeSprite({ createCheckpoint: async () => hungStream }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const handle = await client.get({ sandboxId: 'k' });
+
+      const result = handle!.createCheckpoint('c');
+      const assertion = expect(result).rejects.toThrow(/timed out/i);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+
+      expect(hungStream.close).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('given the SDK call itself never resolves (before any stream is returned), rejects after the timeout without attempting to close a stream', async () => {
+    vi.useFakeTimers();
+    try {
+      const { sdk } = makeSdk({
+        getSprite: async () =>
+          fakeSprite({
+            createCheckpoint: () => new Promise(() => {}), // never resolves
+          }),
+      });
+      const client = createSpritesSandboxClient({ sdk });
+      const handle = await client.get({ sandboxId: 'k' });
+
+      const result = handle!.createCheckpoint('c');
+      const assertion = expect(result).rejects.toThrow(/timed out/i);
+      await vi.advanceTimersByTimeAsync(10_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -1125,7 +1125,7 @@ describe('ExecutableSandbox.createCheckpoint', () => {
     await expect(handle!.createCheckpoint('c')).rejects.toThrow(/quota exceeded/);
   });
 
-  it('resolves cleanly when the SDK call itself rejects (caller decides fail-open policy)', async () => {
+  it('propagates the SDK\'s rejection (caller decides fail-open policy)', async () => {
     const { sdk } = makeSdk({
       getSprite: async () =>
         fakeSprite({

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -6,12 +6,14 @@ import {
   classifyProvisionError,
   planProvisionFailure,
   readSessionInfoId,
+  checkpointStreamErrorMessage,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
   type SpritesSdk,
   type SpriteInstanceLike,
   type SpriteCommandLike,
   type SpriteFsLike,
+  type SpriteCheckpointStreamLike,
 } from '../sprites';
 import { SandboxProvisionError } from '../../sandbox-options';
 import { SANDBOX_EGRESS_ALLOWLIST } from '../../execution-policy';
@@ -99,6 +101,19 @@ function fakeFs(over: Partial<SpriteFsLike> = {}): SpriteFsLike {
   };
 }
 
+/** A fake checkpoint stream: replays `messages` through `processAll`, in order. */
+function fakeCheckpointStream(
+  messages: Array<{ type: string; data?: string; error?: string }> = [{ type: 'info', data: 'done' }],
+): SpriteCheckpointStreamLike {
+  return {
+    processAll: async (handler) => {
+      for (const message of messages) {
+        await handler(message);
+      }
+    },
+  };
+}
+
 function fakeSprite(
   over: Partial<SpriteInstanceLike> & { fs?: SpriteFsLike } = {},
 ): SpriteInstanceLike {
@@ -115,6 +130,7 @@ function fakeSprite(
     listSessions: async () => [],
     filesystem: () => fs,
     updateNetworkPolicy: async () => {},
+    createCheckpoint: async () => fakeCheckpointStream(),
     destroy: async () => {},
     ...over,
   };
@@ -1036,6 +1052,81 @@ describe('ExecutableSandbox file ops', () => {
     const { sdk: sdkMissing } = makeSdk({ getSprite: async () => fakeSprite({ fs: missing }) });
     const miss = await createSpritesSandboxClient({ sdk: sdkMissing }).get({ sandboxId: 'k' });
     expect(await miss!.readFileToBuffer({ path: '/workspace/missing.txt' })).toBeNull();
+  });
+});
+
+describe('checkpointStreamErrorMessage (pure)', () => {
+  assert({
+    given: 'a non-error stream message',
+    should: 'return undefined',
+    actual: checkpointStreamErrorMessage({ type: 'info', data: 'snapshotting' }),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'an error-type message carrying `error`',
+    should: 'return that error text',
+    actual: checkpointStreamErrorMessage({ type: 'error', error: 'disk full' }),
+    expected: 'disk full',
+  });
+
+  assert({
+    given: 'an error-type message with no `error` field but a `data` field',
+    should: 'fall back to `data`',
+    actual: checkpointStreamErrorMessage({ type: 'error', data: 'boom' }),
+    expected: 'boom',
+  });
+
+  assert({
+    given: 'an error-type message with neither `error` nor `data`',
+    should: 'fall back to a generic message',
+    actual: checkpointStreamErrorMessage({ type: 'error' }),
+    expected: 'checkpoint stream reported an error',
+  });
+});
+
+describe('ExecutableSandbox.createCheckpoint', () => {
+  it('calls the SDK with the given comment and drains the stream to completion', async () => {
+    const seenComments: (string | undefined)[] = [];
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          createCheckpoint: async (comment) => {
+            seenComments.push(comment);
+            return fakeCheckpointStream([{ type: 'info', data: 'snapshotting' }, { type: 'info', data: 'done' }]);
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+    await handle!.createCheckpoint('pagespace-pre-agent-turn-1');
+    expect(seenComments).toEqual(['pagespace-pre-agent-turn-1']);
+  });
+
+  it('rejects when the stream reports an error message', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          createCheckpoint: async () => fakeCheckpointStream([{ type: 'error', error: 'quota exceeded' }]),
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+    await expect(handle!.createCheckpoint('c')).rejects.toThrow(/quota exceeded/);
+  });
+
+  it('resolves cleanly when the SDK call itself rejects (caller decides fail-open policy)', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async () =>
+        fakeSprite({
+          createCheckpoint: async () => {
+            throw new Error('sprite unreachable');
+          },
+        }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const handle = await client.get({ sandboxId: 'k' });
+    await expect(handle!.createCheckpoint('c')).rejects.toThrow('sprite unreachable');
   });
 });
 

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
@@ -185,6 +185,7 @@ function fakeSprite(name: string): SpriteInstanceLike {
     listSessions: async () => [],
     filesystem: () => { throw new Error('not used'); },
     updateNetworkPolicy: async () => {},
+    createCheckpoint: async () => { throw new Error('not used'); },
     destroy: async () => {},
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
@@ -35,14 +35,7 @@ export function adaptMachineHandleToExecutableSandbox(handle: MachineHandle): Ex
     runCommand: (args) => handle.exec(args),
     writeFiles: (files) => handle.writeFiles(files),
     readFileToBuffer: (args) => handle.readFile(args),
-    // `MachineHandle.createCheckpoint` is optional (a future non-Sprite backend
-    // need not support it); `ExecutableSandbox.createCheckpoint` is not, so a
-    // backend that omits it rejects rather than silently no-opping — a caller
-    // relying on the checkpoint (even fail-open) should see why it never ran.
-    createCheckpoint: (comment) =>
-      handle.createCheckpoint
-        ? handle.createCheckpoint(comment)
-        : Promise.reject(new Error('This machine backend does not support checkpoints.')),
+    createCheckpoint: (comment) => handle.createCheckpoint(comment),
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/machine-host-adapter.ts
@@ -35,6 +35,14 @@ export function adaptMachineHandleToExecutableSandbox(handle: MachineHandle): Ex
     runCommand: (args) => handle.exec(args),
     writeFiles: (files) => handle.writeFiles(files),
     readFileToBuffer: (args) => handle.readFile(args),
+    // `MachineHandle.createCheckpoint` is optional (a future non-Sprite backend
+    // need not support it); `ExecutableSandbox.createCheckpoint` is not, so a
+    // backend that omits it rejects rather than silently no-opping — a caller
+    // relying on the checkpoint (even fail-open) should see why it never ran.
+    createCheckpoint: (comment) =>
+      handle.createCheckpoint
+        ? handle.createCheckpoint(comment)
+        : Promise.reject(new Error('This machine backend does not support checkpoints.')),
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -146,6 +146,7 @@ function wrapSpriteHandle({
     exec: (args) => exec.runCommand(args),
     writeFiles: (files) => exec.writeFiles(files),
     readFile: (args) => exec.readFileToBuffer(args),
+    createCheckpoint: (comment) => exec.createCheckpoint(comment),
 
     /**
      * Open a PTY stream, surviving the cold-start wake drop.

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -240,6 +240,23 @@ export function readSessionInfoId(message: unknown): string | undefined {
     : undefined;
 }
 
+/**
+ * The subset of the SDK's checkpoint/restore progress stream the driver
+ * consumes — mirrors the real `CheckpointStream`/`RestoreStream` (both expose
+ * `processAll`). Messages are `{type: 'info'|'stdout'|'stderr'|'error', data?,
+ * error?}`; see {@link checkpointStreamErrorMessage} for how an `error`-type
+ * message is surfaced as a rejection.
+ */
+export interface SpriteCheckpointStreamMessage {
+  type: string;
+  data?: string;
+  error?: string;
+}
+
+export interface SpriteCheckpointStreamLike {
+  processAll(handler: (message: SpriteCheckpointStreamMessage) => void | Promise<void>): Promise<void>;
+}
+
 /** The Sprite instance subset the driver consumes. */
 export interface SpriteInstanceLike {
   readonly name: string;
@@ -284,6 +301,14 @@ export interface SpriteInstanceLike {
   listSessions(): Promise<SpriteSessionInfo[]>;
   filesystem(workingDir?: string): SpriteFsLike;
   updateNetworkPolicy(policy: NetworkPolicy): Promise<void>;
+  /**
+   * Create a checkpoint of the writable filesystem overlay, tagged with an
+   * optional `comment` (docs.sprites.dev/concepts/checkpoints — copy-on-write,
+   * ~300ms, does not interrupt the Sprite). Returns a progress stream; the
+   * driver drains it to completion and surfaces any `error`-type message as a
+   * rejection — see {@link checkpointStreamErrorMessage}.
+   */
+  createCheckpoint(comment?: string): Promise<SpriteCheckpointStreamLike>;
   destroy(): Promise<void>;
 }
 
@@ -669,6 +694,19 @@ async function fsWithWakeRetry<T>(
   }
 }
 
+/**
+ * Pure: extract the failure text from a checkpoint/restore stream `message`, or
+ * undefined if it isn't an `error`-type message. `error` is preferred over
+ * `data` (the SDK types `data` as the general payload field and `error` as the
+ * specific failure text when present); a message that types itself `error` but
+ * carries neither falls back to a generic string so a rejection is never
+ * empty.
+ */
+export function checkpointStreamErrorMessage(message: SpriteCheckpointStreamMessage): string | undefined {
+  if (message.type !== 'error') return undefined;
+  return message.error ?? message.data ?? 'checkpoint stream reported an error';
+}
+
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {
   return {
     sandboxId: sprite.name,
@@ -715,6 +753,26 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
         // A missing file (or any read failure after a wake retry) resolves to
         // null; the runner maps null to a handled not-found rather than throwing.
         return null;
+      }
+    },
+
+    async createCheckpoint(comment: string): Promise<void> {
+      // The SDK call itself may reject (transport failure, sprite unreachable)
+      // BEFORE ever returning a stream — that propagates as-is. Once we have a
+      // stream, drain it fully (checkpoints are ~300ms COW, so this is fast)
+      // and surface the first `error`-type message as a rejection. Fail-open
+      // policy (never block the caller's batch on this) is the SHELL's
+      // decision (tool-runners.ts), not this driver's — this method faithfully
+      // reports success or failure.
+      const stream = await sprite.createCheckpoint(comment);
+      let streamError: string | undefined;
+      await stream.processAll((message) => {
+        if (streamError === undefined) {
+          streamError = checkpointStreamErrorMessage(message);
+        }
+      });
+      if (streamError !== undefined) {
+        throw new Error(`Sandbox checkpoint failed: ${streamError}`);
       }
     },
   };

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -255,6 +255,9 @@ export interface SpriteCheckpointStreamMessage {
 
 export interface SpriteCheckpointStreamLike {
   processAll(handler: (message: SpriteCheckpointStreamMessage) => void | Promise<void>): Promise<void>;
+  /** Close the stream — called on a timeout so a stalled read doesn't hold the
+   *  underlying connection open past the point we've given up waiting on it. */
+  close(): void;
 }
 
 /** The Sprite instance subset the driver consumes. */
@@ -707,6 +710,15 @@ export function checkpointStreamErrorMessage(message: SpriteCheckpointStreamMess
   return message.error ?? message.data ?? 'checkpoint stream reported an error';
 }
 
+/**
+ * Wall-clock cap on `ExecutableSandbox.createCheckpoint` (the `createCheckpoint`
+ * call plus draining its stream). The SDK exposes no timeout or abort handle
+ * for either step, so this driver enforces one itself — see the call site's
+ * doc for why a bound is needed here in addition to the shell's own (P2
+ * review finding, PR #2025).
+ */
+const CHECKPOINT_TIMEOUT_MS = 10_000;
+
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {
   return {
     sandboxId: sprite.name,
@@ -764,16 +776,58 @@ function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): Executabl
       // policy (never block the caller's batch on this) is the SHELL's
       // decision (tool-runners.ts), not this driver's — this method faithfully
       // reports success or failure.
-      const stream = await sprite.createCheckpoint(comment);
-      let streamError: string | undefined;
-      await stream.processAll((message) => {
-        if (streamError === undefined) {
-          streamError = checkpointStreamErrorMessage(message);
+      //
+      // Bounded by CHECKPOINT_TIMEOUT_MS: the SDK exposes no timeout or abort
+      // handle for either `createCheckpoint` or the stream it returns, so a
+      // stalled connection would otherwise hang this call forever — the
+      // shell's own timeout (tool-runners.ts) already stops the CALLER from
+      // blocking on that, but without a bound HERE too the abandoned stream
+      // read lingers in the background indefinitely, holding whatever
+      // connection/socket resource it holds. On timeout we best-effort close
+      // the stream (if we got one) to release that resource instead of
+      // leaving it to read forever nobody is listening to.
+      let stream: SpriteCheckpointStreamLike | undefined;
+      const drain = async (): Promise<void> => {
+        stream = await sprite.createCheckpoint(comment);
+        let streamError: string | undefined;
+        await stream.processAll((message) => {
+          if (streamError === undefined) {
+            streamError = checkpointStreamErrorMessage(message);
+          }
+        });
+        if (streamError !== undefined) {
+          throw new Error(`Sandbox checkpoint failed: ${streamError}`);
         }
+      };
+
+      let settled = false;
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          try {
+            stream?.close();
+          } catch {
+            // Best-effort cleanup only; the timeout error below is what
+            // actually propagates.
+          }
+          reject(new Error(`Sandbox checkpoint timed out after ${CHECKPOINT_TIMEOUT_MS}ms`));
+        }, CHECKPOINT_TIMEOUT_MS);
+        drain().then(
+          () => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve();
+          },
+          (error) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            reject(error);
+          },
+        );
       });
-      if (streamError !== undefined) {
-        throw new Error(`Sandbox checkpoint failed: ${streamError}`);
-      }
     },
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/types.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/types.ts
@@ -52,6 +52,13 @@ export interface ExecutableSandbox extends SandboxHandle {
   runCommand(args: RunCommandArgs): Promise<SandboxRunResult>;
   writeFiles(files: WriteFileEntry[]): Promise<void>;
   readFileToBuffer(args: { path: string }): Promise<Buffer | null>;
+  /**
+   * Create a filesystem checkpoint tagged with `comment` (Sprites Platform
+   * Alignment 5-2: a safety net before destructive agent bash batches — see
+   * `checkpoint-policy.ts`). Resolves once the checkpoint is confirmed, or
+   * rejects on failure; the caller decides fail-open policy.
+   */
+  createCheckpoint(comment: string): Promise<void>;
 }
 
 /** Extends the PR2 lifecycle seam so one client serves both layers. */

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -538,20 +538,17 @@ async function maybeCheckpointBeforeBatch({
 
   try {
     const state = checkpoint.getState(sandbox.sandboxId);
-    const now = deps.now();
     if (
       !shouldCheckpoint({
         flagEnabled: checkpoint.isEnabled(),
-        lastCheckpointAt: state.lastCheckpointAt,
         turnId,
         lastCheckpointTurnId: state.lastCheckpointTurnId,
-        now,
       })
     ) {
       return;
     }
     await checkpoint.createCheckpoint({ sandbox, comment: checkpointComment(turnId) });
-    checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: now, lastCheckpointTurnId: turnId });
+    checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: deps.now(), lastCheckpointTurnId: turnId });
   } catch (error) {
     safeLogWarn(deps.logger, 'Pre-agent checkpoint failed (proceeding without one)', {
       sandboxId: sandbox.sandboxId,

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -31,6 +31,7 @@ import { truncateToBytes } from './output-limit';
 import { resolveSandboxPath, SANDBOX_ROOT } from './sandbox-paths';
 import { applyEdit } from './edit-file';
 import { buildSandboxEnv } from './sandbox-env';
+import { shouldCheckpoint, checkpointComment, type CheckpointState } from './checkpoint-policy';
 import { getValidatedEnv } from '../../config/env-validation';
 import {
   resolveMachinePageId,
@@ -60,6 +61,15 @@ export interface SandboxActorContext {
   tier: SubscriptionTier;
   /** The ACTIVE machine this call routes to (Terminal epics); undefined defaults to 'own'. */
   activeMachine?: MachineRefLike;
+  /**
+   * Stable id for the CURRENT agent turn (one streamText run) — the same value
+   * for every tool call within that run, a fresh value for the next one.
+   * Threads into the pre-batch checkpoint's throttle (`deps.checkpoint`, Sprites
+   * Platform Alignment 5-2): at most one checkpoint per turnId. Undefined → no
+   * reliable turn boundary to key the throttle on, so checkpointing is skipped
+   * for that call rather than guessed at.
+   */
+  turnId?: string;
 }
 
 export interface SandboxQuotaDeps {
@@ -114,6 +124,32 @@ export interface TerminalActivityNotification {
   agentLabel: string;
 }
 
+/**
+ * Pre-batch checkpoint seam (Sprites Platform Alignment 5-2): before an agent
+ * bash batch runs, optionally snapshot the sandbox's writable filesystem so a
+ * destructive command (the canonical worry: an agent `rm -rf`ing /workspace —
+ * see `sprites.ts`'s `spawnWithSelfHealingCwd` doc) is a restore, not a
+ * bricked machine. Restore itself stays a manual/admin action — this seam only
+ * ever CREATES checkpoints, never restores one.
+ *
+ * `getState`/`recordCheckpoint` are the bookkeeping the pure `shouldCheckpoint`
+ * policy (`checkpoint-policy.ts`) needs to enforce "at most once per turn" +
+ * the rapid-batch throttle; production wires them to an in-process Map keyed
+ * by sandboxId (mirrors `quota.ts`'s `machineActivityByKey` — no persistence,
+ * no reaper). `createCheckpoint` is the actual SDK call against a live,
+ * already-awake sandbox handle.
+ */
+export interface SandboxCheckpointDeps {
+  /** The feature flag, re-checked fresh per batch. */
+  isEnabled: () => boolean;
+  /** Read the last-checkpoint bookkeeping for `sandboxId` (empty state if never recorded). */
+  getState: (sandboxId: string) => CheckpointState;
+  /** Persist that `sandboxId` was just checkpointed, per the pure policy's decision. */
+  recordCheckpoint: (sandboxId: string, state: CheckpointState) => void;
+  /** Create the checkpoint itself against a live sandbox handle, tagged with `comment`. */
+  createCheckpoint: (input: { sandbox: ExecutableSandbox; comment: string }) => Promise<void>;
+}
+
 export interface SandboxRunDeps {
   isEnabled: () => boolean;
   /** Pre-bound `acquireMachineSandbox` (lifecycle deps already injected). */
@@ -152,6 +188,12 @@ export interface SandboxRunDeps {
    * must never affect the tool result; omitting it disables measurement.
    */
   measureStorage?: (input: { sandbox: ExecutableSandbox; pageId: string }) => Promise<void>;
+  /**
+   * Optional pre-batch checkpoint seam (Sprites Platform Alignment 5-2). Omitted
+   * → no checkpointing (the seam is fully optional, matching every other
+   * optional seam in this file). See `SandboxCheckpointDeps`.
+   */
+  checkpoint?: SandboxCheckpointDeps;
   now: () => Date;
   logger?: {
     warn?: (message: string, metadata?: Record<string, unknown>) => void;
@@ -468,6 +510,57 @@ async function openSession(
   }
 }
 
+/**
+ * Best-effort, fail-open pre-batch checkpoint: if `deps.checkpoint` is wired,
+ * the flag is on, and the pure `shouldCheckpoint` policy says this turn hasn't
+ * been checkpointed yet, snapshot the sandbox's filesystem BEFORE the bash
+ * batch executes (never after — the whole point is a state to restore TO).
+ *
+ * A missing `ctx.turnId` skips checkpointing outright rather than guessing at
+ * a turn boundary. Any failure (state read, the checkpoint SDK call itself) is
+ * logged and swallowed — this must never block or fail the caller's batch on
+ * checkpoint availability. On success the bookkeeping is recorded so a later
+ * batch in the SAME turn does not re-checkpoint; on failure nothing is
+ * recorded, so a later batch in the same turn gets another attempt.
+ */
+async function maybeCheckpointBeforeBatch({
+  ctx,
+  deps,
+  sandbox,
+}: {
+  ctx: SandboxActorContext;
+  deps: SandboxRunDeps;
+  sandbox: ExecutableSandbox;
+}): Promise<void> {
+  const checkpoint = deps.checkpoint;
+  if (!checkpoint || !ctx.turnId) return;
+  const turnId = ctx.turnId;
+
+  try {
+    const state = checkpoint.getState(sandbox.sandboxId);
+    const now = deps.now();
+    if (
+      !shouldCheckpoint({
+        flagEnabled: checkpoint.isEnabled(),
+        lastCheckpointAt: state.lastCheckpointAt,
+        turnId,
+        lastCheckpointTurnId: state.lastCheckpointTurnId,
+        now,
+      })
+    ) {
+      return;
+    }
+    await checkpoint.createCheckpoint({ sandbox, comment: checkpointComment(turnId) });
+    checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: now, lastCheckpointTurnId: turnId });
+  } catch (error) {
+    safeLogWarn(deps.logger, 'Pre-agent checkpoint failed (proceeding without one)', {
+      sandboxId: sandbox.sandboxId,
+      turnId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 export async function runBashInSandbox({
   command,
   cwd,
@@ -521,6 +614,8 @@ export async function runBashInSandbox({
   }>(ctx, deps, async () => {
   const session = await openSession(ctx, deps);
   if (!session.ok) return fail(session.reason);
+
+  await maybeCheckpointBeforeBatch({ ctx, deps, sandbox: session.sandbox });
 
   try {
     const startedAt = deps.now();

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -31,7 +31,12 @@ import { truncateToBytes } from './output-limit';
 import { resolveSandboxPath, SANDBOX_ROOT } from './sandbox-paths';
 import { applyEdit } from './edit-file';
 import { buildSandboxEnv } from './sandbox-env';
-import { shouldCheckpoint, checkpointComment, type CheckpointState } from './checkpoint-policy';
+import {
+  shouldCheckpoint,
+  checkpointComment,
+  coalesceCheckpointAttempt,
+  type CheckpointState,
+} from './checkpoint-policy';
 import { getValidatedEnv } from '../../config/env-validation';
 import {
   resolveMachinePageId,
@@ -511,17 +516,51 @@ async function openSession(
 }
 
 /**
+ * Wall-clock cap on the checkpoint SDK call, so a stalled checkpoint can never
+ * violate `maybeCheckpointBeforeBatch`'s fail-open guarantee below (P2 review
+ * finding, PR #2025: without this, an `await` on a hung checkpoint stream
+ * never reaches the `catch`, so the bash command never starts and the
+ * quota/billing slot stays held until the outer request times out — the
+ * opposite of "never block agent work on checkpoint availability"). Generous
+ * relative to the platform's documented ~300ms COW checkpoint time, but far
+ * short of a bash command's own timeout (`SANDBOX_TIMEOUT_MS`, 120s) so a
+ * hang can't eat meaningfully into the user's command budget. This bounds the
+ * PROMISE from the caller's perspective regardless of what `deps.checkpoint`
+ * happens to be wired to; the production Sprites driver (`sprites.ts`)
+ * additionally bounds and cleans up the underlying stream itself.
+ */
+export const CHECKPOINT_TIMEOUT_MS = 10_000;
+
+function withCheckpointTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Checkpoint timed out after ${ms}ms`)), ms);
+    p.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+/**
  * Best-effort, fail-open pre-batch checkpoint: if `deps.checkpoint` is wired,
  * the flag is on, and the pure `shouldCheckpoint` policy says this turn hasn't
  * been checkpointed yet, snapshot the sandbox's filesystem BEFORE the bash
  * batch executes (never after — the whole point is a state to restore TO).
  *
  * A missing `ctx.turnId` skips checkpointing outright rather than guessing at
- * a turn boundary. Any failure (state read, the checkpoint SDK call itself) is
- * logged and swallowed — this must never block or fail the caller's batch on
- * checkpoint availability. On success the bookkeeping is recorded so a later
- * batch in the SAME turn does not re-checkpoint; on failure nothing is
+ * a turn boundary. Any failure (state read, a timeout, the checkpoint SDK
+ * call itself) is logged and swallowed — this must never block or fail the
+ * caller's batch on checkpoint availability (bounded by
+ * `CHECKPOINT_TIMEOUT_MS` above). On success the bookkeeping is recorded so a
+ * later batch in the SAME turn does not re-checkpoint; on failure nothing is
  * recorded, so a later batch in the same turn gets another attempt.
+ *
+ * The actual attempt is wrapped in `coalesceCheckpointAttempt` so concurrent
+ * tool calls in one turn (the AI SDK can execute several bash calls from one
+ * agent step in parallel) share a single checkpoint instead of each
+ * independently passing the synchronous `shouldCheckpoint` check and racing
+ * to create their own — see that function's doc for why this closes the race
+ * regardless of exact timing between callers.
  */
 async function maybeCheckpointBeforeBatch({
   ctx,
@@ -547,8 +586,13 @@ async function maybeCheckpointBeforeBatch({
     ) {
       return;
     }
-    await checkpoint.createCheckpoint({ sandbox, comment: checkpointComment(turnId) });
-    checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: deps.now(), lastCheckpointTurnId: turnId });
+    await coalesceCheckpointAttempt(sandbox.sandboxId, async () => {
+      await withCheckpointTimeout(
+        checkpoint.createCheckpoint({ sandbox, comment: checkpointComment(turnId) }),
+        CHECKPOINT_TIMEOUT_MS,
+      );
+      checkpoint.recordCheckpoint(sandbox.sandboxId, { lastCheckpointAt: deps.now(), lastCheckpointTurnId: turnId });
+    });
   } catch (error) {
     safeLogWarn(deps.logger, 'Pre-agent checkpoint failed (proceeding without one)', {
       sandboxId: sandbox.sandboxId,


### PR DESCRIPTION
## Summary

Checkpoints are ~300ms copy-on-write filesystem snapshots designed exactly for "unattended agent experiments" and destructive changes (docs.sprites.dev/concepts/checkpoints) — and we used them nowhere, while `sprites.ts`'s own `spawnWithSelfHealingCwd` doc worries an agent that `rm -rf`s `/workspace` would otherwise brick the sandbox. This checkpoints before each agent bash batch, fail-open, at most once per agent turn.

Restore is explicitly **out of scope** (future epic, manual/admin action only) — this leaf only ever creates checkpoints.

## Requirements → how satisfied

- **Given an agent bash tool batch about to execute (flag on), should create a checkpoint tagged with a recognizable comment, at most once per agent turn.**
  `checkpoint-policy.ts`'s pure `shouldCheckpoint({flagEnabled, turnId, lastCheckpointTurnId})` — same `turnId` as the last checkpoint → skip; a different `turnId` → always checkpoint. `tool-runners.ts`'s `maybeCheckpointBeforeBatch` calls it before `runCommand` in `runBashInSandbox`, tagging with `checkpointComment(turnId)` → `pagespace-pre-agent-<turnId>`. `turnId` is lazily stamped once per streamText run onto `ToolExecutionContext` (same mutate-in-place pattern as the existing `activeMachine` field) and threaded into `SandboxActorContext.turnId`. Concurrent tool calls in the same turn (the AI SDK can dispatch several via `Promise.all`) are coalesced onto one checkpoint attempt via `coalesceCheckpointAttempt` — see "Review fixes" below.

- **Given checkpoint API failure, should proceed with the batch (fail-open) and log — never block agent work on checkpoint availability.**
  `maybeCheckpointBeforeBatch` wraps the whole decision+call in try/catch; any failure (including a bounded timeout — see below) calls `safeLogWarn` and returns normally. A failed checkpoint is **not** recorded, so a later batch in the same turn gets another attempt.

- **Given repeated tool batches within one turn, should not create additional checkpoints (pure throttle).**
  `shouldCheckpoint`'s `turnId === lastCheckpointTurnId` comparison — a pure per-turn dedup, made race-safe under concurrent dispatch by `coalesceCheckpointAttempt`.

- **Given the checkpoint list growing, should rely on platform auto-pruning; do not build a custom reaper.**
  No reaper of the *platform's* checkpoint list is built — see Findings below. (The in-process throttle *bookkeeping* map does get an opportunistic eviction sweep — a different, purely local concern, see Review fixes.)

## Review fixes

Two rounds of review — the automated Codex reviewer plus an internal 8-angle multi-agent code-review pass — surfaced real issues, all fixed:

1. **P2 (chatgpt-codex-connector): cross-turn interval throttle could suppress a new turn's checkpoint.** [discussion](https://github.com/2witstudios/PageSpace/pull/2025#discussion_r3567078024) — The original `shouldCheckpoint` also gated on 30s elapsed since the *last* checkpoint, regardless of turn, so two legitimate turns close together would leave only the OLDER turn's restore point on record. **Fixed** (`2a1a3eba3`): removed the interval gate — a different `turnId` is by definition never-before-checkpointed, so it always checkpoints now.

2. **P2 (chatgpt-codex-connector): a stalled checkpoint stream could hang the batch forever.** [discussion](https://github.com/2witstudios/PageSpace/pull/2025#discussion_r3567167379) — The SDK exposes no timeout for `createCheckpoint`/its stream, so an `await` on a hung connection never reached the `catch`, holding the concurrency/billing slot until the outer request timed out — the opposite of "fail-open." **Fixed** (`e56ab7b95`): bounded with `CHECKPOINT_TIMEOUT_MS` (10s) at both the shell layer (`tool-runners.ts`, bounds the promise regardless of the injected implementation) and the driver layer (`sprites.ts`, also best-effort `stream.close()`s on timeout to release the connection).

3. **(internal review, 2 independent finder agents) Concurrent-turn race in "at most once per turn."** The AI SDK can execute multiple tool calls from one agent step concurrently; two bash calls in the same turn could both pass `shouldCheckpoint`'s synchronous check before either recorded, producing two checkpoints for one turn. **Fixed** (`e56ab7b95`): `coalesceCheckpointAttempt` registers an in-flight promise synchronously so concurrent callers for the same sandbox share one attempt regardless of exact timing.

4. **(internal review, 2 independent finder agents) `MachineHandle.createCheckpoint` was optional purely for a hypothetical future non-Sprite backend that doesn't exist.** Premature abstraction per project convention. **Fixed** (`e56ab7b95`): made it required (matching `ExecutableSandbox.createCheckpoint`); removed the runtime `Promise.reject` fallback in `machine-host-adapter.ts`.

5. **(internal review) Dead `CheckpointState` field / duplicated branches.** A repo-wide grep confirmed nothing read `lastCheckpointAt` for the throttle decision anymore after fix #1 — re-justified by repurposing it for an opportunistic eviction sweep (below) rather than deleting it outright. Also de-duplicated the two near-identical return branches of `createResolveSandboxActorContext` in `sandbox-tools-runtime.ts` (9 of 10 fields were byte-identical) into one parallel fetch + shared base object, preserving the original `findDrive`/`findUser`/`getActorInfo` concurrency.

6. **(internal review) In-process checkpoint state map had no bound.** `stateBySandboxId` had no symmetric acquire/release and would grow by one entry per distinct sandbox ever seen for the life of the process. **Fixed**: added an opportunistic 24h-TTL eviction sweep, mirroring `quota.ts`'s `machineActivityByKey` pattern.

## Findings (named-checkpoint accumulation vs. auto-pruning)

I could not exercise a live Sprite in this environment, so I read the SDK (`@fly/sprites` `sprite.d.ts`/`checkpoint.d.ts`) and the docs instead of hitting the API directly. What I found:

- The docs describe **automatic background checkpoints** tagged with `auto-` ids as "pruned over time" and explicitly call them "a safety net rather than a retention strategy."
- Our checkpoints are created via the SDK's `sprite.createCheckpoint(comment)` — the same explicit, user-facing creation path as `sprite checkpoint create --comment "..."` from the CLI, **not** the platform's own automatic background mechanism. The docs don't say whether *explicitly-created* checkpoints are also subject to automatic pruning, or whether they accumulate until a human/admin prunes them.
- Given that ambiguity, this leaf does **not** assume auto-pruning applies to our checkpoints — it just doesn't build a reaper of the platform's list (as instructed) and flags this for a reviewer/operator to confirm against the live API (e.g. `GET /v1/sprites/{name}/checkpoints` after some days of agent activity) before this ships broadly. If explicit checkpoints do NOT get pruned, a lightweight follow-up (e.g. keep only the last N `pagespace-pre-agent-*` checkpoints) would be worth scoping as a separate leaf.

## Other implementation notes

- **Feature flag**: `isCheckpointBeforeAgentBatchEnabled()` — explicit `SANDBOX_CHECKPOINT_BEFORE_AGENT_BATCH=true|false` always wins; unset defaults **ON outside production**, **OFF in production**. The leaf spec explicitly deferred the production default to PR discussion — please weigh in.
- **SDK plumbing**: `SpriteInstanceLike.createCheckpoint(comment?)` mirrors the real SDK's `Sprite.createCheckpoint` (returns a `CheckpointStream`); `wrap()` drains it via `processAll`, bounded by `CHECKPOINT_TIMEOUT_MS`, surfacing the first `error`-type message as a rejection (pure `checkpointStreamErrorMessage` helper, unit tested).
- **State**: in-process `Map<sandboxId, {lastCheckpointAt, lastCheckpointTurnId}>` + a coalescing `Map<sandboxId, Promise<void>>` for in-flight attempts (both mirror `quota.ts`'s in-process-Map conventions). A process restart just re-checkpoints on the next batch, which is harmless (COW, ~300ms).
- **package.json**: added the `./services/sandbox/checkpoint-policy` subpath export (needed it after hitting the "new subpath modules need an exports entry" gotcha from a prior leaf).

## Test evidence

```
packages/lib: 1140/1140 sandbox+machines-dir tests passed
  (bunx vitest run src/services/sandbox src/services/machines)
apps/web:     1077/1078 passed (1 unrelated pre-existing failure —
  activity-tools.test.ts, local DB-role infra issue, predates this branch)
Full monorepo typecheck (lib, db, web, realtime): clean
@pagespace/lib lint: clean (0 warnings/errors)
```

## Checklist for the orchestrator

- [ ] Decide the production default for `SANDBOX_CHECKPOINT_BEFORE_AGENT_BATCH` (currently OFF-by-default in prod pending this discussion).
- [ ] Verify against the live Sprites API whether explicitly-created (non-`auto-`) checkpoints are pruned automatically, or need a follow-up reaper leaf.
- [ ] Confirm scoping bash-only (not writeFile/editFile) is correct — I limited the checkpoint hook to `runBashInSandbox` since that's the explicitly named "batch about to execute" surface and the highest-risk one (arbitrary shell); file-write tools already go through path-escape checks and single-file diffs. (An internal review pass also flagged this exact question independently — noted here for visibility, not acted on without a scope decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LbMMKiXdkHrcxdtLsZH4Y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic filesystem checkpoints before agent bash batches.
  * Checkpoints are limited to once per agent turn and tagged for easier identification.
  * Added checkpoint support across sandbox integrations.

* **Reliability**
  * Checkpoint operations now have a time limit and handle failures without blocking command execution.
  * Concurrent checkpoint requests are consolidated to prevent duplicate checkpoints.

* **Configuration**
  * Checkpointing can be enabled or disabled through the sandbox configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->