### PR TITLE
[publish 1-8] Generalized PublishControls in ViewHeader

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -21,9 +21,9 @@ import { Switch } from '@/components/ui/switch';
 import { PagePickerPopover } from '@/components/common/PagePickerPopover';
 import { PageType } from '@pagespace/lib/utils/enums';
 
-interface CanvasPublishControlsProps {
+interface PublishControlsProps {
   pageId: string;
-  /** Mirrors the canvas document's isDirty flag. When it transitions true→false
+  /** Mirrors the page document's isDirty flag. When it transitions true→false
    *  (a save just completed) and the page is published, the control marks itself
    *  stale so the user sees the Update button without a page reload. */
   contentDirty?: boolean;
@@ -83,7 +83,7 @@ const readError = async (res: Response): Promise<string> => {
   }
 };
 
-const CanvasPublishControls = ({ pageId, contentDirty }: CanvasPublishControlsProps) => {
+const PublishControls = ({ pageId, contentDirty }: PublishControlsProps) => {
   const params = useParams<{ driveId?: string }>();
   const driveId = params?.driveId;
   const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
@@ -418,4 +418,4 @@ function PublishSettingsDialog({ open, onOpenChange, initial, driveId, isBusy, o
   );
 }
 
-export default CanvasPublishControls;
+export default PublishControls;

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -13,8 +13,9 @@ import { useParams } from 'next/navigation';
 import { usePageStore } from '@/hooks/usePage';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
-import { isDocumentPage, isFilePage, isSheetPage, isCodePage } from '@pagespace/lib/content/page-types.config';
+import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
 import { ExportDropdown } from './ExportDropdown';
+import PublishControls from './PublishControls';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useMobile } from '@/hooks/useMobile';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
@@ -52,6 +53,21 @@ const DocumentSaveStatus = memo(function DocumentSaveStatus({
   }
 
   return <SaveStatusIndicator isDirty={isDirty} isSaving={isSaving} />;
+});
+
+const HeaderPublishControls = memo(function HeaderPublishControls({
+  pageId,
+}: {
+  pageId: string;
+}) {
+  const selectIsDirty = useCallback(
+    (state: ReturnType<typeof useDocumentManagerStore.getState>) =>
+      state.documents.get(pageId)?.isDirty ?? false,
+    [pageId]
+  );
+  const contentDirty = useDocumentManagerStore(selectIsDirty);
+
+  return <PublishControls pageId={pageId} contentDirty={contentDirty} />;
 });
 
 export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps = {}) {
@@ -141,6 +157,9 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
               <Download className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
               {!isMobile && (isDownloading ? 'Downloading...' : 'Download')}
             </Button>
+          )}
+          {page && isPublishablePageType(page.type) && (
+            <HeaderPublishControls pageId={page.id} />
           )}
           <PageViewers pageId={pageId} />
           <ShareDialog pageId={pageId} />

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -11,7 +11,6 @@ import { useEditingStore } from '@/stores/useEditingStore';
 import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { useFindStore } from '@/stores/useFindStore';
-import CanvasPublishControls from './CanvasPublishControls';
 import CanvasFormsSettingsTab from './CanvasFormsSettingsTab';
 
 interface CanvasPageViewProps {
@@ -187,9 +186,6 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
         >
           Forms
         </button>
-        <div className="ml-auto min-w-0 max-w-full">
-          <CanvasPublishControls pageId={pageId} contentDirty={documentState?.isDirty} />
-        </div>
       </div>
       {activeTab === 'code' && (
         <div className="flex-1 min-h-0">


### PR DESCRIPTION
## Summary

Task 1-8 of the publish-any-page-type phase: publishing controls move from the canvas-only tab bar into the shared page header, gated by the page-type capability added in 1-1.

- **Move/rename**: `page-views/canvas/CanvasPublishControls.tsx` → `content-header/PublishControls.tsx`. Props (`pageId`, `contentDirty`) and all behavior (Publish/Unpublish/Update/Copy-link, `PublishSettingsDialog` SEO overrides, availability probe) unchanged.
- **ViewHeader mount**: renders `PublishControls` when `page && isPublishablePageType(page.type)`, next to the existing header actions (PageViewers/ShareDialog). `contentDirty` is wired via a memoized `useDocumentManagerStore` selector — the same pattern as `DocumentSaveStatus` — so dirty→clean save transitions surface the Update button for any editor flowing through the document manager.
- **Hard cutover**: the `CanvasPageView.tsx` mount is removed; single mount point, no compat shim (unreleased behavior).

Net effect: DOCUMENT (and every other publishable-capability type) pages get the publish button in their header; CHANNEL and other non-publishable types do not.

## Validation

- `bun run typecheck` — 16/16 tasks green
- `bun run lint` — 14/14 tasks green (only pre-existing warnings in unrelated hooks)
- No DOM tests added per task protocol (dual-React flakiness in pu worktrees); no new pure helpers were extracted — gating reuses `isPublishablePageType` from 1-1, already covered by `page-types-publishable.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hKLnVwZfHqDxhT6X7vm2L