### PR TITLE
[publish 1-4] document CSP + renderDocumentPage

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -992,6 +992,11 @@
       "import": "./dist/publish/document-shell.js",
       "require": "./dist/publish/document-shell.js"
     },
+    "./publish/render-document-page": {
+      "types": "./dist/publish/render-document-page.d.ts",
+      "import": "./dist/publish/render-document-page.js",
+      "require": "./dist/publish/render-document-page.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -2003,6 +2008,9 @@
       ],
       "publish/document-shell": [
         "./dist/publish/document-shell.d.ts"
+      ],
+      "publish/render-document-page": [
+        "./dist/publish/render-document-page.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/src/canvas/__tests__/csp.test.ts
+++ b/packages/lib/src/canvas/__tests__/csp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildBaselineCsp } from '../csp';
+import { buildBaselineCsp, buildDocumentCsp } from '../csp';
 
 describe('buildBaselineCsp', () => {
   it('defaults to form-action \'none\' when no origin is given', () => {
@@ -25,5 +25,27 @@ describe('buildBaselineCsp', () => {
     expect(withOrigin).toContain("object-src 'none'");
     expect(withOrigin).toContain("base-uri 'none'");
     expect(withOrigin).toContain("script-src 'unsafe-inline'");
+  });
+});
+
+describe('buildDocumentCsp', () => {
+  it('blocks scripts entirely', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("script-src 'none'");
+  });
+
+  it('blocks form submission entirely', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  it('keeps the baseline asset/image/font/object/base-uri directives', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain('img-src data: https:');
+    expect(csp).toContain("style-src 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain('font-src https://fonts.gstatic.com');
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
   });
 });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -876,3 +876,21 @@ describe('renderCanvasDocument — Twitter Card', () => {
     });
   });
 });
+
+describe('renderCanvasDocument — cspOverride', () => {
+  it('given no cspOverride, should stay byte-identical to the buildBaselineCsp-derived output', () => {
+    const input = { html: '<p>x</p>', title: 'T', pageUrl: 'https://acme.pagespace.site/x' };
+    expect(renderCanvasDocument(input)).toBe(renderCanvasDocument(input));
+    expect(renderCanvasDocument({ html: '<p>x</p>' })).toContain(`content="${BASELINE_CSP}"`);
+  });
+
+  it('given a cspOverride, should use it verbatim instead of buildBaselineCsp', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      formActionOrigin: 'https://ignored.example',
+      cspOverride: "default-src 'none'; script-src 'none';",
+    });
+    expect(out).toContain('content="default-src \'none\'; script-src \'none\';"');
+    expect(out).not.toContain('ignored.example');
+  });
+});

--- a/packages/lib/src/canvas/csp.ts
+++ b/packages/lib/src/canvas/csp.ts
@@ -18,3 +18,17 @@ export function buildBaselineCsp(formActionOrigin?: string): string {
 
   return `${base} form-action 'self' ${formActionOrigin}; connect-src ${formActionOrigin}`;
 }
+
+/**
+ * Builds the CSP for published DOCUMENT pages (see `../publish/render-document-page.ts`).
+ * Unlike canvas pages, documents never run author scripts — the sanitizer
+ * (`sanitizeDocumentHtml`) already strips `<script>` tags, and this policy is
+ * the hard enforcement layer: `script-src 'none'` blocks any that slip
+ * through, and `form-action 'none'` blocks form submission entirely (the
+ * sanitizer also strips `<form>`). Every other baseline directive (asset/
+ * font/image hosts, `object-src`, `base-uri`) is unchanged from
+ * `buildBaselineCsp()`.
+ */
+export function buildDocumentCsp(): string {
+  return "default-src 'none'; img-src data: https:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";
+}

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -115,6 +115,14 @@ export interface RenderCanvasDocumentInput {
    * standalone documents and use `prefers-color-scheme` for OS-level matching.
    */
   injectThemeBridge?: boolean;
+  /**
+   * When set, used VERBATIM as the emitted CSP `<meta>` content instead of
+   * `buildBaselineCsp(formActionOrigin)`. Lets other renderers (e.g. the
+   * published-document pipeline, which needs `script-src 'none'`) reuse this
+   * renderer's whole head assembly without duplicating it. Omit to keep the
+   * unchanged canvas baseline CSP.
+   */
+  cspOverride?: string;
 }
 
 /**
@@ -314,8 +322,8 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[], no
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce } = input;
-  const csp = buildBaselineCsp(formActionOrigin);
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce, cspOverride } = input;
+  const csp = cspOverride ?? buildBaselineCsp(formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce);
   const rawTitle = title && title.trim() ? title : 'Untitled';

--- a/packages/lib/src/publish/__tests__/render-document-page.test.ts
+++ b/packages/lib/src/publish/__tests__/render-document-page.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentPage } from '../render-document-page';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('renderDocumentPage', () => {
+  it('should return a full standalone HTML document', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a bare document body and title',
+      should: 'wrap it in a full <!doctype html> document',
+      actual: out.startsWith('<!doctype html>') && out.includes('</html>'),
+      expected: true,
+    });
+  });
+
+  it('should lock scripts down with script-src none', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page',
+      should: "embed a CSP with script-src 'none'",
+      actual: out.includes("script-src 'none'"),
+      expected: true,
+    });
+  });
+
+  it('should strip author <script> tags entirely (sanitizer + CSP belt-and-suspenders)', () => {
+    const out = renderDocumentPage({
+      html: '<p>hello</p><script>alert(1)</script>',
+      title: 'My Doc',
+    });
+    assert({
+      given: 'author HTML containing a <script> tag',
+      should: 'contain no <script> remnants in the output',
+      actual: out.includes('<script') || out.includes('alert(1)'),
+      expected: false,
+    });
+  });
+
+  it('should omit the theme-bridge script', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page (standalone, not an in-app iframe)',
+      should: 'not inject the theme-bridge <script>',
+      actual: out.includes('pagespace-theme'),
+      expected: false,
+    });
+  });
+
+  it('should wrap the body in a .ps-document article with a title header', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a body with no leading <h1>',
+      should: 'emit <article class="ps-document"> with a <header><h1> title',
+      actual: out.includes('<article class="ps-document"><header><h1>My Doc</h1></header><p>hello</p></article>'),
+      expected: true,
+    });
+  });
+
+  it('should inline the document typography CSS', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page',
+      should: 'inline the shared document typography rules into <head>',
+      actual: out.includes('.ps-document {') && out.includes('max-width: 42rem'),
+      expected: true,
+    });
+  });
+
+  it('should emit the canonical link and OG tags when pageUrl is provided', () => {
+    const out = renderDocumentPage({
+      html: '<p>hello</p>',
+      title: 'My Doc',
+      pageUrl: 'https://acme.pagespace.site/my-doc',
+      ogImageUrl: 'https://acme.pagespace.site/og.png',
+      ogDescription: 'A great doc',
+    });
+    assert({
+      given: 'pageUrl, ogImageUrl and ogDescription',
+      should: 'emit a canonical link and OG meta tags',
+      actual:
+        out.includes('<link rel="canonical" href="https://acme.pagespace.site/my-doc">') &&
+        out.includes('<meta property="og:image" content="https://acme.pagespace.site/og.png">') &&
+        out.includes('<meta property="og:description" content="A great doc">'),
+      expected: true,
+    });
+  });
+
+  it('should omit the canonical link and OG tags when pageUrl is absent', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'no pageUrl',
+      should: 'omit canonical/OG tags entirely',
+      actual: out.includes('rel="canonical"') || out.includes('property="og:'),
+      expected: false,
+    });
+  });
+
+  it('should sanitize dangerous attributes and iframes from the author body', () => {
+    const out = renderDocumentPage({
+      html: '<p onclick="evil()">hi</p><iframe src="https://evil.example"></iframe>',
+      title: 'My Doc',
+    });
+    assert({
+      given: 'author HTML with an event handler and an <iframe>',
+      should: 'strip both before rendering',
+      actual: out.includes('onclick') || out.includes('<iframe'),
+      expected: false,
+    });
+  });
+
+  it('should HTML-escape the title in both <title> and the header', () => {
+    const out = renderDocumentPage({ html: '<p>x</p>', title: 'Fish & Chips' });
+    assert({
+      given: 'a title with an HTML-special character',
+      should: 'escape it everywhere the title is emitted',
+      actual: out.includes('Fish &amp; Chips') && !out.includes('Fish & Chips'),
+      expected: true,
+    });
+  });
+});

--- a/packages/lib/src/publish/render-document-page.ts
+++ b/packages/lib/src/publish/render-document-page.ts
@@ -1,0 +1,55 @@
+import { renderCanvasDocument } from '../canvas/render-document';
+import { buildDocumentCsp } from '../canvas/csp';
+import { sanitizeDocumentHtml } from './sanitize-document-html';
+import { wrapDocumentBody, DOCUMENT_TYPOGRAPHY_CSS } from './document-shell';
+
+export interface RenderDocumentPageInput {
+  html: string;
+  title: string;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  description?: string;
+  robots?: string;
+  faviconHref?: string;
+  faviconBaseUrl?: string;
+  lang?: string;
+  allowedAssetHosts?: string[];
+}
+
+/**
+ * Render a complete, standalone HTML document for a published DOCUMENT page
+ * (as opposed to a Canvas page — see `../canvas/render-document.ts`). Reuses
+ * the canvas renderer's whole head assembly (SEO/OG/Twitter/JSON-LD, favicon,
+ * CSP `<meta>`) via `cspOverride`/`injectThemeBridge: false` rather than
+ * duplicating it: documents never run author scripts, so they get
+ * `buildDocumentCsp()` (`script-src 'none'`) and no theme-bridge script
+ * (standalone documents use `prefers-color-scheme` only).
+ *
+ * `DOCUMENT_TYPOGRAPHY_CSS` is prepended as a `<style>` block ahead of the
+ * sanitized body so it flows through `renderCanvasDocument`'s existing CSS
+ * sanitization/hoisting path exactly like an author `<style>` tag, landing in
+ * the generated `<head>`.
+ */
+export function renderDocumentPage(input: RenderDocumentPageInput): string {
+  const { html, title, pageUrl, ogImageUrl, ogDescription, description, robots, faviconHref, faviconBaseUrl, lang, allowedAssetHosts } = input;
+
+  const sanitizedBody = sanitizeDocumentHtml(html);
+  const wrappedBody = wrapDocumentBody({ bodyHtml: sanitizedBody, title });
+
+  return renderCanvasDocument({
+    html: `<style>${DOCUMENT_TYPOGRAPHY_CSS}</style>${wrappedBody}`,
+    title,
+    pageUrl,
+    ogImageUrl,
+    ogDescription,
+    description,
+    robots,
+    faviconHref,
+    faviconBaseUrl,
+    lang,
+    allowedAssetHosts,
+    cspOverride: buildDocumentCsp(),
+    injectThemeBridge: false,
+  });
+}


### PR DESCRIPTION
## Summary
- `buildDocumentCsp()` in `csp.ts`: baseline directives with `script-src 'none'` and `form-action 'none'` (documents never run author scripts — enforced by both the sanitizer and this CSP).
- `RenderCanvasDocumentInput` gains optional `cspOverride?: string`, used verbatim instead of `buildBaselineCsp(...)` when present; output is byte-identical to before when absent.
- `renderDocumentPage(input)` in `packages/lib/src/publish/render-document-page.ts`: `sanitizeDocumentHtml` → `wrapDocumentBody` → prepends `DOCUMENT_TYPOGRAPHY_CSS` as a `<style>` block (flows through the existing CSS sanitization path) → delegates to `renderCanvasDocument` with `cspOverride: buildDocumentCsp()` and `injectThemeBridge: false`.

Depends on 1-2 (`sanitizeDocumentHtml`) and 1-3 (`wrapDocumentBody`/`DOCUMENT_TYPOGRAPHY_CSS`), both already merged into `pu/publish-any-page-type`.

## Test plan
- [x] `bunx vitest run src/canvas/__tests__/csp.test.ts src/canvas/__tests__/render-document.test.ts src/publish/__tests__/render-document-page.test.ts` — all green
- [x] `bunx vitest run src/canvas src/publish` — full canvas/publish suite green (343 tests)
- [x] `bun run typecheck` — clean across the monorepo
- [x] `eslint` on changed source files — clean