### PR TITLE
fix(machine): serialize reconcileMachineStorage with a Postgres advisory lock

### DIFF
--- a/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/__tests__/route.test.ts
@@ -14,12 +14,9 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/services/sandbox/machine-storage-reconcile', () => ({
-  reconcileMachineStorage: mockReconcile,
-}));
-
 vi.mock('@pagespace/lib/services/sandbox/machine-storage-billing', () => ({
   defaultReconcileMachineStorageDeps: {},
+  reconcileMachineStorageSerialized: mockReconcile,
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
@@ -47,7 +44,15 @@ describe('/api/cron/reconcile-machine-storage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(validateSignedCronRequest).mockReturnValue(null);
-    mockReconcile.mockResolvedValue({ processed: 3, charged: 2, skipped: 1, failed: 0, staleMeasurements: 1, totalCostDollars: 0.001234 });
+    mockReconcile.mockResolvedValue({
+      outcome: 'reconciled',
+      processed: 3,
+      charged: 2,
+      skipped: 1,
+      failed: 0,
+      staleMeasurements: 1,
+      totalCostDollars: 0.001234,
+    });
   });
 
   it('returns the auth error and never reconciles when auth fails', async () => {
@@ -75,6 +80,17 @@ describe('/api/cron/reconcile-machine-storage', () => {
       }),
     );
     expect(body).toMatchObject({ success: true, processed: 3, charged: 2, skipped: 1, failed: 0, staleMeasurements: 1 });
+  });
+
+  it('given the advisory lock is held by another run, should no-op WITHOUT auditing and report lock_busy', async () => {
+    mockReconcile.mockResolvedValue({ outcome: 'lock_busy' });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({ success: true, outcome: 'lock_busy' });
+    expect(mockAudit).not.toHaveBeenCalled();
   });
 
   it('returns a 500 with the error message when reconcile throws', async () => {

--- a/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
+++ b/apps/web/src/app/api/cron/reconcile-machine-storage/route.ts
@@ -1,5 +1,7 @@
-import { reconcileMachineStorage } from '@pagespace/lib/services/sandbox/machine-storage-reconcile';
-import { defaultReconcileMachineStorageDeps } from '@pagespace/lib/services/sandbox/machine-storage-billing';
+import {
+  defaultReconcileMachineStorageDeps,
+  reconcileMachineStorageSerialized,
+} from '@pagespace/lib/services/sandbox/machine-storage-billing';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
@@ -16,11 +18,13 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
  * Idempotent / drift-correcting for SEQUENTIAL runs: each machine tracks its
  * own last-billed watermark, so a rerun bills zero elapsed time and a missed
  * run is caught up exactly on the next one — see `reconcileMachineStorage`
- * in @pagespace/lib. CONCURRENT invocations are NOT safe — the charge and the
- * watermark advance are two un-transactioned writes, so overlapping runs can
- * bill the same window twice. Callers must serialize externally (the
- * docker/cron crontab entry does, via flock); an in-service advisory lock
- * covering every caller is tracked follow-up work.
+ * in @pagespace/lib. CONCURRENT invocations are made safe by
+ * `reconcileMachineStorageSerialized`'s Postgres advisory try-lock: a run that
+ * cannot acquire it (another container, or a manual/API trigger, already
+ * holds it) no-ops cleanly instead of racing the charge + watermark-advance
+ * writes. The docker/cron crontab flock (defense in depth) still serializes
+ * this ONE container's own scheduled ticks; the advisory lock is what makes
+ * every OTHER caller overlap-safe too.
  *
  * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce,
  * X-Cron-Signature headers.
@@ -32,10 +36,19 @@ export async function GET(request: Request) {
   }
 
   try {
-    const result = await reconcileMachineStorage(defaultReconcileMachineStorageDeps);
+    const run = await reconcileMachineStorageSerialized(defaultReconcileMachineStorageDeps);
+
+    if (run.outcome === 'lock_busy') {
+      console.log('[Cron] Terminal storage reconcile: skipped — advisory lock held by another run');
+      return NextResponse.json({
+        success: true,
+        outcome: 'lock_busy',
+        timestamp: new Date().toISOString(),
+      });
+    }
 
     console.log(
-      `[Cron] Terminal storage reconcile: processed ${result.processed}, charged ${result.charged}, skipped ${result.skipped}, failed ${result.failed}, stale ${result.staleMeasurements}, total $${result.totalCostDollars.toFixed(6)}`,
+      `[Cron] Terminal storage reconcile: processed ${run.processed}, charged ${run.charged}, skipped ${run.skipped}, failed ${run.failed}, stale ${run.staleMeasurements}, total $${run.totalCostDollars.toFixed(6)}`,
     );
 
     audit({
@@ -43,18 +56,23 @@ export async function GET(request: Request) {
       resourceType: 'cron_job',
       resourceId: 'reconcile_machine_storage',
       details: {
-        processed: result.processed,
-        charged: result.charged,
-        skipped: result.skipped,
-        failed: result.failed,
-        staleMeasurements: result.staleMeasurements,
-        totalCostDollars: result.totalCostDollars,
+        processed: run.processed,
+        charged: run.charged,
+        skipped: run.skipped,
+        failed: run.failed,
+        staleMeasurements: run.staleMeasurements,
+        totalCostDollars: run.totalCostDollars,
       },
     });
 
     return NextResponse.json({
       success: true,
-      ...result,
+      processed: run.processed,
+      charged: run.charged,
+      skipped: run.skipped,
+      failed: run.failed,
+      staleMeasurements: run.staleMeasurements,
+      totalCostDollars: run.totalCostDollars,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,10 @@
       "types": "./dist/db.d.ts",
       "default": "./dist/db.js"
     },
+    "./advisory-lock": {
+      "types": "./dist/advisory-lock.d.ts",
+      "default": "./dist/advisory-lock.js"
+    },
     "./admin-db": {
       "types": "./dist/admin-db.d.ts",
       "default": "./dist/admin-db.js"

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { withAdvisoryLock, type AdvisoryLockPool } from './advisory-lock';
+
+function makeClient(overrides: Partial<{ query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> }> = {}) {
+  return {
+    query: vi.fn(),
+    release: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('withAdvisoryLock', () => {
+  it('given the lock is free, should acquire it, run fn, and release cleanly', async () => {
+    const client = makeClient({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] }) // try-lock
+        .mockResolvedValueOnce({ rows: [] }), // unlock
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const fn = vi.fn(async () => 'work-result');
+
+    const result = await withAdvisoryLock(pool, 'my-lock', fn);
+
+    expect(result).toEqual({ outcome: 'acquired', result: 'work-result' });
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toContain('pg_try_advisory_lock');
+    expect(client.query.mock.calls[0][1]).toEqual(['my-lock']);
+    expect(client.query.mock.calls[1][0]).toContain('pg_advisory_unlock');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it('given the lock is already held, should no-op WITHOUT running fn and release without destroying', async () => {
+    const client = makeClient({ query: vi.fn().mockResolvedValueOnce({ rows: [{ acquired: false }] }) });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const fn = vi.fn(async () => 'unreachable');
+
+    const result = await withAdvisoryLock(pool, 'my-lock', fn);
+
+    expect(result).toEqual({ outcome: 'lock_busy' });
+    expect(fn).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it('given the unlock query fails after acquiring, should destroy the connection instead of releasing it alive', async () => {
+    const client = makeClient({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockRejectedValueOnce(new Error('unlock failed')),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+
+    const result = await withAdvisoryLock(pool, 'my-lock', async () => 'ok');
+
+    expect(result).toEqual({ outcome: 'acquired', result: 'ok' });
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('given the try-lock query itself throws, should destroy the connection and rethrow (never resolve acquired/busy)', async () => {
+    const client = makeClient({ query: vi.fn().mockRejectedValueOnce(new Error('connection reset')) });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const fn = vi.fn(async () => 'unreachable');
+
+    await expect(withAdvisoryLock(pool, 'my-lock', fn)).rejects.toThrow('connection reset');
+
+    expect(fn).not.toHaveBeenCalled();
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('given fn itself throws after acquiring, should still unlock cleanly (fn error does not poison the lock connection) and rethrow', async () => {
+    const client = makeClient({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockResolvedValueOnce({ rows: [] }),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const fn = vi.fn(async () => {
+      throw new Error('work failed');
+    });
+
+    await expect(withAdvisoryLock(pool, 'my-lock', fn)).rejects.toThrow('work failed');
+
+    // fn's failure is unrelated to the lock connection's own protocol state —
+    // the unlock still runs and the connection is released alive.
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeUndefined();
+  });
+});

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -1,0 +1,104 @@
+/**
+ * Generic Postgres session-level advisory try-lock: acquire on a dedicated
+ * connection, run `fn`, always release. A caller that cannot acquire the lock
+ * (another process/container already holds it) gets a clean `'lock_busy'`
+ * result and `fn` never runs — the standard shape for serializing a
+ * background job across every caller (multiple containers, manual/API
+ * triggers), not just one process's own scheduled ticks.
+ *
+ * Extracted from the pattern independently duplicated in
+ * apps/processor/src/workers/audit-chainer-worker.ts and
+ * apps/processor/src/workers/siem-delivery-worker.ts (both raw-pg, both
+ * session-level try-lock/finally-unlock) — those two are left as-is (they
+ * predate this helper and run in the processor's separate trust-plane pool;
+ * changing them is out of scope here), but any NEW lib/web-level consumer
+ * should reach for this instead of re-deriving the pattern a fourth time.
+ *
+ * Hardened beyond the two existing copies: if the try-lock QUERY ITSELF
+ * throws (not just resolves with `acquired: false` — e.g. a connection reset
+ * mid-query), the connection is DESTROYED on release instead of returned to
+ * the pool as if healthy, since its protocol state is indeterminate. The
+ * existing copies only destroy-on-failure for the unlock query, not the
+ * try-lock query; this closes that gap without touching them.
+ *
+ * Advisory lock keys share ONE global 64-bit keyspace per Postgres instance
+ * (via `hashtext`, a 32-bit hash) — there is no central registry of lock
+ * keys in this codebase, so a colliding key chosen elsewhere would cause
+ * spurious cross-feature contention. Not solved here (would mean auditing
+ * every existing lock key across the codebase); pick a distinctive,
+ * descriptive `lockKey` string to keep collisions unlikely in practice.
+ */
+
+/**
+ * Minimal subset of pg's Pool/PoolClient API this needs — kept local (not
+ * `import type { Pool, PoolClient } from 'pg'`) so a plain mock object
+ * satisfies it in tests without a real Postgres connection.
+ */
+export interface AdvisoryLockClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  /** pg semantics: release(err) DESTROYS the connection instead of pooling it. */
+  release(destroyWithError?: Error): void;
+}
+
+export interface AdvisoryLockPool {
+  connect(): Promise<AdvisoryLockClient>;
+}
+
+export type WithAdvisoryLockResult<T> = { outcome: 'lock_busy' } | { outcome: 'acquired'; result: T };
+
+export async function withAdvisoryLock<T>(
+  pool: AdvisoryLockPool,
+  lockKey: string,
+  fn: () => Promise<T>,
+): Promise<WithAdvisoryLockResult<T>> {
+  const client = await pool.connect();
+  let lockAcquired = false;
+  // Set only when a query ON THIS CLIENT (try-lock or unlock) itself threw —
+  // NOT when `fn()` throws, since `fn` runs against its own I/O and leaves
+  // this lock connection's protocol state untouched.
+  let clientPoisoned = false;
+
+  try {
+    let lockResult: { rows: Record<string, unknown>[] };
+    try {
+      lockResult = await client.query('SELECT pg_try_advisory_lock(hashtext($1)) AS acquired', [lockKey]);
+    } catch (tryLockError) {
+      clientPoisoned = true;
+      throw tryLockError;
+    }
+    lockAcquired = Boolean(lockResult.rows[0]?.acquired);
+    if (!lockAcquired) {
+      return { outcome: 'lock_busy' };
+    }
+
+    const result = await fn();
+    return { outcome: 'acquired', result };
+  } finally {
+    if (lockAcquired) {
+      try {
+        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey]);
+        client.release();
+      } catch (unlockError) {
+        const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
+        // A session that failed to unlock may still hold the session-level
+        // advisory lock; returned to the pool alive it would leak the lock
+        // permanently (every future try-lock sees lock_busy forever). Destroy
+        // it instead — Postgres releases session advisory locks when the
+        // backend dies. Logged plainly (not via @pagespace/lib's logger —
+        // packages/db must not depend on packages/lib) so a recurring failure
+        // is operator-visible before the dedicated pool is starved.
+        console.error(
+          `[withAdvisoryLock:${lockKey}] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool:`,
+          err.message,
+        );
+        client.release(err);
+      }
+    } else {
+      client.release(
+        clientPoisoned
+          ? new Error(`withAdvisoryLock(${lockKey}): try-lock query failed, connection left in an indeterminate state`)
+          : undefined,
+      );
+    }
+  }
+}

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -23,3 +23,28 @@ registerPool(pool);
 
 export { getPoolStats };
 export const db = drizzle(pool, { schema });
+
+/**
+ * Dedicated small pool for out-of-band Postgres advisory locks (e.g. the
+ * machine-storage reconcile serialization lock) — deliberately SEPARATE from
+ * `pool` above. A caller that holds a session-level advisory lock connection
+ * for an extended duration (the whole span of a background job, not a single
+ * query) must never pin a connection from the SAME pool Drizzle's `db` draws
+ * from: in a tightly configured deployment (DB_POOL_MAX=1) that would starve
+ * every other `db` query for the lock's entire hold time — a self-inflicted
+ * deadlock, independent of how `DB_POOL_MAX` happens to be set. This pool
+ * only ever holds locks; it never runs application queries, so a small max
+ * comfortably covers one lock holder plus a few contenders' non-blocking
+ * try-lock probes (each releases immediately on a busy result).
+ */
+export const advisoryLockPool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
+  max: 3,
+  keepAlive: true,
+  keepAliveInitialDelayMillis: 10000,
+  idleTimeoutMillis: 600000,
+  connectionTimeoutMillis: 10000,
+});
+advisoryLockPool.on('error', (_err, _client) => {});
+registerPool(advisoryLockPool, 'advisory-lock');

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -4,16 +4,25 @@ import { schema } from './schema';
 import { registerPool, getPoolStats } from './pool-stats';
 import 'dotenv/config';
 
+// Shared connection tuning for every pool this module creates — a fresh
+// `connectionString`/`max` get spread in per-pool, everything else (ssl,
+// keepalive, timeouts) stays identical so the pools can't silently drift.
+function basePoolConfig() {
+  return {
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.DATABASE_SSL === 'true' ? ({ rejectUnauthorized: false } as const) : false,
+    keepAlive: true,
+    keepAliveInitialDelayMillis: 10000,
+    idleTimeoutMillis: 600000,
+    connectionTimeoutMillis: 10000,
+  };
+}
+
 // Exported for the adminDb break-glass path (admin-db.ts), which binds an
 // admin-schema client over this same pool — no second connection pool.
 export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
+  ...basePoolConfig(),
   max: process.env.DB_POOL_MAX ? parseInt(process.env.DB_POOL_MAX, 10) : 10,
-  keepAlive: true,
-  keepAliveInitialDelayMillis: 10000,
-  idleTimeoutMillis: 600000,
-  connectionTimeoutMillis: 10000,
 });
 
 // Prevent uncaughtException spam when Fly's network drops idle connections
@@ -25,26 +34,35 @@ export { getPoolStats };
 export const db = drizzle(pool, { schema });
 
 /**
- * Dedicated small pool for out-of-band Postgres advisory locks (e.g. the
- * machine-storage reconcile serialization lock) — deliberately SEPARATE from
- * `pool` above. A caller that holds a session-level advisory lock connection
- * for an extended duration (the whole span of a background job, not a single
- * query) must never pin a connection from the SAME pool Drizzle's `db` draws
- * from: in a tightly configured deployment (DB_POOL_MAX=1) that would starve
- * every other `db` query for the lock's entire hold time — a self-inflicted
- * deadlock, independent of how `DB_POOL_MAX` happens to be set. This pool
- * only ever holds locks; it never runs application queries, so a small max
- * comfortably covers one lock holder plus a few contenders' non-blocking
- * try-lock probes (each releases immediately on a busy result).
+ * Dedicated pool for out-of-band Postgres advisory locks (e.g. the
+ * machine-storage reconcile serialization lock, via `@pagespace/db/advisory-lock`)
+ * — deliberately SEPARATE from `pool` above. A caller that holds a
+ * session-level advisory lock connection for an extended duration (the whole
+ * span of a background job, not a single query) must never pin a connection
+ * from the SAME pool Drizzle's `db` draws from: in a tightly configured
+ * deployment (DB_POOL_MAX=1) that would starve every other `db` query for
+ * the lock's entire hold time — a self-inflicted deadlock, independent of
+ * how `DB_POOL_MAX` happens to be set. This pool only ever holds locks; it
+ * never runs application queries, so `max` need only cover one lock holder
+ * plus a handful of contenders' non-blocking try-lock probes (each releases
+ * immediately on a busy result) — matching the main pool's default headroom
+ * keeps a burst of concurrent callers (multiple containers, a manual
+ * trigger racing the cron) from queuing on `connect()` and timing out
+ * instead of getting a fast, clean `lock_busy`.
+ *
+ * Lazily constructed (mirrors apps/processor/src/db.ts's
+ * `getAdminPoolForWorker()`): `packages/db/db` is imported by every app in
+ * the monorepo, but only advisory-lock consumers ever call this — eagerly
+ * constructing a second `pg.Pool` at module load would pay connection setup
+ * for every process that never uses it.
  */
-export const advisoryLockPool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
-  max: 3,
-  keepAlive: true,
-  keepAliveInitialDelayMillis: 10000,
-  idleTimeoutMillis: 600000,
-  connectionTimeoutMillis: 10000,
-});
-advisoryLockPool.on('error', (_err, _client) => {});
-registerPool(advisoryLockPool, 'advisory-lock');
+let advisoryLockPool: Pool | null = null;
+
+export function getAdvisoryLockPool(): Pool {
+  if (!advisoryLockPool) {
+    advisoryLockPool = new Pool({ ...basePoolConfig(), max: 10 });
+    advisoryLockPool.on('error', (_err, _client) => {});
+    registerPool(advisoryLockPool, 'advisory-lock');
+  }
+  return advisoryLockPool;
+}

--- a/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
@@ -4,7 +4,8 @@ import { assert } from './riteway';
 const mockDb = vi.hoisted(() => ({ select: vi.fn(), update: vi.fn() }));
 const mockAdvisoryLockClient = vi.hoisted(() => ({ query: vi.fn(), release: vi.fn() }));
 const mockAdvisoryLockPool = vi.hoisted(() => ({ connect: vi.fn(async () => mockAdvisoryLockClient) }));
-vi.mock('@pagespace/db/db', () => ({ db: mockDb, advisoryLockPool: mockAdvisoryLockPool }));
+const mockGetAdvisoryLockPool = vi.hoisted(() => vi.fn(() => mockAdvisoryLockPool));
+vi.mock('@pagespace/db/db', () => ({ db: mockDb, getAdvisoryLockPool: mockGetAdvisoryLockPool }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn((a, b) => ({ op: 'eq', a, b })) }));
 vi.mock('@pagespace/db/schema/machine-sessions', () => ({
   machineSessions: {
@@ -40,6 +41,7 @@ beforeEach(() => {
   mockAdvisoryLockPool.connect.mockClear();
   mockAdvisoryLockClient.query.mockReset();
   mockAdvisoryLockClient.release.mockReset();
+  mockGetAdvisoryLockPool.mockClear();
   // Clear the module-level in-process caches so cases don't bleed state.
   __resetStorageMeasurementCachesForTests();
 });
@@ -469,6 +471,7 @@ describe('reconcileMachineStorageSerialized', () => {
     const result = await reconcileMachineStorageSerialized(deps);
 
     expect(result.outcome).toBe('reconciled');
+    expect(mockGetAdvisoryLockPool).toHaveBeenCalledTimes(1);
     expect(mockAdvisoryLockPool.connect).toHaveBeenCalledTimes(1);
     expect(mockAdvisoryLockClient.release).toHaveBeenCalledTimes(1);
   });
@@ -489,5 +492,22 @@ describe('reconcileMachineStorageSerialized', () => {
     expect(result.outcome).toBe('reconciled');
     expect(client.release).toHaveBeenCalledTimes(1);
     expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('given the try-lock query itself throws (not just acquired:false), should destroy the connection and rethrow', async () => {
+    const client = {
+      query: vi.fn().mockRejectedValueOnce(new Error('connection reset')),
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn(async () => client) };
+    const deps = makeDeps();
+
+    await expect(reconcileMachineStorageSerialized(deps, pool)).rejects.toThrow('connection reset');
+
+    // Never resolved acquired/not-acquired — the connection's protocol state
+    // is indeterminate, so it must be destroyed, not pooled alive.
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(deps.listMachines).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
@@ -25,9 +25,11 @@ import {
   defaultReconcileMachineStorageDeps,
   persistStorageMeasurement,
   measureMachineStorageOpportunistically,
+  reconcileMachineStorageSerialized,
   __resetStorageMeasurementCachesForTests,
 } from '../machine-storage-billing';
 import { MACHINE_MARKUP_BPS } from '../../../billing/credit-pricing';
+import type { ReconcileMachineStorageDeps } from '../machine-storage-reconcile';
 
 beforeEach(() => {
   mockDb.select.mockReset();
@@ -366,5 +368,103 @@ describe('measureMachineStorageOpportunistically', () => {
     await expect(
       measureMachineStorageOpportunistically({ handle: { exec }, pageId: 'throws-page' }),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe('reconcileMachineStorageSerialized', () => {
+  // Simulates real Postgres session-advisory-lock semantics with a single
+  // shared in-memory flag: exactly one connection can hold it at a time, and
+  // pg_advisory_unlock releases it for the next contender.
+  function makeFakeLockPool() {
+    let locked = false;
+    const clients: { query: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> }[] = [];
+    const pool = {
+      connect: vi.fn(async () => {
+        const client = {
+          query: vi.fn(async (text: string, _params?: unknown[]) => {
+            if (text.includes('pg_try_advisory_lock')) {
+              if (locked) return { rows: [{ acquired: false }] };
+              locked = true;
+              return { rows: [{ acquired: true }] };
+            }
+            if (text.includes('pg_advisory_unlock')) {
+              locked = false;
+              return { rows: [] };
+            }
+            return { rows: [] };
+          }),
+          release: vi.fn(),
+        };
+        clients.push(client);
+        return client;
+      }),
+    };
+    return { pool, clients, isLocked: () => locked };
+  }
+
+  function makeDeps(overrides: Partial<ReconcileMachineStorageDeps> = {}): ReconcileMachineStorageDeps {
+    return {
+      listMachines: vi.fn(async () => []),
+      lookupPageOwnerId: vi.fn(async () => null),
+      chargeStorage: vi.fn(async () => {}),
+      advanceWatermark: vi.fn(async () => {}),
+      now: () => new Date('2026-07-13T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  it('given the lock is already held elsewhere, should no-op WITHOUT calling reconcileMachineStorage', async () => {
+    const { pool } = makeFakeLockPool();
+    // Pre-acquire the lock so this run's try-lock sees it busy.
+    await pool.connect().then((c) => c.query('SELECT pg_try_advisory_lock(hashtext($1)) AS acquired', ['x']));
+    const deps = makeDeps();
+
+    const result = await reconcileMachineStorageSerialized(deps, pool);
+
+    expect(result).toEqual({ outcome: 'lock_busy' });
+    expect(deps.listMachines).not.toHaveBeenCalled();
+  });
+
+  it('given two concurrent reconcile calls, should let only one proceed while the other no-ops, and release the lock after', async () => {
+    const { pool, isLocked } = makeFakeLockPool();
+    const deps = makeDeps();
+
+    const [first, second] = await Promise.all([
+      reconcileMachineStorageSerialized(deps, pool),
+      reconcileMachineStorageSerialized(deps, pool),
+    ]);
+
+    const outcomes = [first.outcome, second.outcome].sort();
+    assert({
+      given: 'two concurrent calls racing the same advisory lock',
+      should: 'resolve exactly one reconciled and one lock_busy',
+      actual: outcomes,
+      expected: ['lock_busy', 'reconciled'],
+    });
+    expect(deps.listMachines).toHaveBeenCalledTimes(1);
+
+    // Released after the winning run: lock is free and a later run can acquire it.
+    expect(isLocked()).toBe(false);
+    const third = await reconcileMachineStorageSerialized(deps, pool);
+    expect(third.outcome).toBe('reconciled');
+    expect(deps.listMachines).toHaveBeenCalledTimes(2);
+  });
+
+  it('given the unlock query itself fails, should destroy the connection instead of releasing it alive', async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] }) // try-lock
+        .mockRejectedValueOnce(new Error('unlock failed')), // unlock
+      release: vi.fn(),
+    };
+    const pool = { connect: vi.fn(async () => client) };
+    const deps = makeDeps();
+
+    const result = await reconcileMachineStorageSerialized(deps, pool);
+
+    expect(result.outcome).toBe('reconciled');
+    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-storage-billing.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
 
 const mockDb = vi.hoisted(() => ({ select: vi.fn(), update: vi.fn() }));
-vi.mock('@pagespace/db/db', () => ({ db: mockDb }));
+const mockAdvisoryLockClient = vi.hoisted(() => ({ query: vi.fn(), release: vi.fn() }));
+const mockAdvisoryLockPool = vi.hoisted(() => ({ connect: vi.fn(async () => mockAdvisoryLockClient) }));
+vi.mock('@pagespace/db/db', () => ({ db: mockDb, advisoryLockPool: mockAdvisoryLockPool }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn((a, b) => ({ op: 'eq', a, b })) }));
 vi.mock('@pagespace/db/schema/machine-sessions', () => ({
   machineSessions: {
@@ -35,6 +37,9 @@ beforeEach(() => {
   mockDb.select.mockReset();
   mockDb.update.mockReset();
   mockTrackUsage.mockReset();
+  mockAdvisoryLockPool.connect.mockClear();
+  mockAdvisoryLockClient.query.mockReset();
+  mockAdvisoryLockClient.release.mockReset();
   // Clear the module-level in-process caches so cases don't bleed state.
   __resetStorageMeasurementCachesForTests();
 });
@@ -448,6 +453,24 @@ describe('reconcileMachineStorageSerialized', () => {
     const third = await reconcileMachineStorageSerialized(deps, pool);
     expect(third.outcome).toBe('reconciled');
     expect(deps.listMachines).toHaveBeenCalledTimes(2);
+  });
+
+  it('given no explicit pool override, should acquire the lock from the dedicated advisoryLockPool (NOT the shared db pool)', async () => {
+    // Regression test for the pool-exhaustion deadlock a reviewer flagged: at
+    // DB_POOL_MAX=1, pinning the lock connection from the SAME pool Drizzle's
+    // `db` draws from would starve `listMachines`'s own query forever, since
+    // nothing can free the one connection while the lock holds it. The lock
+    // must come from `advisoryLockPool` — a pool dedicated to holding locks,
+    // never application queries — so the two can never contend.
+    mockAdvisoryLockClient.query.mockResolvedValueOnce({ rows: [{ acquired: true }] }); // try-lock
+    mockAdvisoryLockClient.query.mockResolvedValueOnce({ rows: [] }); // unlock
+    const deps = makeDeps();
+
+    const result = await reconcileMachineStorageSerialized(deps);
+
+    expect(result.outcome).toBe('reconciled');
+    expect(mockAdvisoryLockPool.connect).toHaveBeenCalledTimes(1);
+    expect(mockAdvisoryLockClient.release).toHaveBeenCalledTimes(1);
   });
 
   it('given the unlock query itself fails, should destroy the connection instead of releasing it alive', async () => {

--- a/packages/lib/src/services/sandbox/machine-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-storage-billing.ts
@@ -10,7 +10,7 @@
  */
 
 import { eq } from '@pagespace/db/operators';
-import { db } from '@pagespace/db/db';
+import { db, pool } from '@pagespace/db/db';
 import { machineSessions } from '@pagespace/db/schema/machine-sessions';
 import { lookupPageOwnerId } from '../../billing/machine-payer';
 import { MACHINE_MARKUP_BPS } from '../../billing/credit-pricing';
@@ -23,7 +23,11 @@ import {
   STORAGE_MEASUREMENT_THROTTLE_MS,
   type PersistStorageMeasurement,
 } from './machine-storage-measure';
-import type { ReconcileMachineStorageDeps } from './machine-storage-reconcile';
+import {
+  reconcileMachineStorage,
+  type ReconcileMachineStorageDeps,
+  type ReconcileMachineStorageResult,
+} from './machine-storage-reconcile';
 
 export const defaultReconcileMachineStorageDeps: ReconcileMachineStorageDeps = {
   async listMachines() {
@@ -75,6 +79,81 @@ export const defaultReconcileMachineStorageDeps: ReconcileMachineStorageDeps = {
 
   now: () => new Date(),
 };
+
+/**
+ * Advisory-lock key for serializing `reconcileMachineStorage` across EVERY
+ * caller — a second web/worker container, or a manual/API trigger, can run
+ * the cron route concurrently with no shared state to stop it. The crontab
+ * flock (Sprites Platform Alignment, #2032) only guards one container's own
+ * scheduled ticks; it does nothing for a second container or an out-of-band
+ * invocation. `chargeStorage` and `advanceWatermark` are two separate
+ * un-transactioned writes (see machine-storage-reconcile.ts's module doc), so
+ * two overlapping runs can double-bill the same watermark window. This lock
+ * makes every caller overlap-safe, in addition to (not instead of) the flock.
+ */
+const RECONCILE_MACHINE_STORAGE_LOCK_KEY = 'reconcile-machine-storage';
+
+/**
+ * Minimal subset of pg's Pool/PoolClient API the lock needs — kept local
+ * (mirrors audit-chainer-worker.ts's PgClient/PgPool) so it's mockable in
+ * tests without a real Postgres connection.
+ */
+interface AdvisoryLockClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  /** pg semantics: release(err) DESTROYS the connection instead of pooling it. */
+  release(destroyWithError?: Error): void;
+}
+interface AdvisoryLockPool {
+  connect(): Promise<AdvisoryLockClient>;
+}
+
+export type ReconcileMachineStorageRunResult =
+  | { outcome: 'lock_busy' }
+  | ({ outcome: 'reconciled' } & ReconcileMachineStorageResult);
+
+/**
+ * Serializes `reconcileMachineStorage` with a Postgres session-level advisory
+ * try-lock, acquired on a dedicated connection: a run that cannot acquire it
+ * (another run — any process, any container — already holds it) is a clean
+ * no-op and never touches `deps.listMachines`/`chargeStorage`/`advanceWatermark`.
+ * The lock is always released in the `finally` when acquired; if the unlock
+ * query itself fails, the connection is DESTROYED rather than returned to the
+ * pool alive, so a poisoned session cannot leak the session-level lock forever
+ * (same rationale as audit-chainer-worker.ts).
+ */
+export async function reconcileMachineStorageSerialized(
+  deps: ReconcileMachineStorageDeps,
+  pgPool: AdvisoryLockPool = pool,
+): Promise<ReconcileMachineStorageRunResult> {
+  const client = await pgPool.connect();
+  let lockAcquired = false;
+
+  try {
+    const lockResult = await client.query(
+      'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
+      [RECONCILE_MACHINE_STORAGE_LOCK_KEY],
+    );
+    lockAcquired = Boolean(lockResult.rows[0]?.acquired);
+    if (!lockAcquired) {
+      return { outcome: 'lock_busy' };
+    }
+
+    const result = await reconcileMachineStorage(deps);
+    return { outcome: 'reconciled', ...result };
+  } finally {
+    if (lockAcquired) {
+      try {
+        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [RECONCILE_MACHINE_STORAGE_LOCK_KEY]);
+        client.release();
+      } catch (unlockError) {
+        const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
+        client.release(err);
+      }
+    } else {
+      client.release();
+    }
+  }
+}
 
 /**
  * Persist an opportunistic storage measurement onto the machine's

--- a/packages/lib/src/services/sandbox/machine-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-storage-billing.ts
@@ -10,7 +10,8 @@
  */
 
 import { eq } from '@pagespace/db/operators';
-import { db, advisoryLockPool } from '@pagespace/db/db';
+import { db, getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
 import { machineSessions } from '@pagespace/db/schema/machine-sessions';
 import { lookupPageOwnerId } from '../../billing/machine-payer';
 import { MACHINE_MARKUP_BPS } from '../../billing/credit-pricing';
@@ -90,31 +91,11 @@ export const defaultReconcileMachineStorageDeps: ReconcileMachineStorageDeps = {
  * un-transactioned writes (see machine-storage-reconcile.ts's module doc), so
  * two overlapping runs can double-bill the same watermark window. This lock
  * makes every caller overlap-safe, in addition to (not instead of) the flock.
- *
- * Acquired on `@pagespace/db/db`'s dedicated `advisoryLockPool`, NOT the main
- * `pool` `db` itself draws from: `deps` below (listMachines/advanceWatermark)
- * issues its OWN Drizzle queries against the main pool WHILE this lock is
- * held for the whole reconcile run, so pinning the lock's connection from
- * that same pool would deadlock any deployment where `DB_POOL_MAX` doesn't
- * leave a spare connection for those queries (DB_POOL_MAX=1 is the sharpest
- * case: the only connection would be stuck holding the lock while
- * `listMachines`'s first `db.select()` waits forever for one to free up).
+ * Acquired via `withAdvisoryLock` on `getAdvisoryLockPool()`'s dedicated
+ * pool — see that pool's doc in `@pagespace/db/db` for why it must stay
+ * separate from the main `db` pool `deps` below queries against.
  */
 const RECONCILE_MACHINE_STORAGE_LOCK_KEY = 'reconcile-machine-storage';
-
-/**
- * Minimal subset of pg's Pool/PoolClient API the lock needs — kept local
- * (mirrors audit-chainer-worker.ts's PgClient/PgPool) so it's mockable in
- * tests without a real Postgres connection.
- */
-interface AdvisoryLockClient {
-  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
-  /** pg semantics: release(err) DESTROYS the connection instead of pooling it. */
-  release(destroyWithError?: Error): void;
-}
-interface AdvisoryLockPool {
-  connect(): Promise<AdvisoryLockClient>;
-}
 
 export type ReconcileMachineStorageRunResult =
   | { outcome: 'lock_busy' }
@@ -122,46 +103,21 @@ export type ReconcileMachineStorageRunResult =
 
 /**
  * Serializes `reconcileMachineStorage` with a Postgres session-level advisory
- * try-lock, acquired on a dedicated connection: a run that cannot acquire it
- * (another run — any process, any container — already holds it) is a clean
- * no-op and never touches `deps.listMachines`/`chargeStorage`/`advanceWatermark`.
- * The lock is always released in the `finally` when acquired; if the unlock
- * query itself fails, the connection is DESTROYED rather than returned to the
- * pool alive, so a poisoned session cannot leak the session-level lock forever
- * (same rationale as audit-chainer-worker.ts).
+ * try-lock (see `withAdvisoryLock`): a run that cannot acquire it (another
+ * run — any process, any container — already holds it) is a clean no-op and
+ * never touches `deps.listMachines`/`chargeStorage`/`advanceWatermark`.
  */
 export async function reconcileMachineStorageSerialized(
   deps: ReconcileMachineStorageDeps,
-  pgPool: AdvisoryLockPool = advisoryLockPool,
+  pgPool: AdvisoryLockPool = getAdvisoryLockPool(),
 ): Promise<ReconcileMachineStorageRunResult> {
-  const client = await pgPool.connect();
-  let lockAcquired = false;
-
-  try {
-    const lockResult = await client.query(
-      'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
-      [RECONCILE_MACHINE_STORAGE_LOCK_KEY],
-    );
-    lockAcquired = Boolean(lockResult.rows[0]?.acquired);
-    if (!lockAcquired) {
-      return { outcome: 'lock_busy' };
-    }
-
-    const result = await reconcileMachineStorage(deps);
-    return { outcome: 'reconciled', ...result };
-  } finally {
-    if (lockAcquired) {
-      try {
-        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [RECONCILE_MACHINE_STORAGE_LOCK_KEY]);
-        client.release();
-      } catch (unlockError) {
-        const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
-        client.release(err);
-      }
-    } else {
-      client.release();
-    }
+  const locked = await withAdvisoryLock(pgPool, RECONCILE_MACHINE_STORAGE_LOCK_KEY, () =>
+    reconcileMachineStorage(deps),
+  );
+  if (locked.outcome === 'lock_busy') {
+    return { outcome: 'lock_busy' };
   }
+  return { outcome: 'reconciled', ...locked.result };
 }
 
 /**

--- a/packages/lib/src/services/sandbox/machine-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-storage-billing.ts
@@ -10,7 +10,7 @@
  */
 
 import { eq } from '@pagespace/db/operators';
-import { db, pool } from '@pagespace/db/db';
+import { db, advisoryLockPool } from '@pagespace/db/db';
 import { machineSessions } from '@pagespace/db/schema/machine-sessions';
 import { lookupPageOwnerId } from '../../billing/machine-payer';
 import { MACHINE_MARKUP_BPS } from '../../billing/credit-pricing';
@@ -90,6 +90,15 @@ export const defaultReconcileMachineStorageDeps: ReconcileMachineStorageDeps = {
  * un-transactioned writes (see machine-storage-reconcile.ts's module doc), so
  * two overlapping runs can double-bill the same watermark window. This lock
  * makes every caller overlap-safe, in addition to (not instead of) the flock.
+ *
+ * Acquired on `@pagespace/db/db`'s dedicated `advisoryLockPool`, NOT the main
+ * `pool` `db` itself draws from: `deps` below (listMachines/advanceWatermark)
+ * issues its OWN Drizzle queries against the main pool WHILE this lock is
+ * held for the whole reconcile run, so pinning the lock's connection from
+ * that same pool would deadlock any deployment where `DB_POOL_MAX` doesn't
+ * leave a spare connection for those queries (DB_POOL_MAX=1 is the sharpest
+ * case: the only connection would be stuck holding the lock while
+ * `listMachines`'s first `db.select()` waits forever for one to free up).
  */
 const RECONCILE_MACHINE_STORAGE_LOCK_KEY = 'reconcile-machine-storage';
 
@@ -123,7 +132,7 @@ export type ReconcileMachineStorageRunResult =
  */
 export async function reconcileMachineStorageSerialized(
   deps: ReconcileMachineStorageDeps,
-  pgPool: AdvisoryLockPool = pool,
+  pgPool: AdvisoryLockPool = advisoryLockPool,
 ): Promise<ReconcileMachineStorageRunResult> {
   const client = await pgPool.connect();
   let lockAcquired = false;


### PR DESCRIPTION
## Summary
- PR #2032 scheduled the `reconcile-machine-storage` cron with a crontab flock, but flock only guards **one container's own** ticks — a second web/worker container (or a manual/API trigger) could still run `reconcileMachineStorage` concurrently and double-bill/race storage reconciliation (charge + watermark-advance are two un-transactioned writes).
- Adds `reconcileMachineStorageSerialized` in `packages/lib/src/services/sandbox/machine-storage-billing.ts`: serializes the pure `reconcileMachineStorage` core with a Postgres session-level advisory try-lock (skip cleanly if busy, always release, destroy the connection if the unlock/try-lock query itself fails).
- The cron route (`apps/web/src/app/api/cron/reconcile-machine-storage/route.ts`) now calls the serialized wrapper and returns `{ success: true, outcome: 'lock_busy' }` when another run holds the lock.
- The crontab flock stays in place as defense in depth (not replaced).
- `reconcileMachineStorage` itself is untouched — it stays a pure, deps-injected function; the lock lives purely at the service-composition layer.
- **Review fix (Codex):** the lock connection was originally drawn from the same `@pagespace/db/db` pool Drizzle's `db` uses — at `DB_POOL_MAX=1` that could deadlock the cron. Fixed with a dedicated pool that only ever holds locks, never application queries.
- **Proactive self-review (multi-angle diff review) — follow-on hardening beyond the Codex fix:**
  - Extracted `withAdvisoryLock<T>()` into `packages/db/src/advisory-lock.ts`: a generic, directly-unit-tested primitive, replacing the inline try-lock/finally logic that had duplicated `audit-chainer-worker.ts`'s pattern near-verbatim. Hardened beyond the existing copies — if the try-lock QUERY ITSELF throws (not just resolves `acquired:false`), the connection is now destroyed on release instead of returned to the pool as if healthy; unlock failures are now logged.
  - `getAdvisoryLockPool()` in `packages/db/src/db.ts`: the dedicated pool is now **lazily** constructed (mirrors `apps/processor/src/db.ts`'s `getAdminPoolForWorker()`), so only advisory-lock consumers pay for it instead of every one of the ~430 files that import `@pagespace/db/db`. Pool config is shared via a base-config factory. `max` raised 3 → 10 (matching the main pool's default) so a burst of legitimate concurrent callers gets a fast, clean `lock_busy` instead of queuing on `connect()` and timing out.
  - Considered and rejected: an `audit()` call on `lock_busy` (no semantic fit in the `SecurityEventType` enum, and the pattern this mirrors also skips audit on its own busy path); zeroed counters in the `lock_busy` HTTP response (would misrepresent "didn't run" as "ran with 0 results" — no consumer needs it today).

## Test plan
- [x] `packages/db/src/advisory-lock.test.ts` (new): acquired/busy/unlock-failure/try-lock-failure/fn-failure — 5 cases directly against `withAdvisoryLock`.
- [x] `machine-storage-billing.test.ts`: lock already held → no-op; two concurrent calls → exactly one `reconciled` + one `lock_busy`, lock released after; unlock-query failure → connection destroyed; try-lock-query-throws → connection destroyed + rethrows; default parameter resolves to the dedicated pool (not the shared `db` pool).
- [x] Cron route tests: reconciled path unchanged, `lock_busy` path (no audit call, `success: true`).
- [x] `bun run typecheck` green across the monorepo.
- [x] `bun run test` green for all touched test files (`packages/db`, `packages/lib`, `apps/web`).
- [x] `bun run lint` clean on `packages/db` and `packages/lib`.
- [x] All CI checks green: Lint & TypeScript, Unit Tests, Security Test Suite, CodeQL, Secret Scanning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFyQasCYPewwMSLVzDR5zv