### PR TITLE
feat(machines): propagate Claude Code credential into branch-terminal Sprites

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -20,6 +20,7 @@ import {
   acquireMachineSession,
   createDbMachineSessionStore,
   deriveMachineSessionKey,
+  findLiveMachineSandboxId,
 } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/machine-billing';
 import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
@@ -45,6 +46,7 @@ import { createTerminalSessionMap } from './terminal/terminal-session-map';
 import { openPtyShell } from './terminal/sprites-shell';
 import { getRealtimeSpritesSdk } from './terminal/realtime-sprites-client';
 import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+import { propagateClaudeCredential } from '@pagespace/lib/services/machines/machine-branches';
 import { createDbMachineAgentTerminalStore } from '@pagespace/lib/services/machines/agent-terminals-store';
 import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/machine-projects-store';
 import {
@@ -268,6 +270,35 @@ async function resolveAgentTerminalSandbox({
       // scope). A branch-scope target never acquires, so this is its one and only
       // read.
       getSprite: (sandboxId) => sdk.getSprite(sandboxId),
+      // Refresh the branch Sprite's Claude Code credential from the root
+      // Machine's own Sprite (see `propagateClaudeCredential`'s doc comment on
+      // `machine-branches.ts`) — this IS the branch's actual attach path for
+      // opening/reattaching its agent terminal, unlike `spawnBranch`/
+      // `attachBranch`, which this bridge never calls. `resolveMachineSandbox`
+      // only invokes this for branch-scope targets. Shares this connect's
+      // handle cache (`sdk`), so re-reading the ALREADY-fetched branch Sprite
+      // costs nothing; only the root Sprite's read is a genuinely new call.
+      refreshBranchCredential: async ({ machineId: rootMachineId, sandboxId }) => {
+        try {
+          const rawClient = createSpritesSandboxClient({ sdk });
+          const host = createSpriteMachineHost({ sdk, client: rawClient });
+          const branchHandle = await host.attach({ machineId: sandboxId });
+          if (!branchHandle) return;
+          await propagateClaudeCredential({
+            machineId: rootMachineId,
+            branchHandle,
+            resolveRootMachineHandle: async (mid) => {
+              const rootSandboxId = await findLiveMachineSandboxId(mid);
+              if (!rootSandboxId) return null;
+              return host.attach({ machineId: rootSandboxId });
+            },
+          });
+        } catch {
+          // Best-effort — a credential refresh must never block or fail
+          // opening the PTY itself (see `ResolveMachineSandboxDeps.
+          // refreshBranchCredential`'s doc comment).
+        }
+      },
     },
   );
 }

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -103,6 +103,27 @@ export async function resolveActorEmail(rawEmail: string | null | undefined): Pr
 }
 
 /**
+ * A page's CURRENT driveId + that drive's owner (the `tenantId` convention
+ * `deriveMachineSessionKey` uses) — the two reads `buildMachineSandbox.acquire`
+ * already did inline, now shared with `refreshBranchCredential` below so a
+ * bare-`pageId` lookup is never substituted for deriving the exact CURRENT
+ * session key (a page moved between drives can leave its OLD drive's session
+ * row behind under a DIFFERENT key — see `findLiveMachineSandboxId`'s doc
+ * comment on `machine-session-manager.ts`).
+ */
+type DriveOwnerContextResult =
+  | { ok: true; driveId: string; tenantId: string }
+  | { ok: false; reason: 'page_not_found' | 'drive_not_found' };
+
+async function resolveDriveOwnerContext(pageId: string): Promise<DriveOwnerContextResult> {
+  const [pageRow] = await db.select({ driveId: pages.driveId }).from(pages).where(eq(pages.id, pageId)).limit(1);
+  if (!pageRow) return { ok: false, reason: 'page_not_found' };
+  const [driveRow] = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, pageRow.driveId)).limit(1);
+  if (!driveRow) return { ok: false, reason: 'drive_not_found' };
+  return { ok: true, driveId: pageRow.driveId, tenantId: driveRow.ownerId };
+}
+
+/**
  * Acquires the OWNING Machine's persistent Sprite for `AgentTerminalMachineSandbox`
  * (machine/project scope share this one Sprite — see `agent-terminals.ts`),
  * re-authorizing `actorUserId` (resume re-authz) on every call. Mirrors the
@@ -132,10 +153,9 @@ function buildMachineSandbox(actorUserId: string, sdk: SpritesSdk): AgentTermina
 
   return {
     acquire: async (machineId): Promise<AgentTerminalMachineSandboxResult> => {
-      const [pageRow] = await db.select({ driveId: pages.driveId }).from(pages).where(eq(pages.id, machineId)).limit(1);
-      if (!pageRow) return deny('page_not_found', machineId);
-      const [driveRow] = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, pageRow.driveId)).limit(1);
-      if (!driveRow) return deny('drive_not_found', machineId);
+      const context = await resolveDriveOwnerContext(machineId);
+      if (!context.ok) return deny(context.reason, machineId);
+      const { driveId, tenantId } = context;
 
       const nowMs = Date.now();
       const guardrail = checkMachineRuntimeGuardrail({ machineKey: machineId, now: nowMs });
@@ -148,8 +168,8 @@ function buildMachineSandbox(actorUserId: string, sdk: SpritesSdk): AgentTermina
 
       const result = await acquireMachineSession({
         pageId: machineId,
-        driveId: pageRow.driveId,
-        tenantId: driveRow.ownerId,
+        driveId,
+        tenantId,
         userId: actorUserId,
         // Already authorized by the caller's access + canRunCode checks before
         // resolveAgentTerminal ever reaches this acquire.
@@ -289,7 +309,18 @@ async function resolveAgentTerminalSandbox({
             machineId: rootMachineId,
             branchHandle,
             resolveRootMachineHandle: async (mid) => {
-              const rootSandboxId = await findLiveMachineSandboxId(mid);
+              // Derives the CURRENT session key (driveId + drive owner), not
+              // a bare-pageId lookup — see `findLiveMachineSandboxId`'s doc
+              // comment on why that would risk resolving a STALE session
+              // left behind by a prior drive move (caught in review, P1).
+              const context = await resolveDriveOwnerContext(mid);
+              if (!context.ok) return null;
+              const rootSandboxId = await findLiveMachineSandboxId({
+                tenantId: context.tenantId,
+                driveId: context.driveId,
+                pageId: mid,
+                secret: getSandboxSessionSecret(),
+              });
               if (!rootSandboxId) return null;
               return host.attach({ machineId: rootSandboxId });
             },

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -243,6 +243,9 @@ async function resolveAgentTerminalSandbox({
   name: string;
 }) {
   const sdk = createSpriteHandleCache(await getRealtimeSpritesSdk());
+  // Construction only (no I/O) — cheap to build unconditionally even for
+  // machine/project-scope targets that never touch `refreshBranchCredential`.
+  const host = createSpriteMachineHost({ sdk, client: createSpritesSandboxClient({ sdk }) });
 
   return resolveMachineSandbox(
     { machineId, projectName, branchName, name },
@@ -280,8 +283,6 @@ async function resolveAgentTerminalSandbox({
       // costs nothing; only the root Sprite's read is a genuinely new call.
       refreshBranchCredential: async ({ machineId: rootMachineId, sandboxId }) => {
         try {
-          const rawClient = createSpritesSandboxClient({ sdk });
-          const host = createSpriteMachineHost({ sdk, client: rawClient });
           const branchHandle = await host.attach({ machineId: sandboxId });
           if (!branchHandle) return;
           await propagateClaudeCredential({

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, vi } from 'vitest';
 import { assert } from './riteway';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { ResolveAgentTerminalResult } from '@pagespace/lib/services/machines/agent-terminals';
@@ -339,6 +339,33 @@ describe('resolveMachineSandbox', () => {
       actual: result.ok,
       expected: true,
     });
+  });
+
+  it('given a refresh that never settles (a stuck root or branch Sprite), should resolve once the bound elapses rather than hanging forever', async () => {
+    vi.useFakeTimers();
+    try {
+      const pending = resolveMachineSandbox(
+        { machineId: 'm-1', projectName: 'proj', branchName: 'feature-x', name: 'claude' },
+        {
+          resolveAgentTerminal: async () => resolvedOk,
+          getSprite: spyGetSprite().fn,
+          // Never resolves — simulates a Sprite fs op that's stuck (e.g. a
+          // hibernating Sprite mid wake-retry).
+          refreshBranchCredential: () => new Promise<void>(() => {}),
+        },
+      );
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await pending;
+
+      assert({
+        given: 'a refreshBranchCredential that never settles',
+        should: 'still resolve ok once the bound elapses, not hang indefinitely',
+        actual: result.ok,
+        expected: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -221,6 +221,105 @@ describe('resolveMachineSandbox', () => {
       expected: { ok: false, reason: 'provision_failed', sandboxId: 'sbx-1' },
     });
   });
+
+  // -------------------------------------------------------------------------
+  // refreshBranchCredential — this IS the branch's real attach path (a
+  // branch's agent terminal opens/reattaches through resolveMachineSandbox,
+  // never through spawnBranch/attachBranch's machine-branches.ts), so it must
+  // fire on every branch-scope resolution and never for machine/project scope
+  // (those run ON the root Sprite, which already has its own credential).
+  // -------------------------------------------------------------------------
+
+  function spyRefresh() {
+    const calls: { machineId: string; sandboxId: string }[] = [];
+    const fn = async (args: { machineId: string; sandboxId: string }) => {
+      calls.push(args);
+    };
+    return { fn, calls };
+  }
+
+  it('given a BRANCH-scope target, should refresh the branch credential with the resolved machineId and sandboxId', async () => {
+    const refresh = spyRefresh();
+    await resolveMachineSandbox(
+      { machineId: 'm-1', projectName: 'proj', branchName: 'feature-x', name: 'claude' },
+      {
+        resolveAgentTerminal: async () => resolvedOk,
+        getSprite: spyGetSprite().fn,
+        refreshBranchCredential: refresh.fn,
+      },
+    );
+
+    assert({
+      given: 'a branch-scope target (projectName + branchName both set)',
+      should: 'call refreshBranchCredential exactly once with the resolved machineId + sandboxId',
+      actual: refresh.calls,
+      expected: [{ machineId: 'm-1', sandboxId: 'sbx-1' }],
+    });
+  });
+
+  it('given a MACHINE-scope target (no projectName/branchName), should NOT refresh any credential', async () => {
+    const refresh = spyRefresh();
+    await resolveMachineSandbox(
+      { machineId: 'm-1', name: 'shell' },
+      { resolveAgentTerminal: async () => resolvedOk, getSprite: spyGetSprite().fn, refreshBranchCredential: refresh.fn },
+    );
+
+    assert({
+      given: 'a machine-scope target',
+      should: 'never call refreshBranchCredential — the root Sprite already has its own credential',
+      actual: refresh.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('given a PROJECT-scope target (projectName set, no branchName), should NOT refresh any credential', async () => {
+    const refresh = spyRefresh();
+    await resolveMachineSandbox(
+      { machineId: 'm-1', projectName: 'proj', name: 'shell' },
+      { resolveAgentTerminal: async () => resolvedOk, getSprite: spyGetSprite().fn, refreshBranchCredential: refresh.fn },
+    );
+
+    assert({
+      given: 'a project-scope target',
+      should: 'never call refreshBranchCredential — project scope shares the root Sprite too',
+      actual: refresh.calls.length,
+      expected: 0,
+    });
+  });
+
+  it('given a branch-scope target with refreshBranchCredential OMITTED, should still resolve successfully', async () => {
+    const result = await resolveMachineSandbox(
+      { machineId: 'm-1', projectName: 'proj', branchName: 'feature-x', name: 'claude' },
+      { resolveAgentTerminal: async () => resolvedOk, getSprite: spyGetSprite().fn },
+    );
+
+    assert({
+      given: 'a branch-scope target with no refreshBranchCredential dep wired (e.g. a caller/test that omits it)',
+      should: 'resolve ok regardless — the dep is optional',
+      actual: result.ok,
+      expected: true,
+    });
+  });
+
+  it('given refreshBranchCredential throws, should still resolve successfully (defense in depth)', async () => {
+    const result = await resolveMachineSandbox(
+      { machineId: 'm-1', projectName: 'proj', branchName: 'feature-x', name: 'claude' },
+      {
+        resolveAgentTerminal: async () => resolvedOk,
+        getSprite: spyGetSprite().fn,
+        refreshBranchCredential: async () => {
+          throw new Error('root Sprite unreachable');
+        },
+      },
+    );
+
+    assert({
+      given: 'a refreshBranchCredential implementation that violates its best-effort contract by throwing',
+      should: 'still resolve ok — the PTY open must never fail over a credential refresh hiccup',
+      actual: result.ok,
+      expected: true,
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -287,6 +287,26 @@ describe('resolveMachineSandbox', () => {
     });
   });
 
+  it('given branchName set WITHOUT projectName (malformed — a real resolveAgentTerminal would reject this as invalid_target before ever reaching here), should still NOT refresh any credential even against a permissive fake resolver', async () => {
+    // A real `resolveAgentTerminal` (agent-terminals.ts) already rejects this
+    // shape as `invalid_target` before Sprite resolution — but this test's
+    // fake resolver deliberately does NOT enforce that, to prove the gate
+    // itself checks BOTH projectName and branchName rather than relying on
+    // that upstream invariant alone.
+    const refresh = spyRefresh();
+    await resolveMachineSandbox(
+      { machineId: 'm-1', branchName: 'feature-x', name: 'claude' },
+      { resolveAgentTerminal: async () => resolvedOk, getSprite: spyGetSprite().fn, refreshBranchCredential: refresh.fn },
+    );
+
+    assert({
+      given: 'a branchName-only target reaching a permissive fake resolver',
+      should: 'never call refreshBranchCredential — the gate requires projectName too, not branchName alone',
+      actual: refresh.calls.length,
+      expected: 0,
+    });
+  });
+
   it('given a branch-scope target with refreshBranchCredential OMITTED, should still resolve successfully', async () => {
     const result = await resolveMachineSandbox(
       { machineId: 'm-1', projectName: 'proj', branchName: 'feature-x', name: 'claude' },

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -100,9 +100,15 @@ export interface ResolveMachineSandboxDeps {
    * explicit attach API, neither of which this realtime PTY bridge calls.
    *
    * Optional so tests that don't exercise branch scope (or don't care about
-   * credential propagation) can omit it. MUST be best-effort on the
-   * implementation side — swallow its own failures — since a credential
-   * refresh must never block or fail opening the PTY itself.
+   * credential propagation) can omit it. Called fire-and-forget — NEVER
+   * awaited by `resolveMachineSandbox` (a cold/hibernating Sprite's fs
+   * read/write can take up to the Sprite fs API's 30s timeout, with one
+   * retry, so up to ~60s; blocking every branch PTY open on that would
+   * regress the "opening a PTY is itself the wake, nothing upstream waits on
+   * it" invariant). MUST still be best-effort on the implementation side —
+   * swallow its own failures — as defense in depth against an unhandled
+   * rejection, even though a rejection can no longer fail or delay the PTY
+   * resolution itself.
    */
   refreshBranchCredential?: (args: { machineId: string; sandboxId: string }) => Promise<void>;
 }
@@ -156,14 +162,23 @@ export async function resolveMachineSandbox(
   // validation ever changes, or a caller wires a resolver that doesn't
   // enforce it (e.g. a test double).
   if (target.projectName !== undefined && target.branchName !== undefined && deps.refreshBranchCredential) {
-    try {
-      await deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId });
-    } catch {
+    // Fire-and-forget — NEVER awaited (caught in review, P2). A cold or
+    // hibernating Sprite's filesystem read/write can take up to the Sprite
+    // fs API's 30s timeout, WITH one retry (so up to ~60s) — blocking every
+    // branch PTY open on that would regress this codebase's core Sprite
+    // invariant that opening a PTY is itself the wake and NOTHING upstream
+    // of it waits on that wake (see `buildMachineSandbox`'s own doc comment
+    // on this file's sibling `acquire`). The refresh still normally lands
+    // well before a user manually runs `claude`; the narrower race — typing
+    // `claude` faster than an in-flight refresh completes — self-heals
+    // moments later once the copy finishes, and is a FAR smaller cost than a
+    // multi-second stall on every cold terminal open.
+    void deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId }).catch(() => {
       // Best-effort by contract (see the doc comment on
       // `ResolveMachineSandboxDeps.refreshBranchCredential`) — defense in
       // depth here too, so an implementation that forgets to swallow its own
-      // errors still never fails opening the PTY over a credential hiccup.
-    }
+      // errors still never produces an unhandled rejection.
+    });
   }
 
   return {

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -100,17 +100,41 @@ export interface ResolveMachineSandboxDeps {
    * explicit attach API, neither of which this realtime PTY bridge calls.
    *
    * Optional so tests that don't exercise branch scope (or don't care about
-   * credential propagation) can omit it. Called fire-and-forget — NEVER
-   * awaited by `resolveMachineSandbox` (a cold/hibernating Sprite's fs
-   * read/write can take up to the Sprite fs API's 30s timeout, with one
-   * retry, so up to ~60s; blocking every branch PTY open on that would
-   * regress the "opening a PTY is itself the wake, nothing upstream waits on
-   * it" invariant). MUST still be best-effort on the implementation side —
-   * swallow its own failures — as defense in depth against an unhandled
-   * rejection, even though a rejection can no longer fail or delay the PTY
-   * resolution itself.
+   * credential propagation) can omit it. Awaited by `resolveMachineSandbox`,
+   * but bounded by `CREDENTIAL_REFRESH_TIMEOUT_MS` (`withTimeout`) rather
+   * than either fully blocking or fire-and-forget — see the inline comment
+   * at that call site for why both extremes were tried and reverted. MUST
+   * still be best-effort on the implementation side — swallow its own
+   * failures — as defense in depth against an unhandled rejection.
    */
   refreshBranchCredential?: (args: { machineId: string; sandboxId: string }) => Promise<void>;
+}
+
+/**
+ * Hard cap on how long `refreshBranchCredential` may delay a fresh branch
+ * PTY open. Long enough for the common case (warm root + branch Sprite,
+ * normally well under a second) to complete reliably; short enough that a
+ * cold/hibernating Sprite's fs-timeout tail (up to ~60s, see the doc comment
+ * on `machine-branches.ts`'s `propagateClaudeCredential`) never turns into a
+ * near-minute-long terminal-open stall.
+ */
+const CREDENTIAL_REFRESH_TIMEOUT_MS = 5_000;
+
+/** Resolve once `promise` settles OR `timeoutMs` elapses, whichever first — never rejects. The timer is always cleared, and `promise` keeps running past the bound rather than being cancelled (a slow settle still lands, just too late to have been waited on). */
+function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs);
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+    );
+  });
 }
 
 export type ResolveMachineSandboxResult =
@@ -162,23 +186,24 @@ export async function resolveMachineSandbox(
   // validation ever changes, or a caller wires a resolver that doesn't
   // enforce it (e.g. a test double).
   if (target.projectName !== undefined && target.branchName !== undefined && deps.refreshBranchCredential) {
-    // Fire-and-forget — NEVER awaited (caught in review, P2). A cold or
-    // hibernating Sprite's filesystem read/write can take up to the Sprite
-    // fs API's 30s timeout, WITH one retry (so up to ~60s) — blocking every
-    // branch PTY open on that would regress this codebase's core Sprite
-    // invariant that opening a PTY is itself the wake and NOTHING upstream
-    // of it waits on that wake (see `buildMachineSandbox`'s own doc comment
-    // on this file's sibling `acquire`). The refresh still normally lands
-    // well before a user manually runs `claude`; the narrower race — typing
-    // `claude` faster than an in-flight refresh completes — self-heals
-    // moments later once the copy finishes, and is a FAR smaller cost than a
-    // multi-second stall on every cold terminal open.
-    void deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId }).catch(() => {
-      // Best-effort by contract (see the doc comment on
-      // `ResolveMachineSandboxDeps.refreshBranchCredential`) — defense in
-      // depth here too, so an implementation that forgets to swallow its own
-      // errors still never produces an unhandled rejection.
-    });
+    // Awaited, but bounded — NOT fire-and-forget (tried that, reverted: a
+    // fresh branch-scoped Claude terminal calls `openShell` with `claude`
+    // immediately after this resolves, and copying the credential moments
+    // later does nothing for a process that already started without it —
+    // see review history). Also NOT unbounded: a cold/hibernating Sprite's
+    // fs read/write can take up to the Sprite fs API's 30s timeout, WITH one
+    // retry (so up to ~60s), and blocking every branch PTY open on that
+    // would regress this codebase's Sprite invariant that opening a PTY is
+    // itself the wake and nothing upstream waits long on it. The bound
+    // covers the common case (warm root + branch Sprite, sub-second)
+    // reliably while capping the cold-Sprite worst case to a few seconds —
+    // still slower than ideal, but nowhere near a minute-long stall. The
+    // refresh keeps running past the bound rather than being cancelled — a
+    // slow copy still lands, just too late to help THIS launch.
+    await withTimeout(
+      deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId }),
+      CREDENTIAL_REFRESH_TIMEOUT_MS,
+    );
   }
 
   return {

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -90,6 +90,21 @@ export interface ResolveMachineSandboxDeps {
    * `sdk.getSprite`, not three.
    */
   getSprite: (sandboxId: string) => Promise<SpriteInstanceLike>;
+  /**
+   * BRANCH-scope only (never machine/project — those run ON the root
+   * Sprite, which already has its own credential): refresh the branch
+   * Sprite's Claude Code credential from the root Machine's Sprite before
+   * handing back a fresh PTY resolution. This is the actual attach path a
+   * user's branch agent terminal goes through — `spawnBranch`/`attachBranch`
+   * (`machine-branches.ts`) only cover branch creation and the navigator's
+   * explicit attach API, neither of which this realtime PTY bridge calls.
+   *
+   * Optional so tests that don't exercise branch scope (or don't care about
+   * credential propagation) can omit it. MUST be best-effort on the
+   * implementation side — swallow its own failures — since a credential
+   * refresh must never block or fail opening the PTY itself.
+   */
+  refreshBranchCredential?: (args: { machineId: string; sandboxId: string }) => Promise<void>;
 }
 
 export type ResolveMachineSandboxResult =
@@ -130,6 +145,17 @@ export async function resolveMachineSandbox(
     sprite = await deps.getSprite(resolved.sandboxId);
   } catch {
     return { ok: false, reason: 'provision_failed', sandboxId: resolved.sandboxId };
+  }
+
+  if (target.branchName !== undefined && deps.refreshBranchCredential) {
+    try {
+      await deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId });
+    } catch {
+      // Best-effort by contract (see the doc comment on
+      // `ResolveMachineSandboxDeps.refreshBranchCredential`) — defense in
+      // depth here too, so an implementation that forgets to swallow its own
+      // errors still never fails opening the PTY over a credential hiccup.
+    }
   }
 
   return {

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -147,7 +147,15 @@ export async function resolveMachineSandbox(
     return { ok: false, reason: 'provision_failed', sandboxId: resolved.sandboxId };
   }
 
-  if (target.branchName !== undefined && deps.refreshBranchCredential) {
+  // Both `projectName` AND `branchName` must be set for true branch scope —
+  // matching `resolveScopeKey`/`resolveScopeLocation`'s own discriminator
+  // (`agent-terminals.ts`), rather than relying on the implicit invariant
+  // that a real `resolveAgentTerminal` already rejects `branchName` without
+  // `projectName` as `invalid_target` before ever reaching here. Checking
+  // both explicitly means this gate stays correct even if that upstream
+  // validation ever changes, or a caller wires a resolver that doesn't
+  // enforce it (e.g. a test double).
+  if (target.projectName !== undefined && target.branchName !== undefined && deps.refreshBranchCredential) {
     try {
       await deps.refreshBranchCredential({ machineId: target.machineId, sandboxId: resolved.sandboxId });
     } catch {

--- a/apps/web/src/lib/machines/machine-branches-runtime.ts
+++ b/apps/web/src/lib/machines/machine-branches-runtime.ts
@@ -16,7 +16,7 @@
 
 import { eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
-import { pages } from '@pagespace/db/schema/core';
+import { pages, drives } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { decideFullEgressEnablement, isContainmentVerified } from '@pagespace/lib/services/sandbox/containment';
@@ -127,9 +127,30 @@ export async function canViewMachine(actorUserId: string, machineId: string): Pr
  * provision-fresh flow, since this only ever needs read access to an
  * EXISTING session, gracefully returning `null` (never provisioning) when
  * the root Machine has none yet.
+ *
+ * Resolves the page's CURRENT driveId/owner and derives the exact session
+ * key from it — not a bare-`pageId` lookup (see `findLiveMachineSandboxId`'s
+ * doc comment): a page moved between drives can leave its OLD drive's
+ * session row behind, and a bare-`pageId` read could return that STALE row,
+ * handing back a credential that was never this page's current owner's to
+ * give out.
  */
 export async function resolveRootMachineHandle(machineId: string): Promise<MachineHandle | null> {
-  const sandboxId = await findLiveMachineSandboxId(machineId);
+  const page = await findMachinePage(machineId);
+  if (!page) return null;
+
+  const driveRow = await db.query.drives.findFirst({
+    where: eq(drives.id, page.driveId),
+    columns: { ownerId: true },
+  });
+  if (!driveRow) return null;
+
+  const sandboxId = await findLiveMachineSandboxId({
+    tenantId: driveRow.ownerId,
+    driveId: page.driveId,
+    pageId: machineId,
+    secret: getSandboxSessionSecret(),
+  });
   if (!sandboxId) return null;
 
   const host = await getMachineHost();

--- a/apps/web/src/lib/machines/machine-branches-runtime.ts
+++ b/apps/web/src/lib/machines/machine-branches-runtime.ts
@@ -18,10 +18,9 @@ import { eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
-import { machineSessions } from '@pagespace/db/schema/machine-sessions';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { decideFullEgressEnablement, isContainmentVerified } from '@pagespace/lib/services/sandbox/containment';
-import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
+import { getSandboxSessionSecret, findLiveMachineSandboxId } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { resolveSandboxNetworkOptions } from '@pagespace/lib/services/sandbox/network-options';
 import { getConfiguredEgressIpTag } from '@pagespace/lib/services/sandbox/egress-ip';
 import { acquireCodeExecutionSlot, releaseCodeExecutionSlot } from '@pagespace/lib/services/sandbox/quota';
@@ -124,22 +123,17 @@ export async function canViewMachine(actorUserId: string, machineId: string): Pr
 /**
  * Live handle to the ROOT Machine's own persistent Sprite (the one
  * `machine_sessions` tracks for its page), never a branch-terminal's own.
- * Reads the session row directly by `pageId` — the same precedented
- * bare-pageId query `machine-storage-billing.ts` uses — rather than going
- * through `acquireMachineSession`'s full re-authz + provision-fresh flow:
- * this only ever needs read access to an EXISTING session, gracefully
- * returning `null` (never provisioning) when the root Machine has none yet.
+ * Read-only — never goes through `acquireMachineSession`'s full re-authz +
+ * provision-fresh flow, since this only ever needs read access to an
+ * EXISTING session, gracefully returning `null` (never provisioning) when
+ * the root Machine has none yet.
  */
 export async function resolveRootMachineHandle(machineId: string): Promise<MachineHandle | null> {
-  const [row] = await db
-    .select({ sandboxId: machineSessions.sandboxId })
-    .from(machineSessions)
-    .where(eq(machineSessions.pageId, machineId))
-    .limit(1);
-  if (!row) return null;
+  const sandboxId = await findLiveMachineSandboxId(machineId);
+  if (!sandboxId) return null;
 
   const host = await getMachineHost();
-  return host.attach({ machineId: row.sandboxId });
+  return host.attach({ machineId: sandboxId });
 }
 
 export function buildMachineBranchesDeps(): MachineBranchesDeps {

--- a/apps/web/src/lib/machines/machine-branches-runtime.ts
+++ b/apps/web/src/lib/machines/machine-branches-runtime.ts
@@ -18,6 +18,7 @@ import { eq } from '@pagespace/db/operators';
 import { db } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
+import { machineSessions } from '@pagespace/db/schema/machine-sessions';
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { decideFullEgressEnablement, isContainmentVerified } from '@pagespace/lib/services/sandbox/containment';
 import { getSandboxSessionSecret } from '@pagespace/lib/services/sandbox/machine-session-manager';
@@ -29,7 +30,7 @@ import { defaultBuildEnv } from '@pagespace/lib/services/sandbox/tool-runners';
 import { resolveGitHubTokenForSandbox } from '@pagespace/lib/services/sandbox/github-token';
 import { isMachinePage } from '@pagespace/lib/content/page-types.config';
 import type { PageType } from '@pagespace/lib/utils/enums';
-import type { MachineHost } from '@pagespace/lib/services/sandbox/machine-host';
+import type { MachineHandle, MachineHost } from '@pagespace/lib/services/sandbox/machine-host';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
@@ -120,6 +121,27 @@ export async function canViewMachine(actorUserId: string, machineId: string): Pr
   return canUserViewPage(actorUserId, machineId);
 }
 
+/**
+ * Live handle to the ROOT Machine's own persistent Sprite (the one
+ * `machine_sessions` tracks for its page), never a branch-terminal's own.
+ * Reads the session row directly by `pageId` — the same precedented
+ * bare-pageId query `machine-storage-billing.ts` uses — rather than going
+ * through `acquireMachineSession`'s full re-authz + provision-fresh flow:
+ * this only ever needs read access to an EXISTING session, gracefully
+ * returning `null` (never provisioning) when the root Machine has none yet.
+ */
+export async function resolveRootMachineHandle(machineId: string): Promise<MachineHandle | null> {
+  const [row] = await db
+    .select({ sandboxId: machineSessions.sandboxId })
+    .from(machineSessions)
+    .where(eq(machineSessions.pageId, machineId))
+    .limit(1);
+  if (!row) return null;
+
+  const host = await getMachineHost();
+  return host.attach({ machineId: row.sandboxId });
+}
+
 export function buildMachineBranchesDeps(): MachineBranchesDeps {
   return {
     store: {
@@ -151,6 +173,7 @@ export function buildMachineBranchesDeps(): MachineBranchesDeps {
         containment: isContainmentVerified() ? { contained: true } : null,
       }),
     resolveGitHubToken: (userId) => resolveGitHubTokenForSandbox({ userId, db }),
+    resolveRootMachineHandle,
     quota: {
       acquireSlot: acquireCodeExecutionSlot,
       releaseSlot: releaseCodeExecutionSlot,

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -851,7 +851,13 @@ describe('Claude Code credential propagation', () => {
     expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
   });
 
-  it('should chmod both copied files to 600 after writing — writeFiles\' mode only applies at creation, so an overwrite of an ALREADY-EXISTING file (e.g. a refresh) needs an explicit chmod to re-secure it', async () => {
+  it('should delete any existing file before writing the fresh copy, for both the credentials and config files — a fresh CREATION is what makes 0o600 take effect reliably even on a refresh', async () => {
+    // `writeFiles`' `mode` only applies at file CREATION (POSIX open()
+    // semantics) — an overwrite of an already-existing file silently keeps
+    // whatever permissions it already had. Deleting first (rather than
+    // writing then chmod-ing after) means every write IS a creation, so
+    // there's no separate step (and no window where the fresh secret sits
+    // at the OLD mode) that could fail or stall independently.
     const { host, byId } = makeFakeHost();
     const rootHandle = makeRootHandle({
       '/home/sprite/.claude/.credentials.json': 'secret-token',
@@ -863,45 +869,25 @@ describe('Claude Code credential propagation', () => {
     if (!result.ok) throw new Error('expected ok');
 
     const state = byId.get(result.sandboxId);
-    const chmodCalls = state?.execLog.filter((c) => c.cmd === 'chmod') ?? [];
-    expect(chmodCalls).toEqual([
-      { cmd: 'chmod', args: ['600', '/home/sprite/.claude/.credentials.json'] },
-      { cmd: 'chmod', args: ['600', '/home/sprite/.claude.json'] },
+    const rmCalls = state?.execLog.filter((c) => c.cmd === 'rm') ?? [];
+    expect(rmCalls).toEqual([
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json'] },
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json'] },
     ]);
+    expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
+    expect(state?.fileModes.get('/home/sprite/.claude.json')).toBe(0o600);
   });
 
-  it('given the chmod exec fails (non-zero exit), should fail CLOSED by removing the just-copied credential rather than leaving it at the wrong permissions, and should stop copying further files', async () => {
-    // `exec` resolves with an exitCode rather than throwing on a nonzero
-    // exit — a failed chmod must not be silently ignored, since a failed
-    // chmod on an OVERWRITE of an already-existing file leaves it at
-    // whatever permissive mode it already had. Simulates `rm -f` deletion
-    // too, so the file's actual absence can be asserted below.
-    const { host, byId } = makeFakeHost((state, args) => {
-      if (args.cmd === 'chmod') return { exitCode: 1, stdout: '', stderr: 'chmod: permission denied' };
-      if (args.cmd === 'rm' && args.args?.[0] === '-f' && args.args[1] !== undefined) {
-        state.files.delete(args.args[1]);
-        state.fileModes.delete(args.args[1]);
-      }
+  it('given the pre-write rm exec throws (e.g. a transport failure), should not fail the spawn (best-effort)', async () => {
+    const { host } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'rm') throw new Error('exec transport failure');
       return { exitCode: 0, stdout: '', stderr: '' };
     });
-    const rootHandle = makeRootHandle({
-      '/home/sprite/.claude/.credentials.json': 'secret-token',
-      '/home/sprite/.claude.json': '{"theme":"dark"}',
-    });
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'secret-token' });
     const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
 
     const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
-    // Best-effort — a chmod failure must never fail the spawn itself.
     expect(result.ok).toBe(true);
-    if (!result.ok) throw new Error('expected ok');
-
-    // The credentials file's chmod failed — it must have been REMOVED
-    // (fail closed), not left sitting there at the wrong permissions. And
-    // the failure aborted the rest of the copy — the config file (second in
-    // loop order) should never have been reached.
-    const state = byId.get(result.sandboxId);
-    expect(state?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
-    expect(state?.files.has('/home/sprite/.claude.json')).toBe(false);
   });
 
   it('given resolveRootMachineHandle never settles (e.g. a stuck root Sprite), should still return once the bound elapses rather than hanging indefinitely', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -831,6 +831,60 @@ describe('Claude Code credential propagation', () => {
       { cmd: 'chmod', args: ['600', '/home/sprite/.claude.json'] },
     ]);
   });
+
+  // ---------------------------------------------------------------------------
+  // Concurrency safety: the row MUST be persisted before the credential copy's
+  // extra I/O runs — see review (chatgpt-codex-connector, P2). Doing the copy
+  // first would widen the window between "clone succeeded" and "row
+  // persisted", during which a concurrent racer's `reconcileProvisionCollision`
+  // (running because ITS OWN clone failed against this same shared,
+  // name-keyed Sprite) would find no matching row yet, conclude the shared
+  // Sprite is its own redundant one, and kill it out from under the winner —
+  // which is still mid-copy and about to persist that exact sandboxId.
+  // ---------------------------------------------------------------------------
+
+  it('given a brand-new branch, should persist the row BEFORE copying the credential (not after)', async () => {
+    const { host } = makeFakeHost();
+    let sawRowAtCopyTime: unknown;
+    const { deps, store } = makeDeps({
+      host,
+      resolveRootMachineHandle: async (mid) => {
+        // If the row isn't there yet when the copy starts, a concurrent
+        // racer's reconcile step could kill this call's freshly-provisioned
+        // Sprite before it ever gets to persist its own row.
+        sawRowAtCopyTime = await store.findByName(mid, PROJECT_NAME, 'main');
+        return null;
+      },
+    });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    expect(sawRowAtCopyTime).toMatchObject({ branchName: 'main', projectName: PROJECT_NAME });
+  });
+
+  it('given a re-provision of a vanished branch, should persist the updated sandboxId BEFORE copying the credential (not after)', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host, resolveRootMachineHandle: async () => null });
+
+    const first = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!first.ok) throw new Error('expected ok');
+    await host.kill({ machineId: first.sandboxId });
+
+    let sawSandboxIdAtCopyTime: string | undefined;
+    const deps2: MachineBranchesDeps = {
+      ...deps,
+      resolveRootMachineHandle: async (mid) => {
+        const row = await store.findByName(mid, PROJECT_NAME, 'main');
+        sawSandboxIdAtCopyTime = row?.sandboxId;
+        return null;
+      },
+    };
+
+    const second = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps: deps2 });
+    expect(second).toMatchObject({ ok: true, resumed: false });
+    if (!second.ok) throw new Error('expected ok');
+    expect(sawSandboxIdAtCopyTime).toBe(second.sandboxId);
+  });
 });
 
 describe('killBranch', () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -687,6 +687,7 @@ describe('Claude Code credential propagation', () => {
         throw new Error('not used');
       },
       listStreams: async () => [],
+      killSession: async () => {},
     };
   }
 

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -107,15 +107,7 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
       machineId: state.machineId,
       exec: async (args) => {
         state.execLog.push(args);
-        if (execImpl) return execImpl(state, args);
-        // Default `rm -f <path>` semantics, so tests can assert an actual
-        // removal (propagateClaudeCredential's stale-credential cleanup)
-        // rather than only the exec call shape.
-        if (args.cmd === 'rm' && args.args?.[0] === '-f' && args.args[1] !== undefined) {
-          state.files.delete(args.args[1]);
-          state.fileModes.delete(args.args[1]);
-        }
-        return { exitCode: 0, stdout: '', stderr: '' };
+        return execImpl ? execImpl(state, args) : { exitCode: 0, stdout: '', stderr: '' };
       },
       writeFiles: async (files) => {
         for (const f of files) {
@@ -782,7 +774,13 @@ describe('Claude Code credential propagation', () => {
     );
   });
 
-  it('given the root credential is later REMOVED (e.g. a `claude logout`), should remove the stale copy from the branch Sprite too, rather than leaving it silently authenticated', async () => {
+  it('given the root read later comes back empty (e.g. a `claude logout`, OR simply a transient root-Sprite read failure), should NOT delete the branch\'s existing valid credential', async () => {
+    // `readFile` maps EVERY read failure to the same `null` a missing file
+    // produces (see the doc comment on `propagateClaudeCredential`) — an
+    // empty read is NOT reliable evidence of a real logout, so deleting on
+    // it would risk destroying a perfectly valid, working branch credential
+    // on a transient hiccup. Tried deleting on this signal and reverted it
+    // (see review history) — this test guards against reintroducing it.
     const { host, byId } = makeFakeHost();
     let rootFiles: Record<string, string> = { '/home/sprite/.claude/.credentials.json': 'first-token' };
     const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => makeRootHandle(rootFiles) });
@@ -791,16 +789,17 @@ describe('Claude Code credential propagation', () => {
     if (!first.ok) throw new Error('expected ok');
     expect(byId.get(first.sandboxId)?.files.get('/home/sprite/.claude/.credentials.json')).toBe('first-token');
 
-    // Root has since logged out — its own credential file is gone.
+    // The root read now comes back empty (logout, or just a transient blip —
+    // indistinguishable from here).
     rootFiles = {};
     const second = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
     expect(second).toMatchObject({ ok: true, resumed: true });
     if (!second.ok) throw new Error('expected ok');
 
-    expect(byId.get(second.sandboxId)?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
+    expect(byId.get(second.sandboxId)?.files.get('/home/sprite/.claude/.credentials.json')).toBe('first-token');
   });
 
-  it('given the root Machine has never had a credential, removing a nonexistent branch-side file should be a harmless no-op', async () => {
+  it('given the root Machine has never had a credential, should skip the copy without ever touching the branch Sprite\'s exec log', async () => {
     const { host, byId } = makeFakeHost();
     const rootHandle = makeRootHandle({});
     const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
@@ -810,10 +809,7 @@ describe('Claude Code credential propagation', () => {
     if (!result.ok) throw new Error('expected ok');
 
     const state = byId.get(result.sandboxId);
-    expect(state?.execLog.filter((c) => c.cmd === 'rm')).toEqual([
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json'] },
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json'] },
-    ]);
+    expect(state?.execLog.filter((c) => c.cmd === 'rm' || c.cmd === 'chmod')).toEqual([]);
   });
 
   it('should also propagate the credential on attachBranch (not only spawnBranch)', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -887,6 +887,15 @@ describe('Claude Code credential propagation', () => {
     if (!result.ok) throw new Error('expected ok');
 
     const state = byId.get(result.sandboxId);
+    // The temp path is cleared BEFORE each write too — a fixed temp name
+    // isn't guaranteed fresh (a prior attempt could have left it behind),
+    // and writing to an already-existing temp path would silently keep
+    // whatever mode it already had.
+    const rmCalls = state?.execLog.filter((c) => c.cmd === 'rm') ?? [];
+    expect(rmCalls).toEqual([
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json.tmp'] },
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json.tmp'] },
+    ]);
     const mvCalls = state?.execLog.filter((c) => c.cmd === 'mv') ?? [];
     expect(mvCalls).toEqual([
       { cmd: 'mv', args: ['/home/sprite/.claude/.credentials.json.tmp', '/home/sprite/.claude/.credentials.json'] },

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -84,6 +84,7 @@ interface SpriteState {
   machineId: string;
   execLog: RunCommandArgs[];
   files: Map<string, string>;
+  fileModes: Map<string, number | undefined>;
 }
 
 /**
@@ -109,7 +110,10 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
         return execImpl ? execImpl(state, args) : { exitCode: 0, stdout: '', stderr: '' };
       },
       writeFiles: async (files) => {
-        for (const f of files) state.files.set(f.path, String(f.content));
+        for (const f of files) {
+          state.files.set(f.path, String(f.content));
+          state.fileModes.set(f.path, f.mode);
+        }
       },
       readFile: async ({ path }) => {
         const content = state.files.get(path);
@@ -129,7 +133,7 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
       let state = byName.get(name);
       if (!state) {
         counter += 1;
-        state = { machineId: `sbx-${counter}`, execLog: [], files: new Map() };
+        state = { machineId: `sbx-${counter}`, execLog: [], files: new Map(), fileModes: new Map() };
         byName.set(name, state);
         byId.set(state.machineId, state);
       }
@@ -166,6 +170,7 @@ function makeDeps(overrides: Partial<MachineBranchesDeps> = {}, storeSeed: Machi
     secret: SECRET,
     checkFullEgressEnablement: async () => ({ ok: true }),
     resolveGitHubToken: async () => 'ghp_secret_token',
+    resolveRootMachineHandle: async () => null,
     quota: { acquireSlot: () => true, releaseSlot: () => {} },
     buildEnv: () => ({ NODE_ENV: 'test' }),
     audit: async (input) => {
@@ -591,6 +596,8 @@ describe('spawnBranch — isolation between two branches of one project', () => 
   });
 });
 
+const noRootHandle = async () => null;
+
 describe('attachBranch', () => {
   it('given an existing, live branch, should reattach to its Sprite', async () => {
     const { host } = makeFakeHost();
@@ -598,7 +605,14 @@ describe('attachBranch', () => {
     const spawned = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
     if (!spawned.ok) throw new Error('expected ok');
 
-    const result = await attachBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host });
+    const result = await attachBranch({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: 'main',
+      store,
+      host,
+      resolveRootMachineHandle: noRootHandle,
+    });
     expect(result).toEqual({ ok: true, sandboxId: spawned.sandboxId, branchName: 'main' });
   });
 
@@ -620,6 +634,7 @@ describe('attachBranch', () => {
       branchName: 'My Cool Feature',
       store,
       host,
+      resolveRootMachineHandle: noRootHandle,
     });
     expect(result).toEqual({ ok: true, sandboxId: spawned.sandboxId, branchName: 'my-cool-feature' });
   });
@@ -627,7 +642,14 @@ describe('attachBranch', () => {
   it('given no tracked branch, should return not_found', async () => {
     const { host } = makeFakeHost();
     const { store } = makeDeps({ host });
-    const result = await attachBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'nope', store, host });
+    const result = await attachBranch({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: 'nope',
+      store,
+      host,
+      resolveRootMachineHandle: noRootHandle,
+    });
     expect(result).toEqual({ ok: false, reason: 'not_found' });
   });
 
@@ -639,8 +661,156 @@ describe('attachBranch', () => {
 
     await host.kill({ machineId: spawned.sandboxId });
 
-    const result = await attachBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', store, host });
+    const result = await attachBranch({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: 'main',
+      store,
+      host,
+      resolveRootMachineHandle: noRootHandle,
+    });
     expect(result).toEqual({ ok: false, reason: 'vanished' });
+  });
+});
+
+describe('Claude Code credential propagation', () => {
+  /** A fake root Machine's Sprite pre-seeded with the given files, standing in for `resolveRootMachineHandle`. */
+  function makeRootHandle(files: Record<string, string>): MachineHandle {
+    return {
+      machineId: 'root-sbx',
+      exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      writeFiles: async () => {},
+      readFile: async ({ path }) => (path in files ? Buffer.from(files[path]!) : null),
+      createCheckpoint: async () => {},
+      stream: async () => {
+        throw new Error('not used');
+      },
+      listStreams: async () => [],
+    };
+  }
+
+  it('given the root Machine has a live Claude credential, should copy it into a freshly spawned branch Sprite', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'secret-token' });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('secret-token');
+  });
+
+  it('given the root Machine also has a Claude config file, should copy that too', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({
+      '/home/sprite/.claude/.credentials.json': 'secret-token',
+      '/home/sprite/.claude.json': '{"theme":"dark"}',
+    });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.files.get('/home/sprite/.claude.json')).toBe('{"theme":"dark"}');
+  });
+
+  it('given the root Machine has no live session, should skip the copy without failing the spawn', async () => {
+    const { host, byId } = makeFakeHost();
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => null });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
+  });
+
+  it('given the root Machine is live but has never logged into Claude Code, should skip the copy without failing the spawn', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({});
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
+  });
+
+  it('given resolving the root handle throws, should not fail the spawn', async () => {
+    const { host } = makeFakeHost();
+    const { deps } = makeDeps({
+      host,
+      resolveRootMachineHandle: async () => {
+        throw new Error('root Sprite unreachable');
+      },
+    });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given a refreshed credential on reattach (existing, live branch-terminal), should re-copy rather than only copying once at first spawn', async () => {
+    const { host } = makeFakeHost();
+    let currentToken = 'first-token';
+    const rootHandle = () => makeRootHandle({ '/home/sprite/.claude/.credentials.json': currentToken });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle() });
+
+    const first = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!first.ok) throw new Error('expected ok');
+
+    currentToken = 'refreshed-token';
+    const second = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(second).toMatchObject({ ok: true, resumed: true });
+    if (!second.ok) throw new Error('expected ok');
+
+    const state = (await host.attach({ machineId: second.sandboxId }));
+    expect((await state?.readFile({ path: '/home/sprite/.claude/.credentials.json' }))?.toString('utf8')).toBe(
+      'refreshed-token',
+    );
+  });
+
+  it('should also propagate the credential on attachBranch (not only spawnBranch)', async () => {
+    const { host } = makeFakeHost();
+    const { deps, store } = makeDeps({ host });
+    const spawned = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!spawned.ok) throw new Error('expected ok');
+
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'attach-time-token' });
+    const result = await attachBranch({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: 'main',
+      store,
+      host,
+      resolveRootMachineHandle: async () => rootHandle,
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+
+    const handle = await host.attach({ machineId: result.sandboxId });
+    expect((await handle?.readFile({ path: '/home/sprite/.claude/.credentials.json' }))?.toString('utf8')).toBe(
+      'attach-time-token',
+    );
+  });
+
+  it('should write the credential file with restrictive (0o600) permissions', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({
+      '/home/sprite/.claude/.credentials.json': 'secret-token',
+      '/home/sprite/.claude.json': '{"theme":"dark"}',
+    });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -908,6 +908,48 @@ describe('Claude Code credential propagation', () => {
     expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
   });
 
+  it('given an overlapping call reads an OLDER credential and then stalls, should skip its own mv once a NEWER call has already landed — never clobbering the newer credential', async () => {
+    // `withTimeout` deliberately does not cancel a slow call's underlying
+    // work — it keeps running in the background. Without the generation
+    // check, that stalled call finishing LATER with stale data would
+    // overwrite a newer, already-landed credential from a faster call that
+    // started after it.
+    const { host, byId } = makeFakeHost();
+    const handle = await host.provision({ name: 'branch-sprite-race', substrate: { kind: 'sprite' }, options: {} });
+
+    // Call A: reads an OLD token, but its root resolution stays pending
+    // until manually released — simulating a stall on a flaky root Sprite.
+    let releaseA!: () => void;
+    const aRootReady = new Promise<void>((resolve) => {
+      releaseA = resolve;
+    });
+    const callA = propagateClaudeCredential({
+      machineId: TERMINAL_ID,
+      branchHandle: handle,
+      resolveRootMachineHandle: async () => {
+        await aRootReady;
+        return makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'old-token' });
+      },
+    });
+
+    // Call B starts after A and finishes normally with a NEWER (rotated)
+    // token, while A is still stalled.
+    const rootHandleB = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'rotated-token' });
+    await propagateClaudeCredential({
+      machineId: TERMINAL_ID,
+      branchHandle: handle,
+      resolveRootMachineHandle: async () => rootHandleB,
+    });
+    expect(byId.get(handle.machineId)?.files.get('/home/sprite/.claude/.credentials.json')).toBe('rotated-token');
+
+    // Now let A's stalled resolution proceed — it should detect a newer
+    // generation already landed and skip its own mv rather than clobber it.
+    releaseA();
+    await callA;
+
+    expect(byId.get(handle.machineId)?.files.get('/home/sprite/.claude/.credentials.json')).toBe('rotated-token');
+  });
+
   it('given the mv exec fails, should leave the EXISTING valid credential at the real path untouched (no window of total absence) and clean up the orphaned temp file', async () => {
     // The core property this design exists for: a failed rename must never
     // regress a branch from "has a valid, working credential" to "has

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -891,7 +891,7 @@ describe('Claude Code credential propagation', () => {
     // comment on why) and cleared BEFORE each write too — writing to an
     // already-existing temp path would silently keep whatever mode it
     // already had.
-    const tempPathPattern = /^\/home\/sprite\/\.claude(\/\.credentials\.json|\.json)\.tmp\.\d+$/;
+    const tempPathPattern = /^\/home\/sprite\/\.claude(\/\.credentials\.json|\.json)\.tmp\.[a-z0-9]+$/;
     const rmCalls = state?.execLog.filter((c) => c.cmd === 'rm') ?? [];
     expect(rmCalls).toHaveLength(2);
     for (const call of rmCalls) {
@@ -985,7 +985,7 @@ describe('Claude Code credential propagation', () => {
     expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('still-valid-token');
     // The orphaned (generation-suffixed) temp file must have been cleaned
     // up (best-effort).
-    const tempPathPattern = /^\/home\/sprite\/\.claude\/\.credentials\.json\.tmp\.\d+$/;
+    const tempPathPattern = /^\/home\/sprite\/\.claude\/\.credentials\.json\.tmp\.[a-z0-9]+$/;
     expect([...(state?.files.keys() ?? [])].some((k) => tempPathPattern.test(k))).toBe(false);
   });
 

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -911,6 +911,23 @@ describe('Claude Code credential propagation', () => {
     expect([...(state?.files.keys() ?? [])].some((k) => tempPathPattern.test(k))).toBe(false);
   });
 
+  it('should pass a bounded timeoutMs on every housekeeping rm/mv exec — the Sprite runner only installs its SIGKILL timer when one is supplied, so a call with none is unbounded at the transport level', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'secret-token' });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    const housekeepingCalls = state?.execLog.filter((c) => c.cmd === 'rm' || c.cmd === 'mv') ?? [];
+    expect(housekeepingCalls.length).toBeGreaterThan(0);
+    for (const call of housekeepingCalls) {
+      expect(call.timeoutMs).toBeGreaterThan(0);
+      expect(call.maxBytes).toBeGreaterThan(0);
+    }
+  });
+
   it('given an overlapping call reads an OLDER credential and then stalls, should skip its own mv once a NEWER call has already landed — never clobbering the newer credential', async () => {
     // `withTimeout` deliberately does not cancel a slow call's underlying
     // work — it keeps running in the background. Without the generation

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -942,6 +942,34 @@ describe('Claude Code credential propagation', () => {
     expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
   });
 
+  it('given the temp-clearing rm exec fails (non-zero exit), should abort BEFORE writing rather than assume the temp path is clear, and should leave any existing valid credential untouched', async () => {
+    // If the clear itself fails, the temp path might still hold a stale
+    // file — writing to it anyway would risk an OVERWRITE (not a creation),
+    // silently keeping the stale file's permissions, which the subsequent
+    // mv would then promote onto the real credential. Aborting before the
+    // write is what prevents that (caught in review).
+    const { host, byId } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'rm') return { exitCode: 1, stdout: '', stderr: 'rm: permission denied' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const handle = await host.provision({ name: 'branch-sprite', substrate: { kind: 'sprite' }, options: {} });
+    await handle.writeFiles([{ path: '/home/sprite/.claude/.credentials.json', content: 'still-valid-token', mode: 0o600 }]);
+
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'refreshed-token' });
+    await propagateClaudeCredential({
+      machineId: TERMINAL_ID,
+      branchHandle: handle,
+      resolveRootMachineHandle: async () => rootHandle,
+    });
+
+    const state = byId.get(handle.machineId);
+    // Never reached writeFiles/mv for the temp path — the existing valid
+    // credential at the real path must be untouched.
+    expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('still-valid-token');
+    expect(state?.execLog.some((c) => c.cmd === 'mv')).toBe(false);
+  });
+
   it('given the mv exec throws (e.g. a transport failure), should not fail the spawn (best-effort)', async () => {
     const { host } = makeFakeHost((_state, args) => {
       if (args.cmd === 'mv') throw new Error('exec transport failure');

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -107,7 +107,15 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
       machineId: state.machineId,
       exec: async (args) => {
         state.execLog.push(args);
-        return execImpl ? execImpl(state, args) : { exitCode: 0, stdout: '', stderr: '' };
+        if (execImpl) return execImpl(state, args);
+        // Default `rm -f <path>` semantics, so tests can assert an actual
+        // removal (propagateClaudeCredential's stale-credential cleanup)
+        // rather than only the exec call shape.
+        if (args.cmd === 'rm' && args.args?.[0] === '-f' && args.args[1] !== undefined) {
+          state.files.delete(args.args[1]);
+          state.fileModes.delete(args.args[1]);
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
       },
       writeFiles: async (files) => {
         for (const f of files) {
@@ -772,6 +780,40 @@ describe('Claude Code credential propagation', () => {
     expect((await state?.readFile({ path: '/home/sprite/.claude/.credentials.json' }))?.toString('utf8')).toBe(
       'refreshed-token',
     );
+  });
+
+  it('given the root credential is later REMOVED (e.g. a `claude logout`), should remove the stale copy from the branch Sprite too, rather than leaving it silently authenticated', async () => {
+    const { host, byId } = makeFakeHost();
+    let rootFiles: Record<string, string> = { '/home/sprite/.claude/.credentials.json': 'first-token' };
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => makeRootHandle(rootFiles) });
+
+    const first = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!first.ok) throw new Error('expected ok');
+    expect(byId.get(first.sandboxId)?.files.get('/home/sprite/.claude/.credentials.json')).toBe('first-token');
+
+    // Root has since logged out — its own credential file is gone.
+    rootFiles = {};
+    const second = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(second).toMatchObject({ ok: true, resumed: true });
+    if (!second.ok) throw new Error('expected ok');
+
+    expect(byId.get(second.sandboxId)?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
+  });
+
+  it('given the root Machine has never had a credential, removing a nonexistent branch-side file should be a harmless no-op', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({});
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    expect(state?.execLog.filter((c) => c.cmd === 'rm')).toEqual([
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json'] },
+      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json'] },
+    ]);
   });
 
   it('should also propagate the credential on attachBranch (not only spawnBranch)', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -812,6 +812,25 @@ describe('Claude Code credential propagation', () => {
     const state = byId.get(result.sandboxId);
     expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
   });
+
+  it('should chmod both copied files to 600 after writing — writeFiles\' mode only applies at creation, so an overwrite of an ALREADY-EXISTING file (e.g. a refresh) needs an explicit chmod to re-secure it', async () => {
+    const { host, byId } = makeFakeHost();
+    const rootHandle = makeRootHandle({
+      '/home/sprite/.claude/.credentials.json': 'secret-token',
+      '/home/sprite/.claude.json': '{"theme":"dark"}',
+    });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    if (!result.ok) throw new Error('expected ok');
+
+    const state = byId.get(result.sandboxId);
+    const chmodCalls = state?.execLog.filter((c) => c.cmd === 'chmod') ?? [];
+    expect(chmodCalls).toEqual([
+      { cmd: 'chmod', args: ['600', '/home/sprite/.claude/.credentials.json'] },
+      { cmd: 'chmod', args: ['600', '/home/sprite/.claude.json'] },
+    ]);
+  });
 });
 
 describe('killBranch', () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   spawnBranch,
   attachBranch,
@@ -868,6 +868,51 @@ describe('Claude Code credential propagation', () => {
       { cmd: 'chmod', args: ['600', '/home/sprite/.claude/.credentials.json'] },
       { cmd: 'chmod', args: ['600', '/home/sprite/.claude.json'] },
     ]);
+  });
+
+  it('given the chmod exec fails (non-zero exit), should not silently trust the permissions and should stop copying further files', async () => {
+    // `exec` resolves with an exitCode rather than throwing on a nonzero
+    // exit — a failed chmod must not be silently ignored, since a failed
+    // chmod on an OVERWRITE of an already-existing file leaves it at
+    // whatever permissive mode it already had.
+    const { host, byId } = makeFakeHost((_state, args) => {
+      if (args.cmd === 'chmod') return { exitCode: 1, stdout: '', stderr: 'chmod: permission denied' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const rootHandle = makeRootHandle({
+      '/home/sprite/.claude/.credentials.json': 'secret-token',
+      '/home/sprite/.claude.json': '{"theme":"dark"}',
+    });
+    const { deps } = makeDeps({ host, resolveRootMachineHandle: async () => rootHandle });
+
+    const result = await spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+    // Best-effort — a chmod failure must never fail the spawn itself.
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+
+    // The credentials file's chmod failed, aborting the rest of the copy —
+    // the config file (second in loop order) should never have been reached.
+    const state = byId.get(result.sandboxId);
+    expect(state?.files.has('/home/sprite/.claude.json')).toBe(false);
+  });
+
+  it('given resolveRootMachineHandle never settles (e.g. a stuck root Sprite), should still return once the bound elapses rather than hanging indefinitely', async () => {
+    vi.useFakeTimers();
+    try {
+      const { host } = makeFakeHost();
+      const { deps } = makeDeps({
+        host,
+        resolveRootMachineHandle: () => new Promise<MachineHandle | null>(() => {}),
+      });
+
+      const pending = spawnBranch({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: 'main', actor, deps });
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await pending;
+
+      expect(result.ok).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -4,6 +4,7 @@ import {
   attachBranch,
   killBranch,
   listBranches,
+  propagateClaudeCredential,
   BRANCH_REPO_PATH,
   type MachineBranchesDeps,
   type MachineBranchProjectLookup,
@@ -107,7 +108,22 @@ function makeFakeHost(execImpl?: (state: SpriteState, args: RunCommandArgs) => S
       machineId: state.machineId,
       exec: async (args) => {
         state.execLog.push(args);
-        return execImpl ? execImpl(state, args) : { exitCode: 0, stdout: '', stderr: '' };
+        if (execImpl) return execImpl(state, args);
+        // Default `mv <src> <dst>` semantics (moves the in-memory entry),
+        // so tests can assert the write-to-temp-then-atomic-rename
+        // sequence `propagateClaudeCredential` uses lands the final
+        // content at the REAL path, not just the exec call shape.
+        if (args.cmd === 'mv' && args.args?.[0] !== undefined && args.args[1] !== undefined) {
+          const [src, dst] = args.args;
+          const content = state.files.get(src);
+          if (content !== undefined) {
+            state.files.set(dst, content);
+            state.fileModes.set(dst, state.fileModes.get(src));
+          }
+          state.files.delete(src);
+          state.fileModes.delete(src);
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
       },
       writeFiles: async (files) => {
         for (const f of files) {
@@ -853,13 +869,13 @@ describe('Claude Code credential propagation', () => {
     expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
   });
 
-  it('should delete any existing file before writing the fresh copy, for both the credentials and config files — a fresh CREATION is what makes 0o600 take effect reliably even on a refresh', async () => {
+  it('should write to a temp path then atomically rename it onto the real destination, for both the credentials and config files — a fresh CREATION is what makes 0o600 take effect reliably even on a refresh', async () => {
     // `writeFiles`' `mode` only applies at file CREATION (POSIX open()
     // semantics) — an overwrite of an already-existing file silently keeps
-    // whatever permissions it already had. Deleting first (rather than
-    // writing then chmod-ing after) means every write IS a creation, so
-    // there's no separate step (and no window where the fresh secret sits
-    // at the OLD mode) that could fail or stall independently.
+    // whatever permissions it already had. Writing to a temp path (which
+    // never existed before) makes every write a creation, and `mv` on the
+    // same filesystem is atomic — no separate chmod step, no window where
+    // the destination is at the wrong mode or briefly absent.
     const { host, byId } = makeFakeHost();
     const rootHandle = makeRootHandle({
       '/home/sprite/.claude/.credentials.json': 'secret-token',
@@ -871,18 +887,55 @@ describe('Claude Code credential propagation', () => {
     if (!result.ok) throw new Error('expected ok');
 
     const state = byId.get(result.sandboxId);
-    const rmCalls = state?.execLog.filter((c) => c.cmd === 'rm') ?? [];
-    expect(rmCalls).toEqual([
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json'] },
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json'] },
+    const mvCalls = state?.execLog.filter((c) => c.cmd === 'mv') ?? [];
+    expect(mvCalls).toEqual([
+      { cmd: 'mv', args: ['/home/sprite/.claude/.credentials.json.tmp', '/home/sprite/.claude/.credentials.json'] },
+      { cmd: 'mv', args: ['/home/sprite/.claude.json.tmp', '/home/sprite/.claude.json'] },
     ]);
+    // The fake host's `mv` moves the in-memory entry — the final content and
+    // mode must land at the REAL path, with no lingering temp-path entry.
+    expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('secret-token');
     expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
-    expect(state?.fileModes.get('/home/sprite/.claude.json')).toBe(0o600);
+    expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
   });
 
-  it('given the pre-write rm exec throws (e.g. a transport failure), should not fail the spawn (best-effort)', async () => {
+  it('given the mv exec fails, should leave the EXISTING valid credential at the real path untouched (no window of total absence) and clean up the orphaned temp file', async () => {
+    // The core property this design exists for: a failed rename must never
+    // regress a branch from "has a valid, working credential" to "has
+    // none at all" — that would be a regression on exactly the transient
+    // Sprite/FS hiccups this best-effort path is supposed to tolerate.
+    const { host, byId } = makeFakeHost((state, args) => {
+      if (args.cmd === 'mv') return { exitCode: 1, stdout: '', stderr: 'mv: input/output error' };
+      if (args.cmd === 'rm' && args.args?.[0] === '-f' && args.args[1] !== undefined) {
+        state.files.delete(args.args[1]);
+        state.fileModes.delete(args.args[1]);
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    // Provision a branch Sprite directly and seed it with an existing,
+    // valid credential — as if a prior successful copy already happened.
+    const handle = await host.provision({ name: 'branch-sprite', substrate: { kind: 'sprite' }, options: {} });
+    await handle.writeFiles([{ path: '/home/sprite/.claude/.credentials.json', content: 'still-valid-token', mode: 0o600 }]);
+
+    const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'refreshed-token' });
+    await propagateClaudeCredential({
+      machineId: TERMINAL_ID,
+      branchHandle: handle,
+      resolveRootMachineHandle: async () => rootHandle,
+    });
+
+    const state = byId.get(handle.machineId);
+    // The refresh's mv failed — the credential at the real path must be the
+    // one that was there before the failed refresh, not gone.
+    expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('still-valid-token');
+    // The orphaned temp file must have been cleaned up (best-effort).
+    expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
+  });
+
+  it('given the mv exec throws (e.g. a transport failure), should not fail the spawn (best-effort)', async () => {
     const { host } = makeFakeHost((_state, args) => {
-      if (args.cmd === 'rm') throw new Error('exec transport failure');
+      if (args.cmd === 'mv') throw new Error('exec transport failure');
       return { exitCode: 0, stdout: '', stderr: '' };
     });
     const rootHandle = makeRootHandle({ '/home/sprite/.claude/.credentials.json': 'secret-token' });

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -887,25 +887,28 @@ describe('Claude Code credential propagation', () => {
     if (!result.ok) throw new Error('expected ok');
 
     const state = byId.get(result.sandboxId);
-    // The temp path is cleared BEFORE each write too — a fixed temp name
-    // isn't guaranteed fresh (a prior attempt could have left it behind),
-    // and writing to an already-existing temp path would silently keep
-    // whatever mode it already had.
+    // The temp path is generation-suffixed (not a fixed name — see doc
+    // comment on why) and cleared BEFORE each write too — writing to an
+    // already-existing temp path would silently keep whatever mode it
+    // already had.
+    const tempPathPattern = /^\/home\/sprite\/\.claude(\/\.credentials\.json|\.json)\.tmp\.\d+$/;
     const rmCalls = state?.execLog.filter((c) => c.cmd === 'rm') ?? [];
-    expect(rmCalls).toEqual([
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude/.credentials.json.tmp'] },
-      { cmd: 'rm', args: ['-f', '/home/sprite/.claude.json.tmp'] },
-    ]);
+    expect(rmCalls).toHaveLength(2);
+    for (const call of rmCalls) {
+      expect(call.args?.[0]).toBe('-f');
+      expect(call.args?.[1]).toMatch(tempPathPattern);
+    }
     const mvCalls = state?.execLog.filter((c) => c.cmd === 'mv') ?? [];
-    expect(mvCalls).toEqual([
-      { cmd: 'mv', args: ['/home/sprite/.claude/.credentials.json.tmp', '/home/sprite/.claude/.credentials.json'] },
-      { cmd: 'mv', args: ['/home/sprite/.claude.json.tmp', '/home/sprite/.claude.json'] },
-    ]);
+    expect(mvCalls).toHaveLength(2);
+    expect(mvCalls[0]?.args?.[0]).toMatch(tempPathPattern);
+    expect(mvCalls[0]?.args?.[1]).toBe('/home/sprite/.claude/.credentials.json');
+    expect(mvCalls[1]?.args?.[0]).toMatch(tempPathPattern);
+    expect(mvCalls[1]?.args?.[1]).toBe('/home/sprite/.claude.json');
     // The fake host's `mv` moves the in-memory entry — the final content and
     // mode must land at the REAL path, with no lingering temp-path entry.
     expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('secret-token');
     expect(state?.fileModes.get('/home/sprite/.claude/.credentials.json')).toBe(0o600);
-    expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
+    expect([...(state?.files.keys() ?? [])].some((k) => tempPathPattern.test(k))).toBe(false);
   });
 
   it('given an overlapping call reads an OLDER credential and then stalls, should skip its own mv once a NEWER call has already landed — never clobbering the newer credential', async () => {
@@ -980,8 +983,10 @@ describe('Claude Code credential propagation', () => {
     // The refresh's mv failed — the credential at the real path must be the
     // one that was there before the failed refresh, not gone.
     expect(state?.files.get('/home/sprite/.claude/.credentials.json')).toBe('still-valid-token');
-    // The orphaned temp file must have been cleaned up (best-effort).
-    expect(state?.files.has('/home/sprite/.claude/.credentials.json.tmp')).toBe(false);
+    // The orphaned (generation-suffixed) temp file must have been cleaned
+    // up (best-effort).
+    const tempPathPattern = /^\/home\/sprite\/\.claude\/\.credentials\.json\.tmp\.\d+$/;
+    expect([...(state?.files.keys() ?? [])].some((k) => tempPathPattern.test(k))).toBe(false);
   });
 
   it('given the temp-clearing rm exec fails (non-zero exit), should abort BEFORE writing rather than assume the temp path is clear, and should leave any existing valid credential untouched', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches.test.ts
@@ -870,13 +870,18 @@ describe('Claude Code credential propagation', () => {
     ]);
   });
 
-  it('given the chmod exec fails (non-zero exit), should not silently trust the permissions and should stop copying further files', async () => {
+  it('given the chmod exec fails (non-zero exit), should fail CLOSED by removing the just-copied credential rather than leaving it at the wrong permissions, and should stop copying further files', async () => {
     // `exec` resolves with an exitCode rather than throwing on a nonzero
     // exit — a failed chmod must not be silently ignored, since a failed
     // chmod on an OVERWRITE of an already-existing file leaves it at
-    // whatever permissive mode it already had.
-    const { host, byId } = makeFakeHost((_state, args) => {
+    // whatever permissive mode it already had. Simulates `rm -f` deletion
+    // too, so the file's actual absence can be asserted below.
+    const { host, byId } = makeFakeHost((state, args) => {
       if (args.cmd === 'chmod') return { exitCode: 1, stdout: '', stderr: 'chmod: permission denied' };
+      if (args.cmd === 'rm' && args.args?.[0] === '-f' && args.args[1] !== undefined) {
+        state.files.delete(args.args[1]);
+        state.fileModes.delete(args.args[1]);
+      }
       return { exitCode: 0, stdout: '', stderr: '' };
     });
     const rootHandle = makeRootHandle({
@@ -890,9 +895,12 @@ describe('Claude Code credential propagation', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) throw new Error('expected ok');
 
-    // The credentials file's chmod failed, aborting the rest of the copy —
-    // the config file (second in loop order) should never have been reached.
+    // The credentials file's chmod failed — it must have been REMOVED
+    // (fail closed), not left sitting there at the wrong permissions. And
+    // the failure aborted the rest of the copy — the config file (second in
+    // loop order) should never have been reached.
     const state = byId.get(result.sandboxId);
+    expect(state?.files.has('/home/sprite/.claude/.credentials.json')).toBe(false);
     expect(state?.files.has('/home/sprite/.claude.json')).toBe(false);
   });
 

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -210,15 +210,22 @@ async function cloneAndCheckoutBranch({
 /**
  * Copy Claude Code's OAuth credential (and config, if present) from the root
  * Machine's Sprite into a branch-terminal's freshly provisioned/attached one.
- * Each file is handled independently: absent on the root Sprite — most
- * commonly because the user hasn't run `claude` there yet — copies nothing
- * (a branch-terminal always ends up usable even with no credential to copy);
- * absent on the root Sprite when it WAS present before (an explicit `claude
- * logout`, or manual removal) actively REMOVES any stale copy already on the
- * branch Sprite, rather than leaving it silently authenticated after the
- * source was cleared. Since this refresh runs on every reattach specifically
- * to keep rotated credentials in sync, a revocation on the root is exactly
- * the kind of change that sync must also propagate (caught in review).
+ * Each file is copied independently and skipped when the root read comes
+ * back empty — most commonly because the user hasn't run `claude` there yet
+ * — so a branch-terminal always ends up usable even with no credential to
+ * copy.
+ *
+ * Deliberately does NOT delete an existing branch-side copy on an empty
+ * root read, even though that read coming back empty could also mean an
+ * explicit `claude logout` on the root (a tempting "propagate the
+ * revocation" behavior — tried and reverted, see review history). The
+ * driver's `readFile` maps EVERY read failure to the same `null` a missing
+ * file produces (`sprites.ts`'s `readFileToBuffer`: "a missing file (or ANY
+ * read failure after a wake retry) resolves to null") — there is no way,
+ * from this signal alone, to tell "confirmed gone" apart from "root Sprite
+ * was briefly unreachable." Deleting on that ambiguous signal would risk
+ * destroying a branch's perfectly valid, working credential on a transient
+ * hiccup — strictly worse than the staleness this would have closed.
  *
  * Best-effort: any failure (root Sprite unreachable mid-copy, etc.) is
  * swallowed rather than failing the spawn/attach it's called from. A branch
@@ -246,14 +253,7 @@ export async function propagateClaudeCredential({
 
     for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
       const content = await rootHandle.readFile({ path });
-      if (!content) {
-        // The root's own file is gone — most commonly an explicit `claude
-        // logout` (or manual removal) — which must propagate as a
-        // revocation to any branch Sprite that received a copy, not leave a
-        // stale one behind. `rm -f` is a no-op when nothing was ever copied.
-        await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
-        continue;
-      }
+      if (!content) continue;
       // Both restricted 0o600 — the credentials file is the OAuth secret
       // itself, and the config file can carry account/org metadata, so
       // neither belongs world-readable in the branch Sprite's home dir.

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -39,6 +39,16 @@ import { isUniqueViolation, type MachineBranchStore, type MachineBranchRecord } 
 /** The directory on a branch-terminal's OWN Sprite the project is cloned into. */
 export const BRANCH_REPO_PATH = `${SANDBOX_ROOT}/repo`;
 
+/**
+ * Where Claude Code writes its OAuth credential/config on a Sprite's own
+ * persistent filesystem. A branch-terminal is a SEPARATE Sprite from its
+ * owning Machine (see module doc), so it never inherits whatever the user
+ * logged into on the root Sprite — these paths are copied across explicitly,
+ * see `propagateClaudeCredential` below.
+ */
+const CLAUDE_CREDENTIALS_PATH = '/home/sprite/.claude/.credentials.json';
+const CLAUDE_CONFIG_PATH = '/home/sprite/.claude.json';
+
 export type SpawnBranchDenialReason =
   | 'kill_switch_off'
   | 'project_not_found'
@@ -74,6 +84,14 @@ export interface MachineBranchesDeps {
   /** REQUIRED full-egress enablement gate — a branch-terminal's Sprite runs open egress, same as a human Terminal. */
   checkFullEgressEnablement: () => Promise<FullEgressEnablement>;
   resolveGitHubToken: (userId: string) => Promise<string | null>;
+  /**
+   * Live handle to the OWNING Machine's own persistent Sprite (never a
+   * branch's) — the source a branch-terminal's Claude Code credential is
+   * copied from. `null` when the root Machine has no live session yet (the
+   * user hasn't opened its Terminal / isn't logged into Claude Code there),
+   * which `propagateClaudeCredential` treats as a graceful no-op.
+   */
+  resolveRootMachineHandle: (machineId: string) => Promise<MachineHandle | null>;
   quota: SandboxQuotaDeps;
   buildEnv: () => Record<string, string>;
   audit: (input: CodeExecutionAuditInput) => Promise<void>;
@@ -189,6 +207,42 @@ async function cloneAndCheckoutBranch({
   return { ok: true, createdNew: true };
 }
 
+/**
+ * Copy Claude Code's OAuth credential (and config, if present) from the root
+ * Machine's Sprite into a branch-terminal's freshly provisioned/attached one.
+ * Each file is copied independently and skipped when absent on the root
+ * Sprite — most commonly because the user hasn't run `claude` there yet — so
+ * a branch-terminal always ends up usable even with no credential to copy.
+ *
+ * Best-effort: any failure (root Sprite unreachable mid-copy, etc.) is
+ * swallowed rather than failing the spawn/attach it's called from. A branch
+ * without the credential still works, it just needs its own `claude` login.
+ */
+async function propagateClaudeCredential({
+  machineId,
+  branchHandle,
+  resolveRootMachineHandle,
+}: {
+  machineId: string;
+  branchHandle: MachineHandle;
+  resolveRootMachineHandle: (machineId: string) => Promise<MachineHandle | null>;
+}): Promise<void> {
+  try {
+    const rootHandle = await resolveRootMachineHandle(machineId);
+    if (!rootHandle) return;
+
+    for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
+      const content = await rootHandle.readFile({ path });
+      if (!content) continue;
+      await branchHandle.writeFiles([
+        { path, content, mode: path === CLAUDE_CREDENTIALS_PATH ? 0o600 : undefined },
+      ]);
+    }
+  } catch {
+    // best-effort — see doc comment above.
+  }
+}
+
 async function safeKillSprite(host: MachineHost, machineId: string): Promise<void> {
   try {
     await host.kill({ machineId });
@@ -276,7 +330,12 @@ export async function spawnBranch({
 
   if (existing) {
     const handle = await deps.host.attach({ machineId: existing.sandboxId });
-    if (handle) return { ok: true, sandboxId: handle.machineId, branchName, resumed: true };
+    if (handle) {
+      // Refresh on every reattach, not just first spawn — Claude Code OAuth
+      // credentials rotate, so a one-time copy would drift stale over time.
+      await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
+      return { ok: true, sandboxId: handle.machineId, branchName, resumed: true };
+    }
     // Vanished — fall through and re-provision under the SAME session key.
   }
 
@@ -301,6 +360,8 @@ export async function spawnBranch({
     if ('ok' in reconciled) return reconciled;
     return { ok: false, reason: cloned.reason, detail: cloned.detail };
   }
+
+  await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
 
   if (existing) {
     const updated = await deps.store.updateSandboxId({
@@ -364,12 +425,14 @@ export async function attachBranch({
   branchName: requestedBranchName,
   store,
   host,
+  resolveRootMachineHandle,
 }: {
   machineId: string;
   projectName: string;
   branchName: string;
   store: MachineBranchStore;
   host: MachineHost;
+  resolveRootMachineHandle: (machineId: string) => Promise<MachineHandle | null>;
 }): Promise<AttachBranchResult> {
   // Shadow the raw params with their canonical forms, as `spawnBranch` does, so no
   // line below can reach the untrusted text by accident.
@@ -381,6 +444,10 @@ export async function attachBranch({
 
   const handle = await host.attach({ machineId: existing.sandboxId });
   if (!handle) return { ok: false, reason: 'vanished' };
+
+  // Refresh on every reattach — see `propagateClaudeCredential`'s doc comment
+  // on why this isn't a one-time, spawn-only copy.
+  await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle });
   return { ok: true, sandboxId: handle.machineId, branchName };
 }
 

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -290,24 +290,37 @@ export async function propagateClaudeCredential({
         for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
           const content = await rootHandle.readFile({ path });
           if (!content) continue;
-          // Delete any existing file FIRST, so the write below is always a
-          // fresh CREATION rather than an overwrite. `writeFiles`' `mode`
-          // only takes effect at creation (POSIX open()'s mode argument is
-          // ignored once a file already exists) — a refresh on reattach
-          // would otherwise overwrite an ALREADY-EXISTING file and silently
-          // keep whatever permissions it already had. A prior version of
-          // this function wrote first and ran a follow-up `chmod` — but that
-          // left a window where the fresh secret sat at the OLD (possibly
-          // permissive) mode until the chmod resolved, and a slow/stuck
-          // chmod on a flaky Sprite could leave that window open well past
-          // whatever bound the caller waited on (caught in review, twice:
-          // once for a chmod that fails, once for a chmod that never even
-          // returns in time). Deleting first removes the whole class of
-          // problem: there is no "old mode" to inherit, so the requested
-          // `mode: 0o600` is correct from the instant the file exists.
-          // `rm -f` is a no-op when nothing was there yet (fresh spawn).
-          await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
-          await branchHandle.writeFiles([{ path, content, mode: 0o600 }]);
+          // Write to a TEMP path, then atomically rename it onto the real
+          // destination — never delete-then-write or write-then-chmod
+          // directly against the live path. Both were tried and reverted:
+          // write-then-chmod left a window where the fresh secret sat at
+          // the OLD (possibly permissive) mode until the chmod resolved,
+          // and a slow/stuck chmod could leave that window open past
+          // whatever bound the caller waited on. Delete-then-write closed
+          // THAT window but opened a worse one: if the write that follows
+          // the delete then fails (or the caller's timeout elapses in
+          // between), the branch is left with NO credential at all, even
+          // though it had a perfectly valid one moments before — a
+          // regression on exactly the transient Sprite/FS hiccups this
+          // best-effort path exists to tolerate (caught in review, twice).
+          //
+          // `writeFiles`' `mode` reliably applies to a genuine CREATION —
+          // the temp path never existed before — and `mv` on the same
+          // filesystem is atomic: the destination is either the OLD valid
+          // credential or the NEW one, NEVER wrong-permission or briefly
+          // absent in between. If anything fails before the rename, the
+          // live file at `path` is completely untouched.
+          const tempPath = `${path}.tmp`;
+          await branchHandle.writeFiles([{ path: tempPath, content, mode: 0o600 }]);
+          const move = await branchHandle.exec({ cmd: 'mv', args: [tempPath, path] });
+          if (move.exitCode !== 0) {
+            // Best-effort cleanup of the orphaned temp file (itself already
+            // 0o600, so leaving it behind on a rare failure is a harmless
+            // leftover, not an exposure) — the live file at `path` was never
+            // touched by this attempt either way.
+            await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+            throw new Error(`mv ${tempPath} -> ${path} failed: exit ${move.exitCode}`);
+          }
         }
       } catch {
         // best-effort — see doc comment above.

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -378,8 +378,15 @@ export async function spawnBranch({
     return { ok: false, reason: cloned.reason, detail: cloned.detail };
   }
 
-  await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
-
+  // Persist the row FIRST, before the credential copy — not after. A
+  // concurrent racer's `reconcileProvisionCollision` (its own clone having
+  // failed against this same name-keyed shared Sprite) looks up this branch's
+  // row to decide whether the Sprite it's about to kill is actually the
+  // winner's. Doing the credential copy's extra network I/O (a root-Sprite
+  // read + branch-Sprite writes/execs) BEFORE that row exists would widen the
+  // window in which no matching row exists yet — during which the racer would
+  // find nothing, conclude it's *its own* redundant Sprite, and kill the very
+  // Sprite this call is about to record as the winner (caught in review).
   if (existing) {
     const updated = await deps.store.updateSandboxId({
       id: existing.id,
@@ -397,6 +404,7 @@ export async function spawnBranch({
       }
       return { ok: false, reason: 'error', detail: 'lost a concurrent branch-terminal spawn race' };
     }
+    await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
     return { ok: true, sandboxId: handle.machineId, branchName, resumed: false, createdNew: cloned.createdNew };
   }
 
@@ -422,6 +430,7 @@ export async function spawnBranch({
     return { ok: false, reason: 'error', detail: error instanceof Error ? error.message : String(error) };
   }
 
+  await propagateClaudeCredential({ machineId, branchHandle: handle, resolveRootMachineHandle: deps.resolveRootMachineHandle });
   return { ok: true, sandboxId: handle.machineId, branchName, resumed: false, createdNew: cloned.createdNew };
 }
 

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -240,6 +240,12 @@ function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
 }
 
 /**
+ * Latest `propagateClaudeCredential` call number issued per branch Sprite
+ * machineId — see the staleness check before each `mv` below for why.
+ */
+const latestCredentialCopyGeneration = new Map<string, number>();
+
+/**
  * Copy Claude Code's OAuth credential (and config, if present) from the root
  * Machine's Sprite into a branch-terminal's freshly provisioned/attached one.
  * Each file is copied independently and skipped when the root read comes
@@ -281,6 +287,22 @@ export async function propagateClaudeCredential({
   branchHandle: MachineHandle;
   resolveRootMachineHandle: (machineId: string) => Promise<MachineHandle | null>;
 }): Promise<void> {
+  // This call's own generation number for this branch Sprite. `withTimeout`
+  // deliberately does NOT cancel the underlying work when its bound elapses
+  // — it keeps running in the background so a slow copy still lands rather
+  // than being aborted. But that means an OVERLAPPING call that read an
+  // OLDER root credential and then stalled could otherwise finish LATER and
+  // `mv` its stale temp file over a destination a faster, more recent call
+  // already updated with a NEWER (rotated) credential — clobbering it
+  // (caught in review). Checking, right before each `mv`, whether a NEWER
+  // call has since started for this same branch Sprite — and skipping the
+  // rename if so — is what prevents that: a self-contained per-file check
+  // rather than a lock that would need its own release/backstop logic (and
+  // the "what if the thing holding it never finishes" risk that comes with
+  // one).
+  const generation = (latestCredentialCopyGeneration.get(branchHandle.machineId) ?? 0) + 1;
+  latestCredentialCopyGeneration.set(branchHandle.machineId, generation);
+
   await withTimeout(
     (async () => {
       try {
@@ -328,6 +350,16 @@ export async function propagateClaudeCredential({
             throw new Error(`rm -f ${tempPath} failed: exit ${clearTemp.exitCode}`);
           }
           await branchHandle.writeFiles([{ path: tempPath, content, mode: 0o600 }]);
+
+          // A NEWER call already started for this branch Sprite while this
+          // one was working — it will (or already did) land more current
+          // data, so abandon this stale attempt rather than risk this one's
+          // `mv` clobbering it once it finally gets here.
+          if (latestCredentialCopyGeneration.get(branchHandle.machineId) !== generation) {
+            await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+            return;
+          }
+
           const move = await branchHandle.exec({ cmd: 'mv', args: [tempPath, path] });
           if (move.exitCode !== 0) {
             // Best-effort cleanup of the orphaned temp file (itself already

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -305,12 +305,23 @@ export async function propagateClaudeCredential({
           // best-effort path exists to tolerate (caught in review, twice).
           //
           // `writeFiles`' `mode` reliably applies to a genuine CREATION —
-          // the temp path never existed before — and `mv` on the same
-          // filesystem is atomic: the destination is either the OLD valid
-          // credential or the NEW one, NEVER wrong-permission or briefly
-          // absent in between. If anything fails before the rename, the
-          // live file at `path` is completely untouched.
+          // and `mv` on the same filesystem is atomic: the destination is
+          // either the OLD valid credential or the NEW one, NEVER
+          // wrong-permission or briefly absent in between. If anything
+          // fails before the rename, the live file at `path` is completely
+          // untouched.
           const tempPath = `${path}.tmp`;
+          // Clear the temp path FIRST — a fixed name isn't guaranteed to be
+          // fresh (a prior attempt could have crashed between writing it
+          // and renaming it, or its own cleanup could have failed), and
+          // writing to an ALREADY-EXISTING temp path would be an overwrite,
+          // not a creation — silently keeping whatever (possibly
+          // permissive) mode that stale file already had, which the `mv`
+          // below would then promote onto the real credential, reintroducing
+          // the exact problem this temp-file flow exists to avoid (caught
+          // in review). Safe to do unconditionally: any failure here only
+          // ever touches the disposable temp path, never the live file.
+          await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
           await branchHandle.writeFiles([{ path: tempPath, content, mode: 0o600 }]);
           const move = await branchHandle.exec({ cmd: 'mv', args: [tempPath, path] });
           if (move.exitCode !== 0) {

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -332,19 +332,29 @@ export async function propagateClaudeCredential({
           // wrong-permission or briefly absent in between. If anything
           // fails before the rename, the live file at `path` is completely
           // untouched.
-          const tempPath = `${path}.tmp`;
-          // Clear the temp path FIRST — a fixed name isn't guaranteed to be
-          // fresh (a prior attempt could have crashed between writing it
-          // and renaming it, or its own cleanup could have failed), and
-          // writing to an ALREADY-EXISTING temp path would be an overwrite,
-          // not a creation — silently keeping whatever (possibly
-          // permissive) mode that stale file already had, which the `mv`
-          // below would then promote onto the real credential, reintroducing
-          // the exact problem this temp-file flow exists to avoid (caught
-          // in review). Checked, not fire-and-forget: if the clear itself
-          // fails, abort BEFORE writing rather than assume the temp path is
-          // now clear (caught in review, again) — still safe either way,
-          // since nothing has touched the live file yet.
+          // Suffixed with THIS call's own generation number — never shared
+          // with an overlapping call for the same branch Sprite. A fixed
+          // temp name was tried and reverted: when an older call's stale
+          // cleanup (below) ran after a newer, overlapping call had already
+          // written ITS OWN content to that same shared path, the older
+          // cleanup deleted the newer call's temp file out from under it,
+          // making the newer (correct) refresh fail its own `mv` (caught in
+          // review). A per-generation path means no two overlapping calls
+          // ever touch the same temp file, so one's cleanup can never
+          // disturb another's in-progress write.
+          const tempPath = `${path}.tmp.${generation}`;
+          // Still clear it first — a per-generation name is effectively
+          // never reused WITHIN one process lifetime, but this process
+          // could have restarted since a prior crash: `generation` resets
+          // to 1 on every restart (it's in-memory, not persisted), so a
+          // stale temp file from a pre-restart run could coincidentally
+          // share this exact generation number. Writing to an
+          // ALREADY-EXISTING temp path would be an overwrite, not a
+          // creation, silently keeping whatever (possibly permissive) mode
+          // that stale file already had. Checked, not fire-and-forget: if
+          // the clear itself fails, abort BEFORE writing rather than assume
+          // the temp path is now clear — still safe either way, since
+          // nothing has touched the live file yet.
           const clearTemp = await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
           if (clearTemp.exitCode !== 0) {
             throw new Error(`rm -f ${tempPath} failed: exit ${clearTemp.exitCode}`);

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -217,8 +217,15 @@ async function cloneAndCheckoutBranch({
  * Best-effort: any failure (root Sprite unreachable mid-copy, etc.) is
  * swallowed rather than failing the spawn/attach it's called from. A branch
  * without the credential still works, it just needs its own `claude` login.
+ *
+ * Exported for reuse by the realtime agent-terminal PTY bridge
+ * (`apps/realtime/src/index.ts`'s `resolveAgentTerminalSandbox`), which is
+ * the OTHER place a branch's Sprite gets attached to for real use (opening or
+ * reattaching to its Claude agent terminal) — `spawnBranch`/`attachBranch`
+ * alone only cover branch creation and the navigator's explicit attach API,
+ * neither of which the realtime PTY path calls.
  */
-async function propagateClaudeCredential({
+export async function propagateClaudeCredential({
   machineId,
   branchHandle,
   resolveRootMachineHandle,

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -241,9 +241,19 @@ export async function propagateClaudeCredential({
     for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
       const content = await rootHandle.readFile({ path });
       if (!content) continue;
-      await branchHandle.writeFiles([
-        { path, content, mode: path === CLAUDE_CREDENTIALS_PATH ? 0o600 : undefined },
-      ]);
+      // Both restricted 0o600 — the credentials file is the OAuth secret
+      // itself, and the config file can carry account/org metadata, so
+      // neither belongs world-readable in the branch Sprite's home dir.
+      //
+      // `writeFiles`' `mode` only takes effect at file CREATION (POSIX
+      // open()'s mode argument is ignored once a file already exists) — a
+      // refresh on reattach overwrites an ALREADY-EXISTING file (this is
+      // never the first copy after the first reattach), so the requested
+      // mode alone would silently leave whatever permissions that file
+      // already had. An explicit chmod after the write re-secures it either
+      // way, regardless of whether this write created or overwrote it.
+      await branchHandle.writeFiles([{ path, content, mode: 0o600 }]);
+      await branchHandle.exec({ cmd: 'chmod', args: ['600', path] });
     }
   } catch {
     // best-effort — see doc comment above.

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -404,6 +404,24 @@ export async function propagateClaudeCredential({
           // one was working — it will (or already did) land more current
           // data, so abandon this stale attempt rather than risk this one's
           // `mv` clobbering it once it finally gets here.
+          //
+          // KNOWN, ACCEPTED RESIDUAL WINDOW (raised in review, twice): this
+          // check happens BEFORE the `mv` below, not atomically with it. A
+          // newer call could still start, read a rotated credential, and
+          // complete its OWN `mv` entirely within the time this call's own
+          // `mv` (checked as still-current a moment ago) takes to actually
+          // land — landing this stale `mv` last and overwriting the fresher
+          // one anyway. Closing that fully would need either an atomic
+          // compare-and-swap primitive this filesystem abstraction doesn't
+          // expose, or a synchronous per-branch mutex serializing every
+          // `mv` (which would then queue an unrelated caller's response
+          // behind however long a DIFFERENT in-flight refresh's Sprite I/O
+          // takes — reintroducing the unbounded-latency problem this
+          // design exists to avoid). The impact is staleness, not exposure:
+          // worst case, the branch keeps using an old-but-still-valid
+          // token a little longer, and self-heals on the next reattach in
+          // either process — consistent with every other best-effort
+          // guarantee in this function. Deliberately not chased further.
           if (latestCredentialCopyGeneration.get(branchHandle.machineId) !== generation) {
             await branchHandle.exec(housekeepingExecArgs('rm', ['-f', tempPath]));
             return;

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -210,9 +210,15 @@ async function cloneAndCheckoutBranch({
 /**
  * Copy Claude Code's OAuth credential (and config, if present) from the root
  * Machine's Sprite into a branch-terminal's freshly provisioned/attached one.
- * Each file is copied independently and skipped when absent on the root
- * Sprite — most commonly because the user hasn't run `claude` there yet — so
- * a branch-terminal always ends up usable even with no credential to copy.
+ * Each file is handled independently: absent on the root Sprite — most
+ * commonly because the user hasn't run `claude` there yet — copies nothing
+ * (a branch-terminal always ends up usable even with no credential to copy);
+ * absent on the root Sprite when it WAS present before (an explicit `claude
+ * logout`, or manual removal) actively REMOVES any stale copy already on the
+ * branch Sprite, rather than leaving it silently authenticated after the
+ * source was cleared. Since this refresh runs on every reattach specifically
+ * to keep rotated credentials in sync, a revocation on the root is exactly
+ * the kind of change that sync must also propagate (caught in review).
  *
  * Best-effort: any failure (root Sprite unreachable mid-copy, etc.) is
  * swallowed rather than failing the spawn/attach it's called from. A branch
@@ -240,7 +246,14 @@ export async function propagateClaudeCredential({
 
     for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
       const content = await rootHandle.readFile({ path });
-      if (!content) continue;
+      if (!content) {
+        // The root's own file is gone — most commonly an explicit `claude
+        // logout` (or manual removal) — which must propagate as a
+        // revocation to any branch Sprite that received a copy, not leave a
+        // stale one behind. `rm -f` is a no-op when nothing was ever copied.
+        await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
+        continue;
+      }
       // Both restricted 0o600 — the credentials file is the OAuth secret
       // itself, and the config file can carry account/org metadata, so
       // neither belongs world-readable in the branch Sprite's home dir.

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -28,6 +28,7 @@ import type { SubscriptionTier } from '../subscription-utils';
 import { runGitInSandbox, type GitSandboxRunDeps } from '../sandbox/git-tool-runners';
 import type { SandboxActorContext, SandboxQuotaDeps } from '../sandbox/tool-runners';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
+import { SANDBOX_MAX_OUTPUT_BYTES } from '../sandbox/execution-policy';
 import type { MachineHost, MachineHandle, MachineSubstrateSpec } from '../sandbox/machine-host';
 import { adaptMachineHandleToExecutableSandbox } from '../sandbox/sandbox-client/machine-host-adapter';
 import type { SandboxCreateOptions } from '../sandbox/sandbox-options';
@@ -224,6 +225,21 @@ async function cloneAndCheckoutBranch({
  */
 const CREDENTIAL_COPY_TIMEOUT_MS = 5_000;
 
+/**
+ * `MachineHandle.exec`'s underlying Sprite runner only installs its SIGKILL
+ * wall-clock timer when `timeoutMs` is explicitly supplied (`sprites.ts`:
+ * the kill timer is conditional on `timeoutMs && timeoutMs > 0`) — an exec
+ * call with none is genuinely unbounded at the transport level, regardless
+ * of `CREDENTIAL_COPY_TIMEOUT_MS` above (that only stops THIS function's
+ * caller from waiting; it does not touch the exec itself). Without an
+ * explicit bound, a wedged `rm`/`mv` on a cold/unreachable Sprite would
+ * never be killed, leaking its process/socket on every such attach (caught
+ * in review). Every housekeeping exec in this file passes this.
+ */
+function housekeepingExecArgs(cmd: string, args: string[]): { cmd: string; args: string[]; timeoutMs: number; maxBytes: number } {
+  return { cmd, args, timeoutMs: CREDENTIAL_COPY_TIMEOUT_MS, maxBytes: SANDBOX_MAX_OUTPUT_BYTES };
+}
+
 function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
   return new Promise((resolve) => {
     const timer = setTimeout(resolve, timeoutMs);
@@ -378,7 +394,7 @@ export async function propagateClaudeCredential({
           // the clear itself fails, abort BEFORE writing rather than assume
           // the temp path is now clear — still safe either way, since
           // nothing has touched the live file yet.
-          const clearTemp = await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+          const clearTemp = await branchHandle.exec(housekeepingExecArgs('rm', ['-f', tempPath]));
           if (clearTemp.exitCode !== 0) {
             throw new Error(`rm -f ${tempPath} failed: exit ${clearTemp.exitCode}`);
           }
@@ -389,17 +405,17 @@ export async function propagateClaudeCredential({
           // data, so abandon this stale attempt rather than risk this one's
           // `mv` clobbering it once it finally gets here.
           if (latestCredentialCopyGeneration.get(branchHandle.machineId) !== generation) {
-            await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+            await branchHandle.exec(housekeepingExecArgs('rm', ['-f', tempPath]));
             return;
           }
 
-          const move = await branchHandle.exec({ cmd: 'mv', args: [tempPath, path] });
+          const move = await branchHandle.exec(housekeepingExecArgs('mv', [tempPath, path]));
           if (move.exitCode !== 0) {
             // Best-effort cleanup of the orphaned temp file (itself already
             // 0o600, so leaving it behind on a rare failure is a harmless
             // leftover, not an exposure) — the live file at `path` was never
             // touched by this attempt either way.
-            await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+            await branchHandle.exec(housekeepingExecArgs('rm', ['-f', tempPath]));
             throw new Error(`mv ${tempPath} -> ${path} failed: exit ${move.exitCode}`);
           }
         }

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -290,37 +290,24 @@ export async function propagateClaudeCredential({
         for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
           const content = await rootHandle.readFile({ path });
           if (!content) continue;
-          // Both restricted 0o600 — the credentials file is the OAuth secret
-          // itself, and the config file can carry account/org metadata, so
-          // neither belongs world-readable in the branch Sprite's home dir.
-          //
-          // `writeFiles`' `mode` only takes effect at file CREATION (POSIX
-          // open()'s mode argument is ignored once a file already exists) —
-          // a refresh on reattach overwrites an ALREADY-EXISTING file (this
-          // is never the first copy after the first reattach), so the
-          // requested mode alone would silently leave whatever permissions
-          // that file already had. An explicit chmod after the write
-          // re-secures it either way, regardless of whether this write
-          // created or overwrote it.
+          // Delete any existing file FIRST, so the write below is always a
+          // fresh CREATION rather than an overwrite. `writeFiles`' `mode`
+          // only takes effect at creation (POSIX open()'s mode argument is
+          // ignored once a file already exists) — a refresh on reattach
+          // would otherwise overwrite an ALREADY-EXISTING file and silently
+          // keep whatever permissions it already had. A prior version of
+          // this function wrote first and ran a follow-up `chmod` — but that
+          // left a window where the fresh secret sat at the OLD (possibly
+          // permissive) mode until the chmod resolved, and a slow/stuck
+          // chmod on a flaky Sprite could leave that window open well past
+          // whatever bound the caller waited on (caught in review, twice:
+          // once for a chmod that fails, once for a chmod that never even
+          // returns in time). Deleting first removes the whole class of
+          // problem: there is no "old mode" to inherit, so the requested
+          // `mode: 0o600` is correct from the instant the file exists.
+          // `rm -f` is a no-op when nothing was there yet (fresh spawn).
+          await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
           await branchHandle.writeFiles([{ path, content, mode: 0o600 }]);
-
-          // `exec` resolves with an exitCode rather than throwing on a
-          // nonzero exit — a failed chmod would otherwise be silently
-          // ignored, leaving an OVERWRITE of an already-existing file (which
-          // is what the chmod above is specifically for) at whatever
-          // permissive mode it already had, while this function reports
-          // success (caught in review).
-          const chmod = await branchHandle.exec({ cmd: 'chmod', args: ['600', path] });
-          if (chmod.exitCode !== 0) {
-            // Fail CLOSED: don't leave the credential we just copied sitting
-            // at whatever (possibly permissive) mode the destination already
-            // had — remove it rather than leave a valid, freshly-refreshed
-            // secret exposed at the wrong permissions (caught in review).
-            // Best-effort — if even this fails, the outer catch below
-            // swallows it, same as any other failure in this function.
-            await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
-            throw new Error(`chmod 600 failed for ${path}: exit ${chmod.exitCode}`);
-          }
         }
       } catch {
         // best-effort — see doc comment above.

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -312,6 +312,13 @@ export async function propagateClaudeCredential({
           // success (caught in review).
           const chmod = await branchHandle.exec({ cmd: 'chmod', args: ['600', path] });
           if (chmod.exitCode !== 0) {
+            // Fail CLOSED: don't leave the credential we just copied sitting
+            // at whatever (possibly permissive) mode the destination already
+            // had — remove it rather than leave a valid, freshly-refreshed
+            // secret exposed at the wrong permissions (caught in review).
+            // Best-effort — if even this fails, the outer catch below
+            // swallows it, same as any other failure in this function.
+            await branchHandle.exec({ cmd: 'rm', args: ['-f', path] });
             throw new Error(`chmod 600 failed for ${path}: exit ${chmod.exitCode}`);
           }
         }

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -319,9 +319,14 @@ export async function propagateClaudeCredential({
           // permissive) mode that stale file already had, which the `mv`
           // below would then promote onto the real credential, reintroducing
           // the exact problem this temp-file flow exists to avoid (caught
-          // in review). Safe to do unconditionally: any failure here only
-          // ever touches the disposable temp path, never the live file.
-          await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+          // in review). Checked, not fire-and-forget: if the clear itself
+          // fails, abort BEFORE writing rather than assume the temp path is
+          // now clear (caught in review, again) — still safe either way,
+          // since nothing has touched the live file yet.
+          const clearTemp = await branchHandle.exec({ cmd: 'rm', args: ['-f', tempPath] });
+          if (clearTemp.exitCode !== 0) {
+            throw new Error(`rm -f ${tempPath} failed: exit ${clearTemp.exitCode}`);
+          }
           await branchHandle.writeFiles([{ path: tempPath, content, mode: 0o600 }]);
           const move = await branchHandle.exec({ cmd: 'mv', args: [tempPath, path] });
           if (move.exitCode !== 0) {

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -208,6 +208,38 @@ async function cloneAndCheckoutBranch({
 }
 
 /**
+ * Hard cap on how long a single `propagateClaudeCredential` call may run.
+ * Every direct caller in this file (`spawnBranch`'s two success paths,
+ * `attachBranch`) awaits it inline on a real HTTP response, and the
+ * realtime PTY bridge's own bound (`agent-terminal-access.ts`'s
+ * `withTimeout`) only covers ITS OWN wrapper around this call, not a
+ * guarantee this function makes for its OTHER callers — a hibernating root
+ * Sprite's fs read/write can take up to the Sprite fs API's 30s timeout,
+ * with one retry (~60s worst case), and an unbounded copy would hang a
+ * branch-attach HTTP response on that (caught in review). The timer is
+ * always cleared, and the underlying work keeps running past the bound
+ * rather than being cancelled — a slow copy still lands, just too late to
+ * have been waited on by THIS call.
+ */
+const CREDENTIAL_COPY_TIMEOUT_MS = 5_000;
+
+function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, timeoutMs);
+    promise.then(
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+    );
+  });
+}
+
+/**
  * Copy Claude Code's OAuth credential (and config, if present) from the root
  * Machine's Sprite into a branch-terminal's freshly provisioned/attached one.
  * Each file is copied independently and skipped when the root read comes
@@ -228,8 +260,10 @@ async function cloneAndCheckoutBranch({
  * hiccup — strictly worse than the staleness this would have closed.
  *
  * Best-effort: any failure (root Sprite unreachable mid-copy, etc.) is
- * swallowed rather than failing the spawn/attach it's called from. A branch
- * without the credential still works, it just needs its own `claude` login.
+ * swallowed rather than failing the spawn/attach it's called from, AND the
+ * whole call is bounded by `CREDENTIAL_COPY_TIMEOUT_MS` so a slow/hibernating
+ * Sprite can't hang the caller's response. A branch without the credential
+ * still works, it just needs its own `claude` login.
  *
  * Exported for reuse by the realtime agent-terminal PTY bridge
  * (`apps/realtime/src/index.ts`'s `resolveAgentTerminalSandbox`), which is
@@ -247,30 +281,46 @@ export async function propagateClaudeCredential({
   branchHandle: MachineHandle;
   resolveRootMachineHandle: (machineId: string) => Promise<MachineHandle | null>;
 }): Promise<void> {
-  try {
-    const rootHandle = await resolveRootMachineHandle(machineId);
-    if (!rootHandle) return;
+  await withTimeout(
+    (async () => {
+      try {
+        const rootHandle = await resolveRootMachineHandle(machineId);
+        if (!rootHandle) return;
 
-    for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
-      const content = await rootHandle.readFile({ path });
-      if (!content) continue;
-      // Both restricted 0o600 — the credentials file is the OAuth secret
-      // itself, and the config file can carry account/org metadata, so
-      // neither belongs world-readable in the branch Sprite's home dir.
-      //
-      // `writeFiles`' `mode` only takes effect at file CREATION (POSIX
-      // open()'s mode argument is ignored once a file already exists) — a
-      // refresh on reattach overwrites an ALREADY-EXISTING file (this is
-      // never the first copy after the first reattach), so the requested
-      // mode alone would silently leave whatever permissions that file
-      // already had. An explicit chmod after the write re-secures it either
-      // way, regardless of whether this write created or overwrote it.
-      await branchHandle.writeFiles([{ path, content, mode: 0o600 }]);
-      await branchHandle.exec({ cmd: 'chmod', args: ['600', path] });
-    }
-  } catch {
-    // best-effort — see doc comment above.
-  }
+        for (const path of [CLAUDE_CREDENTIALS_PATH, CLAUDE_CONFIG_PATH]) {
+          const content = await rootHandle.readFile({ path });
+          if (!content) continue;
+          // Both restricted 0o600 — the credentials file is the OAuth secret
+          // itself, and the config file can carry account/org metadata, so
+          // neither belongs world-readable in the branch Sprite's home dir.
+          //
+          // `writeFiles`' `mode` only takes effect at file CREATION (POSIX
+          // open()'s mode argument is ignored once a file already exists) —
+          // a refresh on reattach overwrites an ALREADY-EXISTING file (this
+          // is never the first copy after the first reattach), so the
+          // requested mode alone would silently leave whatever permissions
+          // that file already had. An explicit chmod after the write
+          // re-secures it either way, regardless of whether this write
+          // created or overwrote it.
+          await branchHandle.writeFiles([{ path, content, mode: 0o600 }]);
+
+          // `exec` resolves with an exitCode rather than throwing on a
+          // nonzero exit — a failed chmod would otherwise be silently
+          // ignored, leaving an OVERWRITE of an already-existing file (which
+          // is what the chmod above is specifically for) at whatever
+          // permissive mode it already had, while this function reports
+          // success (caught in review).
+          const chmod = await branchHandle.exec({ cmd: 'chmod', args: ['600', path] });
+          if (chmod.exitCode !== 0) {
+            throw new Error(`chmod 600 failed for ${path}: exit ${chmod.exitCode}`);
+          }
+        }
+      } catch {
+        // best-effort — see doc comment above.
+      }
+    })(),
+    CREDENTIAL_COPY_TIMEOUT_MS,
+  );
 }
 
 async function safeKillSprite(host: MachineHost, machineId: string): Promise<void> {

--- a/packages/lib/src/services/machines/machine-branches.ts
+++ b/packages/lib/src/services/machines/machine-branches.ts
@@ -23,6 +23,7 @@
  * directly to that handle, never to a page-keyed Machine lookup.
  */
 
+import { createId } from '@paralleldrive/cuid2';
 import type { SubscriptionTier } from '../subscription-utils';
 import { runGitInSandbox, type GitSandboxRunDeps } from '../sandbox/git-tool-runners';
 import type { SandboxActorContext, SandboxQuotaDeps } from '../sandbox/tool-runners';
@@ -242,6 +243,22 @@ function withTimeout(promise: Promise<void>, timeoutMs: number): Promise<void> {
 /**
  * Latest `propagateClaudeCredential` call number issued per branch Sprite
  * machineId — see the staleness check before each `mv` below for why.
+ *
+ * PROCESS-LOCAL ONLY: `spawnBranch`/`attachBranch` (this file, called from
+ * `apps/web`) and the realtime PTY bridge's `refreshBranchCredential`
+ * (`apps/realtime/src/index.ts`) are TWO SEPARATE PROCESSES, each with its
+ * own copy of this in-memory Map — a call in one process cannot see, or
+ * detect staleness against, an overlapping call in the other (caught in
+ * review). This still closes the WITHIN-process race (e.g. two nearly
+ * simultaneous requests on the same server), and the temp-file path below
+ * is made globally unique regardless of process, so an inter-process race
+ * can never corrupt the OTHER process's in-flight temp file — but an
+ * inter-process race CAN still end with an older credential's `mv` landing
+ * last. Accepted: full cross-process mutual exclusion would need a
+ * database-backed lock or a version marker persisted on the Sprite's own
+ * filesystem, which is disproportionate for a background sync where every
+ * single refresh is already best-effort and self-heals on the next
+ * reattach in either process.
  */
 const latestCredentialCopyGeneration = new Map<string, number>();
 
@@ -332,24 +349,30 @@ export async function propagateClaudeCredential({
           // wrong-permission or briefly absent in between. If anything
           // fails before the rename, the live file at `path` is completely
           // untouched.
-          // Suffixed with THIS call's own generation number — never shared
-          // with an overlapping call for the same branch Sprite. A fixed
-          // temp name was tried and reverted: when an older call's stale
-          // cleanup (below) ran after a newer, overlapping call had already
-          // written ITS OWN content to that same shared path, the older
-          // cleanup deleted the newer call's temp file out from under it,
-          // making the newer (correct) refresh fail its own `mv` (caught in
-          // review). A per-generation path means no two overlapping calls
-          // ever touch the same temp file, so one's cleanup can never
-          // disturb another's in-progress write.
-          const tempPath = `${path}.tmp.${generation}`;
-          // Still clear it first — a per-generation name is effectively
-          // never reused WITHIN one process lifetime, but this process
-          // could have restarted since a prior crash: `generation` resets
-          // to 1 on every restart (it's in-memory, not persisted), so a
-          // stale temp file from a pre-restart run could coincidentally
-          // share this exact generation number. Writing to an
-          // ALREADY-EXISTING temp path would be an overwrite, not a
+          // Suffixed with a globally unique id — never shared with an
+          // overlapping call for the same branch Sprite, WITHIN this
+          // process or across the OTHER process that also calls this
+          // function (`apps/web`'s spawnBranch/attachBranch vs.
+          // `apps/realtime`'s refreshBranchCredential — see the doc comment
+          // on `latestCredentialCopyGeneration`, which is process-local and
+          // therefore cannot be used to key the temp path). A fixed temp
+          // name was tried and reverted: when an older call's stale cleanup
+          // (below) ran after a newer, overlapping call had already written
+          // ITS OWN content to that same shared path, the older cleanup
+          // deleted the newer call's temp file out from under it, making
+          // the newer (correct) refresh fail its own `mv` (caught in
+          // review, twice — once for the intra-process case, once for the
+          // inter-process one this id fixes). A globally unique path means
+          // no two overlapping calls, from either process, ever touch the
+          // same temp file, so one's cleanup can never disturb another's
+          // in-progress write.
+          const tempPath = `${path}.tmp.${createId()}`;
+          // Still clear it first — vanishingly unlikely to collide with a
+          // stale leftover (a cuid2 id, not a small counter), but a
+          // crashed-and-restarted process could in principle still hand out
+          // the same id twice given a broken/predictable random source, and
+          // clearing costs nothing extra. Writing to an ALREADY-EXISTING
+          // temp path would be an overwrite, not a
           // creation, silently keeping whatever (possibly permissive) mode
           // that stale file already had. Checked, not fire-and-forget: if
           // the clear itself fails, abort BEFORE writing rather than assume

--- a/packages/lib/src/services/sandbox/machine-session-manager.ts
+++ b/packages/lib/src/services/sandbox/machine-session-manager.ts
@@ -439,6 +439,34 @@ export async function acquireMachineSession(
 }
 
 /**
+ * Read-only: the `sandboxId` of a page's LIVE machine_session, or `null` if
+ * it has none yet. Unlike `acquireMachineSession`, this never re-authorizes,
+ * provisions, or touches a Sprite — a bare-`pageId` read, the same
+ * precedented direct query `machine-storage-billing.ts` uses. For callers
+ * that only need to know WHERE (if anywhere) a page's Sprite already lives —
+ * e.g. propagating state from the root Machine's Sprite into some other
+ * Sprite (`machine-branches.ts`'s `propagateClaudeCredential`, and the
+ * realtime branch-scope PTY resolution that also refreshes it) — never to
+ * acquire or resume one themselves.
+ *
+ * Lazily resolves the db client, schema table, and `eq` operator so callers
+ * that don't exercise this path (most tests) never load the DB module graph.
+ */
+export async function findLiveMachineSandboxId(pageId: string): Promise<string | null> {
+  const [{ db }, { eq }, { machineSessions }] = await Promise.all([
+    import('@pagespace/db/db'),
+    import('@pagespace/db/operators'),
+    import('@pagespace/db/schema/machine-sessions'),
+  ]);
+  const [row] = await db
+    .select({ sandboxId: machineSessions.sandboxId })
+    .from(machineSessions)
+    .where(eq(machineSessions.pageId, pageId))
+    .limit(1);
+  return row?.sandboxId ?? null;
+}
+
+/**
  * Production DB-backed implementation of MachineSessionStore.
  * Lazily resolves the db client, schema table, and `eq` operator so callers
  * that inject a fake (in tests) never load the DB module graph.

--- a/packages/lib/src/services/sandbox/machine-session-manager.ts
+++ b/packages/lib/src/services/sandbox/machine-session-manager.ts
@@ -441,18 +441,30 @@ export async function acquireMachineSession(
 /**
  * Read-only: the `sandboxId` of a page's LIVE machine_session, or `null` if
  * it has none yet. Unlike `acquireMachineSession`, this never re-authorizes,
- * provisions, or touches a Sprite — a bare-`pageId` read, the same
- * precedented direct query `machine-storage-billing.ts` uses. For callers
- * that only need to know WHERE (if anywhere) a page's Sprite already lives —
- * e.g. propagating state from the root Machine's Sprite into some other
- * Sprite (`machine-branches.ts`'s `propagateClaudeCredential`, and the
- * realtime branch-scope PTY resolution that also refreshes it) — never to
- * acquire or resume one themselves.
+ * provisions, or touches a Sprite. For callers that only need to know WHERE
+ * (if anywhere) a page's Sprite already lives — e.g. propagating state from
+ * the root Machine's Sprite into some other Sprite (`machine-branches.ts`'s
+ * `propagateClaudeCredential`, and the realtime branch-scope PTY resolution
+ * that also refreshes it) — never to acquire or resume one themselves.
+ *
+ * Resolves the CURRENT session key (`deriveMachineSessionKey`) and queries by
+ * it — the table's own unique constraint — rather than a bare `pageId`
+ * (caught in review, P1): `sessionKey` namespaces by tenant + drive + page, so
+ * a page moved between drives can leave its OLD drive's session row behind
+ * (a drive move has no reason to touch `machine_sessions`, and the old row
+ * only disappears once that session tears down on its own). A bare-`pageId`
+ * lookup with no ordering could then non-deterministically return that STALE
+ * row — whose Sprite may belong to a different owner/tenant context entirely
+ * — and hand back state (here, a Claude Code credential) that was never that
+ * page's current owner's to give out. Deriving the exact expected key first
+ * makes the lookup exact by construction: it resolves the CURRENT session or
+ * nothing, never a stale one from a prior drive.
  *
  * Lazily resolves the db client, schema table, and `eq` operator so callers
  * that don't exercise this path (most tests) never load the DB module graph.
  */
-export async function findLiveMachineSandboxId(pageId: string): Promise<string | null> {
+export async function findLiveMachineSandboxId(input: MachineSessionKeyInput): Promise<string | null> {
+  const sessionKey = deriveMachineSessionKey(input);
   const [{ db }, { eq }, { machineSessions }] = await Promise.all([
     import('@pagespace/db/db'),
     import('@pagespace/db/operators'),
@@ -461,7 +473,7 @@ export async function findLiveMachineSandboxId(pageId: string): Promise<string |
   const [row] = await db
     .select({ sandboxId: machineSessions.sandboxId })
     .from(machineSessions)
-    .where(eq(machineSessions.pageId, pageId))
+    .where(eq(machineSessions.sessionKey, sessionKey))
     .limit(1);
   return row?.sandboxId ?? null;
 }


### PR DESCRIPTION
## Summary
- Each branch-terminal runs on its OWN, separate Sprite from the owning Machine's Sprite — no shared filesystem, no shared volume. Claude Code writes its OAuth credential to `/home/sprite/.claude/.credentials.json` on whichever Sprite ran `claude`, so a branch Sprite never has it.
- `propagateClaudeCredential` (`machine-branches.ts`) copies the root Sprite's `.credentials.json` (and `.claude.json` config, if present) into a branch Sprite by writing to a globally-unique (cuid2) temp path and atomically `mv`-ing it onto the real destination — never writing directly to the live path. `writeFiles`' `mode` only reliably applies at file *creation* (POSIX `open()` semantics), so a temp-then-rename is what makes `0o600` land correctly even on a refresh, without ever leaving the live file briefly absent or at the wrong permissions. Every housekeeping `rm`/`mv` exec carries an explicit `timeoutMs`/`maxBytes` so a wedged Sprite can't leak an unbounded background process. A generation counter guards against a stalled, overlapping refresh clobbering a newer one that already landed (process-local — see in-code doc comment on the accepted cross-process residual, which affects staleness only, never exposure).
- Deliberately does **not** delete an existing branch-side copy when the root read comes back empty — the driver maps every read failure to the same `null` a missing file produces, so that signal can't reliably distinguish a real `claude logout` from a transient root-Sprite hiccup.
- Wired at **three** call sites, covering both the explicit branch-management API and the actual PTY attach path a user's agent terminal goes through:
  - `spawnBranch` (fresh-provision and warm-reattach) and `attachBranch` — branch creation / the navigator's explicit attach API. The copy runs **after** the branch row is persisted, not before — doing it earlier would widen the window in which a concurrent racer's collision-reconciliation could kill the shared, name-keyed Sprite out from under the still-in-flight winner. Bounded by a 5s timeout inside `propagateClaudeCredential` itself, so a hibernating root Sprite can't hang a branch-attach HTTP response.
  - Realtime's `resolveAgentTerminalSandbox` → `resolveMachineSandbox` (`agent-terminal-access.ts`), via an optional `refreshBranchCredential` dep fired only for true branch-scope targets (`projectName` **and** `branchName` both set). This is the path a user's branch agent terminal actually opens/reattaches through on every cold PTY open — `spawnBranch`/`attachBranch` alone don't cover it. Awaited but bounded by its own 5s timeout rather than fully blocking or fire-and-forget (both extremes were tried and reverted during review).
- `findLiveMachineSandboxId` (`machine-session-manager.ts`) resolves the page's **current** session key (from its current driveId + drive owner) rather than a bare-`pageId` lookup — a page moved between drives can leave its OLD drive's session row behind under a different key, and a bare-`pageId` read could non-deterministically resolve that stale row. `apps/web/machine-branches-runtime.ts` and `apps/realtime/index.ts` (via a shared `resolveDriveOwnerContext` helper) both resolve the current driveId + owner first.

## Test plan
- [x] `bun run typecheck` — all 16 packages pass
- [x] `bun run build` (web) — passes
- [x] `packages/lib` full suite (`vitest run`) — 357 files / 8193 tests pass
- [x] `apps/realtime` full suite (`vitest run`) — 23 files / 832 tests pass

Coverage includes: credential + config copy on spawn and on attach; no-op when no root session, no credential yet, or an empty-but-ambiguous root read; resolver-throws resilience; refreshed-credential-on-reattach; 0o600 mode via temp-then-atomic-rename; concurrency-safety regression tests for row-persisted-before-copy, a stalled overlapping copy skipping its own stale rename, and a failed rename leaving an existing valid credential untouched; branch-vs-machine-vs-project scope gating in the realtime path; the `refreshBranchCredential` dep being optional and defense-in-depth against a throwing/never-settling implementation (fake-timers tests); every housekeeping exec carrying a bounded `timeoutMs`/`maxBytes`; and current-session-key resolution across a simulated drive move.

## Review history
This PR went through an extensive multi-round automated review cycle (CodeRabbit + Codex) that surfaced and fixed a series of real concurrency/security issues in the credential-copy path — each caught a genuine gap in the previous fix, converging on the write-to-temp-then-atomic-rename design described above. Final Codex pass: "Didn't find any major issues." All CI green, no unresolved merge conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude Code credentials and configuration now carry over automatically from the main machine to newly created or reattached branch terminals.
  - Updated credentials are refreshed when reconnecting to an existing branch.
  - Credential files use secure permissions.

- **Bug Fixes**
  - Terminal access continues normally when credential synchronization fails or no active credentials are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
