### PR TITLE
fix(development): proper machine-list states, test the mobile sheet close

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -21,6 +21,7 @@ import { useMachineTabStore } from '@/stores/machine-workspace/useMachineTabStor
 import { parseSelectedMachineId, buildMachineHref } from '@/lib/development/development-route';
 import MachineTree, { type MachineTreeNode } from '@/components/layout/middle-content/page-views/machine/workspace/MachineTree';
 import WorkspaceLeaves, { WorkspaceNodeExtras } from '@/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves';
+import { SidebarLoading, SidebarNotice } from '@/components/layout/middle-content/page-views/machine/tabs/tab-states';
 
 /**
  * The Development surface's left sidebar. Two modes, one component (mirroring
@@ -68,12 +69,18 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
   // which is structure the Machine page itself withholds from them. Passing a
   // disabled key is what keeps those requests from ever being made. Both hooks
   // are called unconditionally (Rules of Hooks); only one is ever enabled.
-  const { machines, isLoading: driveMachinesLoading, error: driveMachinesError } = useDriveMachines(
-    isAdmin && driveId ? driveId : null,
-  );
-  const { drives: machineDrives, isLoading: allMachinesLoading, error: allMachinesError } = useAllMachines(
-    isAdmin && !driveId,
-  );
+  const {
+    machines,
+    isLoading: driveMachinesLoading,
+    error: driveMachinesError,
+    mutate: retryDriveMachines,
+  } = useDriveMachines(isAdmin && driveId ? driveId : null);
+  const {
+    drives: machineDrives,
+    isLoading: allMachinesLoading,
+    error: allMachinesError,
+    mutate: retryAllMachines,
+  } = useAllMachines(isAdmin && !driveId);
 
   const pathname = usePathname() ?? '';
   const selectedMachineId = parseSelectedMachineId(pathname, driveId);
@@ -106,6 +113,7 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
                 machines={machines}
                 isLoading={driveMachinesLoading}
                 error={driveMachinesError}
+                onRetry={retryDriveMachines}
                 selectedMachineId={selectedMachineId}
                 isSheetBreakpoint={isSheetBreakpoint}
               />
@@ -116,6 +124,7 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
                 drives={machineDrives}
                 isLoading={allMachinesLoading}
                 error={allMachinesError}
+                onRetry={retryAllMachines}
                 selectedMachineId={selectedMachineId}
                 isSheetBreakpoint={isSheetBreakpoint}
               />
@@ -127,11 +136,6 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
       </div>
     </aside>
   );
-}
-
-/** A resting state of the machine list: one line of muted text, no tree. */
-function ListNotice({ children }: { children: string }) {
-  return <div className="py-8 text-center text-sm text-muted-foreground">{children}</div>;
 }
 
 /**
@@ -146,6 +150,12 @@ function ListNotice({ children }: { children: string }) {
  * data on its error path — indistinguishable from "genuinely empty" unless
  * error is checked first — but only when there's nothing to show yet: a
  * background poll's error must not tear down a list the caller already has.
+ *
+ * Built on the Machine page's shared `SidebarLoading`/`SidebarNotice`
+ * vocabulary (see `tab-states.tsx`) rather than a bespoke notice, so this
+ * list reads like every other compact sidebar state in the app: a spinner row
+ * while loading, and a muted/destructive row — with a retry action on the
+ * failure branch — otherwise.
  */
 function resolveListNotice({
   authLoading,
@@ -153,22 +163,34 @@ function resolveListNotice({
   hasError,
   isLoading,
   isEmpty,
-  emptyMessage,
+  emptyTitle,
+  onRetry,
 }: {
   authLoading: boolean;
   isAdmin: boolean;
   hasError: boolean;
   isLoading: boolean;
   isEmpty: boolean;
-  emptyMessage: string;
-}): string | null {
-  if (authLoading) return 'Loading…';
+  emptyTitle: string;
+  onRetry: () => void;
+}): React.ReactNode {
+  if (authLoading) return <SidebarLoading message="Loading…" />;
   // Same wording MachineView uses, so the surface and the page refuse a
   // non-admin identically.
-  if (!isAdmin) return 'Machine access requires administrator privileges';
-  if (hasError && isEmpty) return 'Failed to load machines';
-  if (isLoading) return 'Loading…';
-  if (isEmpty) return emptyMessage;
+  if (!isAdmin) return <SidebarNotice title="Machine access requires administrator privileges" />;
+  if (hasError && isEmpty) {
+    return (
+      <SidebarNotice
+        title="Failed to load machines"
+        description="Check your connection and try again."
+        tone="destructive"
+        actionLabel="Retry"
+        onAction={onRetry}
+      />
+    );
+  }
+  if (isLoading) return <SidebarLoading message="Loading machines…" />;
+  if (isEmpty) return <SidebarNotice title={emptyTitle} />;
   return null;
 }
 
@@ -180,6 +202,7 @@ function DriveMachineList({
   machines,
   isLoading,
   error,
+  onRetry,
   selectedMachineId,
   isSheetBreakpoint,
 }: {
@@ -189,6 +212,7 @@ function DriveMachineList({
   machines: DriveMachine[];
   isLoading: boolean;
   error: Error | undefined;
+  onRetry: () => void;
   selectedMachineId: string | null;
   isSheetBreakpoint: boolean;
 }) {
@@ -198,9 +222,10 @@ function DriveMachineList({
     hasError: !!error,
     isLoading,
     isEmpty: machines.length === 0,
-    emptyMessage: 'No machines in this drive yet',
+    emptyTitle: 'No machines in this drive yet',
+    onRetry,
   });
-  if (notice) return <ListNotice>{notice}</ListNotice>;
+  if (notice) return notice;
 
   return (
     <>
@@ -225,6 +250,7 @@ function GlobalMachineList({
   drives,
   isLoading,
   error,
+  onRetry,
   selectedMachineId,
   isSheetBreakpoint,
 }: {
@@ -233,6 +259,7 @@ function GlobalMachineList({
   drives: DriveMachineGroup[];
   isLoading: boolean;
   error: Error | undefined;
+  onRetry: () => void;
   selectedMachineId: string | null;
   isSheetBreakpoint: boolean;
 }) {
@@ -242,9 +269,14 @@ function GlobalMachineList({
     hasError: !!error,
     isLoading,
     isEmpty: drives.length === 0,
-    emptyMessage: 'No machines across your drives yet',
+    // Backend note (`listMachinesAcrossDrives`): a drive with zero VISIBLE
+    // machines is dropped from the payload entirely rather than served as an
+    // empty group, so there is no reachable "drive with no machines" state to
+    // render here — only the whole-list empty case above.
+    emptyTitle: 'No machines across your drives yet',
+    onRetry,
   });
-  if (notice) return <ListNotice>{notice}</ListNotice>;
+  if (notice) return notice;
 
   return (
     <>

--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -73,14 +73,25 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
     machines,
     isLoading: driveMachinesLoading,
     error: driveMachinesError,
-    mutate: retryDriveMachines,
+    mutate: mutateDriveMachines,
   } = useDriveMachines(isAdmin && driveId ? driveId : null);
   const {
     drives: machineDrives,
     isLoading: allMachinesLoading,
     error: allMachinesError,
-    mutate: retryAllMachines,
+    mutate: mutateAllMachines,
   } = useAllMachines(isAdmin && !driveId);
+  // SidebarNotice's Retry button wires straight to `onClick`, which React calls
+  // with the click's MouseEvent — SWR's `mutate` takes that as replacement cache
+  // DATA, not "revalidate now", so passing it through directly would corrupt the
+  // machines list instead of refetching it. Wrapped to a genuinely no-arg call,
+  // matching how DiffTab's own SWR-backed Retry does it.
+  const retryDriveMachines = useCallback(() => {
+    void mutateDriveMachines();
+  }, [mutateDriveMachines]);
+  const retryAllMachines = useCallback(() => {
+    void mutateAllMachines();
+  }, [mutateAllMachines]);
 
   const pathname = usePathname() ?? '';
   const selectedMachineId = parseSelectedMachineId(pathname, driveId);

--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -151,16 +151,22 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
 
 /**
  * The one ordering-sensitive guard chain both list bodies need, shared so a
- * future fix to the ordering (e.g. why error is checked ahead of loading, or
- * loading ahead of empty) only has to be made once. Returns the notice to
+ * future fix to the ordering (e.g. why loading is checked ahead of error, or
+ * error ahead of empty) only has to be made once. Returns the notice to
  * show, or `null` when the caller should render its actual list.
  *
  * Order matters: auth-pending and non-admin come first so a cold load or a
- * refused user never sees "Failed"/"empty" wording instead. Error is checked
- * ahead of loading and empty because SWR reports `isLoading: false` with no
- * data on its error path — indistinguishable from "genuinely empty" unless
- * error is checked first — but only when there's nothing to show yet: a
- * background poll's error must not tear down a list the caller already has.
+ * refused user never sees "Failed"/"empty" wording instead. Loading is
+ * checked ahead of error so that a Retry click — which sets `isLoading` back
+ * to `true` (SWR does this whenever cached `data` is still `undefined`,
+ * exactly the "nothing loaded yet" state a failed fetch leaves behind) while
+ * `error` stays at its stale, pre-retry value until the new attempt settles —
+ * shows the loading state and not a rerun of the same "Failed" text with no
+ * visible reaction to the click. Error is then checked ahead of empty because
+ * SWR reports `isLoading: false` with no data on its error path —
+ * indistinguishable from "genuinely empty" unless error is checked first —
+ * but only when there's nothing to show yet: a background poll's error must
+ * not tear down a list the caller already has.
  *
  * Built on the Machine page's shared `SidebarLoading`/`SidebarNotice`
  * vocabulary (see `tab-states.tsx`) rather than a bespoke notice, so this
@@ -189,6 +195,7 @@ function resolveListNotice({
   // Same wording MachineView uses, so the surface and the page refuse a
   // non-admin identically.
   if (!isAdmin) return <SidebarNotice title="Machine access requires administrator privileges" />;
+  if (isLoading) return <SidebarLoading message="Loading machines…" />;
   if (hasError && isEmpty) {
     return (
       <SidebarNotice
@@ -200,7 +207,6 @@ function resolveListNotice({
       />
     );
   }
-  if (isLoading) return <SidebarLoading message="Loading machines…" />;
   if (isEmpty) return <SidebarNotice title={emptyTitle} />;
   return null;
 }

--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -73,25 +73,14 @@ export default function DevelopmentSidebar({ className }: SidebarProps) {
     machines,
     isLoading: driveMachinesLoading,
     error: driveMachinesError,
-    mutate: mutateDriveMachines,
+    mutate: retryDriveMachines,
   } = useDriveMachines(isAdmin && driveId ? driveId : null);
   const {
     drives: machineDrives,
     isLoading: allMachinesLoading,
     error: allMachinesError,
-    mutate: mutateAllMachines,
+    mutate: retryAllMachines,
   } = useAllMachines(isAdmin && !driveId);
-  // SidebarNotice's Retry button wires straight to `onClick`, which React calls
-  // with the click's MouseEvent — SWR's `mutate` takes that as replacement cache
-  // DATA, not "revalidate now", so passing it through directly would corrupt the
-  // machines list instead of refetching it. Wrapped to a genuinely no-arg call,
-  // matching how DiffTab's own SWR-backed Retry does it.
-  const retryDriveMachines = useCallback(() => {
-    void mutateDriveMachines();
-  }, [mutateDriveMachines]);
-  const retryAllMachines = useCallback(() => {
-    void mutateAllMachines();
-  }, [mutateAllMachines]);
 
   const pathname = usePathname() ?? '';
   const selectedMachineId = parseSelectedMachineId(pathname, driveId);

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -207,6 +207,34 @@ describe('DevelopmentSidebar', () => {
     expect(mutate).toHaveBeenCalledWith();
   });
 
+  test('a retry IN FLIGHT shows the loading state, not a rerun of the stale error', () => {
+    // SWR sets `isLoading` back to `true` on revalidation whenever cached data
+    // is still `undefined` — exactly what a failed fetch leaves behind — while
+    // `error` stays at its stale, pre-retry value until the new attempt
+    // settles. Both are true at once mid-retry, so the guard chain order
+    // matters: loading must win, or clicking Retry looks like it did nothing.
+    const staleError = new Error('network down');
+    mockUseDriveMachines.mockReturnValueOnce({
+      machines: [],
+      isLoading: false,
+      error: staleError,
+      mutate: vi.fn(),
+    });
+    const { rerender } = render(<DevelopmentSidebar />);
+    expect(screen.getByText(/failed to load machines/i)).toBeDefined();
+
+    mockUseDriveMachines.mockReturnValueOnce({
+      machines: [],
+      isLoading: true,
+      error: staleError,
+      mutate: vi.fn(),
+    });
+    rerender(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/loading machines/i)).toBeDefined();
+    expect(screen.queryByText(/failed to load machines/i)).toBeNull();
+  });
+
   test('closes the mobile sheet after navigating to a machine, at the sheet breakpoint', async () => {
     const user = userEvent.setup();
     mockUseBreakpoint.mockReturnValue(true);

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -16,6 +16,10 @@ const mockPush = vi.fn();
 const mockUseAuth = vi.fn();
 const mockUseParams = vi.fn<() => { driveId?: string }>(() => ({ driveId: 'drive-1' }));
 const mockUsePathname = vi.fn(() => '/dashboard/drive-1/development');
+// Defaults to desktop width (matches the real hook's jsdom default — see
+// test/setup.ts). Individual tests flip this to exercise the sheet-breakpoint
+// (narrow-viewport) branch without needing a real matchMedia listener.
+const mockUseBreakpoint = vi.fn(() => false);
 
 vi.mock('next/navigation', () => ({
   useParams: () => mockUseParams(),
@@ -24,6 +28,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
+vi.mock('@/hooks/useBreakpoint', () => ({ useBreakpoint: () => mockUseBreakpoint() }));
 
 // Spied, not just stubbed: a null/disabled key is HOW the sidebar refuses to
 // fetch for a non-admin, so the argument is the security property — asserting
@@ -89,6 +94,7 @@ import DevelopmentSidebar from '../DevelopmentSidebar';
 import { usePendingWorkspaceStore } from '@/stores/development/usePendingWorkspaceStore';
 import { useMachineTabStore } from '@/stores/machine-workspace/useMachineTabStore';
 import { useMachineWorkspaceStore, selectMachine } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import { useLayoutStore } from '@/stores/useLayoutStore';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -96,9 +102,11 @@ beforeEach(() => {
   usePendingWorkspaceStore.setState({ pending: null });
   useMachineTabStore.setState({ tabs: {} });
   useMachineWorkspaceStore.setState({ machines: {} });
+  useLayoutStore.setState({ leftSheetOpen: false });
   mockUseAuth.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
   mockUseParams.mockReturnValue({ driveId: 'drive-1' });
   mockUsePathname.mockReturnValue('/dashboard/drive-1/development');
+  mockUseBreakpoint.mockReturnValue(false);
 });
 
 describe('DevelopmentSidebar', () => {
@@ -143,6 +151,75 @@ describe('DevelopmentSidebar', () => {
 
     expect(screen.getByText('Dev box')).toBeDefined();
     expect(screen.queryByText(/failed to load machines/i)).toBeNull();
+  });
+
+  test('an initial (cold) load shows a distinct loading state, not the empty notice', () => {
+    mockUseDriveMachines.mockReturnValueOnce({
+      machines: [],
+      isLoading: true,
+      error: undefined,
+      mutate: vi.fn(),
+    });
+
+    render(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/loading machines/i)).toBeDefined();
+    expect(screen.queryByText(/no machines in this drive/i)).toBeNull();
+    expect(screen.queryByText(/failed to load machines/i)).toBeNull();
+  });
+
+  test('a genuinely empty drive shows the empty notice, not "failed"', () => {
+    mockUseDriveMachines.mockReturnValueOnce({
+      machines: [],
+      isLoading: false,
+      error: undefined,
+      mutate: vi.fn(),
+    });
+
+    render(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/no machines in this drive yet/i)).toBeDefined();
+    expect(screen.queryByText(/failed to load machines/i)).toBeNull();
+  });
+
+  test('a failed INITIAL load (nothing to fall back on) offers a retry that revalidates', async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    mockUseDriveMachines.mockReturnValueOnce({
+      machines: [],
+      isLoading: false,
+      error: new Error('network down'),
+      mutate,
+    });
+
+    render(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/failed to load machines/i)).toBeDefined();
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  test('closes the mobile sheet after navigating to a machine, at the sheet breakpoint', async () => {
+    const user = userEvent.setup();
+    mockUseBreakpoint.mockReturnValue(true);
+    useLayoutStore.setState({ leftSheetOpen: true });
+
+    render(<DevelopmentSidebar />);
+    await user.click(await screen.findByText('Dev box'));
+
+    expect(useLayoutStore.getState().leftSheetOpen).toBe(false);
+  });
+
+  test('leaves the sheet alone at desktop width', async () => {
+    const user = userEvent.setup();
+    mockUseBreakpoint.mockReturnValue(false);
+    useLayoutStore.setState({ leftSheetOpen: true });
+
+    render(<DevelopmentSidebar />);
+    await user.click(await screen.findByText('Dev box'));
+
+    expect(useLayoutStore.getState().leftSheetOpen).toBe(true);
   });
 
   test('says nothing about admin rights until auth has resolved', () => {
@@ -259,6 +336,29 @@ describe('DevelopmentSidebar — GLOBAL mode (no driveId)', () => {
     render(<DevelopmentSidebar />);
 
     expect(screen.getByText(/no machines across your drives/i)).toBeDefined();
+    expect(screen.queryByText(/failed to load machines/i)).toBeNull();
+  });
+
+  test('an initial (cold) load shows a distinct loading state, not the empty notice', () => {
+    mockUseAllMachines.mockReturnValueOnce({ drives: [], isLoading: true, error: undefined, mutate: vi.fn() });
+
+    render(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/loading machines/i)).toBeDefined();
+    expect(screen.queryByText(/no machines across your drives/i)).toBeNull();
+  });
+
+  test('a failed INITIAL load offers a retry that revalidates the global list', async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    mockUseAllMachines.mockReturnValueOnce({ drives: [], isLoading: false, error: new Error('boom'), mutate });
+
+    render(<DevelopmentSidebar />);
+
+    expect(screen.getByText(/failed to load machines/i)).toBeDefined();
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
   });
 
   test('a failed POLL keeps the tree — it does not replace it with an error', () => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -197,7 +197,14 @@ describe('DevelopmentSidebar', () => {
     expect(screen.getByText(/failed to load machines/i)).toBeDefined();
     await user.click(screen.getByRole('button', { name: /retry/i }));
 
+    // Called with ZERO arguments: the button's onClick hands React's click
+    // MouseEvent to whatever it's wired to, and SWR's `mutate` treats a first
+    // argument as replacement cache DATA rather than "revalidate now" — so a
+    // naive `onRetry={mutate}` would silently corrupt the machines list
+    // instead of refetching it. Pinning the call shape catches that class of
+    // bug even though `toHaveBeenCalledTimes` alone would not.
     expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith();
   });
 
   test('closes the mobile sheet after navigating to a machine, at the sheet breakpoint', async () => {
@@ -358,7 +365,11 @@ describe('DevelopmentSidebar — GLOBAL mode (no driveId)', () => {
     expect(screen.getByText(/failed to load machines/i)).toBeDefined();
     await user.click(screen.getByRole('button', { name: /retry/i }));
 
+    // Same call-shape guard as the drive-scoped retry test: a naive
+    // `onRetry={mutate}` hands React's click MouseEvent to SWR's `mutate` as
+    // replacement cache data instead of revalidating.
     expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledWith();
   });
 
   test('a failed POLL keeps the tree — it does not replace it with an error', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/tab-states.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/tab-states.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * The one thing this module's Retry buttons must never do: hand `onAction`
+ * anything. `onClick` always receives the click's MouseEvent, and a caller
+ * whose `onAction` is (or wraps) an SWR `mutate` reads that event as
+ * replacement cache data instead of "revalidate now" — silently corrupting
+ * the caller's data instead of refetching it. Every consumer of
+ * `SidebarNotice`/`PaneNotice` depends on this guarantee holding here, once,
+ * rather than each caller having to remember to wrap its own `onAction`.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SidebarNotice, PaneNotice } from './tab-states';
+
+describe('SidebarNotice', () => {
+  test('calls onAction with zero arguments, not the click event', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(<SidebarNotice title="Failed" actionLabel="Retry" onAction={onAction} />);
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction).toHaveBeenCalledWith();
+  });
+});
+
+describe('PaneNotice', () => {
+  test('calls onAction with zero arguments, not the click event', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(<PaneNotice title="Failed" actionLabel="Retry" onAction={onAction} />);
+
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction).toHaveBeenCalledWith();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/tab-states.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/tab-states.tsx
@@ -92,7 +92,13 @@ export function SidebarNotice({
         </p>
       )}
       {actionLabel && onAction && (
-        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-xs" onClick={onAction}>
+        // Wrapped rather than `onClick={onAction}`: React calls onClick with the
+        // click's MouseEvent, and a caller whose `onAction` is (or wraps) an SWR
+        // `mutate` would have that event handed to it as a first argument — SWR
+        // reads that as replacement cache data, not "revalidate now". Calling
+        // onAction() with no arguments here means every caller's zero-arg
+        // contract holds regardless of what onAction closes over.
+        <Button type="button" variant="ghost" size="sm" className="h-6 px-1.5 text-xs" onClick={() => onAction()}>
           {actionLabel}
         </Button>
       )}
@@ -133,7 +139,8 @@ export function PaneNotice({
       <p className={cn('max-w-md text-sm font-medium', toneClass(tone))}>{title}</p>
       {description && <p className="max-w-md text-sm text-muted-foreground">{description}</p>}
       {actionLabel && onAction && (
-        <Button type="button" variant="outline" size="sm" onClick={onAction}>
+        // Same zero-arg wrapping as SidebarNotice above, and for the same reason.
+        <Button type="button" variant="outline" size="sm" onClick={() => onAction()}>
           {actionLabel}
         </Button>
       )}


### PR DESCRIPTION
## Summary
- Replace `DevelopmentSidebar`'s single terse `ListNotice` string with the Machine page's shared `SidebarLoading`/`SidebarNotice` vocabulary (`tab-states.tsx`), so the machine list's loading/empty/failed states read like every other compact sidebar list in the app — in both drive-scoped and global (grouped-by-drive) mode.
- The failed-load state now shows a **Retry** action wired to SWR's `mutate`, instead of a dead end.
- A drive with zero *visible* machines is dropped from the API payload by design (`listMachinesAcrossDrives`), so there's no reachable "empty drive group" state within global mode — documented inline rather than built as unreachable UI.
- Audited the mobile/narrow-viewport story end to end rather than re-implementing it:
  - `DevelopmentSidebar` renders through `MemoizedSidebar`, which `Layout.tsx` already puts in a `Sheet` below the app's mobile breakpoint — the same mechanism every other sidebar variant uses. No new wiring needed there.
  - `MachineView`'s tab bar went icon-only below `sm` in #2006, which landed *before* the Development surface existed (#2015) — so it was inherited for free, not something #2006 missed.
  - Hover-revealed tree controls (add project/branch, remove) are covered globally by #2009's touch-reveal CSS (`globals.css`'s attribute-substring rules), which match any `opacity-0 ... group-hover:opacity-100` button regardless of when it was written.
  - The one real gap: the `isSheetBreakpoint`-driven "close the sheet after navigating to a machine" wiring existed but had **zero test coverage**. Added it.

## Follow-up fixes (post-review)
- **Codex caught a real bug** ([thread](https://github.com/2witstudios/PageSpace/pull/2049#discussion_r3571663996)): `SidebarNotice`'s Retry button wired straight to `onClick`, so React handed it the click's `MouseEvent` — SWR's `mutate` treats a first argument as replacement cache data, not "revalidate now", so clicking Retry would have corrupted the machines cache instead of refetching. Fixed by wrapping both `retryDriveMachines`/`retryAllMachines` in a no-arg `useCallback`, matching `DiffTab`'s existing SWR-backed Retry convention. Strengthened both retry tests to assert `mutate` was called with zero arguments — confirmed the assertion fails against the pre-fix code before restoring the fix.
- **Self-review turned up a second bug**: the guard chain checked `hasError && isEmpty` ahead of `isLoading`, so a Retry click gave zero visible feedback — traced SWR's source (`isLoading` goes back to `true` on any revalidation where cached `data` is still `undefined`, exactly what a failed fetch leaves behind, while `error` stays stale until the new attempt settles). Reordered so loading wins over a stale error, and added a `rerender`-based regression test that simulates the actual retry-in-flight transition — confirmed it fails against the pre-fix ordering before restoring the fix.
- **Fixed the mutate-as-onClick bug at its root** (`apps/web/.../machine/tabs/tab-states.tsx` — outside this PR's original file list, but the direct dependency this PR started consuming): the local `useCallback` workaround from the Codex fix above turned out to be the *4th* independent hand-written copy of the same "wrap onAction so SWR's mutate doesn't get the click MouseEvent" fix — `DiffTab`, `FilesFilePane`/`SettingsTab`'s `reload`, and `FilesTab` each already had one, and nothing stopped a 5th, 6th, 7th caller from forgetting it (TypeScript accepts SWR's `mutate` wherever `onAction: () => void` is declared — the mistake compiles clean). Fixed `SidebarNotice`/`PaneNotice` themselves to always call `onAction()` with zero arguments, verified safe for all 6 pre-existing call sites (108 tests, all green), simplified `DevelopmentSidebar.tsx` back down to passing `mutate` directly, and added `tab-states.test.tsx` — direct coverage pinning the guarantee at the component that now owns it.

## Test plan
- [x] `bun run vitest run src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx` — 23 tests pass (loading/empty/error+retry × 2 modes, retry-arg-shape, retry-in-flight-shows-loading, sheet-close-on-navigate at narrow viewport, sheet-untouched at desktop width)
- [x] `tab-states.test.tsx` (new) — 2 tests pass, pinning the zero-arg guarantee directly
- [x] Full sweep of Development/Machine test files (21 files, 237 tests) — all pass
- [x] Full sweep of every `tab-states.tsx` consumer (DiffTab, FilesTab, SettingsTab, FilesFilePane, MachineFileTree — 108 tests) — all pass, confirming the root-cause fix doesn't regress any of the 6 pre-existing call sites
- [x] `bun run typecheck` (web) — clean
- [x] `bun run lint` (web) — clean (only pre-existing, unrelated warnings)
- [x] Every new regression test mutation-verified: reverted the corresponding fix, confirmed the test fails, restored the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fzw6ieurR2FCLwbyT1wkRi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine list loading, empty, and error states in the Development sidebar.
  * Added retry actions when machine data fails to load.
  * Clarified empty-state messaging for drive-specific and global machine lists.
  * Improved sidebar behavior on mobile by automatically closing the sheet after selecting a machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

