### PR TITLE
fix(machine): enforce allowPageAgents + visibleToGlobalAssistant machine access toggles

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/SettingsTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/SettingsTab.tsx
@@ -34,8 +34,10 @@ import { PaneLoading, PaneNotice, Spinner } from './tab-states';
  * rendering. This component is the form and the delete action.
  *
  * The two access toggles (`visibleToGlobalAssistant` / `allowPageAgents`) are
- * persisted here but not yet enforced anywhere — the whole surface sits behind
- * `CODE_EXECUTION_ENABLED`.
+ * ENFORCED per tool call by the AI sandbox machine gate (isMachineAccessible,
+ * sandbox-tools-runtime.ts; policy in @pagespace/lib machines/machine-access.ts)
+ * — flipping one takes effect on the agent's next terminal tool call. The whole
+ * surface sits behind `CODE_EXECUTION_ENABLED`.
  */
 export default function SettingsTab({ machineId }: { machineId: string }) {
   const router = useRouter();

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-git-tools.test.ts
@@ -37,7 +37,7 @@ function makeDeps(token: string | null = 'ghp_test'): GitSandboxToolsDeps {
     machines: {
       listMachines: vi.fn().mockResolvedValue([{ kind: 'own' }]),
       describeMachine: vi.fn().mockResolvedValue({ name: 'My Machine' }),
-      isMachineAccessible: vi.fn().mockResolvedValue(true),
+      isMachineAccessible: vi.fn().mockResolvedValue({ allowed: true }),
     },
     _runCommandCalls: runCommandCalls,
   } as unknown as GitSandboxToolsDeps & { _runCommandCalls: typeof runCommandCalls };
@@ -1471,7 +1471,7 @@ describe('active machine access', () => {
   it('git_status: given the resolved active machine is no longer accessible, should deny without acquiring a sandbox', async () => {
     const deps = makeDeps();
     deps.machines.listMachines = vi.fn().mockResolvedValue([{ kind: 'existing', machineId: 't1' }]);
-    deps.machines.isMachineAccessible = vi.fn().mockResolvedValue(false);
+    deps.machines.isMachineAccessible = vi.fn().mockResolvedValue({ allowed: false });
     const { git_status } = createSandboxGitTools(deps);
     const result = await git_status.execute!({}, {} as never);
     expect(result).toMatchObject({ success: false });

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -213,6 +213,7 @@ function makeMachineDirectoryDeps(
     getGlobalConfig: async () => ({ machineAccess: false, machines: [] }),
     getOrCreateOwnMachinePageId: async () => 'own-machine-page-1',
     lookupPageOwnerId: async () => 'drive-owner-1',
+    isUserScopedAgent: async () => false,
     ...overrides,
   };
 }
@@ -449,6 +450,21 @@ describe('createMachineDirectory', () => {
         expect(decision.allowed).toBe(false);
       });
 
+      it('given a sub-agent (parentAgentId only, no chatSource), the user-scoped exemption should NOT apply — it keys off chatSource.agentPageId, not parentAgentId', async () => {
+        // isUserScopedAgent would allow ANY id through, proving the exemption
+        // check never even fires: getAgentPageId(context) is undefined here
+        // (no chatSource.type==='page'), so deps.isUserScopedAgent is never called.
+        const isUserScopedAgent = async () => true;
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, isUserScopedAgent }),
+        );
+        const decision = await directory.isMachineAccessible(
+          { userId: 'u1', parentAgentId: 'parent-agent-1' },
+          { kind: 'existing', machineId: 't1' },
+        );
+        expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
+      });
+
       it('given a page-scoped agent and allowPageAgents=true, should allow', async () => {
         const directory = createMachineDirectory(makeMachineDirectoryDeps());
         await expect(
@@ -472,6 +488,35 @@ describe('createMachineDirectory', () => {
         await expect(
           directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
         ).resolves.toEqual({ allowed: false });
+      });
+
+      it('given a USER-SCOPED page agent and allowPageAgents=false, should allow — it acts with the invoking user\'s own reach (mirroring canActorViewPage\'s resolveActingAgentId fallthrough), not the narrower page-agent class the toggle targets', async () => {
+        const isUserScopedAgent = async (agentPageId: string) => agentPageId === 'agent-1';
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, isUserScopedAgent }),
+        );
+        await expect(
+          directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given a user-scoped page agent, should still be denied when the actor cannot VIEW the page (the exemption only bypasses the toggle, not view permissions)', async () => {
+        const isUserScopedAgent = async () => true;
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ canViewPage: async () => false, isUserScopedAgent }),
+        );
+        await expect(
+          directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
+      });
+
+      it('given a NON-user-scoped page agent (isUserScopedAgent returns false for it), should still be denied by allowPageAgents=false', async () => {
+        const isUserScopedAgent = async (agentPageId: string) => agentPageId === 'some-other-agent';
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, isUserScopedAgent }),
+        );
+        const decision = await directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' });
+        expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -204,6 +204,7 @@ function makeMachineDirectoryDeps(
       title: 'Shared Terminal',
       type: 'MACHINE',
       driveId: 'drive-1',
+      isTrashed: false,
       allowPageAgents: true,
       visibleToGlobalAssistant: true,
     }),
@@ -263,62 +264,27 @@ describe('createMachineDirectory', () => {
       ]);
     });
 
-    it('given a global assistant context, should EXCLUDE machines with visibleToGlobalAssistant=false so the default-active fallback skips them', async () => {
+    it('given a global assistant context, should NOT filter hidden machines at resolution — isMachineAccessible is the single policy site (it denies them with the toggle reason)', async () => {
+      const machines: MachineRef[] = [
+        { kind: 'existing', machineId: 'hidden-1' },
+        { kind: 'existing', machineId: 'visible-1' },
+      ];
       const directory = createMachineDirectory(
         makeMachineDirectoryDeps({
-          getGlobalConfig: async () => ({
-            machineAccess: true,
-            machines: [
-              { kind: 'existing', machineId: 'hidden-1' },
-              { kind: 'existing', machineId: 'visible-1' },
-            ],
-          }),
+          getGlobalConfig: async () => ({ machineAccess: true, machines }),
           findPage: async (pageId) => ({
             title: pageId === 'hidden-1' ? 'Hidden Machine' : 'Visible Machine',
             type: 'MACHINE',
             driveId: 'drive-1',
+            isTrashed: false,
             allowPageAgents: true,
             visibleToGlobalAssistant: pageId !== 'hidden-1',
           }),
         }),
       );
-      await expect(directory.listMachines({ userId: 'u1', chatSource: { type: 'global' } })).resolves.toEqual([
-        { kind: 'existing', machineId: 'visible-1' },
-      ]);
-    });
-
-    it('given a global assistant context whose resolved OWN machine page is hidden from the global assistant, should exclude it too', async () => {
-      const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({
-          getGlobalConfig: async () => ({ machineAccess: true, machines: [] }),
-          getOrCreateOwnMachinePageId: async () => 'personal-page-1',
-          findPage: async () => ({
-            title: 'My Machine',
-            type: 'MACHINE',
-            driveId: 'home-drive-1',
-            allowPageAgents: true,
-            visibleToGlobalAssistant: false,
-          }),
-        }),
+      await expect(directory.listMachines({ userId: 'u1', chatSource: { type: 'global' } })).resolves.toEqual(
+        machines,
       );
-      await expect(directory.listMachines({ userId: 'u1', chatSource: { type: 'global' } })).resolves.toEqual([]);
-    });
-
-    it('given a PAGE agent context, should NOT filter its machines by visibleToGlobalAssistant (the flag only gates the global assistant)', async () => {
-      const machines: MachineRef[] = [{ kind: 'existing', machineId: 'hidden-1' }];
-      const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({
-          getAgentConfig: async () => ({ machineAccess: true, machines }),
-          findPage: async () => ({
-            title: 'Hidden Machine',
-            type: 'MACHINE',
-            driveId: 'drive-1',
-            allowPageAgents: true,
-            visibleToGlobalAssistant: false,
-          }),
-        }),
-      );
-      await expect(directory.listMachines(pageContext)).resolves.toEqual(machines);
     });
 
     it('given a page agent with machineAccess off, should return no machines (fail closed)', async () => {
@@ -365,14 +331,14 @@ describe('createMachineDirectory', () => {
 
   describe('describeMachine', () => {
     it('given the own machine, should return a fixed name without a DB lookup', async () => {
-      const findPage = async () => ({ title: 'should not be used', type: 'MACHINE', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true });
+      const findPage = async () => ({ title: 'should not be used', type: 'MACHINE', driveId: 'drive-1', isTrashed: false, allowPageAgents: true, visibleToGlobalAssistant: true });
       const directory = createMachineDirectory(makeMachineDirectoryDeps({ findPage }));
       await expect(directory.describeMachine(undefined, { kind: 'own' })).resolves.toEqual({ name: 'My Machine' });
     });
 
     it('given an existing machine, should return the Terminal page title', async () => {
       const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Shared Terminal', type: 'MACHINE', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }) }),
+        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Shared Terminal', type: 'MACHINE', driveId: 'drive-1', isTrashed: false, allowPageAgents: true, visibleToGlobalAssistant: true }) }),
       );
       await expect(
         directory.describeMachine(undefined, { kind: 'existing', machineId: 't1' }),
@@ -412,7 +378,7 @@ describe('createMachineDirectory', () => {
 
     it('given the page exists but is not a MACHINE page, should deny', async () => {
       const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Not a terminal', type: 'DOCUMENT', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }) }),
+        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Not a terminal', type: 'DOCUMENT', driveId: 'drive-1', isTrashed: false, allowPageAgents: true, visibleToGlobalAssistant: true }) }),
       );
       await expect(
         directory.isMachineAccessible(context, { kind: 'existing', machineId: 'doc-1' }),
@@ -433,22 +399,42 @@ describe('createMachineDirectory', () => {
       ).resolves.toEqual({ allowed: true });
     });
 
+    it('given a TRASHED machine page, should deny (a soft-deleted machine must not accept agent commands)', async () => {
+      const directory = createMachineDirectory(
+        makeMachineDirectoryDeps({
+          findPage: async () => ({
+            title: 'Trashed Machine',
+            type: 'MACHINE',
+            driveId: 'drive-1',
+            isTrashed: true,
+            allowPageAgents: true,
+            visibleToGlobalAssistant: true,
+          }),
+        }),
+      );
+      await expect(
+        directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+      ).resolves.toEqual({ allowed: false });
+    });
+
     describe('allowPageAgents toggle (Machine Settings)', () => {
       const machineDenyingPageAgents = async () => ({
         title: 'Locked Machine',
         type: 'MACHINE',
         driveId: 'drive-1',
+        isTrashed: false,
         allowPageAgents: false,
         visibleToGlobalAssistant: true,
       });
 
-      it('given a page-scoped agent and allowPageAgents=false, should deny with an LLM-facing reason', async () => {
+      it('given a page-scoped agent and allowPageAgents=false, should deny with the toggle code and an LLM-facing reason', async () => {
         const directory = createMachineDirectory(
           makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
         );
         const decision = await directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' });
         expect(decision.allowed).toBe(false);
         if (decision.allowed) return;
+        expect(decision.code).toBe('page_agents_disabled');
         expect(decision.reason).toContain('does not allow page agents');
       });
 
@@ -494,17 +480,19 @@ describe('createMachineDirectory', () => {
         title: 'Hidden Machine',
         type: 'MACHINE',
         driveId: 'drive-1',
+        isTrashed: false,
         allowPageAgents: true,
         visibleToGlobalAssistant: false,
       });
 
-      it('given the GLOBAL assistant and visibleToGlobalAssistant=false, should deny with an LLM-facing reason', async () => {
+      it('given the GLOBAL assistant and visibleToGlobalAssistant=false, should deny with the toggle code and an LLM-facing reason', async () => {
         const directory = createMachineDirectory(
           makeMachineDirectoryDeps({ findPage: machineHiddenFromGlobal }),
         );
         const decision = await directory.isMachineAccessible(globalContext, { kind: 'existing', machineId: 't1' });
         expect(decision.allowed).toBe(false);
         if (decision.allowed) return;
+        expect(decision.code).toBe('hidden_from_global');
         expect(decision.reason).toContain('not visible to the global assistant');
       });
 
@@ -537,7 +525,7 @@ describe('createMachineDirectory', () => {
     it('given an existing machine, should return the Terminal page\'s own driveId, overriding the ambient one', async () => {
       const directory = createMachineDirectory(
         makeMachineDirectoryDeps({
-          findPage: async () => ({ title: 'Personal Machine', type: 'MACHINE', driveId: 'home-drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }),
+          findPage: async () => ({ title: 'Personal Machine', type: 'MACHINE', driveId: 'home-drive-1', isTrashed: false, allowPageAgents: true, visibleToGlobalAssistant: true }),
         }),
       );
       await expect(

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -200,7 +200,13 @@ function makeMachineDirectoryDeps(
   overrides: Partial<MachineDirectoryRuntimeDeps> = {},
 ): MachineDirectoryRuntimeDeps {
   return {
-    findPage: async () => ({ title: 'Shared Terminal', type: 'MACHINE', driveId: 'drive-1' }),
+    findPage: async () => ({
+      title: 'Shared Terminal',
+      type: 'MACHINE',
+      driveId: 'drive-1',
+      allowPageAgents: true,
+      visibleToGlobalAssistant: true,
+    }),
     canViewPage: async () => true,
     getAgentConfig: async () => ({ machineAccess: false, machines: [] }),
     getGlobalConfig: async () => ({ machineAccess: false, machines: [] }),
@@ -257,6 +263,64 @@ describe('createMachineDirectory', () => {
       ]);
     });
 
+    it('given a global assistant context, should EXCLUDE machines with visibleToGlobalAssistant=false so the default-active fallback skips them', async () => {
+      const directory = createMachineDirectory(
+        makeMachineDirectoryDeps({
+          getGlobalConfig: async () => ({
+            machineAccess: true,
+            machines: [
+              { kind: 'existing', machineId: 'hidden-1' },
+              { kind: 'existing', machineId: 'visible-1' },
+            ],
+          }),
+          findPage: async (pageId) => ({
+            title: pageId === 'hidden-1' ? 'Hidden Machine' : 'Visible Machine',
+            type: 'MACHINE',
+            driveId: 'drive-1',
+            allowPageAgents: true,
+            visibleToGlobalAssistant: pageId !== 'hidden-1',
+          }),
+        }),
+      );
+      await expect(directory.listMachines({ userId: 'u1', chatSource: { type: 'global' } })).resolves.toEqual([
+        { kind: 'existing', machineId: 'visible-1' },
+      ]);
+    });
+
+    it('given a global assistant context whose resolved OWN machine page is hidden from the global assistant, should exclude it too', async () => {
+      const directory = createMachineDirectory(
+        makeMachineDirectoryDeps({
+          getGlobalConfig: async () => ({ machineAccess: true, machines: [] }),
+          getOrCreateOwnMachinePageId: async () => 'personal-page-1',
+          findPage: async () => ({
+            title: 'My Machine',
+            type: 'MACHINE',
+            driveId: 'home-drive-1',
+            allowPageAgents: true,
+            visibleToGlobalAssistant: false,
+          }),
+        }),
+      );
+      await expect(directory.listMachines({ userId: 'u1', chatSource: { type: 'global' } })).resolves.toEqual([]);
+    });
+
+    it('given a PAGE agent context, should NOT filter its machines by visibleToGlobalAssistant (the flag only gates the global assistant)', async () => {
+      const machines: MachineRef[] = [{ kind: 'existing', machineId: 'hidden-1' }];
+      const directory = createMachineDirectory(
+        makeMachineDirectoryDeps({
+          getAgentConfig: async () => ({ machineAccess: true, machines }),
+          findPage: async () => ({
+            title: 'Hidden Machine',
+            type: 'MACHINE',
+            driveId: 'drive-1',
+            allowPageAgents: true,
+            visibleToGlobalAssistant: false,
+          }),
+        }),
+      );
+      await expect(directory.listMachines(pageContext)).resolves.toEqual(machines);
+    });
+
     it('given a page agent with machineAccess off, should return no machines (fail closed)', async () => {
       const directory = createMachineDirectory(
         makeMachineDirectoryDeps({ getAgentConfig: async () => ({ machineAccess: false, machines: [{ kind: 'own' }] }) }),
@@ -301,14 +365,14 @@ describe('createMachineDirectory', () => {
 
   describe('describeMachine', () => {
     it('given the own machine, should return a fixed name without a DB lookup', async () => {
-      const findPage = async () => ({ title: 'should not be used', type: 'MACHINE', driveId: 'drive-1' });
+      const findPage = async () => ({ title: 'should not be used', type: 'MACHINE', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true });
       const directory = createMachineDirectory(makeMachineDirectoryDeps({ findPage }));
       await expect(directory.describeMachine(undefined, { kind: 'own' })).resolves.toEqual({ name: 'My Machine' });
     });
 
     it('given an existing machine, should return the Terminal page title', async () => {
       const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Shared Terminal', type: 'MACHINE', driveId: 'drive-1' }) }),
+        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Shared Terminal', type: 'MACHINE', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }) }),
       );
       await expect(
         directory.describeMachine(undefined, { kind: 'existing', machineId: 't1' }),
@@ -325,47 +389,140 @@ describe('createMachineDirectory', () => {
 
   describe('isMachineAccessible', () => {
     const context: ToolExecutionContext = { userId: 'u1' };
+    const globalContext: ToolExecutionContext = { userId: 'u1', chatSource: { type: 'global' } };
 
     it('given the own machine, should always be accessible', async () => {
       const directory = createMachineDirectory(makeMachineDirectoryDeps());
-      await expect(directory.isMachineAccessible(undefined, { kind: 'own' })).resolves.toBe(true);
+      await expect(directory.isMachineAccessible(undefined, { kind: 'own' })).resolves.toEqual({ allowed: true });
     });
 
     it('given no rawContext, should deny an existing machine (fail closed)', async () => {
       const directory = createMachineDirectory(makeMachineDirectoryDeps());
       await expect(
         directory.isMachineAccessible(undefined, { kind: 'existing', machineId: 't1' }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ allowed: false });
     });
 
     it('given the terminal page is missing, should deny', async () => {
       const directory = createMachineDirectory(makeMachineDirectoryDeps({ findPage: async () => undefined }));
       await expect(
         directory.isMachineAccessible(context, { kind: 'existing', machineId: 'gone' }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ allowed: false });
     });
 
     it('given the page exists but is not a MACHINE page, should deny', async () => {
       const directory = createMachineDirectory(
-        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Not a terminal', type: 'DOCUMENT', driveId: 'drive-1' }) }),
+        makeMachineDirectoryDeps({ findPage: async () => ({ title: 'Not a terminal', type: 'DOCUMENT', driveId: 'drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }) }),
       );
       await expect(
         directory.isMachineAccessible(context, { kind: 'existing', machineId: 'doc-1' }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ allowed: false });
     });
 
     it('given a MACHINE page the actor cannot view, should deny', async () => {
       const directory = createMachineDirectory(makeMachineDirectoryDeps({ canViewPage: async () => false }));
       await expect(
         directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
-      ).resolves.toBe(false);
+      ).resolves.toEqual({ allowed: false });
     });
 
     it('given a MACHINE page the actor can view, should allow', async () => {
       const directory = createMachineDirectory(makeMachineDirectoryDeps({ canViewPage: async () => true }));
       await expect(
         directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual({ allowed: true });
+    });
+
+    describe('allowPageAgents toggle (Machine Settings)', () => {
+      const machineDenyingPageAgents = async () => ({
+        title: 'Locked Machine',
+        type: 'MACHINE',
+        driveId: 'drive-1',
+        allowPageAgents: false,
+        visibleToGlobalAssistant: true,
+      });
+
+      it('given a page-scoped agent and allowPageAgents=false, should deny with an LLM-facing reason', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const decision = await directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' });
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toContain('does not allow page agents');
+      });
+
+      it('given a sub-agent (parentAgentId), should be treated as page-scoped and denied when allowPageAgents=false', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const decision = await directory.isMachineAccessible(
+          { userId: 'u1', parentAgentId: 'parent-agent-1' },
+          { kind: 'existing', machineId: 't1' },
+        );
+        expect(decision.allowed).toBe(false);
+      });
+
+      it('given a page-scoped agent and allowPageAgents=true, should allow', async () => {
+        const directory = createMachineDirectory(makeMachineDirectoryDeps());
+        await expect(
+          directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given the GLOBAL assistant and allowPageAgents=false, should allow (the flag only gates page agents)', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        await expect(
+          directory.isMachineAccessible(globalContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given a page-scoped agent that also cannot view the page, should deny WITHOUT the toggle reason (no title leak)', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, canViewPage: async () => false }),
+        );
+        await expect(
+          directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
+      });
+    });
+
+    describe('visibleToGlobalAssistant toggle (Machine Settings)', () => {
+      const machineHiddenFromGlobal = async () => ({
+        title: 'Hidden Machine',
+        type: 'MACHINE',
+        driveId: 'drive-1',
+        allowPageAgents: true,
+        visibleToGlobalAssistant: false,
+      });
+
+      it('given the GLOBAL assistant and visibleToGlobalAssistant=false, should deny with an LLM-facing reason', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineHiddenFromGlobal }),
+        );
+        const decision = await directory.isMachineAccessible(globalContext, { kind: 'existing', machineId: 't1' });
+        expect(decision.allowed).toBe(false);
+        if (decision.allowed) return;
+        expect(decision.reason).toContain('not visible to the global assistant');
+      });
+
+      it('given the GLOBAL assistant and visibleToGlobalAssistant=true, should allow', async () => {
+        const directory = createMachineDirectory(makeMachineDirectoryDeps());
+        await expect(
+          directory.isMachineAccessible(globalContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given a page-scoped agent and visibleToGlobalAssistant=false, should allow (the flag only gates the global assistant)', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineHiddenFromGlobal }),
+        );
+        await expect(
+          directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
     });
   });
 
@@ -380,7 +537,7 @@ describe('createMachineDirectory', () => {
     it('given an existing machine, should return the Terminal page\'s own driveId, overriding the ambient one', async () => {
       const directory = createMachineDirectory(
         makeMachineDirectoryDeps({
-          findPage: async () => ({ title: 'Personal Machine', type: 'MACHINE', driveId: 'home-drive-1' }),
+          findPage: async () => ({ title: 'Personal Machine', type: 'MACHINE', driveId: 'home-drive-1', allowPageAgents: true, visibleToGlobalAssistant: true }),
         }),
       );
       await expect(

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -98,6 +98,83 @@ describe('createSandboxTools', () => {
     });
   });
 
+  it('bash: given the default machines[0] is blocked but a later configured machine is usable, should fall back to the usable one instead of dead-ending', async () => {
+    const seenAcquisitions: Array<{ activeMachine?: unknown }> = [];
+    const runDeps = fakeRunDeps();
+    runDeps.acquireSandbox = async (input) => {
+      seenAcquisitions.push(input as { activeMachine?: unknown });
+      return { ok: true, sandboxId: 'sbx', resumed: false };
+    };
+    const machines: MachineDirectoryDeps = {
+      listMachines: async () => [
+        { kind: 'existing', machineId: 'locked-1' },
+        { kind: 'existing', machineId: 'open-2' },
+      ],
+      describeMachine: async () => ({ name: 'Machine' }),
+      isMachineAccessible: async (_c, m) =>
+        m.kind === 'existing' && m.machineId === 'open-2'
+          ? { allowed: true }
+          : { allowed: false, reason: 'The machine "Locked Machine" does not allow page agents.' },
+    };
+    const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
+    const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+    expect(result).toMatchObject({ success: true });
+    expect(seenAcquisitions).toEqual([
+      expect.objectContaining({ activeMachine: { kind: 'existing', machineId: 'open-2' } }),
+    ]);
+  });
+
+  it('bash: given EVERY configured machine is blocked, should surface the FIRST machine\'s specific denial reason (not the misleading "Terminal access is not enabled")', async () => {
+    const machines: MachineDirectoryDeps = {
+      listMachines: async () => [
+        { kind: 'existing', machineId: 'hidden-1' },
+        { kind: 'existing', machineId: 'hidden-2' },
+      ],
+      describeMachine: async () => ({ name: 'Hidden' }),
+      isMachineAccessible: async (_c, m) => ({
+        allowed: false,
+        reason: `The machine "${m.kind === 'existing' ? m.machineId : 'own'}" is not visible to the global assistant.`,
+      }),
+    };
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+    const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+    expect(result).toEqual({
+      success: false,
+      error: 'The machine "hidden-1" is not visible to the global assistant.',
+    });
+  });
+
+  it('bash: given an explicitly SWITCHED machine becomes blocked, should deny with its reason rather than silently rerouting to another machine', async () => {
+    let acquired = false;
+    const runDeps = fakeRunDeps();
+    runDeps.acquireSandbox = async () => {
+      acquired = true;
+      return { ok: true, sandboxId: 'sbx', resumed: false };
+    };
+    const machines: MachineDirectoryDeps = {
+      listMachines: async () => [
+        { kind: 'existing', machineId: 'open-1' },
+        { kind: 'existing', machineId: 'locked-2' },
+      ],
+      describeMachine: async () => ({ name: 'Machine' }),
+      isMachineAccessible: async (_c, m) =>
+        m.kind === 'existing' && m.machineId === 'locked-2'
+          ? { allowed: false, reason: 'The machine "Locked" does not allow page agents.' }
+          : { allowed: true },
+    };
+    const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
+    const rawContext: ToolExecutionContext = {
+      userId: 'u1',
+      activeMachine: { kind: 'existing', machineId: 'locked-2' },
+    };
+    const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+    expect(result).toEqual({
+      success: false,
+      error: 'The machine "Locked" does not allow page agents.',
+    });
+    expect(acquired).toBe(false);
+  });
+
   it('bash: given no configured machines (machineAccess off), should deny instead of falling back to the own machine', async () => {
     let acquired = false;
     const runDeps = fakeRunDeps();
@@ -324,6 +401,26 @@ describe('createSandboxTools', () => {
       expect(result.machines).toEqual([{ id: 'own', name: 'My Machine', active: true }]);
       expect(result.machines.find((m) => m.id === 'revoked')).toBeUndefined();
     });
+
+    it('given machines[0] is blocked, should mark the fallback machine as active — consistent with where bash will actually route', async () => {
+      const machines: MachineDirectoryDeps = {
+        listMachines: async () => [
+          { kind: 'existing', machineId: 'locked-1' },
+          { kind: 'existing', machineId: 'open-2' },
+        ],
+        describeMachine: async () => ({ name: 'Machine' }),
+        isMachineAccessible: async (_c, m) =>
+          m.kind === 'existing' && m.machineId === 'open-2'
+            ? { allowed: true }
+            : { allowed: false, reason: 'blocked' },
+      };
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+      const result = (await exec(tools.list_machines, {}, {})) as {
+        success: true;
+        machines: Array<{ id: string; active: boolean }>;
+      };
+      expect(result.machines).toEqual([{ id: 'open-2', name: 'Machine', active: true }]);
+    });
   });
 
   describe('switch_machine', () => {
@@ -392,6 +489,27 @@ describe('createSandboxTools', () => {
         success: false,
         error: 'The machine "Locked Machine" does not allow page agents.',
         reason: 'inaccessible',
+      });
+      expect(rawContext.activeMachine).toBeUndefined();
+    });
+
+    it('given a toggle denial carrying a code, should return that code as the machine-readable reason (not "inaccessible")', async () => {
+      const machines: MachineDirectoryDeps = {
+        listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
+        describeMachine: async () => ({ name: 'Locked Machine' }),
+        isMachineAccessible: async () => ({
+          allowed: false,
+          code: 'page_agents_disabled',
+          reason: 'The machine "Locked Machine" does not allow page agents.',
+        }),
+      };
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+      const rawContext: ToolExecutionContext = { userId: 'u1' };
+      const result = await exec(tools.switch_machine, { machine: 't1' }, rawContext);
+      expect(result).toEqual({
+        success: false,
+        error: 'The machine "Locked Machine" does not allow page agents.',
+        reason: 'page_agents_disabled',
       });
       expect(rawContext.activeMachine).toBeUndefined();
     });

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -421,6 +421,23 @@ describe('createSandboxTools', () => {
       };
       expect(result.machines).toEqual([{ id: 'open-2', name: 'Machine', active: true }]);
     });
+
+    it('given N configured machines, should call isMachineAccessible exactly N times — once each, not once for active-selection plus once for the display filter', async () => {
+      const isMachineAccessible = vi.fn(async (_c: unknown, m: { kind: string; machineId?: string }) =>
+        m.kind === 'existing' && m.machineId === 'open-2' ? { allowed: true } : { allowed: false, reason: 'blocked' },
+      );
+      const machines: MachineDirectoryDeps = {
+        listMachines: async () => [
+          { kind: 'existing', machineId: 'locked-1' },
+          { kind: 'existing', machineId: 'open-2' },
+        ],
+        describeMachine: async () => ({ name: 'Machine' }),
+        isMachineAccessible,
+      };
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+      await exec(tools.list_machines, {}, {});
+      expect(isMachineAccessible).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('switch_machine', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -23,7 +23,7 @@ function okMachines(): MachineDirectoryDeps {
   return {
     listMachines: async () => [{ kind: 'own' }],
     describeMachine: async () => ({ name: 'My Machine' }),
-    isMachineAccessible: async () => true,
+    isMachineAccessible: async () => ({ allowed: true }),
   };
 }
 
@@ -73,12 +73,29 @@ describe('createSandboxTools', () => {
     const machines: MachineDirectoryDeps = {
       listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
       describeMachine: async () => ({ name: 'Shared Terminal' }),
-      isMachineAccessible: async () => false,
+      isMachineAccessible: async () => ({ allowed: false }),
     };
     const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
     const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
     expect(result).toMatchObject({ success: false });
     expect(acquired).toBe(false);
+  });
+
+  it('bash: given the access denial carries a reason (e.g. allowPageAgents off), should surface that reason to the model', async () => {
+    const machines: MachineDirectoryDeps = {
+      listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
+      describeMachine: async () => ({ name: 'Locked Machine' }),
+      isMachineAccessible: async () => ({
+        allowed: false,
+        reason: 'The machine "Locked Machine" does not allow page agents.',
+      }),
+    };
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+    const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+    expect(result).toEqual({
+      success: false,
+      error: 'The machine "Locked Machine" does not allow page agents.',
+    });
   });
 
   it('bash: given no configured machines (machineAccess off), should deny instead of falling back to the own machine', async () => {
@@ -95,7 +112,7 @@ describe('createSandboxTools', () => {
     const machines: MachineDirectoryDeps = {
       listMachines: async () => [],
       describeMachine: async () => ({ name: 'My Machine' }),
-      isMachineAccessible: async () => true,
+      isMachineAccessible: async () => ({ allowed: true }),
     };
     const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
     const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
@@ -267,7 +284,7 @@ describe('createSandboxTools', () => {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async (_c, m) =>
           m.kind === 'own' ? { name: 'My Machine' } : { name: 'Shared Terminal', description: 'Team box' },
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const result = (await exec(tools.list_machines, {}, {})) as {
@@ -284,7 +301,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async (_c, m) => (m.kind === 'own' ? { name: 'My Machine' } : { name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const rawContext: ToolExecutionContext = { userId: 'u1', activeMachine: { kind: 'existing', machineId: 't1' } };
@@ -300,7 +317,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 'revoked' }],
         describeMachine: async (_c, m) => (m.kind === 'own' ? { name: 'My Machine' } : { name: 'Should Not Appear' }),
-        isMachineAccessible: async (_c, m) => m.kind === 'own',
+        isMachineAccessible: async (_c, m) => ({ allowed: m.kind === 'own' }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const result = (await exec(tools.list_machines, {}, {})) as { success: true; machines: Array<{ id: string }> };
@@ -314,7 +331,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async (_c, m) => (m.kind === 'own' ? { name: 'My Machine' } : { name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const rawContext: ToolExecutionContext = { userId: 'u1' };
@@ -327,7 +344,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async (_c, m) => (m.kind === 'own' ? { name: 'My Machine' } : { name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const rawContext: ToolExecutionContext = { userId: 'u1' };
@@ -350,7 +367,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async () => ({ name: 'Shared Terminal' }),
-        isMachineAccessible: async (_c, m) => m.kind === 'own',
+        isMachineAccessible: async (_c, m) => ({ allowed: m.kind === 'own' }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       const rawContext: ToolExecutionContext = { userId: 'u1' };
@@ -359,11 +376,31 @@ describe('createSandboxTools', () => {
       expect(rawContext.activeMachine).toBeUndefined();
     });
 
+    it('given the access denial carries a reason, should surface that reason instead of the generic message', async () => {
+      const machines: MachineDirectoryDeps = {
+        listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
+        describeMachine: async () => ({ name: 'Locked Machine' }),
+        isMachineAccessible: async () => ({
+          allowed: false,
+          reason: 'The machine "Locked Machine" does not allow page agents.',
+        }),
+      };
+      const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
+      const rawContext: ToolExecutionContext = { userId: 'u1' };
+      const result = await exec(tools.switch_machine, { machine: 't1' }, rawContext);
+      expect(result).toEqual({
+        success: false,
+        error: 'The machine "Locked Machine" does not allow page agents.',
+        reason: 'inaccessible',
+      });
+      expect(rawContext.activeMachine).toBeUndefined();
+    });
+
     it('given a switch_machine call followed by bash, should route the acquire request to the switched machine', async () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'own' }, { kind: 'existing', machineId: 't1' }],
         describeMachine: async (_c, m) => (m.kind === 'own' ? { name: 'My Machine' } : { name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const seenAcquisitions: unknown[] = [];
       const runDeps = fakeRunDeps();
@@ -426,7 +463,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
         describeMachine: async () => ({ name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
         resolveDriveId: async () => 'home-drive-1',
       };
       const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines });
@@ -456,7 +493,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines: async () => [{ kind: 'existing', machineId: 't1' }],
         describeMachine: async () => ({ name: 'Shared Terminal' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
         resolveDriveId: async () => 'home-drive-1',
         resolveTenantId: async () => 'real-drive-owner',
       };
@@ -474,7 +511,7 @@ describe('createSandboxTools', () => {
       const machines: MachineDirectoryDeps = {
         listMachines,
         describeMachine: async () => ({ name: 'My Machine' }),
-        isMachineAccessible: async () => true,
+        isMachineAccessible: async () => ({ allowed: true }),
       };
       const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate, machines });
       await exec(tools.bash, { command: 'echo hi' }, {});

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -22,7 +22,7 @@ import { runGitInSandbox } from '@pagespace/lib/services/sandbox/git-tool-runner
 import { resolveSandboxPath, SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import {
   MAX_PATH_LENGTH,
-  machineRefId,
+  machineAccessDeniedError,
   resolveActiveMachine,
   type MachineDirectoryDeps,
   type ResolveSandboxContext,
@@ -148,8 +148,12 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate, machin
     if ('error' in ctx) return { ok: false, error: { success: false, error: ctx.error } };
     const decision = await gate(ctx);
     if (!decision.ok) return { ok: false, error: { success: false, error: decision.error } };
-    const activeMachine = await resolveActiveMachine(rawContext, machines);
-    if (!activeMachine) {
+    // resolveActiveMachine re-verifies access on EVERY call, mirroring
+    // sandbox-tools.ts — the actual execution boundary must not trust a
+    // machine reference that was accessible only at a past switch_machine
+    // call (OWASP A01).
+    const resolution = await resolveActiveMachine(rawContext, machines);
+    if (!resolution) {
       return {
         ok: false,
         error: {
@@ -158,21 +162,10 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate, machin
         },
       };
     }
-    // Re-verify page-view access on EVERY call, mirroring sandbox-tools.ts —
-    // the actual execution boundary must not trust a machine reference that
-    // was accessible only at a past switch_machine call (OWASP A01).
-    const access = await machines.isMachineAccessible(rawContext, activeMachine);
-    if (!access.allowed) {
-      return {
-        ok: false,
-        error: {
-          success: false,
-          error:
-            access.reason ??
-            `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
-        },
-      };
+    if (!resolution.access.allowed) {
+      return { ok: false, error: machineAccessDeniedError(resolution.access, resolution.machine) };
     }
+    const activeMachine = resolution.machine;
     // Mirror sandbox-tools.ts's driveId/tenantId resolution: an 'existing'
     // machine can reference a Terminal page outside the ambient drive/tenant
     // (global assistant, or a switched active machine in a shared drive).

--- a/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-git-tools.ts
@@ -161,13 +161,15 @@ export function createSandboxGitTools({ gitRunDeps, resolveContext, gate, machin
     // Re-verify page-view access on EVERY call, mirroring sandbox-tools.ts —
     // the actual execution boundary must not trust a machine reference that
     // was accessible only at a past switch_machine call (OWASP A01).
-    const accessible = await machines.isMachineAccessible(rawContext, activeMachine);
-    if (!accessible) {
+    const access = await machines.isMachineAccessible(rawContext, activeMachine);
+    if (!access.allowed) {
       return {
         ok: false,
         error: {
           success: false,
-          error: `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
+          error:
+            access.reason ??
+            `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
         },
       };
     }

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -52,6 +52,8 @@ import { gateSandboxToolCall } from '@pagespace/lib/services/sandbox/tool-gate';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isMachinePage } from '@pagespace/lib/content/page-types.config';
+import { decideMachineToggleAccess } from '@pagespace/lib/services/machines/machine-access';
+import type { MachineSettings } from '@pagespace/lib/services/machines/machine-settings';
 import type { PageType } from '@pagespace/lib/utils/enums';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { createSandboxTools, type MachineDirectoryDeps, type ResolveSandboxContext } from './sandbox-tools';
@@ -345,16 +347,20 @@ export const resolveSandboxActorContext: ResolveSandboxContext =
  * IO dependencies for the machine directory. Injected so it can be unit-tested
  * without a real database connection.
  */
+/**
+ * The page row the machine directory needs: identity/routing fields plus the
+ * two Machine Settings access toggles (their canonical shape/docs live on
+ * `MachineSettings` in @pagespace/lib machines/machine-settings.ts).
+ */
+export type MachineDirectoryPage = {
+  title: string;
+  type: string;
+  driveId: string;
+  isTrashed: boolean;
+} & Pick<MachineSettings, 'allowPageAgents' | 'visibleToGlobalAssistant'>;
+
 export interface MachineDirectoryRuntimeDeps {
-  findPage: (pageId: string) => Promise<{
-    title: string;
-    type: string;
-    driveId: string;
-    /** Machine access toggle: whether page-scoped agents may use this machine. */
-    allowPageAgents: boolean;
-    /** Machine access toggle: whether the global assistant may see/use this machine. */
-    visibleToGlobalAssistant: boolean;
-  } | undefined>;
+  findPage: (pageId: string) => Promise<MachineDirectoryPage | undefined>;
   canViewPage: (rawContext: ToolExecutionContext, pageId: string) => Promise<boolean>;
   /** `PageAgentConfig.machineAccess`/`machines` — the canonical config source. */
   getAgentConfig: (agentPageId: string) => Promise<{ machineAccess: boolean; machines: MachineRef[] } | null>;
@@ -370,7 +376,14 @@ const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
   findPage: async (pageId) =>
     db.query.pages.findFirst({
       where: eq(pages.id, pageId),
-      columns: { title: true, type: true, driveId: true, allowPageAgents: true, visibleToGlobalAssistant: true },
+      columns: {
+        title: true,
+        type: true,
+        driveId: true,
+        isTrashed: true,
+        allowPageAgents: true,
+        visibleToGlobalAssistant: true,
+      },
     }),
   canViewPage: canActorViewPage,
   getAgentConfig: (agentPageId) => pageAgentRepository.getAgentById(agentPageId),
@@ -388,12 +401,11 @@ const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
  * page — everything downstream (routing, permissions, activity) then treats
  * it exactly like any other 'existing' machine.
  *
- * Machines whose `visibleToGlobalAssistant` toggle is off are EXCLUDED here,
- * at resolution — not just denied at the access check — so the global
- * assistant never sees them and the default-active fallback (machines[0])
- * lands on the next visible machine instead of dead-ending on a hidden one.
- * A machine whose page has vanished passes through unfiltered:
- * `isMachineAccessible` already denies it at the execution boundary.
+ * Machines hidden by `visibleToGlobalAssistant` are deliberately NOT filtered
+ * here: `isMachineAccessible` is the single policy site (it denies them with
+ * the toggle's reason on every call, so list_machines omits them,
+ * switch_machine explains them, and resolveActiveMachine's accessible-first
+ * fallback skips them as a default).
  */
 async function resolveGlobalConfiguredMachines(
   userId: string,
@@ -402,20 +414,13 @@ async function resolveGlobalConfiguredMachines(
   const config = await deps.getGlobalConfig(userId);
   if (!config.machineAccess) return [];
   const configured = config.machines.length > 0 ? config.machines : [{ kind: 'own' as const }];
-  const resolved = await Promise.all(
+  return Promise.all(
     configured.map(async (m) =>
       m.kind === 'own'
         ? { kind: 'existing' as const, machineId: await deps.getOrCreateOwnMachinePageId(userId) }
         : m,
     ),
   );
-  const visible = await Promise.all(
-    resolved.map(async (m) => {
-      const page = await deps.findPage(m.machineId);
-      return !page || page.visibleToGlobalAssistant;
-    }),
-  );
-  return resolved.filter((_, i) => visible[i]);
 }
 
 /**
@@ -459,29 +464,34 @@ export function createMachineDirectory(
       return { name: page?.title ?? 'Terminal' };
     },
     isMachineAccessible: async (rawContext, machine) => {
+      // A page agent's 'own' machine is keyed off its own AI_CHAT page
+      // (resolveMachinePageId, machine-session.ts) — not a MACHINE page, so
+      // there are no Settings toggles to consult. The global assistant's
+      // 'own' machine never reaches here as 'own': it is resolved into an
+      // 'existing' ref (resolveGlobalConfiguredMachines) and fully checked.
       if (machine.kind === 'own') return { allowed: true };
       if (!rawContext) return { allowed: false };
       const page = await deps.findPage(machine.machineId);
-      if (!page || !isMachinePage(page.type as PageType)) return { allowed: false };
+      if (!page || page.isTrashed || !isMachinePage(page.type as PageType)) return { allowed: false };
       const canView = await deps.canViewPage(rawContext, machine.machineId);
       if (!canView) return { allowed: false };
-      // Machine access toggles (Settings tab). An agentPageId — the agent's own
-      // page or the parent's for a sub-agent — marks the actor page-scoped and
-      // subject to `allowPageAgents`; without one the actor is the global
-      // assistant, subject to `visibleToGlobalAssistant`. Checked AFTER
-      // canViewPage so a toggle reason (which names the machine) is never
-      // surfaced to an actor who can't view the page in the first place.
-      const agentPageId = activeMachineAgentPageId(rawContext);
-      if (agentPageId && !page.allowPageAgents) {
+      // Machine access toggles (Settings tab): pure policy in @pagespace/lib
+      // machines/machine-access.ts. An agentPageId — the agent's own page or
+      // the parent's for a sub-agent — marks the actor page-scoped; without
+      // one the actor is the global assistant (the SAME discriminator
+      // resolveConfiguredMachines uses to pick whose machine list applies).
+      // Checked AFTER canViewPage so a toggle reason (which names the
+      // machine) is never surfaced to an actor who can't view the page.
+      const actor = activeMachineAgentPageId(rawContext) ? ('page-agent' as const) : ('global-assistant' as const);
+      const decision = decideMachineToggleAccess({ actor, settings: page });
+      if (!decision.allowed) {
         return {
           allowed: false,
-          reason: `The machine "${page.title}" does not allow page agents ("Allow page agents" is turned off in its settings), so this agent cannot run terminal tools on it.`,
-        };
-      }
-      if (!agentPageId && !page.visibleToGlobalAssistant) {
-        return {
-          allowed: false,
-          reason: `The machine "${page.title}" is not visible to the global assistant ("Visible to global assistant" is turned off in its settings).`,
+          code: decision.code,
+          reason:
+            decision.code === 'page_agents_disabled'
+              ? `The machine "${page.title}" does not allow page agents ("Allow page agents" is turned off in its settings), so this agent cannot run terminal tools on it.`
+              : `The machine "${page.title}" is not visible to the global assistant ("Visible to global assistant" is turned off in its settings).`,
         };
       }
       return { allowed: true };

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -57,7 +57,7 @@ import type { MachineSettings } from '@pagespace/lib/services/machines/machine-s
 import type { PageType } from '@pagespace/lib/utils/enums';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { createSandboxTools, type MachineDirectoryDeps, type ResolveSandboxContext } from './sandbox-tools';
-import { canActorViewPage } from './actor-permissions';
+import { canActorViewPage, getAgentPageId, hasAgentUserScopedAccess } from './actor-permissions';
 import { pageAgentRepository, type MachineRef } from '@/lib/repositories/page-agent-repository';
 import { globalMachineConfigRepository } from '@/lib/repositories/global-machine-config-repository';
 import type { ToolExecutionContext } from '../core/types';
@@ -344,10 +344,6 @@ export const resolveSandboxActorContext: ResolveSandboxContext =
   createResolveSandboxActorContext();
 
 /**
- * IO dependencies for the machine directory. Injected so it can be unit-tested
- * without a real database connection.
- */
-/**
  * The page row the machine directory needs: identity/routing fields plus the
  * two Machine Settings access toggles (their canonical shape/docs live on
  * `MachineSettings` in @pagespace/lib machines/machine-settings.ts).
@@ -359,6 +355,10 @@ export type MachineDirectoryPage = {
   isTrashed: boolean;
 } & Pick<MachineSettings, 'allowPageAgents' | 'visibleToGlobalAssistant'>;
 
+/**
+ * IO dependencies for the machine directory. Injected so it can be unit-tested
+ * without a real database connection.
+ */
 export interface MachineDirectoryRuntimeDeps {
   findPage: (pageId: string) => Promise<MachineDirectoryPage | undefined>;
   canViewPage: (rawContext: ToolExecutionContext, pageId: string) => Promise<boolean>;
@@ -370,6 +370,17 @@ export interface MachineDirectoryRuntimeDeps {
   getOrCreateOwnMachinePageId: (userId: string) => Promise<string>;
   /** A page's owning drive's `ownerId` — the same lookup `resolveMachinePayerId` uses for billing attribution. */
   lookupPageOwnerId: (pageId: string) => Promise<string | null>;
+  /**
+   * Whether the page agent identified by `ownAgentPageId` (its OWN chatSource
+   * agent id — NOT a sub-agent's `parentAgentId`) has opted into user-scoped
+   * reach (`pages.userScopedAccess`). Mirrors the exact seam `canActorViewPage`
+   * already uses (`resolveActingAgentId`/`hasAgentUserScopedAccess` in
+   * actor-permissions.ts): such an agent acts with the INVOKING USER's own
+   * reach for view permissions, so it is exempt from the `allowPageAgents`
+   * toggle too — that toggle targets narrower, embedded page agents, not a
+   * personal/global-style assistant a user already has full page access to.
+   */
+  isUserScopedAgent: (ownAgentPageId: string) => Promise<boolean>;
 }
 
 const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
@@ -390,6 +401,7 @@ const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
   getGlobalConfig: (userId) => globalMachineConfigRepository.getConfig(userId),
   getOrCreateOwnMachinePageId: (userId) => globalMachineConfigRepository.getOrCreateOwnMachinePageId(userId),
   lookupPageOwnerId,
+  isUserScopedAgent: hasAgentUserScopedAccess,
 };
 
 /**
@@ -480,8 +492,19 @@ export function createMachineDirectory(
       // the parent's for a sub-agent — marks the actor page-scoped; without
       // one the actor is the global assistant (the SAME discriminator
       // resolveConfiguredMachines uses to pick whose machine list applies).
+      // EXCEPT: a page agent with userScopedAccess=true acts with the
+      // INVOKING USER's own reach for view permissions (canActorViewPage,
+      // just checked above, already resolved through that fallthrough) — such
+      // an agent is exempt from BOTH toggles. It isn't literally the global
+      // assistant (visibleToGlobalAssistant would apply an unrelated gate:
+      // its machine list comes from its own agent config, not
+      // globalMachineConfigRepository), so it bypasses the toggle decision
+      // entirely rather than being reclassified as 'global-assistant'.
       // Checked AFTER canViewPage so a toggle reason (which names the
       // machine) is never surfaced to an actor who can't view the page.
+      const ownAgentPageId = rawContext ? getAgentPageId(rawContext) : undefined;
+      const isUserScoped = ownAgentPageId ? await deps.isUserScopedAgent(ownAgentPageId) : false;
+      if (isUserScoped) return { allowed: true };
       const actor = activeMachineAgentPageId(rawContext) ? ('page-agent' as const) : ('global-assistant' as const);
       const decision = decideMachineToggleAccess({ actor, settings: page });
       if (!decision.allowed) {

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -346,7 +346,15 @@ export const resolveSandboxActorContext: ResolveSandboxContext =
  * without a real database connection.
  */
 export interface MachineDirectoryRuntimeDeps {
-  findPage: (pageId: string) => Promise<{ title: string; type: string; driveId: string } | undefined>;
+  findPage: (pageId: string) => Promise<{
+    title: string;
+    type: string;
+    driveId: string;
+    /** Machine access toggle: whether page-scoped agents may use this machine. */
+    allowPageAgents: boolean;
+    /** Machine access toggle: whether the global assistant may see/use this machine. */
+    visibleToGlobalAssistant: boolean;
+  } | undefined>;
   canViewPage: (rawContext: ToolExecutionContext, pageId: string) => Promise<boolean>;
   /** `PageAgentConfig.machineAccess`/`machines` — the canonical config source. */
   getAgentConfig: (agentPageId: string) => Promise<{ machineAccess: boolean; machines: MachineRef[] } | null>;
@@ -360,7 +368,10 @@ export interface MachineDirectoryRuntimeDeps {
 
 const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
   findPage: async (pageId) =>
-    db.query.pages.findFirst({ where: eq(pages.id, pageId), columns: { title: true, type: true, driveId: true } }),
+    db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { title: true, type: true, driveId: true, allowPageAgents: true, visibleToGlobalAssistant: true },
+    }),
   canViewPage: canActorViewPage,
   getAgentConfig: (agentPageId) => pageAgentRepository.getAgentById(agentPageId),
   getGlobalConfig: (userId) => globalMachineConfigRepository.getConfig(userId),
@@ -376,6 +387,13 @@ const defaultMachineDirectoryDeps: MachineDirectoryRuntimeDeps = {
  * transparently here into the user's lazily-provisioned personal Terminal
  * page — everything downstream (routing, permissions, activity) then treats
  * it exactly like any other 'existing' machine.
+ *
+ * Machines whose `visibleToGlobalAssistant` toggle is off are EXCLUDED here,
+ * at resolution — not just denied at the access check — so the global
+ * assistant never sees them and the default-active fallback (machines[0])
+ * lands on the next visible machine instead of dead-ending on a hidden one.
+ * A machine whose page has vanished passes through unfiltered:
+ * `isMachineAccessible` already denies it at the execution boundary.
  */
 async function resolveGlobalConfiguredMachines(
   userId: string,
@@ -384,13 +402,20 @@ async function resolveGlobalConfiguredMachines(
   const config = await deps.getGlobalConfig(userId);
   if (!config.machineAccess) return [];
   const configured = config.machines.length > 0 ? config.machines : [{ kind: 'own' as const }];
-  return Promise.all(
+  const resolved = await Promise.all(
     configured.map(async (m) =>
       m.kind === 'own'
         ? { kind: 'existing' as const, machineId: await deps.getOrCreateOwnMachinePageId(userId) }
         : m,
     ),
   );
+  const visible = await Promise.all(
+    resolved.map(async (m) => {
+      const page = await deps.findPage(m.machineId);
+      return !page || page.visibleToGlobalAssistant;
+    }),
+  );
+  return resolved.filter((_, i) => visible[i]);
 }
 
 /**
@@ -434,11 +459,32 @@ export function createMachineDirectory(
       return { name: page?.title ?? 'Terminal' };
     },
     isMachineAccessible: async (rawContext, machine) => {
-      if (machine.kind === 'own') return true;
-      if (!rawContext) return false;
+      if (machine.kind === 'own') return { allowed: true };
+      if (!rawContext) return { allowed: false };
       const page = await deps.findPage(machine.machineId);
-      if (!page || !isMachinePage(page.type as PageType)) return false;
-      return deps.canViewPage(rawContext, machine.machineId);
+      if (!page || !isMachinePage(page.type as PageType)) return { allowed: false };
+      const canView = await deps.canViewPage(rawContext, machine.machineId);
+      if (!canView) return { allowed: false };
+      // Machine access toggles (Settings tab). An agentPageId — the agent's own
+      // page or the parent's for a sub-agent — marks the actor page-scoped and
+      // subject to `allowPageAgents`; without one the actor is the global
+      // assistant, subject to `visibleToGlobalAssistant`. Checked AFTER
+      // canViewPage so a toggle reason (which names the machine) is never
+      // surfaced to an actor who can't view the page in the first place.
+      const agentPageId = activeMachineAgentPageId(rawContext);
+      if (agentPageId && !page.allowPageAgents) {
+        return {
+          allowed: false,
+          reason: `The machine "${page.title}" does not allow page agents ("Allow page agents" is turned off in its settings), so this agent cannot run terminal tools on it.`,
+        };
+      }
+      if (!agentPageId && !page.visibleToGlobalAssistant) {
+        return {
+          allowed: false,
+          reason: `The machine "${page.title}" is not visible to the global assistant ("Visible to global assistant" is turned off in its settings).`,
+        };
+      }
+      return { allowed: true };
     },
     resolveDriveId: async (_rawContext, machine, ambientDriveId) => {
       if (machine.kind === 'own') return ambientDriveId;

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -30,6 +30,7 @@ import {
 } from '@pagespace/lib/services/sandbox/tool-runners';
 import { MAX_COMMAND_BYTES } from '@pagespace/lib/services/sandbox/command-policy';
 import type { SandboxToolGateResult } from '@pagespace/lib/services/sandbox/tool-gate';
+import type { MachineToggleDenialCode } from '@pagespace/lib/services/machines/machine-access';
 import type { ToolExecutionContext } from '../core/types';
 import type { MachineRef } from '@/lib/repositories/page-agent-repository';
 
@@ -99,12 +100,15 @@ export interface MachineDescriptor {
 }
 
 /**
- * Outcome of a machine access check. A denial MAY carry an LLM-facing `reason`
- * explaining the specific policy that blocked access (e.g. the machine's
- * "Allow page agents" toggle is off); without one, callers fall back to their
- * generic revoked-access message.
+ * Outcome of a machine access check. A denial MAY carry a machine-readable
+ * `code` (the Machine Settings toggle that blocked access — see
+ * `decideMachineToggleAccess` in @pagespace/lib machines/machine-access) and
+ * an LLM-facing `reason` explaining it; without them, callers fall back to
+ * their generic revoked-access message.
  */
-export type MachineAccessDecision = { allowed: true } | { allowed: false; reason?: string };
+export type MachineAccessDecision =
+  | { allowed: true }
+  | { allowed: false; code?: MachineToggleDenialCode; reason?: string };
 
 /**
  * Resolves an actor's configured machines and their metadata/accessibility.
@@ -168,15 +172,33 @@ export interface MachineDirectoryDeps {
   ) => Promise<string>;
 }
 
+/** The active machine for a run, paired with its (already-performed) access check. */
+export interface ActiveMachineResolution {
+  machine: MachineRef;
+  access: MachineAccessDecision;
+}
+
 /**
  * Resolves the ACTIVE machine for a run: the switched machine if one is set
- * and still configured, otherwise the configured default (machines[0]).
- * Terminal tools (bash/file/git) call this to determine which machine's
- * session to operate on — `resolveMachinePageId` (packages/lib/services/
- * sandbox/machine-session.ts) then keys the persistent session by it.
+ * and still configured, otherwise the first configured machine the actor can
+ * actually ACCESS (falling back past machines a Settings toggle or revoked
+ * page permission blocks, so a blocked machines[0] doesn't dead-end the whole
+ * tool group while a usable machine sits one slot over). Terminal tools
+ * (bash/file/git) call this to determine which machine's session to operate
+ * on — `resolveMachinePageId` (packages/lib/services/sandbox/
+ * machine-session.ts) then keys the persistent session by it.
  *
- * Returns `undefined` when the actor has no configured machines at all —
- * `listMachines` (createMachineDirectory) already returns `[]` exactly when
+ * The access check happens HERE, on every call, and is returned alongside the
+ * machine so callers enforce it without a second lookup:
+ * - An explicitly switched machine is honored even when access has since been
+ *   revoked — the caller denies it with the specific reason rather than
+ *   silently rerouting the agent's commands to a different machine.
+ * - When NO configured machine is accessible, the first one is returned with
+ *   its denial so the caller surfaces the actual cause (e.g. a toggle reason)
+ *   instead of pretending nothing is configured.
+ *
+ * Returns `undefined` only when the actor has no configured machines at all —
+ * `listMachines` (createMachineDirectory) returns `[]` exactly when
  * `machineAccess` is off, so an empty list here is never "no preference,
  * default to 'own'"; it is "not entitled." Callers MUST treat `undefined` as
  * a denial, not silently fall back to `{ kind: 'own' }` — that fallback used
@@ -186,12 +208,39 @@ export interface MachineDirectoryDeps {
 export async function resolveActiveMachine(
   rawContext: ToolExecutionContext | undefined,
   machines: MachineDirectoryDeps,
-): Promise<MachineRef | undefined> {
+): Promise<ActiveMachineResolution | undefined> {
   const configured = await machines.listMachines(rawContext);
   if (configured.length === 0) return undefined;
   const active = rawContext?.activeMachine;
-  if (active && configured.some((m) => machineRefEquals(m, active))) return active;
-  return configured[0];
+  if (active && configured.some((m) => machineRefEquals(m, active))) {
+    return { machine: active, access: await machines.isMachineAccessible(rawContext, active) };
+  }
+  let firstDenied: ActiveMachineResolution | undefined;
+  for (const machine of configured) {
+    const access = await machines.isMachineAccessible(rawContext, machine);
+    if (access.allowed) return { machine, access };
+    firstDenied ??= { machine, access };
+  }
+  return firstDenied;
+}
+
+/**
+ * Renders a machine access denial as the tool-facing error object, preferring
+ * the decision's specific LLM-facing reason (e.g. which Settings toggle blocked
+ * it) over the generic revoked-access message. Shared by the bash/file tools
+ * here and the git tools (sandbox-git-tools.ts) so both execution boundaries
+ * report identical denials for the same machine.
+ */
+export function machineAccessDeniedError(
+  access: Extract<MachineAccessDecision, { allowed: false }>,
+  machine: MachineRef,
+): { success: false; error: string } {
+  return {
+    success: false,
+    error:
+      access.reason ??
+      `You no longer have access to the active machine ("${machineRefId(machine)}"). Call list_machines to see the available options.`,
+  };
 }
 
 /** Resolves the actor context for a turn, or an error to surface to the model. */
@@ -250,8 +299,13 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
     if ('error' in ctx) return { ok: false, error: { success: false, error: ctx.error } };
     const decision = await gate(ctx);
     if (!decision.ok) return { ok: false, error: gateDenial(decision) };
-    const activeMachine = await resolveActiveMachine(rawContext, machines);
-    if (!activeMachine) {
+    // resolveActiveMachine re-verifies access to the resolved machine on
+    // EVERY call — not just at switch_machine time. A machine's page
+    // permissions or Settings toggles can change between calls, and this is
+    // the actual execution boundary: routing a command to a machine the actor
+    // can no longer use would be a silent access-control bypass (OWASP A01).
+    const resolution = await resolveActiveMachine(rawContext, machines);
+    if (!resolution) {
       return {
         ok: false,
         error: {
@@ -260,23 +314,10 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
         },
       };
     }
-    // Re-verify page-view access to the resolved machine on EVERY call — not
-    // just at switch_machine time. A machine's page permissions (or the
-    // Terminal page itself) can change between calls, and this is the actual
-    // execution boundary: routing a command to a machine the actor can no
-    // longer view would be a silent access-control bypass (OWASP A01).
-    const access = await machines.isMachineAccessible(rawContext, activeMachine);
-    if (!access.allowed) {
-      return {
-        ok: false,
-        error: {
-          success: false,
-          error:
-            access.reason ??
-            `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
-        },
-      };
+    if (!resolution.access.allowed) {
+      return { ok: false, error: machineAccessDeniedError(resolution.access, resolution.machine) };
     }
+    const activeMachine = resolution.machine;
     const driveId = machines.resolveDriveId
       ? await machines.resolveDriveId(rawContext, activeMachine, ctx.driveId)
       : ctx.driveId;
@@ -355,10 +396,12 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
 
         const access = await machines.isMachineAccessible(rawContext, target);
         if (!access.allowed) {
+          // A toggle denial carries its own code so callers can distinguish
+          // "reconfigure the machine's Settings toggles" from revoked access.
           return {
             success: false,
             error: access.reason ?? `You no longer have access to "${requestedId}".`,
-            reason: 'inaccessible' as const,
+            reason: access.code ?? ('inaccessible' as const),
           };
         }
 
@@ -390,11 +433,13 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
         if ('error' in ctx) return { success: false, error: ctx.error };
 
         const configured = await machines.listMachines(rawContext);
-        const active = await resolveActiveMachine(rawContext, machines);
+        const active = (await resolveActiveMachine(rawContext, machines))?.machine;
         // Mirror list_pages: only surface machines the actor can currently
         // access — a machine's page permissions can be revoked after it was
         // configured, and describeMachine's title lookup does not itself
-        // check accessibility.
+        // check accessibility. (When every machine is denied, `active` is the
+        // first configured machine, which is filtered out below with the rest
+        // — the model correctly sees an empty list.)
         const accessibleEntries = await Promise.all(
           configured.map(async (m) => ({
             machine: m,

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -225,6 +225,28 @@ export async function resolveActiveMachine(
 }
 
 /**
+ * Selects the active machine from an ALREADY-COMPUTED decision set. Mirrors
+ * `resolveActiveMachine`'s selection policy (an explicitly switched machine
+ * wins even if it's since become inaccessible; otherwise the first ACCESSIBLE
+ * configured machine; otherwise, when every machine is denied, the first
+ * configured machine) without re-invoking `isMachineAccessible` — for
+ * `list_machines`, which already computes a decision for every configured
+ * machine to build its accessible-only display list, calling
+ * `resolveActiveMachine` separately would re-fetch the machine list and
+ * re-check accessibility, doubling the `isMachineAccessible` calls.
+ */
+function selectActiveFromDecisions(
+  configured: MachineRef[],
+  decisions: MachineAccessDecision[],
+  switched: MachineRef | undefined,
+): MachineRef | undefined {
+  if (configured.length === 0) return undefined;
+  if (switched && configured.some((m) => machineRefEquals(m, switched))) return switched;
+  const firstAllowedIndex = decisions.findIndex((d) => d.allowed);
+  return firstAllowedIndex !== -1 ? configured[firstAllowedIndex] : configured[0];
+}
+
+/**
  * Renders a machine access denial as the tool-facing error object, preferring
  * the decision's specific LLM-facing reason (e.g. which Settings toggle blocked
  * it) over the generic revoked-access message. Shared by the bash/file tools
@@ -433,21 +455,19 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
         if ('error' in ctx) return { success: false, error: ctx.error };
 
         const configured = await machines.listMachines(rawContext);
-        const active = (await resolveActiveMachine(rawContext, machines))?.machine;
-        // Mirror list_pages: only surface machines the actor can currently
-        // access — a machine's page permissions can be revoked after it was
-        // configured, and describeMachine's title lookup does not itself
-        // check accessibility. (When every machine is denied, `active` is the
-        // first configured machine, which is filtered out below with the rest
-        // — the model correctly sees an empty list.)
-        const accessibleEntries = await Promise.all(
-          configured.map(async (m) => ({
-            machine: m,
-            accessible: (await machines.isMachineAccessible(rawContext, m)).allowed,
-          })),
-        );
+        // ONE isMachineAccessible pass, reused for both active-machine
+        // selection (selectActiveFromDecisions, no I/O) and the accessible-only
+        // filter below — mirrors list_pages: only surface machines the actor
+        // can currently access, since a machine's page permissions can be
+        // revoked after it was configured and describeMachine's title lookup
+        // does not itself check accessibility. (When every machine is denied,
+        // `active` is the first configured machine, which is filtered out
+        // below with the rest — the model correctly sees an empty list.)
+        const decisions = await Promise.all(configured.map((m) => machines.isMachineAccessible(rawContext, m)));
+        const active = selectActiveFromDecisions(configured, decisions, rawContext?.activeMachine);
         const entries = await Promise.all(
-          accessibleEntries
+          configured
+            .map((m, i) => ({ machine: m, accessible: decisions[i].allowed }))
             .filter(({ accessible }) => accessible)
             .map(async ({ machine: m }) => {
               const desc = await machines.describeMachine(rawContext, m);

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -99,6 +99,14 @@ export interface MachineDescriptor {
 }
 
 /**
+ * Outcome of a machine access check. A denial MAY carry an LLM-facing `reason`
+ * explaining the specific policy that blocked access (e.g. the machine's
+ * "Allow page agents" toggle is off); without one, callers fall back to their
+ * generic revoked-access message.
+ */
+export type MachineAccessDecision = { allowed: true } | { allowed: false; reason?: string };
+
+/**
  * Resolves an actor's configured machines and their metadata/accessibility.
  * `PageAgentConfig.machineAccess`/`machines` (apps/web/src/lib/repositories/
  * page-agent-repository.ts) is the canonical config source; production wires
@@ -112,8 +120,16 @@ export interface MachineDirectoryDeps {
     rawContext: ToolExecutionContext | undefined,
     machine: MachineRef,
   ) => Promise<MachineDescriptor>;
-  /** Page-permission accessibility check ('existing' checks Terminal page view access; 'own' is always true). */
-  isMachineAccessible: (rawContext: ToolExecutionContext | undefined, machine: MachineRef) => Promise<boolean>;
+  /**
+   * Machine access check ('own' is always allowed). For 'existing' machines this
+   * covers Terminal page view access AND the Machine's own access toggles
+   * (`allowPageAgents` for page-scoped agents, `visibleToGlobalAssistant` for
+   * the global assistant); a toggle denial carries an explanatory `reason`.
+   */
+  isMachineAccessible: (
+    rawContext: ToolExecutionContext | undefined,
+    machine: MachineRef,
+  ) => Promise<MachineAccessDecision>;
   /**
    * Resolve the drive that actually backs a machine, overriding the ambient
    * `ctx.driveId` (from chat location context) when it differs. Needed for
@@ -249,13 +265,15 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
     // Terminal page itself) can change between calls, and this is the actual
     // execution boundary: routing a command to a machine the actor can no
     // longer view would be a silent access-control bypass (OWASP A01).
-    const accessible = await machines.isMachineAccessible(rawContext, activeMachine);
-    if (!accessible) {
+    const access = await machines.isMachineAccessible(rawContext, activeMachine);
+    if (!access.allowed) {
       return {
         ok: false,
         error: {
           success: false,
-          error: `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
+          error:
+            access.reason ??
+            `You no longer have access to the active machine ("${machineRefId(activeMachine)}"). Call list_machines to see the available options.`,
         },
       };
     }
@@ -335,11 +353,11 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
           };
         }
 
-        const accessible = await machines.isMachineAccessible(rawContext, target);
-        if (!accessible) {
+        const access = await machines.isMachineAccessible(rawContext, target);
+        if (!access.allowed) {
           return {
             success: false,
-            error: `You no longer have access to "${requestedId}".`,
+            error: access.reason ?? `You no longer have access to "${requestedId}".`,
             reason: 'inaccessible' as const,
           };
         }
@@ -378,7 +396,10 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
         // configured, and describeMachine's title lookup does not itself
         // check accessibility.
         const accessibleEntries = await Promise.all(
-          configured.map(async (m) => ({ machine: m, accessible: await machines.isMachineAccessible(rawContext, m) })),
+          configured.map(async (m) => ({
+            machine: m,
+            accessible: (await machines.isMachineAccessible(rawContext, m)).allowed,
+          })),
         );
         const entries = await Promise.all(
           accessibleEntries

--- a/packages/lib/src/services/machines/__tests__/machine-access.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-access.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { canViewMachine, canEditMachine, type MachineAccessDeps } from '../machine-access';
+import {
+  canViewMachine,
+  canEditMachine,
+  decideMachineToggleAccess,
+  type MachineAccessDeps,
+} from '../machine-access';
 import { PageType } from '../../../utils/enums';
 
 const MACHINE_ID = 'machine-1';
@@ -68,5 +73,50 @@ describe('canEditMachine', () => {
   it('denies when the page exists but is not a Terminal page', async () => {
     const deps = makeDeps({ findPageType: async () => PageType.FOLDER });
     expect(await canEditMachine(deps, ACTOR_USER_ID, MACHINE_ID)).toBe(false);
+  });
+});
+
+describe('decideMachineToggleAccess', () => {
+  const bothOn = { allowPageAgents: true, visibleToGlobalAssistant: true };
+
+  it('allows a page agent when allowPageAgents is on', () => {
+    expect(decideMachineToggleAccess({ actor: 'page-agent', settings: bothOn })).toEqual({ allowed: true });
+  });
+
+  it('denies a page agent with page_agents_disabled when allowPageAgents is off', () => {
+    expect(
+      decideMachineToggleAccess({
+        actor: 'page-agent',
+        settings: { allowPageAgents: false, visibleToGlobalAssistant: true },
+      }),
+    ).toEqual({ allowed: false, code: 'page_agents_disabled' });
+  });
+
+  it('allows the global assistant when visibleToGlobalAssistant is on', () => {
+    expect(decideMachineToggleAccess({ actor: 'global-assistant', settings: bothOn })).toEqual({ allowed: true });
+  });
+
+  it('denies the global assistant with hidden_from_global when visibleToGlobalAssistant is off', () => {
+    expect(
+      decideMachineToggleAccess({
+        actor: 'global-assistant',
+        settings: { allowPageAgents: true, visibleToGlobalAssistant: false },
+      }),
+    ).toEqual({ allowed: false, code: 'hidden_from_global' });
+  });
+
+  it('each toggle gates ONLY its own actor kind', () => {
+    expect(
+      decideMachineToggleAccess({
+        actor: 'global-assistant',
+        settings: { allowPageAgents: false, visibleToGlobalAssistant: true },
+      }),
+    ).toEqual({ allowed: true });
+    expect(
+      decideMachineToggleAccess({
+        actor: 'page-agent',
+        settings: { allowPageAgents: true, visibleToGlobalAssistant: false },
+      }),
+    ).toEqual({ allowed: true });
   });
 });

--- a/packages/lib/src/services/machines/machine-access.ts
+++ b/packages/lib/src/services/machines/machine-access.ts
@@ -11,6 +11,7 @@
 
 import type { PageType } from '../../utils/enums';
 import { isMachinePage } from '../../content/page-types.config';
+import type { MachineSettings } from './machine-settings';
 
 export interface MachineAccessDeps {
   /** Looks up a page's type by id — returns null if the page doesn't exist. */
@@ -42,4 +43,38 @@ export async function canEditMachine(
 ): Promise<boolean> {
   if (!(await isMachine(deps, machineId))) return false;
   return deps.canUserEditPage(actorUserId, machineId);
+}
+
+/**
+ * The actor kinds the Machine Settings access toggles discriminate between.
+ * A 'page-agent' is any agent acting under an agent page identity (its own
+ * `agentPageId`, or a parent's for a sub-agent); 'global-assistant' is the
+ * user-level assistant with no agent page.
+ */
+export type MachineToggleActor = 'page-agent' | 'global-assistant';
+
+export type MachineToggleDenialCode = 'page_agents_disabled' | 'hidden_from_global';
+
+export type MachineToggleDecision = { allowed: true } | { allowed: false; code: MachineToggleDenialCode };
+
+/**
+ * Pure policy for the two per-Machine access toggles persisted by the
+ * Settings tab (see `MachineSettings` in machine-settings.ts):
+ * `allowPageAgents` gates page-scoped agents, `visibleToGlobalAssistant`
+ * gates the global assistant. Each toggle applies ONLY to its own actor kind.
+ * This is the single source of the toggle semantics — enforcement boundaries
+ * (the AI sandbox machine directory today, any future Machine surface) call
+ * this instead of re-deriving the actor-kind × toggle matrix.
+ */
+export function decideMachineToggleAccess(input: {
+  actor: MachineToggleActor;
+  settings: Pick<MachineSettings, 'allowPageAgents' | 'visibleToGlobalAssistant'>;
+}): MachineToggleDecision {
+  if (input.actor === 'page-agent' && !input.settings.allowPageAgents) {
+    return { allowed: false, code: 'page_agents_disabled' };
+  }
+  if (input.actor === 'global-assistant' && !input.settings.visibleToGlobalAssistant) {
+    return { allowed: false, code: 'hidden_from_global' };
+  }
+  return { allowed: true };
 }

--- a/packages/lib/src/services/machines/machine-settings.ts
+++ b/packages/lib/src/services/machines/machine-settings.ts
@@ -7,15 +7,13 @@
  * dedicated Machine columns, and `visibleToGlobalAssistant` reuses the existing
  * page column.
  *
- * NOTE ON THE TWO ACCESS TOGGLES: this route only PERSISTS `visibleToGlobalAssistant`
- * and `allowPageAgents` for a Machine. Their ENFORCEMENT is a separate consumer,
- * not wired yet (and not this node's scope) — for MACHINE pages nothing reads
- * either flag today: `visibleToGlobalAssistant` is consulted only for `AI_CHAT`
- * agents (agent-awareness.ts), and `allowPageAgents` has no reader at all. The
- * follow-up nodes wire `visibleToGlobalAssistant` into the global-assistant
- * machine picker/resolution and `allowPageAgents` into the page-agent machine gate
- * (`isMachineAccessible`, sandbox-tools-runtime.ts). The whole surface is behind
- * `CODE_EXECUTION_ENABLED` (OFF), so no unenforced toggle is user-visible yet.
+ * NOTE ON THE TWO ACCESS TOGGLES: this route PERSISTS `visibleToGlobalAssistant`
+ * and `allowPageAgents` for a Machine; their ENFORCEMENT lives in the machine
+ * access gate (`isMachineAccessible` / `resolveGlobalConfiguredMachines`,
+ * apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts): `allowPageAgents` denies
+ * page-scoped agents the machine's terminal tools, and `visibleToGlobalAssistant`
+ * excludes the machine from the global assistant's resolution. For `AI_CHAT`
+ * pages `visibleToGlobalAssistant` is separately consulted by agent-awareness.ts.
  * This module is pure orchestration + DI — every DB / Sprite
  * touch is an injected seam (`MachineSettingsStore`, `MachineSpriteTeardown`),
  * so the delete-ordering invariant below is unit-testable without a database or

--- a/packages/lib/src/services/machines/machine-settings.ts
+++ b/packages/lib/src/services/machines/machine-settings.ts
@@ -8,11 +8,12 @@
  * page column.
  *
  * NOTE ON THE TWO ACCESS TOGGLES: this route PERSISTS `visibleToGlobalAssistant`
- * and `allowPageAgents` for a Machine; their ENFORCEMENT lives in the machine
- * access gate (`isMachineAccessible` / `resolveGlobalConfiguredMachines`,
+ * and `allowPageAgents` for a Machine; their POLICY lives in
+ * `decideMachineToggleAccess` (machine-access.ts) and is ENFORCED per tool call
+ * by the AI sandbox machine gate (`isMachineAccessible`,
  * apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts): `allowPageAgents` denies
- * page-scoped agents the machine's terminal tools, and `visibleToGlobalAssistant`
- * excludes the machine from the global assistant's resolution. For `AI_CHAT`
+ * page-scoped agents the machine's terminal tools, `visibleToGlobalAssistant`
+ * hides the machine from (and denies) the global assistant. For `AI_CHAT`
  * pages `visibleToGlobalAssistant` is separately consulted by agent-awareness.ts.
  * This module is pure orchestration + DI — every DB / Sprite
  * touch is an injected seam (`MachineSettingsStore`, `MachineSpriteTeardown`),


### PR DESCRIPTION
## Summary

GA-blocker remediation for deferred items **1 and 2** of the Machine/Terminal arc (page `wm76dkca6cd2jwcldumys5c5`): the two Machine access toggles were **persisted but never enforced** — the Settings switches wrote `allowPageAgents` / `visibleToGlobalAssistant` to the page row, and nothing on the machine-access path read them back.

### What's enforced now

**Policy** (pure, machine-readable codes): `decideMachineToggleAccess` in `packages/lib/src/services/machines/machine-access.ts` — the module the codebase designates for shared machine access checks. `allowPageAgents` gates **page-scoped agents** (own `agentPageId` or a sub-agent's `parentAgentId` — the same discriminator `resolveConfiguredMachines` uses to pick whose machine list applies); `visibleToGlobalAssistant` gates the **global assistant**. Each toggle applies only to its own actor kind.

**Exemption — user-scoped page agents**: a page agent with `userScopedAccess=true` (owner-toggled) already acts with the *invoking user's own reach* for view permissions (`canActorViewPage` → `resolveActingAgentId`). `isMachineAccessible` mirrors that fallthrough via a new `isUserScopedAgent` dep: such an agent bypasses `allowPageAgents` entirely (it isn't reclassified as the global assistant either — `visibleToGlobalAssistant` doesn't apply to it, since its machine list comes from its own agent config, not the global config repository). Matches the task's original scope ("a user-scoped/global agent is unaffected by this flag").

**Enforcement** (single site, every call): `isMachineAccessible` in `createMachineDirectory` (`sandbox-tools-runtime.ts`) consumes the policy and renders an LLM-facing denial reason naming the machine and the exact Settings toggle. Every bash/file/git tool call, `switch_machine`, and `list_machines` goes through it. Trashed machine pages are also denied. Toggle checks run after `canViewPage`, so the reason never leaks to an actor who can't view the page.

**Active-machine resolution** (`resolveActiveMachine`, `sandbox-tools.ts`) performs the access check itself and returns `{machine, access}`:
- The **default** falls back past blocked machines to the first *accessible* configured one — a blocked `machines[0]` doesn't dead-end the whole tool group while a usable machine sits one slot over (both toggles, both actor kinds).
- An **explicitly switched** machine that becomes blocked is denied with its specific reason — never silently rerouted.
- When **every** machine is blocked, the first one's real reason surfaces instead of the misleading "Terminal access is not enabled".
- `list_machines` computes each machine's access decision **once** and derives both the active-machine selection (`selectActiveFromDecisions`, no extra I/O) and its accessible-only display filter from that single pass — avoiding a double `isMachineAccessible` call per configured machine.

`switch_machine` returns the denial code (`page_agents_disabled` / `hidden_from_global`) as its machine-readable `reason` instead of miscategorizing policy denials as `inaccessible`. Denial rendering is shared (`machineAccessDeniedError`) so the bash/file and git execution boundaries cannot drift. Git tools reuse the same `machineDirectory` singleton — no extra wiring.

The flag's existing AI_CHAT/page-agent consumer (`agent-awareness.ts`) is untouched. Whole surface remains behind `CODE_EXECUTION_ENABLED` (OFF).

### Tests

- `packages/lib` `machine-access.test.ts`: pure policy matrix (each toggle gates only its own actor kind, denial codes).
- `sandbox-tools-runtime.test.ts`: page agent denied (code + reason) / allowed; sub-agent treated as page-scoped; global assistant denied (code + reason) / allowed; cross-flag non-interference; no-title-leak; trashed machine denied; user-scoped agent exempt from `allowPageAgents` (but still subject to view-permission checks, and the exemption keys off its own `chatSource.agentPageId` only — not a sub-agent's `parentAgentId`).
- `sandbox-tools.test.ts`: fallback past a blocked `machines[0]` routes bash to the usable machine; all-blocked surfaces the first machine's specific reason; an explicitly switched blocked machine denies without silent rerouting; `list_machines` marks the fallback target active AND calls `isMachineAccessible` exactly once per configured machine (asserted directly); `switch_machine` returns the toggle code.

`vitest`: 236/236 (web sandbox tool files, includes the new call-count assertion) + 22/22 (lib machines). `tsc --noEmit` green in `packages/lib` and `apps/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrdKH5t1RYZrVo9CnE8Jm3