### PR TITLE
fix(cron): schedule machine-storage billing reconcile hourly

### DIFF
--- a/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
@@ -13,10 +13,14 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
  * real work), to the machine's actual page owner. It NEVER wakes a sprite to
  * measure; a never-measured machine bills a conservative 0 for that window.
  *
- * Idempotent / drift-correcting: each machine tracks its own last-billed
- * watermark, so overlapping or repeated runs never double-bill and a missed
- * run is caught up exactly on the next one — see
- * `reconcileMachineStorage` in @pagespace/lib.
+ * Idempotent / drift-correcting for SEQUENTIAL runs: each machine tracks its
+ * own last-billed watermark, so a rerun bills zero elapsed time and a missed
+ * run is caught up exactly on the next one — see `reconcileMachineStorage`
+ * in @pagespace/lib. CONCURRENT invocations are NOT safe — the charge and the
+ * watermark advance are two un-transactioned writes, so overlapping runs can
+ * bill the same window twice. Callers must serialize externally (the
+ * docker/cron crontab entry does, via flock); an in-service advisory lock
+ * covering every caller is tracked follow-up work.
  *
  * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce,
  * X-Cron-Signature headers.

--- a/docker/cron/Dockerfile
+++ b/docker/cron/Dockerfile
@@ -3,8 +3,9 @@
 
 FROM alpine:3.21
 
-# Install curl for making HTTP requests
-RUN apk add --no-cache curl openssl
+# curl/openssl for HMAC-signed requests; flock (util-linux) so entries that
+# must not overlap themselves (e.g. reconcile-machine-storage) can serialize
+RUN apk add --no-cache curl openssl flock
 
 # Create log directory
 RUN mkdir -p /var/log/cron

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -63,15 +63,13 @@
 */10 * * * * cron-curl GET __WEB_URL__/api/cron/reconcile-credits >> /var/log/cron/reconcile-credits.log 2>&1
 
 # Machine storage reconcile - Hourly
-# Bills Terminal Machines' persistent-storage cost from each machine's last
-# persisted measured footprint (active or hibernating; never wakes a sprite).
-# Idempotent via per-machine last-billed watermarks for sequential runs, but
-# the charge and the watermark advance are two un-transactioned writes — two
-# CONCURRENT reconciles could bill the same elapsed window twice. flock -n
-# serializes them at the sole caller: if a run is still going at the next tick
-# the new tick is skipped (not queued), and the skipped window is simply
-# caught up by the watermark on the following hour.
-0 * * * * flock -n /tmp/reconcile-machine-storage.lock cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1
+# Bills each Terminal Machine's persistent storage from its last persisted
+# measurement (see machine-storage-reconcile.ts in @pagespace/lib); watermarks
+# make sequential reruns and missed runs self-correcting, but CONCURRENT runs
+# can double-bill. flock -n is a best-effort guard so this container's own
+# ticks never overlap (a skipped tick is caught up by the watermark next
+# hour); in-service serialization covering ALL callers is tracked follow-up.
+0 * * * * flock -n /run/reconcile-machine-storage.lock cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-machine-storage.log
 
 # Expired row sweep - Every 15 minutes
 # Reaps expired tombstones from append-with-TTL tables (revoked_service_tokens;

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -62,6 +62,13 @@
 # across crashes/deploys. Local-only — makes no Stripe calls.
 */10 * * * * cron-curl GET __WEB_URL__/api/cron/reconcile-credits >> /var/log/cron/reconcile-credits.log 2>&1
 
+# Machine storage reconcile - Hourly
+# Bills Terminal Machines' persistent-storage cost from each machine's last
+# persisted measured footprint (active or hibernating; never wakes a sprite).
+# Idempotent via per-machine last-billed watermarks, so hourly runs never
+# double-bill and a missed run is caught up exactly on the next one.
+0 * * * * cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1
+
 # Expired row sweep - Every 15 minutes
 # Reaps expired tombstones from append-with-TTL tables (revoked_service_tokens;
 # rate_limit_buckets in PR3). Short cadence matches the 5-minute default

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -65,9 +65,13 @@
 # Machine storage reconcile - Hourly
 # Bills Terminal Machines' persistent-storage cost from each machine's last
 # persisted measured footprint (active or hibernating; never wakes a sprite).
-# Idempotent via per-machine last-billed watermarks, so hourly runs never
-# double-bill and a missed run is caught up exactly on the next one.
-0 * * * * cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1
+# Idempotent via per-machine last-billed watermarks for sequential runs, but
+# the charge and the watermark advance are two un-transactioned writes — two
+# CONCURRENT reconciles could bill the same elapsed window twice. flock -n
+# serializes them at the sole caller: if a run is still going at the next tick
+# the new tick is skipped (not queued), and the skipped window is simply
+# caught up by the watermark on the following hour.
+0 * * * * flock -n /tmp/reconcile-machine-storage.lock cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1
 
 # Expired row sweep - Every 15 minutes
 # Reaps expired tombstones from append-with-TTL tables (revoked_service_tokens;

--- a/docker/cron/entrypoint.sh
+++ b/docker/cron/entrypoint.sh
@@ -34,16 +34,21 @@ TIMESTAMP=$(date +%s)
 NONCE=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
 MESSAGE="${TIMESTAMP}:${NONCE}:${METHOD}:${PATH_PART}"
 
+# -sS: no progress noise, but transport errors DO print (they land in each
+# entry's log via 2>&1 instead of vanishing). --max-time bounds every request
+# below the hourly tick so a wedged connection can never wedge a job forever —
+# critical for flock-serialized entries, where a hung holder would otherwise
+# silently starve all future ticks.
 if [ -n "$CRON_SECRET_VAL" ]; then
   SIGNATURE=$(printf '%s' "$MESSAGE" | openssl dgst -sha256 -hmac "$CRON_SECRET_VAL" -hex 2>/dev/null | sed 's/^.* //')
-  curl -s -X "$METHOD" \
+  curl -sS --connect-timeout 10 --max-time 3300 -X "$METHOD" \
     -H "X-Cron-Timestamp: ${TIMESTAMP}" \
     -H "X-Cron-Nonce: ${NONCE}" \
     -H "X-Cron-Signature: ${SIGNATURE}" \
     "$URL"
 else
   # No secret configured — send without HMAC headers (dev/fallback)
-  curl -s -X "$METHOD" "$URL"
+  curl -sS --connect-timeout 10 --max-time 3300 -X "$METHOD" "$URL"
 fi
 SCRIPT
 


### PR DESCRIPTION
## Summary

GA blocker remediation (deferred-items node, item 8): the `/api/cron/reconcile-machine-storage` route landed in PR #2012 with GET and POST handlers, but `docker/cron/crontab` never got an entry for it — so Terminal Machine persistent-storage billing never reconciles. Latent today (`CODE_EXECUTION_ENABLED` is OFF) but storage would ship unbilled at GA.

## Changes

**`docker/cron/crontab`** — hourly entry, placed with the other reconcile/sweep jobs, same GET pattern as `reconcile-credits`:
```
0 * * * * flock -n /run/reconcile-machine-storage.lock cron-curl GET __WEB_URL__/api/cron/reconcile-machine-storage >> /var/log/cron/reconcile-machine-storage.log 2>&1 || echo "$(date -u) tick skipped (lock held) or request failed" >> /var/log/cron/reconcile-machine-storage.log
```
- `flock -n` keeps this container's ticks from overlapping (review finding: charge + watermark-advance are two un-transactioned writes, so concurrent runs can double-bill the same window). A skipped tick is caught up exactly by the per-machine watermark next hour.
- The `|| echo` makes skipped/failed ticks visible in the log — otherwise `flock -n` exits 1 silently and a wedged run would be indistinguishable from a healthy quiet one.
- Lock lives in `/run` (not `/tmp`) so no cleanup can unlink a held lock file (flock locks the inode; unlink would silently break mutual exclusion).

**`docker/cron/entrypoint.sh` (cron-curl helper)** — `curl -s` → `curl -sS --connect-timeout 10 --max-time 3300` for all entries:
- Previously a wedged request hung forever; for the flock-serialized entry that would hold the lock permanently and silently starve every future tick. Now every request is bounded below the hourly tick.
- `-sS` prints transport errors into each entry's log instead of swallowing them.

**`docker/cron/Dockerfile`** — install `flock` (util-linux, confirmed in Alpine 3.21 main) explicitly so the entry can't silently fail on a missing busybox applet.

**`apps/web/src/app/api/cron/reconcile-machine-storage/route.ts`** — comment-only docblock correction (the one deviation from config-only, driven by review): it claimed "overlapping or repeated runs never double-bill", which is false for concurrent runs and contradicted the rest of this PR. No behavior change.

## Known residual (tracked follow-up, out of scope here)

The crontab flock guards only this container's own ticks. A manual signed POST, an out-of-band second cron machine, or a client-disconnect that leaves the server-side run in flight can still overlap. The authoritative fix is in-service serialization (`pg_try_advisory_lock`, same pattern as audit-chainer/siem-delivery workers) — tracked as a task on the deferred-items node with the residual documented in the route/service docs.

## Verification

- Route verified: GET (+POST alias) with `validateSignedCronRequest` HMAC auth — same scheme every entry uses via cron-curl; URL/method/path match the signer.
- Cross-file contract trace: HMAC message shape vs cron-auth verifier, nonce freshness window vs hourly cadence, `STALE_MEASUREMENT_MS`/`RECENTLY_ACTIVE_MS` cadence-independence, single-cron-container topology in compose main, compose tenant, and Fly deploy workflow (`flyctl scale count 1` + verify), log dir exists in image.
- No `%` in the cron command (crontab `%`-to-newline hazard avoided — `date -u` uses its default format).
- 8-angle review pass (line-by-line, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) ran over the diff; all confirmed findings addressed in `84ff9fa85` or explicitly tracked as the residual above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWBkQUgKqCBphueo738YPo