### PR TITLE
[publish 1-6] neutralize-dashboard-links transform

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -977,6 +977,11 @@
       "import": "./dist/canvas/primary-host.js",
       "require": "./dist/canvas/primary-host.js"
     },
+    "./publish/neutralize-dashboard-links": {
+      "types": "./dist/publish/neutralize-dashboard-links.d.ts",
+      "import": "./dist/publish/neutralize-dashboard-links.js",
+      "require": "./dist/publish/neutralize-dashboard-links.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",

--- a/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
+++ b/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+
+import { neutralizeDashboardLinks } from '../neutralize-dashboard-links';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('neutralizeDashboardLinks', () => {
+  it('converts a dashboard mention anchor into a span', () => {
+    assert({
+      given: 'an anchor whose href is a relative /dashboard/ path',
+      should: 'replace the anchor with a span preserving the inner HTML',
+      actual: neutralizeDashboardLinks(
+        '<p><a href="/dashboard/drive1/page1" class="mention" data-mention-type="page" data-page-id="page1">@My Page</a></p>',
+      ),
+      expected:
+        '<p><span data-mention-type="page" data-page-id="page1">@My Page</span></p>',
+    });
+  });
+
+  it('preserves data-mention-type and data-page-id in source order', () => {
+    assert({
+      given: 'an anchor with data-page-id before data-mention-type',
+      should: 'carry both attributes onto the span in their original order',
+      actual: neutralizeDashboardLinks(
+        '<a data-page-id="p9" href="/dashboard/d/p9" data-mention-type="page">@Nine</a>',
+      ),
+      expected: '<span data-page-id="p9" data-mention-type="page">@Nine</span>',
+    });
+  });
+
+  it('drops non-mention attributes from the neutralized span', () => {
+    assert({
+      given: 'an anchor with class, target, and rel attributes',
+      should: 'emit a span carrying only the mention data attributes',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p" class="mention" target="_blank" rel="noopener" data-mention-type="page" data-page-id="p">@Page</a>',
+      ),
+      expected: '<span data-mention-type="page" data-page-id="p">@Page</span>',
+    });
+  });
+
+  it('neutralizes a dashboard anchor without mention data attributes', () => {
+    assert({
+      given: 'a plain dashboard anchor with no data attributes',
+      should: 'replace it with a bare span around the inner HTML',
+      actual: neutralizeDashboardLinks('<a href="/dashboard/d/p">go</a>'),
+      expected: '<span>go</span>',
+    });
+  });
+
+  it('handles single-quoted href values', () => {
+    assert({
+      given: "an anchor whose href uses single quotes",
+      should: 'still neutralize it',
+      actual: neutralizeDashboardLinks(
+        "<a href='/dashboard/d/p' data-mention-type='page' data-page-id='p'>@P</a>",
+      ),
+      expected: '<span data-mention-type="page" data-page-id="p">@P</span>',
+    });
+  });
+
+  it('preserves nested markup inside the anchor', () => {
+    assert({
+      given: 'an anchor containing nested inline markup',
+      should: 'keep the nested markup inside the span',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p"><strong>bold</strong> and <em>italic</em></a>',
+      ),
+      expected: '<span><strong>bold</strong> and <em>italic</em></span>',
+    });
+  });
+
+  it('leaves published absolute URLs byte-identical', () => {
+    const html =
+      '<a href="https://mysite.pagespace.site/about" data-mention-type="page" data-page-id="p2">@About</a>';
+    assert({
+      given: 'an anchor already rewritten to a public https URL',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('leaves same-page fragment links byte-identical', () => {
+    const html = '<a href="#section-2">jump</a>';
+    assert({
+      given: 'a same-page fragment anchor',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('leaves non-dashboard relative links byte-identical', () => {
+    const html = '<a href="/pricing">pricing</a> <a href="mailto:a@b.c">mail</a>';
+    assert({
+      given: 'relative and mailto anchors that are not dashboard links',
+      should: 'leave them byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('does not treat an absolute dashboard URL as a leftover in-app link', () => {
+    const html = '<a href="https://pagespace.ai/dashboard/d/p">@Page</a>';
+    assert({
+      given: 'an anchor whose href is an absolute URL containing /dashboard/',
+      should: 'leave it byte-identical (only relative /dashboard/ paths are dead)',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('does not match paths that merely contain /dashboard/ mid-path', () => {
+    const html = '<a href="/docs/dashboard/setup">docs</a>';
+    assert({
+      given: 'an anchor whose relative href contains /dashboard/ but does not start with it',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('neutralizes only the dashboard anchors in mixed content', () => {
+    assert({
+      given: 'a document mixing dashboard, published, and fragment anchors',
+      should: 'neutralize only the dashboard ones',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p1" data-mention-type="page" data-page-id="p1">@One</a>' +
+          '<a href="https://s.pagespace.site/two">two</a>' +
+          '<a href="/dashboard/d/p3">three</a>' +
+          '<a href="#top">top</a>',
+      ),
+      expected:
+        '<span data-mention-type="page" data-page-id="p1">@One</span>' +
+        '<a href="https://s.pagespace.site/two">two</a>' +
+        '<span>three</span>' +
+        '<a href="#top">top</a>',
+    });
+  });
+
+  it('leaves an unclosed dashboard anchor unchanged without throwing', () => {
+    const html = '<p><a href="/dashboard/d/p">never closed</p>';
+    assert({
+      given: 'a malformed anchor with no closing tag',
+      should: 'leave the malformed region unchanged',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('still neutralizes well-formed anchors after a malformed one', () => {
+    assert({
+      given: 'a malformed anchor followed by a well-formed dashboard anchor',
+      should: 'neutralize the well-formed one and leave the rest intact',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/broken <a href="/dashboard/d/p">ok</a>',
+      ),
+      expected: '<a href="/dashboard/d/broken <span>ok</span>',
+    });
+  });
+
+  it('tolerates an anchor with no href', () => {
+    const html = '<a name="anchor-target">legacy</a>';
+    assert({
+      given: 'an anchor without an href attribute',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('is idempotent', () => {
+    const input =
+      '<p><a href="/dashboard/d/p" data-mention-type="page" data-page-id="p">@P</a> and <a href="#x">x</a></p>';
+    const once = neutralizeDashboardLinks(input);
+    assert({
+      given: 'already-neutralized output run through the transform again',
+      should: 'return it unchanged',
+      actual: neutralizeDashboardLinks(once),
+      expected: once,
+    });
+  });
+
+  it('returns empty input unchanged', () => {
+    assert({
+      given: 'an empty string',
+      should: 'return an empty string',
+      actual: neutralizeDashboardLinks(''),
+      expected: '',
+    });
+  });
+});

--- a/packages/lib/src/publish/neutralize-dashboard-links.ts
+++ b/packages/lib/src/publish/neutralize-dashboard-links.ts
@@ -1,0 +1,52 @@
+// At publish time, inter-page links whose target is itself published are
+// rewritten to public URLs (see apps/web's asset pipeline). Links to
+// UNPUBLISHED pages keep their in-app `/dashboard/{driveId}/{pageId}` href —
+// a dead, login-walled destination for an anonymous visitor. This transform
+// converts those leftover anchors into inert `<span>`s, preserving the inner
+// HTML and the mention data attributes so mention-chip CSS still applies.
+//
+// Pure string transform: no DOM, no I/O. The matcher is deliberately
+// conservative — an anchor tag whose attribute region contains `<` or `>`
+// (i.e. is malformed or unclosed) never matches and is left unchanged.
+
+// A well-formed opening tag (no `<`/`>` inside the attribute region), its
+// inner HTML (lazy, up to the nearest close tag — anchors cannot nest in
+// valid HTML), and the closing tag.
+const ANCHOR_RE = /<a\b([^<>]*)>([\s\S]*?)<\/a\s*>/gi;
+
+const HREF_RE = /(?:^|\s)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/i;
+
+// The mention attributes carried over onto the neutralized span.
+const MENTION_ATTR_RE =
+  /(?:^|\s)(data-mention-type|data-page-id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/gi;
+
+const extractHref = (attrs: string): string | undefined => {
+  const match = attrs.match(HREF_RE);
+  if (!match) return undefined;
+  return match[1] ?? match[2] ?? match[3];
+};
+
+const mentionAttrs = (attrs: string): string => {
+  const kept: string[] = [];
+  for (const match of attrs.matchAll(MENTION_ATTR_RE)) {
+    const name = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    kept.push(`${name}="${value.replace(/"/g, '&quot;')}"`);
+  }
+  return kept.length > 0 ? ` ${kept.join(' ')}` : '';
+};
+
+/**
+ * Replace anchors that still point into the app (`href` starting with the
+ * relative `/dashboard/` path) with inert `<span>`s, preserving inner HTML
+ * and any `data-mention-type`/`data-page-id` attributes. All other anchors —
+ * published `https://` URLs, same-page fragments, non-dashboard paths — and
+ * any malformed/unclosed anchor markup are left byte-identical. Idempotent.
+ */
+export function neutralizeDashboardLinks(html: string): string {
+  return html.replace(ANCHOR_RE, (anchor, attrs: string, inner: string) => {
+    const href = extractHref(attrs);
+    if (href === undefined || !href.startsWith('/dashboard/')) return anchor;
+    return `<span${mentionAttrs(attrs)}>${inner}</span>`;
+  });
+}


### PR DESCRIPTION
## Summary

Adds `packages/lib/src/publish/neutralize-dashboard-links.ts` (Lane B, task 1-6; blocks 1-7): a pure string transform that converts leftover in-app `/dashboard/{driveId}/{pageId}` anchors in published document HTML into inert `<span>`s.

At publish time the asset pipeline rewrites inter-page links whose target is itself published to public URLs — but links to unpublished pages keep their dashboard href, which is a dead login-walled link for an anonymous visitor.

## Behavior

- Anchor with `href` starting with relative `/dashboard/` → replaced by `<span>` preserving inner HTML (including nested markup) and `data-mention-type`/`data-page-id` attributes in source order, so mention-chip CSS from 1-3 still applies.
- Published `https://` URLs (including absolute URLs that contain `/dashboard/`), same-page fragments (`#…`), non-dashboard hrefs, and href-less anchors → byte-identical.
- Malformed/unclosed anchors never match (the opening-tag matcher rejects `<`/`>` inside the attribute region) — left unchanged, never throws; well-formed anchors after a malformed region are still neutralized.
- Idempotent.

Lives in `packages/lib` (cannot import from apps/web), with its own conservative matcher modeled on the `INTER_PAGE_LINK_RE` family in `apps/web/src/lib/canvas/file-view-links.ts`. Added the `./publish/neutralize-dashboard-links` exports entry to `packages/lib/package.json`.

## Testing

- TDD: 17 colocated riteway-style vitest cases in `src/publish/__tests__/neutralize-dashboard-links.test.ts` (written first, red → green).
- `bun run typecheck`, `bun run build`, `bun run lint` in packages/lib: clean.
- No `any`; bun only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYot8EYcBEA77oaNW3mZgo