### PR TITLE
[sprites 2-3] Real session termination via the kill endpoint

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -806,7 +806,7 @@ describe('buildAgentTerminalHandlers', () => {
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).toHaveBeenCalledWith('user-kill');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
 
@@ -867,7 +867,7 @@ describe('buildAgentTerminalHandlers', () => {
       );
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).toHaveBeenCalledWith('user-kill');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
       expect(socket2.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock2' });
     });
@@ -879,7 +879,7 @@ describe('buildAgentTerminalHandlers', () => {
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalledWith();
+      expect(shell.kill).toHaveBeenCalledWith('user-kill');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
       expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock1' });
     });
@@ -1087,7 +1087,7 @@ describe('buildAgentTerminalHandlers', () => {
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
       expect(auth.releaseSlot).toHaveBeenCalledTimes(1);
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).toHaveBeenCalledWith('idle-reap');
     });
 
     it('given the idle timeout elapses, should kill the shell and drop the session', async () => {
@@ -1096,7 +1096,7 @@ describe('buildAgentTerminalHandlers', () => {
       onDisconnect();
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS);
 
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).toHaveBeenCalledWith('idle-reap');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
   });
@@ -1260,7 +1260,7 @@ describe('buildAgentTerminalHandlers', () => {
         expect(calls[0].holdId).toBe('hold-1');
         expect(calls[0].activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
         expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
-        expect(shell.kill).toHaveBeenCalled();
+        expect(shell.kill).toHaveBeenCalledWith('user-kill');
         expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
         expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', expect.objectContaining({ exitCode: -2 }));
       });
@@ -1937,7 +1937,7 @@ describe('buildAgentTerminalHandlers', () => {
       expect(sessionMap.getByKey('branch1:agent:cli')?.idleTimer).toBeDefined();
       await vi.advanceTimersByTimeAsync(DETACHED_IDLE_MS + 1000);
       expect(first.releaseSlot).toHaveBeenCalled();
-      expect(shell.kill).toHaveBeenCalled();
+      expect(shell.kill).toHaveBeenCalledWith('idle-reap');
     });
 
     it('must not take the session away from a pane that is still WATCHING it', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -806,7 +806,7 @@ describe('buildAgentTerminalHandlers', () => {
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalledWith('user-kill');
+      expect(shell.kill).toHaveBeenCalledWith('forced-teardown');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
     });
 
@@ -867,7 +867,7 @@ describe('buildAgentTerminalHandlers', () => {
       );
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalledWith('user-kill');
+      expect(shell.kill).toHaveBeenCalledWith('forced-teardown');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
       expect(socket2.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock2' });
     });
@@ -879,7 +879,7 @@ describe('buildAgentTerminalHandlers', () => {
       checkAuth.mockResolvedValue({ ok: false, reason: 'permission_revoked' });
       await vi.advanceTimersByTimeAsync(60_000);
 
-      expect(shell.kill).toHaveBeenCalledWith('user-kill');
+      expect(shell.kill).toHaveBeenCalledWith('forced-teardown');
       expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
       expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', { exitCode: -2, connectionId: 'sock1' });
     });
@@ -1260,7 +1260,7 @@ describe('buildAgentTerminalHandlers', () => {
         expect(calls[0].holdId).toBe('hold-1');
         expect(calls[0].activeSeconds).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
         expect(calls.reduce((s, c) => s + c.activeSeconds, 0)).toBeCloseTo(SETTLE_HEARTBEAT_MS / 1000, 0);
-        expect(shell.kill).toHaveBeenCalledWith('user-kill');
+        expect(shell.kill).toHaveBeenCalledWith('forced-teardown');
         expect(sessionMap.getByKey('branch1:agent:cli')).toBeUndefined();
         expect(socket.emit).toHaveBeenCalledWith('agent-terminal:closed', expect.objectContaining({ exitCode: -2 }));
       });

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -777,7 +777,7 @@ describe('openPtyShell', () => {
     assert({
       given: 'an explicit user-initiated kill',
       should: 'kill the session by id AND close the local socket',
-      actual: planTeardown({ trigger: 'user-kill' }),
+      actual: planTeardown({ trigger: 'forced-teardown' }),
       expected: { killSession: true, closeSocket: true },
     });
 
@@ -810,7 +810,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
       cmd._emitter.emit('message', announces('sess-1'));
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
 
       expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
       expect(sprite.killSession).toHaveBeenCalledWith('sess-1');
@@ -858,7 +858,7 @@ describe('openPtyShell', () => {
 
       // No 'message'/session_info frame ever arrives — currentSessionId stays undefined.
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
 
       expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
       expect(sprite.killSession).not.toHaveBeenCalled();
@@ -870,7 +870,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
       cmd._emitter.emit('message', announces('sess-1'));
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       shell.kill('idle-reap');
 
       expect(sprite.killSession).toHaveBeenCalledTimes(1);
@@ -885,7 +885,7 @@ describe('openPtyShell', () => {
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
       cmd._emitter.emit('message', announces('sess-1'));
 
-      expect(() => shell.kill('user-kill')).not.toThrow();
+      expect(() => shell.kill('forced-teardown')).not.toThrow();
       await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
 
       errorSpy.mockRestore();
@@ -1186,7 +1186,7 @@ describe('openPtyShell', () => {
       const onExit = vi.fn();
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       cmd._emitter.emit('exit', 0);
 
       expect(onExit).not.toHaveBeenCalled();
@@ -1227,7 +1227,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
       cmd._emitter.emit('error', new Error('keepalive'));
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       await vi.advanceTimersByTimeAsync(500);
 
       expect(sprite.attachSession).not.toHaveBeenCalled();
@@ -1337,7 +1337,7 @@ describe('openPtyShell', () => {
       attachCmd._emitter.emit('error', new Error('keepalive'));
       await vi.advanceTimersByTimeAsync(300); // past backoff; now suspended at await listSessions
 
-      shell.kill('user-kill');               // closed = true mid-await
+      shell.kill('forced-teardown');               // closed = true mid-await
       d.resolve([]);              // sess-dead gone → would otherwise take the create branch
       await vi.advanceTimersByTimeAsync(0);
 
@@ -1527,7 +1527,7 @@ describe('openPtyShell', () => {
       attach._stdout.emit('data', 'nothing here matches the anchor'); // held: window opens
       expect(vi.getTimerCount()).toBeGreaterThan(0); // settle + deadline are armed
 
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
 
       expect(vi.getTimerCount()).toBe(0);
     });
@@ -2767,7 +2767,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
       cmd._emitter.emit('spawn');
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       cmd._stderr.emit('data', 'too late\r\n');
 
       expect(onOutput).not.toHaveBeenCalled();
@@ -2828,7 +2828,7 @@ describe('openPtyShell', () => {
       cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
       attachCmd._stdout.emit('data', 'unalignable\r\n'); // buffered, settle armed
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       // Nothing may reach a client that is no longer there. Two things stand in the way and
       // either would do: kill() cancels the window timers, and every path out of the shell
       // re-checks `closed`. The redundancy is deliberate — a teardown is not the place to
@@ -2856,7 +2856,7 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(500);
       attachCmd._stdout.emit('data', BANNER); // the replay resolves; nothing emitted
 
-      shell.kill('user-kill');
+      shell.kill('forced-teardown');
       attachCmd._stdout.emit('data', 'in flight after the kill\r\n');
       await vi.advanceTimersByTimeAsync(2000);
 

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { openPtyShell, planReconnect, planWatchdogResponse, sessionIds } from '../sprites-shell';
+import { openPtyShell, planReconnect, planWatchdogResponse, planTeardown, sessionIds } from '../sprites-shell';
 import { appendScrollback } from '../terminal-session-map';
 import { spawnWithSelfHealingCwd } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -57,6 +57,7 @@ type FakeSprite = SpriteInstanceLike & {
   createSession: ReturnType<typeof vi.fn>;
   attachSession: ReturnType<typeof vi.fn>;
   listSessions: ReturnType<typeof vi.fn>;
+  killSession: ReturnType<typeof vi.fn>;
 };
 
 function buildFakeSprite(
@@ -75,6 +76,7 @@ function buildFakeSprite(
     filesystem: vi.fn(),
     updateNetworkPolicy: vi.fn(),
     destroy: vi.fn(),
+    killSession: vi.fn(async () => {}),
   } as unknown as FakeSprite;
 }
 
@@ -771,14 +773,123 @@ describe('openPtyShell', () => {
     expect(cmd.resize).toHaveBeenCalledWith(100, 40);
   });
 
-  it('given shell.kill(), should call command.kill with SIGKILL', () => {
-    const cmd = buildFakeCommand();
-    const sprite = buildFakeSprite(cmd);
+  describe('planTeardown (pure)', () => {
+    assert({
+      given: 'an explicit user-initiated kill',
+      should: 'kill the session by id AND close the local socket',
+      actual: planTeardown({ trigger: 'user-kill' }),
+      expected: { killSession: true, closeSocket: true },
+    });
 
-    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
-    shell.kill();
+    assert({
+      given: 'the 30-min detached-idle reap',
+      should: 'kill the session by id AND close the local socket — that is the reap\'s whole point',
+      actual: planTeardown({ trigger: 'idle-reap' }),
+      expected: { killSession: true, closeSocket: true },
+    });
 
-    expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
+    assert({
+      given: 'a viewer detach (navigate away)',
+      should: 'neither kill the session nor signal the local command — detachable means it survives this',
+      actual: planTeardown({ trigger: 'detach' }),
+      expected: { killSession: false, closeSocket: false },
+    });
+
+    assert({
+      given: 'the remote shell already exited on its own',
+      should: 'do nothing — there is no session left to kill and no live socket to signal',
+      actual: planTeardown({ trigger: 'shell-exit' }),
+      expected: { killSession: false, closeSocket: false },
+    });
+  });
+
+  describe('shell.kill(trigger)', () => {
+    it('given a user-initiated kill, should call command.kill(SIGKILL) AND the sprite session-kill endpoint by id', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      shell.kill('user-kill');
+
+      expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(sprite.killSession).toHaveBeenCalledWith('sess-1');
+    });
+
+    it('given the 30-min idle reap, should call command.kill(SIGKILL) AND the sprite session-kill endpoint by id', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      shell.kill('idle-reap');
+
+      expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(sprite.killSession).toHaveBeenCalledWith('sess-1');
+    });
+
+    it('given a viewer detach, should NOT signal the command or kill the session — detach must never terminate', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      shell.kill('detach');
+
+      expect(cmd.kill).not.toHaveBeenCalled();
+      expect(sprite.killSession).not.toHaveBeenCalled();
+    });
+
+    it('given a shell-exit teardown, should NOT signal the command or kill the session — the process already ended', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      shell.kill('shell-exit');
+
+      expect(cmd.kill).not.toHaveBeenCalled();
+      expect(sprite.killSession).not.toHaveBeenCalled();
+    });
+
+    it('given no session id was ever learned, should still close the socket but has nothing to kill by id', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      // No 'message'/session_info frame ever arrives — currentSessionId stays undefined.
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      shell.kill('user-kill');
+
+      expect(cmd.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(sprite.killSession).not.toHaveBeenCalled();
+    });
+
+    it('given kill() called twice, should call the session-kill endpoint only once — idempotent against double-teardown', () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+      shell.kill('user-kill');
+      shell.kill('idle-reap');
+
+      expect(sprite.killSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the session-kill endpoint rejects (already dead, or a transport error), should not throw and should log rather than surface it', async () => {
+      const cmd = buildFakeCommand();
+      const sprite = buildFakeSprite(cmd);
+      sprite.killSession.mockRejectedValue(new Error('sprite unreachable'));
+      const errorSpy = vi.spyOn(loggers.realtime, 'error').mockImplementation(() => {});
+
+      const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+      cmd._emitter.emit('message', announces('sess-1'));
+
+      expect(() => shell.kill('user-kill')).not.toThrow();
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+
+      errorSpy.mockRestore();
+    });
   });
 
   it('given stdin is null, shell.write should be a no-op', () => {
@@ -1075,7 +1186,7 @@ describe('openPtyShell', () => {
       const onExit = vi.fn();
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit });
-      shell.kill();
+      shell.kill('user-kill');
       cmd._emitter.emit('exit', 0);
 
       expect(onExit).not.toHaveBeenCalled();
@@ -1116,7 +1227,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
       cmd._emitter.emit('error', new Error('keepalive'));
-      shell.kill();
+      shell.kill('user-kill');
       await vi.advanceTimersByTimeAsync(500);
 
       expect(sprite.attachSession).not.toHaveBeenCalled();
@@ -1226,7 +1337,7 @@ describe('openPtyShell', () => {
       attachCmd._emitter.emit('error', new Error('keepalive'));
       await vi.advanceTimersByTimeAsync(300); // past backoff; now suspended at await listSessions
 
-      shell.kill();               // closed = true mid-await
+      shell.kill('user-kill');               // closed = true mid-await
       d.resolve([]);              // sess-dead gone → would otherwise take the create branch
       await vi.advanceTimersByTimeAsync(0);
 
@@ -1416,7 +1527,7 @@ describe('openPtyShell', () => {
       attach._stdout.emit('data', 'nothing here matches the anchor'); // held: window opens
       expect(vi.getTimerCount()).toBeGreaterThan(0); // settle + deadline are armed
 
-      shell.kill();
+      shell.kill('user-kill');
 
       expect(vi.getTimerCount()).toBe(0);
     });
@@ -2656,7 +2767,7 @@ describe('openPtyShell', () => {
 
       const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn() });
       cmd._emitter.emit('spawn');
-      shell.kill();
+      shell.kill('user-kill');
       cmd._stderr.emit('data', 'too late\r\n');
 
       expect(onOutput).not.toHaveBeenCalled();
@@ -2717,7 +2828,7 @@ describe('openPtyShell', () => {
       cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
       await vi.advanceTimersByTimeAsync(500);
       attachCmd._stdout.emit('data', 'unalignable\r\n'); // buffered, settle armed
-      shell.kill();
+      shell.kill('user-kill');
       // Nothing may reach a client that is no longer there. Two things stand in the way and
       // either would do: kill() cancels the window timers, and every path out of the shell
       // re-checks `closed`. The redundancy is deliberate — a teardown is not the place to
@@ -2745,7 +2856,7 @@ describe('openPtyShell', () => {
       await vi.advanceTimersByTimeAsync(500);
       attachCmd._stdout.emit('data', BANNER); // the replay resolves; nothing emitted
 
-      shell.kill();
+      shell.kill('user-kill');
       attachCmd._stdout.emit('data', 'in flight after the kill\r\n');
       await vi.advanceTimersByTimeAsync(2000);
 

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -299,9 +299,12 @@ function endAgentTerminalSession(
  * heartbeat): release the concurrency slot, kill the PTY, settle + remove the
  * session (endAgentTerminalSession clears all timers), and notify the viewer.
  *
- * `'user-kill'`: a revoked-access or insolvent-payer teardown is a genuine,
- * permanent termination decided FOR the user, not a mere detach — the same
- * outcome an explicit kill request needs (see `planTeardown`).
+ * `'forced-teardown'`: this is the PLATFORM ending a session on the user's
+ * behalf (revoked access, or an insolvent payer) — never a click. It still
+ * needs a genuine, permanent termination (see `planTeardown`), so it maps to
+ * the same `TeardownPlan` an explicit kill would, but the trigger name says
+ * plainly who actually decided this, not "user-kill" — an incident review
+ * reading this trigger off a log line should not conclude the user did it.
  */
 function teardownAgentTerminalSession(
   billing: SandboxBillingDeps | undefined,
@@ -311,7 +314,7 @@ function teardownAgentTerminalSession(
   exitCode: number,
 ): void {
   session.releaseSlot();
-  session.command.kill('user-kill');
+  session.command.kill('forced-teardown');
   endAgentTerminalSession(billing, sessionMap, session, sessionKey);
   session.closedFn(exitCode);
 }

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -298,6 +298,10 @@ function endAgentTerminalSession(
  * Forced teardown of a live session (failed re-auth, payer insolvent at a
  * heartbeat): release the concurrency slot, kill the PTY, settle + remove the
  * session (endAgentTerminalSession clears all timers), and notify the viewer.
+ *
+ * `'user-kill'`: a revoked-access or insolvent-payer teardown is a genuine,
+ * permanent termination decided FOR the user, not a mere detach — the same
+ * outcome an explicit kill request needs (see `planTeardown`).
  */
 function teardownAgentTerminalSession(
   billing: SandboxBillingDeps | undefined,
@@ -307,7 +311,7 @@ function teardownAgentTerminalSession(
   exitCode: number,
 ): void {
   session.releaseSlot();
-  session.command.kill();
+  session.command.kill('user-kill');
   endAgentTerminalSession(billing, sessionMap, session, sessionKey);
   session.closedFn(exitCode);
 }
@@ -647,7 +651,12 @@ export function buildAgentTerminalHandlers({
     });
     session.idleTimer = setTimeout(() => {
       session.releaseSlot();
-      session.command.kill();
+      // 'idle-reap': ending the session server-side is this timer's whole
+      // point — the exec socket is almost always already dead by now (no
+      // viewer means no reconnect since the detach above), so the REST
+      // session-kill (not a local WS signal that would silently no-op) is
+      // what actually reaches it — see `planTeardown`.
+      session.command.kill('idle-reap');
       // Clears all of the session's timers (re-auth, settle heartbeat, idle).
       endAgentTerminalSession(billing, sessionMap, session, sessionKey);
       loggers.realtime.info('Agent terminal session reaped (idle)', { sessionKey, sandboxId: session.sandboxId });

--- a/apps/realtime/src/terminal/realtime-sprites-client.ts
+++ b/apps/realtime/src/terminal/realtime-sprites-client.ts
@@ -1,5 +1,5 @@
 import {
-  killSpriteSession,
+  withKillSession,
   resolveSpritesToken,
   type SpritesSdk,
   type SpriteInstanceLike,
@@ -37,19 +37,11 @@ export async function getRealtimeSpritesSdk(): Promise<SpritesSdk> {
   const importEsm = new Function('s', 'return import(s)') as <T = unknown>(s: string) => Promise<T>;
   const { SpritesClient } = await importEsm<typeof import('@fly/sprites')>('@fly/sprites');
   const client = new SpritesClient(resolveSpritesToken());
-  // Bolt `killSession` onto a raw SDK `Sprite` instance — `@fly/sprites` (rc37)
-  // exposes no session-kill-by-id, only `attachSession`/`createSession`/`kill()`
-  // (a per-command WebSocket signal); see `killSpriteSession`'s doc for why this
-  // hits the REST endpoint directly. `baseURL`/`token` are public `readonly`
-  // fields on `SpritesClient`, reachable straight off `sprite.client`.
-  const withKillSession = (sprite: Awaited<ReturnType<typeof client.getSprite>>): SpriteInstanceLike =>
-    Object.assign(sprite, {
-      killSession: (sessionId: string) =>
-        killSpriteSession({ baseURL: sprite.client.baseURL, token: sprite.client.token }, sprite.name, sessionId),
-    }) as unknown as SpriteInstanceLike;
+  // withKillSession bolts the REST kill-session method onto the raw SDK
+  // instance — see its doc (sprites.ts) for why the SDK needs this at all.
   cachedSdk = {
-    getSprite: async (name) => withKillSession(await client.getSprite(name)),
-    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)),
+    getSprite: async (name) => withKillSession(await client.getSprite(name)) as unknown as SpriteInstanceLike,
+    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)) as unknown as SpriteInstanceLike,
     deleteSprite: (name) => client.deleteSprite(name),
   };
   return cachedSdk;

--- a/apps/realtime/src/terminal/realtime-sprites-client.ts
+++ b/apps/realtime/src/terminal/realtime-sprites-client.ts
@@ -1,4 +1,5 @@
 import {
+  killSpriteSession,
   resolveSpritesToken,
   type SpritesSdk,
   type SpriteInstanceLike,
@@ -36,9 +37,19 @@ export async function getRealtimeSpritesSdk(): Promise<SpritesSdk> {
   const importEsm = new Function('s', 'return import(s)') as <T = unknown>(s: string) => Promise<T>;
   const { SpritesClient } = await importEsm<typeof import('@fly/sprites')>('@fly/sprites');
   const client = new SpritesClient(resolveSpritesToken());
+  // Bolt `killSession` onto a raw SDK `Sprite` instance — `@fly/sprites` (rc37)
+  // exposes no session-kill-by-id, only `attachSession`/`createSession`/`kill()`
+  // (a per-command WebSocket signal); see `killSpriteSession`'s doc for why this
+  // hits the REST endpoint directly. `baseURL`/`token` are public `readonly`
+  // fields on `SpritesClient`, reachable straight off `sprite.client`.
+  const withKillSession = (sprite: Awaited<ReturnType<typeof client.getSprite>>): SpriteInstanceLike =>
+    Object.assign(sprite, {
+      killSession: (sessionId: string) =>
+        killSpriteSession({ baseURL: sprite.client.baseURL, token: sprite.client.token }, sprite.name, sessionId),
+    }) as unknown as SpriteInstanceLike;
   cachedSdk = {
-    getSprite: (name) => client.getSprite(name) as unknown as Promise<SpriteInstanceLike>,
-    createSprite: (name, config) => client.createSprite(name, config) as unknown as Promise<SpriteInstanceLike>,
+    getSprite: async (name) => withKillSession(await client.getSprite(name)),
+    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)),
     deleteSprite: (name) => client.deleteSprite(name),
   };
   return cachedSdk;

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -101,7 +101,17 @@ export function planReconnect({
 export type PtyShell = {
   write(data: string): void;
   resize(cols: number, rows: number): void;
-  kill(): void;
+  /**
+   * Tear this shell down, per `trigger` — see `planTeardown` for exactly what
+   * each one does and why. The ONE teardown entry point every caller goes
+   * through, so `trigger` is what lets a genuine termination (`user-kill`,
+   * `idle-reap`) be told apart from a mere viewer detach that must survive it.
+   * Best-effort and idempotent: a second `kill()` after the shell is already
+   * closed is a no-op, and the underlying REST kill call
+   * (`SpriteInstanceLike.killSession`) itself succeeds against an
+   * already-dead session id rather than throwing.
+   */
+  kill(trigger: TeardownTrigger): void;
   /**
    * Tell this shell whether a viewer is currently attached — see
    * `planWatchdogResponse`. `false` on a detach stops the watchdog from
@@ -233,6 +243,73 @@ export function planWatchdogResponse({
   if (closed) return 'detach-quiet';
   if (!viewersAttached) return 'detach-quiet';
   return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
+}
+
+/**
+ * Why a PTY shell is being torn down. `PtyShell.kill(trigger)` is the ONE
+ * teardown entry point every caller goes through (see `PtyShell`'s doc) — the
+ * trigger is what lets `planTeardown` tell a genuine termination from a mere
+ * detach, both of which currently reach the same call.
+ */
+export type TeardownTrigger = 'user-kill' | 'detach' | 'idle-reap' | 'shell-exit';
+
+/** What a teardown should actually DO, decided by `planTeardown`. */
+export interface TeardownPlan {
+  /**
+   * Call the REST kill-session endpoint (`sprite.killSession`, sprites.ts) for
+   * the bound session id. This is the ONLY mechanism that reaches a session
+   * whose exec WebSocket is not currently open — exactly the state a
+   * detached-then-reaped shell is almost always in (see `killSession`'s doc on
+   * `SpriteInstanceLike`) — so it is the one that must fire for a trigger that
+   * means genuine, permanent termination.
+   */
+  killSession: boolean;
+  /**
+   * Signal the currently-wired exec command via `SpriteCommandLike.kill()`.
+   * The SDK exposes no side-effect-free way to drop only OUR side of the
+   * connection — `kill()` IS `signal()`, delivered to the REMOTE PROCESS
+   * whenever the socket happens to be open (see `sprite-machine-host.ts`'s
+   * note on the private, unreachable `WSCommand.close()`) — so this is only
+   * ever true alongside `killSession`. For a trigger that must NOT terminate
+   * the remote (a mere detach), signalling would be exactly the bug this leaf
+   * closes in reverse: a socket that is STILL open at the instant of detach
+   * would take the very session down that "detachable" promises survives a
+   * client drop.
+   */
+  closeSocket: boolean;
+}
+
+/**
+ * Pure: what tearing this shell down should actually do, by INTENT — not by
+ * whatever the exec socket's current state happens to be.
+ *
+ * - `user-kill` (an explicit, permanent kill request — an operator/API call,
+ *   or the platform forcibly ending a session whose access was revoked or
+ *   whose payer ran out of credits) and `idle-reap` (the 30-min
+ *   detached-idle timer — ending the session IS the reap's whole point) both
+ *   terminate for real: kill the session by id, which works no matter
+ *   whether our own socket to it is still open, and signal the local command
+ *   too as a redundant, harmless courtesy.
+ * - `detach` (a viewer merely navigating away) must NEVER terminate — the
+ *   entire point of a detachable session is that it survives exactly this.
+ *   Nothing is signalled or killed; the exec connection is simply abandoned
+ *   to the shell's own reconnect/keepalive policy (`planWatchdogResponse`'s
+ *   `detach-quiet`), and the 30-min idle reap is the only thing that will
+ *   ever end it from here.
+ * - `shell-exit` (the remote process already ended on its own — the user
+ *   typed `exit`) has nothing left to tear down either way: the exit already
+ *   happened server-side, so there is no session left to kill and no live
+ *   socket left to signal.
+ */
+export function planTeardown({ trigger }: { trigger: TeardownTrigger }): TeardownPlan {
+  switch (trigger) {
+    case 'user-kill':
+    case 'idle-reap':
+      return { killSession: true, closeSocket: true };
+    case 'detach':
+    case 'shell-exit':
+      return { killSession: false, closeSocket: false };
+  }
 }
 
 /**
@@ -1020,7 +1097,33 @@ export function openPtyShell({
     resize: (c, r) => { lastCols = c; lastRows = r; if (!closed) current.resize?.(c, r); },
     // Anything still held (an unresolved replay, queued stderr) is dropped with it: the
     // viewer is gone, and `closed` stops every listener from speaking after this point.
-    kill: () => { closed = true; cancelReplayTimers(); current.kill('SIGKILL'); },
+    //
+    // Idempotent: a repeat call (or a second trigger racing the first) after
+    // `closed` is already true is a no-op, so the REST kill below never fires
+    // twice for one shell.
+    kill: (trigger) => {
+      if (closed) return;
+      closed = true;
+      cancelReplayTimers();
+      const plan = planTeardown({ trigger });
+      if (plan.closeSocket) current.kill('SIGKILL');
+      // Reaches a session regardless of whether OUR socket to it is still
+      // open — see `killSession`'s doc on `SpriteInstanceLike`. No id in hand
+      // means this shell never learned which session it was driving (the
+      // abandoned-unnamed-session edge case `abandonedUnnamedSessions`
+      // already bounds) — there is nothing to kill BY, so this is a no-op,
+      // not a failure.
+      if (plan.killSession && currentSessionId !== undefined) {
+        const sessionId = currentSessionId;
+        void sprite.killSession(sessionId).catch((error) => {
+          loggers.realtime.error(
+            'Sprite session kill failed',
+            error instanceof Error ? error : new Error(String(error)),
+            { sessionId, trigger },
+          );
+        });
+      }
+    },
     setViewerAttached: (attached) => {
       viewerAttached = attached;
       // A lazy reattach only fires if a watchdog trip actually got swallowed while

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -104,8 +104,9 @@ export type PtyShell = {
   /**
    * Tear this shell down, per `trigger` — see `planTeardown` for exactly what
    * each one does and why. The ONE teardown entry point every caller goes
-   * through, so `trigger` is what lets a genuine termination (`user-kill`,
-   * `idle-reap`) be told apart from a mere viewer detach that must survive it.
+   * through, so `trigger` is what lets a genuine termination
+   * (`forced-teardown`, `idle-reap`) be told apart from a mere viewer detach
+   * that must survive it.
    * Best-effort and idempotent: a second `kill()` after the shell is already
    * closed is a no-op, and the underlying REST kill call
    * (`SpriteInstanceLike.killSession`) itself succeeds against an
@@ -250,8 +251,28 @@ export function planWatchdogResponse({
  * teardown entry point every caller goes through (see `PtyShell`'s doc) — the
  * trigger is what lets `planTeardown` tell a genuine termination from a mere
  * detach, both of which currently reach the same call.
+ *
+ * Deliberately NOT named `user-kill`/`user-*`: an explicit, human-initiated
+ * "kill this terminal" request never reaches this type at all — that flow is
+ * `killAgentTerminal` (`packages/lib/src/services/machines/agent-terminals.ts`),
+ * which calls `MachineHandle.killSession` directly, bypassing `PtyShell` and
+ * this enum entirely. `forced-teardown`'s only real callers
+ * (`agent-terminal-handler.ts`'s `teardownAgentTerminalSession`) are the
+ * PLATFORM ending a session on the user's behalf — revoked access, or an
+ * insolvent payer — never a click. A `user-kill`-style label here would read,
+ * in an incident review, as "the user did this," inverting the actual cause.
+ *
+ * `detach` and `shell-exit` are part of the complete decision matrix
+ * `planTeardown` is unit-tested against (every trigger this shell could ever
+ * face must have a defined, safe answer), but neither has a real call site
+ * today: a plain detach never calls `kill()` at all (see `disconnectConnection`
+ * in `agent-terminal-handler.ts` — it only flips `setViewerAttached(false)`),
+ * and a real shell exit is handled entirely by `fatal()`, which also never
+ * calls `kill()` (the process already ended; there is nothing to close or
+ * kill). Both branches exist so the function's answer is defined and tested
+ * BEFORE a future caller needs it, not because one is wired today.
  */
-export type TeardownTrigger = 'user-kill' | 'detach' | 'idle-reap' | 'shell-exit';
+export type TeardownTrigger = 'forced-teardown' | 'detach' | 'idle-reap' | 'shell-exit';
 
 /** What a teardown should actually DO, decided by `planTeardown`. */
 export interface TeardownPlan {
@@ -283,13 +304,12 @@ export interface TeardownPlan {
  * Pure: what tearing this shell down should actually do, by INTENT — not by
  * whatever the exec socket's current state happens to be.
  *
- * - `user-kill` (an explicit, permanent kill request — an operator/API call,
- *   or the platform forcibly ending a session whose access was revoked or
- *   whose payer ran out of credits) and `idle-reap` (the 30-min
- *   detached-idle timer — ending the session IS the reap's whole point) both
- *   terminate for real: kill the session by id, which works no matter
- *   whether our own socket to it is still open, and signal the local command
- *   too as a redundant, harmless courtesy.
+ * - `forced-teardown` (the platform forcibly ending a session whose access
+ *   was revoked or whose payer ran out of credits) and `idle-reap` (the
+ *   30-min detached-idle timer — ending the session IS the reap's whole
+ *   point) both terminate for real: kill the session by id, which works no
+ *   matter whether our own socket to it is still open, and signal the local
+ *   command too as a redundant, harmless courtesy.
  * - `detach` (a viewer merely navigating away) must NEVER terminate — the
  *   entire point of a detachable session is that it survives exactly this.
  *   Nothing is signalled or killed; the exec connection is simply abandoned
@@ -303,7 +323,7 @@ export interface TeardownPlan {
  */
 export function planTeardown({ trigger }: { trigger: TeardownTrigger }): TeardownPlan {
   switch (trigger) {
-    case 'user-kill':
+    case 'forced-teardown':
     case 'idle-reap':
       return { killSession: true, closeSocket: true };
     case 'detach':

--- a/apps/web/src/lib/sandbox/sprites-client.ts
+++ b/apps/web/src/lib/sandbox/sprites-client.ts
@@ -10,9 +10,10 @@
  * lifetime so the SDK is never touched on the code-execution-OFF path.
  */
 
-import { SpritesClient } from '@fly/sprites';
+import { SpritesClient, type Sprite } from '@fly/sprites';
 import {
   createSpritesSandboxClient,
+  killSpriteSession,
   resolveSpritesToken,
   type SpritesSdk,
   type SpriteInstanceLike,
@@ -29,13 +30,26 @@ export async function getProductionSpritesSdk(): Promise<SpritesSdk> {
   return getSpritesSDK();
 }
 
+/**
+ * Bolt `killSession` onto a raw SDK `Sprite` instance — `@fly/sprites` (rc37)
+ * exposes no session-kill-by-id, only `attachSession`/`createSession`/`kill()`
+ * (a per-command WebSocket signal); see `killSpriteSession`'s doc for why this
+ * hits the REST endpoint directly. `baseURL`/`token` are public `readonly`
+ * fields on `SpritesClient`, reachable straight off `sprite.client`.
+ */
+function withKillSession(sprite: Sprite): SpriteInstanceLike {
+  return Object.assign(sprite, {
+    killSession: (sessionId: string) =>
+      killSpriteSession({ baseURL: sprite.client.baseURL, token: sprite.client.token }, sprite.name, sessionId),
+  }) as unknown as SpriteInstanceLike;
+}
+
 async function getSpritesSDK(): Promise<SpritesSdk> {
   if (cachedSdk) return cachedSdk;
   const client = new SpritesClient(resolveSpritesToken());
   cachedSdk = {
-    getSprite: (name) => client.getSprite(name) as unknown as Promise<SpriteInstanceLike>,
-    createSprite: (name, config) =>
-      client.createSprite(name, config) as unknown as Promise<SpriteInstanceLike>,
+    getSprite: async (name) => withKillSession(await client.getSprite(name)),
+    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)),
     deleteSprite: (name) => client.deleteSprite(name),
   };
   return cachedSdk;

--- a/apps/web/src/lib/sandbox/sprites-client.ts
+++ b/apps/web/src/lib/sandbox/sprites-client.ts
@@ -10,10 +10,10 @@
  * lifetime so the SDK is never touched on the code-execution-OFF path.
  */
 
-import { SpritesClient, type Sprite } from '@fly/sprites';
+import { SpritesClient } from '@fly/sprites';
 import {
   createSpritesSandboxClient,
-  killSpriteSession,
+  withKillSession,
   resolveSpritesToken,
   type SpritesSdk,
   type SpriteInstanceLike,
@@ -30,26 +30,14 @@ export async function getProductionSpritesSdk(): Promise<SpritesSdk> {
   return getSpritesSDK();
 }
 
-/**
- * Bolt `killSession` onto a raw SDK `Sprite` instance — `@fly/sprites` (rc37)
- * exposes no session-kill-by-id, only `attachSession`/`createSession`/`kill()`
- * (a per-command WebSocket signal); see `killSpriteSession`'s doc for why this
- * hits the REST endpoint directly. `baseURL`/`token` are public `readonly`
- * fields on `SpritesClient`, reachable straight off `sprite.client`.
- */
-function withKillSession(sprite: Sprite): SpriteInstanceLike {
-  return Object.assign(sprite, {
-    killSession: (sessionId: string) =>
-      killSpriteSession({ baseURL: sprite.client.baseURL, token: sprite.client.token }, sprite.name, sessionId),
-  }) as unknown as SpriteInstanceLike;
-}
-
 async function getSpritesSDK(): Promise<SpritesSdk> {
   if (cachedSdk) return cachedSdk;
   const client = new SpritesClient(resolveSpritesToken());
   cachedSdk = {
-    getSprite: async (name) => withKillSession(await client.getSprite(name)),
-    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)),
+    // withKillSession bolts the REST kill-session method onto the raw SDK
+    // instance — see its doc (sprites.ts) for why the SDK needs this at all.
+    getSprite: async (name) => withKillSession(await client.getSprite(name)) as unknown as SpriteInstanceLike,
+    createSprite: async (name, config) => withKillSession(await client.createSprite(name, config)) as unknown as SpriteInstanceLike,
     deleteSprite: (name) => client.deleteSprite(name),
   };
   return cachedSdk;

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -15,7 +15,7 @@ import {
   type AgentTerminalMachineSandbox,
 } from '../agent-terminals';
 import type { MachineAgentTerminalStore, MachineAgentTerminalRecord, AgentTerminalScopeKey } from '../agent-terminals-store';
-import { MachineStreamOpenTimeoutError, type MachineHost, type MachineHandle } from '../../sandbox/machine-host';
+import { type MachineHost, type MachineHandle } from '../../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from '../machine-branches';
 
@@ -144,6 +144,7 @@ function makeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
       kill: () => {},
     }),
     listStreams: async () => [],
+    killSession: async () => {},
     ...over,
   };
 }
@@ -784,7 +785,7 @@ describe('killAgentTerminal', () => {
     expect(rows.size).toBe(0);
   });
 
-  it('given a branch-scoped agent terminal whose PTY IS running, should attach the ISOLATED branch Sprite, kill that specific session, and drop the row', async () => {
+  it('given a branch-scoped agent terminal whose PTY IS running, should attach the ISOLATED branch Sprite, kill that specific session by id via the REST endpoint, and drop the row', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -803,26 +804,13 @@ describe('killAgentTerminal', () => {
     ]);
     const killed: string[] = [];
     let attachedMachineId: string | undefined;
-    let attachedSessionId: string | undefined;
     const deps = makeDeps({
       store,
       host: makeHost({
         attach: async ({ machineId }) => {
           attachedMachineId = machineId;
           return machineId === BRANCH_SANDBOX_ID
-            ? makeHandle({
-                stream: async ({ sessionId }) => {
-                  attachedSessionId = sessionId;
-                  return {
-                    write: () => {},
-                    resize: () => {},
-                    onData: () => {},
-                    onExit: () => {},
-                    onError: () => {},
-                    kill: (signal) => killed.push(signal ?? 'SIGTERM'),
-                  };
-                },
-              })
+            ? makeHandle({ killSession: async (sessionId) => { killed.push(sessionId); } })
             : null;
         },
       }),
@@ -832,12 +820,11 @@ describe('killAgentTerminal', () => {
 
     expect(result).toEqual({ ok: true });
     expect(attachedMachineId).toBe(BRANCH_SANDBOX_ID);
-    expect(attachedSessionId).toBe('sess-abc');
-    expect(killed).toEqual(['SIGKILL']);
+    expect(killed).toEqual(['sess-abc']);
     expect(rows.size).toBe(0);
   });
 
-  it('given a project-scoped agent terminal whose PTY IS running, should attach the SAME machine Sprite, kill that session, and drop the row', async () => {
+  it('given a project-scoped agent terminal whose PTY IS running, should attach the SAME machine Sprite, kill that session by id, and drop the row', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -861,17 +848,7 @@ describe('killAgentTerminal', () => {
       host: makeHost({
         attach: async ({ machineId }) => {
           attachedMachineId = machineId;
-          return makeHandle({
-            machineId,
-            stream: async () => ({
-              write: () => {},
-              resize: () => {},
-              onData: () => {},
-              onExit: () => {},
-              onError: () => {},
-              kill: (signal) => killed.push(signal ?? 'SIGTERM'),
-            }),
-          });
+          return makeHandle({ machineId, killSession: async (sessionId) => { killed.push(sessionId); } });
         },
       }),
     });
@@ -880,11 +857,11 @@ describe('killAgentTerminal', () => {
 
     expect(result).toEqual({ ok: true });
     expect(attachedMachineId).toBe(MACHINE_SANDBOX_ID);
-    expect(killed).toEqual(['SIGKILL']);
+    expect(killed).toEqual(['sess-proj']);
     expect(rows.size).toBe(0);
   });
 
-  it('given a machine-scoped agent terminal whose PTY IS running, should attach the machine Sprite, kill that session, and drop the row', async () => {
+  it('given a machine-scoped agent terminal whose PTY IS running, should attach the machine Sprite, kill that session by id, and drop the row', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -909,17 +886,7 @@ describe('killAgentTerminal', () => {
       host: makeHost({
         attach: async ({ machineId }) => {
           attachedMachineId = machineId;
-          return makeHandle({
-            machineId,
-            stream: async () => ({
-              write: () => {},
-              resize: () => {},
-              onData: () => {},
-              onExit: () => {},
-              onError: () => {},
-              kill: (signal) => killed.push(signal ?? 'SIGTERM'),
-            }),
-          });
+          return makeHandle({ machineId, killSession: async (sessionId) => { killed.push(sessionId); } });
         },
       }),
     });
@@ -928,7 +895,7 @@ describe('killAgentTerminal', () => {
 
     expect(result).toEqual({ ok: true });
     expect(attachedMachineId).toBe(MACHINE_SANDBOX_ID);
-    expect(killed).toEqual(['SIGKILL']);
+    expect(killed).toEqual(['sess-machine']);
     expect(rows.size).toBe(0);
   });
 
@@ -957,12 +924,12 @@ describe('killAgentTerminal', () => {
     expect(rows.size).toBe(0);
   });
 
-  // sprites 1-4: a stream that FAILS to open and a stream that never REPORTS are
-  // opposite situations, and conflating them breaks the kill in one direction or
-  // the other. `stream()` retries a cold-start drop internally (and that first
-  // attempt wakes the Sprite), so a failure that survives the retry is a woken
-  // Sprite saying "no such session".
-  it('given the machine does not LIST the session (positive evidence it is gone), should drop the row — there is nothing left to kill', async () => {
+  // sprites 2-3: the REST kill-by-id endpoint (`MachineHandle.killSession`) is
+  // idempotent against a session the Sprite no longer recognizes — it resolves
+  // rather than rejecting (see sprites.ts's `killSpriteSession`) — so a dangling
+  // streamSessionId (the exec session died with a Sprite pause, or was already
+  // killed) drops the row cleanly with no separate listing/corroboration step.
+  it('given a dangling streamSessionId the Sprite no longer recognizes, should still drop the row — killSession is idempotent', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -982,29 +949,17 @@ describe('killAgentTerminal', () => {
     const deps = makeDeps({
       store,
       host: makeHost({
-        attach: async () =>
-          makeHandle({
-            stream: async () => {
-              throw new Error('WebSocket error: TypeError (url: wss://…/exec/sess-dangling)');
-            },
-            // The machine ANSWERS, and this session is not among its live ones.
-            // That listing — a REST call with a real status — is the only positive
-            // evidence available; the WebSocket cannot surface an HTTP status.
-            listStreams: async () => [],
-          }),
+        attach: async () => makeHandle({ killSession: async () => {} }), // already-gone session: resolves, does not throw
       }),
     });
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
-    // Exec sessions do not survive a Sprite pause, so a session id that will not
-    // attach names a process that is already gone. Keeping the row here would
-    // strand the terminal permanently unkillable.
     expect(result).toEqual({ ok: true });
     expect(rows.size).toBe(0);
   });
 
-  it('given a TRANSIENT stream failure (429 / 5xx / hang-up — NOT positive evidence), should KEEP the row rather than orphan a live PTY', async () => {
+  it('given the session-kill call fails (control-plane outage, auth), should KEEP the row rather than orphan a possibly-live PTY', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -1026,52 +981,8 @@ describe('killAgentTerminal', () => {
       host: makeHost({
         attach: async () =>
           makeHandle({
-            stream: async () => {
-              // A control-plane blip resolving the machine, mid-kill. Says NOTHING
-              // about whether the PTY is alive.
-              throw Object.assign(new Error('rate limited'), { status: 429 });
-            },
-            // ...and the machine still lists the session as live.
-            listStreams: async () => [{ id: 'sess-abc', command: 'bash', isActive: true }],
-          }),
-      }),
-    });
-
-    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
-
-    // Dropping the row here would leave a running, billable agent process with
-    // nothing pointing at it. An unknown is not a licence to delete.
-    expect(result).toEqual({ ok: false, reason: 'error' });
-    expect(rows.size).toBe(1);
-  });
-
-  it('given the session LISTING itself fails, should KEEP the row — we never obtained evidence either way', async () => {
-    const { store, rows } = makeStore([
-      {
-        id: 'agent-terminal-1',
-        ownerId: 'user-1',
-        machineId: TERMINAL_ID,
-        scope: 'branch',
-        projectName: PROJECT_NAME,
-        machineBranchId: BRANCH_ID,
-        name: 'cli',
-        agentType: 'pagespace-cli',
-        command: null,
-        streamSessionId: 'sess-abc',
-        createdAt: NOW,
-        updatedAt: NOW,
-      },
-    ]);
-    const deps = makeDeps({
-      store,
-      host: makeHost({
-        attach: async () =>
-          makeHandle({
-            stream: async () => {
-              throw new Error('WebSocket error: TypeError (url: wss://…/exec/sess-abc)');
-            },
-            listStreams: async () => {
-              throw new Error('sprite api down');
+            killSession: async () => {
+              throw Object.assign(new Error('sprite control plane unavailable'), { status: 500 });
             },
           }),
       }),
@@ -1079,55 +990,13 @@ describe('killAgentTerminal', () => {
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
-    // Absence of evidence is not evidence of absence.
+    // Dropping the row here would leave a possibly still-running, billable agent
+    // process with nothing pointing at it. A failed kill is not a licence to delete.
     expect(result).toEqual({ ok: false, reason: 'error' });
     expect(rows.size).toBe(1);
   });
 
-  it('given the stream never reports whether it opened (timeout), should KEEP the row EVEN IF the listing claims the session is gone — a silent machine has not earned trust in its own listing', async () => {
-    const { store, rows } = makeStore([
-      {
-        id: 'agent-terminal-1',
-        ownerId: 'user-1',
-        machineId: TERMINAL_ID,
-        scope: 'branch',
-        projectName: PROJECT_NAME,
-        machineBranchId: BRANCH_ID,
-        name: 'cli',
-        agentType: 'pagespace-cli',
-        command: null,
-        streamSessionId: 'sess-abc',
-        createdAt: NOW,
-        updatedAt: NOW,
-      },
-    ]);
-    const deps = makeDeps({
-      store,
-      host: makeHost({
-        attach: async () =>
-          makeHandle({
-            stream: async () => {
-              throw new MachineStreamOpenTimeoutError(20_000);
-            },
-            // Deliberately reports the session as GONE. For any OTHER failure this
-            // listing would be positive evidence and the row would be dropped — so
-            // this test only passes if the timeout genuinely short-circuits ahead
-            // of the listing, rather than passing for the same reason the
-            // transient-failure test above does.
-            listStreams: async () => [],
-          }),
-      }),
-    });
-
-    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
-
-    // We learned NOTHING: the PTY may be alive and merely unreachable. Dropping
-    // the row would leave a running, billable process with no bookkeeping.
-    expect(result).toEqual({ ok: false, reason: 'error' });
-    expect(rows.size).toBe(1);
-  });
-
-  it('given the Sprite kill throws, should keep the row so a retry can find it again', async () => {
+  it('given the Sprite attach itself throws, should keep the row so a retry can find it again', async () => {
     const { store, rows } = makeStore([
       {
         id: 'agent-terminal-1',
@@ -1180,7 +1049,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
       host: makeHost({
         attach: async ({ machineId }) =>
           machineId === BRANCH_SANDBOX_ID
-            ? makeHandle({ stream: async () => ({ write: () => {}, resize: () => {}, onData: () => {}, onExit: () => {}, onError: () => {}, kill: (s) => killed.push(s ?? 'SIGTERM') }) })
+            ? makeHandle({ killSession: async (sessionId) => { killed.push(sessionId); } })
             : null,
       }),
     };
@@ -1188,7 +1057,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
     const result = await killAgentTerminalById({ agentTerminalId: id, deps: killDeps });
 
     expect(result).toEqual({ ok: true });
-    expect(killed).toEqual(['SIGKILL']);
+    expect(killed).toEqual(['sess-abc']);
     expect(rows.size).toBe(0);
   });
 

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -120,6 +120,7 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
         throw new Error('not used by machine-branches');
       },
       listStreams: async () => [],
+      killSession: async () => {},
     };
   }
 

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -465,7 +465,7 @@ async function killAtLocation(
     if (handle) {
       try {
         // The REST kill-by-id endpoint (`MachineHandle.killSession`, backed by
-        // sprites.dev's `POST .../exec/sessions/{id}/kill`) reaches this session
+        // sprites.dev's `POST .../exec/{session_id}/kill`) reaches this session
         // whether or not we hold a live stream to it, and is idempotent against
         // an already-dead/unknown id — see its doc. That retires the old
         // open-a-stream-then-signal dance entirely: a signal only reaches the

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -36,12 +36,7 @@
  * reconnected or resumed from hibernation.
  */
 
-import {
-  MachineStreamOpenTimeoutError,
-  type MachineHandle,
-  type MachineHost,
-  type MachineStreamSessionInfo,
-} from '../sandbox/machine-host';
+import { type MachineHandle, type MachineHost } from '../sandbox/machine-host';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 import {
@@ -469,40 +464,23 @@ async function killAtLocation(
 
     if (handle) {
       try {
-        const stream = await handle.stream({ sessionId: row.streamSessionId });
-        stream.kill('SIGKILL');
-      } catch (error) {
-        // A TIMEOUT is the one failure we refuse to reason further about. The
-        // machine went silent for the entire cap — it told us neither that the
-        // stream opened nor that it failed. A machine that will not answer the
-        // exec socket has not earned our trust in its session LISTING either, so
-        // we do not go on to ask: we keep the row and let a retry settle it.
-        if (error instanceof MachineStreamOpenTimeoutError) {
-          return { ok: false, reason: 'error' };
-        }
-
-        // Otherwise the stream would not open, and that alone says NOTHING about
-        // whether the PTY is alive: the WebSocket API cannot surface an HTTP status
-        // (see `isPreOpenWakeError`), so a vanished session, a 429, a 5xx
-        // mid-deploy and a socket hang-up are indistinguishable at this layer.
-        //
-        // So we ask the one API that CAN answer: the session LIST. If the machine
-        // tells us this session is not among its live ones, that is positive
-        // evidence it is gone — nothing left to kill, and keeping the row would
-        // strand the terminal permanently unkillable. Anything else (it IS still
-        // listed, or the listing itself failed) is an unknown, and unknowns must
-        // not be acted on: deleting the row of a PTY that is still running leaves a
-        // billable process with nothing pointing at it — silent and unrecoverable,
-        // where keeping the row is merely a visible, retryable annoyance.
-        let sessions: MachineStreamSessionInfo[];
-        try {
-          sessions = await handle.listStreams();
-        } catch {
-          return { ok: false, reason: 'error' };
-        }
-        if (sessions.some((session) => session.id === row.streamSessionId)) {
-          return { ok: false, reason: 'error' };
-        }
+        // The REST kill-by-id endpoint (`MachineHandle.killSession`, backed by
+        // sprites.dev's `POST .../exec/sessions/{id}/kill`) reaches this session
+        // whether or not we hold a live stream to it, and is idempotent against
+        // an already-dead/unknown id — see its doc. That retires the old
+        // open-a-stream-then-signal dance entirely: a signal only reaches the
+        // remote process while that stream's own socket happens to be open, so
+        // it needed a `listStreams()` corroboration fallback to tell "already
+        // gone" apart from "machine didn't answer." None of that is needed once
+        // the kill call itself answers authoritatively.
+        await handle.killSession(row.streamSessionId);
+      } catch {
+        // A genuine failure (control-plane outage, auth) — the kill call
+        // already resolves successfully for a session it no longer recognizes,
+        // so anything that reaches here is a real unknown. Keep the row so a
+        // retry can find it again; deleting it now would strand a possibly
+        // still-running, billable process with nothing pointing at it.
+        return { ok: false, reason: 'error' };
       }
     }
   }

--- a/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-diff.test.ts
@@ -82,6 +82,7 @@ function makeHandle(files: Record<string, string>): { handle: MachineHandle; rea
       throw new Error('not used');
     },
     listStreams: async () => [],
+    killSession: async () => {},
   };
   return { handle, reads };
 }

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -22,6 +22,7 @@ function makeHandle(overrides: {
       throw new Error('stream() is not used by the fs primitives');
     },
     listStreams: async () => [],
+    killSession: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/machine-host.ts
+++ b/packages/lib/src/services/sandbox/machine-host.ts
@@ -107,6 +107,21 @@ export interface MachineHandle {
   stream(args: MachineStreamOptions): Promise<MachineStream>;
   listStreams(): Promise<MachineStreamSessionInfo[]>;
   /**
+   * Terminate a specific interactive-stream session server-side, by id —
+   * reaches a session regardless of whether the caller currently holds a live
+   * `MachineStream` to it (unlike `MachineStream.kill()`, a signal delivered
+   * over that stream's own transport, which reaches nothing once the
+   * transport is closed or was never opened). This is what a genuine
+   * termination (an explicit kill request, or the detached-idle reap) must
+   * call — see `apps/realtime/src/terminal/sprites-shell.ts`'s
+   * `planTeardown`.
+   *
+   * MUST be idempotent: killing an id the machine no longer recognizes
+   * (already dead, or never existed) resolves successfully rather than
+   * rejecting.
+   */
+  killSession(sessionId: string): Promise<void>;
+  /**
    * Create a filesystem checkpoint tagged with `comment` (Sprites Platform
    * Alignment 5-2) — see `sprite-machine-host.ts` for the (today, only)
    * implementation. Required: `MachineHost` has exactly one backend

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/machine-host-adapter.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/machine-host-adapter.test.ts
@@ -17,6 +17,7 @@ function fakeHandle(over: Partial<MachineHandle> = {}): MachineHandle {
       throw new Error('not used by this adapter');
     },
     listStreams: async () => [],
+    killSession: async () => {},
     ...over,
   };
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-machine-host.test.ts
@@ -79,6 +79,7 @@ function fakeSprite(over: Partial<SpriteInstanceLike> = {}): SpriteInstanceLike 
     updateNetworkPolicy: async () => {},
     createCheckpoint: async () => ({ processAll: async () => {}, close: () => {} }),
     destroy: async () => {},
+    killSession: async () => {},
     ...over,
   };
 }
@@ -411,6 +412,31 @@ describe('createSpriteMachineHost', () => {
     expect(writes).toEqual(['ls\n']);
     expect(resizes).toEqual([[100, 40]]);
     expect(killed).toEqual(['SIGKILL']);
+  });
+
+  it('given killSession, should delegate to the underlying Sprite.killSession by id', async () => {
+    const killed: string[] = [];
+    const { sdk } = makeSdk({
+      getSprite: async () => fakeSprite({ killSession: async (id) => { killed.push(id); } }),
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    await handle.killSession('sess-1');
+
+    expect(killed).toEqual(['sess-1']);
+  });
+
+  it('given killSession against an already-dead/unknown session, should resolve rather than reject — idempotent', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async () => fakeSprite({ killSession: async () => {} }), // the driver already treats 404/410 as success
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    const host = createSpriteMachineHost({ sdk, client });
+    const handle = await host.provision({ name: 'k', substrate: { kind: 'sprite' }, options });
+
+    await expect(handle.killSession('sess-dead')).resolves.toBeUndefined();
   });
 
   it('given a MachineStream with no stdin (batch command reused as a stream), should throw on write rather than silently drop input', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -1319,13 +1319,13 @@ describe('killSpriteSession', () => {
   // A fast, no-op sleep — keeps the retry-path tests from paying real backoff wall-clock time.
   const noSleep = async () => {};
 
-  it('given a live session, POSTs the exact kill URL (no "sessions/" segment — sprites.dev/api/sprites/exec#kill-exec-session) with a bearer token', async () => {
+  it('given a live session, POSTs the exact kill URL (no "sessions/" segment — sprites.dev/api/sprites/exec#kill-exec-session) with a bearer token and explicit SIGKILL', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
 
     await killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1');
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill',
+      'https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill?signal=SIGKILL',
       expect.objectContaining({ method: 'POST', headers: { Authorization: 'Bearer test-token' } }),
     );
     expect(fetchImpl).toHaveBeenCalledTimes(1); // no retry needed on the happy path
@@ -1337,9 +1337,17 @@ describe('killSpriteSession', () => {
     await killSpriteSession({ ...transport, fetchImpl }, 'my/sprite', 'sess/1');
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.sprites.dev/v1/sprites/my%2Fsprite/exec/sess%2F1/kill',
+      'https://api.sprites.dev/v1/sprites/my%2Fsprite/exec/sess%2F1/kill?signal=SIGKILL',
       expect.anything(),
     );
+  });
+
+  it('requests signal=SIGKILL explicitly rather than relying on the endpoint\'s SIGTERM default — the old WS-signal path always used SIGKILL, and a process that traps/ignores TERM would survive a default-signal call while this still reports success', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1');
+
+    expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining('signal=SIGKILL'), expect.anything());
   });
 
   it('given a 200 whose NDJSON stream reports only progress (signal -> exited -> complete), resolves — the whole point of draining it', async () => {
@@ -1447,7 +1455,7 @@ describe('withKillSession', () => {
       await wrapped.killSession('sess-1');
 
       expect(calls).toHaveLength(1);
-      expect(calls[0][0]).toBe('https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill');
+      expect(calls[0][0]).toBe('https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill?signal=SIGKILL');
       expect(calls[0][1]).toMatchObject({ method: 'POST', headers: { Authorization: 'Bearer test-token' } });
       expect(wrapped.spawn()).toBe('unrelated-spawn-marker'); // every other method survives untouched
       expect(wrapped).toBe(sprite); // mutates and returns the same instance, not a fresh wrapper

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -9,6 +9,7 @@ import {
   checkpointStreamErrorMessage,
   killSpriteSession,
   killSessionStreamErrorMessage,
+  withKillSession,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
   type SpritesSdk,
@@ -1315,6 +1316,8 @@ describe('killSessionStreamErrorMessage (pure)', () => {
 
 describe('killSpriteSession', () => {
   const transport = { baseURL: 'https://api.sprites.dev', token: 'test-token' };
+  // A fast, no-op sleep — keeps the retry-path tests from paying real backoff wall-clock time.
+  const noSleep = async () => {};
 
   it('given a live session, POSTs the exact kill URL (no "sessions/" segment — sprites.dev/api/sprites/exec#kill-exec-session) with a bearer token', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
@@ -1325,6 +1328,7 @@ describe('killSpriteSession', () => {
       'https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill',
       expect.objectContaining({ method: 'POST', headers: { Authorization: 'Bearer test-token' } }),
     );
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // no retry needed on the happy path
   });
 
   it('given a sprite name or session id with reserved URL characters, encodes them', async () => {
@@ -1350,20 +1354,23 @@ describe('killSpriteSession', () => {
     await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).resolves.toBeUndefined();
   });
 
-  it('given a 200 whose NDJSON stream reports an error line, rejects — a 200 status alone does not confirm the signal was delivered', async () => {
+  it('given a 200 whose NDJSON stream reports an error line, rejects (after exhausting retries) — a 200 status alone does not confirm the signal was delivered', async () => {
     const ndjson = [
       '{"type":"signal","message":"delivering SIGTERM","signal":"SIGTERM","pid":123}',
       '{"type":"error","message":"process would not die"}',
     ].join('\n');
     const fetchImpl = vi.fn(async () => new Response(ndjson, { status: 200 }));
 
-    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).rejects.toThrow(/process would not die/);
+    await expect(
+      killSpriteSession({ ...transport, fetchImpl, sleep: noSleep }, 'my-sprite', 'sess-1'),
+    ).rejects.toThrow(/process would not die/);
   });
 
   it('given the Sprite reports 404 (session already gone — the documented response for a missing session), resolves successfully — idempotent', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 404, statusText: 'Not Found' }));
 
     await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-dead')).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(1); // 404 is success, not a failure — no retry
   });
 
   it('given the Sprite reports 410 (gone), resolves successfully — idempotent', async () => {
@@ -1372,9 +1379,80 @@ describe('killSpriteSession', () => {
     await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-dead')).resolves.toBeUndefined();
   });
 
-  it('given a genuine failure (5xx/auth), rejects rather than swallowing it', async () => {
+  it('given a genuine failure (5xx/auth) that persists across every attempt, rejects rather than swallowing it', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 500, statusText: 'Internal Server Error' }));
 
-    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).rejects.toThrow(/500/);
+    await expect(
+      killSpriteSession({ ...transport, fetchImpl, sleep: noSleep }, 'my-sprite', 'sess-1'),
+    ).rejects.toThrow(/500/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3); // MAX_EXEC_ATTEMPTS — bounded, not infinite
+  });
+
+  it('given a transient failure (e.g. a cold-Sprite wake drop) that succeeds on a later attempt, resolves — retry is safe because kill is idempotent', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('WebSocket error: TypeError (cold wake)'))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      killSpriteSession({ ...transport, fetchImpl, sleep: noSleep }, 'my-sprite', 'sess-1'),
+    ).resolves.toBeUndefined();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('given every attempt fails with a thrown (non-HTTP) error, retries up to the bound and then rejects with that error', async () => {
+    const networkError = new Error('fetch failed: ECONNRESET');
+    const fetchImpl = vi.fn().mockRejectedValue(networkError);
+
+    await expect(
+      killSpriteSession({ ...transport, fetchImpl, sleep: noSleep }, 'my-sprite', 'sess-1'),
+    ).rejects.toThrow(/ECONNRESET/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('given retries are needed, waits with the same linear backoff withWakeRetry uses (500ms, 1000ms)', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 500, statusText: 'Internal Server Error' }));
+    const delays: number[] = [];
+    const sleep = async (ms: number) => { delays.push(ms); };
+
+    await expect(killSpriteSession({ ...transport, fetchImpl, sleep }, 'my-sprite', 'sess-1')).rejects.toThrow();
+
+    expect(delays).toEqual([500, 1000]);
+  });
+});
+
+describe('withKillSession', () => {
+  it('given a raw SDK-shaped sprite, adds a killSession method that calls the REST endpoint using the sprite\'s own name/client credentials', async () => {
+    // withKillSession's killSession always calls killSpriteSession with no
+    // fetchImpl override (it has no injection point of its own — production
+    // wiring always wants the real global fetch), so this stubs the GLOBAL
+    // fetch for the duration of the call rather than threading a fake through.
+    const calls: Array<[string, RequestInit | undefined]> = [];
+    const fetchStub = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push([url, init]);
+      return new Response(null, { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchStub);
+    try {
+      // Duck-typed like the real @fly/sprites `Sprite`: only `.name` and
+      // `.client.{baseURL,token}` are read — everything else (spawn,
+      // createSession, ...) passes through untouched via Object.assign.
+      const sprite = {
+        name: 'my-sprite',
+        client: { baseURL: 'https://api.sprites.dev', token: 'test-token' },
+        spawn: () => 'unrelated-spawn-marker',
+      };
+
+      const wrapped = withKillSession(sprite);
+      await wrapped.killSession('sess-1');
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0][0]).toBe('https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill');
+      expect(calls[0][1]).toMatchObject({ method: 'POST', headers: { Authorization: 'Bearer test-token' } });
+      expect(wrapped.spawn()).toBe('unrelated-spawn-marker'); // every other method survives untouched
+      expect(wrapped).toBe(sprite); // mutates and returns the same instance, not a fresh wrapper
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -7,6 +7,7 @@ import {
   planProvisionFailure,
   readSessionInfoId,
   checkpointStreamErrorMessage,
+  killSpriteSession,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
   type SpritesSdk,
@@ -142,6 +143,7 @@ function fakeSprite(
     updateNetworkPolicy: async () => {},
     createCheckpoint: async () => fakeCheckpointStream(),
     destroy: async () => {},
+    killSession: async () => {},
     ...over,
   };
 }
@@ -1256,5 +1258,49 @@ describe('readSessionInfoId (pure)', () => {
     should: 'return undefined',
     actual: readSessionInfoId(null),
     expected: undefined,
+  });
+});
+
+describe('killSpriteSession', () => {
+  const transport = { baseURL: 'https://api.sprites.dev', token: 'test-token' };
+
+  it('given a live session, POSTs the exact kill URL with a bearer token', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.sprites.dev/v1/sprites/my-sprite/exec/sessions/sess-1/kill',
+      { method: 'POST', headers: { Authorization: 'Bearer test-token' } },
+    );
+  });
+
+  it('given a sprite name or session id with reserved URL characters, encodes them', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
+
+    await killSpriteSession({ ...transport, fetchImpl }, 'my/sprite', 'sess/1');
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://api.sprites.dev/v1/sprites/my%2Fsprite/exec/sessions/sess%2F1/kill',
+      expect.anything(),
+    );
+  });
+
+  it('given the Sprite reports 404 (session already gone), resolves successfully — idempotent', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 404, statusText: 'Not Found' }));
+
+    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-dead')).resolves.toBeUndefined();
+  });
+
+  it('given the Sprite reports 410 (gone), resolves successfully — idempotent', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 410, statusText: 'Gone' }));
+
+    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-dead')).resolves.toBeUndefined();
+  });
+
+  it('given a genuine failure (5xx/auth), rejects rather than swallowing it', async () => {
+    const fetchImpl = vi.fn(async () => new Response(null, { status: 500, statusText: 'Internal Server Error' }));
+
+    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).rejects.toThrow(/500/);
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -8,6 +8,7 @@ import {
   readSessionInfoId,
   checkpointStreamErrorMessage,
   killSpriteSession,
+  killSessionStreamErrorMessage,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
   type SpritesSdk,
@@ -1261,17 +1262,68 @@ describe('readSessionInfoId (pure)', () => {
   });
 });
 
+describe('killSessionStreamErrorMessage (pure)', () => {
+  assert({
+    given: 'a signal event',
+    should: 'return undefined — not a failure',
+    actual: killSessionStreamErrorMessage('{"type":"signal","message":"delivering SIGTERM","signal":"SIGTERM","pid":123}'),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'an exited event',
+    should: 'return undefined — not a failure',
+    actual: killSessionStreamErrorMessage('{"type":"exited","message":"process exited"}'),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'a complete event',
+    should: 'return undefined — not a failure',
+    actual: killSessionStreamErrorMessage('{"type":"complete","exit_code":0}'),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'an error event with a message',
+    should: 'return that message',
+    actual: killSessionStreamErrorMessage('{"type":"error","message":"signal delivery failed"}'),
+    expected: 'signal delivery failed',
+  });
+
+  assert({
+    given: 'an error event with no message field',
+    should: 'return a generic fallback rather than undefined',
+    actual: killSessionStreamErrorMessage('{"type":"error"}'),
+    expected: 'session kill reported an error',
+  });
+
+  assert({
+    given: 'a blank line (the trailing newline of an NDJSON body)',
+    should: 'return undefined',
+    actual: killSessionStreamErrorMessage('   '),
+    expected: undefined,
+  });
+
+  assert({
+    given: 'an unparseable line',
+    should: 'return undefined rather than fail a kill that otherwise succeeded',
+    actual: killSessionStreamErrorMessage('not json'),
+    expected: undefined,
+  });
+});
+
 describe('killSpriteSession', () => {
   const transport = { baseURL: 'https://api.sprites.dev', token: 'test-token' };
 
-  it('given a live session, POSTs the exact kill URL with a bearer token', async () => {
+  it('given a live session, POSTs the exact kill URL (no "sessions/" segment — sprites.dev/api/sprites/exec#kill-exec-session) with a bearer token', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 200 }));
 
     await killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1');
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.sprites.dev/v1/sprites/my-sprite/exec/sessions/sess-1/kill',
-      { method: 'POST', headers: { Authorization: 'Bearer test-token' } },
+      'https://api.sprites.dev/v1/sprites/my-sprite/exec/sess-1/kill',
+      expect.objectContaining({ method: 'POST', headers: { Authorization: 'Bearer test-token' } }),
     );
   });
 
@@ -1281,12 +1333,34 @@ describe('killSpriteSession', () => {
     await killSpriteSession({ ...transport, fetchImpl }, 'my/sprite', 'sess/1');
 
     expect(fetchImpl).toHaveBeenCalledWith(
-      'https://api.sprites.dev/v1/sprites/my%2Fsprite/exec/sessions/sess%2F1/kill',
+      'https://api.sprites.dev/v1/sprites/my%2Fsprite/exec/sess%2F1/kill',
       expect.anything(),
     );
   });
 
-  it('given the Sprite reports 404 (session already gone), resolves successfully — idempotent', async () => {
+  it('given a 200 whose NDJSON stream reports only progress (signal -> exited -> complete), resolves — the whole point of draining it', async () => {
+    const ndjson = [
+      '{"type":"signal","message":"delivering SIGTERM","signal":"SIGTERM","pid":123}',
+      '{"type":"exited","message":"process exited"}',
+      '{"type":"complete","exit_code":0}',
+      '',
+    ].join('\n');
+    const fetchImpl = vi.fn(async () => new Response(ndjson, { status: 200 }));
+
+    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).resolves.toBeUndefined();
+  });
+
+  it('given a 200 whose NDJSON stream reports an error line, rejects — a 200 status alone does not confirm the signal was delivered', async () => {
+    const ndjson = [
+      '{"type":"signal","message":"delivering SIGTERM","signal":"SIGTERM","pid":123}',
+      '{"type":"error","message":"process would not die"}',
+    ].join('\n');
+    const fetchImpl = vi.fn(async () => new Response(ndjson, { status: 200 }));
+
+    await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-1')).rejects.toThrow(/process would not die/);
+  });
+
+  it('given the Sprite reports 404 (session already gone — the documented response for a missing session), resolves successfully — idempotent', async () => {
     const fetchImpl = vi.fn(async () => new Response(null, { status: 404, statusText: 'Not Found' }));
 
     await expect(killSpriteSession({ ...transport, fetchImpl }, 'my-sprite', 'sess-dead')).resolves.toBeUndefined();

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/wake-retry.test.ts
@@ -187,6 +187,7 @@ function fakeSprite(name: string): SpriteInstanceLike {
     updateNetworkPolicy: async () => {},
     createCheckpoint: async () => { throw new Error('not used'); },
     destroy: async () => {},
+    killSession: async () => {},
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -217,6 +217,11 @@ function wrapSpriteHandle({
         .filter((s) => s.tty !== false)
         .map((s) => ({ id: s.id, command: s.command, isActive: s.isActive }));
     },
+
+    async killSession(sessionId: string): Promise<void> {
+      const sprite = await sdk.getSprite(exec.sandboxId);
+      await sprite.killSession(sessionId);
+    },
   };
 }
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-machine-host.ts
@@ -154,13 +154,19 @@ function wrapSpriteHandle({
      * Opening a stream (attachSession/createSession) is itself an exec, so it IS
      * the wake for a hibernated Sprite — there is no wake API
      * (docs.sprites.dev/concepts/lifecycle). But Fly's wake-on-request can drop
-     * that FIRST connection before it ever opens, and this path had no retry at
-     * all: `killAgentTerminal` attaches and immediately SIGKILLs,
-     * so a dropped wake silently failed the kill and left the row behind. The
-     * exec path (`withWakeRetry`) and the realtime PTY (`openPtyShell`'s bounded
-     * reconnect) both already absorb that drop; this is the third caller, and now
-     * it does too — on the same bounded schedule, re-opening a fresh connection
-     * per attempt.
+     * that FIRST connection before it ever opens, so any caller of this method
+     * needs the same absorption the exec path (`withWakeRetry`) and the realtime
+     * PTY (`openPtyShell`'s bounded reconnect) already have — bounded retry,
+     * re-opening a fresh connection per attempt.
+     *
+     * NOTE (Sprites 2-3, the kill-endpoint leaf): `killAgentTerminal` used to be
+     * this method's reason for existing (`stream()` + `MachineStream.kill()`,
+     * with this retry protecting the wake) — it now calls
+     * `MachineHandle.killSession` directly (a REST call to the documented kill
+     * endpoint, idempotent on its own, with its own retry — see
+     * `killSpriteSession` in `sprites.ts`), bypassing `stream()` entirely. This
+     * method is kept as the general PTY-stream primitive `MachineHandle`
+     * promises callers (see file header); it currently has no production caller.
      */
     async stream(args) {
       const open = async (): Promise<MachineStream> => {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -756,6 +756,8 @@ export interface SpriteSessionKillTransport {
   token: string;
   /** Injected so a test can assert the exact request without a real network call. Defaults to the global `fetch`. */
   fetchImpl?: typeof fetch;
+  /** Injected so a test can assert the retry schedule without real wall-clock waits. Defaults to the real timer. */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -791,8 +793,8 @@ export function killSessionStreamErrorMessage(line: string): string | undefined 
 }
 
 /**
- * Drive the one documented Sprites REST endpoint the `@fly/sprites` SDK (rc37)
- * does not wrap: `POST /v1/sprites/{name}/exec/{session_id}/kill`
+ * One attempt at the documented Sprites REST endpoint the `@fly/sprites` SDK
+ * (rc37) does not wrap: `POST /v1/sprites/{name}/exec/{session_id}/kill`
  * (sprites.dev/api/sprites/exec#kill-exec-session — NOT
  * `.../exec/sessions/{id}/kill`; the extra `sessions/` segment 404s against
  * the real API). `Sprite` exposes `attachSession`/`createSession`/`kill()`
@@ -815,7 +817,7 @@ export function killSessionStreamErrorMessage(line: string): string | undefined 
  * destroy never surfaces a user-visible error. Any other non-2xx response, or
  * an `error` line inside a 200 stream, is a genuine failure and rejects.
  */
-export async function killSpriteSession(
+async function attemptKillSpriteSession(
   { baseURL, token, fetchImpl = fetch }: SpriteSessionKillTransport,
   spriteName: string,
   sessionId: string,
@@ -841,6 +843,70 @@ export async function killSpriteSession(
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * {@link attemptKillSpriteSession}, retried up to `MAX_EXEC_ATTEMPTS` times
+ * with the same linear backoff `withWakeRetry` uses (`wakeRetryDelayMs`).
+ *
+ * Deliberately retries on ANY failure, not just a structurally-detected
+ * pre-open drop the way the exec/spawn paths in this file do. Those paths
+ * must retry ONLY a provable pre-open failure, because re-running a
+ * side-effecting command after an ambiguous one risks running it twice. A
+ * kill has no such hazard — it is idempotent by construction (see the
+ * `404`/`410` handling above) — so repeating it after ANY failure, including
+ * the exact cold-Sprite wake-on-request connection drop the exec paths guard
+ * against (docs.sprites.dev/concepts/lifecycle: there is no wake API, so this
+ * REST call may itself be what wakes a hibernating Sprite), costs nothing and
+ * only improves the odds a genuine termination actually lands. This is the
+ * caller-visible guarantee: `killAgentTerminal`'s `MachineHandle.killSession`
+ * and `PtyShell.kill`'s fire-and-forget REST call both inherit it for free,
+ * without either needing its own retry logic.
+ */
+export async function killSpriteSession(
+  transport: SpriteSessionKillTransport,
+  spriteName: string,
+  sessionId: string,
+): Promise<void> {
+  const { sleep = delay } = transport;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_EXEC_ATTEMPTS; attempt += 1) {
+    try {
+      await attemptKillSpriteSession(transport, spriteName, sessionId);
+      return;
+    } catch (error) {
+      lastError = error;
+      if (attempt >= MAX_EXEC_ATTEMPTS) break;
+      await sleep(wakeRetryDelayMs(attempt));
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Bolt `killSession` onto a raw SDK `Sprite`-shaped instance, so it satisfies
+ * `SpriteInstanceLike` — see {@link killSpriteSession}'s doc for why the SDK
+ * needs this at all. Shared by BOTH production `SpritesSdk` factories
+ * (`apps/web/src/lib/sandbox/sprites-client.ts`,
+ * `apps/realtime/src/terminal/realtime-sprites-client.ts`) — this used to be
+ * defined twice, near-verbatim, one per app boundary. Duck-typed (not
+ * `import type { Sprite } from '@fly/sprites'`) so this module never imports
+ * the ESM-only SDK (see the file header); a real `Sprite` instance already
+ * satisfies this shape structurally, and `client.baseURL`/`client.token` are
+ * public `readonly` fields on the real `SpritesClient`.
+ *
+ * Mutates and returns `sprite` (via `Object.assign`) rather than building a
+ * fresh wrapper object, so every OTHER method the caller already relies on
+ * (`spawn`, `createSession`, `attachSession`, `filesystem`, …) keeps working
+ * untouched — this only ever ADDS the one method the SDK is missing.
+ */
+export function withKillSession<T extends { name: string; client: { baseURL: string; token: string } }>(
+  sprite: T,
+): T & { killSession: (sessionId: string) => Promise<void> } {
+  return Object.assign(sprite, {
+    killSession: (sessionId: string) =>
+      killSpriteSession({ baseURL: sprite.client.baseURL, token: sprite.client.token }, sprite.name, sessionId),
+  });
 }
 
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -315,7 +315,7 @@ export interface SpriteInstanceLike {
   destroy(): Promise<void>;
   /**
    * Terminate a specific exec session server-side via `POST
-   * /v1/sprites/{name}/exec/sessions/{id}/kill` (sprites.dev/api) — see
+   * /v1/sprites/{name}/exec/{session_id}/kill` (sprites.dev/api) — see
    * {@link killSpriteSession} for the driver. Unlike `SpriteCommandLike.kill()`
    * (a signal delivered over that command's OWN WebSocket, which reaches the
    * remote process only while that socket happens to be open — see
@@ -759,31 +759,88 @@ export interface SpriteSessionKillTransport {
 }
 
 /**
+ * Wall-clock cap on `killSpriteSession` (the request plus draining its
+ * response stream — see below). A bare `fetch` has no timeout of its own, and
+ * every other network call this driver makes is bounded (filesystem ops via
+ * `withTimeout`, checkpoints via `CHECKPOINT_TIMEOUT_MS`), so an unbounded
+ * kill call would be the one exception that can hang a caller forever against
+ * a stalled connection.
+ */
+const KILL_SESSION_TIMEOUT_MS = 10_000;
+
+/**
+ * Pure: does this line of the kill endpoint's NDJSON progress stream report a
+ * failure? Returns the failure text for a `{"type":"error",...}` line, or
+ * undefined for every other documented event (`signal`/`timeout`/`exited`/
+ * `killed`/`complete`) and for a blank or unparseable line — a malformed
+ * progress line must never mask an otherwise-successful kill.
+ */
+export function killSessionStreamErrorMessage(line: string): string | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  let event: unknown;
+  try {
+    event = JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+  if (typeof event !== 'object' || event === null) return undefined;
+  const { type, message } = event as { type?: unknown; message?: unknown };
+  if (type !== 'error') return undefined;
+  return typeof message === 'string' && message.length > 0 ? message : 'session kill reported an error';
+}
+
+/**
  * Drive the one documented Sprites REST endpoint the `@fly/sprites` SDK (rc37)
- * does not wrap: `POST /v1/sprites/{name}/exec/sessions/{id}/kill`
- * (sprites.dev/api). `Sprite` exposes `attachSession`/`createSession`/`kill()`
+ * does not wrap: `POST /v1/sprites/{name}/exec/{session_id}/kill`
+ * (sprites.dev/api/sprites/exec#kill-exec-session — NOT
+ * `.../exec/sessions/{id}/kill`; the extra `sessions/` segment 404s against
+ * the real API). `Sprite` exposes `attachSession`/`createSession`/`kill()`
  * (a per-command WebSocket signal) but no session-kill-by-id, so this hits the
  * endpoint directly — `baseURL` and `token` are public `readonly` fields on the
  * real `SpritesClient`, reachable off any `Sprite` instance's own `.client`.
  *
- * A 404/410 means the Sprite no longer recognizes this session id — that IS
- * success, not a failure: the caller's whole reason for calling is "make sure
- * this session is dead," and it already is. Idempotent by construction, so a
- * kill racing (or arriving after) another kill, a natural process exit, or a
- * Sprite-level destroy never surfaces a user-visible error. Any other non-2xx
- * response is a genuine failure and rejects.
+ * A success response is `200` with a STREAMING NDJSON body (`signal` ->
+ * `exited`/`killed` -> `complete`, or a `type: 'error'` line if the signal
+ * could not actually be delivered) — the HTTP status alone does not confirm
+ * the session was killed, only that the request was accepted. So a `200` is
+ * drained and checked line-by-line via {@link killSessionStreamErrorMessage};
+ * only a stream with no `error` line resolves.
+ *
+ * `404`/`410` means the Sprite no longer recognizes this session id (the
+ * documented response for a missing session/sprite) — that IS success, not a
+ * failure: the caller's whole reason for calling is "make sure this session
+ * is dead," and it already is. Idempotent by construction, so a kill racing
+ * (or arriving after) another kill, a natural process exit, or a Sprite-level
+ * destroy never surfaces a user-visible error. Any other non-2xx response, or
+ * an `error` line inside a 200 stream, is a genuine failure and rejects.
  */
 export async function killSpriteSession(
   { baseURL, token, fetchImpl = fetch }: SpriteSessionKillTransport,
   spriteName: string,
   sessionId: string,
 ): Promise<void> {
-  const response = await fetchImpl(
-    `${baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/exec/sessions/${encodeURIComponent(sessionId)}/kill`,
-    { method: 'POST', headers: { Authorization: `Bearer ${token}` } },
-  );
-  if (response.ok || response.status === 404 || response.status === 410) return;
-  throw new Error(`Sprite session kill failed: ${response.status} ${response.statusText}`);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), KILL_SESSION_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(
+      `${baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/exec/${encodeURIComponent(sessionId)}/kill`,
+      { method: 'POST', headers: { Authorization: `Bearer ${token}` }, signal: controller.signal },
+    );
+    if (!response.ok) {
+      if (response.status === 404 || response.status === 410) return;
+      throw new Error(`Sprite session kill failed: ${response.status} ${response.statusText}`);
+    }
+    const body = await response.text();
+    for (const line of body.split('\n')) {
+      const errorMessage = killSessionStreamErrorMessage(line);
+      if (errorMessage !== undefined) {
+        throw new Error(`Sprite session kill reported an error: ${errorMessage}`);
+      }
+    }
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -809,6 +809,13 @@ export function killSessionStreamErrorMessage(line: string): string | undefined 
  * drained and checked line-by-line via {@link killSessionStreamErrorMessage};
  * only a stream with no `error` line resolves.
  *
+ * Requests `?signal=SIGKILL` explicitly. The endpoint defaults to `SIGTERM`
+ * when `signal` is omitted, but every caller of this driver is replacing an
+ * old `SpriteCommandLike.kill('SIGKILL')` WebSocket signal — a graceful-only
+ * SIGTERM would let a process that traps/ignores TERM survive the call while
+ * this function still reports success, so the row/session bookkeeping gets
+ * removed out from under a still-live, still-billable session.
+ *
  * `404`/`410` means the Sprite no longer recognizes this session id (the
  * documented response for a missing session/sprite) — that IS success, not a
  * failure: the caller's whole reason for calling is "make sure this session
@@ -826,7 +833,7 @@ async function attemptKillSpriteSession(
   const timer = setTimeout(() => controller.abort(), KILL_SESSION_TIMEOUT_MS);
   try {
     const response = await fetchImpl(
-      `${baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/exec/${encodeURIComponent(sessionId)}/kill`,
+      `${baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/exec/${encodeURIComponent(sessionId)}/kill?signal=SIGKILL`,
       { method: 'POST', headers: { Authorization: `Bearer ${token}` }, signal: controller.signal },
     );
     if (!response.ok) {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -313,6 +313,25 @@ export interface SpriteInstanceLike {
    */
   createCheckpoint(comment?: string): Promise<SpriteCheckpointStreamLike>;
   destroy(): Promise<void>;
+  /**
+   * Terminate a specific exec session server-side via `POST
+   * /v1/sprites/{name}/exec/sessions/{id}/kill` (sprites.dev/api) — see
+   * {@link killSpriteSession} for the driver. Unlike `SpriteCommandLike.kill()`
+   * (a signal delivered over that command's OWN WebSocket, which reaches the
+   * remote process only while that socket happens to be open — see
+   * `sprite-machine-host.ts`'s note on the private, unreachable
+   * `WSCommand.close()`), this reaches a session regardless of whether we hold
+   * a live connection to it: a detachable TTY session has
+   * `max_run_after_disconnect: 0` and keeps running server-side long after its
+   * client socket has dropped, which is exactly the case a stale local `kill()`
+   * silently no-ops on.
+   *
+   * MUST be idempotent: killing an id the Sprite no longer recognizes (already
+   * dead, or never existed) resolves successfully rather than rejecting, so a
+   * caller never surfaces a user-visible failure for a session that is already
+   * gone — see {@link killSpriteSession}.
+   */
+  killSession(sessionId: string): Promise<void>;
 }
 
 /** The injectable Sprites SDK statics. Defaults to the real `@fly/sprites`. */
@@ -724,6 +743,48 @@ export function checkpointStreamErrorMessage(message: SpriteCheckpointStreamMess
  * review finding, PR #2025).
  */
 const CHECKPOINT_TIMEOUT_MS = 10_000;
+
+/**
+ * The HTTP credentials `killSpriteSession` needs — deliberately narrow (not
+ * the whole `SpritesClient`) so production wiring (`apps/web/.../sprites-client.ts`,
+ * `apps/realtime/.../realtime-sprites-client.ts`) can pass the real client's
+ * public `baseURL`/`token` fields without this module importing `@fly/sprites`
+ * (it stays a pure-logic/type-safe-wrapper module — see the file header).
+ */
+export interface SpriteSessionKillTransport {
+  baseURL: string;
+  token: string;
+  /** Injected so a test can assert the exact request without a real network call. Defaults to the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Drive the one documented Sprites REST endpoint the `@fly/sprites` SDK (rc37)
+ * does not wrap: `POST /v1/sprites/{name}/exec/sessions/{id}/kill`
+ * (sprites.dev/api). `Sprite` exposes `attachSession`/`createSession`/`kill()`
+ * (a per-command WebSocket signal) but no session-kill-by-id, so this hits the
+ * endpoint directly — `baseURL` and `token` are public `readonly` fields on the
+ * real `SpritesClient`, reachable off any `Sprite` instance's own `.client`.
+ *
+ * A 404/410 means the Sprite no longer recognizes this session id — that IS
+ * success, not a failure: the caller's whole reason for calling is "make sure
+ * this session is dead," and it already is. Idempotent by construction, so a
+ * kill racing (or arriving after) another kill, a natural process exit, or a
+ * Sprite-level destroy never surfaces a user-visible error. Any other non-2xx
+ * response is a genuine failure and rejects.
+ */
+export async function killSpriteSession(
+  { baseURL, token, fetchImpl = fetch }: SpriteSessionKillTransport,
+  spriteName: string,
+  sessionId: string,
+): Promise<void> {
+  const response = await fetchImpl(
+    `${baseURL}/v1/sprites/${encodeURIComponent(spriteName)}/exec/sessions/${encodeURIComponent(sessionId)}/kill`,
+    { method: 'POST', headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (response.ok || response.status === 404 || response.status === 410) return;
+  throw new Error(`Sprite session kill failed: ${response.status} ${response.statusText}`);
+}
 
 function wrap(sprite: SpriteInstanceLike, egressPolicyToken?: string): ExecutableSandbox {
   return {


### PR DESCRIPTION
## Summary

Every teardown path called `kill('SIGKILL')` on the client WebSocket handle — but TTY sessions have `max_run_after_disconnect: 0` and keep running server-side after the socket closes. Nothing in the codebase called the documented kill endpoint (`POST /v1/sprites/{name}/exec/{session_id}/kill`), so "killed" panes could leak live sessions that later reattach paths rediscover and cross-wire.

This wires the real endpoint into both places that need genuine termination — the explicit `killAgentTerminal` API and the 30-min detached-idle reap — while preserving detach-never-terminates semantics.

Branched from current master (post #2038/#2039/#2041/#2042/#2031); verified against https://sprites.dev/api.

> **Convergence history:** three review passes landed after the initial push — all self-driven, no human review yet requested beyond automated bots. (Commit hashes below reflect the post-rebase history — the branch was rebased onto master after these fixes landed, so earlier hashes cited in review-thread replies predate the rebase but refer to the same changes.)
> 1. Codex caught a P1: the kill URL was `.../exec/sessions/{id}/kill` (extra `sessions/` segment, 404s against the real API) instead of the documented `.../exec/{session_id}/kill`. Since 404 was (correctly) treated as idempotent success, every real kill would have silently no-op'd. Fixed in 0be834f55, along with draining the endpoint's streaming NDJSON response body (a `200` alone doesn't confirm the signal was delivered). See the [review thread](https://github.com/2witstudios/PageSpace/pull/2050#discussion_r3571458978).
> 2. A multi-angle self-review (8 independent finder passes) surfaced three more issues, fixed in 1a3b7cb2c: (a) no retry on transient/cold-wake failures — added, since a kill is idempotent so blanket retry is safe; (b) `withKillSession` SDK-wrapping duplicated near-verbatim across `apps/web`/`apps/realtime` — hoisted into one shared `sprites.ts` export; (c) the `'user-kill'` trigger name was misleading — its only real caller is a platform-forced teardown (revoked access / insolvent payer), never a literal click — renamed to `'forced-teardown'`.
> 3. Codex caught a second P1: the kill endpoint defaults to `SIGTERM` when `signal` is omitted, but the old WS-based `kill('SIGKILL')` path this replaces always sent SIGKILL. A process that traps/ignores TERM would survive a default-signal call while `killSpriteSession` still reported success, silently removing row/session bookkeeping out from under a still-live, still-billable session. Fixed in 3ca3b3ff7 by requesting `?signal=SIGKILL` explicitly on every kill request. See the [review thread](https://github.com/2witstudios/PageSpace/pull/2050#discussion_r3572296188).

## Requirements

- **Given a user-initiated terminal kill, should call the sessions kill endpoint for the exact session id AND close the socket.**
  `packages/lib/src/services/machines/agent-terminals.ts`'s `killAtLocation` now calls `handle.killSession(row.streamSessionId)` — a direct REST call, replacing the old open-a-stream-then-signal-then-corroborate-via-listStreams dance (that dance existed only because a WS signal is unreliable; the REST endpoint answers authoritatively on its own).

- **Given a viewer detach (navigate away), should close/abandon the client socket only — never kill the session.**
  `sprites-shell.ts`'s new `planTeardown({trigger: 'detach'})` returns `{killSession: false, closeSocket: false}`. `agent-terminal-handler.ts`'s `disconnectConnection` main body (immediate detach, not the idle timer) never calls `PtyShell.kill()` at all — it only calls `setViewerAttached(false)`, which stops the reconnect watchdog without touching the exec session. Verified this can never regress into a kill via `planTeardown`'s pure matrix tests plus `shell.kill('detach')` integration tests.

- **Given the detached-idle reap (30-min timer), should kill the server-side session.**
  `agent-terminal-handler.ts`'s `disconnectConnection` idle timer now calls `session.command.kill('idle-reap')`, which `planTeardown` maps to `{killSession: true, closeSocket: true}` — `PtyShell.kill` calls `sprite.killSession(currentSessionId)` (works even though the exec socket is almost certainly already dead by then, since detach stopped reconnecting) plus a best-effort local `current.kill('SIGKILL')`.

- **Given a kill against an already-dead session id, should succeed idempotently.**
  `sprites.ts`'s `killSpriteSession` treats HTTP 404/410 as success rather than throwing (the documented response for a missing session — verified against the "Attach to Exec Session"/"List Exec Sessions" endpoints, which share the resource family). Covered end-to-end: `killAgentTerminal` against a dangling `streamSessionId` still drops the row; `MachineHandle.killSession`/`SpriteInstanceLike.killSession` inherit the idempotency.

## Design notes

- Pure core: `planTeardown({trigger: 'forced-teardown' | 'detach' | 'idle-reap' | 'shell-exit'}) -> {killSession, closeSocket}` in `sprites-shell.ts`, fully unit-tested (all 4 branches). Only `forced-teardown` and `idle-reap` have a real call site today (`agent-terminal-handler.ts`) — `detach`/`shell-exit` complete the tested decision matrix but aren't wired anywhere yet (a plain detach never calls `kill()` at all; a real shell exit is handled by `fatal()`, which also never calls `kill()` since the process already ended). Documented explicitly so this doesn't read as dead code.
- The `@fly/sprites` SDK (rc37) exposes no session-kill-by-id — only `attachSession`/`createSession`/`kill()` (a per-command WS signal, which no-ops once the socket is closed). `killSpriteSession` hits `POST /v1/sprites/{name}/exec/{session_id}/kill` directly using the real `SpritesClient`'s public `baseURL`/`token` fields. `withKillSession` (shared in `sprites.ts`) bolts the method onto a raw SDK `Sprite` instance; both app boundaries (`apps/web/src/lib/sandbox/sprites-client.ts`, `apps/realtime/src/terminal/realtime-sprites-client.ts`) call it instead of each defining their own copy.
- The endpoint's `200` response is **streaming NDJSON** progress (`signal` → `exited`/`killed` → `complete`, or a mid-stream `type: 'error'` line if the signal couldn't actually be delivered) — the HTTP status alone doesn't confirm the kill succeeded. `killSpriteSession` drains the body and rejects on any `error` line (pure `killSessionStreamErrorMessage` helper).
- `killSpriteSession` retries up to `MAX_EXEC_ATTEMPTS` (3, linear backoff — the same schedule `withWakeRetry` uses) on **any** failure, not just a structurally-detected pre-open drop like the exec/spawn paths in this file require. A kill is idempotent by construction (see the 404/410 handling), so blanket retry is safe and closes a real reliability gap: both the fire-and-forget kill in `PtyShell.kill()` and the DB-row-keeping kill in `killAtLocation` previously gave up after one attempt, even against a transient failure like the cold-Sprite wake-on-request connection drop the exec paths already guard against. Each attempt is bounded by a 10s `AbortController` timeout, matching this driver's existing pattern for every other network call (filesystem ops via `withTimeout`, checkpoints via `CHECKPOINT_TIMEOUT_MS`).
- `MachineHandle` gained `killSession(sessionId)`, backed by the same REST call via `sdk.getSprite(...).killSession(...)` in `sprite-machine-host.ts`. Its `stream()` method's wake-retry doc used to describe protecting `killAgentTerminal` — now stale (that caller no longer uses `stream()`), so the comment was corrected; `stream()`/`listStreams()` currently have no production caller at all (kept as the general primitive `MachineHandle` promises, per the file header).
- Every kill request explicitly asks for `?signal=SIGKILL` — the endpoint defaults to `SIGTERM` when the query param is omitted, which would let a process trapping/ignoring TERM survive a call that still reports success. Both real call sites (`killAtLocation`'s explicit kill and `PtyShell.kill`'s idle-reap) go through `attemptKillSpriteSession`, so both inherit this for free.

## Test evidence

```
packages/lib (sandbox+machines): 49 test files, 1234 tests passed
apps/realtime (terminal):        12 test files, 439 tests passed
bun run typecheck: 16/16 packages clean (includes web build)
bun run lint: clean (pre-existing unrelated warnings only)
```

New/changed tests:
- `sprites.test.ts`: `killSpriteSession` (correct URL shape + encoding + explicit `signal=SIGKILL`, NDJSON success/error-line draining, 404/410 idempotency, retry-then-succeed, retry-exhaustion, backoff schedule), `killSessionStreamErrorMessage` (pure NDJSON-line matrix), `withKillSession` (bolt-on delegation, other methods untouched)
- `sprites-shell.test.ts`: `planTeardown` matrix + `shell.kill(trigger)` integration (forced-teardown/idle-reap kill by id, detach/shell-exit never touch the session, idempotent double-kill, kill-failure doesn't throw)
- `agent-terminal-handler.test.ts`: trigger assertions on the two real call sites
- `sprite-machine-host.test.ts`: `MachineHandle.killSession` delegation + idempotency
- `agent-terminals.test.ts`: rewrote `killAgentTerminal`/`killAgentTerminalById` suites for the simplified REST-call path (dropped the now-obsolete transient-stream-failure/listing-corroboration tests, added a dangling-session idempotency test)

## Out of scope (per leaf spec)
Grace-window length; sprite destroy semantics (6-2). Also considered and deliberately NOT done (see PR discussion for full reasoning): removing the now-callerless `MachineHandle.stream()`/`listStreams()` methods (kept as general infrastructure); reusing `packages/lib/src/utils/fetch-with-timeout.ts` for the kill call's timeout (would require adding fetch-injection to an otherwise-unrelated, currently-unused shared utility); eliminating the extra `sdk.getSprite()` round trip in `killAtLocation`'s attach-then-kill sequence (architectural consistency with every other `MachineHandle` operation outweighs the marginal latency win on a non-hot path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mYrPXsCJFegYupazDEDGe
