### PR TITLE
[sprites 3-2] No reconnect churn while detached

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -44,8 +44,13 @@ function makeSocket(id = 'sock1', userId = 'user1'): SocketLike & { emit: Return
  */
 const viewer = (connectionId: string, socketId = 'sock1') => `${socketId}\u0000${connectionId}`;
 
-function makeShell(): PtyShell & { write: ReturnType<typeof vi.fn>; resize: ReturnType<typeof vi.fn>; kill: ReturnType<typeof vi.fn> } {
-  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn() };
+function makeShell(): PtyShell & {
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  setViewerAttached: ReturnType<typeof vi.fn>;
+} {
+  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn() };
 }
 
 function makeSprite(sessions: Array<{ id: string; command: string; isActive: boolean; tty: boolean }> = []) {
@@ -603,6 +608,9 @@ describe('buildAgentTerminalHandlers', () => {
       // the LIVE session's own reservation.
       expect(reattachAuth.releaseSlot).not.toHaveBeenCalled();
       expect(reconnectSocket.emit).toHaveBeenCalledWith('agent-terminal:ready', expect.objectContaining({ scrollback: expect.any(String) }));
+      // The tab-back fast path tells the shell a viewer is attached again, so it
+      // can reattach lazily if its watchdog went quiet while detached (leaf 3-2).
+      expect(shell.setViewerAttached).toHaveBeenCalledWith(true);
     });
 
     it('given no live session, should follow the cold path and resolve the sandbox', async () => {
@@ -1058,6 +1066,14 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeDefined();
       expect(shell.kill).not.toHaveBeenCalled();
+    });
+
+    it('given a disconnect, should signal the shell that no viewer is attached (leaf 3-2: stops the watchdog reconnect loop)', async () => {
+      const { onConnect, onDisconnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+      await onConnect(validPayload);
+      onDisconnect();
+
+      expect(shell.setViewerAttached).toHaveBeenCalledWith(false);
     });
 
     it('given the idle timeout elapses, should HAND BACK the concurrency slot as well as killing the shell', async () => {

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { openPtyShell, planReconnect, sessionIds } from '../sprites-shell';
+import { openPtyShell, planReconnect, planWatchdogResponse, sessionIds } from '../sprites-shell';
 import { appendScrollback } from '../terminal-session-map';
 import { spawnWithSelfHealingCwd } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -125,6 +125,43 @@ describe('planReconnect (pure)', () => {
   });
 });
 
+describe('planWatchdogResponse (pure)', () => {
+  assert({
+    given: 'no viewer attached',
+    should: 'go quiet — no reconnect attempt',
+    actual: planWatchdogResponse({ viewersAttached: 0, closed: false, consecutiveFailures: 0 }),
+    expected: 'detach-quiet' as const,
+  });
+
+  assert({
+    given: 'no viewer attached, even past the reconnect failure budget',
+    should: 'still go quiet rather than declare fatal — nobody is watching to receive the exit, and a later viewer must still be able to reattach',
+    actual: planWatchdogResponse({ viewersAttached: 0, closed: false, consecutiveFailures: 99 }),
+    expected: 'detach-quiet' as const,
+  });
+
+  assert({
+    given: 'the shell already closed',
+    should: 'go quiet — there is nothing left to reconnect',
+    actual: planWatchdogResponse({ viewersAttached: 1, closed: true, consecutiveFailures: 0 }),
+    expected: 'detach-quiet' as const,
+  });
+
+  assert({
+    given: 'an attached viewer and failures within the budget',
+    should: 'reattach transparently',
+    actual: planWatchdogResponse({ viewersAttached: 1, closed: false, consecutiveFailures: 1 }),
+    expected: 'reattach' as const,
+  });
+
+  assert({
+    given: 'an attached viewer but the failure budget is exhausted',
+    should: 'go fatal',
+    actual: planWatchdogResponse({ viewersAttached: 1, closed: false, consecutiveFailures: 6 }),
+    expected: 'fatal' as const,
+  });
+});
+
 describe('sessionIds (pure)', () => {
   assert({
     given: 'the Sprite\'s live sessions',
@@ -229,6 +266,116 @@ describe('openPtyShell session identity (from create, not list-diffing)', () => 
     await vi.advanceTimersByTimeAsync(500);
 
     expect(sprite.attachSession).toHaveBeenCalledWith('sess-mine', { cols: 80, rows: 24 });
+  });
+});
+
+/**
+ * No reconnect churn while detached (leaf 3-2). The 45s @fly/sprites keepalive
+ * still trips on its own cadence — this is not about suppressing that — but a
+ * detached shell must not FOLLOW every trip with a fresh exec connection, and
+ * must reattach lazily the moment a viewer actually returns.
+ */
+describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('given a viewer detach, stops the watchdog loop — no listSessions/attachSession across several idle cycles', async () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+    const onExit = vi.fn();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+
+    // Several simulated idle watchdog cycles while detached. `stale` already
+    // absorbs repeats on the SAME dead command, but the point of this test is
+    // the OUTER gate: nothing here may ever reach the Sprite SDK.
+    for (let i = 0; i < 3; i += 1) {
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    expect(sprite.listSessions).not.toHaveBeenCalled();
+    expect(sprite.attachSession).not.toHaveBeenCalled();
+    expect(sprite.createSession).toHaveBeenCalledTimes(1); // only the original, no replacement
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given a viewer returns while the server-side session is still alive, reattaches lazily and delivers scrollback', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const onOutput = vi.fn();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).not.toHaveBeenCalled(); // still quiet, detached
+
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+
+    attachCmd._stdout.emit('data', 'back\r\n');
+    expect(onOutput).toHaveBeenCalledWith('back\r\n');
+  });
+
+  it('given a viewer returns after the sprite paused and the session died, transparently gets a fresh session (2-1\'s fallback)', async () => {
+    const cmd = buildFakeCommand();
+    const freshCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [] }); // sess-1 is gone: the Sprite paused and cold-woke
+    sprite.createSession.mockReturnValueOnce(cmd).mockReturnValueOnce(freshCmd);
+    const onOutput = vi.fn();
+    const onExit = vi.fn();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.createSession).toHaveBeenCalledTimes(2); // initial + fresh fallback
+    freshCmd._stdout.emit('data', 'fresh prompt\r\n');
+    expect(onOutput).toHaveBeenCalledWith('fresh prompt\r\n');
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given an attached viewer, keeps the existing transparent watchdog reattach unaffected', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const onExit = vi.fn();
+
+    // Default is attached — no setViewerAttached call needed.
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given a viewer toggles attach/detach faster than any watchdog trip, setViewerAttached(true) is a no-op (nothing to reattach)', async () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    shell.setViewerAttached(true); // no error ever tripped — the connection never dropped
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).not.toHaveBeenCalled();
+    expect(sprite.listSessions).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -129,35 +129,35 @@ describe('planWatchdogResponse (pure)', () => {
   assert({
     given: 'no viewer attached',
     should: 'go quiet — no reconnect attempt',
-    actual: planWatchdogResponse({ viewersAttached: 0, closed: false, consecutiveFailures: 0 }),
+    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 0 }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'no viewer attached, even past the reconnect failure budget',
     should: 'still go quiet rather than declare fatal — nobody is watching to receive the exit, and a later viewer must still be able to reattach',
-    actual: planWatchdogResponse({ viewersAttached: 0, closed: false, consecutiveFailures: 99 }),
+    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 99 }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'the shell already closed',
     should: 'go quiet — there is nothing left to reconnect',
-    actual: planWatchdogResponse({ viewersAttached: 1, closed: true, consecutiveFailures: 0 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: true, consecutiveFailures: 0 }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'an attached viewer and failures within the budget',
     should: 'reattach transparently',
-    actual: planWatchdogResponse({ viewersAttached: 1, closed: false, consecutiveFailures: 1 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 1 }),
     expected: 'reattach' as const,
   });
 
   assert({
     given: 'an attached viewer but the failure budget is exhausted',
     should: 'go fatal',
-    actual: planWatchdogResponse({ viewersAttached: 1, closed: false, consecutiveFailures: 6 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 6 }),
     expected: 'fatal' as const,
   });
 });
@@ -376,6 +376,173 @@ describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
 
     expect(sprite.attachSession).not.toHaveBeenCalled();
     expect(sprite.listSessions).not.toHaveBeenCalled();
+  });
+
+  it('given a viewer detaches DURING the reconnect backoff (before the delay resolves), never reaches listSessions/attachSession — and a later return resumes it', async () => {
+    // Closes a gap the entry-only gate missed: the drop trips while ATTACHED
+    // (so reconnect() begins normally), but the viewer leaves mid-backoff,
+    // before any Sprite SDK call has actually happened.
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout')); // attached — reconnect() begins its backoff
+
+    shell.setViewerAttached(false); // detach WHILE still inside the backoff delay
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sprite.listSessions).not.toHaveBeenCalled();
+    expect(sprite.attachSession).not.toHaveBeenCalled();
+
+    shell.setViewerAttached(true); // the swallowed reconnect resumes lazily
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+  });
+
+  it('given a viewer detaches DURING the listSessions() await, does not proceed to attach — and resumes lazily once a viewer returns', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd);
+    const d = deferred<SpriteSessionInfo[]>();
+    sprite.listSessions.mockReturnValue(d.promise);
+    sprite.attachSession.mockReturnValue(attachCmd);
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(300); // past the backoff; now suspended at await listSessions()
+
+    shell.setViewerAttached(false); // detach WHILE listSessions is still in flight
+    d.resolve([liveSession]); // the session is actually still alive
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sprite.attachSession).not.toHaveBeenCalled(); // must not attach for a viewer that's gone
+
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+  });
+
+  it('given the retry budget was exhausted right as the viewer detached, a later reattach still gets a fresh attempt rather than an instant fatal with zero retries', async () => {
+    // Without resetting the budget on a lazy reattach, `setViewerAttached(true)`
+    // would call reconnect(), which increments the STALE consecutiveFailures
+    // straight past MAX_RECONNECT_ATTEMPTS and fatals immediately — even though
+    // the underlying flap may be long over by the time a human reattaches.
+    const attached: FakeCommand[] = [];
+    const sprite = buildFakeSprite(buildFakeCommand(), { sessions: [liveSession] });
+    sprite.attachSession.mockImplementation(() => {
+      const next = buildFakeCommand();
+      attached.push(next);
+      return next; // never spawns — every attempt fails outright
+    });
+    const onExit = vi.fn();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, sessionId: 'sess-1', onOutput: vi.fn(), onExit });
+
+    // Drive exactly MAX_RECONNECT_ATTEMPTS (5) consecutive attached failures —
+    // right up to, but not past, the budget.
+    for (let i = 0; i < 5; i += 1) {
+      attached[attached.length - 1]._emitter.emit('error', new Error('keepalive'));
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+    expect(onExit).not.toHaveBeenCalled();
+
+    // The viewer detaches right as the NEXT trip fires — must go quiet, not fatal.
+    shell.setViewerAttached(false);
+    attached[attached.length - 1]._emitter.emit('error', new Error('keepalive'));
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(onExit).not.toHaveBeenCalled();
+
+    // The viewer returns. A real attempt happens (attachSession called again),
+    // not an instant fatal(-1) with zero attempts.
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(onExit).not.toHaveBeenCalled();
+    expect(sprite.attachSession.mock.calls.length).toBeGreaterThan(6);
+  });
+});
+
+/**
+ * `@fly/sprites`' `writeStdin` THROWS on a closed socket; `SpriteCommand`
+ * catches that and re-emits it as 'error' on the SAME (already-stale) command,
+ * which `wire()`'s error listener then drops silently (`if (stale) return;`).
+ * Without buffering, anything written to `shell.write()` between a command
+ * going stale and its replacement opening — whether an ordinary attached
+ * reconnect's backoff, or leaf 3-2's lazy reattach after an arbitrarily long
+ * detached gap — is lost with no error surfaced anywhere.
+ */
+describe('input queued across a reconnect (no silent stdin loss)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('given the wired command goes stale, buffers writes instead of handing them to the dead socket, and flushes them once the replacement opens', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+
+    // Written WHILE the reconnect is in flight — the wired command is stale,
+    // its replacement hasn't opened yet.
+    shell.write('echo hi\n');
+    expect(cmd.stdin!.write).not.toHaveBeenCalledWith('echo hi\n'); // never handed to the dead socket
+    expect(attachCmd.stdin!.write).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500); // backoff + listSessions resolve; attachSession called
+    attachCmd._emitter.emit('spawn'); // the replacement confirms open
+
+    expect(attachCmd.stdin!.write).toHaveBeenCalledWith('echo hi\n');
+  });
+
+  it('given a viewer tabs back after a detached watchdog trip and types immediately, the keystrokes are not lost', async () => {
+    // The exact scenario flagged in review: `attachToLiveSession` calls
+    // `setViewerAttached(true)` and emits `agent-terminal:ready` synchronously,
+    // before the lazy `reconnect()` (backoff + listSessions + attachSession)
+    // has actually run.
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000); // detached watchdog trip swallowed
+
+    shell.setViewerAttached(true); // tab-back — lazy reconnect starts, asynchronously
+    shell.write('ls\n'); // the client types immediately, before it completes
+
+    await vi.advanceTimersByTimeAsync(500); // reconnect resolves; attachSession called
+    attachCmd._emitter.emit('spawn');
+
+    expect(attachCmd.stdin!.write).toHaveBeenCalledWith('ls\n');
+  });
+
+  it('given several keystrokes arrive while detached, flushes them to the replacement in order', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+
+    shell.write('a');
+    shell.write('b');
+    shell.write('c');
+
+    await vi.advanceTimersByTimeAsync(500);
+    attachCmd._emitter.emit('spawn');
+
+    const writeMock = attachCmd.stdin!.write as ReturnType<typeof vi.fn>;
+    expect(writeMock.mock.calls.map(([data]) => data)).toEqual(['a', 'b', 'c']);
   });
 });
 

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -544,6 +544,87 @@ describe('input queued across a reconnect (no silent stdin loss)', () => {
     const writeMock = attachCmd.stdin!.write as ReturnType<typeof vi.fn>;
     expect(writeMock.mock.calls.map(([data]) => data)).toEqual(['a', 'b', 'c']);
   });
+
+  it('given the replacement delivers stdout WITHOUT a distinct spawn event, still flushes queued input (parity with how `opened` already treats the two as equivalent)', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+
+    shell.write('echo hi\n');
+
+    await vi.advanceTimersByTimeAsync(500);
+    // No 'spawn' ever fires on the replacement — only stdout, the shape some
+    // SDK/test doubles take.
+    attachCmd._stdout.emit('data', 'prompt\r\n');
+
+    expect(attachCmd.stdin!.write).toHaveBeenCalledWith('echo hi\n');
+  });
+
+  it('given both spawn AND stdout fire on the replacement, flushes the queue exactly once (no duplicate write)', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+
+    shell.write('echo hi\n');
+
+    await vi.advanceTimersByTimeAsync(500);
+    attachCmd._emitter.emit('spawn');
+    attachCmd._stdout.emit('data', 'prompt\r\n'); // fires again — must be a no-op for the queue
+
+    const writeMock = attachCmd.stdin!.write as ReturnType<typeof vi.fn>;
+    expect(writeMock.mock.calls.map(([data]) => data)).toEqual(['echo hi\n']);
+  });
+
+  it('given the retry budget is exhausted while input is queued, drops it without throwing (the shell is torn down and the user is told explicitly — see the doc on `pendingInput`)', async () => {
+    const sprite = buildFakeSprite(buildFakeCommand(), { listRejects: true });
+    sprite.createSession.mockImplementation(() => {
+      const next = buildFakeCommand();
+      setTimeout(() => next._emitter.emit('error', new Error('WebSocket closed before open')), 0);
+      return next;
+    });
+    const onOutput = vi.fn();
+    const onExit = vi.fn();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit });
+    await vi.advanceTimersByTimeAsync(0); // the initial command's own error fires — now stale, queueing
+
+    expect(() => shell.write('doomed\n')).not.toThrow();
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onExit).toHaveBeenCalledWith(-1);
+    expect(onOutput).toHaveBeenCalledWith(expect.stringContaining('lost connection'));
+  });
+
+  it('given a SUPERSEDED command emits a late spawn, does not corrupt inputReady for the actually-current command', async () => {
+    const cmd = buildFakeCommand(); // superseded once the fresh fallback is created
+    const freshCmd = buildFakeCommand(); // the fresh session the reconnect falls back to
+    const sprite = buildFakeSprite(cmd, { sessions: [] }); // sess-1 not live -> reconnect creates fresh
+    sprite.createSession.mockReturnValueOnce(cmd).mockReturnValueOnce(freshCmd);
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout')); // cmd goes stale
+
+    shell.write('queued\n'); // queued — inputReady is false
+
+    await vi.advanceTimersByTimeAsync(500); // reconnect() creates freshCmd; it hasn't opened yet
+
+    // cmd's LATE spawn — cmd is no longer `current`, so this must NOT flush.
+    cmd._emitter.emit('spawn');
+    expect(freshCmd.stdin!.write).not.toHaveBeenCalled();
+
+    freshCmd._emitter.emit('spawn'); // the ACTUALLY-current command's own spawn
+    expect(freshCmd.stdin!.write).toHaveBeenCalledWith('queued\n');
+  });
 });
 
 describe('spawnWithSelfHealingCwd', () => {

--- a/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
@@ -3,7 +3,7 @@ import { createTerminalSessionMap, appendScrollback, MAX_SCROLLBACK_BYTES, type 
 
 function fakeSession(sessionKey = 'key1', sandboxId = 'sbx1'): TerminalSession {
   return {
-    command: { write: vi.fn(), kill: vi.fn(), resize: vi.fn() },
+    command: { write: vi.fn(), kill: vi.fn(), resize: vi.fn(), setViewerAttached: vi.fn() },
     sandboxId,
     sessionKey,
     releaseSlot: vi.fn(),

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -548,6 +548,12 @@ export function buildAgentTerminalHandlers({
     session.outputFn = () => {};
     session.closedFn = () => {};
     sessionMap.detach(socketKey(connectionId));
+    // No viewer is left watching this PTY: stop the shell's watchdog reconnect
+    // loop (sprites-shell.ts's `planWatchdogResponse`) so an idle detached
+    // terminal stops waking the Sprite every ~45s for nobody. This only quiets
+    // OUR exec connection — an agent still running inside the shell keeps
+    // running, exactly as it already does across the 30-min idle reap below.
+    session.command.setViewerAttached(false);
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
       session.command.kill();
@@ -576,6 +582,10 @@ export function buildAgentTerminalHandlers({
     session.viewerUserId = viewerUserId;
     session.outputFn = (data) => socket.emit('agent-terminal:output', { data, connectionId });
     session.closedFn = (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId });
+    // A viewer is back: let the shell reattach lazily if its watchdog went quiet
+    // while detached (sprites-shell.ts's `setViewerAttached`) — a no-op when the
+    // connection never actually dropped, since output is already flowing.
+    session.command.setViewerAttached(true);
     sessionMap.reattach(sessionKey, socketKey(connectionId));
     activeConnectionIds.add(connectionId);
     // `resumed` says the agent was ALREADY DOING THINGS before this connect, so a

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -102,6 +102,13 @@ export type PtyShell = {
   write(data: string): void;
   resize(cols: number, rows: number): void;
   kill(): void;
+  /**
+   * Tell this shell whether a viewer is currently attached — see
+   * `planWatchdogResponse`. `false` on a detach stops the watchdog from
+   * reconnecting an idle shell nobody is watching; `true` on a return
+   * reattaches lazily if a reconnect was swallowed while detached.
+   */
+  setViewerAttached(attached: boolean): void;
 };
 
 export type OpenPtyShellArgs = {
@@ -151,6 +158,53 @@ export type OpenPtyShellArgs = {
 // bounded so a genuinely dead Sprite still surfaces an exit.
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 200;
+
+export type WatchdogAction = 'reattach' | 'detach-quiet' | 'fatal';
+
+/**
+ * What the watchdog should do about a dropped socket, given whether anyone is
+ * actually watching. Pure so every branch is unit-testable without a fake SDK.
+ *
+ * A detached shell is bytes for nobody: the client socket is gone (dropped by
+ * `agent-terminal-handler.ts`'s `disconnectConnection`), so reattaching now
+ * would only place a fresh exec connection on the Sprite to relay output no
+ * one will see — exactly the connection docs.sprites.dev/keeping-sprites-running
+ * says prevents the Sprite from pausing ("open TCP connections drop on the
+ * pause, even on warm"). `detach-quiet` lets the drop stand instead: no
+ * `listSessions`/`attachSession` call, so nothing keeps the Sprite awake.
+ *
+ * `detach-quiet` wins over the reconnect BUDGET too, deliberately — a
+ * detached shell must never go `fatal`. `fatal` calls `onExit`, which
+ * `disconnectConnection` has already pointed at a no-op, so the call itself
+ * is harmless — but it also latches `closed = true` on the `PtyShell`
+ * PERMANENTLY, and every one of its methods (`write`/`resize`, and the
+ * lazy reattach `setViewerAttached` triggers) is a no-op once `closed`. A
+ * later viewer returning would then find a shell that can never reattach —
+ * worse than the churn this leaf removes. Only an ATTACHED shell may ever
+ * exhaust the budget and go fatal; a detached one simply stays quiet
+ * indefinitely; until either a viewer returns (lazy reattach) or the 30-min
+ * idle reap kills it outright (see the CAUTION in the module doc: an agent
+ * running inside survives a quiet socket exactly as it already survives the
+ * reap today — leaf 5-1's Tasks API hold is the sanctioned protection, not this).
+ *
+ * `closed` is checked for the same reason: once the shell is already torn
+ * down there is nothing left to reconnect, and treating it as an ordinary
+ * `reattach`/`fatal` case would just repeat a decision that has already been
+ * made.
+ */
+export function planWatchdogResponse({
+  viewersAttached,
+  closed,
+  consecutiveFailures,
+}: {
+  viewersAttached: number;
+  closed: boolean;
+  consecutiveFailures: number;
+}): WatchdogAction {
+  if (closed) return 'detach-quiet';
+  if (viewersAttached <= 0) return 'detach-quiet';
+  return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
+}
 
 /**
  * How many CONSECUTIVE unnamed sessions this shell may abandon (see
@@ -260,6 +314,16 @@ export function openPtyShell({
   // counter, an id we never learn produces a fresh orphan on every keepalive
   // cycle, forever.
   let abandonedUnnamedSessions = 0;
+  // Whether a viewer is currently attached — see `planWatchdogResponse` and
+  // `setViewerAttached`. Starts true: a shell is only ever opened in direct
+  // response to a connecting viewer (agent-terminal-handler's cold-create path).
+  let viewerAttached = true;
+  // Set when a watchdog trip was swallowed while detached (`planWatchdogResponse`
+  // returned 'detach-quiet') instead of reattached. Nothing is wired up any more
+  // to trip a FUTURE keepalive on that dead command, so the next
+  // `setViewerAttached(true)` has to trigger the reattach itself rather than wait
+  // for one that will never come.
+  let needsLazyReattach = false;
   // The tail of the REPLAYABLE stream this client has been shown — the bound session's
   // stdout, and only that (stderr and a foreign session's drain are shown but never
   // recorded; see `deliver`). It is what each attach matches its replayed scrollback
@@ -645,6 +709,15 @@ export function openPtyShell({
       // FIRST — the SDK's own `closed before open` string is only emitted
       // afterwards, and a substring test would miss the real cold-start drop.
       lastErrorWasPreOpenDrop = !opened;
+      const action = planWatchdogResponse({
+        viewersAttached: viewerAttached ? 1 : 0,
+        closed,
+        consecutiveFailures,
+      });
+      if (action === 'detach-quiet') {
+        needsLazyReattach = true;
+        return;
+      }
       void reconnect();
     });
   }
@@ -829,5 +902,15 @@ export function openPtyShell({
     // Anything still held (an unresolved replay, queued stderr) is dropped with it: the
     // viewer is gone, and `closed` stops every listener from speaking after this point.
     kill: () => { closed = true; cancelReplayTimers(); current.kill('SIGKILL'); },
+    setViewerAttached: (attached) => {
+      viewerAttached = attached;
+      // A lazy reattach only fires if a watchdog trip actually got swallowed while
+      // detached — a viewer toggling attach/detach faster than the ~45s keepalive
+      // (nothing ever tripped) is a no-op here, correctly: output is already flowing.
+      if (attached && needsLazyReattach && !closed) {
+        needsLazyReattach = false;
+        void reconnect();
+      }
+    },
   };
 }

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -107,6 +107,20 @@ export type PtyShell = {
    * `planWatchdogResponse`. `false` on a detach stops the watchdog from
    * reconnecting an idle shell nobody is watching; `true` on a return
    * reattaches lazily if a reconnect was swallowed while detached.
+   *
+   * Scope, stated explicitly: this only gates whether WE reconnect after the
+   * SDK's own keepalive declares the socket dead — it never closes a
+   * currently-healthy exec connection on our own initiative. A detached shell
+   * whose process keeps producing output (an agent actively working) never
+   * trips the 45s no-inbound-frame watchdog in the first place, so it stays
+   * connected — and correctly so: an actively-producing session is doing real
+   * work regardless of whether a viewer is watching, and the Sprite's own
+   * activity-based pause decision should govern that case, not viewer
+   * presence. Only a genuinely IDLE detached shell — the wasteful case this
+   * leaf targets, an idle prompt reconnecting every ~45s for nobody —
+   * benefits from (and needs) this gate. A chatty detached shell is bounded
+   * only by the existing 30-min idle reap (`disconnectConnection`), same as
+   * before this leaf.
    */
   setViewerAttached(attached: boolean): void;
 };
@@ -191,18 +205,33 @@ export type WatchdogAction = 'reattach' | 'detach-quiet' | 'fatal';
  * down there is nothing left to reconnect, and treating it as an ordinary
  * `reattach`/`fatal` case would just repeat a decision that has already been
  * made.
+ *
+ * `viewersAttached` is boolean, not a count: `terminal-session-map.ts`'s
+ * `reattach` STEALS the previous socket entry on every new attach, so at most
+ * one viewer can ever be bound to a session at a time — there is no refcount
+ * anywhere in this architecture for a number to represent. A multi-viewer
+ * feature would need that map reworked long before this signature could mean
+ * anything other than boolean.
+ *
+ * `consecutiveFailures` must be the count AFTER `reconnect()`'s own increment
+ * — this is the single place that decision is made (the error handler, the
+ * internal retry recursion, and the lazy `setViewerAttached(true)` reattach
+ * all funnel through `reconnect()`, which consults this function once, right
+ * after incrementing). Passing the pre-increment count would let this
+ * function's `'fatal'` verdict disagree with the actual budget it exists to
+ * enforce.
  */
 export function planWatchdogResponse({
   viewersAttached,
   closed,
   consecutiveFailures,
 }: {
-  viewersAttached: number;
+  viewersAttached: boolean;
   closed: boolean;
   consecutiveFailures: number;
 }): WatchdogAction {
   if (closed) return 'detach-quiet';
-  if (viewersAttached <= 0) return 'detach-quiet';
+  if (!viewersAttached) return 'detach-quiet';
   return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
 }
 
@@ -323,7 +352,37 @@ export function openPtyShell({
   // to trip a FUTURE keepalive on that dead command, so the next
   // `setViewerAttached(true)` has to trigger the reattach itself rather than wait
   // for one that will never come.
+  //
+  // Distinct from `wire()`'s per-command `stale` flag, not a duplicate of it:
+  // `stale` is closure-private to ONE wired command and resets to false the
+  // moment a new one is wired, so it cannot outlive a single `wire()` call.
+  // This has to survive across the WHOLE detached window — however long that
+  // is — until a viewer actually returns, which is exactly the span `stale`
+  // was never built to cover.
   let needsLazyReattach = false;
+  // Whether the CURRENTLY WIRED command is known to actually accept stdin right
+  // now. `false` from the instant that command goes `stale` (its socket errored;
+  // see the 'error' handler below) until its replacement confirms open (`spawn`,
+  // or — for parity with how `opened`/the reconnect budget already treat the
+  // two as equivalent evidence — its first stdout byte). Needed because
+  // `@fly/sprites`' `writeStdin` THROWS on a closed socket, and `SpriteCommand`
+  // catches that throw and re-emits it as an 'error' on the SAME command — which
+  // is already `stale`, so `wire()`'s `error` listener drops it silently
+  // (`if (stale) return;`). Without this flag `write()` would hand bytes straight
+  // to `current.stdin`, which is still the DEAD command for the whole reconnect
+  // window (attached-reconnect's ~200ms-1s backoff, or this leaf's lazy
+  // reattach — which can follow a detached gap of up to 30 minutes) — and every
+  // one of those bytes is lost with no error surfaced anywhere.
+  let inputReady = true;
+  // Input written while `!inputReady`, held in order and flushed to the
+  // replacement command's stdin the moment it opens.
+  let pendingInput: string[] = [];
+  const flushPendingInput = () => {
+    if (pendingInput.length === 0) return;
+    const queued = pendingInput;
+    pendingInput = [];
+    for (const chunk of queued) current.stdin?.write(chunk);
+  };
   // The tail of the REPLAYABLE stream this client has been shown — the bound session's
   // stdout, and only that (stderr and a foreign session's drain are shown but never
   // recorded; see `deliver`). It is what each attach matches its replayed scrollback
@@ -614,6 +673,10 @@ export function openPtyShell({
       // Any inbound data proves the connection recovered; reset the failure budget.
       opened = true;
       consecutiveFailures = 0;
+      // Confirms this command accepts stdin now (see `inputReady`'s doc) — for a
+      // silent shell that never gets a distinct 'spawn' in some SDK/test doubles,
+      // this is the same evidence `opened` already treats it as.
+      if (cmd === current) { inputReady = true; flushPendingInput(); }
       // The first byte of this attach freezes the history it will be matched against.
       if (seen === undefined) {
         seen = materializeSeen(seenTail);
@@ -661,6 +724,8 @@ export function openPtyShell({
     cmd.on('spawn', () => {
       opened = true;
       consecutiveFailures = 0;
+      // Confirms this command accepts stdin now — see `inputReady`'s doc.
+      if (cmd === current) { inputReady = true; flushPendingInput(); }
       // A confirmed open retires the previous failure's classification. Without
       // this, a later reconnect entered WITHOUT a fresh error (listSessions
       // unavailable, or the catch-all retry) would consult a stale verdict from
@@ -698,6 +763,12 @@ export function openPtyShell({
       // them, that replay dedupes against them.
       closeReplayWindow();
       stale = true;
+      // From this instant, writing to `current.stdin` would silently lose the
+      // bytes: `writeStdin` throws on a closed socket, `SpriteCommand` catches
+      // that and re-emits it as 'error' on this SAME (now-stale) command, and
+      // this very listener drops it (`if (stale) return;`, above). Queue
+      // instead — `flushPendingInput` delivers it once the replacement opens.
+      if (cmd === current) inputReady = false;
       // Remember WHY this command died, STRUCTURALLY: if it never reported an open
       // (no 'spawn', no byte of output), its socket never came up, so the session
       // was never started — re-creating it is safe (that is the cold Sprite wake)
@@ -709,15 +780,6 @@ export function openPtyShell({
       // FIRST — the SDK's own `closed before open` string is only emitted
       // afterwards, and a substring test would miss the real cold-start drop.
       lastErrorWasPreOpenDrop = !opened;
-      const action = planWatchdogResponse({
-        viewersAttached: viewerAttached ? 1 : 0,
-        closed,
-        consecutiveFailures,
-      });
-      if (action === 'detach-quiet') {
-        needsLazyReattach = true;
-        return;
-      }
       void reconnect();
     });
   }
@@ -784,7 +846,29 @@ export function openPtyShell({
     if (closed || reconnecting) return;
     reconnecting = true;
     consecutiveFailures += 1;
-    if (consecutiveFailures > MAX_RECONNECT_ATTEMPTS) {
+
+    // The SOLE consult of `planWatchdogResponse` — every entry point funnels
+    // through here: the error handler's direct call, this function's own
+    // recursive retry (the `catch` block below), and the lazy reattach
+    // `setViewerAttached(true)` triggers. Passing the count AFTER the
+    // increment above matches exactly what this decision has always been
+    // keyed on (the inline check this replaces compared the same
+    // post-increment value), so a 'fatal' verdict here is the real one, not
+    // a preview of one `reconnect()` would recompute differently.
+    const action = planWatchdogResponse({ viewersAttached: viewerAttached, closed, consecutiveFailures });
+    if (action === 'detach-quiet') {
+      // No viewer: proceeding would only place a fresh exec connection on the
+      // Sprite to relay output nobody is watching — exactly the churn this
+      // gate exists to remove. Undo the speculative increment above: no
+      // attempt actually ran, so it must not count against the budget.
+      // Remember one is owed; `setViewerAttached(true)` resumes it (with a
+      // fresh budget of its own — see there).
+      consecutiveFailures -= 1;
+      needsLazyReattach = true;
+      reconnecting = false;
+      return;
+    }
+    if (action === 'fatal') {
       reconnecting = false;
       fatal(-1, 'lost connection to shell');
       return;
@@ -792,6 +876,16 @@ export function openPtyShell({
     try {
       await delay(RECONNECT_BASE_DELAY_MS * consecutiveFailures);
       if (closed) { reconnecting = false; return; }
+      if (!viewerAttached) {
+        // Detached during the backoff itself — still nothing to reattach for.
+        // Same bookkeeping as the entry-gate detach-quiet branch: no attempt
+        // actually ran (we never even reached listSessions), so it must not
+        // count against the budget.
+        consecutiveFailures -= 1;
+        needsLazyReattach = true;
+        reconnecting = false;
+        return;
+      }
 
       // No id in hand means the session we are about to replace never announced
       // itself, so replacing it STRANDS it (see `abandonedUnnamedSessions`). The
@@ -830,6 +924,18 @@ export function openPtyShell({
         // session for a terminal the user already closed (that would leak a running,
         // billable Sprite shell with no client attached).
         if (closed) { reconnecting = false; return; }
+        // Same reasoning, for a detach: listSessions can be slow (a rate-limited or
+        // cold-waking control plane), long enough for the viewer to leave mid-await.
+        // Attaching or creating now would be exactly the churn this gate exists to
+        // remove, just discovered a beat later than the entry check above.
+        if (!viewerAttached) {
+          // listSessions itself is not free — it counts toward this attempt
+          // even though nothing further ran. Undo it, same as the earlier checks.
+          consecutiveFailures -= 1;
+          needsLazyReattach = true;
+          reconnecting = false;
+          return;
+        }
         if (listed === undefined) {
           // The control-plane listSessions is transiently unavailable (rate-limited
           // / cold-waking). Don't burn the retry budget killing a shell that's fine:
@@ -897,7 +1003,14 @@ export function openPtyShell({
   wire(current, 'fresh');
 
   return {
-    write: (data) => { if (!closed) current.stdin?.write(data); },
+    write: (data) => {
+      if (closed) return;
+      // The wired command is known-stale (a reconnect — attached or lazy — is
+      // in flight) and its replacement hasn't opened yet: queue rather than
+      // hand bytes to a socket that would silently swallow them.
+      if (!inputReady) { pendingInput.push(data); return; }
+      current.stdin?.write(data);
+    },
     resize: (c, r) => { lastCols = c; lastRows = r; if (!closed) current.resize?.(c, r); },
     // Anything still held (an unresolved replay, queued stderr) is dropped with it: the
     // viewer is gone, and `closed` stops every listener from speaking after this point.
@@ -909,6 +1022,15 @@ export function openPtyShell({
       // (nothing ever tripped) is a no-op here, correctly: output is already flowing.
       if (attached && needsLazyReattach && !closed) {
         needsLazyReattach = false;
+        // A deliberate, viewer-initiated reattach after a (possibly long) detached
+        // gap is a FRESH attempt, not a continuation of whatever consecutive
+        // failures triggered the original quiet-down. Reset both budgets so a
+        // shell that happened to be at/near its cap when it went quiet gets a
+        // real attempt instead of an instant fatal(-1) with zero retries —
+        // "consecutive" is meant to bound rapid retries close together in time,
+        // not something spanning a human-timescale detached window.
+        consecutiveFailures = 0;
+        abandonedUnnamedSessions = 0;
         void reconnect();
       }
     },

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -376,6 +376,12 @@ export function openPtyShell({
   let inputReady = true;
   // Input written while `!inputReady`, held in order and flushed to the
   // replacement command's stdin the moment it opens.
+  //
+  // Never drained on a `fatal()` exit — an accepted, bounded exception, not an
+  // oversight. A fatal tears the whole PTY down (`onExit` fires, the client
+  // sees an explicit "lost connection" error), so there is no replacement
+  // command left to flush these bytes to; unlike the bug this queue fixes,
+  // this loss is never SILENT — the user is told the shell is gone.
   let pendingInput: string[] = [];
   const flushPendingInput = () => {
     if (pendingInput.length === 0) return;


### PR DESCRIPTION
## Summary

The PTY keepalive watchdog (`@fly/sprites` client-side `WS_PONG_WAIT`) trips every ~45s on an idle prompt, and the shell's `reconnect()` transparently reattaches — **even with no viewer attached**, for the whole 30-min detached grace window. Every one of those reattaches is a fresh exec connection to the Sprite, and an open exec connection is exactly what docs.sprites.dev/keeping-sprites-running warns against: it prevents the Sprite from pausing. This leaf makes a detached terminal go quiet instead: drop the connection, let the Sprite pause, and reattach lazily only when a viewer actually comes back.

## Requirements satisfied

- **Given a viewer detach, should stop the watchdog reconnect loop (no `listSessions`/`attachSession` calls while detached)** — `reconnect()` itself consults the pure `planWatchdogResponse({ viewersAttached, closed, consecutiveFailures })` right after incrementing its own failure budget — the single source of truth for whether to proceed, go fatal, or go quiet — so every entry point (the error handler's direct call, the internal retry recursion, and the lazy `setViewerAttached(true)` reattach) is uniformly gated. `reconnect()` also re-checks `viewerAttached` after its backoff delay and after `listSessions()` resolves (mirroring the existing `closed` re-check pattern), closing the mid-flight-detach gap a first pass missed.
- **Given a viewer returning while the server-side session is still alive, should reattach lazily and deliver scrollback** — `setViewerAttached(true)` triggers a lazy `reconnect()` *only if* a watchdog trip was actually swallowed while detached (`needsLazyReattach`), with a **fresh retry budget** (`consecutiveFailures`/`abandonedUnnamedSessions` reset to 0 — a viewer-initiated reattach after a possibly-long gap is a new attempt, not a continuation of whatever failures triggered the quiet-down). This reuses leaf 2-1's `planReconnect` verification and leaf 2-4's dedupe/fast-path exactly as an ordinary transparent reconnect does.
- **Given a viewer returning after the sprite paused and the session died, should transparently get a fresh session** — same lazy-reattach path; `planReconnect` falls back to `launchFreshSession()` when the known id is no longer live.
- **Given an attached viewer, should keep today's transparent watchdog reattach (now silent per 2-4)** — unaffected: `viewerAttached` defaults to `true` on shell creation, and the gate collapses to today's exact behavior when always-attached (all pre-existing tests pass unmodified).

Wiring in `agent-terminal-handler.ts`: `disconnectConnection` calls `setViewerAttached(false)`; `attachToLiveSession` (the tab-back fast path) calls `setViewerAttached(true)`.

### Also fixed, found across two independent review passes after the initial implementation

An 8-angle code-review swarm and a GitHub review comment (`chatgpt-codex-connector`) surfaced real gaps beyond the first pass:

1. **Mid-flight detach wasn't fully re-checked** — closed by hoisting the sole `planWatchdogResponse` consult into `reconnect()` itself (fixing an off-by-one where the pure function's pre-increment verdict didn't match `reconnect()`'s own post-increment budget check) and adding `!viewerAttached` re-checks at both `await` points.
2. **A lazy reattach didn't reset the retry budget** — a shell at/near its failure cap when it went quiet would otherwise fatal on the very first reattach with zero real attempts, even if the underlying issue was long resolved.
3. **`viewersAttached: number` bought nothing** — changed to `boolean` (the architecture only ever has 0 or 1 viewer; `sessionMap.reattach` steals the prior socket).
4. **Silent stdin loss across ANY reconnect** (the codex-flagged bug, verified against the real `@fly/sprites` SDK source: `writeStdin` throws on a closed socket, which `SpriteCommand` catches and re-emits as `'error'` on the same already-stale command, which `wire()`'s listener then drops silently) — fixed by buffering writes while the wired command is known-stale (`inputReady=false`) and flushing them, in order, once the replacement command confirms open. This closes both this leaf's new tab-back window (up to 30 minutes) and a narrower pre-existing window in ordinary attached reconnects.

An adversarial follow-up review of fix #4 confirmed the mechanism is sound (no ordering races, no double-writes, superseded-command guards hold) and flagged two gaps, both closed: queued input dropped on a genuine `fatal()` exit is now documented as an accepted, non-silent exception (the client is told explicitly the shell is gone), and 4 new tests cover the stdout-only flush path, the double-flush no-op, the fatal-path drop, and a superseded command's late event not corrupting state for the actually-current one.

### Why `detach-quiet` beats the retry budget even when past it

`planWatchdogResponse` returns `'detach-quiet'` for a detached shell *unconditionally* — even past `MAX_RECONNECT_ATTEMPTS`. Going `'fatal'` here would call `onExit` (harmless — `disconnectConnection` already points `closedFn` at a no-op) but would also latch `PtyShell`'s internal `closed = true` **permanently**, and every method (`write`/`resize`/`setViewerAttached`'s lazy reattach) is a no-op once `closed`. A later returning viewer would then find a shell that can never reattach — strictly worse than the churn this leaf removes.

### CAUTION honored

An agent (claude/codex) may be running *inside* the detached terminal. Going quiet does not kill it — it only stops our client-side exec socket from propping the Sprite awake. An actively-producing session legitimately keeps the Sprite awake regardless of viewer presence (that's correct — real work is happening); only a genuinely *idle* detached shell benefits from this leaf's fix, which is the wasteful case the epic targets. That boundary is stated explicitly in `setViewerAttached`'s doc comment. The 30-min idle reap hazard already exists today; leaf 5-1's Tasks API hold is the sanctioned protection, not this leaf. No keep-alive was added here.

### Stretch (deepest root-fix) — left as a follow-up

The orchestrator note flagged an optional stretch: killing the 45s `WS_PONG_WAIT` trip at the source via a keepalive to the sprite exec socket, so an idle *attached* terminal never trips the watchdog at all. That's a change to the `@fly/sprites` command's own keepalive behavior (not this shell's reconnect logic) and didn't fit cleanly within this leaf's scope without ballooning it — left as a follow-up per the orchestrator note's own guidance.

## Test plan

- [x] `bun run test:unit` (realtime app): **805/805 tests pass** (started at 795, +10 for the initial implementation, +4 from the adversarial-review follow-up), covering: the detached-quiet gate over multiple idle cycles, lazy reattach to a still-live session, lazy reattach with fresh-session fallback, attached-viewer behavior unchanged, mid-backoff detach, mid-`listSessions` detach, budget reset on lazy reattach, and the full stdin-buffering suite (stale-command queueing, tab-back-and-type-immediately, ordering, stdout-only flush, double-flush no-op, fatal-path drop, superseded-command guard).
- [x] `bun run typecheck` — clean, no `any`.
- [x] `eslint` — clean.
- [x] Updated existing `PtyShell`/`TerminalSession.command` test fakes to satisfy the new required `setViewerAttached` method — all pre-existing tests pass unmodified otherwise.

```
 Test Files  22 passed (22)
      Tests  805 passed (805)
```

## For the orchestrator to verify

- Confirms this composes cleanly with 2-5's (#2024, merged) replay-discard changes in `sprites-shell.ts` — the give-up/discard logic itself is untouched; only whether/when `reconnect()` runs at all was gated.
- The stretch goal (killing the 45s trip at the source) is explicitly NOT done here — flagged above as a follow-up, not silently dropped.
- One review thread (from `chatgpt-codex-connector`, the stdin-loss finding) remains open on GitHub for the reviewer to verify the fix — left unresolved per convention, since it was fixed during this session rather than pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbR75rq9aDRqnvrhKA9xDw