### PR TITLE
feat(publish): publish any page type as static content (documents, code, sheets)

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -235,6 +235,10 @@ describe('POST /api/pages/[pageId]/publish', () => {
       subdomain: 'acme',
       path: 'welcome',
       isHomePage: false,
+      title: null,
+      description: null,
+      ogImageUrl: null,
+      noindex: false,
     });
   });
 
@@ -254,6 +258,10 @@ describe('POST /api/pages/[pageId]/publish', () => {
       subdomain: 'pagespace-2',
       path: 'welcome',
       isHomePage: false,
+      title: null,
+      description: null,
+      ogImageUrl: null,
+      noindex: false,
     });
   });
 
@@ -279,6 +287,10 @@ describe('POST /api/pages/[pageId]/publish', () => {
       subdomain: 'acme',
       path: 'welcome',
       isHomePage: true,
+      title: null,
+      description: null,
+      ogImageUrl: null,
+      noindex: false,
     });
   });
 

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -185,12 +185,12 @@ describe('POST /api/pages/[pageId]/publish', () => {
     expect(putPublishedArtifact).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when the page is not a canvas page', async () => {
-    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'DOCUMENT', title: 'T', content: 'x', driveId: 'drive-1' });
+  it('returns 400 when the page type cannot be published', async () => {
+    findFirstPage.mockResolvedValue({ id: 'page-1', type: 'CHANNEL', title: 'T', content: 'x', driveId: 'drive-1' });
     const res = await POST(makeReq({}), { params });
     expect(res.status).toBe(400);
     const json = await res.json();
-    expect(json.error).toMatch(/canvas/i);
+    expect(json.error).toMatch(/cannot be published/i);
   });
 
   it('returns 403 and touches nothing when the page is in a Home drive', async () => {

--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -154,14 +154,18 @@ const PublishControls = ({ pageId, contentDirty }: PublishControlsProps) => {
         toast.error(await readError(res));
         return false;
       }
-      const data = (await res.json()) as { url: string };
+      const data = (await res.json()) as PublishStatusResponse & { url: string };
       setState((prev) => ({
         ...prev,
         published: true,
         url: data.url,
         available: true,
         isStale: false,
-        settings: overrides ?? prev.settings,
+        // Read the effective settings back from the server rather than caching
+        // the request payload: when `overrides.ogImageFileId` was set, the
+        // request's `ogImageUrl` is a blank placeholder — the server resolves
+        // it to the real CDN URL and returns that resolved value here.
+        settings: overrides ? settingsFromResponse(data) : prev.settings,
       }));
       toast.success(isUpdate ? 'Page updated' : 'Page published');
       return true;

--- a/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PublishControls.tsx
@@ -21,9 +21,9 @@ import { Switch } from '@/components/ui/switch';
 import { PagePickerPopover } from '@/components/common/PagePickerPopover';
 import { PageType } from '@pagespace/lib/utils/enums';
 
-interface CanvasPublishControlsProps {
+interface PublishControlsProps {
   pageId: string;
-  /** Mirrors the canvas document's isDirty flag. When it transitions true→false
+  /** Mirrors the page document's isDirty flag. When it transitions true→false
    *  (a save just completed) and the page is published, the control marks itself
    *  stale so the user sees the Update button without a page reload. */
   contentDirty?: boolean;
@@ -83,7 +83,7 @@ const readError = async (res: Response): Promise<string> => {
   }
 };
 
-const CanvasPublishControls = ({ pageId, contentDirty }: CanvasPublishControlsProps) => {
+const PublishControls = ({ pageId, contentDirty }: PublishControlsProps) => {
   const params = useParams<{ driveId?: string }>();
   const driveId = params?.driveId;
   const [state, setState] = useState<PublishState>({ published: false, url: null, available: false, isStale: false, settings: EMPTY_SETTINGS });
@@ -418,4 +418,4 @@ function PublishSettingsDialog({ open, onOpenChange, initial, driveId, isBusy, o
   );
 }
 
-export default CanvasPublishControls;
+export default PublishControls;

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -159,7 +159,10 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
             </Button>
           )}
           {page && isPublishablePageType(page.type) && (
-            <HeaderPublishControls pageId={page.id} />
+            // Keyed on pageId so navigating to a different page remounts the
+            // control instead of reusing local UI state (e.g. an open Publish
+            // Settings dialog) across pages.
+            <HeaderPublishControls key={page.id} pageId={page.id} />
           )}
           <PageViewers pageId={pageId} />
           <ShareDialog pageId={pageId} />

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -13,8 +13,9 @@ import { useParams } from 'next/navigation';
 import { usePageStore } from '@/hooks/usePage';
 import { Button } from '@/components/ui/button';
 import { Download } from 'lucide-react';
-import { isDocumentPage, isFilePage, isSheetPage, isCodePage } from '@pagespace/lib/content/page-types.config';
+import { isDocumentPage, isFilePage, isSheetPage, isCodePage, isPublishablePageType } from '@pagespace/lib/content/page-types.config';
 import { ExportDropdown } from './ExportDropdown';
+import PublishControls from './PublishControls';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useMobile } from '@/hooks/useMobile';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
@@ -52,6 +53,21 @@ const DocumentSaveStatus = memo(function DocumentSaveStatus({
   }
 
   return <SaveStatusIndicator isDirty={isDirty} isSaving={isSaving} />;
+});
+
+const HeaderPublishControls = memo(function HeaderPublishControls({
+  pageId,
+}: {
+  pageId: string;
+}) {
+  const selectIsDirty = useCallback(
+    (state: ReturnType<typeof useDocumentManagerStore.getState>) =>
+      state.documents.get(pageId)?.isDirty ?? false,
+    [pageId]
+  );
+  const contentDirty = useDocumentManagerStore(selectIsDirty);
+
+  return <PublishControls pageId={pageId} contentDirty={contentDirty} />;
 });
 
 export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps = {}) {
@@ -141,6 +157,9 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
               <Download className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
               {!isMobile && (isDownloading ? 'Downloading...' : 'Download')}
             </Button>
+          )}
+          {page && isPublishablePageType(page.type) && (
+            <HeaderPublishControls pageId={page.id} />
           )}
           <PageViewers pageId={pageId} />
           <ShareDialog pageId={pageId} />

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -11,7 +11,6 @@ import { useEditingStore } from '@/stores/useEditingStore';
 import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { useFindStore } from '@/stores/useFindStore';
-import CanvasPublishControls from './CanvasPublishControls';
 import CanvasFormsSettingsTab from './CanvasFormsSettingsTab';
 
 interface CanvasPageViewProps {
@@ -187,9 +186,6 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
         >
           Forms
         </button>
-        <div className="ml-auto min-w-0 max-w-full">
-          <CanvasPublishControls pageId={pageId} contentDirty={documentState?.isDirty} />
-        </div>
       </div>
       {activeTab === 'code' && (
         <div className="flex-1 min-h-0">

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -459,6 +459,16 @@ describe('publishCanvasPage — per-type render branch', () => {
     );
   });
 
+  it('given a CODE page with no author description, does not derive one from the raw source (would mangle generics as HTML tags)', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CODE', title: 'main.ts', content: 'const x: Array<Map<string, number>> = [];', contentMode: 'html', driveId: 'drive-1',
+    }));
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(renderPublishedCode).toHaveBeenCalledWith(expect.objectContaining({ description: '' }));
+  });
+
   it('given a SHEET page, passes the serialized content straight to renderPublishedSheet without HTML rewriting', async () => {
     const serialized = JSON.stringify({ cells: { A1: 'hi' } });
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({

--- a/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/publish-page.test.ts
@@ -18,6 +18,8 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   isNull: vi.fn(),
+  ne: vi.fn(),
+  inArray: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -59,6 +61,17 @@ vi.mock('@pagespace/lib/canvas/site-files', () => ({
 
 vi.mock('../render-published', () => ({
   renderPublishedPage: vi.fn(({ html }) => `<html>${html}</html>`),
+  renderPublishedDocument: vi.fn(({ html }) => `<doc>${html}</doc>`),
+  renderPublishedCode: vi.fn(({ code }) => `<code>${code}</code>`),
+  renderPublishedSheet: vi.fn(({ serializedContent }) => `<sheet>${serializedContent}</sheet>`),
+}));
+
+vi.mock('@pagespace/lib/publish/neutralize-dashboard-links', () => ({
+  neutralizeDashboardLinks: vi.fn((html: string) => html),
+}));
+
+vi.mock('marked', () => ({
+  marked: { parse: vi.fn((markdown: string) => Promise.resolve(`<p>${markdown}</p>`)) },
 }));
 
 vi.mock('../asset-pipeline', () => ({
@@ -114,8 +127,10 @@ import { putPublishedArtifact, putPublishedSiteFile, publishedArtifactExists, de
 import { publishCanvasPage, publishHomePageAtRoot, clearPublishedHomeRoot, regeneratePublishedSiteFiles, syncPublishedHomeRoot, republishDriveCanonical, PublishError } from '../publish-page';
 import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service';
 import { getActiveDomainRecords } from '../custom-domain-mirror';
-import { renderPublishedPage } from '../render-published';
-import { extractAndStripOgMeta } from '../asset-pipeline';
+import { renderPublishedPage, renderPublishedDocument, renderPublishedCode, renderPublishedSheet } from '../render-published';
+import { neutralizeDashboardLinks } from '@pagespace/lib/publish/neutralize-dashboard-links';
+import { marked } from 'marked';
+import { extractAndStripOgMeta, rewriteCanvasAssets } from '../asset-pipeline';
 
 // The mocked `db` keeps the real relational-query return types, so partial test
 // fixtures are cast through `unknown` to the row shape (never `any`).
@@ -171,9 +186,9 @@ describe('publishCanvasPage', () => {
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'my-drive', path: '', html: expect.any(String) });
   });
 
-  it('given a non-canvas page, throws a 400 PublishError', async () => {
+  it('given a non-publishable page type, throws a 400 PublishError', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-      id: 'page-1', type: 'DOCUMENT', title: 'Doc', content: '', driveId: 'drive-1',
+      id: 'page-1', type: 'CHANNEL', title: 'Chat', content: '', driveId: 'drive-1',
     }));
 
     await expect(publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' }))
@@ -309,7 +324,7 @@ describe('publishCanvasPage', () => {
 
   it('PublishError carries an HTTP status code', async () => {
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-      id: 'page-1', type: 'DOCUMENT', title: 'Doc', content: '', driveId: 'drive-1',
+      id: 'page-1', type: 'CHANNEL', title: 'Chat', content: '', driveId: 'drive-1',
     }));
 
     await expect(publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' }))
@@ -386,6 +401,77 @@ describe('publishCanvasPage', () => {
 
     expect(result.isHomePage).toBe(true);
     expect(result.url).toBe('https://www.acme.com/');
+  });
+});
+
+describe('publishCanvasPage — per-type render branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isPublishConfigured).mockReturnValue(true);
+    vi.mocked(getActiveDomainRecords).mockResolvedValue([]);
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+      id: 'drive-1', slug: 'my-drive', publishSubdomain: 'my-drive', kind: 'STANDARD', homePageId: null,
+    }));
+    vi.mocked(db.query.publishedPages.findFirst).mockResolvedValue(undefined);
+  });
+
+  it('given an HTML-mode DOCUMENT page, rewrites assets/links, neutralizes stale dashboard links, and renders via renderPublishedDocument', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'DOCUMENT', title: 'My Doc', content: '<p>Hi</p>', contentMode: 'html', driveId: 'drive-1',
+    }));
+
+    const result = await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(marked.parse).not.toHaveBeenCalled();
+    expect(neutralizeDashboardLinks).toHaveBeenCalledWith('<p>Hi</p>');
+    expect(renderPublishedDocument).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>Hi</p>', title: 'My Doc' }));
+    expect(renderPublishedPage).not.toHaveBeenCalled();
+    expect(putPublishedArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ html: '<doc><p>Hi</p></doc>' }),
+    );
+    expect(result.path).toBe('my-doc');
+  });
+
+  it('given a markdown-mode DOCUMENT page, converts via marked.parse before the rest of the pipeline', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'DOCUMENT', title: 'My Doc', content: '# Hello', contentMode: 'markdown', driveId: 'drive-1',
+    }));
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(marked.parse).toHaveBeenCalledWith('# Hello');
+    expect(neutralizeDashboardLinks).toHaveBeenCalledWith('<p># Hello</p>');
+    expect(renderPublishedDocument).toHaveBeenCalledWith(expect.objectContaining({ html: '<p># Hello</p>' }));
+  });
+
+  it('given a CODE page, passes the raw code straight to renderPublishedCode without HTML rewriting', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'CODE', title: 'main.ts', content: 'const x = 1;', contentMode: 'html', driveId: 'drive-1',
+    }));
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(rewriteCanvasAssets).not.toHaveBeenCalled();
+    expect(neutralizeDashboardLinks).not.toHaveBeenCalled();
+    expect(renderPublishedCode).toHaveBeenCalledWith(expect.objectContaining({ code: 'const x = 1;', title: 'main.ts' }));
+    expect(putPublishedArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ html: '<code>const x = 1;</code>' }),
+    );
+  });
+
+  it('given a SHEET page, passes the serialized content straight to renderPublishedSheet without HTML rewriting', async () => {
+    const serialized = JSON.stringify({ cells: { A1: 'hi' } });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+      id: 'page-1', type: 'SHEET', title: 'My Sheet', content: serialized, contentMode: 'html', driveId: 'drive-1',
+    }));
+
+    await publishCanvasPage({ pageId: 'page-1', driveId: 'drive-1', userId: 'user-1' });
+
+    expect(rewriteCanvasAssets).not.toHaveBeenCalled();
+    expect(renderPublishedSheet).toHaveBeenCalledWith(expect.objectContaining({ serializedContent: serialized, title: 'My Sheet' }));
+    expect(putPublishedArtifact).toHaveBeenCalledWith(
+      expect.objectContaining({ html: `<sheet>${serialized}</sheet>` }),
+    );
   });
 });
 
@@ -605,14 +691,14 @@ describe('publishHomePageAtRoot', () => {
     expect(putPublishedArtifact).toHaveBeenCalledWith({ subdomain: 'sub', path: '', html: expect.any(String) });
   });
 
-  it('propagates a PublishError when the home page is not a canvas', async () => {
+  it('propagates a PublishError when the home page is not a publishable type', async () => {
     vi.mocked(db.query.drives.findFirst)
       .mockResolvedValueOnce(driveRow({ id: 'drive-1', homePageId: 'page-1' }))
       .mockResolvedValueOnce(driveRow({
         id: 'drive-1', slug: 'my-drive', publishSubdomain: 'sub', kind: 'STANDARD', homePageId: 'page-1',
       }));
     vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-      id: 'page-1', type: 'DOCUMENT', title: 'Doc', content: '', driveId: 'drive-1',
+      id: 'page-1', type: 'CHANNEL', title: 'Chat', content: '', driveId: 'drive-1',
     }));
 
     await expect(publishHomePageAtRoot('drive-1', 'user-1')).rejects.toMatchObject({ statusCode: 400 });
@@ -869,7 +955,7 @@ describe('regeneratePublishedSiteFiles', () => {
         name: 'Acme', publishSubdomain: 'acme', homePageId: null, notFoundPageId: 'nf-page', ownerId: 'owner-1', publishFaviconUrl: null,
       }));
       vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-        title: 'Oops', content: '<p>custom 404 content</p>',
+        type: 'CANVAS', title: 'Oops', content: '<p>custom 404 content</p>', contentMode: 'html',
       }));
 
       await regeneratePublishedSiteFiles('drive-1');
@@ -887,7 +973,7 @@ describe('regeneratePublishedSiteFiles', () => {
         name: 'Acme', publishSubdomain: 'acme', homePageId: null, notFoundPageId: 'nf-page', ownerId: 'owner-1', publishFaviconUrl: null,
       }));
       vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-        title: 'Internal Page Name', content: '<p>custom 404 with og:title</p>',
+        type: 'CANVAS', title: 'Internal Page Name', content: '<p>custom 404 with og:title</p>', contentMode: 'html',
       }));
       vi.mocked(extractAndStripOgMeta).mockReturnValueOnce({
         meta: { ogTitle: 'Author-Chosen Title', faviconHref: undefined, ogImageUrl: undefined, ogDescription: undefined },
@@ -917,7 +1003,7 @@ describe('regeneratePublishedSiteFiles', () => {
         name: 'Acme', publishSubdomain: 'acme', homePageId: null, notFoundPageId: 'nf-page', ownerId: 'owner-1', publishFaviconUrl: null,
       }));
       vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-        title: 'Oops', content: '<p>boom</p>',
+        type: 'CANVAS', title: 'Oops', content: '<p>boom</p>', contentMode: 'html',
       }));
       vi.mocked(renderPublishedPage).mockImplementationOnce(() => {
         throw new Error('render failed');
@@ -935,13 +1021,28 @@ describe('regeneratePublishedSiteFiles', () => {
         publishFaviconUrl: 'https://cdn.example.com/assets/drive-favicon.png',
       }));
       vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
-        title: 'Oops', content: '<p>custom 404</p>',
+        type: 'CANVAS', title: 'Oops', content: '<p>custom 404</p>', contentMode: 'html',
       }));
 
       await regeneratePublishedSiteFiles('drive-1');
 
       const renderInput = vi.mocked(renderPublishedPage).mock.calls.find((c) => c[0].html === '<p>custom 404</p>')?.[0];
       expect(renderInput?.faviconHref).toBe('https://cdn.example.com/assets/drive-favicon.png');
+    });
+
+    it('renders a DOCUMENT page as the custom 404 (a non-canvas page makes a fine 404)', async () => {
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue(driveRow({
+        name: 'Acme', publishSubdomain: 'acme', homePageId: null, notFoundPageId: 'nf-page', ownerId: 'owner-1', publishFaviconUrl: null,
+      }));
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue(pageRow({
+        type: 'DOCUMENT', title: 'Oops', content: '<p>document 404</p>', contentMode: 'html',
+      }));
+
+      await regeneratePublishedSiteFiles('drive-1');
+
+      expect(renderPublishedDocument).toHaveBeenCalledWith(expect.objectContaining({ html: '<p>document 404</p>', robots: 'noindex' }));
+      const notFoundCall = vi.mocked(putPublishedSiteFile).mock.calls.find((c) => c[0].file === '404.html');
+      expect(notFoundCall?.[0].body).toBe('<doc><p>document 404</p></doc>');
     });
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/render-published.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/render-published.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderPublishedPage } from '../render-published';
+import { renderPublishedPage, renderPublishedDocument, renderPublishedCode, renderPublishedSheet } from '../render-published';
 
 describe('renderPublishedPage', () => {
   it('given any input, should return a full HTML document', () => {
@@ -159,5 +159,106 @@ describe('renderPublishedPage — SEO + social passthrough', () => {
     const out = renderPublishedPage({ html: '<p>x</p>', pageUrl });
     expect(out).toContain('prefers-color-scheme');
     expect(out).toContain('pagespace-theme');
+  });
+});
+
+describe('renderPublishedDocument', () => {
+  it('given HTML content, should return a full document with typography and no theme bridge', () => {
+    const out = renderPublishedDocument({ html: '<p>hello</p>', title: 'My Doc' });
+    expect(out.startsWith('<!doctype html>')).toBe(true);
+    expect(out).toContain('ps-document');
+    expect(out).toContain('<p>hello</p>');
+    expect(out).not.toContain('pagespace-theme');
+  });
+
+  it('should apply the document CSP (script-src none)', () => {
+    const out = renderPublishedDocument({ html: '<p>x</p>', title: 'Doc' });
+    expect(out).toContain("script-src 'none'");
+  });
+
+  it('given a raw <script>, should strip it (documents never run author scripts)', () => {
+    const out = renderPublishedDocument({
+      html: '<p>x</p><script>alert(1)</script>',
+      title: 'Doc',
+    });
+    expect(out).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('given a non-HTTPS assetBaseUrl, should reject it (same allowedAssetHosts plumbing as renderPublishedPage)', () => {
+    expect(() => renderPublishedDocument({
+      html: '<p>x</p>',
+      title: 'Doc',
+      assetBaseUrl: 'http://cdn.example.com',
+    })).toThrow(/HTTPS/i);
+  });
+
+  it('given pageUrl, should emit SEO tags (same head assembly as canvas)', () => {
+    const out = renderPublishedDocument({
+      html: '<p>x</p>',
+      title: 'Doc',
+      pageUrl: 'https://acme.pagespace.site/doc',
+    });
+    expect(out).toContain('<link rel="canonical" href="https://acme.pagespace.site/doc">');
+  });
+
+  it('given no title, should default to Untitled', () => {
+    const out = renderPublishedDocument({ html: '<p>x</p>' });
+    expect(out).toContain('<title>Untitled</title>');
+  });
+});
+
+describe('renderPublishedCode', () => {
+  it('given a code string, should escape and wrap it in <pre><code>', () => {
+    const out = renderPublishedCode({ code: '<script>alert(1)</script>', title: 'main.ts' });
+    expect(out).toContain('<pre><code>&lt;script&gt;alert(1)&lt;/script&gt;</code></pre>');
+    expect(out).not.toContain('<script>alert(1)</script>');
+  });
+
+  it('should apply the document CSP (script-src none)', () => {
+    const out = renderPublishedCode({ code: 'const x = 1;', title: 'main.ts' });
+    expect(out).toContain("script-src 'none'");
+  });
+
+  it('given pageUrl, should emit SEO tags', () => {
+    const out = renderPublishedCode({
+      code: 'const x = 1;',
+      title: 'main.ts',
+      pageUrl: 'https://acme.pagespace.site/main-ts',
+    });
+    expect(out).toContain('<link rel="canonical" href="https://acme.pagespace.site/main-ts">');
+  });
+
+  it('given no title, should default to Untitled', () => {
+    const out = renderPublishedCode({ code: 'const x = 1;' });
+    expect(out).toContain('<title>Untitled</title>');
+  });
+});
+
+describe('renderPublishedSheet', () => {
+  it('given serialized sheet content, should render an HTML table', () => {
+    const out = renderPublishedSheet({
+      serializedContent: JSON.stringify({ cells: { A1: 'hi' } }),
+      title: 'My Sheet',
+    });
+    expect(out).toContain('<table>');
+    expect(out).toContain('hi');
+  });
+
+  it('given empty sheet content, should render the empty-state message', () => {
+    const out = renderPublishedSheet({
+      serializedContent: JSON.stringify({ cells: {} }),
+      title: 'My Sheet',
+    });
+    expect(out).toContain('This sheet is empty.');
+  });
+
+  it('should apply the document CSP (script-src none)', () => {
+    const out = renderPublishedSheet({ serializedContent: JSON.stringify({ cells: {} }), title: 'Sheet' });
+    expect(out).toContain("script-src 'none'");
+  });
+
+  it('given no title, should default to Untitled', () => {
+    const out = renderPublishedSheet({ serializedContent: JSON.stringify({ cells: {} }) });
+    expect(out).toContain('<title>Untitled</title>');
   });
 });

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -111,6 +111,17 @@ export interface PublishCanvasPageResult {
   path: string;
   /** True when this page is the drive's home page (also mirrored to the root). */
   isHomePage: boolean;
+  /**
+   * Effective author SEO overrides as persisted (after merging `input`'s
+   * partial overrides with whatever was already stored). Callers that resolve
+   * `ogImageUrl` from an uploaded file id should read it back from here rather
+   * than caching their own request payload — the request may carry a blank
+   * placeholder for a value the server just resolved to a real CDN URL.
+   */
+  title: string | null;
+  description: string | null;
+  ogImageUrl: string | null;
+  noindex: boolean;
 }
 
 /** Final SEO/head fields threaded into whichever type-specific renderer `preparePublishContent` selects. */
@@ -178,7 +189,12 @@ async function preparePublishContent(params: {
       return { meta, body: bodyHtml, render: (args) => renderPublishedDocument({ html: bodyHtml, ...args }) };
     }
     case PageType.CODE:
-      return { meta: {}, body: content ?? '', render: (args) => renderPublishedCode({ code: content ?? '', ...args }) };
+      // `body` (not the rendered `code`) feeds deriveDescription's fallback
+      // meta description when the author sets none — raw source isn't prose,
+      // and deriveDescription's HTML-tag stripping (`/<[^>]+>/g`) would mangle
+      // generics/comparisons in it, so leave it empty like SHEET's non-prose
+      // content (an empty derived description, same accepted tradeoff).
+      return { meta: {}, body: '', render: (args) => renderPublishedCode({ code: content ?? '', ...args }) };
     case PageType.SHEET:
       return { meta: {}, body: '', render: (args) => renderPublishedSheet({ serializedContent: content ?? '', ...args }) };
     default:
@@ -469,7 +485,16 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   // copies the branded link visitors should land on. This is the same canonical
   // host baked into the rendered HTML above — `rootUrl`/`publishedUrl`.
   const responseUrl = isHomePage ? rootUrl : publishedUrl;
-  return { url: responseUrl, subdomain, path, isHomePage };
+  return {
+    url: responseUrl,
+    subdomain,
+    path,
+    isHomePage,
+    title: effectiveTitle,
+    description: effectiveDescription,
+    ogImageUrl: effectiveOgImageUrl,
+    noindex: effectiveNoindex,
+  };
 }
 
 /**

--- a/apps/web/src/lib/canvas/publish-page.ts
+++ b/apps/web/src/lib/canvas/publish-page.ts
@@ -6,12 +6,16 @@ import { allocatePublishSubdomain } from '@pagespace/lib/services/drive-service'
 import { slugify } from '@pagespace/lib/utils/utils';
 import { validatePublishSubdomain, normalizeSubdomain } from '@pagespace/lib/validators/subdomain';
 import { db } from '@pagespace/db/db';
-import { eq, and, ne } from '@pagespace/db/operators';
+import { eq, and, ne, inArray } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { isHomeDrive } from '@pagespace/lib/services/drive-guards';
 import { resolvePublishedMeta } from '@pagespace/lib/canvas/resolve-published-meta';
-import { renderPublishedPage } from './render-published';
+import { isPublishablePageType, getPublishablePageTypes } from '@pagespace/lib/content/page-types.config';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { neutralizeDashboardLinks } from '@pagespace/lib/publish/neutralize-dashboard-links';
+import { marked } from 'marked';
+import { renderPublishedPage, renderPublishedDocument, renderPublishedCode, renderPublishedSheet } from './render-published';
 import {
   buildPublishedKey,
   putPublishedArtifact,
@@ -22,7 +26,7 @@ import {
   isPublishConfigured,
   getPublishAssetBaseUrl,
 } from './published-storage';
-import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta } from './asset-pipeline';
+import { rewriteCanvasAssets, rewriteInterPageLinksForDrive, extractAndStripOgMeta, type OgMeta } from './asset-pipeline';
 import { buildRobotsTxt, buildSitemapXml, buildNotFoundHtml, resolveFaviconTags } from '@pagespace/lib/canvas/site-files';
 import { resolvePrimaryPublishedHost } from '@pagespace/lib/canvas/primary-host';
 import { mirrorPublishedPageToHosts, mirror404ToHosts, getActiveDomainRecords } from './custom-domain-mirror';
@@ -109,10 +113,83 @@ export interface PublishCanvasPageResult {
   isHomePage: boolean;
 }
 
+/** Final SEO/head fields threaded into whichever type-specific renderer `preparePublishContent` selects. */
+interface PublishRenderArgs {
+  title?: string;
+  assetBaseUrl?: string;
+  faviconHref?: string;
+  faviconBaseUrl?: string;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  description?: string;
+  robots?: string;
+  formActionOrigin?: string;
+}
+
+interface PreparedPublishContent {
+  /** Meta the author embedded in the page body (canvas/document only — empty for CODE/SHEET). */
+  meta: OgMeta;
+  /** Text used as the last-resort source for a derived meta description. */
+  body: string;
+  /** Renders the final standalone document once SEO fields are resolved. */
+  render: (args: PublishRenderArgs) => string;
+}
+
 /**
- * Core canvas publishing logic shared by the per-page publish route and the drive
- * home-page auto-publish. Handles subdomain resolution, asset rewriting, OG meta,
- * S3 artifact upload, and published_pages DB upsert.
+ * Per-page-type content pipeline shared by `publishCanvasPage` and
+ * `renderNotFoundPageHtml`. CANVAS and DOCUMENT content is HTML: assets and
+ * inter-page links are rewritten and embedded OG meta is extracted from it
+ * (DOCUMENT additionally converts markdown and neutralizes leftover dashboard
+ * links). CODE and SHEET content is not HTML (a raw code string / serialized
+ * sheet JSON) — it carries no embedded meta and needs none of the HTML
+ * rewriting steps, so it passes straight to its renderer.
+ */
+async function preparePublishContent(params: {
+  type: PageType;
+  content: string | null;
+  contentMode: 'html' | 'markdown';
+  driveId: string;
+  subdomain: string;
+  homePageId: string | null;
+  currentPageId: string;
+  currentPath: string;
+  actingUserId: string;
+}): Promise<PreparedPublishContent> {
+  const { type, content, contentMode, driveId, subdomain, homePageId, currentPageId, currentPath, actingUserId } = params;
+
+  switch (type) {
+    case PageType.CANVAS: {
+      const { html: assetHtml } = await rewriteCanvasAssets({ html: content ?? '', userId: actingUserId, db });
+      const { html: rewrittenHtml } = await rewriteInterPageLinksForDrive({
+        html: assetHtml, driveId, subdomain, homePageId, currentPageId, currentPath, db,
+      });
+      const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
+      return { meta, body: bodyHtml, render: (args) => renderPublishedPage({ html: bodyHtml, ...args }) };
+    }
+    case PageType.DOCUMENT: {
+      const rawHtml = contentMode === 'markdown' ? await marked.parse(content ?? '') : (content ?? '');
+      const { html: assetHtml } = await rewriteCanvasAssets({ html: rawHtml, userId: actingUserId, db });
+      const { html: rewrittenHtml } = await rewriteInterPageLinksForDrive({
+        html: assetHtml, driveId, subdomain, homePageId, currentPageId, currentPath, db,
+      });
+      const neutralizedHtml = neutralizeDashboardLinks(rewrittenHtml);
+      const { meta, html: bodyHtml } = extractAndStripOgMeta(neutralizedHtml);
+      return { meta, body: bodyHtml, render: (args) => renderPublishedDocument({ html: bodyHtml, ...args }) };
+    }
+    case PageType.CODE:
+      return { meta: {}, body: content ?? '', render: (args) => renderPublishedCode({ code: content ?? '', ...args }) };
+    case PageType.SHEET:
+      return { meta: {}, body: '', render: (args) => renderPublishedSheet({ serializedContent: content ?? '', ...args }) };
+    default:
+      throw new PublishError(`Cannot publish page type: ${type}`, 400);
+  }
+}
+
+/**
+ * Core publishing logic shared by the per-page publish route and the drive
+ * home-page auto-publish. Handles subdomain resolution, per-type content
+ * rendering, OG meta, S3 artifact upload, and published_pages DB upsert.
  *
  * Auth and permission checks are the caller's responsibility.
  */
@@ -120,19 +197,19 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
   const { pageId, driveId, userId } = input;
 
   // ------------------------------------------------------------------
-  // 1. Load page (must be canvas)
+  // 1. Load page (must be a publishable type)
   // ------------------------------------------------------------------
   const page = await db.query.pages.findFirst({
     where: eq(pages.id, pageId),
-    columns: { id: true, type: true, title: true, content: true, driveId: true },
+    columns: { id: true, type: true, title: true, content: true, contentMode: true, driveId: true },
   });
 
   if (!page) {
     throw new PublishError('Page not found', 404);
   }
 
-  if (page.type !== 'CANVAS') {
-    throw new PublishError('Only canvas pages can be published', 400);
+  if (!isPublishablePageType(page.type as PageType)) {
+    throw new PublishError('This page type cannot be published', 400);
   }
 
   // The page must actually live in the drive whose subdomain we are about to
@@ -188,22 +265,23 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
       : normalizePublishPath(input.path) || pageId;
 
   // ------------------------------------------------------------------
-  // 4. Rewrite assets + extract OG meta
+  // 4. Per-type content pipeline: rewrite assets/links + extract embedded meta
   // ------------------------------------------------------------------
-  const { html: assetHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId, db });
-  // Rewrite page→page links to their public published URLs so navigation between
-  // published pages works on the subdomain site (drive-scoped; unpublished /
-  // out-of-drive targets are left unchanged).
-  const { html: rewrittenHtml } = await rewriteInterPageLinksForDrive({
-    html: assetHtml,
+  // Rewriting page→page links to their public published URLs makes navigation
+  // between published pages work on the subdomain site (drive-scoped;
+  // unpublished / out-of-drive targets are left unchanged).
+  const prepared = await preparePublishContent({
+    type: page.type as PageType,
+    content: page.content,
+    contentMode: page.contentMode,
     driveId,
     subdomain,
     homePageId: drive.homePageId,
     currentPageId: pageId,
     currentPath: path,
-    db,
+    actingUserId: userId,
   });
-  const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
+  const { meta, body: bodyHtml } = prepared;
   const assetBaseUrl = getPublishAssetBaseUrl();
 
   // ------------------------------------------------------------------
@@ -276,8 +354,7 @@ export async function publishCanvasPage(input: PublishCanvasPageInput): Promise<
     );
   }
 
-  const html = renderPublishedPage({
-    html: bodyHtml,
+  const html = prepared.render({
     title: resolvedMeta.title,
     assetBaseUrl,
     faviconHref: favicon.faviconHref,
@@ -572,28 +649,28 @@ async function renderNotFoundPageHtml(params: {
         eq(pages.id, pageId),
         eq(pages.driveId, driveId),
         eq(pages.isTrashed, false),
-        eq(pages.type, 'CANVAS'),
+        inArray(pages.type, getPublishablePageTypes()),
       ),
-      columns: { title: true, content: true },
+      columns: { type: true, title: true, content: true, contentMode: true },
     });
     if (!page) return null;
 
-    const { html: assetHtml } = await rewriteCanvasAssets({ html: page.content ?? '', userId: ownerId, db });
-    const { html: rewrittenHtml } = await rewriteInterPageLinksForDrive({
-      html: assetHtml,
+    const prepared = await preparePublishContent({
+      type: page.type as PageType,
+      content: page.content,
+      contentMode: page.contentMode,
       driveId,
       subdomain,
       homePageId,
       currentPageId: pageId,
       currentPath: '',
-      db,
+      actingUserId: ownerId,
     });
-    const { meta, html: bodyHtml } = extractAndStripOgMeta(rewrittenHtml);
+    const { meta } = prepared;
     const favicon = resolveFaviconTags(meta.faviconHref, publishFaviconUrl, FAVICON_BASE_URL);
     const formActionOrigin = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
 
-    return renderPublishedPage({
-      html: bodyHtml,
+    return prepared.render({
       // Same precedence as a normal publish (resolvePublishedMeta): the
       // page's own code-authored meta wins over its internal page title.
       title: meta.ogTitle || meta.title || page.title || 'Page not found',

--- a/apps/web/src/lib/canvas/render-published.ts
+++ b/apps/web/src/lib/canvas/render-published.ts
@@ -1,6 +1,9 @@
 import 'server-only';
 
 import { renderCanvasDocument } from '@pagespace/lib/canvas/render-document';
+import { renderDocumentPage } from '@pagespace/lib/publish/render-document-page';
+import { renderCodePage } from '@pagespace/lib/publish/render-code-page';
+import { renderSheetPage } from '@pagespace/lib/publish/render-sheet-page';
 import { getPublicAssetHost } from './published-storage';
 
 /**
@@ -51,4 +54,67 @@ export function renderPublishedPage(input: RenderPublishedPageInput): string {
   const { assetBaseUrl, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, ...rest } = input;
   const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
   return renderCanvasDocument({ ...rest, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, injectThemeBridge: true });
+}
+
+/**
+ * SEO/head fields shared by the non-canvas published-document renderers below.
+ * Same semantics as the matching fields on `RenderPublishedPageInput` — see
+ * `RenderCanvasDocumentInput` for the full doc comments.
+ */
+interface PublishedDocumentHeadInput {
+  /** Defaults to "Untitled" when omitted/blank — matches `renderPublishedPage`. */
+  title?: string;
+  assetBaseUrl?: string;
+  faviconBaseUrl?: string;
+  faviconHref?: string;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  lang?: string;
+  description?: string;
+  robots?: string;
+}
+
+export interface RenderPublishedDocumentInput extends PublishedDocumentHeadInput {
+  html: string;
+}
+
+/**
+ * Server-side renderer for published DOCUMENT pages. Thin wrapper over
+ * `renderDocumentPage` (shared with the DOCUMENT static renderer) plumbing
+ * `assetBaseUrl` through to `allowedAssetHosts` exactly like `renderPublishedPage`.
+ */
+export function renderPublishedDocument(input: RenderPublishedDocumentInput): string {
+  const { assetBaseUrl, title, ...rest } = input;
+  const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
+  return renderDocumentPage({ ...rest, title: title?.trim() || 'Untitled', allowedAssetHosts });
+}
+
+export interface RenderPublishedCodeInput extends PublishedDocumentHeadInput {
+  code: string;
+}
+
+/**
+ * Server-side renderer for published CODE pages. Thin wrapper over
+ * `renderCodePage` — see `renderPublishedDocument` above.
+ */
+export function renderPublishedCode(input: RenderPublishedCodeInput): string {
+  const { assetBaseUrl, title, ...rest } = input;
+  const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
+  return renderCodePage({ ...rest, title: title?.trim() || 'Untitled', allowedAssetHosts });
+}
+
+export interface RenderPublishedSheetInput extends PublishedDocumentHeadInput {
+  serializedContent: unknown;
+  hasHeaders?: boolean;
+}
+
+/**
+ * Server-side renderer for published SHEET pages. Thin wrapper over
+ * `renderSheetPage` — see `renderPublishedDocument` above.
+ */
+export function renderPublishedSheet(input: RenderPublishedSheetInput): string {
+  const { assetBaseUrl, title, ...rest } = input;
+  const allowedAssetHosts = assetBaseUrl ? [getPublicAssetHost(assetBaseUrl)] : [];
+  return renderSheetPage({ ...rest, title: title?.trim() || 'Untitled', allowedAssetHosts });
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -982,6 +982,11 @@
       "import": "./dist/publish/neutralize-dashboard-links.js",
       "require": "./dist/publish/neutralize-dashboard-links.js"
     },
+    "./publish/sanitize-document-html": {
+      "types": "./dist/publish/sanitize-document-html.d.ts",
+      "import": "./dist/publish/sanitize-document-html.js",
+      "require": "./dist/publish/sanitize-document-html.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1987,6 +1992,9 @@
       ],
       "canvas/primary-host": [
         "./dist/canvas/primary-host.d.ts"
+      ],
+      "publish/sanitize-document-html": [
+        "./dist/publish/sanitize-document-html.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -992,6 +992,11 @@
       "import": "./dist/publish/document-shell.js",
       "require": "./dist/publish/document-shell.js"
     },
+    "./publish/render-document-page": {
+      "types": "./dist/publish/render-document-page.d.ts",
+      "import": "./dist/publish/render-document-page.js",
+      "require": "./dist/publish/render-document-page.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -2003,6 +2008,9 @@
       ],
       "publish/document-shell": [
         "./dist/publish/document-shell.d.ts"
+      ],
+      "publish/render-document-page": [
+        "./dist/publish/render-document-page.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -997,6 +997,16 @@
       "import": "./dist/publish/render-document-page.js",
       "require": "./dist/publish/render-document-page.js"
     },
+    "./publish/render-code-page": {
+      "types": "./dist/publish/render-code-page.d.ts",
+      "import": "./dist/publish/render-code-page.js",
+      "require": "./dist/publish/render-code-page.js"
+    },
+    "./publish/render-sheet-page": {
+      "types": "./dist/publish/render-sheet-page.d.ts",
+      "import": "./dist/publish/render-sheet-page.js",
+      "require": "./dist/publish/render-sheet-page.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -2011,6 +2021,12 @@
       ],
       "publish/render-document-page": [
         "./dist/publish/render-document-page.d.ts"
+      ],
+      "publish/render-code-page": [
+        "./dist/publish/render-code-page.d.ts"
+      ],
+      "publish/render-sheet-page": [
+        "./dist/publish/render-sheet-page.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -987,6 +987,11 @@
       "import": "./dist/publish/sanitize-document-html.js",
       "require": "./dist/publish/sanitize-document-html.js"
     },
+    "./publish/document-shell": {
+      "types": "./dist/publish/document-shell.d.ts",
+      "import": "./dist/publish/document-shell.js",
+      "require": "./dist/publish/document-shell.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",
@@ -1995,6 +2000,9 @@
       ],
       "publish/sanitize-document-html": [
         "./dist/publish/sanitize-document-html.d.ts"
+      ],
+      "publish/document-shell": [
+        "./dist/publish/document-shell.d.ts"
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -977,6 +977,11 @@
       "import": "./dist/canvas/primary-host.js",
       "require": "./dist/canvas/primary-host.js"
     },
+    "./publish/neutralize-dashboard-links": {
+      "types": "./dist/publish/neutralize-dashboard-links.d.ts",
+      "import": "./dist/publish/neutralize-dashboard-links.js",
+      "require": "./dist/publish/neutralize-dashboard-links.js"
+    },
     "./notifications/types": {
       "types": "./dist/notifications/types.d.ts",
       "import": "./dist/notifications/types.js",

--- a/packages/lib/src/canvas/__tests__/csp.test.ts
+++ b/packages/lib/src/canvas/__tests__/csp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildBaselineCsp } from '../csp';
+import { buildBaselineCsp, buildDocumentCsp } from '../csp';
 
 describe('buildBaselineCsp', () => {
   it('defaults to form-action \'none\' when no origin is given', () => {
@@ -25,5 +25,27 @@ describe('buildBaselineCsp', () => {
     expect(withOrigin).toContain("object-src 'none'");
     expect(withOrigin).toContain("base-uri 'none'");
     expect(withOrigin).toContain("script-src 'unsafe-inline'");
+  });
+});
+
+describe('buildDocumentCsp', () => {
+  it('blocks scripts entirely', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("script-src 'none'");
+  });
+
+  it('blocks form submission entirely', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("form-action 'none'");
+  });
+
+  it('keeps the baseline asset/image/font/object/base-uri directives', () => {
+    const csp = buildDocumentCsp();
+    expect(csp).toContain("default-src 'none'");
+    expect(csp).toContain('img-src data: https:');
+    expect(csp).toContain("style-src 'unsafe-inline' https://fonts.googleapis.com");
+    expect(csp).toContain('font-src https://fonts.gstatic.com');
+    expect(csp).toContain("object-src 'none'");
+    expect(csp).toContain("base-uri 'none'");
   });
 });

--- a/packages/lib/src/canvas/__tests__/render-document.test.ts
+++ b/packages/lib/src/canvas/__tests__/render-document.test.ts
@@ -876,3 +876,21 @@ describe('renderCanvasDocument — Twitter Card', () => {
     });
   });
 });
+
+describe('renderCanvasDocument — cspOverride', () => {
+  it('given no cspOverride, should stay byte-identical to the buildBaselineCsp-derived output', () => {
+    const input = { html: '<p>x</p>', title: 'T', pageUrl: 'https://acme.pagespace.site/x' };
+    expect(renderCanvasDocument(input)).toBe(renderCanvasDocument(input));
+    expect(renderCanvasDocument({ html: '<p>x</p>' })).toContain(`content="${BASELINE_CSP}"`);
+  });
+
+  it('given a cspOverride, should use it verbatim instead of buildBaselineCsp', () => {
+    const out = renderCanvasDocument({
+      html: '<p>x</p>',
+      formActionOrigin: 'https://ignored.example',
+      cspOverride: "default-src 'none'; script-src 'none';",
+    });
+    expect(out).toContain('content="default-src \'none\'; script-src \'none\';"');
+    expect(out).not.toContain('ignored.example');
+  });
+});

--- a/packages/lib/src/canvas/csp.ts
+++ b/packages/lib/src/canvas/csp.ts
@@ -1,3 +1,7 @@
+/** Asset/font directives shared by every canvas/published CSP variant. */
+const ASSET_CSP_PREFIX =
+  "default-src 'none'; img-src data: https:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com;";
+
 /**
  * Builds the canvas baseline CSP, optionally scoping `form-action`/`connect-src`
  * to a single origin so a published Canvas page's <form> (see
@@ -9,8 +13,7 @@
  * ever the single origin passed in.
  */
 export function buildBaselineCsp(formActionOrigin?: string): string {
-  const base =
-    "default-src 'none'; img-src data: https:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'unsafe-inline'; object-src 'none'; base-uri 'none';";
+  const base = `${ASSET_CSP_PREFIX} script-src 'unsafe-inline'; object-src 'none'; base-uri 'none';`;
 
   if (!formActionOrigin) {
     return `${base} form-action 'none'`;
@@ -30,5 +33,5 @@ export function buildBaselineCsp(formActionOrigin?: string): string {
  * `buildBaselineCsp()`.
  */
 export function buildDocumentCsp(): string {
-  return "default-src 'none'; img-src data: https:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";
+  return `${ASSET_CSP_PREFIX} script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'`;
 }

--- a/packages/lib/src/canvas/csp.ts
+++ b/packages/lib/src/canvas/csp.ts
@@ -18,3 +18,17 @@ export function buildBaselineCsp(formActionOrigin?: string): string {
 
   return `${base} form-action 'self' ${formActionOrigin}; connect-src ${formActionOrigin}`;
 }
+
+/**
+ * Builds the CSP for published DOCUMENT pages (see `../publish/render-document-page.ts`).
+ * Unlike canvas pages, documents never run author scripts — the sanitizer
+ * (`sanitizeDocumentHtml`) already strips `<script>` tags, and this policy is
+ * the hard enforcement layer: `script-src 'none'` blocks any that slip
+ * through, and `form-action 'none'` blocks form submission entirely (the
+ * sanitizer also strips `<form>`). Every other baseline directive (asset/
+ * font/image hosts, `object-src`, `base-uri`) is unchanged from
+ * `buildBaselineCsp()`.
+ */
+export function buildDocumentCsp(): string {
+  return "default-src 'none'; img-src data: https:; style-src 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";
+}

--- a/packages/lib/src/canvas/render-document.ts
+++ b/packages/lib/src/canvas/render-document.ts
@@ -115,6 +115,14 @@ export interface RenderCanvasDocumentInput {
    * standalone documents and use `prefers-color-scheme` for OS-level matching.
    */
   injectThemeBridge?: boolean;
+  /**
+   * When set, used VERBATIM as the emitted CSP `<meta>` content instead of
+   * `buildBaselineCsp(formActionOrigin)`. Lets other renderers (e.g. the
+   * published-document pipeline, which needs `script-src 'none'`) reuse this
+   * renderer's whole head assembly without duplicating it. Omit to keep the
+   * unchanged canvas baseline CSP.
+   */
+  cspOverride?: string;
 }
 
 /**
@@ -314,8 +322,8 @@ function extractAndSanitizeStyles(html: string, allowedHttpsHosts?: string[], no
  * Render a complete, standalone HTML document for a canvas page.
  */
 export function renderCanvasDocument(input: RenderCanvasDocumentInput): string {
-  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce } = input;
-  const csp = buildBaselineCsp(formActionOrigin);
+  const { html, title, baseTarget, allowedAssetHosts, faviconBaseUrl, faviconHref, pageUrl, ogImageUrl, ogDescription, lang, description, robots, formActionOrigin, injectThemeBridge, nonce, cspOverride } = input;
+  const csp = cspOverride ?? buildBaselineCsp(formActionOrigin);
 
   const { css, body } = extractAndSanitizeStyles(unwrapFullDocument(html ?? ''), allowedAssetHosts, nonce);
   const rawTitle = title && title.trim() ? title : 'Untitled';

--- a/packages/lib/src/content/__tests__/page-types-publishable.test.ts
+++ b/packages/lib/src/content/__tests__/page-types-publishable.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PAGE_TYPE_CONFIGS,
+  isPublishablePageType,
+  getPublishablePageTypes,
+} from '../page-types.config';
+import { PageType } from '../../utils/enums';
+
+const assert = ({ given, should, actual, expected }: { given: string; should: string; actual: unknown; expected: unknown }) =>
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+/**
+ * Publishing is lifted from a CANVAS-only hard gate to a per-type capability.
+ * Publishable types are exactly the ones whose content lives in
+ * `pages.content` and can be rendered standalone: CANVAS, DOCUMENT, CODE,
+ * SHEET. The rest (folders, chat, tasks, files, machines) store their real
+ * content in other tables or object storage and cannot be published.
+ */
+const PUBLISHABLE_TYPES = [
+  PageType.CANVAS,
+  PageType.DOCUMENT,
+  PageType.CODE,
+  PageType.SHEET,
+] as const;
+
+const NON_PUBLISHABLE_TYPES = [
+  PageType.FOLDER,
+  PageType.CHANNEL,
+  PageType.AI_CHAT,
+  PageType.FILE,
+  PageType.TASK_LIST,
+  PageType.MACHINE,
+] as const;
+
+describe('publishable page-type capability', () => {
+  it('declares publishable on every page type config', () => {
+    for (const config of Object.values(PAGE_TYPE_CONFIGS)) {
+      assert({
+        given: `the ${config.type} config`,
+        should: 'declare a boolean publishable capability',
+        actual: typeof config.capabilities.publishable,
+        expected: 'boolean',
+      });
+    }
+  });
+
+  it('marks content-bearing types publishable', () => {
+    for (const type of PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type} (content lives in pages.content)`,
+        should: 'be publishable',
+        actual: PAGE_TYPE_CONFIGS[type].capabilities.publishable,
+        expected: true,
+      });
+    }
+  });
+
+  it('marks types whose content lives outside pages.content as not publishable', () => {
+    for (const type of NON_PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type} (content in chat/tasks tables, object storage, or machine state)`,
+        should: 'not be publishable',
+        actual: PAGE_TYPE_CONFIGS[type].capabilities.publishable,
+        expected: false,
+      });
+    }
+  });
+});
+
+describe('isPublishablePageType()', () => {
+  it('returns true for each publishable type', () => {
+    for (const type of PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type}`,
+        should: 'return true',
+        actual: isPublishablePageType(type),
+        expected: true,
+      });
+    }
+  });
+
+  it('returns false for each non-publishable type', () => {
+    for (const type of NON_PUBLISHABLE_TYPES) {
+      assert({
+        given: `page type ${type}`,
+        should: 'return false',
+        actual: isPublishablePageType(type),
+        expected: false,
+      });
+    }
+  });
+
+  it('returns false for an unknown type instead of throwing', () => {
+    assert({
+      given: 'a value not present in PAGE_TYPE_CONFIGS',
+      should: 'return false',
+      actual: isPublishablePageType('NOT_A_REAL_TYPE' as PageType),
+      expected: false,
+    });
+  });
+});
+
+describe('getPublishablePageTypes()', () => {
+  it('returns exactly the publishable types', () => {
+    assert({
+      given: 'the full page-type config table',
+      should: 'return exactly CANVAS, DOCUMENT, CODE, SHEET',
+      actual: [...getPublishablePageTypes()].sort(),
+      expected: [...PUBLISHABLE_TYPES].sort(),
+    });
+  });
+});

--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -7,6 +7,8 @@ export interface PageTypeCapabilities {
   supportsRealtime: boolean;
   supportsVersioning: boolean;
   supportsAI: boolean;
+  /** Content lives in pages.content and can be rendered standalone at a public URL. */
+  publishable: boolean;
 }
 
 export interface PageTypeApiValidation {
@@ -42,6 +44,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => ({ children: [] }),
     uiComponent: 'FolderView',
@@ -59,6 +62,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: false,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'DocumentView',
@@ -76,6 +80,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => ({ messages: [] }),
     uiComponent: 'ChannelView',
@@ -93,6 +98,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: true,
+      publishable: false,
     },
     defaultContent: () => ({ messages: [] }),
     apiValidation: {
@@ -113,6 +119,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: true,
       supportsAI: false,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'CanvasPageView',
@@ -130,6 +137,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: false,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => '',
     uiComponent: 'FileViewer',
@@ -147,6 +155,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: true,
+      publishable: true,
     },
     defaultContent: () => serializeSheetContent(createEmptySheet()),
     uiComponent: 'SheetView',
@@ -164,6 +173,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: true,
+      publishable: false,
     },
     defaultContent: () => '',
     uiComponent: 'TaskListView',
@@ -181,6 +191,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: true,
       supportsAI: true,
+      publishable: true,
     },
     defaultContent: () => '',
     uiComponent: 'CodePageView',
@@ -198,6 +209,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       supportsRealtime: true,
       supportsVersioning: false,
       supportsAI: false,
+      publishable: false,
     },
     defaultContent: () => JSON.stringify({ history: [] }),
     uiComponent: 'MachineView',
@@ -305,4 +317,12 @@ export function isMachinePage(type: PageType): boolean {
 
 export function getCreatablePageTypes(): PageType[] {
   return Object.values(PAGE_TYPE_CONFIGS).filter(c => !c.experimental).map(c => c.type);
+}
+
+export function isPublishablePageType(type: PageType): boolean {
+  return PAGE_TYPE_CONFIGS[type]?.capabilities.publishable || false;
+}
+
+export function getPublishablePageTypes(): PageType[] {
+  return Object.values(PAGE_TYPE_CONFIGS).filter(c => c.capabilities.publishable).map(c => c.type);
 }

--- a/packages/lib/src/publish/__tests__/document-shell.test.ts
+++ b/packages/lib/src/publish/__tests__/document-shell.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  DOCUMENT_TYPOGRAPHY_CSS,
+  documentStartsWithH1,
+  wrapDocumentBody,
+} from '../document-shell';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('DOCUMENT_TYPOGRAPHY_CSS', () => {
+  it('should lay out a readable centered column', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'constrain the column to 42rem, center it, and set body padding + line-height',
+      actual:
+        DOCUMENT_TYPOGRAPHY_CSS.includes('max-width: 42rem') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('margin: 0 auto') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('padding: 2rem 1rem') &&
+        DOCUMENT_TYPOGRAPHY_CSS.includes('line-height: 1.65'),
+      expected: true,
+    });
+  });
+
+  it('should use a system font stack', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'declare a system font stack (no webfont dependency)',
+      actual: DOCUMENT_TYPOGRAPHY_CSS.includes('-apple-system'),
+      expected: true,
+    });
+  });
+
+  it('should include a dark-mode media query', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'override colors under prefers-color-scheme: dark',
+      actual: DOCUMENT_TYPOGRAPHY_CSS.includes('@media (prefers-color-scheme: dark)'),
+      expected: true,
+    });
+  });
+
+  it('should not reference app CSS variables', () => {
+    assert({
+      given: 'the typography CSS (published pages have no app stylesheet)',
+      should: 'contain no var(--…) references',
+      actual: /var\(--/.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: false,
+    });
+  });
+
+  it('should scope every rule under .ps-document except page-canvas rules', () => {
+    // :root/body are the deliberate page-canvas exceptions: this stylesheet is
+    // only ever inlined into standalone published documents, and the canvas
+    // must follow the color scheme or dark mode yields light-on-white text.
+    const pageCanvasSelectors = new Set([':root', 'body', 'html']);
+    const selectors = DOCUMENT_TYPOGRAPHY_CSS
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/@media[^{]+\{/g, '')
+      .replace(/\([^)]*\)/g, '()')
+      .split('}')
+      .map((chunk) => chunk.split('{')[0]?.trim())
+      .filter((selector): selector is string => Boolean(selector));
+    const unscoped = selectors
+      .flatMap((selector) => selector.split(','))
+      .map((part) => part.trim())
+      .filter(
+        (part) =>
+          part.length > 0 && !part.startsWith('.ps-document') && !pageCanvasSelectors.has(part),
+      );
+    assert({
+      given: 'every selector in the typography CSS',
+      should: 'start with .ps-document (page-canvas :root/body rules excepted)',
+      actual: unscoped,
+      expected: [],
+    });
+  });
+
+  it('should give the page canvas a background in both color schemes', () => {
+    const [lightCss, darkCss] = DOCUMENT_TYPOGRAPHY_CSS.split('@media (prefers-color-scheme: dark)');
+    assert({
+      given: 'the page-canvas rules (published pages load no app stylesheet)',
+      should: 'set an explicit light body background and a dark override, not foreground-only',
+      actual:
+        /body\s*\{[^}]*background:\s*#ffffff/s.test(lightCss ?? '') &&
+        /body\s*\{[^}]*background:\s*#0d1117/s.test(darkCss ?? ''),
+      expected: true,
+    });
+  });
+
+  it('should declare color-scheme so UA defaults follow the scheme', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'declare color-scheme: light dark on :root',
+      actual: /:root\s*\{[^}]*color-scheme:\s*light dark/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should reset UA margins before applying the document rhythm', () => {
+    const resetIndex = DOCUMENT_TYPOGRAPHY_CSS.indexOf(':where(');
+    const rhythmIndex = DOCUMENT_TYPOGRAPHY_CSS.indexOf('> * + *');
+    const resetBlock = /\.ps-document\s+:where\(([^)]*)\)\s*\{[^}]*margin:\s*0/s.exec(
+      DOCUMENT_TYPOGRAPHY_CSS,
+    );
+    const resetTargets = resetBlock?.[1] ?? '';
+    assert({
+      given: 'standalone output with browser default margins (no Tailwind Preflight)',
+      should: 'zero UA margins on rich-text descendants via a low-specificity :where reset placed before the sibling rhythm',
+      actual:
+        resetIndex !== -1 &&
+        rhythmIndex !== -1 &&
+        resetIndex < rhythmIndex &&
+        ['p', 'blockquote', 'figure', 'ul', 'h2'].every((tag) =>
+          new RegExp(`(^|[,\\s])${tag}([,\\s]|$)`).test(resetTargets),
+        ),
+      expected: true,
+    });
+  });
+
+  it('should style mention anchors as inline chips', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'target a[data-mention-type] with chip styling (radius + background)',
+      actual:
+        DOCUMENT_TYPOGRAPHY_CSS.includes('a[data-mention-type]') &&
+        /a\[data-mention-type\][^}]*border-radius/s.test(DOCUMENT_TYPOGRAPHY_CSS) &&
+        /a\[data-mention-type\][^}]*background/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should keep images inside the column', () => {
+    assert({
+      given: 'the typography CSS',
+      should: 'cap img width at 100%',
+      actual: /\.ps-document img[^}]*max-width: 100%/s.test(DOCUMENT_TYPOGRAPHY_CSS),
+      expected: true,
+    });
+  });
+
+  it('should cover the core rich-text elements', () => {
+    const requiredSelectors = [
+      '.ps-document h1',
+      '.ps-document h2',
+      '.ps-document h3',
+      '.ps-document ul',
+      '.ps-document ol',
+      '.ps-document table',
+      '.ps-document pre',
+      '.ps-document code',
+      '.ps-document blockquote',
+      '.ps-document hr',
+      '.ps-document a',
+    ];
+    assert({
+      given: 'the typography CSS',
+      should: 'include rules for headings, lists, tables, code, quotes, rules, and links',
+      actual: requiredSelectors.filter((selector) => !DOCUMENT_TYPOGRAPHY_CSS.includes(selector)),
+      expected: [],
+    });
+  });
+});
+
+describe('documentStartsWithH1', () => {
+  it('should detect a leading <h1>', () => {
+    assert({
+      given: 'a body whose first element is <h1>',
+      should: 'return true',
+      actual: documentStartsWithH1('<h1>Title</h1><p>body</p>'),
+      expected: true,
+    });
+  });
+
+  it('should tolerate leading whitespace and HTML comments', () => {
+    assert({
+      given: 'a body with whitespace and comments before the <h1>',
+      should: 'return true',
+      actual: documentStartsWithH1('  \n<!-- generated -->\n <!-- two --> <h1>Title</h1>'),
+      expected: true,
+    });
+  });
+
+  it('should accept an <h1> that carries attributes', () => {
+    assert({
+      given: 'a body starting with <h1 class="…">',
+      should: 'return true',
+      actual: documentStartsWithH1('<h1 class="hero" id="top">Title</h1>'),
+      expected: true,
+    });
+  });
+
+  it('should be case-insensitive', () => {
+    assert({
+      given: 'a body starting with <H1>',
+      should: 'return true',
+      actual: documentStartsWithH1('<H1>Title</H1>'),
+      expected: true,
+    });
+  });
+
+  it('should reject a body starting with another element', () => {
+    assert({
+      given: 'a body starting with <h2>',
+      should: 'return false',
+      actual: documentStartsWithH1('<h2>Subtitle</h2>'),
+      expected: false,
+    });
+  });
+
+  it('should reject an <h1> that is not the first element', () => {
+    assert({
+      given: 'a body whose <h1> comes after a paragraph',
+      should: 'return false',
+      actual: documentStartsWithH1('<p>intro</p><h1>Late title</h1>'),
+      expected: false,
+    });
+  });
+
+  it('should reject empty and comment-only bodies', () => {
+    assert({
+      given: 'an empty body, whitespace, or comments with no content',
+      should: 'return false for each',
+      actual: [
+        documentStartsWithH1(''),
+        documentStartsWithH1('   \n\t '),
+        documentStartsWithH1('<!-- nothing else -->'),
+        documentStartsWithH1('<!-- unterminated'),
+      ],
+      expected: [false, false, false, false],
+    });
+  });
+});
+
+describe('wrapDocumentBody', () => {
+  it('should wrap the body in a .ps-document article with a title header', () => {
+    assert({
+      given: 'a body with no leading <h1> and a title',
+      should: 'emit <article class="ps-document"> with an <header><h1> before the body',
+      actual: wrapDocumentBody({ bodyHtml: '<p>hello</p>', title: 'My Post' }),
+      expected: '<article class="ps-document"><header><h1>My Post</h1></header><p>hello</p></article>',
+    });
+  });
+
+  it('should suppress the header when the body already starts with an <h1>', () => {
+    assert({
+      given: 'a body whose first element is already an <h1>',
+      should: 'not emit a duplicate title header',
+      actual: wrapDocumentBody({ bodyHtml: '<h1>Own Title</h1><p>hello</p>', title: 'My Post' }),
+      expected: '<article class="ps-document"><h1>Own Title</h1><p>hello</p></article>',
+    });
+  });
+
+  it('should suppress the header when comments precede the <h1>', () => {
+    assert({
+      given: 'a body with leading whitespace/comments before its <h1>',
+      should: 'not emit a duplicate title header',
+      actual: wrapDocumentBody({
+        bodyHtml: '\n<!-- exported --><h1>Own Title</h1>',
+        title: 'My Post',
+      }),
+      expected: '<article class="ps-document">\n<!-- exported --><h1>Own Title</h1></article>',
+    });
+  });
+
+  it('should HTML-escape the title', () => {
+    assert({
+      given: 'a title containing HTML-special characters',
+      should: 'escape them in the emitted header',
+      actual: wrapDocumentBody({ bodyHtml: '<p>x</p>', title: 'Fish & <Chips> "rated" 5\'s' }),
+      expected:
+        '<article class="ps-document"><header><h1>Fish &amp; &lt;Chips&gt; &quot;rated&quot; 5&#39;s</h1></header><p>x</p></article>',
+    });
+  });
+
+  it('should keep the body verbatim', () => {
+    const bodyHtml = '<p>a</p><ul><li>b</li></ul><pre><code>c()</code></pre>';
+    assert({
+      given: 'an arbitrary rich-text body',
+      should: 'pass it through unmodified inside the article',
+      actual: wrapDocumentBody({ bodyHtml, title: 'T' }).includes(bodyHtml),
+      expected: true,
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
+++ b/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+
+import { neutralizeDashboardLinks } from '../neutralize-dashboard-links';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('neutralizeDashboardLinks', () => {
+  it('converts a dashboard mention anchor into a span', () => {
+    assert({
+      given: 'an anchor whose href is a relative /dashboard/ path',
+      should: 'replace the anchor with a span preserving the inner HTML',
+      actual: neutralizeDashboardLinks(
+        '<p><a href="/dashboard/drive1/page1" class="mention" data-mention-type="page" data-page-id="page1">@My Page</a></p>',
+      ),
+      expected:
+        '<p><span data-mention-type="page" data-page-id="page1">@My Page</span></p>',
+    });
+  });
+
+  it('preserves data-mention-type and data-page-id in source order', () => {
+    assert({
+      given: 'an anchor with data-page-id before data-mention-type',
+      should: 'carry both attributes onto the span in their original order',
+      actual: neutralizeDashboardLinks(
+        '<a data-page-id="p9" href="/dashboard/d/p9" data-mention-type="page">@Nine</a>',
+      ),
+      expected: '<span data-page-id="p9" data-mention-type="page">@Nine</span>',
+    });
+  });
+
+  it('drops non-mention attributes from the neutralized span', () => {
+    assert({
+      given: 'an anchor with class, target, and rel attributes',
+      should: 'emit a span carrying only the mention data attributes',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p" class="mention" target="_blank" rel="noopener" data-mention-type="page" data-page-id="p">@Page</a>',
+      ),
+      expected: '<span data-mention-type="page" data-page-id="p">@Page</span>',
+    });
+  });
+
+  it('neutralizes a dashboard anchor without mention data attributes', () => {
+    assert({
+      given: 'a plain dashboard anchor with no data attributes',
+      should: 'replace it with a bare span around the inner HTML',
+      actual: neutralizeDashboardLinks('<a href="/dashboard/d/p">go</a>'),
+      expected: '<span>go</span>',
+    });
+  });
+
+  it('handles single-quoted href values', () => {
+    assert({
+      given: "an anchor whose href uses single quotes",
+      should: 'still neutralize it',
+      actual: neutralizeDashboardLinks(
+        "<a href='/dashboard/d/p' data-mention-type='page' data-page-id='p'>@P</a>",
+      ),
+      expected: '<span data-mention-type="page" data-page-id="p">@P</span>',
+    });
+  });
+
+  it('preserves nested markup inside the anchor', () => {
+    assert({
+      given: 'an anchor containing nested inline markup',
+      should: 'keep the nested markup inside the span',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p"><strong>bold</strong> and <em>italic</em></a>',
+      ),
+      expected: '<span><strong>bold</strong> and <em>italic</em></span>',
+    });
+  });
+
+  it('leaves published absolute URLs byte-identical', () => {
+    const html =
+      '<a href="https://mysite.pagespace.site/about" data-mention-type="page" data-page-id="p2">@About</a>';
+    assert({
+      given: 'an anchor already rewritten to a public https URL',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('leaves same-page fragment links byte-identical', () => {
+    const html = '<a href="#section-2">jump</a>';
+    assert({
+      given: 'a same-page fragment anchor',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('leaves non-dashboard relative links byte-identical', () => {
+    const html = '<a href="/pricing">pricing</a> <a href="mailto:a@b.c">mail</a>';
+    assert({
+      given: 'relative and mailto anchors that are not dashboard links',
+      should: 'leave them byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('does not treat an absolute dashboard URL as a leftover in-app link', () => {
+    const html = '<a href="https://pagespace.ai/dashboard/d/p">@Page</a>';
+    assert({
+      given: 'an anchor whose href is an absolute URL containing /dashboard/',
+      should: 'leave it byte-identical (only relative /dashboard/ paths are dead)',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('does not match paths that merely contain /dashboard/ mid-path', () => {
+    const html = '<a href="/docs/dashboard/setup">docs</a>';
+    assert({
+      given: 'an anchor whose relative href contains /dashboard/ but does not start with it',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('neutralizes only the dashboard anchors in mixed content', () => {
+    assert({
+      given: 'a document mixing dashboard, published, and fragment anchors',
+      should: 'neutralize only the dashboard ones',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p1" data-mention-type="page" data-page-id="p1">@One</a>' +
+          '<a href="https://s.pagespace.site/two">two</a>' +
+          '<a href="/dashboard/d/p3">three</a>' +
+          '<a href="#top">top</a>',
+      ),
+      expected:
+        '<span data-mention-type="page" data-page-id="p1">@One</span>' +
+        '<a href="https://s.pagespace.site/two">two</a>' +
+        '<span>three</span>' +
+        '<a href="#top">top</a>',
+    });
+  });
+
+  it('leaves an unclosed dashboard anchor unchanged without throwing', () => {
+    const html = '<p><a href="/dashboard/d/p">never closed</p>';
+    assert({
+      given: 'a malformed anchor with no closing tag',
+      should: 'leave the malformed region unchanged',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('still neutralizes well-formed anchors after a malformed one', () => {
+    assert({
+      given: 'a malformed anchor followed by a well-formed dashboard anchor',
+      should: 'neutralize the well-formed one and leave the rest intact',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/broken <a href="/dashboard/d/p">ok</a>',
+      ),
+      expected: '<a href="/dashboard/d/broken <span>ok</span>',
+    });
+  });
+
+  it('tolerates an anchor with no href', () => {
+    const html = '<a name="anchor-target">legacy</a>';
+    assert({
+      given: 'an anchor without an href attribute',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('is idempotent', () => {
+    const input =
+      '<p><a href="/dashboard/d/p" data-mention-type="page" data-page-id="p">@P</a> and <a href="#x">x</a></p>';
+    const once = neutralizeDashboardLinks(input);
+    assert({
+      given: 'already-neutralized output run through the transform again',
+      should: 'return it unchanged',
+      actual: neutralizeDashboardLinks(once),
+      expected: once,
+    });
+  });
+
+  it('returns empty input unchanged', () => {
+    assert({
+      given: 'an empty string',
+      should: 'return an empty string',
+      actual: neutralizeDashboardLinks(''),
+      expected: '',
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
+++ b/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
@@ -181,6 +181,113 @@ describe('neutralizeDashboardLinks', () => {
     });
   });
 
+  it('ignores an href-lookalike inside another attribute quoted value (false positive)', () => {
+    const html = '<a title="a > b, see href=/dashboard/d/x" href="/pricing">go</a>';
+    assert({
+      given: 'a live /pricing anchor whose title text merely mentions href=/dashboard/…',
+      should: 'leave it byte-identical instead of destroying the link',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('finds the real dashboard href despite an href-lookalike in an earlier attribute (false negative)', () => {
+    assert({
+      given: 'a dashboard anchor whose title contains a decoy href=https://… before the real href',
+      should: 'neutralize using the real href attribute',
+      actual: neutralizeDashboardLinks(
+        '<a title="old href=https://example.com" href="/dashboard/d/p">@Page</a>',
+      ),
+      expected: '<span>@Page</span>',
+    });
+  });
+
+  it('does not fabricate mention attributes from text inside another attribute value', () => {
+    assert({
+      given: 'a dashboard anchor whose title text contains data-page-id=fake',
+      should: 'emit a span without the fabricated attribute',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p" title="x > data-page-id=fake">@P</a>',
+      ),
+      expected: '<span>@P</span>',
+    });
+  });
+
+  it('leaves a tag with a bare quote in attribute-name position unchanged', () => {
+    // A browser's tokenizer ends this tag at the first '>' (quotes only open a
+    // value after '='), so matching past it would delete rendered text.
+    const html = '<a href="/dashboard/d/p" "x > y">text</a>';
+    assert({
+      given: 'an anchor with a stray quoted token where an attribute name belongs',
+      should: 'leave the region byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('never lets an unclosed attribute quote swallow content across tags', () => {
+    const html =
+      "<a href='/dashboard/d/p' title='broken>middle</a><p>It's here>tail</a>";
+    assert({
+      given: 'an unclosed quote that could pair with an apostrophe in later text',
+      should: 'leave the whole region byte-identical instead of deleting elements',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('does not steal the closing tag of the next anchor for a self-closed dashboard anchor', () => {
+    const html = '<a href="/dashboard/d/p"/>gap <a href="#f">f</a>';
+    assert({
+      given: 'a self-closed dashboard anchor followed by a valid fragment anchor',
+      should: 'leave everything byte-identical rather than unbalancing the markup',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
+  it('neutralizes a dashboard anchor nested inside an unclosed non-dashboard anchor', () => {
+    assert({
+      given: 'an unclosed /pricing anchor followed by a well-formed dashboard anchor',
+      should: 'still neutralize the dashboard anchor',
+      actual: neutralizeDashboardLinks(
+        '<a href="/pricing">keep <a href="/dashboard/d/p">dead</a>',
+      ),
+      expected: '<a href="/pricing">keep <span>dead</span>',
+    });
+  });
+
+  it('trims whitespace padding from the href before classifying', () => {
+    assert({
+      given: 'a dashboard href padded with whitespace (browsers strip URL attribute padding)',
+      should: 'still neutralize it',
+      actual: neutralizeDashboardLinks('<a href=" /dashboard/d/p">x</a>'),
+      expected: '<span>x</span>',
+    });
+  });
+
+  it('handles an unquoted dashboard href', () => {
+    assert({
+      given: 'an anchor whose href value is unquoted',
+      should: 'neutralize it',
+      actual: neutralizeDashboardLinks('<a href=/dashboard/d/p>x</a>'),
+      expected: '<span>x</span>',
+    });
+  });
+
+  it('stays fast on pathological unclosed-anchor input', () => {
+    const html = '<a href="/dashboard/d/p">x'.repeat(40_000);
+    const start = performance.now();
+    neutralizeDashboardLinks(html);
+    const elapsed = performance.now() - start;
+    assert({
+      given: '~1MB of repeated dashboard anchor openings with no closing tags',
+      should: 'complete in linear time (well under a second)',
+      actual: elapsed < 1000,
+      expected: true,
+    });
+  });
+
   it('leaves an unclosed dashboard anchor unchanged without throwing', () => {
     const html = '<p><a href="/dashboard/d/p">never closed</p>';
     assert({

--- a/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
+++ b/packages/lib/src/publish/__tests__/neutralize-dashboard-links.test.ts
@@ -149,6 +149,38 @@ describe('neutralizeDashboardLinks', () => {
     });
   });
 
+  it('handles a quoted attribute value containing > in a dashboard anchor', () => {
+    assert({
+      given: 'a dashboard anchor with a quoted attribute containing >',
+      should: 'neutralize the whole anchor without corrupting the markup',
+      actual: neutralizeDashboardLinks(
+        '<a href="/dashboard/d/p" title="2 > 1" data-mention-type="page" data-page-id="p">x</a>',
+      ),
+      expected: '<span data-mention-type="page" data-page-id="p">x</span>',
+    });
+  });
+
+  it('handles a single-quoted attribute value containing > in a dashboard anchor', () => {
+    assert({
+      given: "a dashboard anchor with a single-quoted attribute containing >",
+      should: 'neutralize the whole anchor without corrupting the markup',
+      actual: neutralizeDashboardLinks(
+        "<a href='/dashboard/d/p' title='2 > 1'>x</a>",
+      ),
+      expected: '<span>x</span>',
+    });
+  });
+
+  it('leaves a non-dashboard anchor with a quoted > byte-identical', () => {
+    const html = '<a href="/pricing" title="2 > 1">pricing</a>';
+    assert({
+      given: 'a non-dashboard anchor with a quoted attribute containing >',
+      should: 'leave it byte-identical',
+      actual: neutralizeDashboardLinks(html),
+      expected: html,
+    });
+  });
+
   it('leaves an unclosed dashboard anchor unchanged without throwing', () => {
     const html = '<p><a href="/dashboard/d/p">never closed</p>';
     assert({

--- a/packages/lib/src/publish/__tests__/render-code-page.test.ts
+++ b/packages/lib/src/publish/__tests__/render-code-page.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+
+import { renderCodePage } from '../render-code-page';
+import { buildDocumentCsp } from '../../canvas/csp';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('renderCodePage', () => {
+  it('should emit the code inside a <pre><code> block', () => {
+    assert({
+      given: 'a plain code string',
+      should: 'wrap it in <pre><code>',
+      actual: renderCodePage({ code: 'const x = 1;', title: 'snippet.ts' }).includes(
+        '<pre><code>const x = 1;</code></pre>',
+      ),
+      expected: true,
+    });
+  });
+
+  it('should HTML-escape the code', () => {
+    assert({
+      given: 'code containing HTML-special characters',
+      should: 'escape them so they render as text, not markup',
+      actual: renderCodePage({ code: '<script>alert(1)</script> & "x" \'y\'', title: 'T' }).includes(
+        '<pre><code>&lt;script&gt;alert(1)&lt;/script&gt; &amp; &quot;x&quot; &#39;y&#39;</code></pre>',
+      ),
+      expected: true,
+    });
+  });
+
+  it('should render an empty <pre><code> for empty code', () => {
+    assert({
+      given: 'an empty code string',
+      should: 'still emit a (empty) <pre><code> block, not throw',
+      actual: renderCodePage({ code: '', title: 'T' }).includes('<pre><code></code></pre>'),
+      expected: true,
+    });
+  });
+
+  it('should wrap the code inside the shared .ps-document shell with a title header', () => {
+    const html = renderCodePage({ code: 'x', title: 'My Snippet' });
+    assert({
+      given: 'a code page render',
+      should: 'emit <article class="ps-document"> with a <header><h1> title around the code block',
+      actual: html.includes(
+        '<article class="ps-document"><header><h1>My Snippet</h1></header><pre><code>x</code></pre></article>',
+      ),
+      expected: true,
+    });
+  });
+
+  it('should delegate head assembly to renderCanvasDocument (doctype, title, typography CSS)', () => {
+    const html = renderCodePage({ code: 'x', title: 'My Snippet' });
+    assert({
+      given: 'a code page render',
+      should: 'produce a full standalone document with the title and inlined document typography CSS',
+      actual:
+        html.startsWith('<!doctype html>') &&
+        html.includes('</html>') &&
+        html.includes('<title>My Snippet</title>') &&
+        html.includes('.ps-document {') &&
+        html.includes('max-width: 42rem'),
+      expected: true,
+    });
+  });
+
+  it('should carry buildDocumentCsp() (script-src none) as the CSP override', () => {
+    const html = renderCodePage({ code: 'x', title: 'T' });
+    assert({
+      given: 'a rendered code page',
+      should: "carry buildDocumentCsp()'s content verbatim in the CSP meta tag",
+      actual: html.includes(`content="${buildDocumentCsp()}"`) && html.includes("script-src 'none'"),
+      expected: true,
+    });
+  });
+
+  it('should omit the theme-bridge script', () => {
+    assert({
+      given: 'a rendered code page (standalone, not an in-app iframe)',
+      should: 'not inject the theme-bridge <script>',
+      actual: renderCodePage({ code: 'x', title: 'T' }).includes('pagespace-theme'),
+      expected: false,
+    });
+  });
+
+  it('should never emit a <script> tag, no matter the code content', () => {
+    const html = renderCodePage({
+      code: '</code></pre></article></body></html><script>alert(1)</script>',
+      title: 'T',
+    });
+    assert({
+      given: 'code that attempts to break out of <pre><code> and inject a script tag',
+      should: 'contain no literal <script tag anywhere in the output',
+      actual: /<script/i.test(html),
+      expected: false,
+    });
+  });
+
+  it('should respect an explicit lang override', () => {
+    assert({
+      given: 'an explicit lang',
+      should: 'set <html lang>',
+      actual: renderCodePage({ code: 'x', title: 'T', lang: 'fr' }).includes('<html lang="fr">'),
+      expected: true,
+    });
+  });
+
+  it('should emit the canonical link and OG tags when pageUrl is provided', () => {
+    const html = renderCodePage({
+      code: 'x',
+      title: 'My Snippet',
+      pageUrl: 'https://acme.pagespace.site/snippet',
+      ogImageUrl: 'https://acme.pagespace.site/og.png',
+      ogDescription: 'A great snippet',
+    });
+    assert({
+      given: 'pageUrl, ogImageUrl and ogDescription',
+      should: 'emit a canonical link and OG meta tags (passed through to renderCanvasDocument)',
+      actual:
+        html.includes('<link rel="canonical" href="https://acme.pagespace.site/snippet">') &&
+        html.includes('<meta property="og:image" content="https://acme.pagespace.site/og.png">') &&
+        html.includes('<meta property="og:description" content="A great snippet">'),
+      expected: true,
+    });
+  });
+
+  it('should omit the canonical link and OG tags when pageUrl is absent', () => {
+    const html = renderCodePage({ code: 'x', title: 'T' });
+    assert({
+      given: 'no pageUrl',
+      should: 'omit canonical/OG tags entirely',
+      actual: html.includes('rel="canonical"') || html.includes('property="og:'),
+      expected: false,
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/render-document-page.test.ts
+++ b/packages/lib/src/publish/__tests__/render-document-page.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { renderDocumentPage } from '../render-document-page';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('renderDocumentPage', () => {
+  it('should return a full standalone HTML document', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a bare document body and title',
+      should: 'wrap it in a full <!doctype html> document',
+      actual: out.startsWith('<!doctype html>') && out.includes('</html>'),
+      expected: true,
+    });
+  });
+
+  it('should lock scripts down with script-src none', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page',
+      should: "embed a CSP with script-src 'none'",
+      actual: out.includes("script-src 'none'"),
+      expected: true,
+    });
+  });
+
+  it('should strip author <script> tags entirely (sanitizer + CSP belt-and-suspenders)', () => {
+    const out = renderDocumentPage({
+      html: '<p>hello</p><script>alert(1)</script>',
+      title: 'My Doc',
+    });
+    assert({
+      given: 'author HTML containing a <script> tag',
+      should: 'contain no <script> remnants in the output',
+      actual: out.includes('<script') || out.includes('alert(1)'),
+      expected: false,
+    });
+  });
+
+  it('should omit the theme-bridge script', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page (standalone, not an in-app iframe)',
+      should: 'not inject the theme-bridge <script>',
+      actual: out.includes('pagespace-theme'),
+      expected: false,
+    });
+  });
+
+  it('should wrap the body in a .ps-document article with a title header', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a body with no leading <h1>',
+      should: 'emit <article class="ps-document"> with a <header><h1> title',
+      actual: out.includes('<article class="ps-document"><header><h1>My Doc</h1></header><p>hello</p></article>'),
+      expected: true,
+    });
+  });
+
+  it('should inline the document typography CSS', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'a rendered document page',
+      should: 'inline the shared document typography rules into <head>',
+      actual: out.includes('.ps-document {') && out.includes('max-width: 42rem'),
+      expected: true,
+    });
+  });
+
+  it('should emit the canonical link and OG tags when pageUrl is provided', () => {
+    const out = renderDocumentPage({
+      html: '<p>hello</p>',
+      title: 'My Doc',
+      pageUrl: 'https://acme.pagespace.site/my-doc',
+      ogImageUrl: 'https://acme.pagespace.site/og.png',
+      ogDescription: 'A great doc',
+    });
+    assert({
+      given: 'pageUrl, ogImageUrl and ogDescription',
+      should: 'emit a canonical link and OG meta tags',
+      actual:
+        out.includes('<link rel="canonical" href="https://acme.pagespace.site/my-doc">') &&
+        out.includes('<meta property="og:image" content="https://acme.pagespace.site/og.png">') &&
+        out.includes('<meta property="og:description" content="A great doc">'),
+      expected: true,
+    });
+  });
+
+  it('should omit the canonical link and OG tags when pageUrl is absent', () => {
+    const out = renderDocumentPage({ html: '<p>hello</p>', title: 'My Doc' });
+    assert({
+      given: 'no pageUrl',
+      should: 'omit canonical/OG tags entirely',
+      actual: out.includes('rel="canonical"') || out.includes('property="og:'),
+      expected: false,
+    });
+  });
+
+  it('should sanitize dangerous attributes and iframes from the author body', () => {
+    const out = renderDocumentPage({
+      html: '<p onclick="evil()">hi</p><iframe src="https://evil.example"></iframe>',
+      title: 'My Doc',
+    });
+    assert({
+      given: 'author HTML with an event handler and an <iframe>',
+      should: 'strip both before rendering',
+      actual: out.includes('onclick') || out.includes('<iframe'),
+      expected: false,
+    });
+  });
+
+  it('should HTML-escape the title in both <title> and the header', () => {
+    const out = renderDocumentPage({ html: '<p>x</p>', title: 'Fish & Chips' });
+    assert({
+      given: 'a title with an HTML-special character',
+      should: 'escape it everywhere the title is emitted',
+      actual: out.includes('Fish &amp; Chips') && !out.includes('Fish & Chips'),
+      expected: true,
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/render-sheet-page.test.ts
+++ b/packages/lib/src/publish/__tests__/render-sheet-page.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+
+import { renderSheetPage } from '../render-sheet-page';
+import { buildDocumentCsp } from '../../canvas/csp';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+const GRID = {
+  rowCount: 2,
+  columnCount: 2,
+  cells: { A1: 'Name', B1: 'Age', A2: 'Alice', B2: '30' },
+};
+
+describe('renderSheetPage', () => {
+  it('should render a static <table> from sheet content', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'Roster' });
+    assert({
+      given: 'a small 2x2 sheet',
+      should: 'emit a <table> containing every cell value',
+      actual:
+        html.includes('<table>') &&
+        html.includes('Name') &&
+        html.includes('Age') &&
+        html.includes('Alice') &&
+        html.includes('30'),
+      expected: true,
+    });
+  });
+
+  it('should render the first row as <th> headers when hasHeaders is true', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'Roster', hasHeaders: true });
+    assert({
+      given: 'hasHeaders: true',
+      should: 'emit a <thead> with <th>Name</th><th>Age</th> and the rest as <tbody> <td> rows',
+      actual:
+        html.includes('<thead><tr><th>Name</th><th>Age</th></tr></thead>') &&
+        html.includes('<tbody><tr><td>Alice</td><td>30</td></tr></tbody>'),
+      expected: true,
+    });
+  });
+
+  it('should render every row as <td> data when hasHeaders is false/omitted', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'Roster' });
+    assert({
+      given: 'no hasHeaders flag',
+      should: 'emit no <thead> and put every row (including the first) in <tbody>',
+      actual:
+        !html.includes('<thead>') &&
+        html.includes('<tbody><tr><td>Name</td><td>Age</td></tr><tr><td>Alice</td><td>30</td></tr></tbody>'),
+      expected: true,
+    });
+  });
+
+  it('should HTML-escape cell text', () => {
+    const html = renderSheetPage({
+      serializedContent: { rowCount: 1, columnCount: 1, cells: { A1: '<b>x</b> & "y"' } },
+      title: 'T',
+    });
+    assert({
+      given: 'a cell containing HTML-special characters',
+      should: 'escape them so they render as text, not markup',
+      actual: html.includes('<td>&lt;b&gt;x&lt;/b&gt; &amp; &quot;y&quot;</td>'),
+      expected: true,
+    });
+  });
+
+  it('should render the evaluated display value for a formula cell', () => {
+    const html = renderSheetPage({
+      serializedContent: { rowCount: 1, columnCount: 2, cells: { A1: '5', B1: '=A1*2' } },
+      title: 'T',
+    });
+    assert({
+      given: 'a cell holding a formula referencing another cell',
+      should: 'render the evaluated result, not the raw formula string',
+      actual: html.includes('<td>5</td><td>10</td>') && !html.includes('=A1*2'),
+      expected: true,
+    });
+  });
+
+  it('should render an empty-state message for malformed content, never throwing', () => {
+    const malformedInputs: unknown[] = ['{{{not json', null, undefined, 42, ['a', 'b'], {}];
+    const results = malformedInputs.map((serializedContent) => {
+      try {
+        return renderSheetPage({ serializedContent, title: 'T' });
+      } catch {
+        return 'THREW';
+      }
+    });
+    assert({
+      given: 'a variety of malformed/empty sheet contents',
+      should: 'never throw, and never emit a <table> (empty-state message instead)',
+      actual: results.every((html) => html !== 'THREW' && !html.includes('<table>')),
+      expected: true,
+    });
+  });
+
+  it('should wrap the table inside the shared .ps-document shell with a title header', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'My Sheet' });
+    assert({
+      given: 'a sheet page render',
+      should: 'emit <article class="ps-document"> with a <header><h1> title around the table',
+      actual: /<article class="ps-document"><header><h1>My Sheet<\/h1><\/header><table>.*<\/table><\/article>/.test(
+        html,
+      ),
+      expected: true,
+    });
+  });
+
+  it('should delegate head assembly to renderCanvasDocument (doctype, title, typography CSS)', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'My Sheet' });
+    assert({
+      given: 'a sheet page render',
+      should: 'produce a full standalone document with the title and inlined document typography CSS',
+      actual:
+        html.startsWith('<!doctype html>') &&
+        html.includes('</html>') &&
+        html.includes('<title>My Sheet</title>') &&
+        html.includes('.ps-document {') &&
+        html.includes('max-width: 42rem'),
+      expected: true,
+    });
+  });
+
+  it('should carry buildDocumentCsp() (script-src none) as the CSP override', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'T' });
+    assert({
+      given: 'a rendered sheet page',
+      should: "carry buildDocumentCsp()'s content verbatim in the CSP meta tag",
+      actual: html.includes(`content="${buildDocumentCsp()}"`) && html.includes("script-src 'none'"),
+      expected: true,
+    });
+  });
+
+  it('should omit the theme-bridge script', () => {
+    assert({
+      given: 'a rendered sheet page (standalone, not an in-app iframe)',
+      should: 'not inject the theme-bridge <script>',
+      actual: renderSheetPage({ serializedContent: GRID, title: 'T' }).includes('pagespace-theme'),
+      expected: false,
+    });
+  });
+
+  it('should never emit a <script> tag, even from malicious cell content', () => {
+    const html = renderSheetPage({
+      serializedContent: { rowCount: 1, columnCount: 1, cells: { A1: '</table></article></body><script>alert(1)</script>' } },
+      title: 'T',
+    });
+    assert({
+      given: 'a cell attempting to break out of the table and inject a script tag',
+      should: 'contain no literal <script tag anywhere in the output',
+      actual: /<script/i.test(html),
+      expected: false,
+    });
+  });
+
+  it('should emit the canonical link and OG tags when pageUrl is provided', () => {
+    const html = renderSheetPage({
+      serializedContent: GRID,
+      title: 'My Sheet',
+      pageUrl: 'https://acme.pagespace.site/sheet',
+      ogImageUrl: 'https://acme.pagespace.site/og.png',
+      ogDescription: 'A great sheet',
+    });
+    assert({
+      given: 'pageUrl, ogImageUrl and ogDescription',
+      should: 'emit a canonical link and OG meta tags (passed through to renderCanvasDocument)',
+      actual:
+        html.includes('<link rel="canonical" href="https://acme.pagespace.site/sheet">') &&
+        html.includes('<meta property="og:image" content="https://acme.pagespace.site/og.png">') &&
+        html.includes('<meta property="og:description" content="A great sheet">'),
+      expected: true,
+    });
+  });
+
+  it('should omit the canonical link and OG tags when pageUrl is absent', () => {
+    const html = renderSheetPage({ serializedContent: GRID, title: 'T' });
+    assert({
+      given: 'no pageUrl',
+      should: 'omit canonical/OG tags entirely',
+      actual: html.includes('rel="canonical"') || html.includes('property="og:'),
+      expected: false,
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
+++ b/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeDocumentHtml } from '../sanitize-document-html';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};
+
+describe('sanitizeDocumentHtml', () => {
+  describe('script stripping', () => {
+    it('strips a plain script block, tag and content', () => {
+      assert({
+        given: 'HTML with a <script> block between paragraphs',
+        should: 'remove the whole block (tag + content)',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)</script><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips mixed-case script tags with attributes', () => {
+      assert({
+        given: 'a <SCRIPT> with attributes and mixed-case close tag',
+        should: 'remove the whole block',
+        actual: sanitizeDocumentHtml(
+          '<p>x</p><SCRIPT type="text/javascript" src="https://evil.example/x.js">bad()</ScRiPt><p>y</p>'
+        ),
+        expected: '<p>x</p><p>y</p>',
+      });
+    });
+
+    it('strips a script left unclosed at EOF', () => {
+      assert({
+        given: 'a <script> that is never closed',
+        should: 'remove everything from the open tag to EOF',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)'),
+        expected: '<p>a</p>',
+      });
+    });
+
+    it('strips a close tag padded with junk', () => {
+      assert({
+        given: 'a script closed by `</script foo="bar">`',
+        should: 'still find the close tag and remove the block',
+        actual: sanitizeDocumentHtml('<p>a</p><script>alert(1)</script foo="bar"><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('does not mistake hyphenated custom elements for scripts', () => {
+      assert({
+        given: 'a <script-template> custom element',
+        should: 'leave it untouched (tag name requires a real delimiter)',
+        actual: sanitizeDocumentHtml('<script-template><p>hi</p></script-template>'),
+        expected: '<script-template><p>hi</p></script-template>',
+      });
+    });
+
+    it('defeats the split-tag reassembly trick', () => {
+      const out = sanitizeDocumentHtml('<<script>x</script>script src="https://evil.example/x.js">alert(1)</script>');
+      assert({
+        given: 'a payload whose script tag reassembles after one strip pass',
+        should: 'leave no executable <script open tag in the output',
+        actual: /<script(?=[\s/>])/i.test(out),
+        expected: false,
+      });
+    });
+  });
+
+  describe('forbidden elements', () => {
+    it('strips iframes with their content', () => {
+      assert({
+        given: 'an <iframe> with fallback content',
+        should: 'remove the element entirely',
+        actual: sanitizeDocumentHtml('<p>a</p><iframe src="https://evil.example">fallback</iframe><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips object and embed elements', () => {
+      assert({
+        given: '<object> and <embed> elements',
+        should: 'remove both',
+        actual: sanitizeDocumentHtml('<object data="x.swf">o</object><p>keep</p><embed src="x.swf">'),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips form elements', () => {
+      assert({
+        given: 'a <form> wrapping inputs',
+        should: 'remove the form element entirely',
+        actual: sanitizeDocumentHtml('<p>a</p><form action="/steal"><input name="pw"></form><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+
+    it('strips base, meta and link tags', () => {
+      assert({
+        given: 'void head-manipulation tags (<base>, <meta>, <link>)',
+        should: 'remove all of them',
+        actual: sanitizeDocumentHtml(
+          '<base href="https://evil.example/"><meta http-equiv="refresh" content="0;url=x"><link rel="stylesheet" href="x.css"><p>keep</p>'
+        ),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips style blocks with their content', () => {
+      assert({
+        given: 'a <style> block (documents are styled by the shell)',
+        should: 'remove tag and CSS content',
+        actual: sanitizeDocumentHtml('<style>p { display: none; }</style><p>keep</p>'),
+        expected: '<p>keep</p>',
+      });
+    });
+
+    it('strips a style block left unclosed at EOF', () => {
+      assert({
+        given: 'a <style> that is never closed',
+        should: 'remove everything from the open tag to EOF',
+        actual: sanitizeDocumentHtml('<p>a</p><style>p{}'),
+        expected: '<p>a</p>',
+      });
+    });
+
+    it('strips mixed-case forbidden elements', () => {
+      assert({
+        given: 'an <IFRAME> in caps',
+        should: 'remove it (matching is case-insensitive)',
+        actual: sanitizeDocumentHtml('<IFRAME SRC="x"></IFRAME><p>keep</p>'),
+        expected: '<p>keep</p>',
+      });
+    });
+  });
+
+  describe('event handler attributes', () => {
+    it('removes on* attributes but keeps the element', () => {
+      assert({
+        given: 'an <img> with an onerror handler',
+        should: 'drop the handler, keep the element and its other attributes',
+        actual: sanitizeDocumentHtml('<img src="x.png" onerror="alert(1)" alt="pic">'),
+        expected: '<img src="x.png" alt="pic">',
+      });
+    });
+
+    it('removes on* attributes in any casing', () => {
+      assert({
+        given: 'a <div ONCLICK=...> in caps',
+        should: 'remove the attribute regardless of case',
+        actual: sanitizeDocumentHtml("<div ONCLICK='alert(1)'>hi</div>"),
+        expected: '<div>hi</div>',
+      });
+    });
+
+    it('removes unquoted on* attribute values', () => {
+      assert({
+        given: 'an unquoted onmouseover value',
+        should: 'remove the whole attribute',
+        actual: sanitizeDocumentHtml('<a onmouseover=alert(1) href="/ok">x</a>'),
+        expected: '<a href="/ok">x</a>',
+      });
+    });
+
+    it('does not remove data-* attributes that merely contain "on"', () => {
+      assert({
+        given: 'a span with data-mention-type (contains "on" but is not a handler)',
+        should: 'keep the attribute',
+        actual: sanitizeDocumentHtml('<span data-mention-type="page">@Home</span>'),
+        expected: '<span data-mention-type="page">@Home</span>',
+      });
+    });
+
+    it('removes on* attributes separated by a slash instead of whitespace', () => {
+      assert({
+        given: 'an <img/onerror=...> using "/" as the attribute separator',
+        should: 'remove the handler (browsers treat "/" like whitespace here)',
+        actual: sanitizeDocumentHtml('<img/onerror=alert(1) src="x.png">'),
+        expected: '<img src="x.png">',
+      });
+    });
+
+    it('handles a ">" inside a quoted attribute value before the handler', () => {
+      assert({
+        given: 'an element whose alt contains ">" followed by an onerror',
+        should: 'parse the tag quote-aware and still remove the handler',
+        actual: sanitizeDocumentHtml('<img alt="a>b" onerror="alert(1)" src="x.png">'),
+        expected: '<img alt="a>b" src="x.png">',
+      });
+    });
+  });
+
+  describe('dangerous URL schemes', () => {
+    it('removes javascript: hrefs', () => {
+      assert({
+        given: 'an anchor with a javascript: href',
+        should: 'remove the href attribute, keep the anchor',
+        actual: sanitizeDocumentHtml('<a href="javascript:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes unquoted javascript: hrefs', () => {
+      assert({
+        given: 'an unquoted javascript: href value',
+        should: 'remove the attribute',
+        actual: sanitizeDocumentHtml('<a href=javascript:alert(1)>x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: xlink:href values on SVG elements', () => {
+      assert({
+        given: 'an SVG <a xlink:href="javascript:...">',
+        should: 'remove the attribute, keep the element',
+        actual: sanitizeDocumentHtml('<svg><a xlink:href="javascript:alert(1)"><text>x</text></a></svg>'),
+        expected: '<svg><a><text>x</text></a></svg>',
+      });
+    });
+
+    it('removes javascript: hrefs with case and whitespace tricks', () => {
+      assert({
+        given: 'a href of " JaVaScRiPt:..." with leading space and mixed case',
+        should: 'still detect and remove it',
+        actual: sanitizeDocumentHtml('<a href=" JaVaScRiPt:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: hrefs with embedded tab/newline', () => {
+      assert({
+        given: 'a href with a tab and newline inside the scheme (browser strips them)',
+        should: 'still detect and remove it',
+        actual: sanitizeDocumentHtml('<a href="java\tscri\npt:alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes javascript: hidden behind HTML entities', () => {
+      assert({
+        given: 'a href spelling javascript: with numeric/named entities',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="&#106;avascript&colon;alert(1)">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes data:text/html hidden behind &sol; entities', () => {
+      assert({
+        given: 'a href spelling data:text/html with the slash as &sol;',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="data:text&sol;html,<script>alert(1)</script>">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes data:text/html hidden behind numeric slash entities', () => {
+      assert({
+        given: 'a href spelling data:text/html with the slash as &#47; / &#x2F;',
+        should: 'decode for the check and remove it',
+        actual: sanitizeDocumentHtml('<a href="data:text&#47;html,x">a</a><a href="data:text&#x2F;html,x">b</a>'),
+        expected: '<a>a</a><a>b</a>',
+      });
+    });
+
+    it('removes data:text/html srcs and hrefs', () => {
+      assert({
+        given: 'a href with a data:text/html payload (any casing)',
+        should: 'remove the attribute',
+        actual: sanitizeDocumentHtml('<a href="DATA:text/html;base64,PHNjcmlwdD4=">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('keeps benign URL schemes', () => {
+      const benign =
+        '<a href="https://example.com/a">a</a>' +
+        '<a href="/relative/path">b</a>' +
+        '<a href="mailto:hi@example.com">c</a>' +
+        '<img src="data:image/png;base64,iVBORw0KGgo=">';
+      assert({
+        given: 'https, relative, mailto and data:image URLs',
+        should: 'pass them through untouched',
+        actual: sanitizeDocumentHtml(benign),
+        expected: benign,
+      });
+    });
+  });
+
+  describe('benign TipTap output', () => {
+    const tiptap =
+      '<h1>Title</h1>' +
+      '<h2>Sub</h2><h3>a</h3><h4>b</h4><h5>c</h5><h6>d</h6>' +
+      '<p>Hello <strong>bold</strong> and <em>italic</em> text.</p>' +
+      '<ul><li>one</li><li>two</li></ul>' +
+      '<ol><li>first</li></ol>' +
+      '<table><thead><tr><th>H</th></tr></thead><tbody><tr><td>cell</td></tr></tbody></table>' +
+      '<img src="https://cdn.example.com/img.png" alt="pic" width="100">' +
+      '<a href="https://example.com" target="_blank" rel="noopener">link</a>' +
+      '<pre><code>const x = 1 &lt; 2;</code></pre>' +
+      '<blockquote><p>quote</p></blockquote>' +
+      '<hr>' +
+      '<p><span data-mention-type="page" data-id="abc123">@Home</span></p>';
+
+    it('passes benign TipTap output through byte-identical', () => {
+      assert({
+        given: 'typical TipTap-authored document HTML',
+        should: 'return it byte-identical',
+        actual: sanitizeDocumentHtml(tiptap),
+        expected: tiptap,
+      });
+    });
+  });
+
+  describe('idempotence', () => {
+    const nastyInputs = [
+      '<p>a</p><script>alert(1)</script><p>b</p>',
+      '<<script>x</script>script src="x">alert(1)</script>',
+      '<img src="x.png" onerror="alert(1)">',
+      '<a href="javascript:alert(1)">x</a>',
+      '<style>p{}</style><iframe src="x"></iframe><form><input></form>',
+      '<scri<script></script>pt>alert(1)</scri</script>ipt>',
+      '<p>plain</p>',
+    ];
+
+    it('is idempotent on every input', () => {
+      for (const input of nastyInputs) {
+        const once = sanitizeDocumentHtml(input);
+        assert({
+          given: `input ${JSON.stringify(input.slice(0, 40))}…`,
+          should: 'satisfy sanitize(sanitize(x)) === sanitize(x)',
+          actual: sanitizeDocumentHtml(once),
+          expected: once,
+        });
+      }
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for empty input', () => {
+      assert({
+        given: 'an empty string',
+        should: 'return an empty string',
+        actual: sanitizeDocumentHtml(''),
+        expected: '',
+      });
+    });
+
+    it('leaves a bare "<" literal alone', () => {
+      assert({
+        given: 'text containing a stray "<" that is not a tag',
+        should: 'pass it through',
+        actual: sanitizeDocumentHtml('<p>1 < 2 is true</p>'),
+        expected: '<p>1 < 2 is true</p>',
+      });
+    });
+
+    it('strips orphan close tags of forbidden elements', () => {
+      assert({
+        given: 'a stray </script> with no matching open tag',
+        should: 'remove it',
+        actual: sanitizeDocumentHtml('<p>a</p></script><p>b</p>'),
+        expected: '<p>a</p><p>b</p>',
+      });
+    });
+  });
+});

--- a/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
+++ b/packages/lib/src/publish/__tests__/sanitize-document-html.test.ts
@@ -278,6 +278,24 @@ describe('sanitizeDocumentHtml', () => {
       });
     });
 
+    it('removes data:image/svg+xml hrefs (SVG documents can carry <script>)', () => {
+      assert({
+        given: 'an anchor navigating to an inline SVG document via a data: href',
+        should: 'remove the attribute — unlike data:image/png, svg+xml can execute script on navigation',
+        actual: sanitizeDocumentHtml('<a href="data:image/svg+xml,<svg><script>alert(1)</script></svg>">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
+    it('removes data:image/svg+xml hrefs regardless of casing', () => {
+      assert({
+        given: 'a href with an uppercase DATA:IMAGE/SVG+XML scheme',
+        should: 'remove the attribute',
+        actual: sanitizeDocumentHtml('<a href="DATA:IMAGE/SVG+XML;base64,x">x</a>'),
+        expected: '<a>x</a>',
+      });
+    });
+
     it('keeps benign URL schemes', () => {
       const benign =
         '<a href="https://example.com/a">a</a>' +

--- a/packages/lib/src/publish/document-shell.ts
+++ b/packages/lib/src/publish/document-shell.ts
@@ -1,0 +1,206 @@
+import { escapeHtml } from '../utils/html';
+
+/**
+ * Typography for published documents. Published pages carry no app stylesheet
+ * (no CSS variables, no Tailwind Preflight), so colors are hardcoded light
+ * values with a prefers-color-scheme dark override, and UA element margins
+ * are zeroed via a low-specificity :where reset before the sibling rhythm.
+ * Every rule is scoped under .ps-document except the :root/body page-canvas
+ * rules — this stylesheet is only ever inlined into standalone published
+ * documents, and the canvas must follow the color scheme or dark mode would
+ * render light text on the browser's white default background. Inlined into
+ * <style> by the renderer, same pattern as BASELINE_RESET in
+ * canvas/render-document.ts.
+ */
+export const DOCUMENT_TYPOGRAPHY_CSS = `
+:root {
+  color-scheme: light dark;
+}
+body {
+  background: #ffffff;
+}
+.ps-document {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  line-height: 1.65;
+  color: #1f2328;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  min-width: 0;
+}
+.ps-document :where(h1, h2, h3, h4, h5, h6, p, ul, ol, li, dl, dd, blockquote, pre, figure, hr, table) {
+  margin: 0;
+}
+.ps-document > * + * {
+  margin-top: 0.75em;
+}
+.ps-document h1 {
+  font-size: 2em;
+  font-weight: bold;
+  line-height: 1.25;
+}
+.ps-document h2 {
+  font-size: 1.5em;
+  font-weight: bold;
+  line-height: 1.3;
+  margin-top: 1.5em;
+}
+.ps-document h3 {
+  font-size: 1.17em;
+  font-weight: bold;
+  margin-top: 1.25em;
+}
+.ps-document > header {
+  margin-bottom: 2rem;
+}
+.ps-document ul {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+}
+.ps-document ol {
+  list-style-type: decimal;
+  padding-left: 1.5rem;
+}
+.ps-document code {
+  background-color: #eff1f3;
+  color: #24292f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.9em;
+  border-radius: 0.25rem;
+  padding: 0.15em 0.35em;
+}
+.ps-document pre {
+  background: #f6f8fa;
+  color: #24292f;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+.ps-document pre code {
+  color: inherit;
+  padding: 0;
+  background: none;
+  font-size: 0.85em;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+.ps-document img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.375rem;
+}
+.ps-document table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+.ps-document th,
+.ps-document td {
+  border: 1px solid #d0d7de;
+  padding: 0.5rem;
+  text-align: left;
+}
+.ps-document th {
+  font-weight: bold;
+  background-color: #f6f8fa;
+}
+.ps-document blockquote {
+  border-left: 3px solid #d0d7de;
+  margin-left: 1.5rem;
+  padding-left: 1rem;
+  font-style: italic;
+  color: #57606a;
+}
+.ps-document hr {
+  border: none;
+  border-top: 2px solid rgba(13, 13, 13, 0.1);
+  margin: 2rem 0;
+}
+.ps-document a {
+  color: #0969da;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.ps-document a:hover {
+  opacity: 0.8;
+}
+.ps-document a[data-mention-type] {
+  background-color: rgba(9, 105, 218, 0.08);
+  border: 1px solid rgba(9, 105, 218, 0.2);
+  border-radius: 0.375rem;
+  padding: 0.1em 0.35em;
+  text-decoration: none;
+  font-size: 0.95em;
+  white-space: nowrap;
+}
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #0d1117;
+  }
+  .ps-document {
+    color: #e6edf3;
+  }
+  .ps-document code {
+    background-color: #2d333b;
+    color: #d1d7e0;
+  }
+  .ps-document pre {
+    background: #161b22;
+    color: #e6edf3;
+  }
+  .ps-document th,
+  .ps-document td {
+    border-color: #3d444d;
+  }
+  .ps-document th {
+    background-color: #21262d;
+  }
+  .ps-document blockquote {
+    border-color: #3d444d;
+    color: #9198a1;
+  }
+  .ps-document hr {
+    border-top-color: rgba(255, 255, 255, 0.12);
+  }
+  .ps-document a {
+    color: #4493f8;
+  }
+  .ps-document a[data-mention-type] {
+    background-color: rgba(68, 147, 248, 0.12);
+    border-color: rgba(68, 147, 248, 0.3);
+  }
+}
+`;
+
+/**
+ * True when the first meaningful element of the body is an <h1>. Leading
+ * whitespace and HTML comments are tolerated; an unterminated comment means
+ * no meaningful content follows.
+ */
+export function documentStartsWithH1(html: string): boolean {
+  let rest = html;
+  for (;;) {
+    rest = rest.replace(/^\s+/, '');
+    if (rest.startsWith('<!--')) {
+      const end = rest.indexOf('-->', 4);
+      if (end === -1) return false;
+      rest = rest.slice(end + 3);
+      continue;
+    }
+    return /^<h1[\s>]/i.test(rest);
+  }
+}
+
+export function wrapDocumentBody({ bodyHtml, title }: { bodyHtml: string; title: string }): string {
+  const header = documentStartsWithH1(bodyHtml)
+    ? ''
+    : `<header><h1>${escapeHtml(title)}</h1></header>`;
+  return `<article class="ps-document">${header}${bodyHtml}</article>`;
+}

--- a/packages/lib/src/publish/document-shell.ts
+++ b/packages/lib/src/publish/document-shell.ts
@@ -131,7 +131,8 @@ body {
 .ps-document a:hover {
   opacity: 0.8;
 }
-.ps-document a[data-mention-type] {
+.ps-document a[data-mention-type],
+.ps-document span[data-mention-type] {
   background-color: rgba(9, 105, 218, 0.08);
   border: 1px solid rgba(9, 105, 218, 0.2);
   border-radius: 0.375rem;
@@ -139,6 +140,14 @@ body {
   text-decoration: none;
   font-size: 0.95em;
   white-space: nowrap;
+}
+.ps-document span[data-mention-type] {
+  /* Neutralized mention (target unpublished): span isn't a link, so the anchor's
+   * base color/cursor never applies -- restate them here to keep the chip
+   * looking identical to a live mention instead of falling back to plain text. */
+  color: #0969da;
+  cursor: default;
+  display: inline-block;
 }
 @media (prefers-color-scheme: dark) {
   body {
@@ -172,9 +181,13 @@ body {
   .ps-document a {
     color: #4493f8;
   }
-  .ps-document a[data-mention-type] {
+  .ps-document a[data-mention-type],
+  .ps-document span[data-mention-type] {
     background-color: rgba(68, 147, 248, 0.12);
     border-color: rgba(68, 147, 248, 0.3);
+  }
+  .ps-document span[data-mention-type] {
+    color: #4493f8;
   }
 }
 `;

--- a/packages/lib/src/publish/neutralize-dashboard-links.ts
+++ b/packages/lib/src/publish/neutralize-dashboard-links.ts
@@ -5,40 +5,66 @@
 // converts those leftover anchors into inert `<span>`s, preserving the inner
 // HTML and the mention data attributes so mention-chip CSS still applies.
 //
-// Pure string transform: no DOM, no I/O. The matcher is deliberately
-// conservative — an anchor tag whose attribute region contains a bare `<`
-// or `>` outside a quoted value (i.e. is malformed or unclosed) never
-// matches and is left unchanged.
+// Pure string transform: no DOM, no I/O. The expected input is TipTap
+// document HTML (double-quoted attributes, `<`/`>` entity-encoded in text
+// and attribute values), but the matcher is hardened for hand-authored
+// markup by following the HTML tokenizer's grammar for the attribute
+// region: a quote opens a value only after `=`, and a quoted value may
+// contain `>` (title="2 > 1") but not `<`, so a match can never extend
+// across a tag boundary. Anything that violates the grammar — a bare quote
+// in name position, an unclosed quote, an unclosed anchor — simply never
+// matches and is left byte-identical; when corrupt output and a missed
+// anchor are the only options, this module always prefers the miss.
+//
+// Deliberately out of scope (per the 1-6 spec): absolute or
+// protocol-relative dashboard URLs (`https://host/dashboard/…`) — matching
+// those by path alone would false-positive external sites whose paths
+// merely contain /dashboard/, and this module reads no config to know the
+// app's own host.
 
-// A well-formed opening tag, its inner HTML (lazy, up to the nearest close
-// tag — anchors cannot nest in valid HTML), and the closing tag. The
-// attribute region is a run of quoted values and non-`<`/`>` characters, so
-// a quoted value may legally contain `>` (title="2 > 1") without ending the
-// tag. The three alternatives start with disjoint characters, so the
-// quantifier backtracks linearly.
-const ANCHOR_RE = /<a\b((?:"[^"]*"|'[^']*'|[^<>"'])*)>([\s\S]*?)<\/a\s*>/gi;
+// The value grammar is shared by the tag matcher and the attribute
+// tokenizer so both always accept the same syntax.
+const ATTR_VALUE_SRC = `"[^"<]*"|'[^'<]*'|[^\\s"'<>=\`]+`;
+const ATTR_NAME_SRC = `[^\\s"'<>=/]+`;
 
-const HREF_RE = /(?:^|\s)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/i;
+// A well-formed opening tag whose attribute region is a run of
+// name(=value)? tokens, its inner HTML, and the closing tag. The inner
+// content is lazy and additionally refuses to cross another `<a` opening:
+// anchors cannot nest in valid HTML, so an unclosed anchor can never steal
+// a later anchor's closing tag, and a failed scan stops at the next anchor
+// instead of the end of the input (keeping worst-case time linear).
+const ANCHOR_RE = new RegExp(
+  `<a\\b((?:\\s+${ATTR_NAME_SRC}(?:\\s*=\\s*(?:${ATTR_VALUE_SRC}))?)*\\s*/?)>` +
+    `((?:(?!<a\\b)[\\s\\S])*?)</a\\s*>`,
+  'gi',
+);
+
+// Tokenizes an attribute region ANCHOR_RE has already validated. Because a
+// quoted value is consumed as a single token, `href=` or `data-page-id=`
+// text INSIDE another attribute's value is never mistaken for an attribute.
+const ATTR_TOKEN_RE = new RegExp(
+  `(${ATTR_NAME_SRC})\\s*(?:=\\s*(${ATTR_VALUE_SRC}))?`,
+  'g',
+);
+
+interface AttrToken {
+  name: string;
+  value: string;
+}
+
+const unquote = (raw: string): string =>
+  raw.startsWith('"') || raw.startsWith("'") ? raw.slice(1, -1) : raw;
+
+const parseAttrs = (attrs: string): AttrToken[] => {
+  const tokens: AttrToken[] = [];
+  for (const match of attrs.matchAll(ATTR_TOKEN_RE)) {
+    tokens.push({ name: match[1].toLowerCase(), value: unquote(match[2] ?? '') });
+  }
+  return tokens;
+};
 
 // The mention attributes carried over onto the neutralized span.
-const MENTION_ATTR_RE =
-  /(?:^|\s)(data-mention-type|data-page-id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/gi;
-
-const extractHref = (attrs: string): string | undefined => {
-  const match = attrs.match(HREF_RE);
-  if (!match) return undefined;
-  return match[1] ?? match[2] ?? match[3];
-};
-
-const mentionAttrs = (attrs: string): string => {
-  const kept: string[] = [];
-  for (const match of attrs.matchAll(MENTION_ATTR_RE)) {
-    const name = match[1].toLowerCase();
-    const value = match[2] ?? match[3] ?? match[4] ?? '';
-    kept.push(`${name}="${value.replace(/"/g, '&quot;')}"`);
-  }
-  return kept.length > 0 ? ` ${kept.join(' ')}` : '';
-};
+const MENTION_ATTR_NAMES = new Set(['data-mention-type', 'data-page-id']);
 
 /**
  * Replace anchors that still point into the app (`href` starting with the
@@ -48,9 +74,16 @@ const mentionAttrs = (attrs: string): string => {
  * any malformed/unclosed anchor markup are left byte-identical. Idempotent.
  */
 export function neutralizeDashboardLinks(html: string): string {
+  if (!html.includes('/dashboard/')) return html;
   return html.replace(ANCHOR_RE, (anchor, attrs: string, inner: string) => {
-    const href = extractHref(attrs);
+    const tokens = parseAttrs(attrs);
+    // Browsers strip whitespace padding from URL attributes, so trim before
+    // classifying; like the HTML tokenizer, the first href wins.
+    const href = tokens.find((token) => token.name === 'href')?.value.trim();
     if (href === undefined || !href.startsWith('/dashboard/')) return anchor;
-    return `<span${mentionAttrs(attrs)}>${inner}</span>`;
+    const kept = tokens
+      .filter((token) => MENTION_ATTR_NAMES.has(token.name))
+      .map((token) => `${token.name}="${token.value.replace(/"/g, '&quot;')}"`);
+    return `<span${kept.length > 0 ? ` ${kept.join(' ')}` : ''}>${inner}</span>`;
   });
 }

--- a/packages/lib/src/publish/neutralize-dashboard-links.ts
+++ b/packages/lib/src/publish/neutralize-dashboard-links.ts
@@ -6,13 +6,17 @@
 // HTML and the mention data attributes so mention-chip CSS still applies.
 //
 // Pure string transform: no DOM, no I/O. The matcher is deliberately
-// conservative — an anchor tag whose attribute region contains `<` or `>`
-// (i.e. is malformed or unclosed) never matches and is left unchanged.
+// conservative — an anchor tag whose attribute region contains a bare `<`
+// or `>` outside a quoted value (i.e. is malformed or unclosed) never
+// matches and is left unchanged.
 
-// A well-formed opening tag (no `<`/`>` inside the attribute region), its
-// inner HTML (lazy, up to the nearest close tag — anchors cannot nest in
-// valid HTML), and the closing tag.
-const ANCHOR_RE = /<a\b([^<>]*)>([\s\S]*?)<\/a\s*>/gi;
+// A well-formed opening tag, its inner HTML (lazy, up to the nearest close
+// tag — anchors cannot nest in valid HTML), and the closing tag. The
+// attribute region is a run of quoted values and non-`<`/`>` characters, so
+// a quoted value may legally contain `>` (title="2 > 1") without ending the
+// tag. The three alternatives start with disjoint characters, so the
+// quantifier backtracks linearly.
+const ANCHOR_RE = /<a\b((?:"[^"]*"|'[^']*'|[^<>"'])*)>([\s\S]*?)<\/a\s*>/gi;
 
 const HREF_RE = /(?:^|\s)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/i;
 

--- a/packages/lib/src/publish/neutralize-dashboard-links.ts
+++ b/packages/lib/src/publish/neutralize-dashboard-links.ts
@@ -1,0 +1,52 @@
+// At publish time, inter-page links whose target is itself published are
+// rewritten to public URLs (see apps/web's asset pipeline). Links to
+// UNPUBLISHED pages keep their in-app `/dashboard/{driveId}/{pageId}` href —
+// a dead, login-walled destination for an anonymous visitor. This transform
+// converts those leftover anchors into inert `<span>`s, preserving the inner
+// HTML and the mention data attributes so mention-chip CSS still applies.
+//
+// Pure string transform: no DOM, no I/O. The matcher is deliberately
+// conservative — an anchor tag whose attribute region contains `<` or `>`
+// (i.e. is malformed or unclosed) never matches and is left unchanged.
+
+// A well-formed opening tag (no `<`/`>` inside the attribute region), its
+// inner HTML (lazy, up to the nearest close tag — anchors cannot nest in
+// valid HTML), and the closing tag.
+const ANCHOR_RE = /<a\b([^<>]*)>([\s\S]*?)<\/a\s*>/gi;
+
+const HREF_RE = /(?:^|\s)href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/i;
+
+// The mention attributes carried over onto the neutralized span.
+const MENTION_ATTR_RE =
+  /(?:^|\s)(data-mention-type|data-page-id)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'<>=`]+))/gi;
+
+const extractHref = (attrs: string): string | undefined => {
+  const match = attrs.match(HREF_RE);
+  if (!match) return undefined;
+  return match[1] ?? match[2] ?? match[3];
+};
+
+const mentionAttrs = (attrs: string): string => {
+  const kept: string[] = [];
+  for (const match of attrs.matchAll(MENTION_ATTR_RE)) {
+    const name = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    kept.push(`${name}="${value.replace(/"/g, '&quot;')}"`);
+  }
+  return kept.length > 0 ? ` ${kept.join(' ')}` : '';
+};
+
+/**
+ * Replace anchors that still point into the app (`href` starting with the
+ * relative `/dashboard/` path) with inert `<span>`s, preserving inner HTML
+ * and any `data-mention-type`/`data-page-id` attributes. All other anchors —
+ * published `https://` URLs, same-page fragments, non-dashboard paths — and
+ * any malformed/unclosed anchor markup are left byte-identical. Idempotent.
+ */
+export function neutralizeDashboardLinks(html: string): string {
+  return html.replace(ANCHOR_RE, (anchor, attrs: string, inner: string) => {
+    const href = extractHref(attrs);
+    if (href === undefined || !href.startsWith('/dashboard/')) return anchor;
+    return `<span${mentionAttrs(attrs)}>${inner}</span>`;
+  });
+}

--- a/packages/lib/src/publish/render-code-page.ts
+++ b/packages/lib/src/publish/render-code-page.ts
@@ -1,0 +1,55 @@
+import { renderCanvasDocument } from '../canvas/render-document';
+import { buildDocumentCsp } from '../canvas/csp';
+import { escapeHtml } from '../utils/html';
+import { wrapDocumentBody, DOCUMENT_TYPOGRAPHY_CSS } from './document-shell';
+
+export interface RenderCodePageInput {
+  code: string;
+  title: string;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  description?: string;
+  robots?: string;
+  faviconHref?: string;
+  faviconBaseUrl?: string;
+  lang?: string;
+  allowedAssetHosts?: string[];
+}
+
+/**
+ * Render a CODE page as a complete, standalone HTML document. No syntax
+ * highlighting (Shiki is client-side in this repo) — the raw code string is
+ * HTML-escaped and emitted verbatim inside `<pre><code>`, so it can never
+ * carry live markup.
+ *
+ * Mirrors `render-document-page.ts`: reuses the canvas renderer's whole head
+ * assembly (SEO/OG/Twitter/JSON-LD, favicon, CSP `<meta>`) via
+ * `cspOverride`/`injectThemeBridge: false` rather than duplicating it — CODE
+ * pages never run author scripts, so they get `buildDocumentCsp()`
+ * (`script-src 'none'`) and no theme-bridge script.
+ */
+export function renderCodePage(input: RenderCodePageInput): string {
+  const { code, title, pageUrl, ogImageUrl, ogDescription, description, robots, faviconHref, faviconBaseUrl, lang, allowedAssetHosts } = input;
+
+  const wrappedBody = wrapDocumentBody({
+    bodyHtml: `<pre><code>${escapeHtml(code ?? '')}</code></pre>`,
+    title,
+  });
+
+  return renderCanvasDocument({
+    html: `<style>${DOCUMENT_TYPOGRAPHY_CSS}</style>${wrappedBody}`,
+    title,
+    pageUrl,
+    ogImageUrl,
+    ogDescription,
+    description,
+    robots,
+    faviconHref,
+    faviconBaseUrl,
+    lang,
+    allowedAssetHosts,
+    cspOverride: buildDocumentCsp(),
+    injectThemeBridge: false,
+  });
+}

--- a/packages/lib/src/publish/render-document-page.ts
+++ b/packages/lib/src/publish/render-document-page.ts
@@ -1,0 +1,55 @@
+import { renderCanvasDocument } from '../canvas/render-document';
+import { buildDocumentCsp } from '../canvas/csp';
+import { sanitizeDocumentHtml } from './sanitize-document-html';
+import { wrapDocumentBody, DOCUMENT_TYPOGRAPHY_CSS } from './document-shell';
+
+export interface RenderDocumentPageInput {
+  html: string;
+  title: string;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  description?: string;
+  robots?: string;
+  faviconHref?: string;
+  faviconBaseUrl?: string;
+  lang?: string;
+  allowedAssetHosts?: string[];
+}
+
+/**
+ * Render a complete, standalone HTML document for a published DOCUMENT page
+ * (as opposed to a Canvas page — see `../canvas/render-document.ts`). Reuses
+ * the canvas renderer's whole head assembly (SEO/OG/Twitter/JSON-LD, favicon,
+ * CSP `<meta>`) via `cspOverride`/`injectThemeBridge: false` rather than
+ * duplicating it: documents never run author scripts, so they get
+ * `buildDocumentCsp()` (`script-src 'none'`) and no theme-bridge script
+ * (standalone documents use `prefers-color-scheme` only).
+ *
+ * `DOCUMENT_TYPOGRAPHY_CSS` is prepended as a `<style>` block ahead of the
+ * sanitized body so it flows through `renderCanvasDocument`'s existing CSS
+ * sanitization/hoisting path exactly like an author `<style>` tag, landing in
+ * the generated `<head>`.
+ */
+export function renderDocumentPage(input: RenderDocumentPageInput): string {
+  const { html, title, pageUrl, ogImageUrl, ogDescription, description, robots, faviconHref, faviconBaseUrl, lang, allowedAssetHosts } = input;
+
+  const sanitizedBody = sanitizeDocumentHtml(html);
+  const wrappedBody = wrapDocumentBody({ bodyHtml: sanitizedBody, title });
+
+  return renderCanvasDocument({
+    html: `<style>${DOCUMENT_TYPOGRAPHY_CSS}</style>${wrappedBody}`,
+    title,
+    pageUrl,
+    ogImageUrl,
+    ogDescription,
+    description,
+    robots,
+    faviconHref,
+    faviconBaseUrl,
+    lang,
+    allowedAssetHosts,
+    cspOverride: buildDocumentCsp(),
+    injectThemeBridge: false,
+  });
+}

--- a/packages/lib/src/publish/render-sheet-page.ts
+++ b/packages/lib/src/publish/render-sheet-page.ts
@@ -1,0 +1,91 @@
+import { renderCanvasDocument } from '../canvas/render-document';
+import { buildDocumentCsp } from '../canvas/csp';
+import { escapeHtml } from '../utils/html';
+import { evaluateSheet, parseSheetContent } from '../sheets/sheet';
+import { wrapDocumentBody, DOCUMENT_TYPOGRAPHY_CSS } from './document-shell';
+
+export interface RenderSheetPageInput {
+  serializedContent: unknown;
+  title: string;
+  /** Render the first row as `<th>` column headers instead of data. */
+  hasHeaders?: boolean;
+  pageUrl?: string;
+  ogImageUrl?: string;
+  ogDescription?: string;
+  description?: string;
+  robots?: string;
+  faviconHref?: string;
+  faviconBaseUrl?: string;
+  lang?: string;
+  allowedAssetHosts?: string[];
+}
+
+const EMPTY_STATE_HTML = '<p>This sheet is empty.</p>';
+
+/**
+ * Build the static `<table>` markup for a sheet, or an empty-state message
+ * when the sheet has no cells (either genuinely blank, or `serializedContent`
+ * failed to parse — `parseSheetContent` never throws and falls back to an
+ * empty sheet for unparseable input, so the two cases are indistinguishable
+ * at this layer and are handled identically). Formula cells render their
+ * evaluated display value via `evaluateSheet`, the same evaluation the sheet
+ * editor itself uses — no formula engine is reimplemented here.
+ */
+function buildSheetTableHtml(serializedContent: unknown, hasHeaders?: boolean): string {
+  try {
+    const sheet = parseSheetContent(serializedContent);
+    if (Object.keys(sheet.cells).length === 0) {
+      return EMPTY_STATE_HTML;
+    }
+
+    const { display } = evaluateSheet(sheet);
+    const headerRow = hasHeaders ? display[0] : null;
+    const bodyRows = hasHeaders ? display.slice(1) : display;
+    const theadHtml = headerRow
+      ? `<thead><tr>${headerRow.map((cell) => `<th>${escapeHtml(cell)}</th>`).join('')}</tr></thead>`
+      : '';
+    const tbodyHtml = `<tbody>${bodyRows
+      .map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join('')}</tr>`)
+      .join('')}</tbody>`;
+
+    return `<table>${theadHtml}${tbodyHtml}</table>`;
+  } catch {
+    return EMPTY_STATE_HTML;
+  }
+}
+
+/**
+ * Render a SHEET page as a complete, standalone HTML document: a plain
+ * `<table>` snapshot of the sheet's evaluated cell values. No client-side
+ * grid, no editing.
+ *
+ * Mirrors `render-document-page.ts`: reuses the canvas renderer's whole head
+ * assembly (SEO/OG/Twitter/JSON-LD, favicon, CSP `<meta>`) via
+ * `cspOverride`/`injectThemeBridge: false` rather than duplicating it — SHEET
+ * pages never run author scripts, so they get `buildDocumentCsp()`
+ * (`script-src 'none'`) and no theme-bridge script.
+ */
+export function renderSheetPage(input: RenderSheetPageInput): string {
+  const { serializedContent, title, hasHeaders, pageUrl, ogImageUrl, ogDescription, description, robots, faviconHref, faviconBaseUrl, lang, allowedAssetHosts } = input;
+
+  const wrappedBody = wrapDocumentBody({
+    bodyHtml: buildSheetTableHtml(serializedContent, hasHeaders),
+    title,
+  });
+
+  return renderCanvasDocument({
+    html: `<style>${DOCUMENT_TYPOGRAPHY_CSS}</style>${wrappedBody}`,
+    title,
+    pageUrl,
+    ogImageUrl,
+    ogDescription,
+    description,
+    robots,
+    faviconHref,
+    faviconBaseUrl,
+    lang,
+    allowedAssetHosts,
+    cspOverride: buildDocumentCsp(),
+    injectThemeBridge: false,
+  });
+}

--- a/packages/lib/src/publish/sanitize-document-html.ts
+++ b/packages/lib/src/publish/sanitize-document-html.ts
@@ -12,8 +12,12 @@
  *     fallback/control junk, not document prose). `<embed>`/`<base>`/`<meta>`/
  *     `<link>` are void — the tags are removed.
  *   - `on*` event-handler attributes are removed; the element is kept.
- *   - `href`/`src` values with `javascript:` or `data:text/html` schemes are
- *     removed (attribute only), after undoing case/whitespace/entity tricks.
+ *   - `href`/`src` values with `javascript:`, `data:text/html`, or
+ *     `data:image/svg+xml` schemes are removed (attribute only), after undoing
+ *     case/whitespace/entity tricks. SVG documents can carry `<script>`, so an
+ *     `<a href="data:image/svg+xml,...">` navigates to a live script context on
+ *     click even though `data:image/*` in general (png/jpeg/webp/gif) is inert
+ *     and kept — see the "keeps benign URL schemes" test.
  *
  * Pure function: no DOM, no I/O, deterministic — it runs identically in Node
  * and the browser. Benign TipTap output passes through byte-identical, and the
@@ -49,7 +53,8 @@ const isForbiddenElement = (name: string): boolean =>
  * numeric references plus every named entity that yields a character the two
  * denied scheme prefixes are built from — `:` (`&colon;`), `/` (`&sol;`) and
  * the whitespace browsers strip (`&Tab;`, `&NewLine;`). ASCII letters have no
- * named entities, so this set is complete for `javascript:`/`data:text/html`.
+ * named entities, so this set is complete for `javascript:`/`data:text/html`/
+ * `data:image/svg+xml`.
  * Decoding more would risk changing benign values; matching is deliberately
  * case-insensitive (broader than HTML) — a false decode only means we inspect
  * a stricter string.
@@ -85,7 +90,11 @@ const hasDangerousScheme = (rawValue: string): boolean => {
   const normalized = decodeEntitiesForCheck(rawValue)
     .replace(/[\u0000-\u0020]+/g, '')
     .toLowerCase();
-  return normalized.startsWith('javascript:') || normalized.startsWith('data:text/html');
+  return (
+    normalized.startsWith('javascript:') ||
+    normalized.startsWith('data:text/html') ||
+    normalized.startsWith('data:image/svg+xml')
+  );
 };
 
 interface ScannedAttribute {

--- a/packages/lib/src/publish/sanitize-document-html.ts
+++ b/packages/lib/src/publish/sanitize-document-html.ts
@@ -1,0 +1,249 @@
+/**
+ * Sanitize TipTap-authored DOCUMENT HTML for publishing.
+ *
+ * Published documents must never execute author scripts — unlike CANVAS pages,
+ * whose whole point is author JS (see `canvas/render-document.ts`, which
+ * PRESERVES scripts because canvas isolation is by origin). The hard
+ * enforcement for documents is CSP (`script-src 'none'`); this module is the
+ * hygiene layer that keeps the markup itself clean:
+ *
+ *   - `<script>`/`<style>` blocks are removed with their content, and
+ *     `<iframe>`/`<object>`/`<form>` elements likewise (their inner content is
+ *     fallback/control junk, not document prose). `<embed>`/`<base>`/`<meta>`/
+ *     `<link>` are void — the tags are removed.
+ *   - `on*` event-handler attributes are removed; the element is kept.
+ *   - `href`/`src` values with `javascript:` or `data:text/html` schemes are
+ *     removed (attribute only), after undoing case/whitespace/entity tricks.
+ *
+ * Pure function: no DOM, no I/O, deterministic — it runs identically in Node
+ * and the browser. Benign TipTap output passes through byte-identical, and the
+ * function is idempotent.
+ *
+ * Parsing mirrors the HTML tokenizer the same way `render-document.ts` does:
+ * a tag name only counts when followed by a genuine delimiter (whitespace, `/`
+ * or `>`), so `<script-template>` is never mistaken for `<script>`; and
+ * attribute scanning is quote-aware, so a `>` inside a quoted value (e.g.
+ * `alt="a>b"`) cannot end the tag early and smuggle a handler past the scan.
+ *
+ * The whole pass loops to a fixpoint because removals can concatenate
+ * surrounding text into a NEW dangerous construct (`<` + stripped block +
+ * `script src=…>` reassembles into a live script tag). Every pass only ever
+ * deletes characters, so the loop strictly shrinks and always terminates.
+ */
+
+/** Elements removed together with their content (first matching close tag wins,
+ * as in the HTML tokenizer; unclosed at EOF consumes the rest). */
+const STRIP_WITH_CONTENT = new Set(['script', 'style', 'iframe', 'object', 'form']);
+
+/** Void (or effectively void) elements whose tags are removed outright. */
+const STRIP_TAG_ONLY = new Set(['embed', 'base', 'meta', 'link']);
+
+/** Attributes whose values are URLs and must not carry executable schemes. */
+const URL_ATTRIBUTES = new Set(['href', 'src', 'xlink:href']);
+
+const isForbiddenElement = (name: string): boolean =>
+  STRIP_WITH_CONTENT.has(name) || STRIP_TAG_ONLY.has(name);
+
+/**
+ * Minimal entity decoding for the scheme CHECK only (never for output):
+ * numeric references plus every named entity that yields a character the two
+ * denied scheme prefixes are built from — `:` (`&colon;`), `/` (`&sol;`) and
+ * the whitespace browsers strip (`&Tab;`, `&NewLine;`). ASCII letters have no
+ * named entities, so this set is complete for `javascript:`/`data:text/html`.
+ * Decoding more would risk changing benign values; matching is deliberately
+ * case-insensitive (broader than HTML) — a false decode only means we inspect
+ * a stricter string.
+ */
+const NAMED_ENTITIES_FOR_CHECK: ReadonlyArray<[RegExp, string]> = [
+  [/&colon;/gi, ':'],
+  [/&sol;/gi, '/'],
+  [/&tab;/gi, '\t'],
+  [/&newline;/gi, '\n'],
+];
+
+const decodeEntitiesForCheck = (value: string): string =>
+  NAMED_ENTITIES_FOR_CHECK.reduce(
+    (decoded, [entity, char]) => decoded.replace(entity, char),
+    value
+      .replace(/&#x([0-9a-f]+);?/gi, (_, hex: string) => {
+        const code = parseInt(hex, 16);
+        return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+      })
+      .replace(/&#(\d+);?/g, (_, dec: string) => {
+        const code = parseInt(dec, 10);
+        return code >= 0 && code <= 0x10ffff ? String.fromCodePoint(code) : '';
+      })
+  );
+
+/**
+ * True when a URL attribute value resolves to an executable scheme. Browsers
+ * strip ASCII control characters and whitespace inside/around the scheme
+ * before matching it, so the check does the same (only for the comparison —
+ * kept attributes are emitted verbatim).
+ */
+const hasDangerousScheme = (rawValue: string): boolean => {
+  const normalized = decodeEntitiesForCheck(rawValue)
+    .replace(/[\u0000-\u0020]+/g, '')
+    .toLowerCase();
+  return normalized.startsWith('javascript:') || normalized.startsWith('data:text/html');
+};
+
+interface ScannedAttribute {
+  /** Lowercased attribute name. */
+  name: string;
+  /** Attribute value with surrounding quotes removed ('' when valueless). */
+  value: string;
+  /** Slice bounds in the source covering leading whitespace + name + value. */
+  start: number;
+  end: number;
+}
+
+interface ScannedTag {
+  /** Index just past the closing `>` (or EOF for an unterminated tag). */
+  end: number;
+  attributes: ScannedAttribute[];
+}
+
+/**
+ * Scan an open tag's attribute area starting just past the tag name.
+ * Quote-aware per the HTML attribute-value states: `>` inside a quoted value
+ * does not end the tag.
+ */
+const scanTag = (html: string, from: number): ScannedTag => {
+  const attributes: ScannedAttribute[] = [];
+  let i = from;
+  while (i < html.length) {
+    const attrStart = i;
+    while (i < html.length && (/\s/.test(html[i]) || html[i] === '/')) i++;
+    if (i >= html.length) break;
+    if (html[i] === '>') return { end: i + 1, attributes };
+
+    // Attribute name: anything up to whitespace, `=`, `/` or `>`.
+    const nameStart = i;
+    while (i < html.length && !/[\s=/>]/.test(html[i])) i++;
+    const name = html.slice(nameStart, i).toLowerCase();
+
+    // Optional `= value`.
+    let value = '';
+    let valueEnd = i;
+    let j = i;
+    while (j < html.length && /\s/.test(html[j])) j++;
+    if (html[j] === '=') {
+      j++;
+      while (j < html.length && /\s/.test(html[j])) j++;
+      const quote = html[j];
+      if (quote === '"' || quote === "'") {
+        const closeQuote = html.indexOf(quote, j + 1);
+        const valueTo = closeQuote === -1 ? html.length : closeQuote;
+        value = html.slice(j + 1, valueTo);
+        valueEnd = closeQuote === -1 ? html.length : closeQuote + 1;
+      } else {
+        const valueStart = j;
+        while (j < html.length && !/[\s>]/.test(html[j])) j++;
+        value = html.slice(valueStart, j);
+        valueEnd = j;
+      }
+      i = valueEnd;
+    }
+    attributes.push({ name, value, start: attrStart, end: valueEnd });
+  }
+  return { end: html.length, attributes };
+};
+
+const isDroppedAttribute = (attr: ScannedAttribute): boolean =>
+  attr.name.startsWith('on') || (URL_ATTRIBUTES.has(attr.name) && hasDangerousScheme(attr.value));
+
+/** Re-emit an open tag with its offending attributes spliced out. */
+const cleanTagMarkup = (html: string, tagStart: number, scanned: ScannedTag): string => {
+  let out = '';
+  let cursor = tagStart;
+  for (const attr of scanned.attributes) {
+    if (!isDroppedAttribute(attr)) continue;
+    out += html.slice(cursor, attr.start);
+    cursor = attr.end;
+  }
+  return out + html.slice(cursor, scanned.end);
+};
+
+/**
+ * Find the index just past the first `</name …>` close tag at or after `from`.
+ * Same close-tag shape as `render-document.ts`: junk after the name is
+ * tolerated up to `>`, but the name itself needs a genuine delimiter so
+ * `</script-template>` never closes a `<script>`. Returns EOF when unclosed.
+ */
+const skipPastCloseTag = (html: string, name: string, from: number): number => {
+  const close = new RegExp(`</${name}(?=[\\s/>])[^>]*>`, 'gi');
+  close.lastIndex = from;
+  const match = close.exec(html);
+  return match ? match.index + match[0].length : html.length;
+};
+
+// Sticky so it matches in place at lastIndex — no per-tag slicing.
+const TAG_NAME = /[a-zA-Z][a-zA-Z0-9-]*/y;
+
+/** One full sanitize pass. Only ever deletes characters, never inserts. */
+const sanitizePass = (html: string): string => {
+  let out = '';
+  let i = 0;
+  while (i < html.length) {
+    const lt = html.indexOf('<', i);
+    if (lt === -1) {
+      out += html.slice(i);
+      break;
+    }
+    out += html.slice(i, lt);
+
+    const isCloseTag = html[lt + 1] === '/';
+    TAG_NAME.lastIndex = lt + (isCloseTag ? 2 : 1);
+    const nameMatch = TAG_NAME.exec(html);
+    if (!nameMatch) {
+      // Not a tag (stray `<`, comment, doctype…) — emit the `<` and move on.
+      out += '<';
+      i = lt + 1;
+      continue;
+    }
+    const name = nameMatch[0].toLowerCase();
+    const afterName = lt + (isCloseTag ? 2 : 1) + nameMatch[0].length;
+    // A real tag name must be followed by a delimiter — `<script-template>`
+    // already failed the Set lookups (full name matched), this guards `<p<`.
+    const scanned = scanTag(html, afterName);
+
+    if (isCloseTag) {
+      // Orphan close tags of forbidden elements are dropped; others verbatim.
+      out += isForbiddenElement(name) ? '' : html.slice(lt, scanned.end);
+      i = scanned.end;
+      continue;
+    }
+
+    if (STRIP_WITH_CONTENT.has(name)) {
+      i = skipPastCloseTag(html, name, scanned.end);
+      continue;
+    }
+    if (STRIP_TAG_ONLY.has(name)) {
+      i = scanned.end;
+      continue;
+    }
+
+    out += scanned.attributes.some(isDroppedAttribute)
+      ? cleanTagMarkup(html, lt, scanned)
+      : html.slice(lt, scanned.end);
+    i = scanned.end;
+  }
+  return out;
+};
+
+/**
+ * Sanitize published DOCUMENT HTML. Idempotent; benign TipTap output passes
+ * through byte-identical.
+ */
+export const sanitizeDocumentHtml = (html: string): string => {
+  // Loop to a fixpoint: removing a block can concatenate its neighbours into
+  // a new dangerous construct. Passes only delete, so length strictly
+  // decreases until stable — guaranteed termination.
+  let previous = html;
+  for (;;) {
+    const next = sanitizePass(previous);
+    if (next === previous) return next;
+    previous = next;
+  }
+};


### PR DESCRIPTION
## Summary

Lifts the CANVAS-only publishing gate: DOCUMENT, CODE, and SHEET pages now publish as static content through the existing pipeline (storage, custom domains, sitemap/robots/404, SEO overrides, staleness — all already type-agnostic).

- **Capability flag**: `publishable` on every page-type config (`isPublishablePageType` / `getPublishablePageTypes`) instead of scattered type checks
- **Documents** render through a typography shell (`.ps-document`, dark-mode aware) with CSP **`script-src 'none'`** as hard enforcement, backed by a tokenizer-mirroring HTML sanitizer (hygiene layer); markdown converts via `marked`; mention links to unpublished pages are neutralized to inert spans
- **Code/Sheets** render as escaped `<pre><code>` / static `<table>` via the same head-assembly delegation (`renderCanvasDocument` + `cspOverride`) — one head assembler for every published type
- **Publish UI** generalized: `PublishControls` moved to the ViewHeader, shown for any publishable type (single mount point; removed from CanvasPageView)
- **404 renderer** accepts any publishable type via the shared per-type pipeline
- Canvas publishing behavior is byte-identical (existing tests unchanged)

Board: PageSpace epic `kiq4dgqrvd2le6d0i3m6cvs3`, Phase 1 (leaves 1-1…1-8, PRs #2033–#2052 into this branch).

## Review-convergence fixes (eccaaeecf)

An 8-angle review pass (correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, conventions) plus the one existing Codex bot comment surfaced and fixed:

- **OG-image state sync** (Codex-flagged): `publishCanvasPage` now returns the effective server-resolved `title`/`description`/`ogImageUrl`/`noindex`; `PublishControls` reads settings back from the response instead of caching its own request payload — fixes stale/blank `ogImageUrl` after publishing via an uploaded file.
- **Sanitizer gap**: `sanitizeDocumentHtml` now also blocks `data:image/svg+xml` href/src values (SVG documents can carry `<script>`, unlike inert raster `data:` URIs) — closes a gap in the DOCUMENT `script-src 'none'` hygiene layer.
- **State-leak fix**: `HeaderPublishControls` is now keyed on `pageId` so navigating between publishable pages remounts it instead of leaking local UI state (e.g. an open Publish Settings dialog) across pages.
- **CSS fix**: mention-chip styling now also matches the neutralized `<span data-mention-type>` markup unpublished-target mentions render as (previously only `<a data-mention-type>` matched, even though the attribute was already preserved).
- **SEO fix**: CODE pages no longer derive a fallback meta description from raw source text (HTML-tag-stripping mangled generics/comparisons); left empty like SHEET's already-accepted non-prose fallback.
- **Dedup**: `buildDocumentCsp`/`buildBaselineCsp` now share one asset/font CSP prefix constant instead of two independently maintained literals.

## Test plan
- [x] packages/lib: sanitizer, shell, renderers, CSP, capability tests (new suites, riteway-style)
- [x] apps/web: publish-page per-type branch, render-published wrappers, publish route (139 tests)
- [x] Full CI on this PR (lint/typecheck, unit tests — green on both commits)
- [x] Review-convergence pass: 692 apps/web + 402 packages/lib tests pass locally; typecheck, build, lint green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUpYbSJd9QT7CMRnWbWomB