### PR TITLE
fix(machine): rebind terminal PTY on socket reconnect

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
@@ -46,7 +46,7 @@ vi.mock('@/stores/useEditingStore', () => ({
   useEditingStore: { getState: () => ({ startEditing: vi.fn(), endEditing: vi.fn() }) },
 }));
 
-import XtermTerminal from './XtermTerminal';
+import XtermTerminal, { RECONNECTING_NOTICE } from './XtermTerminal';
 
 /** A socket that records emits and lets a test drive the server's events. */
 function fakeSocket() {
@@ -56,6 +56,7 @@ function fakeSocket() {
   // failed to unregister. Both are the machinery the prompt latches rest on.
   const handlers = new Map<string, Set<(payload: unknown) => void>>();
   const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const fire = (event: string, payload: unknown) => handlers.get(event)?.forEach((handler) => handler(payload));
   const socket = {
     connected: true,
     on: (event: string, handler: (payload: unknown) => void) => {
@@ -77,14 +78,21 @@ function fakeSocket() {
     setConnected: (value: boolean) => {
       socket.connected = value;
     },
+    /** One full transport cycle: drop, then come back — flag flips before the
+     * matching lifecycle event fires, in socket.io's order. */
+    reconnect: () => {
+      socket.connected = false;
+      fire('disconnect', {});
+      socket.connected = true;
+      fire('connect', {});
+    },
     /** The connectionIds the mounted panes announced — every event is tagged with one. */
     connectionIds: () =>
       emitted
         .filter((entry) => entry.event === 'agent-terminal:connect')
         .map((entry) => entry.payload.connectionId as string),
     connectionId: () => emitted.find((entry) => entry.event === 'agent-terminal:connect')?.payload.connectionId,
-    server: (event: string, payload: Record<string, unknown>) =>
-      handlers.get(event)?.forEach((handler) => handler(payload)),
+    server: (event: string, payload: Record<string, unknown>) => fire(event, payload),
     listenerCount: (event: string) => handlers.get(event)?.size ?? 0,
     hasHandlers: () => handlers.size > 0,
   };
@@ -477,9 +485,6 @@ describe('XtermTerminal — starting-prompt delivery', () => {
   });
 });
 
-/** What XtermTerminal prints when a bound pane's transport drops. */
-const RECONNECTING_NOTICE = '\r\n\x1b[90mConnection lost — reconnecting…\x1b[0m';
-
 describe('XtermTerminal — PTY binding across socket reconnects', () => {
   beforeEach(() => {
     written.length = 0;
@@ -500,10 +505,7 @@ describe('XtermTerminal — PTY binding across socket reconnects', () => {
     // The transport drops and comes back. socket.io reuses the SAME Socket
     // object, so the [socket, sessionId]-keyed mount effect never re-runs —
     // the `connect` event is the only signal a re-bind can hang off.
-    fake.setConnected(false);
-    fake.server('disconnect', {});
-    fake.setConnected(true);
-    fake.server('connect', {});
+    fake.reconnect();
 
     assert({
       given: 'a live pane whose socket dropped its transport and reconnected',
@@ -552,10 +554,7 @@ describe('XtermTerminal — PTY binding across socket reconnects', () => {
     fake.server('agent-terminal:ready', { scrollback: '$ bun run build\n', connectionId });
     fake.server('agent-terminal:output', { data: 'compiling…\n', connectionId });
 
-    fake.setConnected(false);
-    fake.server('disconnect', {});
-    fake.setConnected(true);
-    fake.server('connect', {});
+    fake.reconnect();
     // The server answers a re-bind with the session's FULL scrollback —
     // everything already on this screen plus whatever landed during the gap.
     fake.server('agent-terminal:ready', {
@@ -583,6 +582,114 @@ describe('XtermTerminal — PTY binding across socket reconnects', () => {
         ],
         disposed: 0,
       },
+    });
+  });
+
+  test('a re-bind ready WITHOUT a replay keeps the buffer — resetting would blank a pane full of history', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+    fake.server('agent-terminal:ready', { scrollback: '$ ls\n', connectionId });
+    fake.server('agent-terminal:output', { data: 'README.md\n', connectionId });
+
+    fake.reconnect();
+    // The session died while disconnected and the server cold-created a fresh
+    // PTY (no scrollback) — or a resumed session's over-cap ring trimmed to
+    // empty. Either way there is nothing to repaint FROM.
+    fake.server('agent-terminal:ready', { resumed: true, connectionId });
+    fake.server('agent-terminal:output', { data: '$ ', connectionId });
+
+    assert({
+      given: 'a re-bind answered by a ready that carries no scrollback',
+      should: 'keep every byte on screen and let new output append under the notice — a reset would leave nothing to redraw',
+      actual: { rendered: written, disposed: disposals },
+      expected: {
+        rendered: ['$ ls\n', 'README.md\n', RECONNECTING_NOTICE, '$ '],
+        disposed: 0,
+      },
+    });
+  });
+
+  test('a pane whose process EXITED never auto-rebinds — a reconnect must not resurrect a finished agent', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+    fake.server('agent-terminal:ready', { connectionId });
+    fake.server('agent-terminal:closed', { exitCode: 0, connectionId });
+
+    const printedBeforeDrop = written.length;
+    fake.reconnect();
+
+    assert({
+      given: 'a pane showing "process exited" whose socket then drops and reconnects',
+      should:
+        'emit no further agent-terminal:connect and print no reconnecting promise — the server has no session left under this key, so a re-bind would take its cold CREATE path and silently launch (and bill) a brand-new agent nobody asked for',
+      actual: { connects: fake.connectionIds().length, printedOnDrop: written.length - printedBeforeDrop },
+      expected: { connects: 1, printedOnDrop: 0 },
+    });
+  });
+
+  test('a pane the server REFUSED never auto-rebinds — reconnect cycles must not retry a denied bind', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+    fake.server('agent-terminal:error', { message: 'Agent terminal access denied', connectionId });
+
+    const printedBeforeDrop = written.length;
+    fake.reconnect();
+
+    assert({
+      given: 'a pane whose bind the server denied (access revoked, insufficient credits), riding out a transport cycle',
+      should:
+        'stay in its error state — re-emitting the denied connect on every reconnect would flap between "reconnecting" and the same denial forever',
+      actual: { connects: fake.connectionIds().length, printedOnDrop: written.length - printedBeforeDrop },
+      expected: { connects: 1, printedOnDrop: 0 },
+    });
+  });
+
+  test('output racing ahead of a re-bind’s ready is never typed at — the OLD binding’s ready does not vouch for the NEW agent', async () => {
+    const fake = fakeSocket();
+    const onSent = vi.fn();
+    render(
+      <XtermTerminal
+        socket={fake.socket}
+        sessionId="s1"
+        connectPayload={CONNECT}
+        initialInput="fix the build"
+        onInitialInputSent={onSent}
+      />
+    );
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+
+    // The old binding: a fresh boot's ready arrives (arming the backstop), but
+    // the transport drops before anything was typed.
+    fake.server('agent-terminal:ready', { resumed: false, connectionId });
+    fake.reconnect();
+
+    // The new binding's output beats its ready (the server's ordering, not
+    // ours). The old ready's `resumed: false` said nothing about THIS agent —
+    // typing here would trust stale evidence.
+    fake.server('agent-terminal:output', { data: 'y/n? ', connectionId });
+    const typedBeforeNewReady = inputs(fake.emitted);
+
+    // And the new ready reveals the truth: the agent was already running.
+    fake.server('agent-terminal:ready', { resumed: true, connectionId });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    assert({
+      given: 'a re-bind whose output arrives before its ready, after the OLD binding had seen a fresh-boot ready',
+      should:
+        'type NOTHING on the stale latches and spend the prompt only when the new ready says resumed — each binding must re-prove what it is talking to',
+      actual: {
+        typedBeforeNewReady,
+        typed: inputs(fake.emitted),
+        promptDropped: onSent.mock.calls.length,
+      },
+      expected: { typedBeforeNewReady: [], typed: [], promptDropped: 1 },
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
@@ -6,6 +6,10 @@ import type { Socket } from 'socket.io-client';
 // xterm is a DOM/canvas library the pane imports dynamically; stub it so what's
 // under test is the PROTOCOL this component speaks over the socket.
 const written: string[] = [];
+/** Rendered in `written` where a buffer reset happened — the reconnect repaint
+ * must RESET-then-replay, never append the replay under what's already shown. */
+const RESET_MARK = '⟪reset⟫';
+let disposals = 0;
 vi.mock('@xterm/xterm', () => ({
   Terminal: class {
     cols = 80;
@@ -22,7 +26,12 @@ vi.mock('@xterm/xterm', () => ({
     writeln(data: string) {
       written.push(data);
     }
-    dispose() {}
+    reset() {
+      written.push(RESET_MARK);
+    }
+    dispose() {
+      disposals += 1;
+    }
   },
 }));
 vi.mock('@xterm/addon-fit', () => ({
@@ -47,20 +56,27 @@ function fakeSocket() {
   // failed to unregister. Both are the machinery the prompt latches rest on.
   const handlers = new Map<string, Set<(payload: unknown) => void>>();
   const emitted: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const socket = {
+    connected: true,
+    on: (event: string, handler: (payload: unknown) => void) => {
+      const set = handlers.get(event) ?? new Set();
+      set.add(handler);
+      handlers.set(event, set);
+    },
+    off: (event: string, handler: (payload: unknown) => void) => {
+      handlers.get(event)?.delete(handler);
+    },
+    emit: (event: string, payload: Record<string, unknown>) => emitted.push({ event, payload }),
+  };
   return {
-    socket: {
-      connected: true,
-      on: (event: string, handler: (payload: unknown) => void) => {
-        const set = handlers.get(event) ?? new Set();
-        set.add(handler);
-        handlers.set(event, set);
-      },
-      off: (event: string, handler: (payload: unknown) => void) => {
-        handlers.get(event)?.delete(handler);
-      },
-      emit: (event: string, payload: Record<string, unknown>) => emitted.push({ event, payload }),
-    } as unknown as Socket,
+    socket: socket as unknown as Socket,
     emitted,
+    /** Drive the transport. socket.io reuses the SAME Socket object across a
+     * reconnect — a component only ever learns about one from `connected`
+     * flipping and the `connect`/`disconnect` lifecycle events. */
+    setConnected: (value: boolean) => {
+      socket.connected = value;
+    },
     /** The connectionIds the mounted panes announced — every event is tagged with one. */
     connectionIds: () =>
       emitted
@@ -457,6 +473,116 @@ describe('XtermTerminal — starting-prompt delivery', () => {
         'keep the prompt unspent — socket.io buffers the emit and flushes it on reconnect carrying a connectionId the server no longer knows, so it is dropped there while the prompt would already have been thrown away here',
       actual: { typed: inputs(fake.emitted), promptSpent: onSent.mock.calls.length },
       expected: { typed: [], promptSpent: 0 },
+    });
+  });
+});
+
+/** What XtermTerminal prints when a bound pane's transport drops. */
+const RECONNECTING_NOTICE = '\r\n\x1b[90mConnection lost — reconnecting…\x1b[0m';
+
+describe('XtermTerminal — PTY binding across socket reconnects', () => {
+  beforeEach(() => {
+    written.length = 0;
+    disposals = 0;
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('a transport reconnect re-fires agent-terminal:connect exactly once, on the pane’s own connectionId', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    fake.server('agent-terminal:ready', { connectionId: fake.connectionId() });
+
+    // The transport drops and comes back. socket.io reuses the SAME Socket
+    // object, so the [socket, sessionId]-keyed mount effect never re-runs —
+    // the `connect` event is the only signal a re-bind can hang off.
+    fake.setConnected(false);
+    fake.server('disconnect', {});
+    fake.setConnected(true);
+    fake.server('connect', {});
+
+    assert({
+      given: 'a live pane whose socket dropped its transport and reconnected',
+      should:
+        're-emit agent-terminal:connect exactly once, reusing the pane’s connectionId, without recreating the terminal — the server side of the binding died with the transport, and without this the pane looks alive until the idle reap kills its agent',
+      actual: {
+        connects: fake.connectionIds().length,
+        distinctIds: new Set(fake.connectionIds()).size,
+        disposed: disposals,
+      },
+      expected: { connects: 2, distinctIds: 1, disposed: 0 },
+    });
+  });
+
+  test('the initial connection binds exactly once, wherever mount falls relative to it', async () => {
+    // Mounted AFTER the socket connected: the mount effect binds, and no
+    // `connect` event follows to double it.
+    const early = fakeSocket();
+    render(<XtermTerminal socket={early.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(early.connectionIds().length).toBe(1));
+
+    // Mounted BEFORE the socket connected: nothing is emitted into the void —
+    // the `connect` event does the one and only bind. (`connect` firing on the
+    // INITIAL connection is exactly why re-binding cannot be unconditional.)
+    const late = fakeSocket();
+    late.setConnected(false);
+    render(<XtermTerminal socket={late.socket} sessionId="s2" connectPayload={CONNECT} />);
+    await waitFor(() => expect(late.hasHandlers()).toBe(true));
+    const whileDown = late.connectionIds().length;
+    late.setConnected(true);
+    late.server('connect', {});
+
+    assert({
+      given: 'one pane mounted after its socket connected, another mounted before',
+      should: 'emit exactly one agent-terminal:connect each — never zero, never two',
+      actual: { early: early.connectionIds().length, whileDown, late: late.connectionIds().length },
+      expected: { early: 1, whileDown: 0, late: 1 },
+    });
+  });
+
+  test('a reconnect reattach repaints from the replayed scrollback instead of appending it under what is shown', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+    fake.server('agent-terminal:ready', { scrollback: '$ bun run build\n', connectionId });
+    fake.server('agent-terminal:output', { data: 'compiling…\n', connectionId });
+
+    fake.setConnected(false);
+    fake.server('disconnect', {});
+    fake.setConnected(true);
+    fake.server('connect', {});
+    // The server answers a re-bind with the session's FULL scrollback —
+    // everything already on this screen plus whatever landed during the gap.
+    fake.server('agent-terminal:ready', {
+      scrollback: '$ bun run build\ncompiling…\ndone\n',
+      resumed: true,
+      connectionId,
+    });
+    // A later duplicate ready on the SAME connection must not wipe live output.
+    fake.server('agent-terminal:output', { data: '$ ', connectionId });
+    fake.server('agent-terminal:ready', { connectionId });
+
+    assert({
+      given: 'a pane with content on screen whose re-bind is answered with the full scrollback replay',
+      should:
+        'surface the drop, then reset the buffer ONCE and repaint from the replay — appending would duplicate everything already shown, and disposing would tear down the terminal the fix exists to preserve',
+      actual: { rendered: written, disposed: disposals },
+      expected: {
+        rendered: [
+          '$ bun run build\n',
+          'compiling…\n',
+          RECONNECTING_NOTICE,
+          RESET_MARK,
+          '$ bun run build\ncompiling…\ndone\n',
+          '$ ',
+        ],
+        disposed: 0,
+      },
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
@@ -451,7 +451,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     const fake = fakeSocket();
     const onSent = vi.fn();
     // The socket dropped (a realtime deploy) while the agent was booting.
-    (fake.socket as unknown as { connected: boolean }).connected = false;
+    fake.setConnected(false);
     render(
       <XtermTerminal
         socket={fake.socket}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
@@ -10,12 +10,16 @@ const written: string[] = [];
  * must RESET-then-replay, never append the replay under what's already shown. */
 const RESET_MARK = '⟪reset⟫';
 let disposals = 0;
+/** The pane's `terminal.onData` callback, captured so a test can simulate the
+ * user typing — reset per mount by the mock Terminal's own constructor. */
+let onDataHandler: ((data: string) => void) | undefined;
 vi.mock('@xterm/xterm', () => ({
   Terminal: class {
     cols = 80;
     rows = 24;
     options = {};
-    onData() {
+    onData(handler: (data: string) => void) {
+      onDataHandler = handler;
       return { dispose: () => {} };
     }
     loadAddon() {}
@@ -42,8 +46,11 @@ vi.mock('@xterm/addon-fit', () => ({
   },
 }));
 vi.mock('@/hooks/useXtermTheme', () => ({ useXtermTheme: () => ({}) }));
+/** Stable across calls (unlike a fresh `vi.fn()` per `getState()`) so tests can
+ * assert on endEditing — the dead-pane leak fix needs it to see across events. */
+const editingStore = { startEditing: vi.fn(), endEditing: vi.fn() };
 vi.mock('@/stores/useEditingStore', () => ({
-  useEditingStore: { getState: () => ({ startEditing: vi.fn(), endEditing: vi.fn() }) },
+  useEditingStore: { getState: () => editingStore },
 }));
 
 import XtermTerminal, { RECONNECTING_NOTICE } from './XtermTerminal';
@@ -489,6 +496,8 @@ describe('XtermTerminal — PTY binding across socket reconnects', () => {
   beforeEach(() => {
     written.length = 0;
     disposals = 0;
+    editingStore.startEditing.mockClear();
+    editingStore.endEditing.mockClear();
     vi.useFakeTimers({ shouldAdvanceTime: true });
   });
 
@@ -690,6 +699,47 @@ describe('XtermTerminal — PTY binding across socket reconnects', () => {
         promptDropped: onSent.mock.calls.length,
       },
       expected: { typedBeforeNewReady: [], typed: [], promptDropped: 1 },
+    });
+  });
+
+  test('a pane that goes dead (exited, or refused) releases its editing-store registration immediately', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="exited-pane" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+    const connectionId = fake.connectionId();
+    fake.server('agent-terminal:ready', { connectionId });
+    expect(editingStore.startEditing).toHaveBeenCalledWith('exited-pane', 'other', { componentName: 'agent-terminal' });
+
+    fake.server('agent-terminal:closed', { exitCode: 0, connectionId });
+
+    assert({
+      given: 'a pane whose agent process exits while the pane stays mounted (dead panes never unmount on their own)',
+      should:
+        'release the editing-store registration right away — a finished pane must not go on blocking auth refresh/SWR updates for its sessionId until some later, unrelated unmount',
+      actual: editingStore.endEditing.mock.calls,
+      expected: [['exited-pane']],
+    });
+  });
+
+  test('typed input is never emitted while the transport is down — it would only sit in socket.io’s buffer and be dropped on the other side anyway', async () => {
+    const fake = fakeSocket();
+    render(<XtermTerminal socket={fake.socket} sessionId="s1" connectPayload={CONNECT} />);
+    await waitFor(() => expect(fake.connectionIds().length).toBe(1));
+
+    fake.setConnected(false);
+    fake.server('disconnect', {});
+    onDataHandler?.('y');
+    const emittedWhileDown = inputs(fake.emitted);
+
+    fake.setConnected(true);
+    fake.server('connect', {});
+    onDataHandler?.('y');
+
+    assert({
+      given: 'a keystroke typed while the socket is disconnected, then one typed after it reconnects',
+      should: 'emit nothing for the disconnected keystroke, and emit normally once reconnected',
+      actual: { emittedWhileDown, emittedAfterReconnect: inputs(fake.emitted) },
+      expected: { emittedWhileDown: [], emittedAfterReconnect: ['y'] },
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
@@ -100,7 +100,16 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         terminal.open(containerRef.current);
         fitAddon.fit();
 
-        const onData = terminal.onData((data) => socket.emit('agent-terminal:input', { data, connectionId }));
+        const onData = terminal.onData((data) => {
+          // Disconnected: this would only sit in socket.io's send buffer and
+          // flush on the NEW server socket ahead of our re-bind (a client's
+          // 'connect' event fires only after its buffered emits are flushed),
+          // where the server drops it — its connectionId isn't active there
+          // yet (see `onInput`'s `activeConnectionIds.has` guard). It is lost
+          // either way; not emitting it avoids pinning it in that buffer.
+          if (!socket.connected) return;
+          socket.emit('agent-terminal:input', { data, connectionId });
+        });
 
         // Every mounted XtermTerminal shares this one socket, so every one of
         // its listeners sees every pane's events — drop anything tagged with
@@ -233,11 +242,17 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         const handleClosed = (payload: { exitCode: number; connectionId?: string }) => {
           if (!isMine(payload)) return;
           dead = true;
+          // Nothing left to edit: a dead pane must not go on blocking auth
+          // refresh / SWR updates for this sessionId until whenever it happens
+          // to unmount (teardown's own endEditing is now redundant, and stays
+          // as a no-op safety net — the store deletes-if-present).
+          useEditingStore.getState().endEditing(sessionId);
           terminal.writeln(`\r\n\x1b[90mProcess exited with code ${payload.exitCode}\x1b[0m`);
         };
         const handleError = (payload: { message: string; connectionId?: string }) => {
           if (!isMine(payload)) return;
           dead = true;
+          useEditingStore.getState().endEditing(sessionId);
           terminal.writeln(`\r\n\x1b[31mError: ${payload.message}\x1b[0m`);
           onError?.(payload.message);
         };

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
@@ -148,6 +148,14 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         let readySeen = false;
         /** Has the agent drawn anything? Proof it is up and reading its stdin. */
         let outputSeen = false;
+        /** A re-bind's `ready` (see `handleSocketConnect` below) replies with the
+         * session's FULL scrollback, and this terminal already displays everything
+         * from before the drop — writing the replay on top would duplicate it.
+         * Repaint instead: reset the buffer (the Terminal instance and its DOM
+         * stay) and let the replay redraw, which also delivers output produced
+         * while the socket was down. Cleared on the first `ready` after a re-bind
+         * so a later duplicate `ready` cannot wipe live output. */
+        let repaintOnReady = false;
 
         /** Spends the prompt without writing it — for a session that is past
          * taking one. The caller drops it either way, so it can never come back. */
@@ -165,8 +173,15 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
           // carrying a connectionId the server no longer knows — so it is dropped
           // there, while `onSent` here would already have spent the prompt. Keep it
           // unspent instead: whether a later connect may deliver it is decided by
-          // that connect's own `resumed`, which is the only safe judge.
-          if (socket.connected === false) return;
+          // that connect's own `resumed`, which is the only safe judge. The armed
+          // backstop is disarmed too, so a re-bind's `ready` can arm it afresh
+          // (its `promptTimer === undefined` re-arm check would otherwise see the
+          // spent handle and never schedule another).
+          if (socket.connected === false) {
+            clearTimeout(promptTimer);
+            promptTimer = undefined;
+            return;
+          }
           initialInputSent = true;
           clearTimeout(promptTimer);
           for (const chunk of toPtyInput(input)) {
@@ -188,6 +203,10 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         const handleReady = (payload: { scrollback?: string; resumed?: boolean; connectionId?: string } = {}) => {
           if (!isMine(payload)) return;
           readySeen = true;
+          if (repaintOnReady) {
+            repaintOnReady = false;
+            terminal.reset();
+          }
           if (payload.scrollback) terminal.write(payload.scrollback);
           useEditingStore.getState().startEditing(sessionId, 'other', { componentName: 'agent-terminal' });
 
@@ -214,12 +233,48 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
           onError?.(payload.message);
         };
 
+        /**
+         * The PTY binding is per TRANSPORT CONNECTION, not per socket object:
+         * socket.io reuses this same Socket across a transport reconnect, so this
+         * effect (keyed [socket, sessionId]) never re-runs for one — but the
+         * server side of the binding died with the transport (each server socket
+         * holds its own connection registry and tears every pane down on
+         * disconnect), leaving a pane that looks alive while its PTY drifts
+         * toward the server's detached-idle reap. So the bind is re-emitted on
+         * every `connect`. The server treats a connect for a scope whose session
+         * is still live as a reattach (`attachToLiveSession` in
+         * agent-terminal-handler.ts), so re-binding is idempotent: same
+         * connectionId (the new server socket has a fresh registry, so it cannot
+         * collide), same client listeners, no new PTY.
+         */
+        let bound = false;
+        const bindPty = () => {
+          socket.emit('agent-terminal:connect', { ...connectPayload, connectionId, cols: terminal.cols, rows: terminal.rows });
+        };
+        const handleSocketConnect = () => {
+          // `connect` also fires for the INITIAL connection when this pane
+          // mounted while the socket was still down — only a bind AFTER a
+          // previous bind is a re-bind whose `ready` must repaint.
+          repaintOnReady = bound;
+          bound = true;
+          bindPty();
+        };
+        const handleSocketDisconnect = () => {
+          // Nothing is torn down here — the terminal, its buffer and every
+          // listener stay, waiting for the re-bind. Just tell the user their
+          // pane went quiet for a reason.
+          if (!bound) return;
+          terminal.writeln('\r\n\x1b[90mConnection lost — reconnecting…\x1b[0m');
+        };
+
         // Register listeners BEFORE emitting agent-terminal:connect so we don't
         // miss early agent-terminal:ready / agent-terminal:output events.
         socket.on('agent-terminal:output', handleOutput);
         socket.on('agent-terminal:ready', handleReady);
         socket.on('agent-terminal:closed', handleClosed);
         socket.on('agent-terminal:error', handleError);
+        socket.on('connect', handleSocketConnect);
+        socket.on('disconnect', handleSocketDisconnect);
 
         // A kept-alive terminal is CSS-hidden (display:none) when its page is
         // not the active tab. While hidden the container has zero size, so any
@@ -247,6 +302,8 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
           socket.off('agent-terminal:ready', handleReady);
           socket.off('agent-terminal:closed', handleClosed);
           socket.off('agent-terminal:error', handleError);
+          socket.off('connect', handleSocketConnect);
+          socket.off('disconnect', handleSocketDisconnect);
           // Tell the server THIS pane is gone (not the whole socket) — with
           // several panes multiplexed over one socket, only an explicit
           // per-connection signal (not the socket's own disconnect/idle
@@ -263,7 +320,14 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         // picker (or the tab's add-terminal dialog) reserves it via
         // spawnAgentTerminal before the pane is ever bound to it, so connecting
         // here only ever attaches to (or resumes) an already-known session.
-        socket.emit('agent-terminal:connect', { ...connectPayload, connectionId, cols: terminal.cols, rows: terminal.rows });
+        //
+        // Bind now if the socket is up; otherwise the `connect` handler above
+        // does the first bind when it comes up. (Emitting while down would only
+        // sit in socket.io's send buffer and flush as a DUPLICATE of that bind.)
+        if (socket.connected) {
+          bound = true;
+          bindPty();
+        }
 
         resize.observer = new ResizeObserver(() => {
           // Skip while hidden (0×0) — avoids garbage fits and 0-wide resizes.

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.tsx
@@ -10,6 +10,10 @@ import { toPtyInput } from './pty-input';
 
 const FALLBACK_FONT_FAMILY = "ui-monospace, SFMono-Regular, Menlo, Monaco, 'Courier New', monospace";
 
+/** Printed into a bound pane when its socket's transport drops — cleared by the
+ * repaint when the re-bind's `ready` replays the session's scrollback. */
+export const RECONNECTING_NOTICE = '\r\n\x1b[90mConnection lost — reconnecting…\x1b[0m';
+
 /** How long to wait for a cold agent to print something before writing the
  * starting prompt anyway. Some agents boot silently; the prompt still has to
  * go in, and a wait this short is invisible next to a Sprite cold boot. */
@@ -148,13 +152,13 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         let readySeen = false;
         /** Has the agent drawn anything? Proof it is up and reading its stdin. */
         let outputSeen = false;
-        /** A re-bind's `ready` (see `handleSocketConnect` below) replies with the
-         * session's FULL scrollback, and this terminal already displays everything
+        /** A re-bind's `ready` (see `handleSocketConnect` below) replays the
+         * session's scrollback, and this terminal already displays everything
          * from before the drop — writing the replay on top would duplicate it.
          * Repaint instead: reset the buffer (the Terminal instance and its DOM
          * stay) and let the replay redraw, which also delivers output produced
-         * while the socket was down. Cleared on the first `ready` after a re-bind
-         * so a later duplicate `ready` cannot wipe live output. */
+         * while the socket was down. Consumed by the first `ready` after a
+         * re-bind, so a later duplicate `ready` cannot wipe live output. */
         let repaintOnReady = false;
 
         /** Spends the prompt without writing it — for a session that is past
@@ -169,21 +173,18 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         const sendInitialInput = () => {
           const { input, onSent } = initialInputRef.current;
           if (!input || initialInputSent || !readySeen) return;
+          // Either branch below settles the pending backstop, so disarm it here —
+          // leaving it merely "fired" would make handleReady's
+          // `promptTimer === undefined` re-arm check refuse a re-bind's fresh arm.
+          clearTimeout(promptTimer);
+          promptTimer = undefined;
           // A disconnected socket BUFFERS this emit and flushes it on reconnect,
           // carrying a connectionId the server no longer knows — so it is dropped
           // there, while `onSent` here would already have spent the prompt. Keep it
           // unspent instead: whether a later connect may deliver it is decided by
-          // that connect's own `resumed`, which is the only safe judge. The armed
-          // backstop is disarmed too, so a re-bind's `ready` can arm it afresh
-          // (its `promptTimer === undefined` re-arm check would otherwise see the
-          // spent handle and never schedule another).
-          if (socket.connected === false) {
-            clearTimeout(promptTimer);
-            promptTimer = undefined;
-            return;
-          }
+          // that connect's own `resumed`, which is the only safe judge.
+          if (socket.connected === false) return;
           initialInputSent = true;
-          clearTimeout(promptTimer);
           for (const chunk of toPtyInput(input)) {
             socket.emit('agent-terminal:input', { data: chunk, connectionId });
           }
@@ -205,7 +206,13 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
           readySeen = true;
           if (repaintOnReady) {
             repaintOnReady = false;
-            terminal.reset();
+            // Only a ready that CARRIES a replay repaints. One without (the
+            // session died while disconnected and the server cold-created a
+            // fresh PTY, or a resumed session whose over-cap ring trimmed to
+            // empty) has nothing to redraw from — resetting would blank a pane
+            // full of history; keeping the buffer and letting new output append
+            // under the reconnect notice preserves it.
+            if (payload.scrollback) terminal.reset();
           }
           if (payload.scrollback) terminal.write(payload.scrollback);
           useEditingStore.getState().startEditing(sessionId, 'other', { componentName: 'agent-terminal' });
@@ -225,10 +232,12 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         };
         const handleClosed = (payload: { exitCode: number; connectionId?: string }) => {
           if (!isMine(payload)) return;
+          dead = true;
           terminal.writeln(`\r\n\x1b[90mProcess exited with code ${payload.exitCode}\x1b[0m`);
         };
         const handleError = (payload: { message: string; connectionId?: string }) => {
           if (!isMine(payload)) return;
+          dead = true;
           terminal.writeln(`\r\n\x1b[31mError: ${payload.message}\x1b[0m`);
           onError?.(payload.message);
         };
@@ -248,23 +257,45 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
          * collide), same client listeners, no new PTY.
          */
         let bound = false;
-        const bindPty = () => {
-          socket.emit('agent-terminal:connect', { ...connectPayload, connectionId, cols: terminal.cols, rows: terminal.rows });
-        };
+        /** The PTY this pane was showing is finished — the process exited
+         * (`closed`) or the binding was refused (`error`). A re-bind after that
+         * would not reattach anything: the server has no session under the key
+         * anymore, so the connect would take its cold CREATE path and silently
+         * launch (and bill) a brand-new agent nobody asked for, in a pane whose
+         * screen says the old one ended. Dead panes stay dead; only an explicit
+         * user action (re-opening the session) may connect again, via a fresh
+         * mount. */
+        let dead = false;
         const handleSocketConnect = () => {
+          if (dead) return;
+          if (bound) {
+            // A re-bind targets a NEW server-side binding. What the old one told
+            // us no longer holds: its `ready` must repaint (the reattach replays
+            // the scrollback), and the prompt gates must be re-proven — the new
+            // binding's own `ready` carries the only trustworthy `resumed`, and
+            // only ITS output shows the agent is up. Stale latches here would
+            // type the starting prompt on the old binding's evidence, and the
+            // old binding's armed backstop would fire against the new one — the
+            // new `ready` arms its own if the prompt is still deliverable.
+            repaintOnReady = true;
+            readySeen = false;
+            outputSeen = false;
+            clearTimeout(promptTimer);
+            promptTimer = undefined;
+          }
           // `connect` also fires for the INITIAL connection when this pane
-          // mounted while the socket was still down — only a bind AFTER a
-          // previous bind is a re-bind whose `ready` must repaint.
-          repaintOnReady = bound;
+          // mounted while the socket was still down — that first bind is not a
+          // re-bind, so none of the above applies to it.
           bound = true;
-          bindPty();
+          socket.emit('agent-terminal:connect', { ...connectPayload, connectionId, cols: terminal.cols, rows: terminal.rows });
         };
         const handleSocketDisconnect = () => {
           // Nothing is torn down here — the terminal, its buffer and every
           // listener stay, waiting for the re-bind. Just tell the user their
-          // pane went quiet for a reason.
-          if (!bound) return;
-          terminal.writeln('\r\n\x1b[90mConnection lost — reconnecting…\x1b[0m');
+          // pane went quiet for a reason. A dead pane stays quiet: it will not
+          // re-bind, so promising "reconnecting" would be a lie.
+          if (!bound || dead) return;
+          terminal.writeln(RECONNECTING_NOTICE);
         };
 
         // Register listeners BEFORE emitting agent-terminal:connect so we don't
@@ -321,13 +352,10 @@ export default function XtermTerminal({ socket, sessionId, connectPayload, initi
         // spawnAgentTerminal before the pane is ever bound to it, so connecting
         // here only ever attaches to (or resumes) an already-known session.
         //
-        // Bind now if the socket is up; otherwise the `connect` handler above
-        // does the first bind when it comes up. (Emitting while down would only
-        // sit in socket.io's send buffer and flush as a DUPLICATE of that bind.)
-        if (socket.connected) {
-          bound = true;
-          bindPty();
-        }
+        // Bind now if the socket is up; otherwise the `connect` handler does the
+        // first bind when it comes up. (Emitting while down would only sit in
+        // socket.io's send buffer and flush as a DUPLICATE of that bind.)
+        if (socket.connected) handleSocketConnect();
 
         resize.observer = new ResizeObserver(() => {
           // Skip while hidden (0×0) — avoids garbage fits and 0-wide resizes.

--- a/apps/web/src/hooks/__tests__/useSocket.swap.test.ts
+++ b/apps/web/src/hooks/__tests__/useSocket.swap.test.ts
@@ -1,0 +1,48 @@
+/**
+ * useSocket must SUBSCRIBE to the store's socket, not read it through the
+ * stable getSocket accessor. The store replaces the Socket object outright —
+ * on its initial async creation, and on the auth-refresh `connect(true)` path
+ * that disconnects the old socket and mints a new one. A consumer reading
+ * through the accessor only noticed a swap on its next incidental re-render;
+ * a terminal pane keyed on the socket prop kept listening to a permanently
+ * disconnected Socket whose 'connect' event would never fire again — a
+ * silently dead pane.
+ *
+ * This file deliberately uses the REAL useSocketStore (unlike useSocket.test.ts,
+ * which mocks the whole store): the property under test is the zustand
+ * subscription itself.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { Socket } from 'socket.io-client';
+
+// Unauthenticated, so the hook's effect calls disconnect() (a no-op on a null
+// socket) instead of connect(), which would try to open a real connection.
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: false, user: null }),
+}));
+
+import { useSocket } from '../useSocket';
+import { useSocketStore } from '@/stores/useSocketStore';
+
+describe('useSocket — socket swaps reach consumers', () => {
+  afterEach(() => {
+    act(() => {
+      useSocketStore.setState({ socket: null });
+    });
+  });
+
+  it('given the store replaces the Socket object, should hand consumers the new one WITHOUT an incidental re-render', () => {
+    const { result } = renderHook(() => useSocket());
+    expect(result.current).toBeNull();
+
+    const swapped = { id: 'socket-after-refresh', connected: true } as unknown as Socket;
+    // No rerender() around this — the store subscription alone must propagate.
+    act(() => {
+      useSocketStore.setState({ socket: swapped });
+    });
+
+    expect(result.current).toBe(swapped);
+  });
+});

--- a/apps/web/src/hooks/__tests__/useSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useSocket.test.ts
@@ -26,6 +26,12 @@ vi.mock('@/hooks/useAuth', () => ({
 // Mock socket store with proper getState
 vi.mock('@/stores/useSocketStore', () => {
   const mockState = {
+    // The hook subscribes to `state.socket`; route it through the same mock the
+    // tests already drive so their mockGetSocket.mockReturnValue setup keeps
+    // expressing "what the store currently holds".
+    get socket() {
+      return mockGetSocket();
+    },
     getSocket: mockGetSocket,
     connect: mockConnect,
     disconnect: mockDisconnect,

--- a/apps/web/src/hooks/useSocket.ts
+++ b/apps/web/src/hooks/useSocket.ts
@@ -4,7 +4,14 @@ import { useSocketStore } from '@/stores/useSocketStore';
 
 export function useSocket() {
   const { isAuthenticated, user } = useAuth();
-  const getSocket = useSocketStore(state => state.getSocket);
+  // Subscribe to the socket itself, not the stable getSocket accessor: the
+  // store REPLACES the Socket object (initial async creation, and the
+  // auth-refresh `connect(true)` path disconnects the old one and mints a new
+  // one). A consumer reading through the accessor only noticed a swap on its
+  // next incidental re-render — a terminal pane keyed on the socket prop kept
+  // listening to a permanently-disconnected Socket whose 'connect' event
+  // would never fire again, i.e. a silently dead pane.
+  const socket = useSocketStore(state => state.socket);
 
   useEffect(() => {
     // Get stable methods directly without subscribing (they don't change)
@@ -26,5 +33,5 @@ export function useSocket() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated, user?.id]); // user intentionally omitted - only depends on ID for stability
 
-  return getSocket();
+  return socket;
 }


### PR DESCRIPTION
Fixes deferred item 7 (GA blocker) of the Machine/Terminal arc: **socket reconnect leaves panes silently dead** (task `o4wt7zrhg90zmy68k4v87h0v`).

## Problem

`XtermTerminal`'s connection effect is keyed on `[socket, sessionId]` and emitted `agent-terminal:connect` once. socket.io **reuses the same `Socket` object across a transport reconnect**, so the effect never re-ran — but the server side of the binding died with the transport (each server socket tears down every pane's connection on disconnect and arms the detached-idle reap). The pane looked connected while its PTY drifted toward the ~30-min reap. The Machine keep-alive work (#1989) removed the navigate-away-and-back remount that used to accidentally self-heal this.

## Fix

**The PTY binding is per transport connection, not per mount** (`XtermTerminal.tsx`):

- A `connect` handler on the shared socket re-emits `agent-terminal:connect` with the pane's existing `connectionId`. The server treats a connect for a scope whose session is live as an idempotent reattach (`attachToLiveSession` in `agent-terminal-handler.ts`) — reap cancelled, output re-pointed, no new PTY.
- **No double-connect on first mount**: if the socket is up at mount, the mount binds and `connect` won't fire without a drop; if it's down, nothing is emitted into socket.io's send buffer and the `connect` event does the one and only bind.
- **Nothing is torn down**: the Terminal instance, buffer, DOM and listeners survive the drop. A dim `Connection lost — reconnecting…` line (exported as `RECONNECTING_NOTICE`) surfaces the state.
- **Repaint, not append**: a re-bind's `ready` replays the session's scrollback — everything already on screen plus output produced during the gap — so the handler resets the buffer once (latched) and repaints. A ready **without** a replay (session cold-created while disconnected, or a ring trimmed to empty) does NOT reset: there'd be nothing to redraw from, and resetting would blank a pane full of history.
- **Dead panes stay dead**: after `agent-terminal:closed` (process exited) or `agent-terminal:error` (bind refused — access revoked, credits), the pane never auto-rebinds, and immediately releases its `useEditingStore` registration (a dead pane must not go on blocking auth refresh/SWR updates until some unrelated later unmount). The server has no session left under that key, so a re-emitted connect would take the cold CREATE path and silently launch (and bill) a brand-new agent nobody asked for.
- **Prompt safety is per binding**: a re-bind resets `readySeen`/`outputSeen` and disarms the old backstop timer, so only the NEW binding's own `ready` (which carries the authoritative `resumed`) and its own output can authorize typing the starting prompt.
- **No emitting into a dead transport**: `onData` (regular typed input, not just the starting prompt) now skips the emit while disconnected — verified the server's `onInput` guard means a buffered keystroke that flushes ahead of the re-bind is safely dropped (never misdirected), so this is a hygiene fix, not a correctness one.

**`useSocket` staleness fix** (`useSocket.ts`) — the other half of the same symptom: the hook subscribed to the stable `getSocket` accessor, so when the store *replaces* the Socket object (initial async creation; the auth-refresh `connect(true)` path), consumers only noticed on their next incidental re-render. A pane keyed on the socket prop kept listening to a permanently-disconnected Socket whose `connect` event would never fire again. It now subscribes to `state.socket`, so swaps re-render consumers and re-key the pane effect.

## Known residuals (deliberate)

- Keystrokes typed during the gap are lost (dropped server-side by the `activeConnectionIds` guard on the fresh post-reconnect socket); the reconnecting notice makes the gap visible. Queuing input would be new machinery, out of scope.
- A re-bind to a session that produced output during the gap arrives `resumed: true`, so a still-undelivered starting prompt is discarded — the pre-existing safety rule (never type into an agent that has been running unobserved).
- Long client-side history beyond the server's 64 KB scrollback ring is lost on a with-replay repaint — identical to what the old remount self-heal did.

## Tests

`XtermTerminal — PTY binding across socket reconnects` suite (9 tests):
- reconnect re-fires `agent-terminal:connect` exactly once, same `connectionId`, terminal never disposed
- initial connection binds exactly once whether the pane mounts before or after the socket comes up
- with-replay re-bind resets-then-repaints (once, latched); replay-less re-bind keeps the buffer
- exited and refused panes never auto-rebind and print no false "reconnecting" promise
- output racing ahead of a re-bind's ready is never typed at — stale latches can't vouch for the new agent
- a dead pane releases its editing-store registration immediately
- typed input is never emitted while disconnected, and resumes normally after reconnect

Plus `useSocket.swap.test.ts` pinning that a store socket swap reaches consumers with no incidental re-render, against the real zustand store.

Validation: XtermTerminal 23/23, useSocket 8/8 + swap 1/1, TerminalPanes 18/18, GlobalChatContext/ThreadPanel/useSocketStore/useNotificationStore 124/124, `tsc --noEmit` green, eslint clean. Branch merged with latest master (no conflicts, no file overlap with sibling deferred-item PRs #2039/#2041/#2042/#2043/#2044).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPZpwKud6HoJ5VrP7RWiVj