### PR TITLE
feat(machines): rename Code tab to Files, reframe as file viewer

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.test.tsx
@@ -23,7 +23,7 @@ function tabDouble(name: string) {
 }
 
 vi.mock('./tabs/TerminalTab', () => ({ default: tabDouble('terminal') }));
-vi.mock('./tabs/CodeTab', () => ({ default: tabDouble('code') }));
+vi.mock('./tabs/FilesTab', () => ({ default: tabDouble('files') }));
 vi.mock('./tabs/DiffTab', () => ({ default: tabDouble('diff') }));
 vi.mock('./tabs/SettingsTab', () => ({ default: tabDouble('settings') }));
 
@@ -67,7 +67,7 @@ describe('MachineView (Machine 4-tab shell)', () => {
 
     assert({
       given: 'a freshly-rendered Machine page',
-      should: 'mount only the default Terminal tab, leaving Code/Diff/Settings unmounted',
+      should: 'mount only the default Terminal tab, leaving Files/Diff/Settings unmounted',
       actual: lifecycle,
       expected: ['mount:terminal'],
     });
@@ -89,13 +89,13 @@ describe('MachineView (Machine 4-tab shell)', () => {
     asAdmin();
     render(<MachineView pageId="machine-1" />);
 
-    await userEvent.click(screen.getByRole('tab', { name: /code/i }));
+    await userEvent.click(screen.getByRole('tab', { name: /files/i }));
 
     assert({
-      given: 'the user switches from Terminal to Code',
-      should: 'mount the Code body and unmount the Terminal body (lazy, one at a time)',
+      given: 'the user switches from Terminal to Files',
+      should: 'mount the Files body and unmount the Terminal body (lazy, one at a time)',
       actual: lifecycle,
-      expected: ['mount:terminal', 'unmount:terminal', 'mount:code'],
+      expected: ['mount:terminal', 'unmount:terminal', 'mount:files'],
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
@@ -3,7 +3,7 @@
 import '@xterm/xterm/css/xterm.css';
 import React from 'react';
 import { motion } from 'motion/react';
-import { Code2, GitCompare, Settings, TerminalSquare } from 'lucide-react';
+import { FolderTree, GitCompare, Settings, TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import {
@@ -13,7 +13,7 @@ import {
 } from '@/stores/machine-workspace/useMachineTabStore';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import TerminalTab from './tabs/TerminalTab';
-import CodeTab from './tabs/CodeTab';
+import FilesTab from './tabs/FilesTab';
 import DiffTab from './tabs/DiffTab';
 import SettingsTab from './tabs/SettingsTab';
 
@@ -21,15 +21,20 @@ interface MachineViewProps {
   pageId: string;
 }
 
+// The tab's stored value/id stays `'code'` — it's the key `useMachineTabStore`
+// persists under and the Development sidebar reads to land a session on this
+// tab, so renaming it would ripple into that surface. Only the label, icon,
+// and component are reframed here: this tab VIEWS a checkout's files, it
+// doesn't edit code.
 const TAB_TRIGGERS: { value: MachineTabValue; label: string; icon: React.ElementType }[] = [
   { value: 'terminal', label: 'Terminal', icon: TerminalSquare },
-  { value: 'code', label: 'Code', icon: Code2 },
+  { value: 'code', label: 'Files', icon: FolderTree },
   { value: 'diff', label: 'Diff', icon: GitCompare },
   { value: 'settings', label: 'Settings', icon: Settings },
 ];
 
 /**
- * The Machine page's 4-tab command center (Terminal / Code / Diff / Settings).
+ * The Machine page's 4-tab command center (Terminal / Files / Diff / Settings).
  *
  * `pageId` IS the Machine id, so it's threaded down to every tab as `machineId`.
  * Radix `TabsContent` (no `forceMount`) renders only the active tab's body and
@@ -42,7 +47,7 @@ const TAB_TRIGGERS: { value: MachineTabValue; label: string; icon: React.Element
  * The active tab is held in `useMachineTabStore` rather than by Radix, so that
  * "show me this machine's terminal" is something another surface can ask for.
  * The Development sidebar needs it: only the Terminal tab mounts a machine's
- * workspace, so a session clicked on a machine parked on Code/Diff/Settings had
+ * workspace, so a session clicked on a machine parked on Files/Diff/Settings had
  * nowhere to land. Behaviour is otherwise unchanged — a machine with no stored
  * tab shows Terminal, as before.
  */
@@ -102,7 +107,7 @@ const MachineView = ({ pageId }: MachineViewProps) => {
             <TerminalTab machineId={pageId} />
           </TabsContent>
           <TabsContent value="code" className="min-h-0 flex-1 outline-none">
-            <CodeTab machineId={pageId} />
+            <FilesTab machineId={pageId} />
           </TabsContent>
           <TabsContent value="diff" className="min-h-0 flex-1 outline-none">
             <DiffTab machineId={pageId} />

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -33,13 +33,13 @@ vi.mock('@/components/editors/MonacoEditor', () => ({
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import CodeFilePane from './CodeFilePane';
+import FilesFilePane from './FilesFilePane';
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 
 const renderPane = (path = 'src/index.ts') =>
-  render(<CodeFilePane machineId="machine-1" projectName="repo" branchName="main" path={path} />);
+  render(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path={path} />);
 
 const requested = (call: unknown[], param: string): string | null =>
   new URL(String(call[0]), 'http://test').searchParams.get(param);
@@ -53,7 +53,7 @@ const deferredResponse = () => {
   return { promise, resolve };
 };
 
-describe('CodeFilePane', () => {
+describe('FilesFilePane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     monacoRenders.length = 0;
@@ -182,7 +182,7 @@ describe('CodeFilePane', () => {
     const { rerender } = renderPane('a.ts');
     await waitFor(() => screen.getByTestId('monaco'));
 
-    rerender(<CodeFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.ts" />);
     await waitFor(() => {
       const lastPath = requested(vi.mocked(fetchWithAuth).mock.calls.at(-1) ?? [], 'path');
       if (lastPath !== 'b.ts') throw new Error('new path not fetched yet');
@@ -209,7 +209,7 @@ describe('CodeFilePane', () => {
       .mockResolvedValueOnce(jsonResponse({ content: 'the file I clicked second', encoding: 'utf8', truncated: false }));
 
     const { rerender } = renderPane('slow.ts');
-    rerender(<CodeFilePane machineId="machine-1" projectName="repo" branchName="main" path="quick.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="quick.ts" />);
     await waitFor(() => screen.getByTestId('monaco'));
 
     // Only NOW does the abandoned first read resolve. Flush inside act() so any
@@ -252,7 +252,7 @@ describe('CodeFilePane', () => {
     const { rerender } = renderPane('assets/logo.png');
     await waitFor(() => screen.getByTestId('binary-file'));
 
-    rerender(<CodeFilePane machineId="machine-1" projectName="repo" branchName="main" path="src/a.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="src/a.ts" />);
     const monaco = await waitFor(() => screen.getByTestId('monaco'));
 
     assert({
@@ -340,7 +340,7 @@ describe('CodeFilePane', () => {
     const { rerender } = renderPane('a.ts');
     await waitFor(() => screen.getByText('contents of a.ts'));
 
-    rerender(<CodeFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.py" />);
+    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.py" />);
     await waitFor(() => screen.getByText('Loading file…'));
 
     assert({

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * CodeFilePane — the Code tab's main pane: fetches ONE selected file's content
+ * FilesFilePane — the Files tab's main pane: fetches ONE selected file's content
  * from the machine files route (`mode=read`) and shows it in a read-only Monaco
  * (Machine page rebuild, Phase 3).
  *
@@ -49,7 +49,7 @@ import { CHECKOUT_ABSENT_COPY, asAbsentReason, readErrorBody, type CheckoutAbsen
 // every other MonacoEditor mount in the app (CodePageView, DocumentView, …).
 const MonacoEditor = dynamic(() => import('@/components/editors/MonacoEditor'), { ssr: false });
 
-interface CodeFilePaneProps {
+interface FilesFilePaneProps {
   machineId: string;
   projectName: string;
   branchName: string;
@@ -106,7 +106,7 @@ const looksBinary = (content: string): boolean => {
   return replacements >= MIN_REPLACEMENTS && replacements / sample.length > MAX_REPLACEMENT_RATIO;
 };
 
-export default function CodeFilePane({ machineId, projectName, branchName, path }: CodeFilePaneProps) {
+export default function FilesFilePane({ machineId, projectName, branchName, path }: FilesFilePaneProps) {
   const [state, setState] = useState<FileState>({ status: 'loading' });
   // Bumped by Retry to re-run the read without changing the selected file.
   const [attempt, setAttempt] = useState(0);

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -9,7 +9,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 }));
 
 // Stub the branch picker: expose one button per node kind so a test can drive
-// exactly the selection CodeTab reacts to, without pulling MachineTree's whole
+// exactly the selection FilesTab reacts to, without pulling MachineTree's whole
 // projects/branches hook subtree.
 vi.mock('../workspace/MachineTree', () => ({
   default: ({ onSelectNode }: { onSelectNode?: (node: unknown) => void }) => (
@@ -38,7 +38,7 @@ vi.mock('../workspace/MachineTree', () => ({
  * tab's correctness depends on: it self-keys on `${machineId}/${projectName}/
  * ${branchName}`, so mounting it — or handing it a new branch — fetches that
  * branch's root listing. A dumb stub that never fetches would let the "no wasted
- * listing" test pass even with CodeTab's key deleted, which is exactly the hole
+ * listing" test pass even with FilesTab's key deleted, which is exactly the hole
  * a reviewer caught: the wasted listing came from the REAL tree, so a stub that
  * doesn't list cannot witness it.
  */
@@ -63,15 +63,15 @@ vi.mock('../workspace/MachineFileTree', () => ({
   },
 }));
 
-// Stub the main pane so CodeTab's composition (which file, which branch) is what's asserted.
-vi.mock('./CodeFilePane', () => ({
+// Stub the main pane so FilesTab's composition (which file, which branch) is what's asserted.
+vi.mock('./FilesFilePane', () => ({
   default: ({ path, branchName }: { path: string; branchName: string }) => (
     <div data-testid="file-pane">pane:{branchName}:{path}</div>
   ),
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import CodeTab from './CodeTab';
+import FilesTab from './FilesTab';
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
@@ -85,7 +85,7 @@ const cannedFetch = (perBranch: Record<string, () => Promise<Response>>) =>
     return jsonResponse({ error: 'unexpected branch' }, 500);
   });
 
-describe('CodeTab', () => {
+describe('FilesTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     treeListings.length = 0;
@@ -93,10 +93,10 @@ describe('CodeTab', () => {
 
   test('shows the branch prompt before any branch is picked', () => {
     cannedFetch({});
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     assert({
-      given: 'a freshly mounted Code tab',
+      given: 'a freshly mounted Files tab',
       should: 'prompt to select a branch and probe nothing',
       actual: {
         prompt: screen.queryByText('Select a branch to browse its checkout.') !== null,
@@ -108,7 +108,7 @@ describe('CodeTab', () => {
 
   test('selecting a machine (non-branch) node is ignored', async () => {
     cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-machine'));
 
@@ -125,7 +125,7 @@ describe('CodeTab', () => {
 
   test('picking a ready branch probes its checkout ONCE and mounts the file tree', async () => {
     cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     const tree = await waitFor(() => screen.getByTestId('file-tree'));
@@ -147,7 +147,7 @@ describe('CodeTab', () => {
       main: async () => jsonResponse({ entries: [] }),
       dev: async () => jsonResponse({ entries: [] }),
     });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByText('tree:main'));
@@ -169,7 +169,7 @@ describe('CodeTab', () => {
 
   test('re-picking the branch already open keeps the open file', async () => {
     cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -187,7 +187,7 @@ describe('CodeTab', () => {
 
   test('a not-yet-cloned branch shows the empty state, not the file tree', async () => {
     cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine not_found', reason: 'not_found' }, 404) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -205,7 +205,7 @@ describe('CodeTab', () => {
 
   test("a vanished sandbox reports the checkout is gone", async () => {
     cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine vanished', reason: 'vanished' }, 503) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     const gone = await waitFor(() => screen.getByText('This branch checkout is gone'));
@@ -224,7 +224,7 @@ describe('CodeTab', () => {
     cannedFetch({
       main: async () => jsonResponse({ error: 'You do not have access to this machine' }, 403),
     });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-error'));
@@ -249,7 +249,7 @@ describe('CodeTab', () => {
           ? jsonResponse({ entries: [] })
           : jsonResponse({ error: 'This branch checkout is unavailable', reason: 'not_found' }, 404),
     });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -271,7 +271,7 @@ describe('CodeTab', () => {
 
   test('selecting a file in the tree opens it in the main pane', async () => {
     cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -290,7 +290,7 @@ describe('CodeTab', () => {
       main: async () => jsonResponse({ entries: [] }),
       dev: async () => jsonResponse({ entries: [] }),
     });
-    render(<CodeTab machineId="machine-1" />);
+    render(<FilesTab machineId="machine-1" />);
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 /**
- * CodeTab — the Machine page's Code tab (Machine page rebuild, Phase 3).
+ * FilesTab — the Machine page's Files tab: a read-only viewer over a branch
+ * checkout's working tree (Machine page rebuild, Phase 3).
  *
  * Composes the pieces the earlier phases landed: an inner page-scoped sidebar
  * (plain border-border chrome, deliberately NOT one of the app's liquid-glass
@@ -32,7 +33,7 @@ import { FileCode2 } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
 import MachineFileTree from '../workspace/MachineFileTree';
-import CodeFilePane from './CodeFilePane';
+import FilesFilePane from './FilesFilePane';
 import TabSidebar from './TabSidebar';
 import { PaneNotice, SidebarLoading, SidebarNotice } from './tab-states';
 import {
@@ -42,7 +43,7 @@ import {
   type CheckoutAbsentReason,
 } from './checkout-states';
 
-interface CodeTabProps {
+interface FilesTabProps {
   /** The Machine page's own id (= pageId). */
   machineId: string;
 }
@@ -62,7 +63,7 @@ interface Selection {
 const branchKey = (branch: NonNullable<Selection['branch']>): string =>
   JSON.stringify([branch.projectName, branch.branchName]);
 
-export default function CodeTab({ machineId }: CodeTabProps) {
+export default function FilesTab({ machineId }: FilesTabProps) {
   // Branch and path move as ONE value: a path only means something inside the
   // checkout it came from, so switching branches must drop the open file in the
   // same update — never as a second, separately-scheduled setState.
@@ -86,7 +87,7 @@ export default function CodeTab({ machineId }: CodeTabProps) {
 
   return (
     <TabSidebar
-      title="Code"
+      title="Files"
       pane={
         branch && path ? (
           // Deliberately UNKEYED. Keying by path would tear down and recreate
@@ -94,7 +95,7 @@ export default function CodeTab({ machineId }: CodeTabProps) {
           // refuses to render a state belonging to a different file. Keying by
           // branch would be dead code: a branch switch clears `path` in the same
           // update, so the pane unmounts anyway.
-          <CodeFilePane
+          <FilesFilePane
             machineId={machineId}
             projectName={branch.projectName}
             branchName={branch.branchName}
@@ -165,7 +166,7 @@ type CheckoutState =
  * branch was never cloned" is a state of the world and belongs in the sidebar as
  * an empty state, not as a red error row buried inside a file tree. The
  * duplicate is bounded — once per branch selection, never per directory, and
- * CodeTab keys us by branch so it cannot fire on a re-render.
+ * FilesTab keys us by branch so it cannot fire on a re-render.
  *
  * It is not free, and it is not the only design: MachineFileTree is mounted here
  * and nowhere else, so it could instead report a root-level absence back to us
@@ -193,7 +194,7 @@ function BranchFiles({
   useEffect(() => {
     // Retry makes an in-flight probe's answer stale — this flag, flipped by the
     // cleanup, keeps it from landing on the newer one. (A branch switch can't
-    // race us at all: CodeTab keys this component by branch, so a switch is a
+    // race us at all: FilesTab keys this component by branch, so a switch is a
     // remount, not a re-render.)
     let cancelled = false;
     setState({ status: 'loading' });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
@@ -1,5 +1,5 @@
 /**
- * Shared vocabulary for the Code tab's "the checkout isn't there" states
+ * Shared vocabulary for the Files tab's "the checkout isn't there" states
  * (Machine page rebuild, Phase 3).
  *
  * The files route reports why a branch checkout couldn't be reached with a typed
@@ -7,7 +7,7 @@
  * the tab have to speak about it: the sidebar (which can't list files) and the
  * main pane (which can't read the open file). They live in separate modules and
  * the tab imports the pane, so this copy lives here rather than in either one —
- * importing it back out of CodeTab would be a cycle.
+ * importing it back out of FilesTab would be a cycle.
  *
  * The user-facing rule this encodes: NEVER render the route's internal phrasing
  * ("Branch machine vanished") at a person. A checkout that isn't there is a


### PR DESCRIPTION
## Summary
- Sub-task `hitwtwtzk0tu1aepo69f7qr2` of the Terminal UX redesign node — renames the Machine page's "Code" tab to "Files" and reframes it as a file viewer, not a code editor.
- `MachineView.tsx`: tab label "Code" → "Files", icon `Code2` → `FolderTree`.
- `CodeTab.tsx` → `FilesTab.tsx` (component `CodeTab` → `FilesTab`), `CodeFilePane.tsx` → `FilesFilePane.tsx` (component `CodeFilePane` → `FilesFilePane`), with doc comments and the sidebar title ("Code" → "Files") updated to match.
- Tab's stored `value`/id is deliberately left as `'code'` — `useMachineTabStore` persists it and the Development sidebar reads it to land a session on this tab; changing it would ripple into that out-of-scope surface. Only the label, icon, and component naming changed.
- No behavior change: still read-only file browsing + viewing (MachineFileTree + read-only Monaco).

## Test plan
- [x] `bun run typecheck` green for `apps/web` (after `bun install` + building `@pagespace/db`/`@pagespace/lib`, required in this fresh worktree)
- [x] `vitest run` on `MachineView.test.tsx`, `FilesTab.test.tsx`, `FilesFilePane.test.tsx`, `DevelopmentSidebar.test.tsx` — 38/38 passing, confirming the Development surface's `'code'` tab-id contract is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVVs3ZRGXxzC9TsfsLj5Gi