### PR TITLE
[1-1] publishable capability flag in page-types config

### DIFF
--- a/packages/lib/src/content/__tests__/page-types-publishable.test.ts
+++ b/packages/lib/src/content/__tests__/page-types-publishable.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PAGE_TYPE_CONFIGS,
+  isPublishablePageType,
+  getPublishablePageTypes,
+} from '../page-types.config';
+import { PageType } from '../../utils/enums';
+
+const assert = ({ given, should, actual, expected }: { given: string; should: string; actual: unknown; expected: unknown }) =>
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+/**
+ * Publishing is lifted from a CANVAS-only hard gate to a per-type capability.
+ * Publishable types are exactly the ones whose content lives in
+ * `pages.content` and can be rendered standalone: CANVAS, DOCUMENT, CODE,
+ * SHEET. The rest (folders, chat, tasks, files, machines) store their real
+ * content in other tables or object storage and cannot be published.
+ */
+const PUBLISHABLE_TYPES = [
+  PageType.CANVAS,
+  PageType.DOCUMENT,
+  PageType.CODE,
+  PageType.SHEET,
+] as const;
+
+const NON_PUBLISHABLE_TYPES = [
+  PageType.FOLDER,
+  PageType.CHANNEL,
+  PageType.AI_CHAT,
+  PageType.FILE,
+  PageType.TASK_LIST,
+  PageType.MACHINE,
+] as const;
+
+describe('publishable page-type capability', () => {
+  it('declares publishable on every page type config', () => {
+    for (const config of Object.values(PAGE_TYPE_CONFIGS)) {
+      assert({
+        given: `the ${config.type} config`,
+        should: 'declare a boolean publishable capability',
+        actual: typeof config.capabilities.publishable,
+        expected: 'boolean',
+      });
+    }
+  });
+
+  it('marks content-bearing types publishable', () => {
+    for (const type of PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type} (content lives in pages.content)`,
+        should: 'be publishable',
+        actual: PAGE_TYPE_CONFIGS[type].capabilities.publishable,
+        expected: true,
+      });
+    }
+  });
+
+  it('marks types whose content lives outside pages.content as not publishable', () => {
+    for (const type of NON_PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type} (content in chat/tasks tables, object storage, or machine state)`,
+        should: 'not be publishable',
+        actual: PAGE_TYPE_CONFIGS[type].capabilities.publishable,
+        expected: false,
+      });
+    }
+  });
+});
+
+describe('isPublishablePageType()', () => {
+  it('returns true for each publishable type', () => {
+    for (const type of PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type}`,
+        should: 'return true',
+        actual: isPublishablePageType(type),
+        expected: true,
+      });
+    }
+  });
+
+  it('returns false for each non-publishable type', () => {
+    for (const type of NON_PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type}`,
+        should: 'return false',
+        actual: isPublishablePageType(type),
+        expected: false,
+      });
+    }
+  });
+
+  it('returns false for an unknown type instead of throwing', () => {
+    assert({
+      given: 'a value not present in PAGE_TYPE_CONFIGS',
+      should: 'return false',
+      actual: isPublishablePageType('NOT_A_REAL_TYPE' as PageType),
+      expected: false,
+    });
+  });
+});
+
+describe('getPublishablePageTypes()', () => {
+  it('returns exactly the publishable types', () => {
+    assert({
+      given: 'the full page-type config table',
+      should: 'return exactly CANVAS, DOCUMENT, CODE, SHEET',
+      actual: [...getPublishablePageTypes()].sort(),
+      expected: [...PUBLISHABLE_TYPES].sort(),
+    });
+  });
+});

--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -7,6 +7,8 @@ export interface PageTypeCapabilities {
   supportsRealtime: boolean;
   supportsVersioning: boolean;
   supportsAI: boolean;
+  /** Content lives in pages.content and can be rendered standalone at a public URL. */
+  publishable: boolean;
 }
 
 export interface PageTypeApiValidation {
@@ -42,6 +44,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => ({ children: [] }),
     uiComponent: 'FolderView',
@@ -59,6 +62,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: false,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'DocumentView',
@@ -76,6 +80,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => ({ messages: [] }),
     uiComponent: 'ChannelView',
@@ -93,6 +98,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: true,
+      publishable: false,
     },
     defaultContent: () => ({ messages: [] }),
     apiValidation: {
@@ -113,6 +119,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: true,
       supportsAI: false,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'CanvasPageView',
@@ -130,6 +137,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => '',
     uiComponent: 'FileViewer',
@@ -147,6 +155,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: true,
+      publishable: true,
     },
     defaultContent: () => serializeSheetContent(createEmptySheet()),
     uiComponent: 'SheetView',
@@ -164,6 +173,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: true,
+      publishable: false,
     },
     defaultContent: () => '',
     uiComponent: 'TaskListView',
@@ -181,6 +191,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: true,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'CodePageView',
@@ -198,6 +209,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => JSON.stringify({ history: [] }),
     uiComponent: 'MachineView',
@@ -305,4 +317,12 @@ export function isMachinePage(type: PageType): boolean {
 
 export function getCreatablePageTypes(): PageType[] {
   return Object.values(PAGE_TYPE_CONFIGS).filter(c => !c.experimental).map(c => c.type);
+}
+
+export function isPublishablePageType(type: PageType): boolean {
+  return PAGE_TYPE_CONFIGS[type]?.capabilities.publishable || false;
+}
+
+export function getPublishablePageTypes(): PageType[] {
+  return Object.values(PAGE_TYPE_CONFIGS).filter(c => c.capabilities.publishable).map(c => c.type);
 }


### PR DESCRIPTION
## Summary

Lane B leaf **1-1** (blocks 1-7 and 1-8). Lifts publishing eligibility into the per-type capability pattern instead of the CANVAS-only hard gate in `apps/web/src/lib/canvas/publish-page.ts`.

- `PageTypeCapabilities` gains a **required** `publishable: boolean` — a future page type cannot typecheck without declaring it.
- `publishable: true` for CANVAS, DOCUMENT, CODE, SHEET (content lives in `pages.content`).
- `publishable: false` for FOLDER, CHANNEL, AI_CHAT, FILE, TASK_LIST, MACHINE (content lives in chat/tasks tables, object storage, or machine state).
- New helpers `isPublishablePageType(type)` and `getPublishablePageTypes()`, mirroring the existing helper style in `page-types.config.ts`.

## Tests

TDD: `packages/lib/src/content/__tests__/page-types-publishable.test.ts` (riteway-style asserts) written first and confirmed red, then implementation.

- All 6 test files touching page-type config: 98/98 pass.
- Full `@pagespace/lib` suite: 7933 passed; 3 failures in 2 unrelated files on one run did not reproduce on a second run (flaky, pre-existing — see known .pu-worktree React test flakiness).
- `tsc --noEmit` clean in `packages/lib` and `apps/web`; no external code constructs `PageTypeCapabilities`, so the new required field breaks no consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3WTcZGWpLBszpdkuqNpan