### PR TITLE
[publish 1-3] document shell + typography CSS

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -987,6 +987,11 @@
       "import": "./dist/publish/sanitize-document-html.js",
       "require": "./dist/publish/sanitize-document-html.js"
     },
+    "./publish/document-shell": {
+      "types": "./dist/publish/document-shell.d.ts",
+      "import": "./dist/publish/document-shell.js",
+      "require": "./dist/publish/document-shell.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1995,6 +2000,9 @@
       ],
       "publish/sanitize-document-html": [
         "./dist/publish/sanitize-document-html.d.ts"
+      ],
+      "publish/document-shell": [
+        "./dist/publish/document-shell.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/src/publish/__tests__/document-shell.test.ts
+++ b/packages/lib/src/publish/__tests__/document-shell.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DOCUMENT_TYPOGRAPHY_CSS,
+  documentStartsWithH1,
+  wrapDocumentBody,
+} from '../document-shell';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('DOCUMENT_TYPOGRAPHY_CSS', () => {
+  it('should lay out a readable centered column', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'constrain the column to 42rem, center it, and set body padding + line-height',
+      actual:
+        DOCUMENT_TYPOGRAPHY_CSS.includes('max-width: 42rem') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('margin: 0 auto') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('padding: 2rem 1rem') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('line-height: 1.65'),
+      expected: true,
+    });
+  });
+
+  it('should use a system font stack', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'declare a system font stack (no webfont dependency)',
+      actual: DOCUMENT_TYPOGRAPHY_CSS.includes('-apple-system'),
+      expected: true,
+    });
+  });
+
+  it('should include a dark-mode media query', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'override colors under prefers-color-scheme: dark',
+      actual: DOCUMENT_TYPOGRAPHY_CSS.includes('@media (prefers-color-scheme: dark)'),
+      expected: true,
+    });
+  });
+
+  it('should not reference app CSS variables', () => {
+    assert({
+      given: 'the typography CSS (published pages have no app stylesheet)',
+      should: 'contain no var(--…) references',
+      actual: /var\(--/.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: false,
+    });
+  });
+
+  it('should scope every rule under .ps-document', () => {
+    const selectors = DOCUMENT_TYPOGRAPHY_CSS
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/@media[^{]+\{/g, '')
+      .split('}')
+      .map((chunk) => chunk.split('{')[0]?.trim())
+      .filter((selector): selector is string => Boolean(selector));
+    const unscoped = selectors
+      .flatMap((selector) => selector.split(','))
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0 && !part.startsWith('.ps-document'));
+    assert({
+      given: 'every selector in the typography CSS',
+      should: 'start with .ps-document so rules cannot leak into a host page',
+      actual: unscoped,
+      expected: [],
+    });
+  });
+
+  it('should style mention anchors as inline chips', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'target a[data-mention-type] with chip styling (radius + background)',
+      actual:
+        DOCUMENT_TYPOGRAPHY_CSS.includes('a[data-mention-type]') &&
+        /a\[data-mention-type\][^}]*border-radius/s.test(DOCUMENT_TYPOGRAPHY_CSS) &&
+        /a\[data-mention-type\][^}]*background/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should keep images inside the column', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'cap img width at 100%',
+      actual: /\.ps-document img[^}]*max-width: 100%/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should cover the core rich-text elements', () => {
+    const requiredSelectors = [
+      '.ps-document h1',
+      '.ps-document h2',
+      '.ps-document h3',
+      '.ps-document ul',
+      '.ps-document ol',
+      '.ps-document table',
+      '.ps-document pre',
+      '.ps-document code',
+      '.ps-document blockquote',
+      '.ps-document hr',
+      '.ps-document a',
+    ];
+    assert({
+      given: 'the typography CSS',
+      should: 'include rules for headings, lists, tables, code, quotes, rules, and links',
+      actual: requiredSelectors.filter((selector) => !DOCUMENT_TYPOGRAPHY_CSS.includes(selector)),
+      expected: [],
+    });
+  });
+});
+
+describe('documentStartsWithH1', () => {
+  it('should detect a leading <h1>', () => {
+    assert({
+      given: 'a body whose first element is <h1>',
+      should: 'return true',
+      actual: documentStartsWithH1('<h1>Title</h1><p>body</p>'),
+      expected: true,
+    });
+  });
+
+  it('should tolerate leading whitespace and HTML comments', () => {
+    assert({
+      given: 'a body with whitespace and comments before the <h1>',
+      should: 'return true',
+      actual: documentStartsWithH1('  \n<!-- generated -->\n <!-- two --> <h1>Title</h1>'),
+      expected: true,
+    });
+  });
+
+  it('should accept an <h1> that carries attributes', () => {
+    assert({
+      given: 'a body starting with <h1 class="…">',
+      should: 'return true',
+      actual: documentStartsWithH1('<h1 class="hero" id="top">Title</h1>'),
+      expected: true,
+    });
+  });
+
+  it('should be case-insensitive', () => {
+    assert({
+      given: 'a body starting with <H1>',
+      should: 'return true',
+      actual: documentStartsWithH1('<H1>Title</H1>'),
+      expected: true,
+    });
+  });
+
+  it('should reject a body starting with another element', () => {
+    assert({
+      given: 'a body starting with <h2>',
+      should: 'return false',
+      actual: documentStartsWithH1('<h2>Subtitle</h2>'),
+      expected: false,
+    });
+  });
+
+  it('should reject an <h1> that is not the first element', () => {
+    assert({
+      given: 'a body whose <h1> comes after a paragraph',
+      should: 'return false',
+      actual: documentStartsWithH1('<p>intro</p><h1>Late title</h1>'),
+      expected: false,
+    });
+  });
+
+  it('should reject empty and comment-only bodies', () => {
+    assert({
+      given: 'an empty body, whitespace, or comments with no content',
+      should: 'return false for each',
+      actual: [
+        documentStartsWithH1(''),
+        documentStartsWithH1('   \n\t '),
+        documentStartsWithH1('<!-- nothing else -->'),
+        documentStartsWithH1('<!-- unterminated'),
+      ],
+      expected: [false, false, false, false],
+    });
+  });
+});
+
+describe('wrapDocumentBody', () => {
+  it('should wrap the body in a .ps-document article with a title header', () => {
+    assert({
+      given: 'a body with no leading <h1> and a title',
+      should: 'emit <article class="ps-document"> with an <header><h1> before the body',
+      actual: wrapDocumentBody({ bodyHtml: '<p>hello</p>', title: 'My Post' }),
+      expected: '<article class="ps-document"><header><h1>My Post</h1></header><p>hello</p></article>',
+    });
+  });
+
+  it('should suppress the header when the body already starts with an <h1>', () => {
+    assert({
+      given: 'a body whose first element is already an <h1>',
+      should: 'not emit a duplicate title header',
+      actual: wrapDocumentBody({ bodyHtml: '<h1>Own Title</h1><p>hello</p>', title: 'My Post' }),
+      expected: '<article class="ps-document"><h1>Own Title</h1><p>hello</p></article>',
+    });
+  });
+
+  it('should suppress the header when comments precede the <h1>', () => {
+    assert({
+      given: 'a body with leading whitespace/comments before its <h1>',
+      should: 'not emit a duplicate title header',
+      actual: wrapDocumentBody({
+        bodyHtml: '\n<!-- exported --><h1>Own Title</h1>',
+        title: 'My Post',
+      }),
+      expected: '<article class="ps-document">\n<!-- exported --><h1>Own Title</h1></article>',
+    });
+  });
+
+  it('should HTML-escape the title', () => {
+    assert({
+      given: 'a title containing HTML-special characters',
+      should: 'escape them in the emitted header',
+      actual: wrapDocumentBody({ bodyHtml: '<p>x</p>', title: 'Fish & <Chips> "rated" 5\'s' }),
+      expected:
+        '<article class="ps-document"><header><h1>Fish &amp; &lt;Chips&gt; &quot;rated&quot; 5&#39;s</h1></header><p>x</p></article>',
+    });
+  });
+
+  it('should keep the body verbatim', () => {
+    const bodyHtml = '<p>a</p><ul><li>b</li></ul><pre><code>c()</code></pre>';
+    assert({
+      given: 'an arbitrary rich-text body',
+      should: 'pass it through unmodified inside the article',
+      actual: wrapDocumentBody({ bodyHtml, title: 'T' }).includes(bodyHtml),
+      expected: true,
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/document-shell.test.ts
+++ b/packages/lib/src/publish/__tests__/document-shell.test.ts
@@ -59,22 +59,72 @@ describe('DOCUMENT_TYPOGRAPHY_CSS', () => {
     });
   });
 
-  it('should scope every rule under .ps-document', () => {
+  it('should scope every rule under .ps-document except page-canvas rules', () => {
+    // :root/body are the deliberate page-canvas exceptions: this stylesheet is
+    // only ever inlined into standalone published documents, and the canvas
+    // must follow the color scheme or dark mode yields light-on-white text.
+    const pageCanvasSelectors = new Set([':root', 'body', 'html']);
     const selectors = DOCUMENT_TYPOGRAPHY_CSS
       .replace(/\/\*[\s\S]*?\*\//g, '')
       .replace(/@media[^{]+\{/g, '')
+      .replace(/\([^)]*\)/g, '()')
       .split('}')
       .map((chunk) => chunk.split('{')[0]?.trim())
       .filter((selector): selector is string => Boolean(selector));
     const unscoped = selectors
       .flatMap((selector) => selector.split(','))
       .map((part) => part.trim())
-      .filter((part) => part.length > 0 && !part.startsWith('.ps-document'));
+      .filter(
+        (part) =>
+          part.length > 0 && !part.startsWith('.ps-document') && !pageCanvasSelectors.has(part),
+      );
     assert({
       given: 'every selector in the typography CSS',
-      should: 'start with .ps-document so rules cannot leak into a host page',
+      should: 'start with .ps-document (page-canvas :root/body rules excepted)',
       actual: unscoped,
       expected: [],
+    });
+  });
+
+  it('should give the page canvas a background in both color schemes', () => {
+    const [lightCss, darkCss] = DOCUMENT_TYPOGRAPHY_CSS.split('@media (prefers-color-scheme: dark)');
+    assert({
+      given: 'the page-canvas rules (published pages load no app stylesheet)',
+      should: 'set an explicit light body background and a dark override, not foreground-only',
+      actual:
+        /body\s*\{[^}]*background:\s*#ffffff/s.test(lightCss ?? '') &&
+        /body\s*\{[^}]*background:\s*#0d1117/s.test(darkCss ?? ''),
+      expected: true,
+    });
+  });
+
+  it('should declare color-scheme so UA defaults follow the scheme', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'declare color-scheme: light dark on :root',
+      actual: /:root\s*\{[^}]*color-scheme:\s*light dark/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should reset UA margins before applying the document rhythm', () => {
+    const resetIndex = DOCUMENT_TYPOGRAPHY_CSS.indexOf(':where(');
+    const rhythmIndex = DOCUMENT_TYPOGRAPHY_CSS.indexOf('> * + *');
+    const resetBlock = /\.ps-document\s+:where\(([^)]*)\)\s*\{[^}]*margin:\s*0/s.exec(
+      DOCUMENT_TYPOGRAPHY_CSS,
+    );
+    const resetTargets = resetBlock?.[1] ?? '';
+    assert({
+      given: 'standalone output with browser default margins (no Tailwind Preflight)',
+      should: 'zero UA margins on rich-text descendants via a low-specificity :where reset placed before the sibling rhythm',
+      actual:
+        resetIndex !== -1 &&
+        rhythmIndex !== -1 &&
+        resetIndex < rhythmIndex &&
+        ['p', 'blockquote', 'figure', 'ul', 'h2'].every((tag) =>
+          new RegExp(`(^|[,\\s])${tag}([,\\s]|$)`).test(resetTargets),
+        ),
+      expected: true,
     });
   });
 

--- a/packages/lib/src/publish/document-shell.ts
+++ b/packages/lib/src/publish/document-shell.ts
@@ -2,12 +2,23 @@ import { escapeHtml } from '../utils/html';
 
 /**
  * Typography for published documents. Published pages carry no app stylesheet
- * (no CSS variables), so colors are hardcoded light values with a
- * prefers-color-scheme dark override. Every rule is scoped under .ps-document
- * so nothing leaks into a host page. Inlined into <style> by the renderer,
- * same pattern as BASELINE_RESET in canvas/render-document.ts.
+ * (no CSS variables, no Tailwind Preflight), so colors are hardcoded light
+ * values with a prefers-color-scheme dark override, and UA element margins
+ * are zeroed via a low-specificity :where reset before the sibling rhythm.
+ * Every rule is scoped under .ps-document except the :root/body page-canvas
+ * rules — this stylesheet is only ever inlined into standalone published
+ * documents, and the canvas must follow the color scheme or dark mode would
+ * render light text on the browser's white default background. Inlined into
+ * <style> by the renderer, same pattern as BASELINE_RESET in
+ * canvas/render-document.ts.
  */
 export const DOCUMENT_TYPOGRAPHY_CSS = `
+:root {
+  color-scheme: light dark;
+}
+body {
+  background: #ffffff;
+}
 .ps-document {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
   max-width: 42rem;
@@ -18,6 +29,9 @@ export const DOCUMENT_TYPOGRAPHY_CSS = `
   overflow-wrap: break-word;
   word-wrap: break-word;
   min-width: 0;
+}
+.ps-document :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, dl, dd, blockquote, pre, figure, hr, table) {
+  margin: 0;
 }
 .ps-document > * + * {
   margin-top: 0.75em;
@@ -127,6 +141,9 @@ export const DOCUMENT_TYPOGRAPHY_CSS = `
   white-space: nowrap;
 }
 @media (prefers-color-scheme: dark) {
+  body {
+    background: #0d1117;
+  }
   .ps-document {
     color: #e6edf3;
   }

--- a/packages/lib/src/publish/document-shell.ts
+++ b/packages/lib/src/publish/document-shell.ts
@@ -1,0 +1,189 @@
+import { escapeHtml } from '../utils/html';
+
+/**
+ * Typography for published documents. Published pages carry no app stylesheet
+ * (no CSS variables), so colors are hardcoded light values with a
+ * prefers-color-scheme dark override. Every rule is scoped under .ps-document
+ * so nothing leaks into a host page. Inlined into <style> by the renderer,
+ * same pattern as BASELINE_RESET in canvas/render-document.ts.
+ */
+export const DOCUMENT_TYPOGRAPHY_CSS = `
+.ps-document {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  line-height: 1.65;
+  color: #1f2328;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  min-width: 0;
+}
+.ps-document > * + * {
+  margin-top: 0.75em;
+}
+.ps-document h1 {
+  font-size: 2em;
+  font-weight: bold;
+  line-height: 1.25;
+}
+.ps-document h2 {
+  font-size: 1.5em;
+  font-weight: bold;
+  line-height: 1.3;
+  margin-top: 1.5em;
+}
+.ps-document h3 {
+  font-size: 1.17em;
+  font-weight: bold;
+  margin-top: 1.25em;
+}
+.ps-document > header {
+  margin-bottom: 2rem;
+}
+.ps-document ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+.ps-document ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+}
+.ps-document code {
+  background-color: #eff1f3;
+  color: #24292f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  border-radius: 0.25rem;
+  padding: 0.15em 0.35em;
+}
+.ps-document pre {
+  background: #f6f8fa;
+  color: #24292f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+.ps-document pre code {
+  color: inherit;
+  padding: 0;
+  background: none;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.ps-document img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+}
+.ps-document table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+.ps-document th,
+.ps-document td {
+  border: 1px solid #d0d7de;
+  padding: 0.5rem;
+  text-align: left;
+}
+.ps-document th {
+  font-weight: bold;
+  background-color: #f6f8fa;
+}
+.ps-document blockquote {
+  border-left: 3px solid #d0d7de;
+  margin-left: 1.5rem;
+  padding-left: 1rem;
+  font-style: italic;
+  color: #57606a;
+}
+.ps-document hr {
+  border: none;
+  border-top: 2px solid rgba(13, 13, 13, 0.1);
+  margin: 2rem 0;
+}
+.ps-document a {
+  color: #0969da;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.ps-document a:hover {
+  opacity: 0.8;
+}
+.ps-document a[data-mention-type] {
+  background-color: rgba(9, 105, 218, 0.08);
+  border: 1px solid rgba(9, 105, 218, 0.2);
+  border-radius: 0.375rem;
+  padding: 0.1em 0.35em;
+  text-decoration: none;
+  font-size: 0.95em;
+  white-space: nowrap;
+}
+@media (prefers-color-scheme: dark) {
+  .ps-document {
+    color: #e6edf3;
+  }
+  .ps-document code {
+    background-color: #2d333b;
+    color: #d1d7e0;
+  }
+  .ps-document pre {
+    background: #161b22;
+    color: #e6edf3;
+  }
+  .ps-document th,
+  .ps-document td {
+    border-color: #3d444d;
+  }
+  .ps-document th {
+    background-color: #21262d;
+  }
+  .ps-document blockquote {
+    border-color: #3d444d;
+    color: #9198a1;
+  }
+  .ps-document hr {
+    border-top-color: rgba(255, 255, 255, 0.12);
+  }
+  .ps-document a {
+    color: #4493f8;
+  }
+  .ps-document a[data-mention-type] {
+    background-color: rgba(68, 147, 248, 0.12);
+    border-color: rgba(68, 147, 248, 0.3);
+  }
+}
+`;
+
+/**
+ * True when the first meaningful element of the body is an <h1>. Leading
+ * whitespace and HTML comments are tolerated; an unterminated comment means
+ * no meaningful content follows.
+ */
+export function documentStartsWithH1(html: string): boolean {
+  let rest = html;
+  for (;;) {
+    rest = rest.replace(/^\s+/, '');
+    if (rest.startsWith('<!--')) {
+      const end = rest.indexOf('-->', 4);
+      if (end === -1) return false;
+      rest = rest.slice(end + 3);
+      continue;
+    }
+    return /^<h1[\s>]/i.test(rest);
+  }
+}
+
+export function wrapDocumentBody({ bodyHtml, title }: { bodyHtml: string; title: string }): string {
+  const header = documentStartsWithH1(bodyHtml)
+    ? ''
+    : `<header><h1>${escapeHtml(title)}</h1></header>`;
+  return `<article class="ps-document">${header}${bodyHtml}</article>`;
+}


### PR DESCRIPTION
## Summary

Leaf 1-3 of the publish-any-page-type epic (Lane A start; blocks 1-4 and 1-5). Adds `packages/lib/src/publish/document-shell.ts` — the zero-dependency document shell published documents are rendered into:

- **`DOCUMENT_TYPOGRAPHY_CSS`** — blog-post typography modeled on `apps/web/src/styles/tiptap.css` (headings scale, lists, tables, `pre`/`code`, `blockquote`, `hr`, links, mention chips, `img { max-width: 100% }`). Every rule is scoped under `.ps-document` except `:root`/`body` page-canvas rules (the one deliberate exception — this CSS is only ever inlined into standalone published pages, so the canvas itself must follow the color scheme); system font stack; `max-width: 42rem; margin: 0 auto; padding: 2rem 1rem; line-height: 1.65`. App CSS vars don't exist on published pages, so colors are hardcoded light values with a `@media (prefers-color-scheme: dark)` override, including an explicit dark body background (`#0d1117`) and `:root { color-scheme: light dark }` — not just a foreground-only color flip. UA default element margins are zeroed via a low-specificity `:where(...)` reset placed before the sibling-rhythm rule (`> * + * { margin-top: 0.75em }`), since standalone output has no Tailwind Preflight to have already done this.
- **`wrapDocumentBody({ bodyHtml, title })`** — emits `<article class="ps-document">` with an `<header><h1>{title}</h1></header>` (title HTML-escaped via the shared `utils/html` escapeHtml).
- **`documentStartsWithH1(html)`** — true when the first meaningful element is an `<h1>` (leading whitespace/HTML comments tolerated); `wrapDocumentBody` then suppresses the header so titles never duplicate.
- Mention anchors (`a[data-mention-type]`) styled as subtle inline chips in both color schemes.

Leaf 1-2 landed after this PR opened (and leaf 1-6 + two follow-up fixes + a page-type-config commit landed on the base too) — rebased twice to stay mergeable; `packages/lib/package.json`'s `./publish/*` exports/typesVersions entries now include this leaf's plus `neutralize-dashboard-links` and `sanitize-document-html` from the others.

## Review fixes

Two Codex review comments addressed (see inline replies for detail):
- **Dark-mode page canvas**: the original CSS only recolored `.ps-document` text in dark mode, leaving the browser's default white page background — fixed by adding explicit `body` backgrounds in both schemes plus `color-scheme: light dark`.
- **UA margin reset**: this stylesheet ships without Tailwind Preflight, so browser default element margins would double up against the `> * + *` rhythm rule — fixed with a `:where(...)` low-specificity reset applied first.

## Tests

TDD, colocated in `src/publish/__tests__/document-shell.test.ts` (riteway-style `assert({given, should, actual, expected})`), 23 tests covering column layout, `.ps-document` scoping of every selector (page-canvas `:root`/`body` exception explicitly allowlisted, no leakage elsewhere, no `var(--…)`), dark-mode query, dark page-canvas background, `color-scheme` declaration, the UA-margin reset (existence + ordering + tag coverage), mention-chip styling, rich-text element coverage, h1 detection edge cases (attributes, case, comments, unterminated comment, non-first h1), header suppression, and title escaping.

- `packages/lib/src/publish` suite: **87 tests passed** (23 in this leaf, rest from sibling leaves on the base)
- `bun run typecheck` (full monorepo, all 16 turbo tasks): **green**
- `bun run build` (`@pagespace/lib`): **green**
- No CI workflow runs against this base branch — `.github/workflows/test.yml` only triggers `pull_request` for `main/master/develop/pu/flash-sandbox`; this PR targets `pu/publish-any-page-type`, so local validation is the gate until the phase branch merges to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NfYFfxkMtytdp4zAhPyNZ