### PR TITLE
fix(machine): remove unsupported pagespace-cli agent option, verify codex

### DIFF
--- a/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
@@ -83,18 +83,7 @@ describe('GET /api/machines/agent-terminals', () => {
     );
   });
 
-  it('given a known agentType, marks the terminal launchable', async () => {
-    mockCanViewMachine.mockResolvedValue(true);
-    mockListAgentTerminals.mockResolvedValue({
-      ok: true,
-      terminals: [{ name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
-    });
-    const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
-    const body = await res.json();
-    expect(body.agentTerminals[0]).toMatchObject({ name: 'cli', agentType: 'claude', launchable: true });
-  });
-
-  it('given a legacy row whose agentType is the retired pagespace-cli, still lists it but marks it NOT launchable', async () => {
+  it('given a legacy row whose agentType is the retired pagespace-cli, still lists it as-is — launchability is the client\'s call via isAgentRuntimeType, not this route\'s', async () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
@@ -102,7 +91,7 @@ describe('GET /api/machines/agent-terminals', () => {
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     const body = await res.json();
-    expect(body.agentTerminals[0]).toMatchObject({ name: 'legacy-cli', agentType: 'pagespace-cli', launchable: false });
+    expect(body.agentTerminals[0]).toEqual({ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-07-01T00:00:00.000Z' });
   });
 
   it('given no view access, returns 403 without listing', async () => {

--- a/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
@@ -71,7 +71,7 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ name: 'cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
+      terminals: [{ name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     expect(res.status).toBe(200);
@@ -81,6 +81,28 @@ describe('GET /api/machines/agent-terminals', () => {
     expect(mockListAgentTerminals).toHaveBeenCalledWith(
       expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main' }),
     );
+  });
+
+  it('given a known agentType, marks the terminal launchable', async () => {
+    mockCanViewMachine.mockResolvedValue(true);
+    mockListAgentTerminals.mockResolvedValue({
+      ok: true,
+      terminals: [{ name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
+    });
+    const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
+    const body = await res.json();
+    expect(body.agentTerminals[0]).toMatchObject({ name: 'cli', agentType: 'claude', launchable: true });
+  });
+
+  it('given a legacy row whose agentType is the retired pagespace-cli, still lists it but marks it NOT launchable', async () => {
+    mockCanViewMachine.mockResolvedValue(true);
+    mockListAgentTerminals.mockResolvedValue({
+      ok: true,
+      terminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
+    });
+    const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
+    const body = await res.json();
+    expect(body.agentTerminals[0]).toMatchObject({ name: 'legacy-cli', agentType: 'pagespace-cli', launchable: false });
   });
 
   it('given no view access, returns 403 without listing', async () => {
@@ -133,7 +155,7 @@ describe('POST /api/machines/agent-terminals', () => {
       headers: { 'content-type': 'application/json' },
     });
   }
-  const VALID_BODY = { machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'pagespace-cli' };
+  const VALID_BODY = { machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' };
 
   it('given no edit access, returns 403 without spawning', async () => {
     mockCanAccessMachine.mockResolvedValue(false);
@@ -142,30 +164,30 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
 
-  it('given a fresh spawn of a pagespace-cli terminal, returns 201', async () => {
+  it('given a fresh spawn of a claude terminal, returns 201', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'pagespace-cli', resumed: false });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ name: 'cli', agentType: 'pagespace-cli', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ name: 'cli', agentType: 'claude', resumed: false });
     expect(mockSpawnAgentTerminal).toHaveBeenCalledWith(
-      expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'pagespace-cli' }),
+      expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' }),
     );
   });
 
-  it('given a fresh spawn of a claude terminal, returns 201', async () => {
+  it('given a fresh spawn of a codex terminal, returns 201', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-2', agentType: 'claude', resumed: false });
-    const res = await POST(req({ ...VALID_BODY, name: 'reviewer', agentType: 'claude' }));
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-2', agentType: 'codex', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, name: 'reviewer', agentType: 'codex' }));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ name: 'reviewer', agentType: 'claude', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ name: 'reviewer', agentType: 'codex', resumed: false });
   });
 
   it('given a resumed spawn, returns 200', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'pagespace-cli', resumed: true });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: true });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(200);
   });

--- a/apps/web/src/app/api/machines/agent-terminals/route.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/route.ts
@@ -20,7 +20,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { spawnAgentTerminal, killAgentTerminal, listAgentTerminals } from '@pagespace/lib/services/machines/agent-terminals';
-import { isAgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   buildSpawnAgentTerminalDeps,
   buildKillAgentTerminalDeps,
@@ -97,15 +96,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: result.reason }, { status: SCOPE_DENIAL_STATUS[result.reason] ?? 500 });
   }
   return NextResponse.json({
-    // `launchable` is false for a row whose agentType predates a since-retired
-    // AGENT_LAUNCH_SPECS entry (e.g. the removed 'pagespace-cli') — still listed
-    // (so it stays discoverable/removable), but the UI must not try to open it.
-    agentTerminals: result.terminals.map((t) => ({
-      name: t.name,
-      agentType: t.agentType,
-      createdAt: t.createdAt,
-      launchable: isAgentRuntimeType(t.agentType),
-    })),
+    agentTerminals: result.terminals.map((t) => ({ name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
   });
 }
 

--- a/apps/web/src/app/api/machines/agent-terminals/route.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/route.ts
@@ -20,6 +20,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { spawnAgentTerminal, killAgentTerminal, listAgentTerminals } from '@pagespace/lib/services/machines/agent-terminals';
+import { isAgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   buildSpawnAgentTerminalDeps,
   buildKillAgentTerminalDeps,
@@ -96,7 +97,15 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: result.reason }, { status: SCOPE_DENIAL_STATUS[result.reason] ?? 500 });
   }
   return NextResponse.json({
-    agentTerminals: result.terminals.map((t) => ({ name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
+    // `launchable` is false for a row whose agentType predates a since-retired
+    // AGENT_LAUNCH_SPECS entry (e.g. the removed 'pagespace-cli') — still listed
+    // (so it stays discoverable/removable), but the UI must not try to open it.
+    agentTerminals: result.terminals.map((t) => ({
+      name: t.name,
+      agentType: t.agentType,
+      createdAt: t.createdAt,
+      launchable: isAgentRuntimeType(t.agentType),
+    })),
   });
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -8,6 +8,14 @@ import type { OpenTerminalScope, WorkspaceState } from '@/stores/machine-workspa
 const mockUseMobile = vi.fn<() => boolean>();
 vi.mock('@/hooks/useMobile', () => ({ useMobile: () => mockUseMobile() }));
 
+// jsdom has neither the pointer-capture APIs nor scrollIntoView Radix's Select
+// uses when opening — without these stubs, clicking the agent-type trigger
+// throws instead of rendering its options.
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+Element.prototype.scrollIntoView ??= () => {};
+
 // The pane's terminal is an xterm/socket subtree — stub it so what's under test
 // is the LAYOUT the workspace picks, not the stream inside it.
 vi.mock('../XtermTerminal', () => ({
@@ -298,7 +306,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
       },
       expected: {
         spawns: 1,
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         autoNamed: true,
         bind: [
           'm1',
@@ -308,6 +316,20 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
           'fix the build',
         ],
       },
+    });
+  });
+
+  test('the agent picker offers only claude and codex — no retired pagespace-cli, no internal shell sentinel', async () => {
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByLabelText('Agent type'));
+    const options = screen.getAllByRole('option').map((el) => el.textContent);
+
+    assert({
+      given: 'the empty pane\'s agent picker',
+      should: 'list exactly the user-spawnable agent types, excluding the retired pagespace-cli option and the shell sentinel',
+      actual: options,
+      expected: ['claude', 'codex'],
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -306,7 +306,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
       },
       expected: {
         spawns: 1,
-        agentType: 'claude',
+        agentType: 'shell',
         autoNamed: true,
         bind: [
           'm1',
@@ -319,7 +319,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers only claude and codex — no retired pagespace-cli, no internal shell sentinel', async () => {
+  test('the agent picker offers shell (primary), claude, and codex — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -327,9 +327,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list exactly the user-spawnable agent types, excluding the retired pagespace-cli option and the shell sentinel',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude and codex as secondary AI agents — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['claude', 'codex'],
+      expected: ['shell', 'claude', 'codex'],
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -18,7 +18,7 @@ import {
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
-import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
@@ -33,7 +33,12 @@ import { PaneLoading, PaneNotice } from '../tabs/tab-states';
 
 const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
 
-const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
+// User-pickable agent types for the empty-pane picker below — deliberately NOT
+// every AGENT_LAUNCH_SPECS key: `shell` is an internal sentinel (a bare machine
+// shell, not an AI agent a user spawns from this picker; see
+// agent-terminal-types.ts), so it's excluded here even though it's a valid
+// AgentRuntimeType elsewhere.
+const AGENT_TYPES: AgentRuntimeType[] = ['claude', 'codex'];
 
 interface TerminalPanesProps {
   machineId: string;

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -18,7 +18,7 @@ import {
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
-import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { PICKABLE_AGENT_TYPES, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
@@ -33,12 +33,7 @@ import { PaneLoading, PaneNotice } from '../tabs/tab-states';
 
 const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
 
-// User-pickable agent types for the empty-pane picker below — deliberately NOT
-// every AGENT_LAUNCH_SPECS key: `shell` is an internal sentinel (a bare machine
-// shell, not an AI agent a user spawns from this picker; see
-// agent-terminal-types.ts), so it's excluded here even though it's a valid
-// AgentRuntimeType elsewhere.
-const AGENT_TYPES: AgentRuntimeType[] = ['claude', 'codex'];
+const AGENT_TYPES = PICKABLE_AGENT_TYPES;
 
 interface TerminalPanesProps {
   machineId: string;

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   del: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 
+import { toast } from 'sonner';
 import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
@@ -227,7 +228,7 @@ describe('WorkspaceLeaves', () => {
   test('a server-backed session with no local workspace is reachable — clicking adopts it into a real workspace', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
-        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'claude', createdAt: '2026-01-01', launchable: true }] }),
+        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'claude', createdAt: '2026-01-01' }] }),
         { status: 200 },
       ),
     );
@@ -255,14 +256,16 @@ describe('WorkspaceLeaves', () => {
 
   // Codex review (PR #2053): dropping a legacy/unsupported row from the list
   // entirely would make it undiscoverable — DELETE still works by name, but
-  // nothing in the UI would ever offer that name again. Instead it's listed
-  // with `launchable: false`, rendered as remove-only (never adopt), so it
-  // stays cleanable without ever being treated as an openable session.
-  test('a listed session with launchable: false cannot be adopted, only removed', async () => {
+  // nothing in the UI would ever offer that name again. Instead it stays
+  // listed and the client itself derives launchability from `agentType` via
+  // `isAgentRuntimeType` (no server-sent flag), rendering remove-only (never
+  // adopt) so it stays cleanable without ever being treated as an openable
+  // session.
+  test('a listed session whose agentType is not a recognized AgentRuntimeType cannot be adopted, only removed', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
         JSON.stringify({
-          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01', launchable: false }],
+          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01' }],
         }),
         { status: 200 },
       ),
@@ -288,7 +291,7 @@ describe('WorkspaceLeaves', () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
         JSON.stringify({
-          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01', launchable: false }],
+          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01' }],
         }),
         { status: 200 },
       ),
@@ -304,6 +307,35 @@ describe('WorkspaceLeaves', () => {
         should: 'DELETE it by name server-side, exactly like a normal running agent',
         actual: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=legacy-cli')),
         expected: true,
+      });
+    });
+  });
+
+  // Self-review finding (PR #2053): unlike removing a live workspace (routed
+  // through ConfirmRemoveDialog, which reports a thrown error via toast), a
+  // fire-and-forget remove call with nothing observing the rejection would
+  // silently no-op on failure — the row stays, but the user gets no signal why.
+  test('a failed removal of an unlaunchable session is reported via toast, not swallowed silently', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01' }],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.mocked(del).mockRejectedValueOnce(new Error('Failed to remove'));
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove unsupported session legacy-cli/ }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a DELETE that rejects for an unlaunchable session\'s remove button',
+        should: 'surface the failure via toast.error rather than swallowing it',
+        actual: vi.mocked(toast.error).mock.calls.length,
+        expected: 1,
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -227,7 +227,7 @@ describe('WorkspaceLeaves', () => {
   test('a server-backed session with no local workspace is reachable — clicking adopts it into a real workspace', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
-        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'claude', createdAt: '2026-01-01' }] }),
+        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'claude', createdAt: '2026-01-01', launchable: true }] }),
         { status: 200 },
       ),
     );
@@ -249,6 +249,61 @@ describe('WorkspaceLeaves', () => {
           nowRemovable: screen.queryByTitle('Remove workspace orphan-1') !== null,
         },
         expected: { reportedId: expectedWorkspaceId, nowActive: true, nowRemovable: true },
+      });
+    });
+  });
+
+  // Codex review (PR #2053): dropping a legacy/unsupported row from the list
+  // entirely would make it undiscoverable — DELETE still works by name, but
+  // nothing in the UI would ever offer that name again. Instead it's listed
+  // with `launchable: false`, rendered as remove-only (never adopt), so it
+  // stays cleanable without ever being treated as an openable session.
+  test('a listed session with launchable: false cannot be adopted, only removed', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01', launchable: false }],
+        }),
+        { status: 200 },
+      ),
+    );
+    const onSelectWorkspace = vi.fn();
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={onSelectWorkspace} />);
+
+    const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
+    await userEvent.click(screen.getByText('legacy-cli'));
+
+    assert({
+      given: 'a legacy row whose agentType is no longer a recognized AgentRuntimeType',
+      should: 'render it without an adopt affordance (clicking its name does nothing) but WITH a remove button',
+      actual: {
+        adoptedAnything: onSelectWorkspace.mock.calls.length,
+        hasRemoveButton: within(row).queryByRole('button', { name: /Remove unsupported session legacy-cli/ }) !== null,
+      },
+      expected: { adoptedAnything: 0, hasRemoveButton: true },
+    });
+  });
+
+  test('removing an unlaunchable session calls DELETE by name, same as any other agent terminal', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01', launchable: false }],
+        }),
+        { status: 200 },
+      ),
+    );
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove unsupported session legacy-cli/ }));
+
+    await waitFor(() => {
+      assert({
+        given: 'the remove button on an unlaunchable session',
+        should: 'DELETE it by name server-side, exactly like a normal running agent',
+        actual: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=legacy-cli')),
+        expected: true,
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -147,15 +147,33 @@ export default function WorkspaceLeaves({
           key={`unclaimed-${session.name}`}
           className="group flex items-center gap-1 rounded-sm py-0.5 pr-1 leading-none hover:bg-accent/50"
         >
-          <button
-            type="button"
-            onClick={() => adopt(session.name)}
-            title="Running session not yet in this browser's workspace list — click to open it"
-            className="flex flex-1 items-center gap-1 text-left"
-          >
-            <TerminalSquare className="size-3 shrink-0 text-muted-foreground" />
-            <span className="truncate font-normal text-sm leading-none text-muted-foreground">{session.name}</span>
-          </button>
+          {session.launchable ? (
+            <button
+              type="button"
+              onClick={() => adopt(session.name)}
+              title="Running session not yet in this browser's workspace list — click to open it"
+              className="flex flex-1 items-center gap-1 text-left"
+            >
+              <TerminalSquare className="size-3 shrink-0 text-muted-foreground" />
+              <span className="truncate font-normal text-sm leading-none text-muted-foreground">{session.name}</span>
+            </button>
+          ) : (
+            <>
+              {/* A row whose agentType is no longer supported (e.g. the retired
+                  'pagespace-cli') can't be adopted — resolving it server-side would
+                  just come back not_found. Still shown (not dropped from the list),
+                  because removing it is the only way to reclaim its name and stop
+                  billing on any PTY still running under it. */}
+              <span
+                title="This session's agent type is no longer supported — it can't be opened, only removed"
+                className="flex flex-1 cursor-default items-center gap-1 text-left"
+              >
+                <TerminalSquare className="size-3 shrink-0 text-muted-foreground/60" />
+                <span className="truncate font-normal text-sm leading-none text-muted-foreground/60 italic">{session.name}</span>
+              </span>
+              <RemoveButton onClick={() => void removeAgentTerminal(session.name)} label={`Remove unsupported session ${session.name}`} />
+            </>
+          )}
         </div>
       ))}
       <ConfirmRemoveDialog

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -36,6 +36,7 @@
 
 import { useEffect, useState } from 'react';
 import { Plus, TerminalSquare } from 'lucide-react';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   useMachineWorkspaceStore,
@@ -48,6 +49,7 @@ import {
   type MachineNodeScope,
 } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { isAgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import type { MachineTreeNode } from './MachineTree';
 import ConfirmRemoveDialog from './ConfirmRemoveDialog';
 import RemoveButton, { AddButton } from './RemoveButton';
@@ -120,6 +122,18 @@ export default function WorkspaceLeaves({
     onSelectWorkspace(sessionWorkspaceId({ ...scope, name }));
   };
 
+  /** Unlike removing a live workspace (routed through {@link ConfirmRemoveDialog}, which
+   * surfaces a thrown error as a toast), this is a one-click cleanup of an already-dead
+   * row — no confirmation step, but a failed DELETE must still be reported rather than
+   * silently no-op'ing (the row would otherwise look un-removable with no feedback why). */
+  const removeUnlaunchableSession = async (name: string) => {
+    try {
+      await removeAgentTerminal(name);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to remove session');
+    }
+  };
+
   return (
     <div>
       {workspaces.map((workspace) => (
@@ -142,40 +156,48 @@ export default function WorkspaceLeaves({
           <RemoveButton onClick={() => setPendingRemove(workspace.id)} label={`Remove workspace ${workspace.name}`} />
         </div>
       ))}
-      {unclaimedSessions.map((session) => (
-        <div
-          key={`unclaimed-${session.name}`}
-          className="group flex items-center gap-1 rounded-sm py-0.5 pr-1 leading-none hover:bg-accent/50"
-        >
-          {session.launchable ? (
+      {unclaimedSessions.map((session) => {
+        // A row whose agentType predates a since-retired AGENT_LAUNCH_SPECS entry
+        // (e.g. the removed 'pagespace-cli') can't be adopted — resolving it
+        // server-side would just come back not_found. Still shown (not dropped
+        // from the list), because removing it is the only way to reclaim its
+        // name and stop billing on any PTY still running under it.
+        const launchable = isAgentRuntimeType(session.agentType);
+        return (
+          <div
+            key={`unclaimed-${session.name}`}
+            className="group flex items-center gap-1 rounded-sm py-0.5 pr-1 leading-none hover:bg-accent/50"
+          >
             <button
               type="button"
-              onClick={() => adopt(session.name)}
-              title="Running session not yet in this browser's workspace list — click to open it"
-              className="flex flex-1 items-center gap-1 text-left"
+              onClick={launchable ? () => adopt(session.name) : undefined}
+              disabled={!launchable}
+              title={
+                launchable
+                  ? "Running session not yet in this browser's workspace list — click to open it"
+                  : "This session's agent type is no longer supported — it can't be opened, only removed"
+              }
+              className={cn('flex flex-1 items-center gap-1 text-left', !launchable && 'cursor-default')}
             >
-              <TerminalSquare className="size-3 shrink-0 text-muted-foreground" />
-              <span className="truncate font-normal text-sm leading-none text-muted-foreground">{session.name}</span>
-            </button>
-          ) : (
-            <>
-              {/* A row whose agentType is no longer supported (e.g. the retired
-                  'pagespace-cli') can't be adopted — resolving it server-side would
-                  just come back not_found. Still shown (not dropped from the list),
-                  because removing it is the only way to reclaim its name and stop
-                  billing on any PTY still running under it. */}
+              <TerminalSquare className={cn('size-3 shrink-0', launchable ? 'text-muted-foreground' : 'text-muted-foreground/60')} />
               <span
-                title="This session's agent type is no longer supported — it can't be opened, only removed"
-                className="flex flex-1 cursor-default items-center gap-1 text-left"
+                className={cn(
+                  'truncate font-normal text-sm leading-none',
+                  launchable ? 'text-muted-foreground' : 'text-muted-foreground/60 italic',
+                )}
               >
-                <TerminalSquare className="size-3 shrink-0 text-muted-foreground/60" />
-                <span className="truncate font-normal text-sm leading-none text-muted-foreground/60 italic">{session.name}</span>
+                {session.name}
               </span>
-              <RemoveButton onClick={() => void removeAgentTerminal(session.name)} label={`Remove unsupported session ${session.name}`} />
-            </>
-          )}
-        </div>
-      ))}
+            </button>
+            {!launchable && (
+              <RemoveButton
+                onClick={() => void removeUnlaunchableSession(session.name)}
+                label={`Remove unsupported session ${session.name}`}
+              />
+            )}
+          </div>
+        );
+      })}
       <ConfirmRemoveDialog
         open={pendingWorkspace !== undefined}
         onOpenChange={(open) => !open && setPendingRemove(null)}

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -7,8 +7,13 @@ import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-te
 
 export interface AgentTerminal {
   name: string;
-  agentType: AgentRuntimeType;
+  // A raw DB value, not narrowed to AgentRuntimeType — a row can carry an
+  // agentType from a since-retired AGENT_LAUNCH_SPECS entry (e.g. the removed
+  // 'pagespace-cli'). Check `launchable` before treating it as one.
+  agentType: string;
   createdAt: string;
+  /** False for a row whose agentType is no longer a recognized AgentRuntimeType — still listed for cleanup, but the navigator must not try to open it. */
+  launchable: boolean;
 }
 
 const fetcher = (url: string) =>

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -9,11 +9,10 @@ export interface AgentTerminal {
   name: string;
   // A raw DB value, not narrowed to AgentRuntimeType — a row can carry an
   // agentType from a since-retired AGENT_LAUNCH_SPECS entry (e.g. the removed
-  // 'pagespace-cli'). Check `launchable` before treating it as one.
+  // 'pagespace-cli'). Callers check `isAgentRuntimeType(agentType)` before
+  // treating it as a launchable one (see WorkspaceLeaves.tsx).
   agentType: string;
   createdAt: string;
-  /** False for a row whose agentType is no longer a recognized AgentRuntimeType — still listed for cleanup, but the navigator must not try to open it. */
-  launchable: boolean;
 }
 
 const fetcher = (url: string) =>

--- a/packages/db/src/schema/machine-agent-terminals.ts
+++ b/packages/db/src/schema/machine-agent-terminals.ts
@@ -42,9 +42,9 @@ import { machineBranches } from './machine-branches';
  * treats NULL <> NULL).
  *
  * `agentType` selects a pluggable launch spec (binary + args — see
- * `services/machines/agent-terminal-types.ts`; first-party `pagespace-cli`,
- * adapters for `claude`/`codex`, and `shell` — a bare interactive shell is
- * just a machine-scope agent terminal of this type, not a separate concept).
+ * `services/machines/agent-terminal-types.ts`; adapters for `claude`/`codex`,
+ * and `shell` — a bare interactive shell is just a machine-scope agent
+ * terminal of this type, not a separate concept).
  * `command` is an OPTIONAL per-terminal program override — an agent terminal
  * can run an arbitrary command in its PTY instead of `agentType`'s default
  * binary (mirrors PurePoint's `AgentEntry.command`). `streamSessionId` is the

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   AGENT_LAUNCH_SPECS,
+  PICKABLE_AGENT_TYPES,
   isAgentRuntimeType,
   resolveAgentLaunchSpec,
   isValidAgentTerminalName,
@@ -51,6 +52,16 @@ describe('resolveAgentLaunchSpec', () => {
 
   it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
     expect(Object.keys(AGENT_LAUNCH_SPECS)).not.toContain('pagespace-cli');
+  });
+});
+
+describe('PICKABLE_AGENT_TYPES', () => {
+  it('should include every AI-agent AgentRuntimeType a user can pick from the empty-pane picker', () => {
+    expect(PICKABLE_AGENT_TYPES).toEqual(['claude', 'codex']);
+  });
+
+  it('should exclude the shell sentinel — a bare shell is not an AI agent identity to pick', () => {
+    expect(PICKABLE_AGENT_TYPES).not.toContain('shell');
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -9,7 +9,6 @@ import {
 
 describe('isAgentRuntimeType', () => {
   it('given each first-party agent type, should recognize it', () => {
-    expect(isAgentRuntimeType('pagespace-cli')).toBe(true);
     expect(isAgentRuntimeType('claude')).toBe(true);
     expect(isAgentRuntimeType('codex')).toBe(true);
     expect(isAgentRuntimeType('shell')).toBe(true);
@@ -20,13 +19,13 @@ describe('isAgentRuntimeType', () => {
     expect(isAgentRuntimeType('')).toBe(false);
     expect(isAgentRuntimeType('constructor')).toBe(false);
   });
+
+  it('given the retired pagespace-cli agent type, should reject it as unrecognized (not crash)', () => {
+    expect(isAgentRuntimeType('pagespace-cli')).toBe(false);
+  });
 });
 
 describe('resolveAgentLaunchSpec', () => {
-  it('given pagespace-cli, should resolve its command with no args', () => {
-    expect(resolveAgentLaunchSpec('pagespace-cli')).toEqual({ command: 'pagespace-cli', args: [] });
-  });
-
   it('given claude, should resolve the claude binary', () => {
     expect(resolveAgentLaunchSpec('claude')).toEqual({ command: 'claude', args: [] });
   });
@@ -47,7 +46,11 @@ describe('resolveAgentLaunchSpec', () => {
   });
 
   it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['pagespace-cli', 'claude', 'codex', 'shell']);
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['claude', 'codex', 'shell']);
+  });
+
+  it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).not.toContain('pagespace-cli');
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -47,7 +47,7 @@ describe('resolveAgentLaunchSpec', () => {
   });
 
   it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['claude', 'codex', 'shell']);
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex']);
   });
 
   it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
@@ -56,12 +56,12 @@ describe('resolveAgentLaunchSpec', () => {
 });
 
 describe('PICKABLE_AGENT_TYPES', () => {
-  it('should include every AI-agent AgentRuntimeType a user can pick from the empty-pane picker', () => {
-    expect(PICKABLE_AGENT_TYPES).toEqual(['claude', 'codex']);
+  it('should include shell (primary) plus claude and codex (secondary) — only the retired pagespace-cli is excluded', () => {
+    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex']);
   });
 
-  it('should exclude the shell sentinel — a bare shell is not an AI agent identity to pick', () => {
-    expect(PICKABLE_AGENT_TYPES).not.toContain('shell');
+  it('should list shell FIRST — a plain interactive shell is the default, primary way to work on a Machine', () => {
+    expect(PICKABLE_AGENT_TYPES[0]).toBe('shell');
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -807,7 +807,7 @@ describe('listAgentTerminals', () => {
     expect(result).toEqual({ ok: true, terminals: [] });
   });
 
-  it('given a legacy row whose agentType is the retired pagespace-cli, should hide it rather than surface an unlaunchable session', async () => {
+  it('given a legacy row whose agentType is the retired pagespace-cli, should STILL list it — dropping it would strand it with no way to clean it up', async () => {
     const legacyRow: MachineAgentTerminalRecord = {
       id: 'agent-terminal-legacy',
       ownerId: actor.userId,
@@ -829,7 +829,7 @@ describe('listAgentTerminals', () => {
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, deps });
 
     expect(result.ok).toBe(true);
-    expect(result.ok && result.terminals.map((t) => t.name)).toEqual(['cli']);
+    expect(result.ok && result.terminals.map((t) => t.name).sort()).toEqual(['cli', 'legacy-cli']);
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -193,6 +193,13 @@ describe('planSpawnAgentTerminal', () => {
     });
   });
 
+  it('given the retired pagespace-cli agent type, should reject a FRESH spawn as invalid_agent_type', () => {
+    expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'pagespace-cli' })).toEqual({
+      ok: false,
+      reason: 'invalid_agent_type',
+    });
+  });
+
   it('given an empty command override, should reject it', () => {
     expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'shell', command: '   ' })).toEqual({
       ok: false,
@@ -213,7 +220,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -226,14 +233,14 @@ describe('spawnAgentTerminal — branch scope', () => {
       machineId: TERMINAL_ID,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
     expect(result).toEqual({ ok: false, reason: 'invalid_target' });
   });
 
-  it('given a fresh name, should reserve a pagespace-cli agent terminal keyed to the branch with scope="branch"', async () => {
+  it('given a fresh name, should reserve a claude agent terminal keyed to the branch with scope="branch"', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
     const result = await spawnAgentTerminal({
@@ -241,13 +248,13 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
     const row = [...rows.values()][0];
-    expect(row).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, projectName: PROJECT_NAME, agentType: 'pagespace-cli', command: null });
+    expect(row).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, projectName: PROJECT_NAME, agentType: 'claude', command: null });
   });
 
   it('given a command override, should persist it on the row', async () => {
@@ -267,7 +274,7 @@ describe('spawnAgentTerminal — branch scope', () => {
     expect(row.command).toBe('htop');
   });
 
-  it('given a second, differently-named spawn in the SAME branch, should let a claude terminal coexist with the pagespace-cli one', async () => {
+  it('given a second, differently-named spawn in the SAME branch, should let a claude terminal coexist with a codex one', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
 
@@ -276,7 +283,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'codex',
       actor,
       deps,
     });
@@ -292,7 +299,7 @@ describe('spawnAgentTerminal — branch scope', () => {
 
     expect(claudeResult).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
     expect(rows.size).toBe(2);
-    expect([...rows.values()].map((r) => r.agentType).sort()).toEqual(['claude', 'pagespace-cli']);
+    expect([...rows.values()].map((r) => r.agentType).sort()).toEqual(['claude', 'codex']);
   });
 
   it('given a repeat spawn of the same (name, agentType), should resume idempotently rather than duplicate', async () => {
@@ -304,7 +311,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -313,7 +320,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -356,7 +363,7 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -369,7 +376,7 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -383,11 +390,11 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
     const row = [...rows.values()][0];
     expect(row).toMatchObject({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
   });
@@ -400,11 +407,11 @@ describe('spawnAgentTerminal — machine scope', () => {
     const result = await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'pagespace-cli', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
     const row = [...rows.values()][0];
     expect(row).toMatchObject({ scope: 'machine', machineId: TERMINAL_ID, projectName: null, machineBranchId: null });
   });
@@ -429,7 +436,7 @@ describe('spawnAgentTerminal — machine scope', () => {
     const result = await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -446,11 +453,11 @@ describe('resolveAgentTerminalRow', () => {
   it('given a machine-scoped terminal, should resolve the row WITHOUT any machineSandbox', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, machineSandbox: undefined });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'cli', deps });
 
-    expect(result).toEqual({ ok: true, agentTerminalId: expect.any(String), agentType: 'pagespace-cli' });
+    expect(result).toEqual({ ok: true, agentTerminalId: expect.any(String), agentType: 'claude' });
   });
 
   it('given a project-scoped terminal whose project row is GONE, should deny project_not_found without a Sprite', async () => {
@@ -459,6 +466,29 @@ describe('resolveAgentTerminalRow', () => {
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given an EXISTING row whose agentType is the retired pagespace-cli, should deny not_found rather than crash', async () => {
+    const legacyRow: MachineAgentTerminalRecord = {
+      id: 'agent-terminal-legacy',
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'machine',
+      projectName: null,
+      machineBranchId: null,
+      name: 'legacy-cli',
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const { store } = makeStore([legacyRow]);
+    const deps = makeDeps({ store, machineSandbox: undefined });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'legacy-cli', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
   });
 
   it('given a branch-scoped terminal whose branch row is GONE, should deny branch_not_found without a Sprite', async () => {
@@ -523,6 +553,29 @@ describe('resolveAgentTerminal', () => {
     expect(result).toEqual({ ok: false, reason: 'not_found' });
   });
 
+  it('given an EXISTING row whose agentType is the retired pagespace-cli, should deny not_found rather than crash or hand it to resolveAgentLaunchSpec', async () => {
+    const legacyRow: MachineAgentTerminalRecord = {
+      id: 'agent-terminal-legacy',
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'machine',
+      projectName: null,
+      machineBranchId: null,
+      name: 'legacy-cli',
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const { store } = makeStore([legacyRow]);
+    const deps = makeDeps({ store });
+
+    const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'legacy-cli', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
   it('given a branch-scoped agent terminal, should resolve the isolated branch Sprite and its repo cwd', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
@@ -531,7 +584,7 @@ describe('resolveAgentTerminal', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -549,7 +602,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: BRANCH_SANDBOX_ID,
       cwd: BRANCH_REPO_PATH,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -571,7 +624,7 @@ describe('resolveAgentTerminal', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -588,7 +641,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: PROJECT_PATH,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -601,7 +654,7 @@ describe('resolveAgentTerminal', () => {
     await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -617,7 +670,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: SANDBOX_ROOT,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -626,7 +679,7 @@ describe('resolveAgentTerminal', () => {
   it('given the machine Sprite fails to acquire, should deny as machine_unavailable', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const failingDeps = { ...deps, machineSandbox: makeMachineSandbox({ acquire: async () => ({ ok: false, reason: 'provision_failed' }) }) };
     const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', deps: failingDeps });
@@ -660,7 +713,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       actor,
       deps,
     });
@@ -674,7 +727,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: BRANCH_SANDBOX_ID,
       cwd: BRANCH_REPO_PATH,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -684,7 +737,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a project-scoped row id, should resolve the SAME machine Sprite with cwd=project.path', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
@@ -693,7 +746,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: PROJECT_PATH,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -702,7 +755,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a machine-scoped row id, should resolve the machine Sprite with cwd=SANDBOX_ROOT', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
@@ -711,7 +764,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: SANDBOX_ROOT,
-      agentType: 'pagespace-cli',
+      agentType: 'claude',
       command: null,
       streamSessionId: null,
     });
@@ -720,7 +773,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a row whose branch has vanished, should deny as branch_not_found', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
 
     const goneDeps = { ...deps, branchStore: makeBranchLookup() };
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps: goneDeps });
@@ -733,10 +786,10 @@ describe('listAgentTerminals', () => {
   it('given two agent terminals spawned in one branch, should list both without leaking the project/machine-scoped ones', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
     await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'reviewer', agentType: 'claude', actor, deps });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'project-cli', agentType: 'pagespace-cli', actor, deps });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'machine-cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'project-cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'machine-cli', agentType: 'claude', actor, deps });
 
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, deps });
 
@@ -747,11 +800,36 @@ describe('listAgentTerminals', () => {
   it('given a machine scope with zero spawned terminals, should list empty rather than surfacing project/branch ones', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, deps });
 
     expect(result).toEqual({ ok: true, terminals: [] });
+  });
+
+  it('given a legacy row whose agentType is the retired pagespace-cli, should hide it rather than surface an unlaunchable session', async () => {
+    const legacyRow: MachineAgentTerminalRecord = {
+      id: 'agent-terminal-legacy',
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'machine',
+      projectName: null,
+      machineBranchId: null,
+      name: 'legacy-cli',
+      agentType: 'pagespace-cli',
+      command: null,
+      streamSessionId: null,
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const { store } = makeStore([legacyRow]);
+    const deps = makeDeps({ store });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+
+    const result = await listAgentTerminals({ machineId: TERMINAL_ID, deps });
+
+    expect(result.ok).toBe(true);
+    expect(result.ok && result.terminals.map((t) => t.name)).toEqual(['cli']);
   });
 });
 
@@ -775,7 +853,7 @@ describe('killAgentTerminal', () => {
       store,
       host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
     });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
@@ -794,7 +872,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -847,7 +925,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: null,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-proj',
         createdAt: NOW,
@@ -894,7 +972,7 @@ describe('killAgentTerminal', () => {
         projectName: null,
         machineBranchId: null,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-machine',
         createdAt: NOW,
@@ -942,7 +1020,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -972,7 +1050,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-dangling',
         createdAt: NOW,
@@ -1014,7 +1092,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1055,7 +1133,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1094,7 +1172,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1137,7 +1215,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'pagespace-cli',
+        agentType: 'claude',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1170,7 +1248,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
   it('given a branch-scoped row id whose PTY IS running, should kill it purely by id (no project/branch name needed)', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
     const id = spawned.ok ? spawned.id : '';
     await store.updateStreamSessionId({ id, streamSessionId: 'sess-abc', now: NOW });
 
@@ -1195,7 +1273,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
   it('given a machine-scoped row id, should acquire the machine Sprite and drop the row', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'pagespace-cli', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -160,6 +160,27 @@ function makeDeps(overrides: Partial<AgentTerminalsDeps> = {}): AgentTerminalsDe
   };
 }
 
+/** A pre-existing DB row stuck with the retired 'pagespace-cli' agentType — simulates a machine
+ * that spawned one before it was removed from AGENT_LAUNCH_SPECS, bypassing planSpawnAgentTerminal's
+ * validation (which now rejects it) since this is seeded directly into the store. */
+function makeLegacyRow(overrides: Partial<MachineAgentTerminalRecord> = {}): MachineAgentTerminalRecord {
+  return {
+    id: 'agent-terminal-legacy',
+    ownerId: actor.userId,
+    machineId: TERMINAL_ID,
+    scope: 'machine',
+    projectName: null,
+    machineBranchId: null,
+    name: 'legacy-cli',
+    agentType: 'pagespace-cli',
+    command: null,
+    streamSessionId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
 describe('deriveAgentTerminalScope', () => {
   it('given machineBranchId set, should classify branch (regardless of projectName)', () => {
     expect(deriveAgentTerminalScope({ projectName: PROJECT_NAME, machineBranchId: BRANCH_ID })).toBe('branch');
@@ -469,21 +490,7 @@ describe('resolveAgentTerminalRow', () => {
   });
 
   it('given an EXISTING row whose agentType is the retired pagespace-cli, should deny not_found rather than crash', async () => {
-    const legacyRow: MachineAgentTerminalRecord = {
-      id: 'agent-terminal-legacy',
-      ownerId: actor.userId,
-      machineId: TERMINAL_ID,
-      scope: 'machine',
-      projectName: null,
-      machineBranchId: null,
-      name: 'legacy-cli',
-      agentType: 'pagespace-cli',
-      command: null,
-      streamSessionId: null,
-      createdAt: NOW,
-      updatedAt: NOW,
-    };
-    const { store } = makeStore([legacyRow]);
+    const { store } = makeStore([makeLegacyRow()]);
     const deps = makeDeps({ store, machineSandbox: undefined });
 
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'legacy-cli', deps });
@@ -554,21 +561,7 @@ describe('resolveAgentTerminal', () => {
   });
 
   it('given an EXISTING row whose agentType is the retired pagespace-cli, should deny not_found rather than crash or hand it to resolveAgentLaunchSpec', async () => {
-    const legacyRow: MachineAgentTerminalRecord = {
-      id: 'agent-terminal-legacy',
-      ownerId: actor.userId,
-      machineId: TERMINAL_ID,
-      scope: 'machine',
-      projectName: null,
-      machineBranchId: null,
-      name: 'legacy-cli',
-      agentType: 'pagespace-cli',
-      command: null,
-      streamSessionId: null,
-      createdAt: NOW,
-      updatedAt: NOW,
-    };
-    const { store } = makeStore([legacyRow]);
+    const { store } = makeStore([makeLegacyRow()]);
     const deps = makeDeps({ store });
 
     const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'legacy-cli', deps });
@@ -808,21 +801,7 @@ describe('listAgentTerminals', () => {
   });
 
   it('given a legacy row whose agentType is the retired pagespace-cli, should STILL list it — dropping it would strand it with no way to clean it up', async () => {
-    const legacyRow: MachineAgentTerminalRecord = {
-      id: 'agent-terminal-legacy',
-      ownerId: actor.userId,
-      machineId: TERMINAL_ID,
-      scope: 'machine',
-      projectName: null,
-      machineBranchId: null,
-      name: 'legacy-cli',
-      agentType: 'pagespace-cli',
-      command: null,
-      streamSessionId: null,
-      createdAt: NOW,
-      updatedAt: NOW,
-    };
-    const { store } = makeStore([legacyRow]);
+    const { store } = makeStore([makeLegacyRow()]);
     const deps = makeDeps({ store });
     await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -23,19 +23,18 @@
  * PTY (the realtime bridge), not this pure module.
  *
  * `pickable` gates the empty-pane "spawn an agent" picker (`TerminalPanes.tsx`
- * — see `PICKABLE_AGENT_TYPES` below): `shell` is a real, fully-launchable
- * `AgentRuntimeType`, but picking one from that flow means choosing an AI
- * agent identity, not a bare interactive shell — spawning a default/bare
- * shell terminal is a distinct UX (a separate follow-up wires that up) this
- * picker doesn't own. Keeping the marker on the registry entry itself (rather
- * than a hardcoded exclusion list living in the UI file) is what keeps the
- * picker in sync when a new entry is added here: forgetting to set `pickable`
- * fails safe (excluded, not silently spawnable) instead of failing open.
+ * — see `PICKABLE_AGENT_TYPES` below). `shell` is PRIMARY here — a plain
+ * interactive shell is the default, first-class way to work on a Machine —
+ * with `claude`/`codex` as secondary, opt-in AI agents. Only the retired
+ * `pagespace-cli` is excluded. Keeping the marker on the registry entry
+ * itself (rather than a hardcoded list living in the UI file) is what keeps
+ * the picker in sync when a new entry is added here: forgetting to set
+ * `pickable: true` fails safe (excluded, not silently spawnable).
  */
 export const AGENT_LAUNCH_SPECS = {
+  shell: { command: 'shell', args: [], pickable: true },
   claude: { command: 'claude', args: [], pickable: true },
   codex: { command: 'codex', args: [], pickable: true },
-  shell: { command: 'shell', args: [], pickable: false },
 } as const satisfies Record<string, { command: string; args: readonly string[]; pickable: boolean }>;
 
 export type AgentRuntimeType = keyof typeof AGENT_LAUNCH_SPECS;

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -23,7 +23,6 @@
  * PTY (the realtime bridge), not this pure module.
  */
 export const AGENT_LAUNCH_SPECS = {
-  'pagespace-cli': { command: 'pagespace-cli', args: [] },
   claude: { command: 'claude', args: [] },
   codex: { command: 'codex', args: [] },
   shell: { command: 'shell', args: [] },

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -21,14 +21,29 @@
  * Resolving the sentinel to an actual shell binary is an IO concern (reading
  * `process.env.SHELL`) that belongs to whichever layer actually spawns the
  * PTY (the realtime bridge), not this pure module.
+ *
+ * `pickable` gates the empty-pane "spawn an agent" picker (`TerminalPanes.tsx`
+ * — see `PICKABLE_AGENT_TYPES` below): `shell` is a real, fully-launchable
+ * `AgentRuntimeType`, but picking one from that flow means choosing an AI
+ * agent identity, not a bare interactive shell — spawning a default/bare
+ * shell terminal is a distinct UX (a separate follow-up wires that up) this
+ * picker doesn't own. Keeping the marker on the registry entry itself (rather
+ * than a hardcoded exclusion list living in the UI file) is what keeps the
+ * picker in sync when a new entry is added here: forgetting to set `pickable`
+ * fails safe (excluded, not silently spawnable) instead of failing open.
  */
 export const AGENT_LAUNCH_SPECS = {
-  claude: { command: 'claude', args: [] },
-  codex: { command: 'codex', args: [] },
-  shell: { command: 'shell', args: [] },
-} as const satisfies Record<string, { command: string; args: readonly string[] }>;
+  claude: { command: 'claude', args: [], pickable: true },
+  codex: { command: 'codex', args: [], pickable: true },
+  shell: { command: 'shell', args: [], pickable: false },
+} as const satisfies Record<string, { command: string; args: readonly string[]; pickable: boolean }>;
 
 export type AgentRuntimeType = keyof typeof AGENT_LAUNCH_SPECS;
+
+/** The subset of `AgentRuntimeType`s a user can pick from the empty-pane "spawn an agent" picker — see the `pickable` doc comment above. */
+export const PICKABLE_AGENT_TYPES: readonly AgentRuntimeType[] = (Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[]).filter(
+  (type) => AGENT_LAUNCH_SPECS[type].pickable,
+);
 
 export interface AgentLaunchSpec {
   command: string;

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -446,7 +446,11 @@ export async function listAgentTerminals({
 }): Promise<{ ok: true; terminals: MachineAgentTerminalRecord[] } | { ok: false; reason: 'invalid_target' | 'project_not_found' | 'branch_not_found' | 'scope_unsupported' }> {
   const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
   if (!scope.ok) return scope;
-  const terminals = await deps.store.list(scope.scopeKey);
+  const rows = await deps.store.list(scope.scopeKey);
+  // A row whose agentType predates a since-retired AGENT_LAUNCH_SPECS entry (e.g. the
+  // removed 'pagespace-cli') is invalid, not launchable — hide it rather than surface
+  // it as an adoptable session the navigator can't actually resolve or launch.
+  const terminals = rows.filter((row) => isAgentRuntimeType(row.agentType));
   return { ok: true, terminals };
 }
 

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -446,11 +446,18 @@ export async function listAgentTerminals({
 }): Promise<{ ok: true; terminals: MachineAgentTerminalRecord[] } | { ok: false; reason: 'invalid_target' | 'project_not_found' | 'branch_not_found' | 'scope_unsupported' }> {
   const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
   if (!scope.ok) return scope;
-  const rows = await deps.store.list(scope.scopeKey);
-  // A row whose agentType predates a since-retired AGENT_LAUNCH_SPECS entry (e.g. the
-  // removed 'pagespace-cli') is invalid, not launchable — hide it rather than surface
-  // it as an adoptable session the navigator can't actually resolve or launch.
-  const terminals = rows.filter((row) => isAgentRuntimeType(row.agentType));
+  // Deliberately UNFILTERED — a row whose agentType predates a since-retired
+  // AGENT_LAUNCH_SPECS entry (e.g. the removed 'pagespace-cli') is still listed.
+  // Dropping it here would make it undiscoverable: DELETE kills by name, and the
+  // navigator's "unclaimed session" adopt flow is the only way a name the local
+  // workspace store doesn't already know about ever resurfaces (see
+  // `WorkspaceLeaves.tsx`). Hiding it would strand the row (and any live PTY/
+  // billing session under it) with no path to clean it up. Callers distinguish
+  // "listed" from "launchable" via `isAgentRuntimeType(row.agentType)` themselves
+  // (the API route does this — see `agent-terminals/route.ts`); the actual launch
+  // path (`resolveAgentTerminal`/`resolveAgentTerminalRow`, below) still refuses
+  // to hand an invalid agentType to `resolveAgentLaunchSpec`.
+  const terminals = await deps.store.list(scope.scopeKey);
   return { ok: true, terminals };
 }
 


### PR DESCRIPTION
## Summary

Live testing (code execution now enabled) found the **`pagespace-cli` Machine agent-terminal option doesn't work and won't be supported** — this is the coding-CLI-launched-in-a-terminal option (`AGENT_LAUNCH_SPECS['pagespace-cli']`), not the `pagespace` CLI tool itself. `claude` works. `codex` was uncertain and needed verification. `shell` is the **primary** interface — a plain interactive shell is the default way to work on a Machine — with `claude`/`codex` as secondary, opt-in AI agents.

- **Removed `pagespace-cli`** from `AGENT_LAUNCH_SPECS` (`packages/lib/src/services/machines/agent-terminal-types.ts`) — the only agent type actually being retired. `AgentRuntimeType` (`keyof typeof AGENT_LAUNCH_SPECS`) narrows automatically to `'shell' | 'claude' | 'codex'`.
- **Picker** (`TerminalPanes.tsx`'s empty-pane `PaneAgentPicker`): imports an exported `PICKABLE_AGENT_TYPES` constant instead of hand-maintaining a list. Each `AGENT_LAUNCH_SPECS` entry carries a `pickable: boolean` marker — `shell`, `claude`, and `codex` are all `true` (only the retired `pagespace-cli` is excluded) — so the picker stays in sync with the registry: a future entry defaults to NOT pickable (fails safe) instead of silently missing from — or silently appearing in — the picker. `shell` is listed first, making it the picker's default selection (matching its role as the primary interface).
- **Legacy rows**: an existing `machine_agent_terminals` row with `agentType: 'pagespace-cli'` is handled gracefully, not crashed on, and kept **discoverable for cleanup**:
  - `listAgentTerminals` still lists it (an earlier revision of this PR filtered it out; see "Review feedback" below).
  - The navigator's "unclaimed session" row computes launchability client-side via the already-exported `isAgentRuntimeType(agentType)` (no extra server-sent field) and renders a non-launchable row as **remove-only**: a single semantically-disabled `<button>` (no adopt affordance — adopting would just hit `resolveAgentTerminal`'s `not_found` guard) plus a working `RemoveButton` that DELETEs it by name, same as any other agent terminal. A failed removal is reported via `toast.error`, not swallowed silently.
  - `resolveAgentTerminalRow`/`resolveAgentTerminal` already guarded with `isAgentRuntimeType` (pre-existing code) — a legacy row resolves to `not_found` rather than ever reaching `resolveAgentLaunchSpec`'s throw-on-unknown-type path.
  - `planSpawnAgentTerminal` already rejects unknown types via `isAgentRuntimeType`, so a **fresh** spawn can no longer request `pagespace-cli` (`invalid_agent_type`).

## Review feedback addressed

**Codex bot flagged (P2, [thread](https://github.com/2witstudios/PageSpace/pull/2053#discussion_r3571548026)):** an earlier revision filtered legacy `pagespace-cli` rows out of `listAgentTerminals` entirely, making them undiscoverable. Fixed by un-filtering the list and computing launchability client-side instead.

**Self-review (`/code-review` at high effort) + Codex bot ([thread](https://github.com/2witstudios/PageSpace/pull/2053#discussion_r3572076417)) both independently flagged**: an earlier revision hardcoded the picker to `['claude', 'codex']`, which also silently dropped `shell` — a real, already-working capability. **Corrected directly by the repo owner**: `shell` is the primary interface and must stay pickable; only `pagespace-cli` is retired. Fixed in a86c6b9 — `shell.pickable = true`, listed first (default selection).

**Other self-review fixes**: the new "remove unsupported session" button now reports failures via `toast.error` (previously fire-and-forget with no error handling, unlike every other destructive action in the file); `launchable` simplified to a client-side `isAgentRuntimeType` call instead of a redundant server-computed field; the unclaimed-session row's button/span fork fixed to a single semantically-correct `<button disabled>` (matching `MachineTree`'s `TreeRow` pattern); deduped a 3x-repeated test fixture.

## Codex (the AI CLI, not the reviewer bot)

The launch spec (`{ command: 'codex', args: [] }`) is structurally correct and consistent with `claude`'s entry — same shape, no special-casing needed elsewhere in the realtime bridge.

**However**, this repo has no Dockerfile or provisioning script for the Sprite base image — Sprites are provisioned externally via the fly.io Sprites platform, and `tasks/terminal.md` already flags this as an open question: *"how a per-terminal Sprite inherits the Machine's installed tools — checkpoint/restore from a base Machine."*

**Whether the `codex` binary is actually installed in the Sprite image cannot be verified from this repo.** Left in place per instructions, flagged for a live-Sprite check before it can be considered confirmed working: attach/exec into a live Sprite and run `which codex` / `codex --version`; if absent, it needs to be added wherever the base image/checkpoint is actually provisioned (external to this codebase).

## Test plan

- [x] `isAgentRuntimeType('pagespace-cli') === false` (new test)
- [x] `resolveAgentTerminalRow`/`resolveAgentTerminal` given a legacy row with `agentType: 'pagespace-cli'` → `{ ok: false, reason: 'not_found' }`, no throw (new tests)
- [x] `listAgentTerminals` given a legacy row → still lists it (new test)
- [x] `PICKABLE_AGENT_TYPES` is `['shell', 'claude', 'codex']`, shell first (default) (new tests)
- [x] The empty-pane picker renders `shell`, `claude`, `codex` (new test), default agent type is `shell`
- [x] A non-launchable unclaimed session can't be adopted but has a working remove button that DELETEs by name, reporting failures via toast (new tests)
- [x] `planSpawnAgentTerminal` rejects a fresh `pagespace-cli` spawn as `invalid_agent_type` (new test)
- [x] `bun run typecheck` — clean (full monorepo + scoped `tsc --noEmit` on `packages/lib`, `packages/db`, `apps/web`, `apps/realtime`)
- [x] All touched test suites green: `packages/lib` agent-terminal(s) (76 tests), `apps/web` TerminalPanes/route/workspace-reducer/WorkspaceLeaves/MachineTree (118 tests), `apps/realtime` agent-terminal-handler + sprites-shell (228 tests)
- [x] No merge conflicts with `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JJwVRFDBjKUUjTPXXi2Kk