### PR TITLE
fix(machine): route Machine DELETE through canonical page services + scrub agent refs

### DIFF
--- a/apps/web/src/app/api/machines/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/settings/__tests__/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockCanViewMachine,
   mockCreateDbMachineSettingsStore,
   mockCreateMachineSpriteTeardown,
+  mockCreateDbMachineRefScrub,
   mockGetMachineSettings,
   mockUpdateMachineSettings,
   mockDeleteMachine,
@@ -23,6 +24,7 @@ const {
   mockCanViewMachine: vi.fn(),
   mockCreateDbMachineSettingsStore: vi.fn(),
   mockCreateMachineSpriteTeardown: vi.fn(),
+  mockCreateDbMachineRefScrub: vi.fn(),
   mockGetMachineSettings: vi.fn(),
   mockUpdateMachineSettings: vi.fn(),
   mockDeleteMachine: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock('@/lib/machines/machine-settings-runtime', () => ({
   canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
   createDbMachineSettingsStore: (...args: unknown[]) => mockCreateDbMachineSettingsStore(...args),
   createMachineSpriteTeardown: (...args: unknown[]) => mockCreateMachineSpriteTeardown(...args),
+  createDbMachineRefScrub: (...args: unknown[]) => mockCreateDbMachineRefScrub(...args),
 }));
 
 vi.mock('@pagespace/lib/services/machines/machine-settings', () => ({
@@ -66,12 +69,14 @@ const SETTINGS = {
 
 const FAKE_STORE = {} as never;
 const FAKE_SPRITE = {} as never;
+const FAKE_REFS = {} as never;
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockAuthenticateRequest.mockResolvedValue(AUTH_OK);
   mockCreateDbMachineSettingsStore.mockReturnValue(FAKE_STORE);
   mockCreateMachineSpriteTeardown.mockReturnValue(FAKE_SPRITE);
+  mockCreateDbMachineRefScrub.mockReturnValue(FAKE_REFS);
 });
 
 describe('GET /api/machines/settings', () => {
@@ -233,23 +238,26 @@ describe('DELETE /api/machines/settings', () => {
     expect(res.status).toBe(404);
   });
 
-  it('given a successful delete, returns 200 with the teardown outcome and audits the delete', async () => {
+  it('given a successful delete, returns 200 with the teardown/scrub outcomes and audits the delete', async () => {
     mockCanDeleteMachine.mockResolvedValue(true);
-    mockDeleteMachine.mockResolvedValue({ ok: true, spriteTornDown: true });
+    mockDeleteMachine.mockResolvedValue({ ok: true, spriteTornDown: true, agentRefsScrubbed: true });
     const res = await DELETE(new Request('https://x.test/api/machines/settings?machineId=t1', { method: 'DELETE' }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, spriteTornDown: true });
+    expect(body).toEqual({ success: true, spriteTornDown: true, agentRefsScrubbed: true });
     expect(mockDeleteMachine).toHaveBeenCalledWith(
-      expect.objectContaining({ machineId: 't1', store: FAKE_STORE, sprite: FAKE_SPRITE }),
+      expect.objectContaining({ machineId: 't1', store: FAKE_STORE, sprite: FAKE_SPRITE, refs: FAKE_REFS }),
     );
+    // The canonical trash + ref scrub both act AS the deleting user.
+    expect(mockCreateDbMachineSettingsStore).toHaveBeenCalledWith('user-1');
+    expect(mockCreateDbMachineRefScrub).toHaveBeenCalledWith('user-1');
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         eventType: 'data.delete',
         userId: 'user-1',
         resourceId: 't1',
-        details: { spriteTornDown: true },
+        details: { spriteTornDown: true, agentRefsScrubbed: true },
       }),
     );
   });
@@ -269,10 +277,19 @@ describe('DELETE /api/machines/settings', () => {
 
   it('given a delete where Sprite teardown failed, still returns 200 (page trashed)', async () => {
     mockCanDeleteMachine.mockResolvedValue(true);
-    mockDeleteMachine.mockResolvedValue({ ok: true, spriteTornDown: false });
+    mockDeleteMachine.mockResolvedValue({ ok: true, spriteTornDown: false, agentRefsScrubbed: true });
     const res = await DELETE(new Request('https://x.test/api/machines/settings?machineId=t1', { method: 'DELETE' }));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true, spriteTornDown: false });
+    expect(body).toEqual({ success: true, spriteTornDown: false, agentRefsScrubbed: true });
+  });
+
+  it('given a delete where the ref scrub failed, still returns 200 and reports it', async () => {
+    mockCanDeleteMachine.mockResolvedValue(true);
+    mockDeleteMachine.mockResolvedValue({ ok: true, spriteTornDown: true, agentRefsScrubbed: false });
+    const res = await DELETE(new Request('https://x.test/api/machines/settings?machineId=t1', { method: 'DELETE' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true, spriteTornDown: true, agentRefsScrubbed: false });
   });
 });

--- a/apps/web/src/app/api/machines/settings/route.ts
+++ b/apps/web/src/app/api/machines/settings/route.ts
@@ -13,8 +13,9 @@
  * permission, matching the canonical page-trash), mirroring
  * machine-projects/machine-branches/agent-terminals.
  *
- * DELETE has two side effects with a REQUIRED fail-safe order — trash the page
- * first (reversible), then tear down the Sprite — enforced in `deleteMachine`.
+ * DELETE has three side effects with a REQUIRED fail-safe order — trash the page
+ * first (reversible, via the canonical page-trash), then scrub agent configs that
+ * reference the Machine, then tear down the Sprite — enforced in `deleteMachine`.
  */
 
 import { NextResponse } from 'next/server';
@@ -30,6 +31,7 @@ import {
   canAccessMachine,
   canDeleteMachine,
   canViewMachine,
+  createDbMachineRefScrub,
   createDbMachineSettingsStore,
   createMachineSpriteTeardown,
 } from '@/lib/machines/machine-settings-runtime';
@@ -72,7 +74,7 @@ export async function GET(request: Request) {
 
   if (!(await canViewMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
 
-  const settings = await getMachineSettings({ machineId: machineId.value, store: createDbMachineSettingsStore() });
+  const settings = await getMachineSettings({ machineId: machineId.value, store: createDbMachineSettingsStore(auth.userId) });
   if (!settings) return notFound();
   return NextResponse.json({ settings });
 }
@@ -160,7 +162,7 @@ export async function PATCH(request: Request) {
   const settings = await updateMachineSettings({
     machineId: machineId.value,
     patch: parsed.patch,
-    store: createDbMachineSettingsStore(),
+    store: createDbMachineSettingsStore(auth.userId),
   });
   if (!settings) return notFound();
 
@@ -190,8 +192,9 @@ export async function DELETE(request: Request) {
 
   const result = await deleteMachine({
     machineId: machineId.value,
-    store: createDbMachineSettingsStore(),
+    store: createDbMachineSettingsStore(auth.userId),
     sprite: createMachineSpriteTeardown(),
+    refs: createDbMachineRefScrub(auth.userId),
   });
   if (!result.ok) return notFound();
 
@@ -200,8 +203,12 @@ export async function DELETE(request: Request) {
     userId: auth.userId,
     resourceType: RESOURCE_TYPE,
     resourceId: machineId.value,
-    details: { spriteTornDown: result.spriteTornDown },
+    details: { spriteTornDown: result.spriteTornDown, agentRefsScrubbed: result.agentRefsScrubbed },
     riskScore: 0.5,
   });
-  return NextResponse.json({ success: true, spriteTornDown: result.spriteTornDown });
+  return NextResponse.json({
+    success: true,
+    spriteTornDown: result.spriteTornDown,
+    agentRefsScrubbed: result.agentRefsScrubbed,
+  });
 }

--- a/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
@@ -1,6 +1,5 @@
 /**
- * Unit tests for the Machine Settings runtime wiring — specifically the two
- * delete-path seams:
+ * Unit tests for the Machine Settings runtime wiring — the delete-path seams:
  *
  * - `createDbMachineSettingsStore().trashPage` must route through the CANONICAL
  *   `pageService.trashPage` (descendant cascade-trash, revision bump + page
@@ -9,10 +8,15 @@
  *   SOFT delete so restore keeps working.
  * - `createDbMachineRefScrub().scrub` must remove the deleted machineId from
  *   referencing AI_CHAT agents' `machines` arrays (through the canonical
- *   `applyPageMutation`) and from `global_assistant_config.machines`.
+ *   `applyPageMutation`), disabling `machineAccess` when the last ref goes
+ *   (an empty list with access on silently falls back to {kind:'own'}), and
+ *   rewrite `global_assistant_config.machines` the same way.
+ * - `createMachineSpriteTeardown().teardown` must free the compute of EVERY
+ *   Machine page the cascade-trash hides — nested Machines included — branch
+ *   Sprites before each machine's own Sprite.
  *
  * DB access and the canonical services are mocked; these tests verify THIS
- * module's routing and element-filtering logic.
+ * module's routing, filtering, and traversal logic.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -25,6 +29,11 @@ const {
   mockSelectWhere,
   mockUpdateSet,
   mockUpdateWhere,
+  mockFindPage,
+  mockFindDrive,
+  mockSessionFind,
+  mockSessionRemove,
+  mockHostKill,
 } = vi.hoisted(() => ({
   mockTrashPage: vi.fn(),
   mockApplyPageMutation: vi.fn(),
@@ -37,6 +46,11 @@ const {
   mockSelectWhere: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
+  mockFindPage: vi.fn(),
+  mockFindDrive: vi.fn(),
+  mockSessionFind: vi.fn(),
+  mockSessionRemove: vi.fn(),
+  mockHostKill: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -49,30 +63,42 @@ vi.mock('@pagespace/db/db', () => ({
       },
     }),
     query: {
-      pages: { findFirst: vi.fn() },
-      drives: { findFirst: vi.fn() },
+      pages: { findFirst: (...args: unknown[]) => mockFindPage(...args) },
+      drives: { findFirst: (...args: unknown[]) => mockFindDrive(...args) },
     },
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  inArray: vi.fn((...args: unknown[]) => ({ inArray: args })),
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings.join('?'), values })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'id', type: 'type', revision: 'revision', machines: 'machines', isTrashed: 'isTrashed' },
+  pages: {
+    id: 'id',
+    type: 'type',
+    parentId: 'parentId',
+    revision: 'revision',
+    machines: 'machines',
+    machineAccess: 'machineAccess',
+    isTrashed: 'isTrashed',
+  },
   drives: { id: 'id', ownerId: 'ownerId' },
 }));
 vi.mock('@pagespace/db/schema/integrations', () => ({
-  globalAssistantConfig: { machines: 'machines' },
+  globalAssistantConfig: { machines: 'machines', machineAccess: 'machineAccess' },
 }));
 vi.mock('@pagespace/db/schema/machine-branches', () => ({
   machineBranches: { machineId: 'machineId', sandboxId: 'sandboxId' },
 }));
 vi.mock('@pagespace/lib/services/sandbox/machine-session-manager', () => ({
-  createDbMachineSessionStore: vi.fn(),
-  deriveMachineSessionKey: vi.fn(),
-  getSandboxSessionSecret: vi.fn(),
+  createDbMachineSessionStore: vi.fn(async () => ({
+    findBySessionKey: (...args: unknown[]) => mockSessionFind(...args),
+    remove: (...args: unknown[]) => mockSessionRemove(...args),
+  })),
+  deriveMachineSessionKey: vi.fn((input: { pageId: string }) => `key-${input.pageId}`),
+  getSandboxSessionSecret: vi.fn(() => 'secret'),
 }));
 vi.mock('@/lib/websocket', () => ({
   broadcastPageEvent: (...args: unknown[]) => mockBroadcastPageEvent(...args),
@@ -82,7 +108,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserDeletePage: vi.fn(),
 }));
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
-  isMachinePage: vi.fn(),
+  isMachinePage: vi.fn((type: string) => type === 'MACHINE'),
 }));
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   getActorInfo: (...args: unknown[]) => mockGetActorInfo(...args),
@@ -94,14 +120,18 @@ vi.mock('@/services/api/page-mutation-service', () => ({
   applyPageMutation: (...args: unknown[]) => mockApplyPageMutation(...args),
 }));
 vi.mock('../machine-branches-runtime', () => ({
-  getMachineHostForBranches: vi.fn(),
+  getMachineHostForBranches: vi.fn(async () => ({ kill: (...args: unknown[]) => mockHostKill(...args) })),
 }));
 vi.mock('../machine-access-runtime', () => ({
   canViewMachine: vi.fn(),
   canEditMachine: vi.fn(),
 }));
 
-import { createDbMachineSettingsStore, createDbMachineRefScrub } from '../machine-settings-runtime';
+import {
+  createDbMachineSettingsStore,
+  createDbMachineRefScrub,
+  createMachineSpriteTeardown,
+} from '../machine-settings-runtime';
 
 const USER = 'user-1';
 const MACHINE = 'machine-1';
@@ -112,6 +142,11 @@ beforeEach(() => {
   mockSelectWhere.mockResolvedValue([]);
   mockUpdateWhere.mockResolvedValue(undefined);
   mockApplyPageMutation.mockResolvedValue({});
+  mockFindPage.mockResolvedValue({ driveId: 'drive-1' });
+  mockFindDrive.mockResolvedValue({ ownerId: 'tenant-1' });
+  mockSessionFind.mockImplementation(async (key: string) => ({ sandboxId: `own-${key}` }));
+  mockSessionRemove.mockResolvedValue(undefined);
+  mockHostKill.mockResolvedValue(undefined);
 });
 
 describe('createDbMachineSettingsStore().trashPage', () => {
@@ -150,7 +185,7 @@ describe('createDbMachineSettingsStore().trashPage', () => {
 
   it('throws (and does not broadcast) when the canonical trash reports failure', async () => {
     // deleteMachine treats a trashPage throw as the non-recoverable first step
-    // failing: the Sprite teardown and ref scrub never run.
+    // failing: the ref scrub and Sprite teardown never run.
     mockTrashPage.mockResolvedValue({ success: false, error: 'nope', status: 403 });
     await expect(createDbMachineSettingsStore(USER).trashPage(MACHINE)).rejects.toThrow('nope');
     expect(mockBroadcastPageEvent).not.toHaveBeenCalled();
@@ -171,6 +206,7 @@ describe('createDbMachineRefScrub().scrub', () => {
       {
         id: 'agent-1',
         revision: 7,
+        machineAccess: true,
         machines: [
           { kind: 'own' },
           { kind: 'existing', machineId: MACHINE },
@@ -199,10 +235,48 @@ describe('createDbMachineRefScrub().scrub', () => {
     );
   });
 
+  it('disables machineAccess when the deleted machine was the agent\'s ONLY ref (no silent own-machine fallback)', async () => {
+    // resolveConfiguredMachines treats machineAccess=true + machines=[] as
+    // "fall back to {kind:'own'}" — so an emptied list must flip access off,
+    // or the agent silently switches to a different machine.
+    mockSelectWhere.mockResolvedValue([
+      { id: 'agent-1', revision: 3, machineAccess: true, machines: [{ kind: 'existing', machineId: MACHINE }] },
+    ]);
+
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updates: { machines: [], machineAccess: false },
+        updatedFields: ['machines', 'machineAccess'],
+      }),
+    );
+  });
+
+  it('leaves machineAccess alone when other refs remain after the scrub', async () => {
+    mockSelectWhere.mockResolvedValue([
+      {
+        id: 'agent-1',
+        revision: 3,
+        machineAccess: true,
+        machines: [{ kind: 'own' }, { kind: 'existing', machineId: MACHINE }],
+      },
+    ]);
+
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updates: { machines: [{ kind: 'own' }] },
+        updatedFields: ['machines'],
+      }),
+    );
+  });
+
   it('preserves malformed sibling entries byte-for-byte (removes ONLY the deleted ref)', async () => {
     const malformed = { kind: 'existing' }; // no machineId — fails isMachineRef
     mockSelectWhere.mockResolvedValue([
-      { id: 'agent-1', revision: 1, machines: [malformed, { kind: 'existing', machineId: MACHINE }] },
+      { id: 'agent-1', revision: 1, machineAccess: true, machines: [malformed, { kind: 'existing', machineId: MACHINE }] },
     ]);
 
     await createDbMachineRefScrub(USER).scrub(MACHINE);
@@ -214,8 +288,8 @@ describe('createDbMachineRefScrub().scrub', () => {
 
   it('keeps sweeping the remaining agents when one fails, then throws so the delete reports the scrub as failed', async () => {
     mockSelectWhere.mockResolvedValue([
-      { id: 'agent-1', revision: 1, machines: [{ kind: 'existing', machineId: MACHINE }] },
-      { id: 'agent-2', revision: 2, machines: [{ kind: 'existing', machineId: MACHINE }] },
+      { id: 'agent-1', revision: 1, machineAccess: true, machines: [{ kind: 'existing', machineId: MACHINE }] },
+      { id: 'agent-2', revision: 2, machineAccess: true, machines: [{ kind: 'existing', machineId: MACHINE }] },
     ]);
     mockApplyPageMutation
       .mockRejectedValueOnce(new Error('revision mismatch'))
@@ -226,9 +300,13 @@ describe('createDbMachineRefScrub().scrub', () => {
     expect(mockApplyPageMutation).toHaveBeenLastCalledWith(expect.objectContaining({ pageId: 'agent-2' }));
   });
 
-  it('also rewrites global_assistant_config.machines (same MachineRef shape as migration 0195)', async () => {
+  it('also rewrites global_assistant_config.machines and clears machineAccess when the list empties', async () => {
     await createDbMachineRefScrub(USER).scrub(MACHINE);
     expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+    // The single UPDATE must rewrite the list AND carry the machineAccess CASE
+    // (both SET expressions read the OLD row, so they see the same list).
+    const setArg = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(setArg).sort()).toEqual(['machineAccess', 'machines']);
     expect(mockUpdateWhere).toHaveBeenCalledTimes(1);
   });
 
@@ -236,5 +314,65 @@ describe('createDbMachineRefScrub().scrub', () => {
     await createDbMachineRefScrub(USER).scrub(MACHINE);
     expect(mockApplyPageMutation).not.toHaveBeenCalled();
     expect(mockGetActorInfo).not.toHaveBeenCalled();
+  });
+});
+
+describe('createMachineSpriteTeardown().teardown', () => {
+  it('kills branch Sprites before the machine\'s own Sprite and removes the session row', async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([]) // children of the root — none
+      .mockResolvedValueOnce([{ sandboxId: 'sb-branch' }]); // root's branch rows
+
+    await createMachineSpriteTeardown().teardown(MACHINE);
+
+    expect(mockHostKill.mock.calls.map((c) => c[0])).toEqual([
+      { machineId: 'sb-branch' },
+      { machineId: `own-key-${MACHINE}` },
+    ]);
+    expect(mockSessionRemove).toHaveBeenCalledWith(`key-${MACHINE}`);
+  });
+
+  it('tears down nested Machine pages hidden by the cascade-trash (descendants first, root last)', async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([
+        { id: 'child-doc', type: 'DOCUMENT' },
+        { id: 'child-machine', type: 'MACHINE' },
+      ]) // children of the root
+      .mockResolvedValueOnce([]) // grandchildren — none
+      .mockResolvedValueOnce([{ sandboxId: 'sb-child-branch' }]) // child machine's branches
+      .mockResolvedValueOnce([]); // root's branches — none
+
+    await createMachineSpriteTeardown().teardown(MACHINE);
+
+    expect(mockHostKill.mock.calls.map((c) => c[0])).toEqual([
+      { machineId: 'sb-child-branch' },
+      { machineId: 'own-key-child-machine' },
+      { machineId: `own-key-${MACHINE}` },
+    ]);
+  });
+
+  it('still tears down the root when a descendant fails, then throws so the delete reports spriteTornDown=false', async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([{ id: 'child-machine', type: 'MACHINE' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]) // child branches
+      .mockResolvedValueOnce([]); // root branches
+    mockHostKill.mockImplementation(async ({ machineId }: { machineId: string }) => {
+      if (machineId === 'own-key-child-machine') throw new Error('host down');
+    });
+
+    await expect(createMachineSpriteTeardown().teardown(MACHINE)).rejects.toThrow('1 machine(s)');
+    // The root's own Sprite was still killed — one failure never strands the rest.
+    expect(mockHostKill.mock.calls.map((c) => c[0])).toContainEqual({ machineId: `own-key-${MACHINE}` });
+  });
+
+  it('does nothing when neither branches nor a live session exist', async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([]) // no children
+      .mockResolvedValueOnce([]); // no branches
+    mockSessionFind.mockResolvedValue(null);
+
+    await createMachineSpriteTeardown().teardown(MACHINE);
+    expect(mockHostKill).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
@@ -366,6 +366,21 @@ describe('createMachineSpriteTeardown().teardown', () => {
     expect(mockHostKill.mock.calls.map((c) => c[0])).toContainEqual({ machineId: `own-key-${MACHINE}` });
   });
 
+  it('terminates and tears down each machine ONCE even when the page tree contains a parentId cycle', async () => {
+    mockSelectWhere
+      .mockResolvedValueOnce([{ id: 'child-machine', type: 'MACHINE' }]) // children of root
+      .mockResolvedValueOnce([{ id: MACHINE, type: 'MACHINE' }]) // corrupt: cycles back to the root
+      .mockResolvedValueOnce([]) // child machine's branches
+      .mockResolvedValueOnce([]); // root's branches
+
+    await createMachineSpriteTeardown().teardown(MACHINE);
+
+    expect(mockHostKill.mock.calls.map((c) => c[0])).toEqual([
+      { machineId: 'own-key-child-machine' },
+      { machineId: `own-key-${MACHINE}` },
+    ]);
+  });
+
   it('does nothing when neither branches nor a live session exist', async () => {
     mockSelectWhere
       .mockResolvedValueOnce([]) // no children

--- a/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the Machine Settings runtime wiring — specifically the two
+ * delete-path seams:
+ *
+ * - `createDbMachineSettingsStore().trashPage` must route through the CANONICAL
+ *   `pageService.trashPage` (descendant cascade-trash, revision bump + page
+ *   version, page-trash workflow triggers — all of which are that service's
+ *   own tested behavior), not a raw `pageRepository.trash`, and must stay a
+ *   SOFT delete so restore keeps working.
+ * - `createDbMachineRefScrub().scrub` must remove the deleted machineId from
+ *   referencing AI_CHAT agents' `machines` arrays (through the canonical
+ *   `applyPageMutation`) and from `global_assistant_config.machines`.
+ *
+ * DB access and the canonical services are mocked; these tests verify THIS
+ * module's routing and element-filtering logic.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockTrashPage,
+  mockApplyPageMutation,
+  mockGetActorInfo,
+  mockBroadcastPageEvent,
+  mockCreatePageEventPayload,
+  mockSelectWhere,
+  mockUpdateSet,
+  mockUpdateWhere,
+} = vi.hoisted(() => ({
+  mockTrashPage: vi.fn(),
+  mockApplyPageMutation: vi.fn(),
+  mockGetActorInfo: vi.fn(),
+  mockBroadcastPageEvent: vi.fn(),
+  mockCreatePageEventPayload: vi.fn((...args: unknown[]) => {
+    const [driveId, pageId, event, payload] = args;
+    return { driveId, pageId, event, payload };
+  }),
+  mockSelectWhere: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({ from: () => ({ where: (...args: unknown[]) => mockSelectWhere(...args) }) }),
+    update: () => ({
+      set: (values: unknown) => {
+        mockUpdateSet(values);
+        return { where: (...args: unknown[]) => mockUpdateWhere(...args) };
+      },
+    }),
+    query: {
+      pages: { findFirst: vi.fn() },
+      drives: { findFirst: vi.fn() },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  eq: vi.fn((...args: unknown[]) => ({ eq: args })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ sql: strings.join('?'), values })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', revision: 'revision', machines: 'machines', isTrashed: 'isTrashed' },
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/integrations', () => ({
+  globalAssistantConfig: { machines: 'machines' },
+}));
+vi.mock('@pagespace/db/schema/machine-branches', () => ({
+  machineBranches: { machineId: 'machineId', sandboxId: 'sandboxId' },
+}));
+vi.mock('@pagespace/lib/services/sandbox/machine-session-manager', () => ({
+  createDbMachineSessionStore: vi.fn(),
+  deriveMachineSessionKey: vi.fn(),
+  getSandboxSessionSecret: vi.fn(),
+}));
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: (...args: unknown[]) => mockBroadcastPageEvent(...args),
+  createPageEventPayload: (...args: unknown[]) => mockCreatePageEventPayload(...args),
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserDeletePage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  isMachinePage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: (...args: unknown[]) => mockGetActorInfo(...args),
+}));
+vi.mock('@/services/api/page-service', () => ({
+  pageService: { trashPage: (...args: unknown[]) => mockTrashPage(...args) },
+}));
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: (...args: unknown[]) => mockApplyPageMutation(...args),
+}));
+vi.mock('../machine-branches-runtime', () => ({
+  getMachineHostForBranches: vi.fn(),
+}));
+vi.mock('../machine-access-runtime', () => ({
+  canViewMachine: vi.fn(),
+  canEditMachine: vi.fn(),
+}));
+
+import { createDbMachineSettingsStore, createDbMachineRefScrub } from '../machine-settings-runtime';
+
+const USER = 'user-1';
+const MACHINE = 'machine-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetActorInfo.mockResolvedValue({ actorEmail: 'jono@x.test', actorDisplayName: 'Jono' });
+  mockSelectWhere.mockResolvedValue([]);
+  mockUpdateWhere.mockResolvedValue(undefined);
+  mockApplyPageMutation.mockResolvedValue({});
+});
+
+describe('createDbMachineSettingsStore().trashPage', () => {
+  const trashOk = {
+    success: true,
+    driveId: 'drive-1',
+    pageTitle: 'My Machine',
+    pageType: 'MACHINE',
+    parentId: 'parent-1',
+    isAIChatPage: false,
+  };
+
+  it('routes through the canonical pageService.trashPage with the descendant cascade enabled', async () => {
+    // trashChildren: true is what gives the delete its cascade; the revision
+    // bump, page version, and page-trash workflow triggers are pageService.
+    // trashPage's own (separately tested) behavior — asserting this call IS
+    // the fix for the raw pageRepository.trash bypass.
+    mockTrashPage.mockResolvedValue(trashOk);
+    await createDbMachineSettingsStore(USER).trashPage(MACHINE);
+    expect(mockTrashPage).toHaveBeenCalledWith(
+      MACHINE,
+      USER,
+      expect.objectContaining({ trashChildren: true }),
+    );
+  });
+
+  it('broadcasts the trashed event (same payload shape as the page DELETE route) after a successful trash', async () => {
+    mockTrashPage.mockResolvedValue(trashOk);
+    await createDbMachineSettingsStore(USER).trashPage(MACHINE);
+    expect(mockCreatePageEventPayload).toHaveBeenCalledWith('drive-1', MACHINE, 'trashed', {
+      title: 'My Machine',
+      parentId: 'parent-1',
+    });
+    expect(mockBroadcastPageEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws (and does not broadcast) when the canonical trash reports failure', async () => {
+    // deleteMachine treats a trashPage throw as the non-recoverable first step
+    // failing: the Sprite teardown and ref scrub never run.
+    mockTrashPage.mockResolvedValue({ success: false, error: 'nope', status: 403 });
+    await expect(createDbMachineSettingsStore(USER).trashPage(MACHINE)).rejects.toThrow('nope');
+    expect(mockBroadcastPageEvent).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes only — never issues a hard delete (restore must keep working)', async () => {
+    mockTrashPage.mockResolvedValue(trashOk);
+    await createDbMachineSettingsStore(USER).trashPage(MACHINE);
+    // The store performs no writes of its own besides the canonical trash call:
+    // no raw update/delete that a restore couldn't undo.
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+});
+
+describe('createDbMachineRefScrub().scrub', () => {
+  it('removes only the deleted machineId from a referencing AI_CHAT agent, via the canonical applyPageMutation', async () => {
+    mockSelectWhere.mockResolvedValue([
+      {
+        id: 'agent-1',
+        revision: 7,
+        machines: [
+          { kind: 'own' },
+          { kind: 'existing', machineId: MACHINE },
+          { kind: 'existing', machineId: 'machine-2' },
+        ],
+      },
+    ]);
+
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+
+    expect(mockApplyPageMutation).toHaveBeenCalledTimes(1);
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageId: 'agent-1',
+        operation: 'agent_config_update',
+        updates: { machines: [{ kind: 'own' }, { kind: 'existing', machineId: 'machine-2' }] },
+        updatedFields: ['machines'],
+        expectedRevision: 7,
+        context: expect.objectContaining({
+          userId: USER,
+          actorEmail: 'jono@x.test',
+          changeGroupType: 'system',
+          resourceType: 'agent',
+        }),
+      }),
+    );
+  });
+
+  it('preserves malformed sibling entries byte-for-byte (removes ONLY the deleted ref)', async () => {
+    const malformed = { kind: 'existing' }; // no machineId — fails isMachineRef
+    mockSelectWhere.mockResolvedValue([
+      { id: 'agent-1', revision: 1, machines: [malformed, { kind: 'existing', machineId: MACHINE }] },
+    ]);
+
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+
+    expect(mockApplyPageMutation).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: { machines: [malformed] } }),
+    );
+  });
+
+  it('keeps sweeping the remaining agents when one fails, then throws so the delete reports the scrub as failed', async () => {
+    mockSelectWhere.mockResolvedValue([
+      { id: 'agent-1', revision: 1, machines: [{ kind: 'existing', machineId: MACHINE }] },
+      { id: 'agent-2', revision: 2, machines: [{ kind: 'existing', machineId: MACHINE }] },
+    ]);
+    mockApplyPageMutation
+      .mockRejectedValueOnce(new Error('revision mismatch'))
+      .mockResolvedValueOnce({});
+
+    await expect(createDbMachineRefScrub(USER).scrub(MACHINE)).rejects.toThrow('1 agent config');
+    expect(mockApplyPageMutation).toHaveBeenCalledTimes(2);
+    expect(mockApplyPageMutation).toHaveBeenLastCalledWith(expect.objectContaining({ pageId: 'agent-2' }));
+  });
+
+  it('also rewrites global_assistant_config.machines (same MachineRef shape as migration 0195)', async () => {
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing agent-side when no AI_CHAT agent references the machine', async () => {
+    await createDbMachineRefScrub(USER).scrub(MACHINE);
+    expect(mockApplyPageMutation).not.toHaveBeenCalled();
+    expect(mockGetActorInfo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/machines/machine-settings-runtime.ts
+++ b/apps/web/src/lib/machines/machine-settings-runtime.ts
@@ -358,6 +358,9 @@ async function teardownOneMachine(machineId: string): Promise<void> {
  * not just the root. Runs AFTER the trash, so it must not filter on isTrashed.
  */
 async function collectDescendantMachineIds(rootId: string): Promise<string[]> {
+  // `seen` guards against parentId cycles: page moves reject them, but a
+  // corrupt tree must degrade to a bounded walk, not an infinite teardown loop.
+  const seen = new Set<string>([rootId]);
   const machineIds: string[] = [];
   let frontier = [rootId];
   while (frontier.length > 0) {
@@ -365,9 +368,11 @@ async function collectDescendantMachineIds(rootId: string): Promise<string[]> {
       .select({ id: pages.id, type: pages.type })
       .from(pages)
       .where(inArray(pages.parentId, frontier));
-    frontier = children.map((child) => child.id);
+    const fresh = children.filter((child) => !seen.has(child.id));
+    for (const child of fresh) seen.add(child.id);
+    frontier = fresh.map((child) => child.id);
     machineIds.push(
-      ...children.filter((child) => isMachinePage(child.type as PageType)).map((child) => child.id),
+      ...fresh.filter((child) => isMachinePage(child.type as PageType)).map((child) => child.id),
     );
   }
   return machineIds;

--- a/apps/web/src/lib/machines/machine-settings-runtime.ts
+++ b/apps/web/src/lib/machines/machine-settings-runtime.ts
@@ -25,17 +25,18 @@
  * Scrubbed refs are NOT restored when the Machine page is restored — a ref is
  * the referencing agent's setting, and its owner re-links explicitly.
  *
- * `createMachineSpriteTeardown` tears down ALL the compute a Machine spawned:
- * each branch's OWN Sprite (tracked only in `machine_branches` — a Sprite that
- * goes idle simply hibernates on its own, it is never destroyed automatically,
- * so a Machine delete that skipped these would leak live microVMs), then the
- * Machine's own persistent Sprite (resolved the same way
- * the shell/session layer does: derive the `machine_sessions` key from (tenant,
- * drive, page), look up its `sandboxId`, kill through the `MachineHost` seam).
- * Everything runs inside `teardown()` so any host error surfaces AFTER the page is
- * trashed, landing in `deleteMachine`'s recoverable path. Only the Machine's OWN
- * Sprite kill governs `spriteTornDown`; branch kills and the tracking-row removal
- * are best-effort so they never invert that flag.
+ * `createMachineSpriteTeardown` tears down ALL the compute the delete hides:
+ * every MACHINE page in the trashed subtree (the cascade-trash hides nested
+ * Machines too, so skipping them would leak live microVMs behind hidden pages),
+ * and per machine, each branch's OWN Sprite (tracked only in `machine_branches`
+ * — a Sprite that goes idle simply hibernates on its own, it is never destroyed
+ * automatically), then that Machine's own persistent Sprite (resolved the same
+ * way the shell/session layer does: derive the `machine_sessions` key from
+ * (tenant, drive, page), look up its `sandboxId`, kill through the `MachineHost`
+ * seam). Everything runs inside `teardown()` so any host error surfaces AFTER
+ * the page is trashed, landing in `deleteMachine`'s recoverable path. Only
+ * own-Sprite kill failures govern `spriteTornDown`; branch kills and the
+ * tracking-row removal are best-effort so they never invert that flag.
  *
  * The Machine's dependent metadata ROWS (`machine_projects` / `machine_branches` /
  * `machine_agent_terminals`) are intentionally left in place — they FK-cascade on
@@ -53,7 +54,7 @@
  * path as well.
  */
 
-import { and, eq, sql } from '@pagespace/db/operators';
+import { and, eq, inArray, sql } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { globalAssistantConfig } from '@pagespace/db/schema/integrations';
@@ -211,7 +212,12 @@ export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
       const refArrayJson = JSON.stringify([ref]);
 
       const agents = await db
-        .select({ id: pages.id, revision: pages.revision, machines: pages.machines })
+        .select({
+          id: pages.id,
+          revision: pages.revision,
+          machines: pages.machines,
+          machineAccess: pages.machineAccess,
+        })
         .from(pages)
         .where(and(eq(pages.type, 'AI_CHAT'), sql`${pages.machines} @> ${refArrayJson}::jsonb`));
 
@@ -223,12 +229,18 @@ export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
         const filtered = current.filter(
           (entry) => !(isMachineRef(entry) && entry.kind === 'existing' && entry.machineId === machineId),
         );
+        // When the scrub empties the list, machine access must be disabled too:
+        // `resolveConfiguredMachines` treats machineAccess=true + machines=[] as
+        // "fall back to {kind:'own'}", so leaving access on would silently
+        // repoint the agent at a DIFFERENT machine instead of removing the one
+        // it had. The agent's owner re-enables (and re-links) explicitly.
+        const disableAccess = filtered.length === 0 && agent.machineAccess;
         try {
           await applyPageMutation({
             pageId: agent.id,
             operation: 'agent_config_update',
-            updates: { machines: filtered },
-            updatedFields: ['machines'],
+            updates: disableAccess ? { machines: filtered, machineAccess: false } : { machines: filtered },
+            updatedFields: disableAccess ? ['machines', 'machineAccess'] : ['machines'],
             expectedRevision: agent.revision,
             context: {
               userId: actorUserId,
@@ -246,6 +258,11 @@ export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
         }
       }
 
+      // Both SET expressions read the OLD row, so the machineAccess CASE and
+      // the machines rewrite see the same pre-update list: when removing the
+      // ref empties it, access flips off in the same statement — same reason
+      // as the agent path (`resolveGlobalConfiguredMachines` falls back to
+      // {kind:'own'} and would auto-provision the user's personal Machine).
       await db
         .update(globalAssistantConfig)
         .set({
@@ -254,6 +271,11 @@ export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
             FROM jsonb_array_elements(${globalAssistantConfig.machines}) AS elem
             WHERE NOT (elem @> ${refJson}::jsonb)
           )`,
+          machineAccess: sql`CASE WHEN NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(${globalAssistantConfig.machines}) AS elem
+            WHERE NOT (elem @> ${refJson}::jsonb)
+          ) THEN false ELSE ${globalAssistantConfig.machineAccess} END`,
         })
         .where(sql`${globalAssistantConfig.machines} @> ${refArrayJson}::jsonb`);
 
@@ -265,68 +287,113 @@ export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
 }
 
 /**
- * Tears down all the Sprites a Machine spawned. See the module doc: branch
- * Sprites (never destroyed automatically — only hibernated on idle) are killed
- * best-effort first, then the Machine's own Sprite whose kill governs
- * `spriteTornDown`; the tracking-row removal is best-effort so a post-kill DB
- * error can't falsely report the Sprite as still alive.
+ * Tears down the Sprites of ONE Machine page: branch Sprites (never destroyed
+ * automatically — only hibernated on idle) are killed best-effort first, then
+ * the Machine's own Sprite, whose kill failure throws; the tracking-row
+ * removal is best-effort so a post-kill DB error can't falsely report the
+ * Sprite as still alive.
+ */
+async function teardownOneMachine(machineId: string): Promise<void> {
+  const page = await db.query.pages.findFirst({
+    where: eq(pages.id, machineId),
+    columns: { driveId: true },
+  });
+  if (!page) return;
+
+  const branchRows = await db
+    .select({ sandboxId: machineBranches.sandboxId })
+    .from(machineBranches)
+    .where(eq(machineBranches.machineId, machineId));
+
+  const drive = await db.query.drives.findFirst({
+    where: eq(drives.id, page.driveId),
+    columns: { ownerId: true },
+  });
+  const sessionKey = drive
+    ? deriveMachineSessionKey({
+        tenantId: drive.ownerId,
+        driveId: page.driveId,
+        pageId: machineId,
+        secret: getSandboxSessionSecret(),
+      })
+    : null;
+  const sessionStore = await createDbMachineSessionStore();
+  const session = sessionKey ? await sessionStore.findBySessionKey(sessionKey) : null;
+
+  if (branchRows.length === 0 && !session) return; // Nothing live to tear down.
+
+  const host = await getMachineHostForBranches();
+
+  // Branch Sprites: best-effort. A failure leaves a microVM the hard-purge
+  // cascade won't reclaim (rows are kept), but it must not fail the delete or
+  // invert spriteTornDown — the branch row stays so a retry can find it.
+  for (const branch of branchRows) {
+    try {
+      await host.kill({ machineId: branch.sandboxId });
+    } catch {
+      // Best-effort; leave the row for a later retry.
+    }
+  }
+
+  // The Machine's OWN Sprite. THIS kill's failure propagates — if it throws,
+  // deleteMachine reports spriteTornDown=false. The tracking-row removal is
+  // best-effort so a remove failure AFTER a successful kill doesn't invert the
+  // flag into falsely reporting the Sprite as still alive.
+  if (session && sessionKey) {
+    await host.kill({ machineId: session.sandboxId });
+    try {
+      await sessionStore.remove(sessionKey);
+    } catch {
+      // Sprite is dead; a stale machine_sessions row is harmless (the reaper
+      // or a re-provision under the same key reclaims it).
+    }
+  }
+}
+
+/**
+ * Collects the ids of every MACHINE-typed page strictly BELOW the given page.
+ * Nothing prevents nesting a Machine under another Machine (page creation only
+ * validates that the parent exists), and the delete's cascade-trash hides the
+ * whole subtree — so the teardown must free the compute of every Machine in it,
+ * not just the root. Runs AFTER the trash, so it must not filter on isTrashed.
+ */
+async function collectDescendantMachineIds(rootId: string): Promise<string[]> {
+  const machineIds: string[] = [];
+  let frontier = [rootId];
+  while (frontier.length > 0) {
+    const children = await db
+      .select({ id: pages.id, type: pages.type })
+      .from(pages)
+      .where(inArray(pages.parentId, frontier));
+    frontier = children.map((child) => child.id);
+    machineIds.push(
+      ...children.filter((child) => isMachinePage(child.type as PageType)).map((child) => child.id),
+    );
+  }
+  return machineIds;
+}
+
+/**
+ * Tears down all the Sprites a Machine delete hides: every Machine page in the
+ * trashed subtree (descendants first, the deleted root last), each via
+ * `teardownOneMachine`. Every machine is ATTEMPTED even when an earlier one
+ * fails; any own-Sprite kill failure is rethrown at the end so `deleteMachine`
+ * reports `spriteTornDown: false` (the recoverable orphaned-Sprite state).
  */
 export function createMachineSpriteTeardown(): MachineSpriteTeardown {
   return {
     async teardown(machineId: string): Promise<void> {
-      const page = await db.query.pages.findFirst({
-        where: eq(pages.id, machineId),
-        columns: { driveId: true },
-      });
-      if (!page) return;
-
-      const branchRows = await db
-        .select({ sandboxId: machineBranches.sandboxId })
-        .from(machineBranches)
-        .where(eq(machineBranches.machineId, machineId));
-
-      const drive = await db.query.drives.findFirst({
-        where: eq(drives.id, page.driveId),
-        columns: { ownerId: true },
-      });
-      const sessionKey = drive
-        ? deriveMachineSessionKey({
-            tenantId: drive.ownerId,
-            driveId: page.driveId,
-            pageId: machineId,
-            secret: getSandboxSessionSecret(),
-          })
-        : null;
-      const sessionStore = await createDbMachineSessionStore();
-      const session = sessionKey ? await sessionStore.findBySessionKey(sessionKey) : null;
-
-      if (branchRows.length === 0 && !session) return; // Nothing live to tear down.
-
-      const host = await getMachineHostForBranches();
-
-      // Branch Sprites: best-effort. A failure leaves a microVM the hard-purge
-      // cascade won't reclaim (rows are kept), but it must not fail the delete or
-      // invert spriteTornDown — the branch row stays so a retry can find it.
-      for (const branch of branchRows) {
+      const descendants = await collectDescendantMachineIds(machineId);
+      let failures = 0;
+      for (const id of [...descendants, machineId]) {
         try {
-          await host.kill({ machineId: branch.sandboxId });
+          await teardownOneMachine(id);
         } catch {
-          // Best-effort; leave the row for a later retry.
+          failures += 1;
         }
       }
-
-      // The Machine's OWN Sprite. THIS kill governs spriteTornDown — if it throws,
-      // deleteMachine reports spriteTornDown=false. The tracking-row removal is
-      // best-effort so a remove failure AFTER a successful kill doesn't invert the
-      // flag into falsely reporting the Sprite as still alive.
-      if (session && sessionKey) {
-        await host.kill({ machineId: session.sandboxId });
-        try {
-          await sessionStore.remove(sessionKey);
-        } catch {
-          // Sprite is dead; a stale machine_sessions row is harmless (the reaper
-          // or a re-provision under the same key reclaims it).
-        }
+      if (failures > 0) {
+        throw new Error(`Sprite teardown failed for ${failures} machine(s) under ${machineId}`);
       }
     },
   };

--- a/apps/web/src/lib/machines/machine-settings-runtime.ts
+++ b/apps/web/src/lib/machines/machine-settings-runtime.ts
@@ -11,7 +11,19 @@
  * Machine's `pages` row, broadcasts a page `updated`/`trashed` event (so other
  * clients and the drive tree don't show a stale name/still-present page — the
  * same events the canonical page routes emit), and soft-deletes the page via
- * `pageRepository.trash`.
+ * the canonical `pageService.trashPage` (descendant cascade-trash, revision
+ * bump + page version, page-trash workflow triggers — exactly what the page
+ * DELETE route does).
+ *
+ * `createDbMachineRefScrub` removes the deleted machineId from every agent
+ * config that references it: AI_CHAT agents' `machines` MachineRef arrays
+ * (written through the canonical `applyPageMutation` so each agent page gets
+ * its own revision bump/version/activity entry, as `pageAgentRepository.
+ * updateAgentConfig` does) and the per-user `global_assistant_config.machines`
+ * blob (same MachineRef shape — migration 0195 rewrote both together). Without
+ * this, a freshly-deleted Machine lingers in agent configs as a dangling ref.
+ * Scrubbed refs are NOT restored when the Machine page is restored — a ref is
+ * the referencing agent's setting, and its owner re-links explicitly.
  *
  * `createMachineSpriteTeardown` tears down ALL the compute a Machine spawned:
  * each branch's OWN Sprite (tracked only in `machine_branches` — a Sprite that
@@ -31,24 +43,21 @@
  * user's configured-repo metadata (killing the Sprites frees the compute; the rows
  * stay for a restore).
  *
- * NOT handled here (deliberate scope — see the PR's flagged architecture decision):
- * this route writes the page via raw `db.update` / `pageRepository.trash` rather
- * than the canonical `applyPageMutation` / `pageService.trashPage` paths, so it does
- * NOT (yet): trash DESCENDANT pages of a Machine (Machine pages are
- * leaf-like in practice), bump the page `revision` / write a page-version / fire
- * page-update|trash workflow triggers, or scrub the deleted `machineId` from
- * AI_CHAT agents' `machines` arrays. Wiring those through the canonical services is
- * a follow-up (the Settings-UI node that exercises these paths is separate, and the
- * surface is behind `CODE_EXECUTION_ENABLED`, OFF). Also not handled: returning 404
- * (vs 403) for an already-deleted machineId. DELETE-permission gating IS enforced
- * (`canDeleteMachine`), matching the canonical page-trash.
+ * NOT handled here (deliberate scope): PATCH (`updateSettings`) still writes the
+ * settings fields via raw `db.update` — a Machine rename/toggle does not bump the
+ * page revision or fire page-update workflow triggers (the DELETE path is now
+ * fully canonical; PATCH canonicalization is a separate follow-up). Also not
+ * handled: returning 404 (vs 403) for an already-deleted machineId.
+ * DELETE-permission gating IS enforced (`canDeleteMachine`), matching the
+ * canonical page-trash — `pageService.trashPage` re-checks it on the canonical
+ * path as well.
  */
 
-import { and, eq } from '@pagespace/db/operators';
+import { and, eq, sql } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { pages, drives } from '@pagespace/db/schema/core';
+import { globalAssistantConfig } from '@pagespace/db/schema/integrations';
 import { machineBranches } from '@pagespace/db/schema/machine-branches';
-import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import {
   createDbMachineSessionStore,
   deriveMachineSessionKey,
@@ -57,12 +66,17 @@ import {
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { isMachinePage } from '@pagespace/lib/content/page-types.config';
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { pageService } from '@/services/api/page-service';
+import { applyPageMutation } from '@/services/api/page-mutation-service';
+import { isMachineRef, type MachineRef } from '@/lib/repositories/page-agent-repository';
 import type { PageType } from '@pagespace/lib/utils/enums';
 import type {
   MachineSettings,
   MachineSettingsPatch,
   MachineSettingsStore,
   MachineSpriteTeardown,
+  MachineRefScrub,
 } from '@pagespace/lib/services/machines/machine-settings';
 import { getMachineHostForBranches } from './machine-branches-runtime';
 import { canViewMachine, canEditMachine } from './machine-access-runtime';
@@ -115,7 +129,7 @@ async function readSettings(machineId: string): Promise<MachineSettings | null> 
   return toMachineSettings(page);
 }
 
-export function createDbMachineSettingsStore(): MachineSettingsStore {
+export function createDbMachineSettingsStore(actorUserId: string): MachineSettingsStore {
   return {
     getSettings: readSettings,
     async updateSettings(machineId: string, patch: MachineSettingsPatch): Promise<MachineSettings | null> {
@@ -154,15 +168,97 @@ export function createDbMachineSettingsStore(): MachineSettingsStore {
       return toMachineSettings(row);
     },
     async trashPage(machineId: string): Promise<void> {
-      const page = await db.query.pages.findFirst({
-        where: eq(pages.id, machineId),
-        columns: { driveId: true, parentId: true },
+      // The canonical page-trash: descendant cascade, revision bump + page
+      // version, and page-trash workflow triggers, exactly like the page
+      // DELETE route. It re-checks delete permission for `actorUserId` — the
+      // route's canDeleteMachine gate is the same check, so this never flips
+      // an authorized delete to a failure.
+      const result = await pageService.trashPage(machineId, actorUserId, {
+        trashChildren: true,
+        metadata: { source: 'machine_settings' },
       });
-      await pageRepository.trash(machineId);
-      if (page) {
-        await broadcastPageEvent(
-          createPageEventPayload(page.driveId, machineId, 'trashed', { parentId: page.parentId }),
+      if (!result.success) {
+        // deleteMachine treats a trashPage throw as the non-recoverable step
+        // failing — nothing has been torn down yet, so surfacing is correct.
+        throw new Error(`Failed to trash Machine page: ${result.error}`);
+      }
+      await broadcastPageEvent(
+        createPageEventPayload(result.driveId, machineId, 'trashed', {
+          title: result.pageTitle ?? undefined,
+          parentId: result.parentId ?? undefined,
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * Delete-time scrub of MachineRef entries pointing at a deleted Machine. Two
+ * homes hold them (the same pair migration 0195 rewrote): AI_CHAT agent pages'
+ * `machines` jsonb — written through `applyPageMutation` so each touched agent
+ * gets the canonical revision/version/activity treatment — and the per-user
+ * `global_assistant_config.machines` blob (not a page; a direct jsonb rewrite,
+ * filtered element-wise in SQL). Only elements matching the deleted machineId
+ * are removed; every other element (including any malformed one) is preserved
+ * byte-for-byte. Per-agent failures don't stop the sweep — the error is thrown
+ * at the end so `deleteMachine` reports `agentRefsScrubbed: false`.
+ */
+export function createDbMachineRefScrub(actorUserId: string): MachineRefScrub {
+  return {
+    async scrub(machineId: string): Promise<void> {
+      const ref = { kind: 'existing', machineId } satisfies MachineRef;
+      const refJson = JSON.stringify(ref);
+      const refArrayJson = JSON.stringify([ref]);
+
+      const agents = await db
+        .select({ id: pages.id, revision: pages.revision, machines: pages.machines })
+        .from(pages)
+        .where(and(eq(pages.type, 'AI_CHAT'), sql`${pages.machines} @> ${refArrayJson}::jsonb`));
+
+      const actorInfo = agents.length > 0 ? await getActorInfo(actorUserId) : null;
+
+      let failures = 0;
+      for (const agent of agents) {
+        const current = Array.isArray(agent.machines) ? (agent.machines as unknown[]) : [];
+        const filtered = current.filter(
+          (entry) => !(isMachineRef(entry) && entry.kind === 'existing' && entry.machineId === machineId),
         );
+        try {
+          await applyPageMutation({
+            pageId: agent.id,
+            operation: 'agent_config_update',
+            updates: { machines: filtered },
+            updatedFields: ['machines'],
+            expectedRevision: agent.revision,
+            context: {
+              userId: actorUserId,
+              actorEmail: actorInfo?.actorEmail,
+              actorDisplayName: actorInfo?.actorDisplayName ?? undefined,
+              changeGroupType: 'system',
+              resourceType: 'agent',
+              metadata: { cascade: 'machine_delete', machineId },
+            },
+          });
+        } catch {
+          // Keep sweeping — one blocked agent (e.g. a concurrent config save
+          // bumped its revision) must not leave the rest dangling.
+          failures += 1;
+        }
+      }
+
+      await db
+        .update(globalAssistantConfig)
+        .set({
+          machines: sql`(
+            SELECT coalesce(jsonb_agg(elem), '[]'::jsonb)
+            FROM jsonb_array_elements(${globalAssistantConfig.machines}) AS elem
+            WHERE NOT (elem @> ${refJson}::jsonb)
+          )`,
+        })
+        .where(sql`${globalAssistantConfig.machines} @> ${refArrayJson}::jsonb`);
+
+      if (failures > 0) {
+        throw new Error(`Failed to scrub deleted machine ${machineId} from ${failures} agent config(s)`);
       }
     },
   };

--- a/packages/lib/src/services/machines/__tests__/machine-settings.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-settings.test.ts
@@ -6,6 +6,7 @@ import {
   type MachineSettings,
   type MachineSettingsStore,
   type MachineSpriteTeardown,
+  type MachineRefScrub,
 } from '../machine-settings';
 
 const SETTINGS: MachineSettings = {
@@ -26,6 +27,10 @@ function makeStore(overrides: Partial<MachineSettingsStore> = {}): MachineSettin
 
 function makeSprite(overrides: Partial<MachineSpriteTeardown> = {}): MachineSpriteTeardown {
   return { teardown: vi.fn().mockResolvedValue(undefined), ...overrides };
+}
+
+function makeRefs(overrides: Partial<MachineRefScrub> = {}): MachineRefScrub {
+  return { scrub: vi.fn().mockResolvedValue(undefined), ...overrides };
 }
 
 describe('getMachineSettings', () => {
@@ -56,38 +61,56 @@ describe('updateMachineSettings', () => {
 });
 
 describe('deleteMachine', () => {
-  it('returns not_found without trashing or tearing down when the machine is missing', async () => {
+  it('returns not_found without trashing, scrubbing, or tearing down when the machine is missing', async () => {
     const store = makeStore({ getSettings: vi.fn().mockResolvedValue(null) });
     const sprite = makeSprite();
-    const result = await deleteMachine({ machineId: 'gone', store, sprite });
+    const refs = makeRefs();
+    const result = await deleteMachine({ machineId: 'gone', store, sprite, refs });
     expect(result).toEqual({ ok: false, reason: 'not_found' });
     expect(store.trashPage).not.toHaveBeenCalled();
+    expect(refs.scrub).not.toHaveBeenCalled();
     expect(sprite.teardown).not.toHaveBeenCalled();
   });
 
-  it('trashes the page BEFORE tearing down the Sprite', async () => {
+  it('trashes the page FIRST, then scrubs agent refs, then tears down the Sprite', async () => {
     const calls: string[] = [];
     const store = makeStore({ trashPage: vi.fn().mockImplementation(async () => void calls.push('trash')) });
     const sprite = makeSprite({ teardown: vi.fn().mockImplementation(async () => void calls.push('teardown')) });
-    const result = await deleteMachine({ machineId: 't1', store, sprite });
-    expect(result).toEqual({ ok: true, spriteTornDown: true });
-    expect(calls).toEqual(['trash', 'teardown']);
+    const refs = makeRefs({ scrub: vi.fn().mockImplementation(async () => void calls.push('scrub')) });
+    const result = await deleteMachine({ machineId: 't1', store, sprite, refs });
+    expect(result).toEqual({ ok: true, spriteTornDown: true, agentRefsScrubbed: true });
+    expect(calls).toEqual(['trash', 'scrub', 'teardown']);
+    expect(refs.scrub).toHaveBeenCalledWith('t1');
   });
 
   it('still reports success with the page trashed when Sprite teardown fails', async () => {
     const store = makeStore();
     const sprite = makeSprite({ teardown: vi.fn().mockRejectedValue(new Error('sprite gone')) });
-    const result = await deleteMachine({ machineId: 't1', store, sprite });
+    const refs = makeRefs();
+    const result = await deleteMachine({ machineId: 't1', store, sprite, refs });
     // Page trash happened; teardown failure is a recoverable orphaned-Sprite state.
     expect(store.trashPage).toHaveBeenCalledWith('t1');
-    expect(result).toEqual({ ok: true, spriteTornDown: false });
+    expect(result).toEqual({ ok: true, spriteTornDown: false, agentRefsScrubbed: true });
+  });
+
+  it('reports a ref-scrub failure without failing the delete or skipping the Sprite teardown', async () => {
+    const store = makeStore();
+    const sprite = makeSprite();
+    const refs = makeRefs({ scrub: vi.fn().mockRejectedValue(new Error('scrub failed')) });
+    const result = await deleteMachine({ machineId: 't1', store, sprite, refs });
+    // The page is already trashed; a dangling ref is a degraded (reported) state,
+    // and the Sprite kill must still run or we leak a live microVM.
+    expect(sprite.teardown).toHaveBeenCalledWith('t1');
+    expect(result).toEqual({ ok: true, spriteTornDown: true, agentRefsScrubbed: false });
   });
 
   it('does not swallow a page-trash failure (the non-recoverable step)', async () => {
     const store = makeStore({ trashPage: vi.fn().mockRejectedValue(new Error('db down')) });
     const sprite = makeSprite();
-    await expect(deleteMachine({ machineId: 't1', store, sprite })).rejects.toThrow('db down');
-    // Sprite was never touched, so no live-page/dead-Sprite mismatch can arise.
+    const refs = makeRefs();
+    await expect(deleteMachine({ machineId: 't1', store, sprite, refs })).rejects.toThrow('db down');
+    // Neither post-trash step ran, so no live-page/dead-Sprite mismatch can arise.
+    expect(refs.scrub).not.toHaveBeenCalled();
     expect(sprite.teardown).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/services/machines/machine-settings.ts
+++ b/packages/lib/src/services/machines/machine-settings.ts
@@ -17,9 +17,9 @@
  * (`isMachineAccessible`, sandbox-tools-runtime.ts). The whole surface is behind
  * `CODE_EXECUTION_ENABLED` (OFF), so no unenforced toggle is user-visible yet.
  * This module is pure orchestration + DI — every DB / Sprite
- * touch is an injected seam (`MachineSettingsStore`, `MachineSpriteTeardown`),
- * so the delete-ordering invariant below is unit-testable without a database or
- * a live Sprite. Route wiring lives in
+ * touch is an injected seam (`MachineSettingsStore`, `MachineSpriteTeardown`,
+ * `MachineRefScrub`), so the delete-ordering invariant below is unit-testable
+ * without a database or a live Sprite. Route wiring lives in
  * `apps/web/src/lib/machines/machine-settings-runtime.ts`.
  */
 
@@ -63,14 +63,27 @@ export interface MachineSpriteTeardown {
   teardown(machineId: string): Promise<void>;
 }
 
+/**
+ * Removes every reference to a deleted Machine from agent configurations
+ * (AI_CHAT agents' `machines` MachineRef arrays, plus the per-user global
+ * assistant config). Best-effort like the Sprite teardown: a throw is reported
+ * (`agentRefsScrubbed: false`), never a failure of the delete — the page is
+ * already trashed by then, and a dangling ref only degrades to today's
+ * behavior (agents pointing at a trashed Machine).
+ */
+export interface MachineRefScrub {
+  scrub(machineId: string): Promise<void>;
+}
+
 export interface DeleteMachineDeps {
   machineId: string;
   store: MachineSettingsStore;
   sprite: MachineSpriteTeardown;
+  refs: MachineRefScrub;
 }
 
 export type DeleteMachineResult =
-  | { ok: true; spriteTornDown: boolean }
+  | { ok: true; spriteTornDown: boolean; agentRefsScrubbed: boolean }
   | { ok: false; reason: 'not_found' };
 
 export async function getMachineSettings(input: {
@@ -89,7 +102,8 @@ export async function updateMachineSettings(input: {
 }
 
 /**
- * Destroy a Machine: trash its page, then tear down its Sprite.
+ * Destroy a Machine: trash its page, scrub agent references to it, then tear
+ * down its Sprite.
  *
  * The ORDER is a hard requirement, not an implementation detail. We trash the
  * page FIRST because that step is reversible (restore) and immediately hides the
@@ -100,6 +114,13 @@ export async function updateMachineSettings(input: {
  * tearing the Sprite down first and then failing to trash the page leaves a live
  * page pointing at a dead Sprite, with no easy recovery path.
  *
+ * The ref scrub sits between the two: it runs after the trash (so the refs it
+ * removes point at an already-hidden page, and a scrub failure still leaves the
+ * delete done) and before the remote host calls (all DB writes settle before we
+ * talk to the Sprite provider). Both post-trash steps are independently
+ * best-effort — a scrub failure never skips the Sprite teardown and vice versa,
+ * and each is reported in its own result flag.
+ *
  * The `sprite.teardown` seam frees ALL the compute the Machine spawned — the
  * Machine's own Sprite AND each branch's own Sprite (branch Sprites have no idle
  * reaper, so skipping them would leak microVMs). The dependent metadata ROWS
@@ -108,16 +129,28 @@ export async function updateMachineSettings(input: {
  * soft (reversible) delete never permanently destroys the user's configured-repo
  * metadata — restoring the page brings that config back (the Sprites re-provision
  * on next use). An earlier revision hard-deleted these rows and was reverted:
- * destroying config during a reversible delete is data loss.
+ * destroying config during a reversible delete is data loss. The ref scrub is
+ * the deliberate exception: a MachineRef in another agent's config is that
+ * AGENT's setting, not the Machine's own metadata — restoring the Machine does
+ * not re-add it (the agent's owner re-links if they want it back).
  */
-export async function deleteMachine({ machineId, store, sprite }: DeleteMachineDeps): Promise<DeleteMachineResult> {
+export async function deleteMachine({ machineId, store, sprite, refs }: DeleteMachineDeps): Promise<DeleteMachineResult> {
   const settings = await store.getSettings(machineId);
   if (!settings) return { ok: false, reason: 'not_found' };
 
   // 1. Trash the page first — reversible, and hides the Machine immediately.
   await store.trashPage(machineId);
 
-  // 2. Then tear down the Machine's own Sprite. A failure here is recoverable
+  // 2. Scrub agent configs that reference the now-trashed Machine. Best-effort:
+  //    a failure is reported, and must not block the Sprite teardown below.
+  let agentRefsScrubbed = true;
+  try {
+    await refs.scrub(machineId);
+  } catch {
+    agentRefsScrubbed = false;
+  }
+
+  // 3. Then tear down the Machine's own Sprite. A failure here is recoverable
   //    (orphaned Sprite), so it never fails the delete — we just report it.
   let spriteTornDown = true;
   try {
@@ -126,5 +159,5 @@ export async function deleteMachine({ machineId, store, sprite }: DeleteMachineD
     spriteTornDown = false;
   }
 
-  return { ok: true, spriteTornDown };
+  return { ok: true, spriteTornDown, agentRefsScrubbed };
 }


### PR DESCRIPTION
## Summary

GA-blocker remediation for deferred items **4 + 5** of the Machine/Terminal arc (page `wm76dkca6cd2jwcldumys5c5`, task `cj9bdw5wj4yfgbje2uuflzfu`): Machine DELETE previously soft-deleted its page via raw `pageRepository.trash`, bypassing the canonical page services. That meant **no descendant cascade-trash, no revision bump / page version, no page-trash workflow triggers**, and the deleted `machineId` was left **dangling in AI_CHAT agents' `machines` jsonb arrays**.

## What changed

**1. Canonical page-trash** — `createDbMachineSettingsStore().trashPage` now routes through `pageService.trashPage(machineId, actorUserId, { trashChildren: true })`, exactly what the page DELETE route (`/api/pages/[pageId]`) does: descendant cascade, `applyPageMutation` revision bump + page version, and deferred page-trash workflow triggers. The `trashed` broadcast keeps the canonical payload shape (`title` + `parentId`). A trash failure still throws (the non-recoverable first step), so `deleteMachine` never proceeds to teardown on a failed trash.

**2. Delete-time ref scrub** — new `MachineRefScrub` seam in `deleteMachine`, wired by `createDbMachineRefScrub(actorUserId)`:
- Every **AI_CHAT agent** whose `machines` array contains `{kind:'existing', machineId}` gets that entry removed via the canonical `applyPageMutation` (`operation: 'agent_config_update'`, `changeGroupType: 'system'`, per-agent `expectedRevision`) — same treatment as `pageAgentRepository.updateAgentConfig`. Only the matching element is removed; all other entries (including malformed ones) are preserved byte-for-byte. Per-agent failures don't stop the sweep; the failure is thrown at the end so the result reports it.
- **`global_assistant_config.machines`** is rewritten too — the same MachineRef pair migration **0195** covered in the rename backfill; this is the delete-time counterpart.
- Scrubbed refs are deliberately NOT restored when the Machine page is restored — a MachineRef is the *referencing agent's* setting; its owner re-links explicitly.

**3. PR #1967 ordering/reversibility preserved** — `deleteMachine` order is now trash (reversible, FIRST) → ref scrub → Sprite teardown (remote, LAST, so host errors land in the recoverable path). Both post-trash steps are independently best-effort with their own result flags (`agentRefsScrubbed` joins `spriteTornDown`) — a scrub failure never skips the Sprite kill (no leaked microVMs) and vice versa. Branch-Sprites-then-machine-Sprite teardown order and the "dependent `machine_*` metadata rows stay for restore" invariant are untouched.

## Review fixes (a2f19c2ae)

- **Subtree Sprite teardown** — nothing prevents nesting a MACHINE page under another, and the new cascade-trash hides nested Machines whose Sprites were never killed. Teardown now BFS-walks the trashed subtree (no `isTrashed` filter — it runs post-trash) and tears down every Machine in it, descendants first, root last; one failure never strands the rest, and any own-Sprite kill failure still reports `spriteTornDown: false`.
- **Disable `machineAccess` when the scrub empties the refs** — `resolveConfiguredMachines` / `resolveGlobalConfiguredMachines` treat `machineAccess: true` + `machines: []` as a fallback to `{kind:'own'}` (the global path even auto-provisions a personal Machine), so removing an agent's last ref would have silently repointed it at a *different* machine. The agent write carries `machineAccess: false` in the same canonical mutation; the global-config UPDATE flips it via a CASE in the same statement.
- **Cycle-guard hardening** (a33f3ad8f, self-identified, not reviewer-flagged) — `collectDescendantMachineIds`'s subtree walk now tracks visited ids. Page moves reject cycles today, but a corrupt tree must degrade to a bounded walk, not an infinite teardown loop.
- 439958a17 merges latest `master` (two unrelated sibling fixes — cron scheduling, Canvas CSP nonce — no file overlap with this PR's changes); no conflicts.

## Out of scope (unchanged, documented in the module doc)

- PATCH (`updateSettings`) still writes settings fields via raw `db.update` — canonicalizing the rename/toggle path is a separate follow-up.
- `machine_agent_terminals` / `machine_projects` / `machine_branches` rows are deliberately left in place (FK-cascade on hard purge; kept for restore — per PR #1967's reverted-hard-delete lesson).

## Tests

- **Pure module** (`packages/lib`): trash→scrub→teardown ordering, scrub failure isolation (delete still succeeds, teardown still runs), teardown failure isolation, trash failure propagation, not_found short-circuit — 9 pass.
- **Runtime** (new, `apps/web/src/lib/machines/__tests__/machine-settings-runtime.test.ts`): canonical `pageService.trashPage` routing with `trashChildren: true` (the cascade + revision + trigger behavior is that service's own tested contract), trashed broadcast parity, failure propagation without broadcast, no hard deletes (restore-compatible), ref filtering incl. malformed-sibling preservation, last-ref scrub disabling `machineAccess` (and leaving it alone when refs remain), sweep-on-partial-failure then throw, global-config rewrite incl. the access CASE, nested-machine subtree teardown order, descendant-failure isolation, parentId-cycle termination, teardown no-op — 16 pass.
- **Route contract**: store/scrub constructed as the deleting user, `refs` dep wired, `agentRefsScrubbed` in response + audit — 21 pass.
- `tsc --noEmit` green in `packages/lib` and `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMmatEURu4tTTrdjP8yYQR

