### PR TITLE
[sprites 5-1] Tasks API hold during agent runs

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -1287,12 +1287,23 @@ io.on('connection', (socket: AuthSocket) => {
     createTaskHold: ({ sprite, sessionKey }) =>
       createTaskHoldController({
         client: createSpriteTasksClient({ sprite }),
-        taskName: taskHoldName(sessionKey),
+        // Per-INCARNATION name (session key + creation time), not per key: a
+        // torn-down session's queued final DELETE runs on its own serialized
+        // queue, so under a shared name it could land AFTER a quickly
+        // reopened session's CREATE and destroy the live hold. Distinct names
+        // make that race unrepresentable; an orphaned old task self-expires.
+        taskName: taskHoldName(`${sessionKey}:${Date.now()}`),
         ...resolveTaskHoldConfig(process.env),
         onError: (stage, result) => {
           // Degrade gracefully: a lost hold means a possible pause, which the
           // checkpoint work (5-2) already survives — log and carry on.
-          loggers.realtime.warn(`Sprite task hold ${stage} failed`, { sessionKey, status: result.status });
+          // exitCode 127 = curl missing from the sprite image (feature inert
+          // for this sprite); an HTTP status = the tasks API answered.
+          loggers.realtime.warn(`Sprite task hold ${stage} failed`, {
+            sessionKey,
+            status: result.status,
+            exitCode: result.exitCode,
+          });
         },
       }),
   });

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -26,6 +26,12 @@ import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/
 import { checkMachineRuntimeGuardrail, recordMachineActivity, acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
 import { createSpritesSandboxClient, createSpriteHandleCache, type SpritesSdk } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { createSpriteMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-machine-host';
+import {
+  createSpriteTasksClient,
+  createTaskHoldController,
+  taskHoldName,
+  resolveTaskHoldConfig,
+} from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
 import { createExecClientFromMachineHost } from '@pagespace/lib/services/sandbox/sandbox-client/machine-host-adapter';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
 import {
@@ -1272,6 +1278,23 @@ io.on('connection', (socket: AuthSocket) => {
       await store.updateStreamSessionId({ id: agentTerminalId, streamSessionId: sessionId, now: new Date() });
     },
     billing: defaultSandboxBillingDeps,
+    // Sprites Tasks API hold (leaf 5-1): while an agent is running or a
+    // viewer attached, a short-expiry platform task (refreshed on a
+    // heartbeat, deleted on exit) keeps the sprite from cold-pausing mid-run;
+    // released when idle so the sprite CAN pause. 5m expiry / 60s refresh
+    // defaults, overridable via SPRITE_TASK_HOLD_EXPIRE_SECONDS /
+    // SPRITE_TASK_HOLD_REFRESH_MS.
+    createTaskHold: ({ sprite, sessionKey }) =>
+      createTaskHoldController({
+        client: createSpriteTasksClient({ sprite }),
+        taskName: taskHoldName(sessionKey),
+        ...resolveTaskHoldConfig(process.env),
+        onError: (stage, result) => {
+          // Degrade gracefully: a lost hold means a possible pause, which the
+          // checkpoint work (5-2) already survives — log and carry on.
+          loggers.realtime.warn(`Sprite task hold ${stage} failed`, { sessionKey, status: result.status });
+        },
+      }),
   });
 
   socket.on('agent-terminal:connect', (payload) => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
@@ -136,9 +136,9 @@ describe('agent terminal task holds (wiring)', () => {
 
     assert({
       given: 'a successful cold connect',
-      should: 'tick once immediately with the viewer attached',
-      actual: hold.ticks,
-      expected: [{ attached: true, lastOutputAt: undefined }],
+      should: 'tick once immediately with the viewer attached and observation live',
+      actual: { count: hold.ticks.length, attached: hold.ticks[0].attached, observable: hold.ticks[0].activityObservable },
+      expected: { count: 1, attached: true, observable: true },
     });
   });
 
@@ -170,8 +170,40 @@ describe('agent terminal task holds (wiring)', () => {
     assert({
       given: 'agent output followed by a heartbeat tick',
       should: 'report when output last flowed',
-      actual: lastTick.lastOutputAt !== undefined && lastTick.lastOutputAt >= before,
+      actual: lastTick.lastActivityAt !== undefined && lastTick.lastActivityAt >= before,
       expected: true,
+    });
+  });
+
+  it('counts the PTY launch itself as activity (a silent boot must not drop the hold)', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    assert({
+      given: 'a fresh connect whose agent has not yet produced output',
+      should: 'already carry an activity timestamp (the launch)',
+      actual: hold.ticks[0].lastActivityAt !== undefined,
+      expected: true,
+    });
+  });
+
+  it('counts typed input as activity so detach-before-first-output keeps the hold', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    // The user types a prompt that kicks off a long silent run…
+    vi.advanceTimersByTime(1_000);
+    const typedAt = Date.now();
+    handlers.onInput({ data: 'build the thing\r' });
+    // …and disconnects before the agent has emitted a single byte.
+    handlers.onDisconnect();
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'input typed, then detach before any output',
+      should: 'tick detached but with the input counted as fresh activity',
+      actual: { attached: lastTick.attached, activityFresh: (lastTick.lastActivityAt ?? 0) >= typedAt },
+      expected: { attached: false, activityFresh: true },
     });
   });
 
@@ -183,10 +215,26 @@ describe('agent terminal task holds (wiring)', () => {
 
     const lastTick = hold.ticks[hold.ticks.length - 1];
     assert({
-      given: 'the viewer disconnecting',
-      should: 'tick with attached: false (delete when the agent is idle)',
-      actual: lastTick.attached,
-      expected: false,
+      given: 'the viewer disconnecting from a fresh (non-resumed) session',
+      should: 'tick with attached: false and staleness trusted (silence was real until now)',
+      actual: { attached: lastTick.attached, observable: lastTick.activityObservable },
+      expected: { attached: false, observable: true },
+    });
+  });
+
+  it('heartbeats while detached are marked unobservable (the socket may be dead)', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+    handlers.onDisconnect();
+
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'a heartbeat tick after the viewer detached',
+      should: 'report activity as unobservable so the controller never deletes on a frozen clock',
+      actual: { attached: lastTick.attached, observable: lastTick.activityObservable },
+      expected: { attached: false, observable: false },
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Wiring tests for the Sprites Tasks API hold (leaf 5-1): the terminal handler
+ * must hold the sprite up while a viewer is attached or agent output is
+ * flowing, release it on detach-with-idle-agent, and delete it at session end
+ * — all through the injected `createTaskHold` seam, so these tests drive the
+ * handler with a recording fake controller and never touch a platform.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { buildAgentTerminalHandlers } from '../agent-terminal-handler';
+import { createTerminalSessionMap } from '../terminal-session-map';
+import type { AgentTerminalCheckAuthFn, OpenShellFn, SocketLike } from '../agent-terminal-handler';
+import type { OpenPtyShellArgs, PtyShell } from '../sprites-shell';
+import type { TaskHoldController, TaskHoldState } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
+import { assert } from './riteway';
+
+const TICK_INTERVAL_MS = 60_000;
+
+function makeShell(): PtyShell & { kill: ReturnType<typeof vi.fn> } {
+  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn() };
+}
+
+function makeSocket(id = 'sock1', userId = 'user1'): SocketLike & { emit: ReturnType<typeof vi.fn> } {
+  return { id, data: { user: { id: userId } }, emit: vi.fn() };
+}
+
+function makeSprite() {
+  return {
+    name: 'sbx1',
+    spawn: vi.fn(),
+    createSession: vi.fn(),
+    attachSession: vi.fn(),
+    listSessions: vi.fn(async () => []),
+    filesystem: vi.fn(),
+    updateNetworkPolicy: vi.fn(),
+    destroy: vi.fn(),
+  };
+}
+
+function makeAuthSuccess(sessionKey = 'branch1:agent:cli') {
+  const sprite = makeSprite();
+  return {
+    ok: true as const,
+    sessionKey,
+    payerId: 'owner-1',
+    sprite,
+    resolveSandbox: vi.fn(async () => ({
+      ok: true as const,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: 'sbx1',
+      cwd: '/workspace',
+      sprite,
+      command: 'claude',
+      args: [],
+      commandOverride: null,
+      streamSessionId: null,
+      releaseSlot: vi.fn(),
+    })),
+  };
+}
+
+/** A recording TaskHoldController: every tick's state, and whether end() ran. */
+function makeRecordingHold() {
+  const ticks: TaskHoldState[] = [];
+  let ended = false;
+  const controller: TaskHoldController = {
+    tickIntervalMs: TICK_INTERVAL_MS,
+    tick: (state) => {
+      ticks.push({ ...state });
+    },
+    end: () => {
+      ended = true;
+    },
+  };
+  return { controller, ticks, isEnded: () => ended };
+}
+
+const validPayload = { machineId: 't1', projectName: 'repo', branchName: 'feature-x', name: 'cli', cols: 80, rows: 24 };
+
+describe('agent terminal task holds (wiring)', () => {
+  let sessionMap: ReturnType<typeof createTerminalSessionMap>;
+  let shell: ReturnType<typeof makeShell>;
+  let openShell: ReturnType<typeof vi.fn> & OpenShellFn;
+  let checkAuth: ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+  let socket: ReturnType<typeof makeSocket>;
+  let persistStreamSessionId: ReturnType<typeof vi.fn>;
+  let hold: ReturnType<typeof makeRecordingHold>;
+  let createTaskHold: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionMap = createTerminalSessionMap();
+    shell = makeShell();
+    openShell = vi.fn().mockReturnValue(shell) as unknown as ReturnType<typeof vi.fn> & OpenShellFn;
+    checkAuth = vi.fn().mockResolvedValue(makeAuthSuccess()) as unknown as ReturnType<typeof vi.fn> & AgentTerminalCheckAuthFn;
+    socket = makeSocket();
+    persistStreamSessionId = vi.fn().mockResolvedValue(undefined);
+    hold = makeRecordingHold();
+    createTaskHold = vi.fn().mockReturnValue(hold.controller);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function build() {
+    return buildAgentTerminalHandlers({
+      sessionMap,
+      openShell,
+      checkAuth,
+      socket,
+      persistStreamSessionId,
+      createTaskHold: createTaskHold as unknown as Parameters<typeof buildAgentTerminalHandlers>[0]['createTaskHold'],
+    });
+  }
+
+  it('creates the hold immediately on a fresh attached connect', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    assert({
+      given: 'a successful cold connect',
+      should: 'construct one controller for the session',
+      actual: createTaskHold.mock.calls.length,
+      expected: 1,
+    });
+
+    assert({
+      given: 'a successful cold connect',
+      should: 'hand the factory the resolved sprite and session key',
+      actual: {
+        sessionKey: (createTaskHold.mock.calls[0][0] as { sessionKey: string }).sessionKey,
+        hasSprite: Boolean((createTaskHold.mock.calls[0][0] as { sprite?: unknown }).sprite),
+      },
+      expected: { sessionKey: 'branch1:agent:cli', hasSprite: true },
+    });
+
+    assert({
+      given: 'a successful cold connect',
+      should: 'tick once immediately with the viewer attached',
+      actual: hold.ticks,
+      expected: [{ attached: true, lastOutputAt: undefined }],
+    });
+  });
+
+  it('heartbeats on the controller cadence while the session lives', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+
+    assert({
+      given: 'two elapsed heartbeat intervals',
+      should: 'have ticked twice more (refresh cadence)',
+      actual: hold.ticks.length,
+      expected: 3,
+    });
+  });
+
+  it('carries the latest PTY output time into hold decisions', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    const args = (openShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as OpenPtyShellArgs;
+    const before = Date.now();
+    args.onOutput('agent says hi');
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'agent output followed by a heartbeat tick',
+      should: 'report when output last flowed',
+      actual: lastTick.lastOutputAt !== undefined && lastTick.lastOutputAt >= before,
+      expected: true,
+    });
+  });
+
+  it('ticks detached on viewer disconnect so an idle hold is released', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    handlers.onDisconnect();
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'the viewer disconnecting',
+      should: 'tick with attached: false (delete when the agent is idle)',
+      actual: lastTick.attached,
+      expected: false,
+    });
+  });
+
+  it('ticks attached again when a viewer reattaches to the live session', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+    handlers.onDisconnect();
+
+    const socket2 = makeSocket('sock2');
+    const handlers2 = buildAgentTerminalHandlers({
+      sessionMap,
+      openShell,
+      checkAuth,
+      socket: socket2,
+      persistStreamSessionId,
+      createTaskHold: createTaskHold as unknown as Parameters<typeof buildAgentTerminalHandlers>[0]['createTaskHold'],
+    });
+    await handlers2.onConnect(validPayload);
+
+    assert({
+      given: 'a reattach to the live session',
+      should: 'not construct a second controller (reattach touches no sprite)',
+      actual: createTaskHold.mock.calls.length,
+      expected: 1,
+    });
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'a reattach to the live session',
+      should: 'tick attached again (the hold must come back)',
+      actual: lastTick.attached,
+      expected: true,
+    });
+  });
+
+  it('ends the hold and stops the heartbeat when the PTY exits', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    const args = (openShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as OpenPtyShellArgs;
+    args.onExit(0);
+
+    assert({
+      given: 'the PTY exiting',
+      should: 'end the hold (delete on session end)',
+      actual: hold.isEnded(),
+      expected: true,
+    });
+
+    const ticksAtExit = hold.ticks.length;
+    vi.advanceTimersByTime(TICK_INTERVAL_MS * 3);
+    assert({
+      given: 'time passing after the session ended',
+      should: 'tick no further (heartbeat cleared by the teardown funnel)',
+      actual: hold.ticks.length,
+      expected: ticksAtExit,
+    });
+  });
+
+  it('still connects when no hold factory is wired (optional seam)', async () => {
+    const handlers = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId });
+    await handlers.onConnect(validPayload);
+
+    expect(socket.emit).toHaveBeenCalledWith('agent-terminal:ready', { connectionId: 'sock1', resumed: false });
+  });
+});

--- a/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
+++ b/apps/realtime/src/terminal/__tests__/terminal-session-map.test.ts
@@ -12,6 +12,7 @@ function fakeSession(sessionKey = 'key1', sandboxId = 'sbx1'): TerminalSession {
     scrollback: [],
     scrollbackBytes: 0,
     hasOutput: false,
+    viewerAttached: true,
     resumedAtCreate: false,
     reAuthInterval: undefined,
     idleTimer: undefined,

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -2,6 +2,7 @@ import type { TerminalSessionMap, TerminalSession } from './terminal-session-map
 import { DETACHED_IDLE_MS, appendScrollback } from './terminal-session-map';
 import type { OpenPtyShellArgs, PtyShell } from './sprites-shell';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import type { TaskHoldController } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
 import type { SandboxBillingDeps } from '@pagespace/lib/services/sandbox/tool-runners';
 import {
   validateAgentTerminalConnectPayload,
@@ -170,6 +171,16 @@ export type AgentTerminalHandlerDeps = {
   persistStreamSessionId: (args: { agentTerminalId: string; sessionId: string }) => Promise<void>;
   /** Terminal Epic 3 metering seam — see module doc. Omitted -> unmetered. */
   billing?: SandboxBillingDeps;
+  /**
+   * Sprites Tasks API hold seam (leaf 5-1). Called once per COLD create with
+   * the resolved Sprite; the controller it returns keeps a self-expiring
+   * platform task hold alive while work is in progress (viewer attached OR
+   * agent output flowing) and releases it when idle, so a sprite that leaves
+   * 3-1/3-2's now-real idle pause can't cold-pause an agent mid-run — and CAN
+   * pause the moment the agent goes quiet. Omitted -> no holds (the sprite
+   * pauses on the platform's own idle clock, mid-run or not).
+   */
+  createTaskHold?: (args: { sprite: SpriteInstanceLike; sessionKey: string }) => TaskHoldController;
 };
 
 export type AgentTerminalHandlers = {
@@ -259,6 +270,17 @@ function endAgentTerminalSession(
   if (session.idleTimer !== undefined) {
     clearTimeout(session.idleTimer);
     session.idleTimer = undefined;
+  }
+  if (session.holdInterval !== undefined) {
+    clearInterval(session.holdInterval);
+    session.holdInterval = undefined;
+  }
+  // Session over: delete the platform task hold so the sprite can pause.
+  // Best-effort (end() never throws) — and even a lost delete self-expires,
+  // because every hold this seam creates carries a short expiry.
+  if (session.taskHold !== undefined) {
+    session.taskHold.end();
+    session.taskHold = undefined;
   }
   if (billing && session.payerId && session.connectedAt !== undefined) {
     const activeSeconds = Math.max(0, (Date.now() - session.connectedAt) / 1000);
@@ -395,6 +417,31 @@ function startSettleHeartbeat(
   return interval;
 }
 
+/**
+ * Arms the platform-task-hold heartbeat (leaf 5-1): one immediate tick — the
+ * viewer is attached, so the hold must exist NOW, not a cadence from now —
+ * then one tick per controller cadence (the documented 60s refresh against a
+ * 5m expiry) for as long as the session is live. Each tick re-reads the
+ * session's CURRENT attached/output state, so the same beat that refreshes a
+ * busy session's hold deletes an idle one's. A module-level factory for the
+ * same reason as `startSettleHeartbeat`: the long-lived callback captures
+ * only what it needs, not the whole connect scope.
+ */
+function startTaskHoldHeartbeat(
+  taskHold: TaskHoldController,
+  sessionMap: TerminalSessionMap,
+  session: TerminalSession,
+  sessionKey: string,
+): ReturnType<typeof setInterval> {
+  const tick = () => taskHold.tick({ attached: session.viewerAttached, lastOutputAt: session.lastOutputAt });
+  tick();
+  const interval = setInterval(() => {
+    if (sessionMap.getByKey(sessionKey) !== session) { clearInterval(interval); return; }
+    tick();
+  }, taskHold.tickIntervalMs);
+  return interval;
+}
+
 /** How long the connect will wait to hear which sessions a Sprite has. */
 const LIST_SESSIONS_TIMEOUT_MS = 5_000;
 
@@ -460,6 +507,7 @@ export function buildAgentTerminalHandlers({
   socket,
   persistStreamSessionId,
   billing,
+  createTaskHold,
 }: AgentTerminalHandlerDeps): AgentTerminalHandlers {
   /**
    * Every connectionId this SOCKET currently has a live agent-terminal
@@ -554,6 +602,11 @@ export function buildAgentTerminalHandlers({
     // OUR exec connection — an agent still running inside the shell keeps
     // running, exactly as it already does across the 30-min idle reap below.
     session.command.setViewerAttached(false);
+    session.viewerAttached = false;
+    // Re-evaluate the platform task hold now that the viewer is gone: with no
+    // agent output flowing this DELETES the hold, so the sprite can pause
+    // long before the 30-min reap — an agent mid-run (recent output) keeps it.
+    session.taskHold?.tick({ attached: false, lastOutputAt: session.lastOutputAt });
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
       session.command.kill();
@@ -586,6 +639,11 @@ export function buildAgentTerminalHandlers({
     // while detached (sprites-shell.ts's `setViewerAttached`) — a no-op when the
     // connection never actually dropped, since output is already flowing.
     session.command.setViewerAttached(true);
+    session.viewerAttached = true;
+    // A viewer is attached again — that alone is "work in progress", so the
+    // hold (deleted while detached-and-idle) is re-created immediately rather
+    // than waiting out a heartbeat interval.
+    session.taskHold?.tick({ attached: true, lastOutputAt: session.lastOutputAt });
     sessionMap.reattach(sessionKey, socketKey(connectionId));
     activeConnectionIds.add(connectionId);
     // `resumed` says the agent was ALREADY DOING THINGS before this connect, so a
@@ -789,6 +847,7 @@ export function buildAgentTerminalHandlers({
         closedFn: (exitCode) => socket.emit('agent-terminal:closed', { exitCode, connectionId }),
         scrollback: [],
         hasOutput: false,
+        viewerAttached: true,
         // Fails safe, EXACTLY as the wire does. The reattach path has no way to
         // say "unknown" — it re-derives `resumed` from this field — so recording
         // `false` for an unknown liveness would put a live agent straight back
@@ -827,6 +886,9 @@ export function buildAgentTerminalHandlers({
           args: launch.args,
           cwd: sandbox.cwd,
           onOutput: (data) => {
+            // The hold's "agent output is flowing" signal — kept fresh here so
+            // a DETACHED session with an agent mid-run keeps its sprite up.
+            session.lastOutputAt = Date.now();
             appendScrollback(session, data);
             session.outputFn(data);
           },
@@ -873,6 +935,17 @@ export function buildAgentTerminalHandlers({
       session.command = shell;
       sessionMap.setNew(sessionKey, socketKey(connectionId), session);
       activeConnectionIds.add(connectionId);
+
+      // Sprites Tasks API hold (leaf 5-1): tell the platform work is in
+      // progress so the sprite can't cold-pause an agent mid-run — and stop
+      // telling it the moment nothing is (see startTaskHoldHeartbeat). Armed
+      // only on the cold path: a reattach joins a session whose controller
+      // and heartbeat already live for exactly as long as the session does
+      // (cleared in endAgentTerminalSession).
+      if (createTaskHold) {
+        session.taskHold = createTaskHold({ sprite, sessionKey });
+        session.holdInterval = startTaskHoldHeartbeat(session.taskHold, sessionMap, session, sessionKey);
+      }
 
       // Heartbeat settle (see SETTLE_HEARTBEAT_MS): bill the accrued window and
       // re-hold on an interval so a realtime restart loses at most one interval

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -418,6 +418,22 @@ function startSettleHeartbeat(
 }
 
 /**
+ * Pure: when this session was last ACTIVE — output produced, input typed, or
+ * the PTY launched (creation seeds `lastInputAt`). This is what the task hold
+ * feeds on rather than output alone: a typed prompt that kicks off a long
+ * silent run is work in progress from the moment it is typed, not from the
+ * agent's first byte.
+ */
+export function latestActivityAt(
+  session: Pick<TerminalSession, 'lastOutputAt' | 'lastInputAt'>,
+): number | undefined {
+  const { lastOutputAt, lastInputAt } = session;
+  if (lastOutputAt === undefined) return lastInputAt;
+  if (lastInputAt === undefined) return lastOutputAt;
+  return Math.max(lastOutputAt, lastInputAt);
+}
+
+/**
  * Arms the platform-task-hold heartbeat (leaf 5-1): one immediate tick — the
  * viewer is attached, so the hold must exist NOW, not a cadence from now —
  * then one tick per controller cadence (the documented 60s refresh against a
@@ -433,7 +449,18 @@ function startTaskHoldHeartbeat(
   session: TerminalSession,
   sessionKey: string,
 ): ReturnType<typeof setInterval> {
-  const tick = () => taskHold.tick({ attached: session.viewerAttached, lastOutputAt: session.lastOutputAt });
+  const tick = () =>
+    taskHold.tick({
+      attached: session.viewerAttached,
+      lastActivityAt: latestActivityAt(session),
+      // While DETACHED the exec socket may be dead (the shell deliberately
+      // never reconnects it — leaf 3-2), so a frozen activity clock is not
+      // evidence of idleness; the controller then keeps an existing hold
+      // rather than deleting it under an agent it can no longer see. And a
+      // detached agent that FINISHES while the socket survived still releases
+      // promptly: its PTY exit reaches onExit, whose teardown ends the hold.
+      activityObservable: session.viewerAttached,
+    });
   tick();
   const interval = setInterval(() => {
     if (sessionMap.getByKey(sessionKey) !== session) { clearInterval(interval); return; }
@@ -604,9 +631,20 @@ export function buildAgentTerminalHandlers({
     session.command.setViewerAttached(false);
     session.viewerAttached = false;
     // Re-evaluate the platform task hold now that the viewer is gone: with no
-    // agent output flowing this DELETES the hold, so the sprite can pause
-    // long before the 30-min reap — an agent mid-run (recent output) keeps it.
-    session.taskHold?.tick({ attached: false, lastOutputAt: session.lastOutputAt });
+    // recent activity this DELETES the hold, so the sprite can pause long
+    // before the 30-min reap — an agent mid-run (recent output OR a
+    // just-typed prompt still awaiting its first byte) keeps it. Staleness is
+    // trustworthy AT this instant (the viewer was attached until now, so the
+    // socket was live and silence was real silence) — with one exception: a
+    // RESUMED agent that has never emitted a byte since we picked it up. Our
+    // silence says nothing about a run that was verified live at connect
+    // (`resumedAtCreate`), so that one keeps its hold rather than being
+    // paused on ignorance.
+    session.taskHold?.tick({
+      attached: false,
+      lastActivityAt: latestActivityAt(session),
+      activityObservable: session.hasOutput || !session.resumedAtCreate,
+    });
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
       session.command.kill();
@@ -643,7 +681,7 @@ export function buildAgentTerminalHandlers({
     // A viewer is attached again — that alone is "work in progress", so the
     // hold (deleted while detached-and-idle) is re-created immediately rather
     // than waiting out a heartbeat interval.
-    session.taskHold?.tick({ attached: true, lastOutputAt: session.lastOutputAt });
+    session.taskHold?.tick({ attached: true, lastActivityAt: latestActivityAt(session), activityObservable: true });
     sessionMap.reattach(sessionKey, socketKey(connectionId));
     activeConnectionIds.add(connectionId);
     // `resumed` says the agent was ALREADY DOING THINGS before this connect, so a
@@ -848,6 +886,10 @@ export function buildAgentTerminalHandlers({
         scrollback: [],
         hasOutput: false,
         viewerAttached: true,
+        // The launch itself is the session's first activity: an agent booted
+        // with a command that works silently must hold its sprite up through
+        // that silence, not wait for its first byte of output.
+        lastInputAt: Date.now(),
         // Fails safe, EXACTLY as the wire does. The reattach path has no way to
         // say "unknown" — it re-derives `resumed` from this field — so recording
         // `false` for an unknown liveness would put a live agent straight back
@@ -1081,6 +1123,9 @@ export function buildAgentTerminalHandlers({
       if (!session) return;
       const p = payload as { data?: string };
       if (typeof p?.data === 'string' && p.data.length <= MAX_INPUT_BYTES) {
+        // Input is activity for the task hold: a typed prompt is work in
+        // progress even before the agent's first byte of output.
+        session.lastInputAt = Date.now();
         session.command.write(p.data);
       }
     },

--- a/apps/realtime/src/terminal/terminal-activity.ts
+++ b/apps/realtime/src/terminal/terminal-activity.ts
@@ -162,6 +162,11 @@ export async function handleTerminalActivityRequest(
 
   const text = formatTerminalActivityLine(parsed.payload);
   appendScrollback(session, text);
+  // An agent's bash run on this machine IS activity for the session's
+  // platform task hold: a detached multi-step agent run must not have its
+  // hold deleted between steps (agent-terminal-handler's hold heartbeat
+  // reads this via latestActivityAt).
+  session.lastOutputAt = Date.now();
   session.outputFn(text);
 
   return { status: 200, body: { success: true, delivered: true } };

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -25,8 +25,16 @@ export type TerminalSession = {
    * a coincidence of the reap machinery.
    */
   viewerAttached: boolean;
-  /** When the PTY last produced output — the hold's "agent output is flowing" signal. */
+  /** When the PTY last produced output — half of the hold's activity signal. */
   lastOutputAt?: number;
+  /**
+   * When the viewer last typed into the PTY (or the PTY was launched — the
+   * launch counts as the first input). The other half of the hold's activity
+   * signal: a prompt that kicks off a long SILENT run has produced no output
+   * yet, and a detach in that window must not read as "agent idle" and delete
+   * the hold out from under work that has already started.
+   */
+  lastInputAt?: number;
   /** The session's platform task hold (Sprites Tasks API), when the seam is wired. */
   taskHold?: TaskHoldController;
   /** Heartbeat driving `taskHold` ticks on the refresh cadence. */

--- a/apps/realtime/src/terminal/terminal-session-map.ts
+++ b/apps/realtime/src/terminal/terminal-session-map.ts
@@ -1,4 +1,5 @@
 import type { PtyShell } from './sprites-shell';
+import type { TaskHoldController } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
 
 export const MAX_SCROLLBACK_BYTES = 64 * 1024;
 export const DETACHED_IDLE_MS = 30 * 60 * 1000;
@@ -16,6 +17,20 @@ export type TerminalSession = {
   viewerUserId: string;
   /** Detachable exec session id on the Sprite, used to reattach after a WS drop. */
   sessionId?: string;
+  /**
+   * Is a viewer currently attached? Set true on create/reattach, false on
+   * detach — one of the two "work is in progress" signals the Sprites Tasks
+   * API hold (leaf 5-1) keys on. Kept explicit rather than inferred from
+   * `idleTimer === undefined` so the hold heartbeat reads a stated fact, not
+   * a coincidence of the reap machinery.
+   */
+  viewerAttached: boolean;
+  /** When the PTY last produced output — the hold's "agent output is flowing" signal. */
+  lastOutputAt?: number;
+  /** The session's platform task hold (Sprites Tasks API), when the seam is wired. */
+  taskHold?: TaskHoldController;
+  /** Heartbeat driving `taskHold` ticks on the refresh cadence. */
+  holdInterval?: ReturnType<typeof setInterval>;
   reAuthInterval?: ReturnType<typeof setInterval>;
   /** Heartbeat that settles the accrued active window mid-session (see agent-terminal-handler), bounding what a realtime restart can lose to one interval. */
   settleInterval?: ReturnType<typeof setInterval>;

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -542,6 +542,11 @@
       "import": "./dist/services/sandbox/sandbox-client/sprites.js",
       "require": "./dist/services/sandbox/sandbox-client/sprites.js"
     },
+    "./services/sandbox/sandbox-client/sprite-tasks": {
+      "types": "./dist/services/sandbox/sandbox-client/sprite-tasks.d.ts",
+      "import": "./dist/services/sandbox/sandbox-client/sprite-tasks.js",
+      "require": "./dist/services/sandbox/sandbox-client/sprite-tasks.js"
+    },
     "./services/sandbox/sandbox-client/sprite-machine-host": {
       "types": "./dist/services/sandbox/sandbox-client/sprite-machine-host.d.ts",
       "import": "./dist/services/sandbox/sandbox-client/sprite-machine-host.js",

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'vitest';
 import { assert } from '../../__tests__/riteway';
 import {
   planHold,
-  isAgentOutputFlowing,
+  isAgentActive,
   taskHoldName,
   taskUpsertExecArgs,
   taskDeleteExecArgs,
@@ -178,20 +178,20 @@ describe('planHold', () => {
   });
 });
 
-describe('isAgentOutputFlowing', () => {
-  it('treats recent output as a running agent', () => {
+describe('isAgentActive', () => {
+  it('treats recent activity as a running agent', () => {
     assert({
-      given: 'output produced inside the idle window',
-      should: 'be flowing',
-      actual: isAgentOutputFlowing({ lastOutputAt: T0 - 1_000, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
+      given: 'activity inside the idle window',
+      should: 'be active',
+      actual: isAgentActive({ lastActivityAt: T0 - 1_000, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
       expected: true,
     });
 
     assert({
-      given: 'output exactly one idle window old',
+      given: 'activity exactly one idle window old',
       should: 'be idle',
-      actual: isAgentOutputFlowing({
-        lastOutputAt: T0 - TASK_HOLD_AGENT_IDLE_MS,
+      actual: isAgentActive({
+        lastActivityAt: T0 - TASK_HOLD_AGENT_IDLE_MS,
         now: T0,
         idleMs: TASK_HOLD_AGENT_IDLE_MS,
       }),
@@ -199,9 +199,9 @@ describe('isAgentOutputFlowing', () => {
     });
 
     assert({
-      given: 'no output ever produced',
+      given: 'no activity ever recorded',
       should: 'be idle',
-      actual: isAgentOutputFlowing({ lastOutputAt: undefined, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
+      actual: isAgentActive({ lastActivityAt: undefined, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
       expected: false,
     });
   });
@@ -455,6 +455,28 @@ describe('resolveTaskHoldConfig', () => {
       expected: true,
     });
   });
+
+  it('rejects duration-suffixed values instead of silently truncating them', () => {
+    assert({
+      given: "an expiry of '5m' (parseInt would read it as five SECONDS)",
+      should: 'fall back to the default rather than mis-parse',
+      actual: resolveTaskHoldConfig({ SPRITE_TASK_HOLD_EXPIRE_SECONDS: '5m' }).expireSeconds,
+      expected: TASK_HOLD_EXPIRE_SECONDS,
+    });
+  });
+
+  it('caps the refresh at half the expiry so jitter can never straddle it', () => {
+    const config = resolveTaskHoldConfig({
+      SPRITE_TASK_HOLD_EXPIRE_SECONDS: '300',
+      SPRITE_TASK_HOLD_REFRESH_MS: '299999',
+    });
+    assert({
+      given: 'a refresh one millisecond under the expiry',
+      should: 'fall back — a beat must land well inside the window it extends',
+      actual: config.refreshMs <= (config.expireSeconds * 1000) / 2,
+      expected: true,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -514,9 +536,9 @@ describe('createSpriteTasksClient', () => {
 
     assert({
       given: 'a curl exec that exits 0 with a 200 status',
-      should: 'be ok with the parsed status',
+      should: 'be ok with the parsed status and exit code',
       actual: result,
-      expected: { ok: true, status: 200 },
+      expected: { ok: true, status: 200, exitCode: 0 },
     });
 
     assert({
@@ -619,7 +641,7 @@ describe('createTaskHoldController', () => {
       now: () => now,
     });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -630,7 +652,7 @@ describe('createTaskHoldController', () => {
     });
 
     now += 10_000;
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -641,7 +663,7 @@ describe('createTaskHoldController', () => {
     });
 
     now += TASK_HOLD_REFRESH_MS;
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -657,10 +679,10 @@ describe('createTaskHoldController', () => {
     const { client, calls } = fakeClient();
     const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
     now += 1_000;
-    controller.tick({ attached: false, lastOutputAt: undefined });
+    controller.tick({ attached: false, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -671,7 +693,7 @@ describe('createTaskHoldController', () => {
     });
 
     now += 1_000;
-    controller.tick({ attached: false, lastOutputAt: undefined });
+    controller.tick({ attached: false, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -687,12 +709,12 @@ describe('createTaskHoldController', () => {
     const { client, calls } = fakeClient();
     const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     // Viewer leaves; agent is mid-run (output seconds ago).
     now += TASK_HOLD_REFRESH_MS;
-    controller.tick({ attached: false, lastOutputAt: now - 1_000 });
+    controller.tick({ attached: false, lastActivityAt: now - 1_000 });
     await settle();
 
     assert({
@@ -704,7 +726,7 @@ describe('createTaskHoldController', () => {
 
     // Output stops; the agent goes idle past the idle window.
     now += TASK_HOLD_AGENT_IDLE_MS + 1;
-    controller.tick({ attached: false, lastOutputAt: now - TASK_HOLD_AGENT_IDLE_MS - 1 });
+    controller.tick({ attached: false, lastActivityAt: now - TASK_HOLD_AGENT_IDLE_MS - 1 });
     await settle();
 
     assert({
@@ -741,7 +763,7 @@ describe('createTaskHoldController', () => {
       onError: (stage) => errors.push(stage),
     });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -752,7 +774,7 @@ describe('createTaskHoldController', () => {
     });
 
     now += 1_000; // well inside the refresh interval — only the failure forces a retry
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
 
     assert({
@@ -777,7 +799,7 @@ describe('createTaskHoldController', () => {
       now: () => T0,
     });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
     controller.end();
     await settle();
@@ -795,7 +817,7 @@ describe('createTaskHoldController', () => {
     const { client, calls } = fakeClient();
     const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
 
-    controller.tick({ attached: true, lastOutputAt: undefined });
+    controller.tick({ attached: true, lastActivityAt: undefined });
     await settle();
     controller.end();
     await settle();
@@ -808,7 +830,7 @@ describe('createTaskHoldController', () => {
     });
 
     now += TASK_HOLD_REFRESH_MS * 2;
-    controller.tick({ attached: true, lastOutputAt: now });
+    controller.tick({ attached: true, lastActivityAt: now });
     await settle();
 
     assert({
@@ -831,6 +853,124 @@ describe('createTaskHoldController', () => {
       should: 'not exec anything',
       actual: calls.length,
       expected: 0,
+    });
+  });
+
+  it('still deletes on end() after a reported-failed upsert (the PUT may have landed)', async () => {
+    const { client, calls } = fakeClient({ upsert: { ok: false, exitCode: 28 } });
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => T0 });
+
+    controller.tick({ attached: true, lastActivityAt: undefined });
+    await settle();
+    controller.end();
+    await settle();
+
+    assert({
+      given: 'an upsert whose exec timed out AFTER the request may have applied',
+      should: 'delete on end() anyway — bookkeeping resets must not skip the cleanup',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'remove'],
+    });
+  });
+
+  it('keeps a blind detached hold instead of trusting a frozen activity clock', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
+
+    controller.tick({ attached: true, lastActivityAt: now });
+    await settle();
+
+    // Viewer detaches; the exec socket then dies (leaf 3-2 never reconnects
+    // it), so activity can no longer be observed. The clock is now well past
+    // the idle window (2×refresh) but inside the hold's expiry:
+    now += TASK_HOLD_REFRESH_MS * 3;
+    controller.tick({ attached: false, lastActivityAt: T0, activityObservable: false });
+    await settle();
+
+    assert({
+      given: 'a detached, unobservable session with a live hold and a stale clock',
+      should: 'keep refreshing the hold rather than deleting under a possibly-working agent',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert'],
+    });
+
+    assert({
+      given: 'a blind refresh',
+      should: 'never issue a remove',
+      actual: calls.some((c) => c.op === 'remove'),
+      expected: false,
+    });
+  });
+
+  it('stays quiet while blind when no hold exists (blindness must not CREATE work)', async () => {
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => T0 });
+
+    controller.tick({ attached: false, lastActivityAt: undefined, activityObservable: false });
+    await settle();
+
+    assert({
+      given: 'a blind tick with no live hold and no fresh activity',
+      should: 'do nothing',
+      actual: calls.length,
+      expected: 0,
+    });
+  });
+
+  it('re-creates over a possibly-live task with DELETE-then-PUT at the 1h lifetime boundary', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
+
+    controller.tick({ attached: true, lastActivityAt: now });
+    await settle();
+
+    // Refreshed along the way; the platform still retires the task at the
+    // ORIGINAL creation + 1h, so the re-create must genuinely re-create.
+    now += TASK_HOLD_MAX_LIFETIME_MS;
+    controller.tick({ attached: true, lastActivityAt: now });
+    await settle();
+
+    assert({
+      given: 'a hold reaching the platform max-task-lifetime boundary',
+      should: 'DELETE the old task before PUTting the new one (a bare upsert would not restart the platform clock)',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'remove', 'upsert'],
+    });
+  });
+
+  it('derives the idle window from the configured refresh cadence', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const refreshMs = 10_000;
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', refreshMs, now: () => now });
+
+    controller.tick({ attached: true, lastActivityAt: now });
+    await settle();
+
+    // Detached, observable, activity 1.5 refresh intervals old: inside the
+    // derived 2×refresh idle window, so still running.
+    now += refreshMs * 1.5;
+    controller.tick({ attached: false, lastActivityAt: T0 });
+    await settle();
+
+    assert({
+      given: 'activity 1.5 refresh intervals old under a custom cadence',
+      should: 'still count as running (idle window scales with the cadence)',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert'],
+    });
+
+    now += refreshMs;
+    controller.tick({ attached: false, lastActivityAt: T0 });
+    await settle();
+
+    assert({
+      given: 'activity 2.5 refresh intervals old',
+      should: 'now be idle and delete',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert', 'remove'],
     });
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
@@ -1,0 +1,836 @@
+import { describe, it } from 'vitest';
+import { assert } from '../../__tests__/riteway';
+import {
+  planHold,
+  isAgentOutputFlowing,
+  taskHoldName,
+  taskUpsertExecArgs,
+  taskDeleteExecArgs,
+  parseCurlStatus,
+  isHoldCallOk,
+  createSpriteTasksClient,
+  createTaskHoldController,
+  resolveTaskHoldConfig,
+  TASK_HOLD_EXPIRE_SECONDS,
+  TASK_HOLD_REFRESH_MS,
+  TASK_HOLD_MAX_LIFETIME_MS,
+  TASK_HOLD_AGENT_IDLE_MS,
+  type SpriteTasksClient,
+  type SpriteTaskCallResult,
+} from '../sprite-tasks';
+import type { SpriteCommandLike } from '../sprites';
+
+const T0 = 1_000_000; // an arbitrary fixed "now" — the pure core never reads the clock
+
+/** planHold inputs for the common "hold should exist" case, overridable per assertion. */
+function holdInputs(over: Partial<Parameters<typeof planHold>[0]> = {}): Parameters<typeof planHold>[0] {
+  return {
+    attached: true,
+    agentRunning: false,
+    createdAt: undefined,
+    lastRefreshAt: undefined,
+    expireSeconds: TASK_HOLD_EXPIRE_SECONDS,
+    refreshMs: TASK_HOLD_REFRESH_MS,
+    maxLifetimeMs: TASK_HOLD_MAX_LIFETIME_MS,
+    now: T0,
+    ...over,
+  };
+}
+
+describe('planHold', () => {
+  it('creates a hold when work is in progress and none exists', () => {
+    assert({
+      given: 'a viewer attached and no existing hold',
+      should: 'create',
+      actual: planHold(holdInputs()),
+      expected: 'create',
+    });
+
+    assert({
+      given: 'agent output flowing with no viewer and no existing hold',
+      should: 'create',
+      actual: planHold(holdInputs({ attached: false, agentRunning: true })),
+      expected: 'create',
+    });
+  });
+
+  it('is a noop while a live hold is inside its refresh interval', () => {
+    assert({
+      given: 'a hold refreshed less than the refresh interval ago',
+      should: 'noop',
+      actual: planHold(
+        holdInputs({ createdAt: T0 - 10_000, lastRefreshAt: T0 - 10_000 }),
+      ),
+      expected: 'noop',
+    });
+
+    assert({
+      given: 'a hold created (never refreshed) less than the refresh interval ago',
+      should: 'noop',
+      actual: planHold(holdInputs({ createdAt: T0 - 10_000 })),
+      expected: 'noop',
+    });
+  });
+
+  it('refreshes on the heartbeat cadence', () => {
+    assert({
+      given: 'a hold whose last refresh is exactly one refresh interval old',
+      should: 'refresh',
+      actual: planHold(
+        holdInputs({
+          createdAt: T0 - TASK_HOLD_REFRESH_MS,
+          lastRefreshAt: T0 - TASK_HOLD_REFRESH_MS,
+        }),
+      ),
+      expected: 'refresh',
+    });
+
+    assert({
+      given: 'a hold with several missed heartbeats but still inside its expiry margin',
+      should: 'refresh (the 5m expiry gives four missed heartbeats of margin)',
+      actual: planHold(
+        holdInputs({
+          createdAt: T0 - 4 * TASK_HOLD_REFRESH_MS,
+          lastRefreshAt: T0 - 4 * TASK_HOLD_REFRESH_MS,
+        }),
+      ),
+      expected: 'refresh',
+    });
+  });
+
+  it('re-creates a hold that has expired server-side (missed too many heartbeats)', () => {
+    assert({
+      given: 'a hold whose last refresh is older than the whole expiry window',
+      should: 'create (the platform already freed the task; a refresh names a dead hold)',
+      actual: planHold(
+        holdInputs({
+          createdAt: T0 - TASK_HOLD_EXPIRE_SECONDS * 1000,
+          lastRefreshAt: T0 - TASK_HOLD_EXPIRE_SECONDS * 1000,
+        }),
+      ),
+      expected: 'create',
+    });
+  });
+
+  it('re-creates at the 1h max-task-lifetime boundary', () => {
+    assert({
+      given: 'a hold created 1h ago and refreshed every minute since',
+      should: 'create (max task lifetime per creation is 1h — longer work re-creates)',
+      actual: planHold(
+        holdInputs({
+          createdAt: T0 - TASK_HOLD_MAX_LIFETIME_MS,
+          lastRefreshAt: T0 - TASK_HOLD_REFRESH_MS,
+        }),
+      ),
+      expected: 'create',
+    });
+
+    assert({
+      given: 'a hold created just under 1h ago, due an ordinary refresh',
+      should: 'refresh',
+      actual: planHold(
+        holdInputs({
+          createdAt: T0 - TASK_HOLD_MAX_LIFETIME_MS + 1,
+          lastRefreshAt: T0 - TASK_HOLD_REFRESH_MS,
+        }),
+      ),
+      expected: 'refresh',
+    });
+  });
+
+  it('deletes the hold when no work is in progress', () => {
+    assert({
+      given: 'a live hold, viewer detached, agent idle',
+      should: 'delete (let the sprite pause)',
+      actual: planHold(
+        holdInputs({
+          attached: false,
+          agentRunning: false,
+          createdAt: T0 - 10_000,
+          lastRefreshAt: T0 - 10_000,
+        }),
+      ),
+      expected: 'delete',
+    });
+
+    assert({
+      given: 'no hold, viewer detached, agent idle',
+      should: 'noop',
+      actual: planHold(holdInputs({ attached: false, agentRunning: false })),
+      expected: 'noop',
+    });
+  });
+
+  it('keeps holding for a detached viewer while agent output flows', () => {
+    assert({
+      given: 'viewer detached but agent output flowing, hold due a refresh',
+      should: 'refresh',
+      actual: planHold(
+        holdInputs({
+          attached: false,
+          agentRunning: true,
+          createdAt: T0 - TASK_HOLD_REFRESH_MS,
+          lastRefreshAt: T0 - TASK_HOLD_REFRESH_MS,
+        }),
+      ),
+      expected: 'refresh',
+    });
+  });
+});
+
+describe('isAgentOutputFlowing', () => {
+  it('treats recent output as a running agent', () => {
+    assert({
+      given: 'output produced inside the idle window',
+      should: 'be flowing',
+      actual: isAgentOutputFlowing({ lastOutputAt: T0 - 1_000, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
+      expected: true,
+    });
+
+    assert({
+      given: 'output exactly one idle window old',
+      should: 'be idle',
+      actual: isAgentOutputFlowing({
+        lastOutputAt: T0 - TASK_HOLD_AGENT_IDLE_MS,
+        now: T0,
+        idleMs: TASK_HOLD_AGENT_IDLE_MS,
+      }),
+      expected: false,
+    });
+
+    assert({
+      given: 'no output ever produced',
+      should: 'be idle',
+      actual: isAgentOutputFlowing({ lastOutputAt: undefined, now: T0, idleMs: TASK_HOLD_AGENT_IDLE_MS }),
+      expected: false,
+    });
+  });
+});
+
+describe('taskHoldName', () => {
+  it('derives a URL/exec-safe task name from a session key', () => {
+    const name = taskHoldName('branch1:agent:cli');
+    assert({
+      given: 'a session key with separator characters',
+      should: 'produce only [a-z0-9-] characters',
+      actual: /^[a-z0-9-]+$/.test(name),
+      expected: true,
+    });
+  });
+
+  it('is deterministic and collision-resistant across keys that sanitize alike', () => {
+    assert({
+      given: 'the same session key twice',
+      should: 'produce the same name',
+      actual: taskHoldName('a:b') === taskHoldName('a:b'),
+      expected: true,
+    });
+
+    assert({
+      given: 'two keys that differ only in separator characters',
+      should: 'produce different names (one terminal must not delete a sibling hold)',
+      actual: taskHoldName('a:b') === taskHoldName('a-b'),
+      expected: false,
+    });
+  });
+
+  it('stays within the task-name length budget for very long keys', () => {
+    assert({
+      given: 'a 72-char HMAC-hex session key',
+      should: 'produce a name no longer than 63 chars',
+      actual: taskHoldName('f'.repeat(72)).length <= 63,
+      expected: true,
+    });
+  });
+});
+
+describe('taskUpsertExecArgs', () => {
+  it('PUTs the documented upsert with an ALWAYS-set expiry', () => {
+    const [file, args] = taskUpsertExecArgs({ name: 'ps-hold-x', expireSeconds: 300 });
+    assert({
+      given: 'an upsert argv',
+      should: 'exec curl against the in-sprite management socket',
+      actual: file === 'curl' && args.includes('--unix-socket') && args.includes('/.sprite/api.sock'),
+      expected: true,
+    });
+
+    assert({
+      given: 'an upsert argv',
+      should: 'PUT the named task on the documented path',
+      actual: args.includes('PUT') && args.includes('http://sprite/v1/tasks/ps-hold-x'),
+      expected: true,
+    });
+
+    // Requirement: a realtime restart must leave only self-expiring holds —
+    // so the expiry is structurally part of EVERY create/refresh call.
+    assert({
+      given: 'an upsert argv',
+      should: 'always carry the expiry in the body',
+      actual: args.includes('{"expire":300}'),
+      expected: true,
+    });
+  });
+
+  it('rejects a task name that is not exec/URL-safe', () => {
+    let threw = false;
+    try {
+      taskUpsertExecArgs({ name: 'bad name/../x', expireSeconds: 300 });
+    } catch {
+      threw = true;
+    }
+    assert({
+      given: 'a task name with unsafe characters',
+      should: 'throw rather than interpolate it into an exec/URL',
+      actual: threw,
+      expected: true,
+    });
+  });
+
+  it('rejects a non-positive or out-of-range expiry', () => {
+    let threw = false;
+    try {
+      taskUpsertExecArgs({ name: 'ok-name', expireSeconds: 0 });
+    } catch {
+      threw = true;
+    }
+    assert({
+      given: 'a zero expiry (a task that would never hold)',
+      should: 'throw',
+      actual: threw,
+      expected: true,
+    });
+
+    let threwOverMax = false;
+    try {
+      taskUpsertExecArgs({ name: 'ok-name', expireSeconds: 3601 });
+    } catch {
+      threwOverMax = true;
+    }
+    assert({
+      given: 'an expiry above the 1h max task lifetime',
+      should: 'throw',
+      actual: threwOverMax,
+      expected: true,
+    });
+  });
+});
+
+describe('taskDeleteExecArgs', () => {
+  it('DELETEs the named task on the documented path', () => {
+    const [file, args] = taskDeleteExecArgs({ name: 'ps-hold-x' });
+    assert({
+      given: 'a delete argv',
+      should: 'DELETE the named task over the management socket',
+      actual:
+        file === 'curl' &&
+        args.includes('DELETE') &&
+        args.includes('http://sprite/v1/tasks/ps-hold-x') &&
+        args.includes('/.sprite/api.sock'),
+      expected: true,
+    });
+  });
+});
+
+describe('parseCurlStatus', () => {
+  it('reads the %{http_code} write-out', () => {
+    assert({
+      given: 'a bare status code with whitespace',
+      should: 'parse it',
+      actual: parseCurlStatus(' 201\n'),
+      expected: 201,
+    });
+
+    assert({
+      given: 'curl noise instead of a status',
+      should: 'be undefined',
+      actual: parseCurlStatus('curl: (7) Failed to connect'),
+      expected: undefined,
+    });
+
+    assert({
+      given: 'empty output',
+      should: 'be undefined',
+      actual: parseCurlStatus(''),
+      expected: undefined,
+    });
+  });
+});
+
+describe('isHoldCallOk', () => {
+  it('accepts 2xx for upsert, and 2xx or 404 for remove', () => {
+    assert({
+      given: 'an upsert that returned 200',
+      should: 'be ok',
+      actual: isHoldCallOk({ action: 'upsert', exitCode: 0, status: 200 }),
+      expected: true,
+    });
+
+    assert({
+      given: 'an upsert that returned 404',
+      should: 'not be ok',
+      actual: isHoldCallOk({ action: 'upsert', exitCode: 0, status: 404 }),
+      expected: false,
+    });
+
+    assert({
+      given: 'a remove whose task was already gone (404)',
+      should: 'be ok (the desired state holds)',
+      actual: isHoldCallOk({ action: 'remove', exitCode: 0, status: 404 }),
+      expected: true,
+    });
+
+    assert({
+      given: 'a remove that returned 204',
+      should: 'be ok',
+      actual: isHoldCallOk({ action: 'remove', exitCode: 0, status: 204 }),
+      expected: true,
+    });
+  });
+
+  it('fails a call whose curl exec itself failed', () => {
+    assert({
+      given: 'a non-zero curl exit (connection failure writes 000)',
+      should: 'not be ok',
+      actual: isHoldCallOk({ action: 'upsert', exitCode: 7, status: 0 }),
+      expected: false,
+    });
+
+    assert({
+      given: 'an unparsable status',
+      should: 'not be ok',
+      actual: isHoldCallOk({ action: 'remove', exitCode: 0, status: undefined }),
+      expected: false,
+    });
+  });
+});
+
+describe('resolveTaskHoldConfig', () => {
+  it('defaults to the documented 5m expiry / 60s refresh', () => {
+    assert({
+      given: 'an env with no overrides',
+      should: 'use the documented defaults',
+      actual: resolveTaskHoldConfig({}),
+      expected: { expireSeconds: TASK_HOLD_EXPIRE_SECONDS, refreshMs: TASK_HOLD_REFRESH_MS },
+    });
+  });
+
+  it('honors valid overrides', () => {
+    assert({
+      given: 'a valid expiry and refresh override',
+      should: 'use them',
+      actual: resolveTaskHoldConfig({
+        SPRITE_TASK_HOLD_EXPIRE_SECONDS: '600',
+        SPRITE_TASK_HOLD_REFRESH_MS: '120000',
+      }),
+      expected: { expireSeconds: 600, refreshMs: 120_000 },
+    });
+  });
+
+  it('rejects garbage and out-of-range values back to safe settings', () => {
+    assert({
+      given: 'a non-numeric expiry and a refresh no shorter than the expiry',
+      should: 'fall back to defaults / a refresh inside the expiry',
+      actual: resolveTaskHoldConfig({
+        SPRITE_TASK_HOLD_EXPIRE_SECONDS: 'soon',
+        SPRITE_TASK_HOLD_REFRESH_MS: String(TASK_HOLD_EXPIRE_SECONDS * 1000),
+      }),
+      expected: { expireSeconds: TASK_HOLD_EXPIRE_SECONDS, refreshMs: TASK_HOLD_REFRESH_MS },
+    });
+
+    const overMax = resolveTaskHoldConfig({ SPRITE_TASK_HOLD_EXPIRE_SECONDS: '7200' });
+    assert({
+      given: 'an expiry above the 1h max task lifetime',
+      should: 'fall back to the default expiry',
+      actual: overMax.expireSeconds,
+      expected: TASK_HOLD_EXPIRE_SECONDS,
+    });
+  });
+
+  it('keeps the refresh a genuine heartbeat under a short custom expiry', () => {
+    const config = resolveTaskHoldConfig({ SPRITE_TASK_HOLD_EXPIRE_SECONDS: '30' });
+    assert({
+      given: 'a 30s expiry with the default 60s refresh now too slow',
+      should: 'shrink the refresh below the expiry',
+      actual: config.refreshMs < config.expireSeconds * 1000,
+      expected: true,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Thin shells below — exercised with hand-rolled fakes (no mocking library).
+// ---------------------------------------------------------------------------
+
+type Listener = (...args: never[]) => void;
+
+/** A hand-rolled SpriteCommandLike whose exit/error/output the test drives. */
+function fakeCommand() {
+  const listeners = new Map<string, Listener[]>();
+  const on = (event: string, listener: Listener) => {
+    const list = listeners.get(event) ?? [];
+    list.push(listener);
+    listeners.set(event, list);
+  };
+  const fire = (event: string, ...args: unknown[]) => {
+    for (const listener of listeners.get(event) ?? []) {
+      (listener as (...a: unknown[]) => void)(...args);
+    }
+  };
+  let killed: string | undefined;
+  const command: SpriteCommandLike = {
+    stdout: { on: (event, listener) => on(`stdout:${event}`, listener as Listener) },
+    stderr: { on: (event, listener) => on(`stderr:${event}`, listener as Listener) },
+    on: (event: string, listener: Listener) => on(event, listener),
+    kill: (signal?: string) => {
+      killed = signal ?? 'SIGKILL';
+    },
+  } as SpriteCommandLike;
+  return {
+    command,
+    emitStdout: (data: string) => fire('stdout:data', data),
+    exit: (code: number) => fire('exit', code),
+    error: (error: unknown) => fire('error', error),
+    wasKilled: () => killed !== undefined,
+  };
+}
+
+describe('createSpriteTasksClient', () => {
+  it('reports ok on a successful upsert exec', async () => {
+    const spawned: Array<{ file: string; args: string[] }> = [];
+    const fake = fakeCommand();
+    const client = createSpriteTasksClient({
+      sprite: {
+        spawn: (file: string, args?: string[]) => {
+          spawned.push({ file, args: args ?? [] });
+          return fake.command;
+        },
+      },
+    });
+
+    const pending = client.upsert({ name: 'ps-hold-x', expireSeconds: 300 });
+    fake.emitStdout('200');
+    fake.exit(0);
+    const result = await pending;
+
+    assert({
+      given: 'a curl exec that exits 0 with a 200 status',
+      should: 'be ok with the parsed status',
+      actual: result,
+      expected: { ok: true, status: 200 },
+    });
+
+    assert({
+      given: 'the spawned argv',
+      should: 'carry the expiry (self-expiring holds only)',
+      actual: spawned[0].args.includes('{"expire":300}'),
+      expected: true,
+    });
+  });
+
+  it('degrades to ok:false on transport errors instead of throwing', async () => {
+    const fake = fakeCommand();
+    const client = createSpriteTasksClient({
+      sprite: { spawn: () => fake.command },
+    });
+
+    const pending = client.remove({ name: 'ps-hold-x' });
+    fake.error(new Error('WebSocket closed before open'));
+    const result = await pending;
+
+    assert({
+      given: 'an exec whose socket errored',
+      should: 'resolve ok:false rather than reject',
+      actual: result.ok,
+      expected: false,
+    });
+  });
+
+  it('kills and fails an exec that outlives its timeout', async () => {
+    const fake = fakeCommand();
+    const client = createSpriteTasksClient({
+      sprite: { spawn: () => fake.command },
+      timeoutMs: 5,
+    });
+
+    const result = await client.upsert({ name: 'ps-hold-x', expireSeconds: 300 });
+
+    assert({
+      given: 'an exec that never exits',
+      should: 'resolve ok:false after the timeout',
+      actual: result.ok,
+      expected: false,
+    });
+
+    assert({
+      given: 'an exec that never exits',
+      should: 'have been killed',
+      actual: fake.wasKilled(),
+      expected: true,
+    });
+  });
+
+  it('refuses an invalid name without throwing to the caller', async () => {
+    let spawnCalls = 0;
+    const client = createSpriteTasksClient({
+      sprite: {
+        spawn: () => {
+          spawnCalls += 1;
+          return fakeCommand().command;
+        },
+      },
+    });
+
+    const result = await client.upsert({ name: 'bad name', expireSeconds: 300 });
+
+    assert({
+      given: 'an unsafe task name',
+      should: 'resolve ok:false without ever spawning',
+      actual: { ok: result.ok, spawnCalls },
+      expected: { ok: false, spawnCalls: 0 },
+    });
+  });
+});
+
+describe('createTaskHoldController', () => {
+  function fakeClient(results: { upsert?: SpriteTaskCallResult; remove?: SpriteTaskCallResult } = {}) {
+    const calls: Array<{ op: 'upsert' | 'remove'; name: string; expireSeconds?: number }> = [];
+    const client: SpriteTasksClient = {
+      upsert: async ({ name, expireSeconds }) => {
+        calls.push({ op: 'upsert', name, expireSeconds });
+        return results.upsert ?? { ok: true, status: 200 };
+      },
+      remove: async ({ name }) => {
+        calls.push({ op: 'remove', name });
+        return results.remove ?? { ok: true, status: 204 };
+      },
+    };
+    return { client, calls };
+  }
+
+  /** Let the controller's internal op queue drain. */
+  const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  it('creates on the first attached tick and refreshes on the cadence', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({
+      client,
+      taskName: 'ps-hold-x',
+      now: () => now,
+    });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'the first tick with a viewer attached',
+      should: 'create the hold (one upsert)',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert'],
+    });
+
+    now += 10_000;
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'a tick inside the refresh interval',
+      should: 'not call the platform again',
+      actual: calls.length,
+      expected: 1,
+    });
+
+    now += TASK_HOLD_REFRESH_MS;
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'a tick past the refresh interval',
+      should: 'refresh (a second upsert)',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert'],
+    });
+  });
+
+  it('deletes the hold on detach with an idle agent', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+    now += 1_000;
+    controller.tick({ attached: false, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'a detach with no agent output',
+      should: 'delete the hold so the sprite can pause',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'remove'],
+    });
+
+    now += 1_000;
+    controller.tick({ attached: false, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'further detached-idle ticks',
+      should: 'stay quiet (no hold to delete)',
+      actual: calls.length,
+      expected: 2,
+    });
+  });
+
+  it('holds through a detach while agent output is flowing', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    // Viewer leaves; agent is mid-run (output seconds ago).
+    now += TASK_HOLD_REFRESH_MS;
+    controller.tick({ attached: false, lastOutputAt: now - 1_000 });
+    await settle();
+
+    assert({
+      given: 'a detached viewer with output still flowing',
+      should: 'keep refreshing the hold',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert'],
+    });
+
+    // Output stops; the agent goes idle past the idle window.
+    now += TASK_HOLD_AGENT_IDLE_MS + 1;
+    controller.tick({ attached: false, lastOutputAt: now - TASK_HOLD_AGENT_IDLE_MS - 1 });
+    await settle();
+
+    assert({
+      given: 'the agent going idle while detached',
+      should: 'delete the hold',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'upsert', 'remove'],
+    });
+  });
+
+  it('retries as a fresh create after a failed upsert (lost hold, graceful degrade)', async () => {
+    let now = T0;
+    let failNext = true;
+    const calls: Array<'upsert' | 'remove'> = [];
+    const client: SpriteTasksClient = {
+      upsert: async () => {
+        calls.push('upsert');
+        if (failNext) {
+          failNext = false;
+          return { ok: false };
+        }
+        return { ok: true, status: 200 };
+      },
+      remove: async () => {
+        calls.push('remove');
+        return { ok: true, status: 204 };
+      },
+    };
+    const errors: string[] = [];
+    const controller = createTaskHoldController({
+      client,
+      taskName: 'ps-hold-x',
+      now: () => now,
+      onError: (stage) => errors.push(stage),
+    });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'a failed create',
+      should: 'report the failure and carry on',
+      actual: errors,
+      expected: ['upsert'],
+    });
+
+    now += 1_000; // well inside the refresh interval — only the failure forces a retry
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+
+    assert({
+      given: 'the next tick after a failed create',
+      should: 'retry the create immediately rather than wait a full cadence',
+      actual: calls,
+      expected: ['upsert', 'upsert'],
+    });
+  });
+
+  it('never throws out of tick when the client itself throws', async () => {
+    const controller = createTaskHoldController({
+      client: {
+        upsert: async () => {
+          throw new Error('boom');
+        },
+        remove: async () => {
+          throw new Error('boom');
+        },
+      },
+      taskName: 'ps-hold-x',
+      now: () => T0,
+    });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+    controller.end();
+    await settle();
+
+    assert({
+      given: 'a client that throws on every call',
+      should: 'swallow the failure (holds are best-effort)',
+      actual: true,
+      expected: true,
+    });
+  });
+
+  it('deletes the hold on end() and goes inert', async () => {
+    let now = T0;
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => now });
+
+    controller.tick({ attached: true, lastOutputAt: undefined });
+    await settle();
+    controller.end();
+    await settle();
+
+    assert({
+      given: 'session end with a live hold',
+      should: 'delete it',
+      actual: calls.map((c) => c.op),
+      expected: ['upsert', 'remove'],
+    });
+
+    now += TASK_HOLD_REFRESH_MS * 2;
+    controller.tick({ attached: true, lastOutputAt: now });
+    await settle();
+
+    assert({
+      given: 'a tick after end()',
+      should: 'do nothing',
+      actual: calls.length,
+      expected: 2,
+    });
+  });
+
+  it('does not call the platform on end() when no hold was ever created', async () => {
+    const { client, calls } = fakeClient();
+    const controller = createTaskHoldController({ client, taskName: 'ps-hold-x', now: () => T0 });
+
+    controller.end();
+    await settle();
+
+    assert({
+      given: 'end() with no hold',
+      should: 'not exec anything',
+      actual: calls.length,
+      expected: 0,
+    });
+  });
+});

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
@@ -1,0 +1,498 @@
+/**
+ * Sprites Tasks API hold — "work is in progress, don't pause this sprite".
+ *
+ * A task is a hold on the current run: while at least one task is live, the
+ * Sprite runs (docs.sprites.dev/keeping-sprites-running). The documented
+ * pattern is a heartbeat — a SHORT expiry refreshed on a SHORTER interval,
+ * deleted on exit — so an undeleted hold always frees itself: 5-minute expiry
+ * refreshed every 60 seconds gives four missed heartbeats of margin, and a
+ * realtime-process restart can never leak a permanent hold.
+ *
+ * ENDPOINT SHAPE (verified 2026-07-12 against docs.sprites.dev and
+ * https://sprites.dev/api): the Tasks API is served ONLY by the Sprite's own
+ * management socket — `/.sprite/api.sock` inside the VM, virtual host
+ * `sprite`, plain HTTP/JSON (`PUT/POST/DELETE http://sprite/v1/tasks[/:name]`,
+ * body `{"expire": <seconds|"5m">}`). The public REST API (api.sprites.dev)
+ * documents no tasks endpoints, and the pinned @fly/sprites SDK (0.0.1-rc37)
+ * exposes no tasks primitive. So this "REST client" issues the documented
+ * REST calls by EXEC'ING `curl --unix-socket` inside the sprite through the
+ * SDK's spawn — the same authenticated exec channel every other operation
+ * uses (same auth/config as the SDK, no second credential path). That is
+ * semantically sound: a hold is only ever created/refreshed while work is in
+ * progress (viewer attached or agent output flowing), i.e. while the sprite
+ * is already awake — the exec never wakes a deliberately-paused sprite.
+ *
+ * Pure core / imperative shell: `planHold` (every lifecycle decision),
+ * `isAgentOutputFlowing`, the argv builders and the response classifiers are
+ * pure and unit-tested without mocks; `createSpriteTasksClient` (exec) and
+ * `createTaskHoldController` (bookkeeping + serialized queue) are thin shells.
+ *
+ * Failure policy: best-effort throughout. A failed call is reported and
+ * retried as a fresh create on the next tick; a lost hold means a possible
+ * mid-run pause, which the checkpoint work (leaf 2-1) already survives.
+ * Nothing here ever throws into the terminal handler.
+ */
+
+import type { SpriteCommandLike } from './sprites';
+
+/** Hold expiry — the platform frees the task this long after its last refresh. */
+export const TASK_HOLD_EXPIRE_SECONDS = 300;
+/** Heartbeat cadence — refresh every 60s against the 5m expiry (4 missed beats of margin). */
+export const TASK_HOLD_REFRESH_MS = 60_000;
+/** Max task lifetime per creation (docs: 1 hour) — longer work re-creates the hold. */
+export const TASK_HOLD_MAX_LIFETIME_MS = 60 * 60 * 1000;
+/**
+ * How recently the PTY must have produced output to count as "agent output is
+ * flowing". Two refresh intervals: long enough that a thinking agent between
+ * tool calls isn't declared idle, short enough that an agent sitting at its
+ * prompt releases the hold within a couple of minutes so the sprite can pause.
+ */
+export const TASK_HOLD_AGENT_IDLE_MS = 2 * TASK_HOLD_REFRESH_MS;
+/** Wall-clock bound on one tasks-API exec — holds are best-effort, never worth a hang. */
+export const TASK_EXEC_TIMEOUT_MS = 10_000;
+
+export type HoldAction = 'create' | 'refresh' | 'delete' | 'noop';
+
+/**
+ * Pure: what to do with this session's hold, now.
+ *
+ * `createdAt`/`lastRefreshAt` are OUR bookkeeping of the hold we believe is
+ * live (undefined -> no hold). Transitions:
+ *  - work in progress (attached viewer OR agent output flowing), no hold -> create
+ *  - work in progress, hold older than the 1h max-task-lifetime  -> create
+ *    (each creation lives at most 1h; longer work re-creates)
+ *  - work in progress, last refresh older than the whole expiry   -> create
+ *    (too many missed heartbeats — the platform already freed the task, so a
+ *    "refresh" would be upserting a dead hold; bookkeeping restarts its clock)
+ *  - work in progress, refresh interval elapsed                   -> refresh
+ *  - work in progress, inside the refresh interval                -> noop
+ *  - no work, hold exists                                         -> delete
+ *    (let the sprite pause — that pausing is now real is WHY this exists)
+ *  - no work, no hold                                             -> noop
+ */
+export function planHold({
+  attached,
+  agentRunning,
+  createdAt,
+  lastRefreshAt,
+  expireSeconds = TASK_HOLD_EXPIRE_SECONDS,
+  refreshMs = TASK_HOLD_REFRESH_MS,
+  maxLifetimeMs = TASK_HOLD_MAX_LIFETIME_MS,
+  now,
+}: {
+  attached: boolean;
+  agentRunning: boolean;
+  createdAt: number | undefined;
+  lastRefreshAt: number | undefined;
+  expireSeconds?: number;
+  refreshMs?: number;
+  maxLifetimeMs?: number;
+  now: number;
+}): HoldAction {
+  const needHold = attached || agentRunning;
+  const holdExists = createdAt !== undefined;
+  if (!needHold) return holdExists ? 'delete' : 'noop';
+  if (!holdExists) return 'create';
+  if (now - createdAt >= maxLifetimeMs) return 'create';
+  const last = lastRefreshAt ?? createdAt;
+  if (now - last >= expireSeconds * 1000) return 'create';
+  if (now - last >= refreshMs) return 'refresh';
+  return 'noop';
+}
+
+/** Pure: does output this recent count as a running agent? Never-output -> idle. */
+export function isAgentOutputFlowing({
+  lastOutputAt,
+  now,
+  idleMs = TASK_HOLD_AGENT_IDLE_MS,
+}: {
+  lastOutputAt: number | undefined;
+  now: number;
+  idleMs?: number;
+}): boolean {
+  if (lastOutputAt === undefined) return false;
+  return now - lastOutputAt < idleMs;
+}
+
+/** Task names are a URL path segment AND an exec argument — allow nothing else. */
+const SAFE_TASK_NAME = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * Pure: a 32-bit FNV-1a hash, hex-encoded. Not cryptographic — it only has to
+ * keep two session keys that sanitize identically from claiming (and deleting)
+ * each other's hold on a shared sprite.
+ */
+function fnv1aHex(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Pure: the platform task name for one terminal session's hold. Deterministic
+ * per session key (a reconnect refreshes the SAME hold), sanitized to
+ * [a-z0-9-], hash-suffixed so keys that sanitize alike stay distinct, and
+ * bounded to 63 chars (the platform's DNS-label-sized name budget).
+ */
+export function taskHoldName(sessionKey: string): string {
+  const sanitized = sessionKey
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const prefix = `ps-hold-${sanitized}`.slice(0, 54).replace(/-+$/, '');
+  return `${prefix}-${fnv1aHex(sessionKey)}`;
+}
+
+function assertSafeName(name: string): void {
+  if (!SAFE_TASK_NAME.test(name)) {
+    throw new TypeError(`Unsafe sprite task name: ${JSON.stringify(name)}`);
+  }
+}
+
+function assertSafeExpiry(expireSeconds: number): void {
+  if (
+    !Number.isInteger(expireSeconds) ||
+    expireSeconds <= 0 ||
+    expireSeconds * 1000 > TASK_HOLD_MAX_LIFETIME_MS
+  ) {
+    throw new TypeError(`Sprite task expiry out of range: ${expireSeconds}`);
+  }
+}
+
+/** Shared curl argv prefix: management socket, silent, status-code-only output, bounded. */
+function curlBase(): string[] {
+  return [
+    '--unix-socket',
+    '/.sprite/api.sock',
+    '-s',
+    '-o',
+    '/dev/null',
+    '-w',
+    '%{http_code}',
+    '--max-time',
+    '8',
+  ];
+}
+
+/**
+ * Pure: the exec argv for creating OR refreshing the hold — one idempotent
+ * upsert (docs: `PUT /v1/tasks/:name` is Refresh/Create), so create-vs-refresh
+ * is a bookkeeping distinction, never a wire race. The expiry is structurally
+ * part of EVERY call: there is no argv this module can produce that creates a
+ * hold without one, which is what makes a realtime restart leak-proof.
+ */
+export function taskUpsertExecArgs({
+  name,
+  expireSeconds,
+}: {
+  name: string;
+  expireSeconds: number;
+}): [string, string[]] {
+  assertSafeName(name);
+  assertSafeExpiry(expireSeconds);
+  return [
+    'curl',
+    [
+      ...curlBase(),
+      '-X',
+      'PUT',
+      '-H',
+      'Content-Type: application/json',
+      '-d',
+      JSON.stringify({ expire: expireSeconds }),
+      `http://sprite/v1/tasks/${name}`,
+    ],
+  ];
+}
+
+/** Pure: the exec argv for deleting the hold (`DELETE /v1/tasks/:name`). */
+export function taskDeleteExecArgs({ name }: { name: string }): [string, string[]] {
+  assertSafeName(name);
+  return ['curl', [...curlBase(), '-X', 'DELETE', `http://sprite/v1/tasks/${name}`]];
+}
+
+/** Pure: the `%{http_code}` write-out, or undefined for anything that isn't one. */
+export function parseCurlStatus(stdout: string): number | undefined {
+  const match = stdout.trim().match(/^(\d{3})$/);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+}
+
+/**
+ * Pure: did the call leave the desired state in place? Any 2xx does; a remove
+ * whose task was already gone (404 — expired, or a concurrent delete) also
+ * does. A non-zero curl exit is always a failure (curl writes `000` when it
+ * never got a response).
+ */
+export function isHoldCallOk({
+  action,
+  exitCode,
+  status,
+}: {
+  action: 'upsert' | 'remove';
+  exitCode: number;
+  status: number | undefined;
+}): boolean {
+  if (exitCode !== 0 || status === undefined) return false;
+  if (status >= 200 && status < 300) return true;
+  return action === 'remove' && status === 404;
+}
+
+/**
+ * Pure: the hold cadence from the environment, defaulting to the documented
+ * 5m expiry / 60s refresh. Invalid or out-of-range values fall back rather
+ * than throw (a bad env var must not take terminals down), and the refresh is
+ * always kept a genuine heartbeat — strictly inside the expiry window — so a
+ * misconfiguration can never produce a hold that expires between beats.
+ */
+export function resolveTaskHoldConfig(
+  env: Record<string, string | undefined>,
+): { expireSeconds: number; refreshMs: number } {
+  const rawExpire = Number.parseInt(env.SPRITE_TASK_HOLD_EXPIRE_SECONDS ?? '', 10);
+  const expireSeconds =
+    Number.isInteger(rawExpire) && rawExpire > 0 && rawExpire * 1000 <= TASK_HOLD_MAX_LIFETIME_MS
+      ? rawExpire
+      : TASK_HOLD_EXPIRE_SECONDS;
+  const fallbackRefreshMs = Math.min(
+    TASK_HOLD_REFRESH_MS,
+    Math.max(1000, Math.floor((expireSeconds * 1000) / 5)),
+  );
+  const rawRefresh = Number.parseInt(env.SPRITE_TASK_HOLD_REFRESH_MS ?? '', 10);
+  const refreshMs =
+    Number.isInteger(rawRefresh) && rawRefresh > 0 && rawRefresh < expireSeconds * 1000
+      ? rawRefresh
+      : fallbackRefreshMs;
+  return { expireSeconds, refreshMs };
+}
+
+export interface SpriteTaskCallResult {
+  ok: boolean;
+  status?: number;
+}
+
+export interface SpriteTasksClient {
+  /** Create or refresh the named hold — one idempotent PUT upsert. */
+  upsert(args: { name: string; expireSeconds: number }): Promise<SpriteTaskCallResult>;
+  /** Delete the named hold; a hold that is already gone counts as success. */
+  remove(args: { name: string }): Promise<SpriteTaskCallResult>;
+}
+
+/** The one Sprite capability this client consumes. */
+export type SpriteTaskSpawnLike = {
+  spawn(file: string, args?: string[]): SpriteCommandLike;
+};
+
+/**
+ * Run one curl exec and collect its exit code + stdout, bounded by `timeoutMs`
+ * (kill on expiry). Deliberately NOT `withWakeRetry`: holds only matter while
+ * the sprite is already awake, and a failed best-effort call is degraded, not
+ * retried inline — the controller's next tick is the retry.
+ */
+function runTaskExec(
+  sprite: SpriteTaskSpawnLike,
+  file: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ exitCode: number; stdout: string }> {
+  return new Promise((resolve, reject) => {
+    const command = sprite.spawn(file, args);
+    const chunks: string[] = [];
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        command.kill('SIGKILL');
+      } catch {
+        // Best-effort; the sprite reaps its own orphans.
+      }
+      reject(new Error(`Sprite tasks exec timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    command.stdout.on('data', (chunk) => {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
+    });
+    command.stderr.on('data', () => {
+      // Silenced (`-s`); listener kept so an SDK that buffers stderr never stalls.
+    });
+    command.on('exit', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ exitCode: code, stdout: chunks.join('') });
+    });
+    command.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+}
+
+/**
+ * The tasks "REST client": the documented `/v1/tasks` calls, issued over the
+ * sprite's management socket via the SDK's authenticated exec channel (see the
+ * module doc for why that IS the sanctioned surface). Never throws — every
+ * failure (bad name, transport error, timeout, non-2xx) resolves `ok: false`.
+ */
+export function createSpriteTasksClient({
+  sprite,
+  timeoutMs = TASK_EXEC_TIMEOUT_MS,
+}: {
+  sprite: SpriteTaskSpawnLike;
+  timeoutMs?: number;
+}): SpriteTasksClient {
+  const call = async (
+    action: 'upsert' | 'remove',
+    build: () => [string, string[]],
+  ): Promise<SpriteTaskCallResult> => {
+    try {
+      const [file, args] = build();
+      const { exitCode, stdout } = await runTaskExec(sprite, file, args, timeoutMs);
+      const status = parseCurlStatus(stdout);
+      return { ok: isHoldCallOk({ action, exitCode, status }), status };
+    } catch {
+      return { ok: false };
+    }
+  };
+  return {
+    upsert: ({ name, expireSeconds }) => call('upsert', () => taskUpsertExecArgs({ name, expireSeconds })),
+    remove: ({ name }) => call('remove', () => taskDeleteExecArgs({ name })),
+  };
+}
+
+export interface TaskHoldState {
+  /** Is a viewer currently attached to this terminal? */
+  attached: boolean;
+  /** When the PTY last produced output, if ever. */
+  lastOutputAt: number | undefined;
+}
+
+export interface TaskHoldController {
+  /** Re-evaluate the hold against the session's current state. Synchronous and non-throwing; the platform call (if any) runs on a serialized background queue. */
+  tick(state: TaskHoldState): void;
+  /** Session over: delete any live hold and go inert. Idempotent. */
+  end(): void;
+  /** The heartbeat cadence the owner should tick at (== refreshMs). */
+  readonly tickIntervalMs: number;
+}
+
+/**
+ * Per-session hold lifecycle: pure `planHold` decisions over private
+ * bookkeeping, acted on through a SERIALIZED queue (so a delete can never
+ * overtake the refresh before it, and `end()`'s delete always lands last).
+ *
+ * Bookkeeping is updated optimistically at decision time and RESET on a failed
+ * upsert, so the very next tick retries as a fresh create instead of waiting
+ * out a refresh interval it may no longer have. Failures are reported via
+ * `onError` and otherwise swallowed — a hold is protection, never a
+ * precondition (requirement: degrade gracefully; a lost hold means a possible
+ * pause, which the checkpoint work already survives).
+ */
+export function createTaskHoldController({
+  client,
+  taskName,
+  expireSeconds = TASK_HOLD_EXPIRE_SECONDS,
+  refreshMs = TASK_HOLD_REFRESH_MS,
+  maxLifetimeMs = TASK_HOLD_MAX_LIFETIME_MS,
+  agentIdleMs = TASK_HOLD_AGENT_IDLE_MS,
+  now = Date.now,
+  onError,
+}: {
+  client: SpriteTasksClient;
+  taskName: string;
+  expireSeconds?: number;
+  refreshMs?: number;
+  maxLifetimeMs?: number;
+  agentIdleMs?: number;
+  now?: () => number;
+  onError?: (stage: 'upsert' | 'delete', result: SpriteTaskCallResult) => void;
+}): TaskHoldController {
+  let createdAt: number | undefined;
+  let lastRefreshAt: number | undefined;
+  let ended = false;
+  let queue: Promise<void> = Promise.resolve();
+
+  const enqueue = (op: () => Promise<void>): void => {
+    queue = queue.then(op).catch(() => {});
+  };
+
+  const report = (stage: 'upsert' | 'delete', result: SpriteTaskCallResult): void => {
+    try {
+      onError?.(stage, result);
+    } catch {
+      // A logging callback must never break the hold loop.
+    }
+  };
+
+  const enqueueRemove = (): void => {
+    enqueue(async () => {
+      let result: SpriteTaskCallResult;
+      try {
+        result = await client.remove({ name: taskName });
+      } catch {
+        result = { ok: false };
+      }
+      // A failed delete is only a delayed pause: the hold self-expires within
+      // `expireSeconds` regardless — the leak-proofing lives in the expiry.
+      if (!result.ok) report('delete', result);
+    });
+  };
+
+  return {
+    tickIntervalMs: refreshMs,
+
+    tick({ attached, lastOutputAt }) {
+      if (ended) return;
+      const t = now();
+      const action = planHold({
+        attached,
+        agentRunning: isAgentOutputFlowing({ lastOutputAt, now: t, idleMs: agentIdleMs }),
+        createdAt,
+        lastRefreshAt,
+        expireSeconds,
+        refreshMs,
+        maxLifetimeMs,
+        now: t,
+      });
+      if (action === 'noop') return;
+
+      if (action === 'delete') {
+        createdAt = undefined;
+        lastRefreshAt = undefined;
+        enqueueRemove();
+        return;
+      }
+
+      // create | refresh — the same idempotent PUT upsert on the wire; only
+      // the bookkeeping differs (create restarts the 1h-lifetime clock).
+      if (action === 'create') createdAt = t;
+      lastRefreshAt = t;
+      enqueue(async () => {
+        let result: SpriteTaskCallResult;
+        try {
+          result = await client.upsert({ name: taskName, expireSeconds });
+        } catch {
+          result = { ok: false };
+        }
+        if (!result.ok) {
+          // Reset so the next tick plans a fresh create (an immediate retry).
+          createdAt = undefined;
+          lastRefreshAt = undefined;
+          report('upsert', result);
+        }
+      });
+    },
+
+    end() {
+      if (ended) return;
+      ended = true;
+      const hadHold = createdAt !== undefined;
+      createdAt = undefined;
+      lastRefreshAt = undefined;
+      if (hadHold) enqueueRemove();
+    },
+  };
+}

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
@@ -33,7 +33,7 @@
  * Nothing here ever throws into the terminal handler.
  */
 
-import type { SpriteCommandLike } from './sprites';
+import { runSpawned, type SpriteCommandLike } from './sprites';
 
 /** Hold expiry — the platform frees the task this long after its last refresh. */
 export const TASK_HOLD_EXPIRE_SECONDS = 300;
@@ -100,18 +100,24 @@ export function planHold({
   return 'noop';
 }
 
-/** Pure: does output this recent count as a running agent? Never-output -> idle. */
-export function isAgentOutputFlowing({
-  lastOutputAt,
+/**
+ * Pure: does activity this recent count as a running agent? Never-active ->
+ * idle. "Activity" is deliberately wider than output: typed input (a prompt
+ * that kicks off a long silent run) and the PTY launch itself both count, so
+ * a viewer who types and detaches before the agent's first byte doesn't get
+ * their agent's hold deleted out from under a run that has already started.
+ */
+export function isAgentActive({
+  lastActivityAt,
   now,
   idleMs = TASK_HOLD_AGENT_IDLE_MS,
 }: {
-  lastOutputAt: number | undefined;
+  lastActivityAt: number | undefined;
   now: number;
   idleMs?: number;
 }): boolean {
-  if (lastOutputAt === undefined) return false;
-  return now - lastOutputAt < idleMs;
+  if (lastActivityAt === undefined) return false;
+  return now - lastActivityAt < idleMs;
 }
 
 /** Task names are a URL path segment AND an exec argument — allow nothing else. */
@@ -138,11 +144,20 @@ function fnv1aHex(input: string): string {
  * bounded to 63 chars (the platform's DNS-label-sized name budget).
  */
 export function taskHoldName(sessionKey: string): string {
-  const sanitized = sessionKey
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-  const prefix = `ps-hold-${sanitized}`.slice(0, 54).replace(/-+$/, '');
+  // Single-pass character map — no backtracking-capable regex over the
+  // caller-controlled key (CodeQL: polynomial regex on uncontrolled data).
+  const lower = sessionKey.toLowerCase();
+  let sanitized = '';
+  for (let i = 0; i < lower.length && sanitized.length < 45; i += 1) {
+    const ch = lower[i];
+    if ((ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9')) {
+      sanitized += ch;
+    } else if (sanitized.length > 0 && !sanitized.endsWith('-')) {
+      sanitized += '-';
+    }
+  }
+  while (sanitized.endsWith('-')) sanitized = sanitized.slice(0, -1);
+  const prefix = sanitized.length > 0 ? `ps-hold-${sanitized}` : 'ps-hold';
   return `${prefix}-${fnv1aHex(sessionKey)}`;
 }
 
@@ -241,35 +256,50 @@ export function isHoldCallOk({
 }
 
 /**
+ * Pure: an env var as a positive integer, or undefined. Digits-only by
+ * construction — `Number.parseInt('5m')` is 5, so a lenient parse would turn
+ * `SPRITE_TASK_HOLD_EXPIRE_SECONDS=5m` into five SECONDS instead of falling
+ * back; the same convention the repo's other `envInt` helpers use.
+ */
+function envPositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined || !/^\d{1,15}$/.test(value)) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return parsed > 0 ? parsed : undefined;
+}
+
+/**
  * Pure: the hold cadence from the environment, defaulting to the documented
  * 5m expiry / 60s refresh. Invalid or out-of-range values fall back rather
  * than throw (a bad env var must not take terminals down), and the refresh is
- * always kept a genuine heartbeat — strictly inside the expiry window — so a
- * misconfiguration can never produce a hold that expires between beats.
+ * always kept a genuine heartbeat — at most HALF the expiry window, so timer
+ * jitter on a beat can never coincide with the hold's own expiry (a refresh
+ * of expiry−ε would otherwise leave a recurring no-hold gap every interval).
  */
 export function resolveTaskHoldConfig(
   env: Record<string, string | undefined>,
 ): { expireSeconds: number; refreshMs: number } {
-  const rawExpire = Number.parseInt(env.SPRITE_TASK_HOLD_EXPIRE_SECONDS ?? '', 10);
+  const rawExpire = envPositiveInt(env.SPRITE_TASK_HOLD_EXPIRE_SECONDS);
   const expireSeconds =
-    Number.isInteger(rawExpire) && rawExpire > 0 && rawExpire * 1000 <= TASK_HOLD_MAX_LIFETIME_MS
+    rawExpire !== undefined && rawExpire * 1000 <= TASK_HOLD_MAX_LIFETIME_MS
       ? rawExpire
       : TASK_HOLD_EXPIRE_SECONDS;
+  const maxRefreshMs = Math.max(1000, Math.floor((expireSeconds * 1000) / 2));
   const fallbackRefreshMs = Math.min(
     TASK_HOLD_REFRESH_MS,
     Math.max(1000, Math.floor((expireSeconds * 1000) / 5)),
   );
-  const rawRefresh = Number.parseInt(env.SPRITE_TASK_HOLD_REFRESH_MS ?? '', 10);
+  const rawRefresh = envPositiveInt(env.SPRITE_TASK_HOLD_REFRESH_MS);
   const refreshMs =
-    Number.isInteger(rawRefresh) && rawRefresh > 0 && rawRefresh < expireSeconds * 1000
-      ? rawRefresh
-      : fallbackRefreshMs;
+    rawRefresh !== undefined && rawRefresh <= maxRefreshMs ? rawRefresh : fallbackRefreshMs;
   return { expireSeconds, refreshMs };
 }
 
 export interface SpriteTaskCallResult {
   ok: boolean;
+  /** The parsed HTTP status, when the exec produced one. */
   status?: number;
+  /** The exec's exit code, when it ran — 127 pinpoints a missing curl binary. */
+  exitCode?: number;
 }
 
 export interface SpriteTasksClient {
@@ -285,51 +315,11 @@ export type SpriteTaskSpawnLike = {
 };
 
 /**
- * Run one curl exec and collect its exit code + stdout, bounded by `timeoutMs`
- * (kill on expiry). Deliberately NOT `withWakeRetry`: holds only matter while
- * the sprite is already awake, and a failed best-effort call is degraded, not
- * retried inline — the controller's next tick is the retry.
+ * Output cap for one hold exec — the whole expected payload is a 3-digit
+ * `%{http_code}` write-out, so anything past a few KB is a misbehaving exec
+ * that `runSpawned` should kill rather than buffer.
  */
-function runTaskExec(
-  sprite: SpriteTaskSpawnLike,
-  file: string,
-  args: string[],
-  timeoutMs: number,
-): Promise<{ exitCode: number; stdout: string }> {
-  return new Promise((resolve, reject) => {
-    const command = sprite.spawn(file, args);
-    const chunks: string[] = [];
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      try {
-        command.kill('SIGKILL');
-      } catch {
-        // Best-effort; the sprite reaps its own orphans.
-      }
-      reject(new Error(`Sprite tasks exec timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-    command.stdout.on('data', (chunk) => {
-      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf8'));
-    });
-    command.stderr.on('data', () => {
-      // Silenced (`-s`); listener kept so an SDK that buffers stderr never stalls.
-    });
-    command.on('exit', (code) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      resolve({ exitCode: code, stdout: chunks.join('') });
-    });
-    command.on('error', (error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      reject(error instanceof Error ? error : new Error(String(error)));
-    });
-  });
-}
+const TASK_EXEC_MAX_OUTPUT_BYTES = 4096;
 
 /**
  * The tasks "REST client": the documented `/v1/tasks` calls, issued over the
@@ -350,9 +340,19 @@ export function createSpriteTasksClient({
   ): Promise<SpriteTaskCallResult> => {
     try {
       const [file, args] = build();
-      const { exitCode, stdout } = await runTaskExec(sprite, file, args, timeoutMs);
+      // runSpawned (sprites.ts) is the driver's own collect-bounded-output-or-
+      // kill executor: hard timeout with SIGKILL, output cap, exit-code-as-
+      // result. Deliberately NOT wrapped in `withWakeRetry` — holds only
+      // matter while the sprite is already awake, and a failed best-effort
+      // call is degraded, not retried inline (the controller's next tick is
+      // the retry).
+      const { exitCode, stdout } = await runSpawned(
+        sprite.spawn(file, args),
+        TASK_EXEC_MAX_OUTPUT_BYTES,
+        timeoutMs,
+      );
       const status = parseCurlStatus(stdout);
-      return { ok: isHoldCallOk({ action, exitCode, status }), status };
+      return { ok: isHoldCallOk({ action, exitCode, status }), status, exitCode };
     } catch {
       return { ok: false };
     }
@@ -366,8 +366,21 @@ export function createSpriteTasksClient({
 export interface TaskHoldState {
   /** Is a viewer currently attached to this terminal? */
   attached: boolean;
-  /** When the PTY last produced output, if ever. */
-  lastOutputAt: number | undefined;
+  /** When the PTY was last ACTIVE — launch, typed input, or produced output — if ever (see {@link isAgentActive}). */
+  lastActivityAt: number | undefined;
+  /**
+   * Can the caller still OBSERVE activity? While a viewer is attached the
+   * exec WebSocket is kept alive (the shell's watchdog reconnects), so "no
+   * output for N minutes" is real data. While DETACHED the shell deliberately
+   * never reconnects a dropped socket (leaf 3-2), so the activity clock can
+   * freeze under an agent that is still working. FRESH activity is always
+   * trustworthy evidence of work (we saw the bytes); STALE activity is only
+   * trustworthy evidence of idleness when this is true. When false, an
+   * existing hold is kept refreshed (until the session ends or is reaped —
+   * a bounded ~30min) rather than deleted on a clock that may be blind.
+   * Defaults to true.
+   */
+  activityObservable?: boolean;
 }
 
 export interface TaskHoldController {
@@ -386,18 +399,38 @@ export interface TaskHoldController {
  *
  * Bookkeeping is updated optimistically at decision time and RESET on a failed
  * upsert, so the very next tick retries as a fresh create instead of waiting
- * out a refresh interval it may no longer have. Failures are reported via
- * `onError` and otherwise swallowed — a hold is protection, never a
- * precondition (requirement: degrade gracefully; a lost hold means a possible
- * pause, which the checkpoint work already survives).
+ * out a refresh interval it may no longer have. `mayHoldRemotely` is the one
+ * flag that survives that reset: a PUT that REPORTED failure may still have
+ * landed (curl killed after the request was applied), so `end()` keys its
+ * final delete on "was an upsert ever attempted since the last delete", never
+ * on the retry bookkeeping — otherwise a failed-then-closed session would
+ * leak its hold for the full expiry.
+ *
+ * Blind-staleness policy (see {@link TaskHoldState.activityObservable}):
+ * fresh activity always counts as work; STALE activity only counts as
+ * idleness when the caller can still observe activity. When it can't
+ * (detached, exec socket dropped and deliberately not reconnected — leaf
+ * 3-2), an existing hold is kept refreshed instead of deleted on a frozen
+ * clock; the session's own end/reap (bounded, ~30min) is what releases it.
+ *
+ * A re-create over a possibly-live task (the 1h max-lifetime boundary)
+ * DELETEs before PUTting: the platform's max task lifetime is per CREATION,
+ * so a plain upsert would refresh a task the platform still retires at the
+ * original creation+1h — bookkeeping would then claim an hour the platform
+ * never granted.
+ *
+ * Failures are reported via `onError` (with the exec exit code / HTTP status,
+ * so a missing-curl 127 is distinguishable from an API error) and otherwise
+ * swallowed — a hold is protection, never a precondition (requirement:
+ * degrade gracefully; a lost hold means a possible pause, which the
+ * checkpoint work already survives).
  */
 export function createTaskHoldController({
   client,
   taskName,
   expireSeconds = TASK_HOLD_EXPIRE_SECONDS,
   refreshMs = TASK_HOLD_REFRESH_MS,
-  maxLifetimeMs = TASK_HOLD_MAX_LIFETIME_MS,
-  agentIdleMs = TASK_HOLD_AGENT_IDLE_MS,
+  agentIdleMs,
   now = Date.now,
   onError,
 }: {
@@ -405,13 +438,15 @@ export function createTaskHoldController({
   taskName: string;
   expireSeconds?: number;
   refreshMs?: number;
-  maxLifetimeMs?: number;
+  /** How stale activity may be before a DETACHED-but-observable agent counts as idle. Defaults to two refresh intervals, whatever the refresh cadence is configured to. */
   agentIdleMs?: number;
   now?: () => number;
   onError?: (stage: 'upsert' | 'delete', result: SpriteTaskCallResult) => void;
 }): TaskHoldController {
+  const idleMs = agentIdleMs ?? 2 * refreshMs;
   let createdAt: number | undefined;
   let lastRefreshAt: number | undefined;
+  let mayHoldRemotely = false;
   let ended = false;
   let queue: Promise<void> = Promise.resolve();
 
@@ -428,6 +463,7 @@ export function createTaskHoldController({
   };
 
   const enqueueRemove = (): void => {
+    mayHoldRemotely = false;
     enqueue(async () => {
       let result: SpriteTaskCallResult;
       try {
@@ -444,17 +480,24 @@ export function createTaskHoldController({
   return {
     tickIntervalMs: refreshMs,
 
-    tick({ attached, lastOutputAt }) {
+    tick({ attached, lastActivityAt, activityObservable = true }) {
       if (ended) return;
       const t = now();
+      // Fresh activity is always evidence of work (we saw the bytes). Stale
+      // activity is only evidence of IDLENESS while activity is observable;
+      // blind (detached, socket gone), an existing hold outweighs the frozen
+      // clock — see the blind-staleness policy in the function doc.
+      const agentRunning =
+        isAgentActive({ lastActivityAt, now: t, idleMs }) ||
+        (!activityObservable && createdAt !== undefined);
+      const hadBookkeeping = createdAt !== undefined;
       const action = planHold({
         attached,
-        agentRunning: isAgentOutputFlowing({ lastOutputAt, now: t, idleMs: agentIdleMs }),
+        agentRunning,
         createdAt,
         lastRefreshAt,
         expireSeconds,
         refreshMs,
-        maxLifetimeMs,
         now: t,
       });
       if (action === 'noop') return;
@@ -466,19 +509,29 @@ export function createTaskHoldController({
         return;
       }
 
-      // create | refresh — the same idempotent PUT upsert on the wire; only
-      // the bookkeeping differs (create restarts the 1h-lifetime clock).
+      // create | refresh — the same idempotent PUT upsert on the wire, EXCEPT
+      // a re-create over a task the platform may still be tracking (the 1h
+      // max-lifetime boundary): its lifetime is per CREATION, so that one is
+      // DELETE-then-PUT to genuinely restart the platform's clock.
+      const recreateOverLiveTask = action === 'create' && hadBookkeeping;
       if (action === 'create') createdAt = t;
       lastRefreshAt = t;
+      mayHoldRemotely = true;
       enqueue(async () => {
         let result: SpriteTaskCallResult;
         try {
+          if (recreateOverLiveTask) {
+            // Best-effort delete first; 404 (already expired) is success.
+            await client.remove({ name: taskName });
+          }
           result = await client.upsert({ name: taskName, expireSeconds });
         } catch {
           result = { ok: false };
         }
         if (!result.ok) {
           // Reset so the next tick plans a fresh create (an immediate retry).
+          // `mayHoldRemotely` deliberately stays true: the PUT may have
+          // landed even though we could not read its answer.
           createdAt = undefined;
           lastRefreshAt = undefined;
           report('upsert', result);
@@ -489,10 +542,9 @@ export function createTaskHoldController({
     end() {
       if (ended) return;
       ended = true;
-      const hadHold = createdAt !== undefined;
       createdAt = undefined;
       lastRefreshAt = undefined;
-      if (hadHold) enqueueRemove();
+      if (mayHoldRemotely) enqueueRemove();
     },
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
@@ -19,11 +19,11 @@
  * SDK's spawn — the same authenticated exec channel every other operation
  * uses (same auth/config as the SDK, no second credential path). That is
  * semantically sound: a hold is only ever created/refreshed while work is in
- * progress (viewer attached or agent output flowing), i.e. while the sprite
- * is already awake — the exec never wakes a deliberately-paused sprite.
+ * progress (viewer attached or the agent recently active), i.e. while the
+ * sprite is already awake — the exec never wakes a deliberately-paused sprite.
  *
  * Pure core / imperative shell: `planHold` (every lifecycle decision),
- * `isAgentOutputFlowing`, the argv builders and the response classifiers are
+ * `isAgentActive`, the argv builders and the response classifiers are
  * pure and unit-tested without mocks; `createSpriteTasksClient` (exec) and
  * `createTaskHoldController` (bookkeeping + serialized queue) are thin shells.
  *

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -350,8 +350,14 @@ function toBuffer(chunk: Buffer | string): Buffer {
  * not a failure, so it resolves with its code; only a transport error, an output
  * overflow, or a timeout rejects. The first settle wins and always clears the
  * timer.
+ *
+ * Exported for the sprite-tasks hold client (`./sprite-tasks.ts`), which runs
+ * one-shot curl execs against the in-sprite management socket and needs
+ * exactly this collect-bounded-output-or-kill contract — WITHOUT
+ * `withWakeRetry` (a hold call must never wake a paused sprite; the pre-open
+ * marking below is inert unless that wrapper is applied).
  */
-function runSpawned(
+export function runSpawned(
   command: SpriteCommandLike,
   maxBytes: number,
   timeoutMs: number | undefined,


### PR DESCRIPTION
## Why

Leaves 3-1 (#2020) and 3-2 (#2029) made idle-pause real: a detached, idle agent terminal now actually lets its sprite pause. That leaves a gap this leaf closes — nothing told the platform "work is in progress", so a sprite could cold-pause **mid-run** and kill a running agent. The sanctioned mechanism (docs.sprites.dev/keeping-sprites-running) is a Tasks API hold: short expiry, refreshed on a heartbeat, deleted on exit.

## Endpoint-shape verification (spec asked for this first)

- **The public REST API has no tasks endpoints.** https://sprites.dev/api documents sprites/exec/services/filesystem/checkpoints/policies/proxy only; an unauthenticated probe can't discriminate further (auth is checked before routing — unknown `/v1/sprites/*` paths also return 401).
- **The docs serve the Tasks API ONLY via the sprite's own management socket**: `/.sprite/api.sock`, virtual host `sprite`, plain HTTP/JSON — `POST/PUT/DELETE http://sprite/v1/tasks[/:name]`, body `{"expire": <seconds|"5m">}`, `PUT /v1/tasks/:name` is an idempotent Refresh/Create upsert. Max task lifetime per creation: 1h.
- **The pinned @fly/sprites 0.0.1-rc37 has no tasks primitive** (verified in `dist/`).

**Adaptation** (recorded per spec): the "minimal REST client" issues the documented REST calls by exec'ing `curl --unix-socket /.sprite/api.sock ...` inside the sprite through the SDK's authenticated exec channel — the same auth/config as every other SDK operation, no second credential path. Semantically sound: holds are only created/refreshed while work is in progress, i.e. while the sprite is already awake, so the exec never wakes a deliberately-paused sprite.

## Requirements → how satisfied

- **Attached terminal with agent running → hold maintained on the documented cadence (5m/60s, configurable)**: `startTaskHoldHeartbeat` ticks immediately on connect and then every `tickIntervalMs`; `planHold` returns `refresh` once the refresh interval elapses; `resolveTaskHoldConfig` makes expiry/refresh overridable via `SPRITE_TASK_HOLD_EXPIRE_SECONDS` / `SPRITE_TASK_HOLD_REFRESH_MS` (digits-only parse — no `5m`→5s mis-parse; refresh capped at half the expiry; the agent-idle window derives from the configured cadence).
- **Viewer detach with no active agent output → hold deleted**: the detach tick runs with staleness trusted (the socket was live until that instant, so silence was real) and deletes an idle session's hold immediately. "Activity" is wider than output: typed input, the PTY launch, and agent bash runs injected via `terminal-activity.ts` all count — a prompt that kicks off a long silent run keeps its hold from the moment it is typed.
- **Realtime restart → only self-expiring holds**: the argv builder structurally cannot emit a hold without an expiry (`taskUpsertExecArgs` throws on missing/zero/over-1h expiry; unit-asserted), and every create/refresh carries it. An orphaned hold frees itself within the expiry. (Flip side, spec-accepted: a restart also orphans a detached mid-run agent's hold, which then expires within 5min — requirement 3 explicitly chose self-expiry over restart persistence; 5-2 checkpoints protect the data.)
- **Hold API failures → degrade gracefully**: the exec client never throws (bad name / transport error / timeout / non-2xx all resolve `ok:false` with the exec exit code, so a missing-curl 127 is diagnosable in logs); the controller resets bookkeeping so the next tick retries as a fresh create, reports via `onError` → `loggers.realtime.warn`, and never propagates into the handler.

## Design

- **Pure core** (`packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts`, tested without mocks): `planHold` (all transitions incl. missed-heartbeat expiry margin and the 1h max-lifetime re-creation boundary), `isAgentActive`, `taskHoldName` (single-pass linear sanitizer — no regex over caller-controlled input — plus FNV suffix so sibling terminals on one sprite can't collide), argv builders, `parseCurlStatus`/`isHoldCallOk`, `resolveTaskHoldConfig`.
- **Thin shells**: `createSpriteTasksClient` (via sprites.ts's exported `runSpawned`: hard timeout, SIGKILL, output cap) and `createTaskHoldController` (serialized op queue; `end()` idempotent).
- **Blind-detach policy**: while detached the exec socket may be dead (3-2 never reconnects it), so a frozen activity clock is not evidence of idleness — stale activity only deletes when activity is *observable*; blind, an existing hold is kept refreshed until PTY exit or the bounded 30-min reap. Fresh activity always counts. A resumed agent that has never emitted a byte is not paused on our ignorance.
- **Hold hygiene**: `end()` keys its final DELETE on "an upsert was ever attempted" (`mayHoldRemotely`) so a PUT that landed-but-reported-failure can't leak past session end; re-creates over a possibly-live task DELETE-then-PUT (platform max lifetime is per CREATION); task names are per-incarnation so a torn-down session's queued DELETE can never destroy a reopened session's fresh hold.
- **Wiring** (`agent-terminal-handler.ts`): controller armed once per cold create; `viewerAttached`/`lastOutputAt`/`lastInputAt` tracked on the session; immediate ticks on attach/detach; heartbeat + hold torn down in the one `endAgentTerminalSession` funnel every teardown path already goes through.

## Accepted tradeoffs (reviewed deliberately, not oversights)

- **Per-session (not per-sprite) holds**: platform semantics only need ≥1 live task, but per-session names are what make "delete on MY session's end" safe next to a sibling's live work; session-per-sprite counts are small (tier-capped) and one 100-byte exec/min/busy-session is comparable to the keep-alive churn this epic removes. A long-lived in-sprite refresher loop was rejected because its own open exec connection would itself keep the sprite awake — defeating release-on-idle.
- **Scrollback replay stamps activity**: a brief peek at an idle terminal can hold its sprite ≤1 idle window (~2min) past detach. Self-correcting and far cheaper than plumbing replay-vs-live discrimination out of sprites-shell.
- **Detached hold lives until reap when work was in progress at detach**: while blind we cannot distinguish "finished" from "working silently"; killing a run is the worse error. Bounded by the existing 30-min reap; PTY exit still releases promptly when the socket survived. Finer granularity is the 5-3 Services spike's territory.

## Test evidence (after hardening round 536a7fd9a)

```
packages/lib  sprite-tasks.test.ts            40 passed (40)
apps/realtime terminal suite                  12 files, 429 passed (429)
turbo typecheck @pagespace/lib + realtime     clean
eslint (touched files)                        clean
```

## Out of scope (unchanged)

Services adoption (5-3 spike), billing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UCWAVunNQfy1Jxn51oUqo