### PR TITLE
[publish 1-2] sanitize-document-html pure module

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -982,6 +982,11 @@
       "import": "./dist/publish/neutralize-dashboard-links.js",
       "require": "./dist/publish/neutralize-dashboard-links.js"
     },
+    "./publish/sanitize-document-html": {
+      "types": "./dist/publish/sanitize-document-html.d.ts",
+      "import": "./dist/publish/sanitize-document-html.js",
+      "require": "./dist/publish/sanitize-document-html.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1987,6 +1992,9 @@
       ],
       "canvas/primary-host": [
         "./dist/canvas/primary-host.d.ts"
+      ],
+      "publish/sanitize-document-html": [
+        "./dist/publish/sanitize-document-html.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
+++ b/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
@@ -177,6 +177,15 @@ describe('sanitizeDocumentHtml', () => {
       });
     });
 
+    it('removes on* attributes separated by a slash instead of whitespace', () => {
+      assert({
+        given: 'an <img/onerror=...> using "/" as the attribute separator',
+        should: 'remove the handler (browsers treat "/" like whitespace here)',
+        actual: sanitizeDocumentHtml('<img/onerror=alert(1) src="x.png">'),
+        expected: '<img src="x.png">',
+      });
+    });
+
     it('handles a ">" inside a quoted attribute value before the handler', () => {
       assert({
         given: 'an element whose alt contains ">" followed by an onerror',
@@ -194,6 +203,24 @@ describe('sanitizeDocumentHtml', () => {
         should: 'remove the href attribute, keep the anchor',
         actual: sanitizeDocumentHtml('<a href="javascript:alert(1)">x</a>'),
         expected: '<a>x</a>',
+      });
+    });
+
+    it('removes unquoted javascript: hrefs', () => {
+      assert({
+        given: 'an unquoted javascript: href value',
+        should: 'remove the attribute',
+        actual: sanitizeDocumentHtml('<a href=javascript:alert(1)>x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: xlink:href values on SVG elements', () => {
+      assert({
+        given: 'an SVG <a xlink:href="javascript:...">',
+        should: 'remove the attribute, keep the element',
+        actual: sanitizeDocumentHtml('<svg><a xlink:href="javascript:alert(1)"><text>x</text></a></svg>'),
+        expected: '<svg><a><text>x</text></a></svg>',
       });
     });
 

--- a/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
+++ b/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
@@ -224,6 +224,24 @@ describe('sanitizeDocumentHtml', () => {
       });
     });
 
+    it('removes data:text/html hidden behind &sol; entities', () => {
+      assert({
+        given: 'a href spelling data:text/html with the slash as &sol;',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="data:text&sol;html,<script>alert(1)</script>">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes data:text/html hidden behind numeric slash entities', () => {
+      assert({
+        given: 'a href spelling data:text/html with the slash as &#47; / &#x2F;',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="data:text&#47;html,x">a</a><a href="data:text&#x2F;html,x">b</a>'),
+        expected: '<a>a</a><a>b</a>',
+      });
+    });
+
     it('removes data:text/html srcs and hrefs', () => {
       assert({
         given: 'a href with a data:text/html payload (any casing)',

--- a/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
+++ b/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeDocumentHtml } from '../sanitize-document-html';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('sanitizeDocumentHtml', () => {
+  describe('script stripping', () => {
+    it('strips a plain script block, tag and content', () => {
+      assert({
+        given: 'HTML with a <script> block between paragraphs',
+        should: 'remove the whole block (tag + content)',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)</script><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips mixed-case script tags with attributes', () => {
+      assert({
+        given: 'a <SCRIPT> with attributes and mixed-case close tag',
+        should: 'remove the whole block',
+        actual: sanitizeDocumentHtml(
+          '<p>x</p><SCRIPT type="text/javascript" src="https://evil.example/x.js">bad()</ScRiPt><p>y</p>'
+        ),
+        expected: '<p>x</p><p>y</p>',
+      });
+    });
+
+    it('strips a script left unclosed at EOF', () => {
+      assert({
+        given: 'a <script> that is never closed',
+        should: 'remove everything from the open tag to EOF',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)'),
+        expected: '<p>a</p>',
+      });
+    });
+
+    it('strips a close tag padded with junk', () => {
+      assert({
+        given: 'a script closed by `</script foo="bar">`',
+        should: 'still find the close tag and remove the block',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)</script foo="bar"><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('does not mistake hyphenated custom elements for scripts', () => {
+      assert({
+        given: 'a <script-template> custom element',
+        should: 'leave it untouched (tag name requires a real delimiter)',
+        actual: sanitizeDocumentHtml('<script-template><p>hi</p></script-template>'),
+        expected: '<script-template><p>hi</p></script-template>',
+      });
+    });
+
+    it('defeats the split-tag reassembly trick', () => {
+      const out = sanitizeDocumentHtml('<<script>x</script>script src="https://evil.example/x.js">alert(1)</script>');
+      assert({
+        given: 'a payload whose script tag reassembles after one strip pass',
+        should: 'leave no executable <script open tag in the output',
+        actual: /<script(?=[\s/>])/i.test(out),
+        expected: false,
+      });
+    });
+  });
+
+  describe('forbidden elements', () => {
+    it('strips iframes with their content', () => {
+      assert({
+        given: 'an <iframe> with fallback content',
+        should: 'remove the element entirely',
+        actual: sanitizeDocumentHtml('<p>a</p><iframe src="https://evil.example">fallback</iframe><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips object and embed elements', () => {
+      assert({
+        given: '<object> and <embed> elements',
+        should: 'remove both',
+        actual: sanitizeDocumentHtml('<object data="x.swf">o</object><p>keep</p><embed src="x.swf">'),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips form elements', () => {
+      assert({
+        given: 'a <form> wrapping inputs',
+        should: 'remove the form element entirely',
+        actual: sanitizeDocumentHtml('<p>a</p><form action="/steal"><input name="pw"></form><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips base, meta and link tags', () => {
+      assert({
+        given: 'void head-manipulation tags (<base>, <meta>, <link>)',
+        should: 'remove all of them',
+        actual: sanitizeDocumentHtml(
+          '<base href="https://evil.example/"><meta http-equiv="refresh" content="0;url=x"><link rel="stylesheet" href="x.css"><p>keep</p>'
+        ),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips style blocks with their content', () => {
+      assert({
+        given: 'a <style> block (documents are styled by the shell)',
+        should: 'remove tag and CSS content',
+        actual: sanitizeDocumentHtml('<style>p { display: none; }</style><p>keep</p>'),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips a style block left unclosed at EOF', () => {
+      assert({
+        given: 'a <style> that is never closed',
+        should: 'remove everything from the open tag to EOF',
+        actual: sanitizeDocumentHtml('<p>a</p><style>p{}'),
+        expected: '<p>a</p>',
+      });
+    });
+
+    it('strips mixed-case forbidden elements', () => {
+      assert({
+        given: 'an <IFRAME> in caps',
+        should: 'remove it (matching is case-insensitive)',
+        actual: sanitizeDocumentHtml('<IFRAME SRC="x"></IFRAME><p>keep</p>'),
+        expected: '<p>keep</p>',
+      });
+    });
+  });
+
+  describe('event handler attributes', () => {
+    it('removes on* attributes but keeps the element', () => {
+      assert({
+        given: 'an <img> with an onerror handler',
+        should: 'drop the handler, keep the element and its other attributes',
+        actual: sanitizeDocumentHtml('<img src="x.png" onerror="alert(1)" alt="pic">'),
+        expected: '<img src="x.png" alt="pic">',
+      });
+    });
+
+    it('removes on* attributes in any casing', () => {
+      assert({
+        given: 'a <div ONCLICK=...> in caps',
+        should: 'remove the attribute regardless of case',
+        actual: sanitizeDocumentHtml("<div ONCLICK='alert(1)'>hi</div>"),
+        expected: '<div>hi</div>',
+      });
+    });
+
+    it('removes unquoted on* attribute values', () => {
+      assert({
+        given: 'an unquoted onmouseover value',
+        should: 'remove the whole attribute',
+        actual: sanitizeDocumentHtml('<a onmouseover=alert(1) href="/ok">x</a>'),
+        expected: '<a href="/ok">x</a>',
+      });
+    });
+
+    it('does not remove data-* attributes that merely contain "on"', () => {
+      assert({
+        given: 'a span with data-mention-type (contains "on" but is not a handler)',
+        should: 'keep the attribute',
+        actual: sanitizeDocumentHtml('<span data-mention-type="page">@Home</span>'),
+        expected: '<span data-mention-type="page">@Home</span>',
+      });
+    });
+
+    it('handles a ">" inside a quoted attribute value before the handler', () => {
+      assert({
+        given: 'an element whose alt contains ">" followed by an onerror',
+        should: 'parse the tag quote-aware and still remove the handler',
+        actual: sanitizeDocumentHtml('<img alt="a>b" onerror="alert(1)" src="x.png">'),
+        expected: '<img alt="a>b" src="x.png">',
+      });
+    });
+  });
+
+  describe('dangerous URL schemes', () => {
+    it('removes javascript: hrefs', () => {
+      assert({
+        given: 'an anchor with a javascript: href',
+        should: 'remove the href attribute, keep the anchor',
+        actual: sanitizeDocumentHtml('<a href="javascript:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: hrefs with case and whitespace tricks', () => {
+      assert({
+        given: 'a href of " JaVaScRiPt:..." with leading space and mixed case',
+        should: 'still detect and remove it',
+        actual: sanitizeDocumentHtml('<a href=" JaVaScRiPt:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: hrefs with embedded tab/newline', () => {
+      assert({
+        given: 'a href with a tab and newline inside the scheme (browser strips them)',
+        should: 'still detect and remove it',
+        actual: sanitizeDocumentHtml('<a href="java\tscri\npt:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: hidden behind HTML entities', () => {
+      assert({
+        given: 'a href spelling javascript: with numeric/named entities',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="&#106;avascript&colon;alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes data:text/html srcs and hrefs', () => {
+      assert({
+        given: 'a href with a data:text/html payload (any casing)',
+        should: 'remove the attribute',
+        actual: sanitizeDocumentHtml('<a href="DATA:text/html;base64,PHNjcmlwdD4=">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('keeps benign URL schemes', () => {
+      const benign =
+        '<a href="https://example.com/a">a</a>' +
+        '<a href="/relative/path">b</a>' +
+        '<a href="mailto:hi@example.com">c</a>' +
+        '<img src="data:image/png;base64,iVBORw0KGgo=">';
+      assert({
+        given: 'https, relative, mailto and data:image URLs',
+        should: 'pass them through untouched',
+        actual: sanitizeDocumentHtml(benign),
+        expected: benign,
+      });
+    });
+  });
+
+  describe('benign TipTap output', () => {
+    const tiptap =
+      '<h1>Title</h1>' +
+      '<h2>Sub</h2><h3>a</h3><h4>b</h4><h5>c</h5><h6>d</h6>' +
+      '<p>Hello <strong>bold</strong> and <em>italic</em> text.</p>' +
+      '<ul><li>one</li><li>two</li></ul>' +
+      '<ol><li>first</li></ol>' +
+      '<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>cell</td></tr></tbody></table>' +
+      '<img src="https://cdn.example.com/img.png" alt="pic" width="100">' +
+      '<a href="https://example.com" target="_blank" rel="noopener">link</a>' +
+      '<pre><code>const x = 1 &lt; 2;</code></pre>' +
+      '<blockquote><p>quote</p></blockquote>' +
+      '<hr>' +
+      '<p><span data-mention-type="page" data-id="abc123">@Home</span></p>';
+
+    it('passes benign TipTap output through byte-identical', () => {
+      assert({
+        given: 'typical TipTap-authored document HTML',
+        should: 'return it byte-identical',
+        actual: sanitizeDocumentHtml(tiptap),
+        expected: tiptap,
+      });
+    });
+  });
+
+  describe('idempotence', () => {
+    const nastyInputs = [
+      '<p>a</p><script>alert(1)</script><p>b</p>',
+      '<<script>x</script>script src="x">alert(1)</script>',
+      '<img src="x.png" onerror="alert(1)">',
+      '<a href="javascript:alert(1)">x</a>',
+      '<style>p{}</style><iframe src="x"></iframe><form><input></form>',
+      '<scri<script></script>pt>alert(1)</scri</script>ipt>',
+      '<p>plain</p>',
+    ];
+
+    it('is idempotent on every input', () => {
+      for (const input of nastyInputs) {
+        const once = sanitizeDocumentHtml(input);
+        assert({
+          given: `input ${JSON.stringify(input.slice(0, 40))}…`,
+          should: 'satisfy sanitize(sanitize(x)) === sanitize(x)',
+          actual: sanitizeDocumentHtml(once),
+          expected: once,
+        });
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for empty input', () => {
+      assert({
+        given: 'an empty string',
+        should: 'return an empty string',
+        actual: sanitizeDocumentHtml(''),
+        expected: '',
+      });
+    });
+
+    it('leaves a bare "<" literal alone', () => {
+      assert({
+        given: 'text containing a stray "<" that is not a tag',
+        should: 'pass it through',
+        actual: sanitizeDocumentHtml('<p>1 < 2 is true</p>'),
+        expected: '<p>1 < 2 is true</p>',
+      });
+    });
+
+    it('strips orphan close tags of forbidden elements', () => {
+      assert({
+        given: 'a stray </script> with no matching open tag',
+        should: 'remove it',
+        actual: sanitizeDocumentHtml('<p>a</p></script><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+  });
+});

--- a/packages/lib/src/publish/sanitize-document-html.ts
+++ b/packages/lib/src/publish/sanitize-document-html.ts
@@ -46,23 +46,34 @@ const isForbiddenElement = (name: string): boolean =>
 
 /**
  * Minimal entity decoding for the scheme CHECK only (never for output):
- * numeric references plus the handful of named ones attackers use to split a
- * scheme (`&colon;`, `&tab;`, `&newline;`). Decoding more would risk changing
- * benign values; here a decode error only means we inspect a stricter string.
+ * numeric references plus every named entity that yields a character the two
+ * denied scheme prefixes are built from — `:` (`&colon;`), `/` (`&sol;`) and
+ * the whitespace browsers strip (`&Tab;`, `&NewLine;`). ASCII letters have no
+ * named entities, so this set is complete for `javascript:`/`data:text/html`.
+ * Decoding more would risk changing benign values; matching is deliberately
+ * case-insensitive (broader than HTML) — a false decode only means we inspect
+ * a stricter string.
  */
+const NAMED_ENTITIES_FOR_CHECK: ReadonlyArray<[RegExp, string]> = [
+  [/&colon;/gi, ':'],
+  [/&sol;/gi, '/'],
+  [/&tab;/gi, '\t'],
+  [/&newline;/gi, '\n'],
+];
+
 const decodeEntitiesForCheck = (value: string): string =>
-  value
-    .replace(/&#x([0-9a-f]+);?/gi, (_, hex: string) => {
-      const code = parseInt(hex, 16);
-      return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
-    })
-    .replace(/&#(\d+);?/g, (_, dec: string) => {
-      const code = parseInt(dec, 10);
-      return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
-    })
-    .replace(/&colon;/gi, ':')
-    .replace(/&tab;/gi, '\t')
-    .replace(/&newline;/gi, '\n');
+  NAMED_ENTITIES_FOR_CHECK.reduce(
+    (decoded, [entity, char]) => decoded.replace(entity, char),
+    value
+      .replace(/&#x([0-9a-f]+);?/gi, (_, hex: string) => {
+        const code = parseInt(hex, 16);
+        return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+      })
+      .replace(/&#(\d+);?/g, (_, dec: string) => {
+        const code = parseInt(dec, 10);
+        return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+      })
+  );
 
 /**
  * True when a URL attribute value resolves to an executable scheme. Browsers

--- a/packages/lib/src/publish/sanitize-document-html.ts
+++ b/packages/lib/src/publish/sanitize-document-html.ts
@@ -1,0 +1,236 @@
+/**
+ * Sanitize TipTap-authored DOCUMENT HTML for publishing.
+ *
+ * Published documents must never execute author scripts — unlike CANVAS pages,
+ * whose whole point is author JS (see `canvas/render-document.ts`, which
+ * PRESERVES scripts because canvas isolation is by origin). The hard
+ * enforcement for documents is CSP (`script-src 'none'`); this module is the
+ * hygiene layer that keeps the markup itself clean:
+ *
+ *   - `<script>`/`<style>` blocks are removed with their content, and
+ *     `<iframe>`/`<object>`/`<form>` elements likewise (their inner content is
+ *     fallback/control junk, not document prose). `<embed>`/`<base>`/`<meta>`/
+ *     `<link>` are void — the tags are removed.
+ *   - `on*` event-handler attributes are removed; the element is kept.
+ *   - `href`/`src` values with `javascript:` or `data:text/html` schemes are
+ *     removed (attribute only), after undoing case/whitespace/entity tricks.
+ *
+ * Pure function: no DOM, no I/O, deterministic — it runs identically in Node
+ * and the browser. Benign TipTap output passes through byte-identical, and the
+ * function is idempotent.
+ *
+ * Parsing mirrors the HTML tokenizer the same way `render-document.ts` does:
+ * a tag name only counts when followed by a genuine delimiter (whitespace, `/`
+ * or `>`), so `<script-template>` is never mistaken for `<script>`; and
+ * attribute scanning is quote-aware, so a `>` inside a quoted value (e.g.
+ * `alt="a>b"`) cannot end the tag early and smuggle a handler past the scan.
+ *
+ * The whole pass loops to a fixpoint because removals can concatenate
+ * surrounding text into a NEW dangerous construct (`<` + stripped block +
+ * `script src=…>` reassembles into a live script tag). Every pass only ever
+ * deletes characters, so the loop strictly shrinks and always terminates.
+ */
+
+/** Elements removed together with their content (first matching close tag wins,
+ * as in the HTML tokenizer; unclosed at EOF consumes the rest). */
+const STRIP_WITH_CONTENT = new Set(['script', 'style', 'iframe', 'object', 'form']);
+
+/** Void (or effectively void) elements whose tags are removed outright. */
+const STRIP_TAG_ONLY = new Set(['embed', 'base', 'meta', 'link']);
+
+/** Attributes whose values are URLs and must not carry executable schemes. */
+const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
+
+const isForbiddenElement = (name: string): boolean =>
+  STRIP_WITH_CONTENT.has(name) || STRIP_TAG_ONLY.has(name);
+
+/**
+ * Minimal entity decoding for the scheme CHECK only (never for output):
+ * numeric references plus the handful of named ones attackers use to split a
+ * scheme (`&colon;`, `&tab;`, `&newline;`). Decoding more would risk changing
+ * benign values; here a decode error only means we inspect a stricter string.
+ */
+const decodeEntitiesForCheck = (value: string): string =>
+  value
+    .replace(/&#x([0-9a-f]+);?/gi, (_, hex: string) => {
+      const code = parseInt(hex, 16);
+      return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+    })
+    .replace(/&#(\d+);?/g, (_, dec: string) => {
+      const code = parseInt(dec, 10);
+      return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+    })
+    .replace(/&colon;/gi, ':')
+    .replace(/&tab;/gi, '\t')
+    .replace(/&newline;/gi, '\n');
+
+/**
+ * True when a URL attribute value resolves to an executable scheme. Browsers
+ * strip ASCII control characters and whitespace inside/around the scheme
+ * before matching it, so the check does the same (only for the comparison —
+ * kept attributes are emitted verbatim).
+ */
+const hasDangerousScheme = (rawValue: string): boolean => {
+  const normalized = decodeEntitiesForCheck(rawValue)
+    .replace(/[\u0000-\u0020]+/g, '')
+    .toLowerCase();
+  return normalized.startsWith('javascript:') || normalized.startsWith('data:text/html');
+};
+
+interface ScannedAttribute {
+  /** Lowercased attribute name. */
+  name: string;
+  /** Attribute value with surrounding quotes removed ('' when valueless). */
+  value: string;
+  /** Slice bounds in the source covering leading whitespace + name + value. */
+  start: number;
+  end: number;
+}
+
+interface ScannedTag {
+  /** Index just past the closing `>` (or EOF for an unterminated tag). */
+  end: number;
+  attributes: ScannedAttribute[];
+}
+
+/**
+ * Scan an open tag's attribute area starting just past the tag name.
+ * Quote-aware per the HTML attribute-value states: `>` inside a quoted value
+ * does not end the tag.
+ */
+const scanTag = (html: string, from: number): ScannedTag => {
+  const attributes: ScannedAttribute[] = [];
+  let i = from;
+  while (i < html.length) {
+    const attrStart = i;
+    while (i < html.length && (/\s/.test(html[i]) || html[i] === '/')) i++;
+    if (i >= html.length) break;
+    if (html[i] === '>') return { end: i + 1, attributes };
+
+    // Attribute name: anything up to whitespace, `=`, `/` or `>`.
+    const nameStart = i;
+    while (i < html.length && !/[\s=/>]/.test(html[i])) i++;
+    const name = html.slice(nameStart, i).toLowerCase();
+
+    // Optional `= value`.
+    let value = '';
+    let valueEnd = i;
+    let j = i;
+    while (j < html.length && /\s/.test(html[j])) j++;
+    if (html[j] === '=') {
+      j++;
+      while (j < html.length && /\s/.test(html[j])) j++;
+      const quote = html[j];
+      if (quote === '"' || quote === "'") {
+        const closeQuote = html.indexOf(quote, j + 1);
+        const valueTo = closeQuote === -1 ? html.length : closeQuote;
+        value = html.slice(j + 1, valueTo);
+        valueEnd = closeQuote === -1 ? html.length : closeQuote + 1;
+      } else {
+        const valueStart = j;
+        while (j < html.length && !/[\s>]/.test(html[j])) j++;
+        value = html.slice(valueStart, j);
+        valueEnd = j;
+      }
+      i = valueEnd;
+    }
+    attributes.push({ name, value, start: attrStart, end: valueEnd });
+  }
+  return { end: html.length, attributes };
+};
+
+const isDroppedAttribute = (attr: ScannedAttribute): boolean =>
+  attr.name.startsWith('on') || (URL_ATTRIBUTES.has(attr.name) && hasDangerousScheme(attr.value));
+
+/** Re-emit an open tag with its offending attributes spliced out. */
+const cleanTagMarkup = (html: string, tagStart: number, scanned: ScannedTag): string => {
+  let out = '';
+  let cursor = tagStart;
+  for (const attr of scanned.attributes) {
+    if (!isDroppedAttribute(attr)) continue;
+    out += html.slice(cursor, attr.start);
+    cursor = attr.end;
+  }
+  return out + html.slice(cursor, scanned.end);
+};
+
+/**
+ * Find the index just past the first `</name …>` close tag at or after `from`.
+ * Same close-tag shape as `render-document.ts`: junk after the name is
+ * tolerated up to `>`, but the name itself needs a genuine delimiter so
+ * `</script-template>` never closes a `<script>`. Returns EOF when unclosed.
+ */
+const skipPastCloseTag = (html: string, name: string, from: number): number => {
+  const close = new RegExp(`</${name}(?=[\\s/>])[^>]*>`, 'gi');
+  close.lastIndex = from;
+  const match = close.exec(html);
+  return match ? match.index + match[0].length : html.length;
+};
+
+const TAG_NAME = /^[a-zA-Z][a-zA-Z0-9-]*/;
+
+/** One full sanitize pass. Only ever deletes characters, never inserts. */
+const sanitizePass = (html: string): string => {
+  let out = '';
+  let i = 0;
+  while (i < html.length) {
+    const lt = html.indexOf('<', i);
+    if (lt === -1) {
+      out += html.slice(i);
+      break;
+    }
+    out += html.slice(i, lt);
+
+    const isCloseTag = html[lt + 1] === '/';
+    const nameMatch = TAG_NAME.exec(html.slice(lt + (isCloseTag ? 2 : 1)));
+    if (!nameMatch) {
+      // Not a tag (stray `<`, comment, doctype…) — emit the `<` and move on.
+      out += '<';
+      i = lt + 1;
+      continue;
+    }
+    const name = nameMatch[0].toLowerCase();
+    const afterName = lt + (isCloseTag ? 2 : 1) + nameMatch[0].length;
+    // A real tag name must be followed by a delimiter — `<script-template>`
+    // already failed the Set lookups (full name matched), this guards `<p<`.
+    const scanned = scanTag(html, afterName);
+
+    if (isCloseTag) {
+      // Orphan close tags of forbidden elements are dropped; others verbatim.
+      out += isForbiddenElement(name) ? '' : html.slice(lt, scanned.end);
+      i = scanned.end;
+      continue;
+    }
+
+    if (STRIP_WITH_CONTENT.has(name)) {
+      i = skipPastCloseTag(html, name, scanned.end);
+      continue;
+    }
+    if (STRIP_TAG_ONLY.has(name)) {
+      i = scanned.end;
+      continue;
+    }
+
+    out += scanned.attributes.some(isDroppedAttribute)
+      ? cleanTagMarkup(html, lt, scanned)
+      : html.slice(lt, scanned.end);
+    i = scanned.end;
+  }
+  return out;
+};
+
+/**
+ * Sanitize published DOCUMENT HTML. Idempotent; benign TipTap output passes
+ * through byte-identical.
+ */
+export const sanitizeDocumentHtml = (html: string): string => {
+  // Loop to a fixpoint: removing a block can concatenate its neighbours into
+  // a new dangerous construct. Passes only delete, so length strictly
+  // decreases until stable — guaranteed termination.
+  let previous = html;
+  for (;;) {
+    const next = sanitizePass(previous);
+    if (next === previous) return next;
+    previous = next;
+  }
+};

--- a/packages/lib/src/publish/sanitize-document-html.ts
+++ b/packages/lib/src/publish/sanitize-document-html.ts
@@ -178,7 +178,8 @@ const skipPastCloseTag = (html: string, name: string, from: number): number => {
   return match ? match.index + match[0].length : html.length;
 };
 
-const TAG_NAME = /^[a-zA-Z][a-zA-Z0-9-]*/;
+// Sticky so it matches in place at lastIndex — no per-tag slicing.
+const TAG_NAME = /[a-zA-Z][a-zA-Z0-9-]*/y;
 
 /** One full sanitize pass. Only ever deletes characters, never inserts. */
 const sanitizePass = (html: string): string => {
@@ -193,7 +194,8 @@ const sanitizePass = (html: string): string => {
     out += html.slice(i, lt);
 
     const isCloseTag = html[lt + 1] === '/';
-    const nameMatch = TAG_NAME.exec(html.slice(lt + (isCloseTag ? 2 : 1)));
+    TAG_NAME.lastIndex = lt + (isCloseTag ? 2 : 1);
+    const nameMatch = TAG_NAME.exec(html);
     if (!nameMatch) {
       // Not a tag (stray `<`, comment, doctype…) — emit the `<` and move on.
       out += '<';


### PR DESCRIPTION
## Summary

Leaf **1-2** of the publish-any-page-type epic (Lane A start; blocks 1-4).

Published DOCUMENT pages must never execute author scripts — unlike CANVAS, whose whole point is author JS. The hard enforcement is CSP (`script-src 'none'`, leaf 1-4); this PR adds the hygiene layer on TipTap-authored HTML: `sanitizeDocumentHtml` in `packages/lib/src/publish/sanitize-document-html.ts`, a pure function (no DOM, no I/O, deterministic).

## Behavior

- `<script>` blocks stripped entirely — tag + content, any casing, attributes, junk-padded close tags (`</script foo>`), unclosed at EOF
- `<style>/<iframe>/<object>/<form>` stripped with content; `<embed>/<base>/<meta>/<link>` tags stripped (documents get styling from the shell)
- `on*` attributes removed (any casing, whitespace- or `/`-separated), element kept
- `href`/`src`/`xlink:href` with `javascript:` or `data:text/html` schemes: attribute removed — case, embedded tab/newline, and HTML-entity tricks (numeric plus `&colon;`/`&sol;`/`&Tab;`/`&NewLine;`) are normalized for the check only; kept attributes are emitted verbatim
- Benign TipTap output (`p, h1–h6, lists, tables, img, a, code/pre, blockquote, hr, strong/em, data-mention-type spans`) passes through **byte-identical**
- Idempotent: `sanitize(sanitize(x)) === sanitize(x)`

## Implementation notes

- Reuses the `(?=[\s/>])` tag-name delimiter lookahead from `canvas/render-document.ts` — `<script-template>` custom elements survive; no naive `<script>.*?</script>` regex
- Quote-aware attribute scanner, so `alt="a>b"` can't end a tag early and smuggle a handler past the scan
- Whole pass loops to a fixpoint: removals only ever delete characters, so split-tag reassembly payloads (`<<script>x</script>script src=…>`) can't survive a single call
- `packages/lib/package.json` gets `exports` + `typesVersions` entries for the new `publish/` subpath

## Review history

- Codex P2 (`&sol;` entity bypassed the `data:text/html` check): fixed in 8d15e20c3 with regression tests for `&sol;`/`&#47;`/`&#x2F;`
- Rebased onto base after #2033 landed (kept both `publish/` exports entries)
- Self-review pass: sticky tag-name regex, added tests for unquoted `javascript:` href, `xlink:href`, `/`-separated `on*`
- Findings recorded on epic leaf page `o5n1fp7woe3ii565y4p5bt5t` (## Findings)

## Testing

- 34 colocated riteway-style vitest cases (TDD — written failing first): stripping, handler/scheme attribute removal, byte-identical passthrough, idempotence, split-tag/orphan-close/entity edge cases
- `bun run typecheck` + `bun run build` clean in packages/lib; full lib suite 7957 passed (one pre-existing `security-audit-cutover.test.ts` timing flake, passes on rerun, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wrz5eTSEE6z3QxhUgW6iVP