### PR TITLE
fix(machine): stop leaking Sprite stderr and absolute paths from Diff & git-blob routes

### DIFF
--- a/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
@@ -24,6 +24,11 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(() => false),
 }));
 
+const logApiError = vi.fn();
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: (...args: unknown[]) => logApiError(...(args as [])) } },
+}));
+
 type HandleResult =
   | { ok: true; handle: { machineId: string } }
   | { ok: false; reason: 'not_found' | 'vanished' };
@@ -222,11 +227,28 @@ describe('GET /api/machines/diff — list form', () => {
   it.each([
     { reason: 'exec_failed' as const, status: 502 },
     { reason: 'merge_base_failed' as const, status: 502 },
-  ])('maps a $reason service failure to $status', async ({ reason, status }) => {
-    listMachineDiffFiles.mockResolvedValue({ ok: false, reason, detail: 'boom' });
+  ])('maps a $reason service failure to $status with a sanitized error, logging the stderr detail', async ({ reason, status }) => {
+    const detail = "fatal: cannot access '/workspace/repo/.git': No such file or directory";
+    listMachineDiffFiles.mockResolvedValue({ ok: false, reason, detail });
     const res = await GET(get({}));
     expect(res.status).toBe(status);
-    expect(await res.json()).toEqual({ error: 'boom', reason });
+    const body = (await res.json()) as { error: string; reason: string };
+    expect(body).toEqual({ error: 'Failed to compute the changed-file list', reason });
+    expect(JSON.stringify(body)).not.toContain('/workspace');
+    expect(JSON.stringify(body)).not.toContain('fatal:');
+    expect(logApiError).toHaveBeenCalledWith(
+      'Machine diff list failed',
+      undefined,
+      expect.objectContaining({ reason, detail }),
+    );
+  });
+
+  it('does not log when a service failure carries no detail', async () => {
+    listMachineDiffFiles.mockResolvedValue({ ok: false, reason: 'exec_failed' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: 'Failed to compute the changed-file list', reason: 'exec_failed' });
+    expect(logApiError).not.toHaveBeenCalled();
   });
 });
 
@@ -311,9 +333,19 @@ describe('GET /api/machines/diff — per-file pair form', () => {
     expect(res.status).toBe(404);
   });
 
-  it('maps a pair-read exec failure to 502', async () => {
-    readMachineDiffPair.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'boom' });
+  it('maps a pair-read exec failure to 502 with a sanitized error, logging the stderr detail', async () => {
+    const detail = "fatal: path '/workspace/repo/src/a.ts' does not exist in 'HEAD'";
+    readMachineDiffPair.mockResolvedValue({ ok: false, reason: 'exec_failed', detail });
     const res = await GET(get({ path: 'src/a.ts' }));
     expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; reason: string };
+    expect(body).toEqual({ error: 'Failed to read the diff for this file', reason: 'exec_failed' });
+    expect(JSON.stringify(body)).not.toContain('/workspace');
+    expect(JSON.stringify(body)).not.toContain('fatal:');
+    expect(logApiError).toHaveBeenCalledWith(
+      'Machine diff pair read failed',
+      undefined,
+      expect.objectContaining({ reason: 'exec_failed', detail, path: 'src/a.ts' }),
+    );
   });
 });

--- a/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/diff/__tests__/route.test.ts
@@ -243,12 +243,16 @@ describe('GET /api/machines/diff — list form', () => {
     );
   });
 
-  it('does not log when a service failure carries no detail', async () => {
+  it('still error-logs a detail-less service failure — the 502 must stay diagnosable', async () => {
     listMachineDiffFiles.mockResolvedValue({ ok: false, reason: 'exec_failed' });
     const res = await GET(get({}));
     expect(res.status).toBe(502);
     expect(await res.json()).toEqual({ error: 'Failed to compute the changed-file list', reason: 'exec_failed' });
-    expect(logApiError).not.toHaveBeenCalled();
+    expect(logApiError).toHaveBeenCalledWith(
+      'Machine diff list failed',
+      undefined,
+      expect.objectContaining({ reason: 'exec_failed', machineId: 't1', branchName: 'feature/x', scope: 'uncommitted' }),
+    );
   });
 });
 

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -27,7 +27,8 @@
  * FAILURES are `{ error, reason }` — `reason` is the machine-readable token
  * clients switch on; `error` is a sentence fit to show a human, NEVER git's
  * stderr (which names absolute paths inside the Sprite). The stderr goes to
- * the server log. Same contract as the Files route.
+ * the server log. Same `error`/`reason` split as the Files route, but stricter
+ * on the stderr: `detail` is only ever logged here, never returned.
  *
  * On the main branch ('master'/'main' — the literal default-branch names,
  * there is no schema flag), the 'committed' and 'branch' scopes are
@@ -154,6 +155,19 @@ export async function GET(request: Request) {
   const ctx = buildDiffActorContext(scopeKey, actor);
   const deps = buildDiffGitDepsForHandle(resolved.handle);
 
+  // Every diff failure is a 5xx (see DENIAL_STATUS) and is ALWAYS logged, even
+  // when git died with empty stderr — the meta is what makes the 502
+  // diagnosable. `detail` (git stderr, naming absolute in-Sprite paths) belongs
+  // here and never in `error`, which the Diff tab renders straight at a person.
+  const logDiffFailure = (message: string, extra: Record<string, unknown>) =>
+    loggers.api.error(message, undefined, {
+      machineId: machineId.value,
+      projectName: projectName.value,
+      branchName: branchName.value,
+      scope,
+      ...extra,
+    });
+
   if (rawPath !== null && rawPath.length > 0 && workingTreePath !== null) {
     const result = await readMachineDiffPair({
       branchName: branchName.value,
@@ -169,21 +183,7 @@ export async function GET(request: Request) {
       deps,
     });
     if (!result.ok) {
-      // The exec's stderr has real diagnostic value, but it is OUR stderr: it
-      // names absolute paths inside the Sprite ("fatal: ... '/workspace/repo/…'").
-      // It goes to the server log — never into `error`, which the Diff tab
-      // renders straight at a person. Same contract as the Files route.
-      if (result.detail !== undefined) {
-        loggers.api.error('Machine diff pair read failed', undefined, {
-          machineId: machineId.value,
-          projectName: projectName.value,
-          branchName: branchName.value,
-          scope,
-          path: rawPath,
-          reason: result.reason,
-          detail: result.detail,
-        });
-      }
+      logDiffFailure('Machine diff pair read failed', { path: rawPath, reason: result.reason, detail: result.detail });
       return NextResponse.json(
         { error: 'Failed to read the diff for this file', reason: result.reason },
         { status: DENIAL_STATUS[result.reason] ?? 500 },
@@ -211,17 +211,7 @@ export async function GET(request: Request) {
     deps,
   });
   if (!result.ok) {
-    // Same rule as the pair form above: stderr detail is logged, never returned.
-    if (result.detail !== undefined) {
-      loggers.api.error('Machine diff list failed', undefined, {
-        machineId: machineId.value,
-        projectName: projectName.value,
-        branchName: branchName.value,
-        scope,
-        reason: result.reason,
-        detail: result.detail,
-      });
-    }
+    logDiffFailure('Machine diff list failed', { reason: result.reason, detail: result.detail });
     return NextResponse.json(
       { error: 'Failed to compute the changed-file list', reason: result.reason },
       { status: DENIAL_STATUS[result.reason] ?? 500 },

--- a/apps/web/src/app/api/machines/diff/route.ts
+++ b/apps/web/src/app/api/machines/diff/route.ts
@@ -24,6 +24,11 @@
  *     status) so a deletion's modified side is forced null rather than reading
  *     an untracked file masquerading at the same path (e.g. `git rm --cached`).
  *
+ * FAILURES are `{ error, reason }` — `reason` is the machine-readable token
+ * clients switch on; `error` is a sentence fit to show a human, NEVER git's
+ * stderr (which names absolute paths inside the Sprite). The stderr goes to
+ * the server log. Same contract as the Files route.
+ *
  * On the main branch ('master'/'main' — the literal default-branch names,
  * there is no schema flag), the 'committed' and 'branch' scopes are
  * meaningless (a merge-base with itself), so both forms return
@@ -39,6 +44,7 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { listMachineDiffFiles, readMachineDiffPair } from '@pagespace/lib/services/sandbox/machine-diff';
 import {
   isMachineDiffFileStatus,
@@ -163,8 +169,23 @@ export async function GET(request: Request) {
       deps,
     });
     if (!result.ok) {
+      // The exec's stderr has real diagnostic value, but it is OUR stderr: it
+      // names absolute paths inside the Sprite ("fatal: ... '/workspace/repo/…'").
+      // It goes to the server log — never into `error`, which the Diff tab
+      // renders straight at a person. Same contract as the Files route.
+      if (result.detail !== undefined) {
+        loggers.api.error('Machine diff pair read failed', undefined, {
+          machineId: machineId.value,
+          projectName: projectName.value,
+          branchName: branchName.value,
+          scope,
+          path: rawPath,
+          reason: result.reason,
+          detail: result.detail,
+        });
+      }
       return NextResponse.json(
-        { error: result.detail ?? result.reason, reason: result.reason },
+        { error: 'Failed to read the diff for this file', reason: result.reason },
         { status: DENIAL_STATUS[result.reason] ?? 500 },
       );
     }
@@ -190,8 +211,19 @@ export async function GET(request: Request) {
     deps,
   });
   if (!result.ok) {
+    // Same rule as the pair form above: stderr detail is logged, never returned.
+    if (result.detail !== undefined) {
+      loggers.api.error('Machine diff list failed', undefined, {
+        machineId: machineId.value,
+        projectName: projectName.value,
+        branchName: branchName.value,
+        scope,
+        reason: result.reason,
+        detail: result.detail,
+      });
+    }
     return NextResponse.json(
-      { error: result.detail ?? result.reason, reason: result.reason },
+      { error: 'Failed to compute the changed-file list', reason: result.reason },
       { status: DENIAL_STATUS[result.reason] ?? 500 },
     );
   }

--- a/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
@@ -18,8 +18,14 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 const logApiError = vi.fn();
+const logApiWarn = vi.fn();
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: { api: { error: (...args: unknown[]) => logApiError(...(args as [])) } },
+  loggers: {
+    api: {
+      error: (...args: unknown[]) => logApiError(...(args as [])),
+      warn: (...args: unknown[]) => logApiWarn(...(args as [])),
+    },
+  },
 }));
 
 type HandleResult =
@@ -138,11 +144,17 @@ describe('/api/machines/git-blob request contract', () => {
     expect(await res.json()).toEqual({ error: 'That git reference is not valid', reason: 'invalid_ref' });
   });
 
-  it('maps not_found to 404 without echoing the git detail', async () => {
-    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'not_found', detail: "does not exist in 'HEAD'" });
+  it('maps not_found to 404 without echoing the git detail, logging at warn (an expected miss, not an error)', async () => {
+    const detail = "fatal: path 'src/index.ts' does not exist in 'HEAD'";
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'not_found', detail });
     const res = await GET(get({}));
     expect(res.status).toBe(404);
     expect(await res.json()).toEqual({ error: 'File not found at this ref', reason: 'not_found' });
+    expect(logApiError).not.toHaveBeenCalled();
+    expect(logApiWarn).toHaveBeenCalledWith(
+      'Machine git-blob read failed',
+      expect.objectContaining({ reason: 'not_found', detail }),
+    );
   });
 
   it('maps exec_failed to 502 with a sanitized error, logging the stderr detail', async () => {
@@ -166,5 +178,6 @@ describe('/api/machines/git-blob request contract', () => {
     const res = await GET(get({}));
     expect(res.status).toBe(502);
     expect(logApiError).not.toHaveBeenCalled();
+    expect(logApiWarn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
@@ -17,6 +17,11 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(() => false),
 }));
 
+const logApiError = vi.fn();
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { error: (...args: unknown[]) => logApiError(...(args as [])) } },
+}));
+
 type HandleResult =
   | { ok: true; handle: { machineId: string } }
   | { ok: false; reason: 'not_found' | 'vanished' };
@@ -130,17 +135,36 @@ describe('/api/machines/git-blob request contract', () => {
     readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'invalid_ref' });
     const res = await GET(get({ ref: '--output=/tmp/x' }));
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'That git reference is not valid', reason: 'invalid_ref' });
   });
 
-  it('maps not_found to 404', async () => {
+  it('maps not_found to 404 without echoing the git detail', async () => {
     readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'not_found', detail: "does not exist in 'HEAD'" });
     const res = await GET(get({}));
     expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'File not found at this ref', reason: 'not_found' });
   });
 
-  it('maps exec_failed to 502', async () => {
-    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'boom' });
+  it('maps exec_failed to 502 with a sanitized error, logging the stderr detail', async () => {
+    const detail = "fatal: cannot access '/workspace/repo/.git': No such file or directory";
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'exec_failed', detail });
     const res = await GET(get({}));
     expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string; reason: string };
+    expect(body).toEqual({ error: 'Failed to read the file at this ref', reason: 'exec_failed' });
+    expect(JSON.stringify(body)).not.toContain('/workspace');
+    expect(JSON.stringify(body)).not.toContain('fatal:');
+    expect(logApiError).toHaveBeenCalledWith(
+      'Machine git-blob read failed',
+      undefined,
+      expect.objectContaining({ reason: 'exec_failed', detail, path: 'src/index.ts' }),
+    );
+  });
+
+  it('does not log when a failure carries no detail', async () => {
+    readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'exec_failed' });
+    const res = await GET(get({}));
+    expect(res.status).toBe(502);
+    expect(logApiError).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/git-blob/__tests__/route.test.ts
@@ -137,11 +137,13 @@ describe('/api/machines/git-blob request contract', () => {
     expect(body).toEqual({ content: 'file body', truncated: false });
   });
 
-  it('maps invalid_ref to 400', async () => {
+  it('maps invalid_ref to 400 without logging (an expected miss with nothing to diagnose)', async () => {
     readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'invalid_ref' });
     const res = await GET(get({ ref: '--output=/tmp/x' }));
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'That git reference is not valid', reason: 'invalid_ref' });
+    expect(logApiError).not.toHaveBeenCalled();
+    expect(logApiWarn).not.toHaveBeenCalled();
   });
 
   it('maps not_found to 404 without echoing the git detail, logging at warn (an expected miss, not an error)', async () => {
@@ -173,11 +175,15 @@ describe('/api/machines/git-blob request contract', () => {
     );
   });
 
-  it('does not log when a failure carries no detail', async () => {
+  it('still error-logs a detail-less exec failure — the 502 must stay diagnosable', async () => {
     readMachineGitBlob.mockResolvedValue({ ok: false, reason: 'exec_failed' });
     const res = await GET(get({}));
     expect(res.status).toBe(502);
-    expect(logApiError).not.toHaveBeenCalled();
+    expect(logApiError).toHaveBeenCalledWith(
+      'Machine git-blob read failed',
+      undefined,
+      expect.objectContaining({ reason: 'exec_failed', machineId: 't1', ref: 'origin/master', path: 'src/index.ts' }),
+    );
     expect(logApiWarn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/machines/git-blob/route.ts
+++ b/apps/web/src/app/api/machines/git-blob/route.ts
@@ -10,7 +10,8 @@
  * FAILURES are `{ error, reason }` — `reason` is the machine-readable token
  * clients switch on; `error` is a sentence fit to show a human, NEVER git's
  * stderr (which names absolute paths inside the Sprite). The stderr goes to
- * the server log. Same contract as the Files route.
+ * the server log. Same `error`/`reason` split as the Files route, but stricter
+ * on the stderr: `detail` is only ever logged here, never returned.
  *
  * `ref` is a resolved commit-ish (a branch, tag, SHA, or a merge-base the
  * caller already computed — see `sandbox-git-tools.ts`'s `gitDiff` three-dot
@@ -57,8 +58,7 @@ const DENIAL_STATUS: Record<string, number> = {
 
 // `error` is user-facing (clients render it straight into the UI), so it is a
 // sentence per reason token — never the token itself and never git's stderr,
-// which names absolute paths inside the Sprite. Same contract as the Files
-// route; the stderr goes to the server log instead.
+// which names absolute paths inside the Sprite (that goes to the server log).
 const DENIAL_MESSAGE: Record<string, string> = {
   invalid_ref: 'That git reference is not valid',
   not_found: 'File not found at this ref',
@@ -113,10 +113,13 @@ export async function GET(request: Request) {
     deps,
   });
   if (!result.ok) {
-    if (result.detail !== undefined) {
-      // Level follows severity: only exec_failed (502) is an operational error.
-      // A not_found miss is an expected 404 (a file absent at this ref) — its
-      // stderr detail is still kept, but at warn so it never pages anyone.
+    const status = DENIAL_STATUS[result.reason] ?? 500;
+    // A 5xx is an operational failure and is ALWAYS logged — even when git died
+    // with empty stderr, the meta is what makes the 502 diagnosable. An expected
+    // miss (400/404) is logged only when it carries stderr detail, at warn so it
+    // never pages anyone. Level follows the response status, the same >=500
+    // convention as logger-config's logResponse.
+    if (status >= 500 || result.detail !== undefined) {
       const meta = {
         machineId: machineId.value,
         projectName: projectName.value,
@@ -126,7 +129,7 @@ export async function GET(request: Request) {
         reason: result.reason,
         detail: result.detail,
       };
-      if (result.reason === 'exec_failed') {
+      if (status >= 500) {
         loggers.api.error('Machine git-blob read failed', undefined, meta);
       } else {
         loggers.api.warn('Machine git-blob read failed', meta);
@@ -134,7 +137,7 @@ export async function GET(request: Request) {
     }
     return NextResponse.json(
       { error: DENIAL_MESSAGE[result.reason] ?? 'Failed to read the file at this ref', reason: result.reason },
-      { status: DENIAL_STATUS[result.reason] ?? 500 },
+      { status },
     );
   }
   return NextResponse.json({ content: result.content, truncated: result.truncated });

--- a/apps/web/src/app/api/machines/git-blob/route.ts
+++ b/apps/web/src/app/api/machines/git-blob/route.ts
@@ -114,7 +114,10 @@ export async function GET(request: Request) {
   });
   if (!result.ok) {
     if (result.detail !== undefined) {
-      loggers.api.error('Machine git-blob read failed', undefined, {
+      // Level follows severity: only exec_failed (502) is an operational error.
+      // A not_found miss is an expected 404 (a file absent at this ref) — its
+      // stderr detail is still kept, but at warn so it never pages anyone.
+      const meta = {
         machineId: machineId.value,
         projectName: projectName.value,
         branchName: branchName.value,
@@ -122,7 +125,12 @@ export async function GET(request: Request) {
         path: path.value,
         reason: result.reason,
         detail: result.detail,
-      });
+      };
+      if (result.reason === 'exec_failed') {
+        loggers.api.error('Machine git-blob read failed', undefined, meta);
+      } else {
+        loggers.api.warn('Machine git-blob read failed', meta);
+      }
     }
     return NextResponse.json(
       { error: DENIAL_MESSAGE[result.reason] ?? 'Failed to read the file at this ref', reason: result.reason },

--- a/apps/web/src/app/api/machines/git-blob/route.ts
+++ b/apps/web/src/app/api/machines/git-blob/route.ts
@@ -7,6 +7,11 @@
  * GET ?machineId=&projectName=&branchName=&ref=&path=
  *   → { content, truncated }
  *
+ * FAILURES are `{ error, reason }` — `reason` is the machine-readable token
+ * clients switch on; `error` is a sentence fit to show a human, NEVER git's
+ * stderr (which names absolute paths inside the Sprite). The stderr goes to
+ * the server log. Same contract as the Files route.
+ *
  * `ref` is a resolved commit-ish (a branch, tag, SHA, or a merge-base the
  * caller already computed — see `sandbox-git-tools.ts`'s `gitDiff` three-dot
  * `base...head` composition for how a caller derives one); this route does not
@@ -24,6 +29,7 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { readMachineGitBlob } from '@pagespace/lib/services/sandbox/machine-git-blob';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import {
@@ -47,6 +53,16 @@ const DENIAL_STATUS: Record<string, number> = {
   invalid_ref: 400,
   not_found: 404,
   exec_failed: 502,
+};
+
+// `error` is user-facing (clients render it straight into the UI), so it is a
+// sentence per reason token — never the token itself and never git's stderr,
+// which names absolute paths inside the Sprite. Same contract as the Files
+// route; the stderr goes to the server log instead.
+const DENIAL_MESSAGE: Record<string, string> = {
+  invalid_ref: 'That git reference is not valid',
+  not_found: 'File not found at this ref',
+  exec_failed: 'Failed to read the file at this ref',
 };
 
 export async function GET(request: Request) {
@@ -97,8 +113,19 @@ export async function GET(request: Request) {
     deps,
   });
   if (!result.ok) {
+    if (result.detail !== undefined) {
+      loggers.api.error('Machine git-blob read failed', undefined, {
+        machineId: machineId.value,
+        projectName: projectName.value,
+        branchName: branchName.value,
+        ref: ref.value,
+        path: path.value,
+        reason: result.reason,
+        detail: result.detail,
+      });
+    }
     return NextResponse.json(
-      { error: result.detail ?? result.reason, reason: result.reason },
+      { error: DENIAL_MESSAGE[result.reason] ?? 'Failed to read the file at this ref', reason: result.reason },
       { status: DENIAL_STATUS[result.reason] ?? 500 },
     );
   }


### PR DESCRIPTION
## Problem

The Diff tab's two remaining read routes returned raw exec stderr to the client:

- `apps/web/src/app/api/machines/diff/route.ts` (pair form + list form) and `apps/web/src/app/api/machines/git-blob/route.ts` responded with `{ error: result.detail ?? result.reason }` on service failures.
- `result.detail` carries git/ls stderr naming absolute in-Sprite paths (`/workspace/repo/...`), and `useMachineDiff` renders `body.error` straight into the Diff tab UI.

PR #2004 fixed this class of leak in `files/route.ts` only (deferred-items audit, item 3).

## Fix

- `error` is now a generic human-facing sentence per failure; `reason` stays the safe machine-readable token clients switch on (`invalid_ref` / `not_found` / `exec_failed` / `merge_base_failed`). Status-code mapping unchanged.
- The stderr `detail` never enters the response body. It goes to the server log with route context (machineId, project, branch, scope, path/ref) — stricter than the Files route, which still returns `detail` in its body (flagged follow-up, out of scope here).
- Log level follows response status, matching `logger-config`'s `>=500 error / >=400 warn` convention: **5xx failures always log at error — even when git dies with empty stderr and `detail` is absent** (the meta is what makes the 502 diagnosable); expected misses (400/404) log at warn and only when they carry stderr detail, so an ordinary stale-file refresh never feeds the alerting path (codex review finding, addressed in a24ee1595).
- The `Branch machine ${reason}` handle-resolution messages are kept — `reason` there is a safe enum, not stderr.

## Tests

Colocated route contract tests extended: exec failures assert the exact sanitized `{ error, reason }` body, that the serialized response contains no `/workspace` path and no stderr text, that detail is logged server-side at the right level (error for 5xx, warn for a detailed 404), that a detail-less 502 still logs, and that a detail-less expected miss doesn't. 49/49 pass across the diff/git-blob/files suites; `tsc --noEmit` green for apps/web.

## Review decisions

- codex P2 (error-logging expected 404 misses): fixed — level now derived from response status.
- Declined extracting a shared `respondMachineFailure` helper across the three machines routes: the Files route can't share it until its `detail`-in-body behavior is changed (the flagged follow-up), and this PR intentionally mirrors the established per-route style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7cp6yY6SuZFg9Auh8GrhP