### PR TITLE
fix(ios): sync app-icon badge to unread count (reactive SSOT projection)

### DIFF
--- a/apps/ios/ios/App/CapApp-SPM/Package.swift
+++ b/apps/ios/ios/App/CapApp-SPM/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "7.6.5"),
+        .package(name: "CapawesomeCapacitorBadge", path: "../../../../../node_modules/.bun/@capawesome+capacitor-badge@7.0.1+abcf0b523ff3394e/node_modules/@capawesome/capacitor-badge"),
         .package(name: "CapacitorApp", path: "../../../../../node_modules/.bun/@capacitor+app@7.1.2+abcf0b523ff3394e/node_modules/@capacitor/app"),
         .package(name: "CapacitorBrowser", path: "../../../../../node_modules/.bun/@capacitor+browser@7.0.5+abcf0b523ff3394e/node_modules/@capacitor/browser"),
         .package(name: "CapacitorKeyboard", path: "../../../../../node_modules/.bun/@capacitor+keyboard@7.0.6+abcf0b523ff3394e/node_modules/@capacitor/keyboard"),
@@ -27,6 +28,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapawesomeCapacitorBadge", package: "CapawesomeCapacitorBadge"),
                 .product(name: "CapacitorApp", package: "CapacitorApp"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapacitorKeyboard", package: "CapacitorKeyboard"),

--- a/apps/ios/package.json
+++ b/apps/ios/package.json
@@ -13,6 +13,7 @@
     "add-platform": "bun x cap add ios"
   },
   "dependencies": {
+    "@capawesome/capacitor-badge": "^7.0.0",
     "@capacitor/app": "^7.0.3",
     "@capacitor/browser": "^7.0.3",
     "@capacitor/core": "^7.4.5",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -130,6 +130,7 @@
   "devDependencies": {
     "@pagespace/sdk": "workspace:*",
     "@capacitor/app": "^7.1.1",
+    "@capawesome/capacitor-badge": "^7.0.0",
     "@capacitor/browser": "^7.0.3",
     "@capacitor/core": "^7.0.0",
     "@capacitor/preferences": "^7.0.0",

--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -5,6 +5,7 @@ import { useSocket } from "@/hooks/useSocket";
 import { useAccessRevocation } from "@/hooks/useAccessRevocation";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
 import { useDesktopNotifications } from "@/hooks/useDesktopNotifications";
+import { useIosBadgeSync } from "@/hooks/useIosBadgeSync";
 import TopBar from "@/components/layout/main-header";
 import MemoizedSidebar from "@/components/layout/left-sidebar/MemoizedSidebar";
 import CenterPanel from "@/components/layout/middle-content/CenterPanel";
@@ -136,6 +137,9 @@ function Layout({ children }: LayoutProps) {
 
   // Show native OS notifications for new notifications when the desktop app is unfocused
   useDesktopNotifications();
+
+  // Keep the native iOS app-icon badge in sync with the unread count (reactive SSOT projection)
+  useIosBadgeSync();
 
   // Monitor performance
   usePerformanceMonitor();

--- a/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
+++ b/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 
-const { mockBadgeSet, mockFetchNotifications } = vi.hoisted(() => ({
+const { mockBadgeSet, mockCheckPermissions, mockFetchNotifications } = vi.hoisted(() => ({
   mockBadgeSet: vi.fn().mockResolvedValue(undefined),
+  mockCheckPermissions: vi.fn().mockResolvedValue({ display: 'granted' }),
   mockFetchNotifications: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -33,7 +34,7 @@ vi.mock('@/hooks/useCapacitor', () => ({
 }));
 
 vi.mock('@capawesome/capacitor-badge', () => ({
-  Badge: { set: mockBadgeSet },
+  Badge: { set: mockBadgeSet, checkPermissions: mockCheckPermissions },
 }));
 
 import { useIosBadgeSync } from '../useIosBadgeSync';
@@ -57,6 +58,7 @@ describe('useIosBadgeSync', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockBadgeSet.mockResolvedValue(undefined);
+    mockCheckPermissions.mockResolvedValue({ display: 'granted' });
     mockFetchNotifications.mockResolvedValue(undefined);
     mockCapacitorState = {
       isNative: true,
@@ -94,6 +96,41 @@ describe('useIosBadgeSync', () => {
     renderHook(() => useIosBadgeSync());
 
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 0 }));
+  });
+
+  it('regression: never calls Badge.set when badge permission is not granted (prompt), to avoid Badge.set itself triggering the first-ever authorization request', async () => {
+    mockCheckPermissions.mockResolvedValue({ display: 'prompt' });
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useIosBadgeSync());
+    await waitFor(() => expect(mockCheckPermissions).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
+  it('regression: never calls Badge.set when badge permission is denied', async () => {
+    mockCheckPermissions.mockResolvedValue({ display: 'denied' });
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useIosBadgeSync());
+    await waitFor(() => expect(mockCheckPermissions).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
+  it('calls Badge.set once permission checks as granted', async () => {
+    mockCheckPermissions.mockResolvedValue({ display: 'granted' });
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useIosBadgeSync());
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
   });
 
   it('regression: does not project the default unreadCount 0 before the store has hydrated (cold launch)', async () => {

--- a/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
+++ b/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
@@ -69,6 +69,7 @@ describe('useIosBadgeSync', () => {
     useNotificationStore.setState({
       notifications: [],
       unreadCount: 0,
+      hasHydrated: true,
       fetchNotifications: mockFetchNotifications,
     });
   });
@@ -93,6 +94,55 @@ describe('useIosBadgeSync', () => {
     renderHook(() => useIosBadgeSync());
 
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 0 }));
+  });
+
+  it('regression: does not project the default unreadCount 0 before the store has hydrated (cold launch)', async () => {
+    // Simulates cold launch: the store still holds its default unreadCount 0
+    // and the initial server fetch (kicked off elsewhere, e.g. NotificationBell)
+    // hasn't resolved yet. Projecting here would incorrectly zero a
+    // possibly-nonzero native badge left over from a prior session.
+    useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
+
+    renderHook(() => useIosBadgeSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
+  it('regression: once hydration completes with a real count of 0 (e.g. mark-all-read before the initial fetch resolved), still projects 0', async () => {
+    // The gate must be on hydration, not on the count value — projecting 0
+    // is the whole point of this feature (it's how the badge clears), so a
+    // hydrated 0 must always reach Badge.set, unlike an unhydrated 0.
+    useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
+    renderHook(() => useIosBadgeSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+
+    act(() => {
+      useNotificationStore.setState({ unreadCount: 0, hasHydrated: true });
+    });
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 0 }));
+  });
+
+  it('regression: projects the real count once hydration completes after a cold launch', async () => {
+    useNotificationStore.setState({ unreadCount: 0, hasHydrated: false });
+    renderHook(() => useIosBadgeSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+
+    // The store's own initial fetch (elsewhere in the app) resolves with the real count.
+    act(() => {
+      useNotificationStore.setState({ unreadCount: 4, hasHydrated: true });
+    });
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 4 }));
   });
 
   it('projects unreadCount 3 on mount', async () => {
@@ -130,12 +180,16 @@ describe('useIosBadgeSync', () => {
     await waitFor(() => expect(mockBadgeSet).toHaveBeenLastCalledWith({ count: 5 }));
   });
 
-  it('swallows a Badge.set failure without throwing', async () => {
+  it('swallows a Badge.set failure without throwing, but logs it', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     mockBadgeSet.mockRejectedValueOnce(new Error('not supported on this device'));
     useNotificationStore.setState({ unreadCount: 2 });
 
     expect(() => renderHook(() => useIosBadgeSync())).not.toThrow();
     await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 2 }));
+    await waitFor(() => expect(consoleError).toHaveBeenCalled());
+
+    consoleError.mockRestore();
   });
 
   it('stops projecting after unmount', async () => {

--- a/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
+++ b/apps/web/src/hooks/__tests__/useIosBadgeSync.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { mockBadgeSet, mockFetchNotifications } = vi.hoisted(() => ({
+  mockBadgeSet: vi.fn().mockResolvedValue(undefined),
+  mockFetchNotifications: vi.fn().mockResolvedValue(undefined),
+}));
+
+type MockCapacitorState = {
+  isNative: boolean;
+  platform: 'ios' | 'android' | 'web';
+  isIOS: boolean;
+  isAndroid: boolean;
+  isIPad: boolean;
+  isReady: boolean;
+};
+
+let mockCapacitorState: MockCapacitorState = {
+  isNative: true,
+  platform: 'ios',
+  isIOS: true,
+  isAndroid: false,
+  isIPad: false,
+  isReady: true,
+};
+
+// isCapacitorApp() is what useAppStateRecovery uses internally to pick its Capacitor
+// vs. web resume path — forcing it false makes the test drive resume via
+// document.visibilitychange (jsdom has no real Capacitor bridge to fire appStateChange).
+vi.mock('@/hooks/useCapacitor', () => ({
+  useCapacitor: () => mockCapacitorState,
+  isCapacitorApp: () => false,
+}));
+
+vi.mock('@capawesome/capacitor-badge', () => ({
+  Badge: { set: mockBadgeSet },
+}));
+
+import { useIosBadgeSync } from '../useIosBadgeSync';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+
+/** Drive useAppStateRecovery's web visibilitychange resume path. */
+const backgroundThenResume = async () => {
+  Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+  await act(async () => {
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+  });
+};
+
+describe('useIosBadgeSync', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockBadgeSet.mockResolvedValue(undefined);
+    mockFetchNotifications.mockResolvedValue(undefined);
+    mockCapacitorState = {
+      isNative: true,
+      platform: 'ios',
+      isIOS: true,
+      isAndroid: false,
+      isIPad: false,
+      isReady: true,
+    };
+    useNotificationStore.setState({
+      notifications: [],
+      unreadCount: 0,
+      fetchNotifications: mockFetchNotifications,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('never calls Badge.set when not on iOS', async () => {
+    mockCapacitorState = { ...mockCapacitorState, isNative: false, platform: 'web', isIOS: false };
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useIosBadgeSync());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+
+  it('projects count 0 on mount when iOS and unreadCount is 0', async () => {
+    renderHook(() => useIosBadgeSync());
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 0 }));
+  });
+
+  it('projects unreadCount 3 on mount', async () => {
+    useNotificationStore.setState({ unreadCount: 3 });
+
+    renderHook(() => useIosBadgeSync());
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
+  });
+
+  it('re-projects when the count changes from 3 to 0', async () => {
+    useNotificationStore.setState({ unreadCount: 3 });
+    renderHook(() => useIosBadgeSync());
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 3 }));
+
+    act(() => {
+      useNotificationStore.getState().setUnreadCount(0);
+    });
+
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenLastCalledWith({ count: 0 }));
+  });
+
+  it('on app resume, refreshes the store from the server and re-projects the refreshed count', async () => {
+    useNotificationStore.setState({ unreadCount: 1 });
+    renderHook(() => useIosBadgeSync());
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 1 }));
+
+    mockFetchNotifications.mockImplementation(async () => {
+      useNotificationStore.setState({ unreadCount: 5 });
+    });
+
+    await backgroundThenResume();
+
+    expect(mockFetchNotifications).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenLastCalledWith({ count: 5 }));
+  });
+
+  it('swallows a Badge.set failure without throwing', async () => {
+    mockBadgeSet.mockRejectedValueOnce(new Error('not supported on this device'));
+    useNotificationStore.setState({ unreadCount: 2 });
+
+    expect(() => renderHook(() => useIosBadgeSync())).not.toThrow();
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 2 }));
+  });
+
+  it('stops projecting after unmount', async () => {
+    useNotificationStore.setState({ unreadCount: 1 });
+    const { unmount } = renderHook(() => useIosBadgeSync());
+    await waitFor(() => expect(mockBadgeSet).toHaveBeenCalledWith({ count: 1 }));
+
+    unmount();
+    mockBadgeSet.mockClear();
+
+    act(() => {
+      useNotificationStore.getState().setUnreadCount(9);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBadgeSet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useIosBadgeSync.ts
+++ b/apps/web/src/hooks/useIosBadgeSync.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useCapacitor } from './useCapacitor';
+import { useAppStateRecovery } from './useAppStateRecovery';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+import { deriveBadgeCount } from '@pagespace/lib/notifications/derive-badge-count';
+
+async function projectNativeBadge(unreadCount: number): Promise<void> {
+  try {
+    const { Badge } = await import('@capawesome/capacitor-badge');
+    await Badge.set({ count: deriveBadgeCount(unreadCount) });
+  } catch {
+    // Badge plugin unsupported/unavailable on this device — best effort only.
+  }
+}
+
+/**
+ * Projects `unreadCount` (the single source of truth) onto the native iOS
+ * app-icon badge. Reactive: re-projects on every store change and re-syncs
+ * from the server on app resume, instead of relying on the lossy APNs
+ * silent push to teach the client the truth (which is why the badge used to
+ * get stuck).
+ */
+export function useIosBadgeSync(): void {
+  const { isIOS, isReady } = useCapacitor();
+  const unreadCount = useNotificationStore((state) => state.unreadCount);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !isReady || !isIOS) return;
+    void projectNativeBadge(unreadCount);
+  }, [isReady, isIOS, unreadCount]);
+
+  useAppStateRecovery({
+    onResume: async () => {
+      await useNotificationStore.getState().fetchNotifications();
+      await projectNativeBadge(useNotificationStore.getState().unreadCount);
+    },
+    enabled: () => isIOS,
+    minBackgroundTime: 0,
+  });
+}

--- a/apps/web/src/hooks/useIosBadgeSync.ts
+++ b/apps/web/src/hooks/useIosBadgeSync.ts
@@ -8,10 +8,25 @@ import { deriveBadgeCount } from '@pagespace/lib/notifications/derive-badge-coun
 
 async function projectNativeBadge(unreadCount: number): Promise<void> {
   try {
+    // NOTE: on iOS, Badge.set() internally calls
+    // UNUserNotificationCenter.requestAuthorization(options: .badge) before
+    // writing the count (see @capawesome/capacitor-badge's ios/Plugin/Badge.swift).
+    // iOS only ever shows the permission prompt once per install and honors
+    // whichever options were in the FIRST request an app ever makes — so if this
+    // badge-only request somehow raced ahead of PushNotificationManager's broader
+    // [.alert, .badge, .sound] request, alert/sound could be silently capped forever
+    // with no re-prompt. In practice this hook's Badge.set() only runs after
+    // `hasHydrated` (a completed /api/notifications network round trip), which is
+    // far slower than PushNotificationManager's native-bridge-only permission
+    // check+request, so the push flow wins in all observed conditions. Flagged for
+    // device verification during TestFlight rather than fixed here, since resolving
+    // it for certain would mean coordinating with usePushNotifications/
+    // PushNotificationManager — out of this PR's scope.
     const { Badge } = await import('@capawesome/capacitor-badge');
     await Badge.set({ count: deriveBadgeCount(unreadCount) });
-  } catch {
-    // Badge plugin unsupported/unavailable on this device — best effort only.
+  } catch (error) {
+    // Best-effort only — never let a missing/broken native plugin crash the app.
+    console.error('[useIosBadgeSync] Failed to project native badge:', error);
   }
 }
 
@@ -21,15 +36,27 @@ async function projectNativeBadge(unreadCount: number): Promise<void> {
  * from the server on app resume, instead of relying on the lossy APNs
  * silent push to teach the client the truth (which is why the badge used to
  * get stuck).
+ *
+ * Waits for `hasHydrated` before projecting anything: the store defaults to
+ * unreadCount 0 before its first successful fetch resolves, and projecting
+ * that default would incorrectly zero a possibly-nonzero badge on cold
+ * launch (or during the auth-bootstrap window).
+ *
+ * Re-projects explicitly after the resume-triggered fetch (rather than
+ * relying solely on the reactive effect below) because the silent push
+ * stays a second, best-effort writer to the same native badge — an
+ * unrelated silent push could have overwritten it correctly-but-stale value
+ * while the app was backgrounded, even if unreadCount itself hasn't changed.
  */
 export function useIosBadgeSync(): void {
   const { isIOS, isReady } = useCapacitor();
   const unreadCount = useNotificationStore((state) => state.unreadCount);
+  const hasHydrated = useNotificationStore((state) => state.hasHydrated);
 
   useEffect(() => {
-    if (typeof window === 'undefined' || !isReady || !isIOS) return;
+    if (!isReady || !isIOS || !hasHydrated) return;
     void projectNativeBadge(unreadCount);
-  }, [isReady, isIOS, unreadCount]);
+  }, [isReady, isIOS, hasHydrated, unreadCount]);
 
   useAppStateRecovery({
     onResume: async () => {

--- a/apps/web/src/hooks/useIosBadgeSync.ts
+++ b/apps/web/src/hooks/useIosBadgeSync.ts
@@ -8,21 +8,21 @@ import { deriveBadgeCount } from '@pagespace/lib/notifications/derive-badge-coun
 
 async function projectNativeBadge(unreadCount: number): Promise<void> {
   try {
-    // NOTE: on iOS, Badge.set() internally calls
-    // UNUserNotificationCenter.requestAuthorization(options: .badge) before
-    // writing the count (see @capawesome/capacitor-badge's ios/Plugin/Badge.swift).
-    // iOS only ever shows the permission prompt once per install and honors
-    // whichever options were in the FIRST request an app ever makes — so if this
-    // badge-only request somehow raced ahead of PushNotificationManager's broader
-    // [.alert, .badge, .sound] request, alert/sound could be silently capped forever
-    // with no re-prompt. In practice this hook's Badge.set() only runs after
-    // `hasHydrated` (a completed /api/notifications network round trip), which is
-    // far slower than PushNotificationManager's native-bridge-only permission
-    // check+request, so the push flow wins in all observed conditions. Flagged for
-    // device verification during TestFlight rather than fixed here, since resolving
-    // it for certain would mean coordinating with usePushNotifications/
-    // PushNotificationManager — out of this PR's scope.
     const { Badge } = await import('@capawesome/capacitor-badge');
+    // Badge.set() internally calls UNUserNotificationCenter.requestAuthorization(
+    // options: .badge) before writing the count (see @capawesome/capacitor-badge's
+    // ios/Plugin/Badge.swift). iOS shows the permission prompt only once per
+    // install and permanently caps the granted option set to whatever the FIRST
+    // request ever asked for, with no re-prompt — so if this badge-only request
+    // won the race against PushNotificationManager's broader
+    // [.alert, .badge, .sound] request, alert/sound notifications could be
+    // silently disabled forever. checkPermissions() reads the current status
+    // WITHOUT prompting, so gating on it here guarantees Badge.set() can never
+    // itself be the first-ever authorization request — by the time badge
+    // permission reads as granted, the push flow's broader request already
+    // decided the option set.
+    const permissions = await Badge.checkPermissions();
+    if (permissions.display !== 'granted') return;
     await Badge.set({ count: deriveBadgeCount(unreadCount) });
   } catch (error) {
     // Best-effort only — never let a missing/broken native plugin crash the app.

--- a/apps/web/src/stores/__tests__/useNotificationStore.test.ts
+++ b/apps/web/src/stores/__tests__/useNotificationStore.test.ts
@@ -54,6 +54,7 @@ describe('useNotificationStore', () => {
       unreadCount: 0,
       isLoading: false,
       isDropdownOpen: false,
+      hasHydrated: false,
     });
     vi.clearAllMocks();
   });
@@ -320,9 +321,10 @@ describe('useNotificationStore', () => {
       expect(state.notifications).toEqual(mockNotifications);
       expect(state.unreadCount).toBe(5);
       expect(state.isLoading).toBe(false);
+      expect(state.hasHydrated).toBe(true);
     });
 
-    it('given API error, should set loading to false', async () => {
+    it('given API error, should set loading to false and not mark as hydrated', async () => {
       mockFetchWithAuth.mockResolvedValue({ ok: false });
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => { });
 
@@ -330,10 +332,11 @@ describe('useNotificationStore', () => {
       await fetchNotifications();
 
       expect(useNotificationStore.getState().isLoading).toBe(false);
+      expect(useNotificationStore.getState().hasHydrated).toBe(false);
       consoleError.mockRestore();
     });
 
-    it('given network error, should handle gracefully', async () => {
+    it('given network error, should handle gracefully and not mark as hydrated', async () => {
       mockFetchWithAuth.mockRejectedValue(new Error('Network error'));
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => { });
 
@@ -341,6 +344,7 @@ describe('useNotificationStore', () => {
       await fetchNotifications();
 
       expect(useNotificationStore.getState().isLoading).toBe(false);
+      expect(useNotificationStore.getState().hasHydrated).toBe(false);
       expect(consoleError).toHaveBeenCalled();
       consoleError.mockRestore();
     });

--- a/apps/web/src/stores/useNotificationStore.ts
+++ b/apps/web/src/stores/useNotificationStore.ts
@@ -14,7 +14,9 @@ interface NotificationStore {
   unreadCount: number;
   isLoading: boolean;
   isDropdownOpen: boolean;
-  
+  /** True once unreadCount has been populated from the server at least once. Distinguishes "truth is 0" from "truth not yet loaded" for consumers (e.g. the iOS badge projection) that must not act on the default 0 before a real fetch resolves. */
+  hasHydrated: boolean;
+
   setNotifications: (notifications: Notification[]) => void;
   setUnreadCount: (count: number) => void;
   setIsLoading: (loading: boolean) => void;
@@ -40,7 +42,8 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
   unreadCount: 0,
   isLoading: false,
   isDropdownOpen: false,
-  
+  hasHydrated: false,
+
   setNotifications: (notifications) => set({ notifications }),
   setUnreadCount: (count) => set({ unreadCount: count }),
   setIsLoading: (loading) => set({ isLoading: loading }),
@@ -137,6 +140,7 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
         const data = await response.json();
         setNotifications(data.notifications || []);
         setUnreadCount(data.unreadCount || 0);
+        set({ hasHydrated: true });
       }
     } catch (error) {
       console.error('Failed to fetch notifications:', error);

--- a/bun.lock
+++ b/bun.lock
@@ -189,6 +189,7 @@
         "@capacitor/push-notifications": "^7.0.0",
         "@capacitor/splash-screen": "^7.0.3",
         "@capacitor/status-bar": "^7.0.3",
+        "@capawesome/capacitor-badge": "^7.0.0",
         "@capgo/capacitor-social-login": "^7.20.0",
       },
       "devDependencies": {
@@ -437,6 +438,7 @@
         "@capacitor/browser": "^7.0.3",
         "@capacitor/core": "^7.0.0",
         "@capacitor/preferences": "^7.0.0",
+        "@capawesome/capacitor-badge": "^7.0.0",
         "@capgo/capacitor-social-login": "^7.0.5",
         "@eslint/eslintrc": "^3",
         "@next/eslint-plugin-next": "15.5.18",
@@ -772,6 +774,8 @@
     "@capacitor/splash-screen": ["@capacitor/splash-screen@7.0.5", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-bPG2SamFL7VT5I3XsgsGgJhkiyxq3OXCOVKEDupSieVdtEiG7j2vLbSD0xL+91zteF/qLuxsjbugGy5LD8mS2A=="],
 
     "@capacitor/status-bar": ["@capacitor/status-bar@7.0.6", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-7AVqj46b26QikImQzWfsJmzG8NUJZBGkrVSuoeTo+SX/YH3hXH0MqwwFgMqMGHfa/BICDgSvTjM9miVFlq0+RQ=="],
+
+    "@capawesome/capacitor-badge": ["@capawesome/capacitor-badge@7.0.1", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-jhVieRRVLgGO1NU7PW8uWZmf3WD4IsYUlkrJ82KuoRgLFx1tbJGwHU1ro0sUJmEwfLO9vldhBnJJ/J5nHrjbQQ=="],
 
     "@capgo/capacitor-social-login": ["@capgo/capacitor-social-login@7.20.0", "", { "peerDependencies": { "@capacitor/core": ">=7.0.0" } }, "sha512-rHlEALFUonLe4sDG+qybDowh2/XDiHJ4DK9pShe1aPTGSrmA5j7kz8VbHYGqgof5xdyeC7pAY3+8PASTW+qGKg=="],
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -997,6 +997,11 @@
       "import": "./dist/notifications/types.js",
       "require": "./dist/notifications/types.js"
     },
+    "./notifications/derive-badge-count": {
+      "types": "./dist/notifications/derive-badge-count.d.ts",
+      "import": "./dist/notifications/derive-badge-count.js",
+      "require": "./dist/notifications/derive-badge-count.js"
+    },
     "./notifications/guards": {
       "types": "./dist/notifications/guards.d.ts",
       "import": "./dist/notifications/guards.js",
@@ -2006,6 +2011,9 @@
       ],
       "notifications/types": [
         "./dist/notifications/types.d.ts"
+      ],
+      "notifications/derive-badge-count": [
+        "./dist/notifications/derive-badge-count.d.ts"
       ],
       "notifications/guards": [
         "./dist/notifications/guards.d.ts"

--- a/packages/lib/src/notifications/__tests__/derive-badge-count.test.ts
+++ b/packages/lib/src/notifications/__tests__/derive-badge-count.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { deriveBadgeCount } from '../derive-badge-count';
+
+describe('deriveBadgeCount', () => {
+  it('returns 0 for 0', () => {
+    expect(deriveBadgeCount(0)).toBe(0);
+  });
+
+  it('returns the same value for positive integers', () => {
+    expect(deriveBadgeCount(5)).toBe(5);
+    expect(deriveBadgeCount(1)).toBe(1);
+  });
+
+  it('clamps negative values to 0', () => {
+    expect(deriveBadgeCount(-1)).toBe(0);
+    expect(deriveBadgeCount(-100)).toBe(0);
+  });
+
+  it('truncates non-integer values toward 0', () => {
+    expect(deriveBadgeCount(3.7)).toBe(3);
+    expect(deriveBadgeCount(3.2)).toBe(3);
+    expect(deriveBadgeCount(-3.7)).toBe(0);
+  });
+});

--- a/packages/lib/src/notifications/derive-badge-count.ts
+++ b/packages/lib/src/notifications/derive-badge-count.ts
@@ -1,0 +1,1 @@
+export const deriveBadgeCount = (unreadCount: number): number => Math.max(0, Math.trunc(unreadCount));

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -13,11 +13,13 @@ import { decryptField } from '../encryption/field-crypto';
 // Export types and guards
 export * from './types';
 export * from './guards';
+export * from './derive-badge-count';
 import type { NotificationType } from './types';
+import { deriveBadgeCount } from './derive-badge-count';
 
 async function sendBadgedPush(userId: string, payload: PushNotificationPayload) {
   try {
-    const badge = await getUnreadNotificationCount(userId);
+    const badge = deriveBadgeCount(await getUnreadNotificationCount(userId));
     await sendPushNotification(userId, { ...payload, badge });
   } catch (error) {
     console.error('Failed to send badged push notification:', error);
@@ -26,7 +28,7 @@ async function sendBadgedPush(userId: string, payload: PushNotificationPayload) 
 
 async function sendSilentBadgeUpdate(userId: string) {
   try {
-    const badge = await getUnreadNotificationCount(userId);
+    const badge = deriveBadgeCount(await getUnreadNotificationCount(userId));
     await sendPushNotification(userId, { silent: true, badge });
   } catch (error) {
     console.error('Failed to send silent badge update:', error);


### PR DESCRIPTION
## Root cause

Push notifications now deliver reliably (#1971/#1974/#1985), but the iOS app-icon badge gets stuck — e.g. shows "1" when unread is 0 — and mark-all-read / clear do **not** clear it.

The badge was written *only* by APNs delivery pushes (`aps.badge`), and the *only* mechanism that ever reset it was a **silent/background** push (`content-available`, `apns-priority: 5`) sent on read/clear. iOS treats background pushes as best-effort and routinely throttles or drops them, so the reset frequently never lands and the badge sticks. There was zero client-side badge management — `AppDelegate.swift` does nothing on foreground, and `navigator.setAppBadge()` doesn't reach the native icon inside Capacitor's WKWebView.

This was a single-source-of-truth violation: "unread count" was duplicated across the DB, the client store, the APNs `badge` field, and the OS icon, kept in sync by pushing mutations over a lossy channel.

## Fix — functional core / imperative shell

The badge is now a **pure projection** of one source of truth (`unreadCount`), re-derived whenever that truth changes, instead of a value pushed over a lossy channel.

- **`packages/lib/src/notifications/derive-badge-count.ts`** (new): `deriveBadgeCount(unreadCount) => Math.max(0, Math.trunc(unreadCount))` — the one pure core, unit tested. Given its own package-export subpath so client bundles can import it without pulling in the server-only APNs/`node:http2` code that lives in the `notifications/notifications` barrel (this bit the Next.js client build during development — see below).
- **`packages/lib/src/notifications/notifications.ts`**: `sendBadgedPush` / `sendSilentBadgeUpdate` now both route their badge value through `deriveBadgeCount` for symmetry. The silent push is kept as a best-effort backup — it's no longer the primary mechanism.
- **`apps/web/src/hooks/useIosBadgeSync.ts`** (new): the client shell, iOS-only (gated on `useCapacitor().isIOS`). Subscribes to `useNotificationStore.unreadCount` and reactively calls `Badge.set({ count: deriveBadgeCount(unreadCount) })` (via `@capawesome/capacitor-badge`, dynamically imported) on every change. Reuses the existing `useAppStateRecovery` hook to refresh the store from the server on app resume before re-projecting, so a background push that was dropped while the app was away gets corrected as soon as the app comes back to the foreground.
- Mounted in `Layout.tsx` alongside the other notification hooks (`useNotificationToasts`, `useDesktopNotifications`) so it's active for all authenticated dashboard users.
- Added `@capawesome/capacitor-badge` (`^7.0.0`) to `apps/web` and `apps/ios`; ran `bun install` + `bun x cap sync ios` to regenerate `Package.swift` with the plugin linked.

## Review follow-ups (post-open fixes)

Two real issues surfaced during review and were fixed on the same branch:

1. **Unhydrated-zero projection (found independently by CodeRabbit/Codex review and multiple internal review passes).** `useNotificationStore` defaults to `unreadCount: 0` before its first successful `/api/notifications` fetch resolves. The original reactive effect projected that default immediately, so a cold launch (or the auth-bootstrap window) could zero a possibly-nonzero native badge before the real count ever loaded. **Fix:** added a `hasHydrated` flag to the store, set `true` only once `fetchNotifications()`'s first successful response lands; `useIosBadgeSync` now gates projection on `hasHydrated`, not on `unreadCount === 0` (projecting 0 is still required — that's how the badge clears after mark-all-read). Regression tests cover both directions.
2. **Notification-permission race (found via review + verified against the plugin's native source).** `Badge.set()` internally calls `UNUserNotificationCenter.requestAuthorization(options: .badge)` on iOS. iOS shows the permission prompt only once per install and permanently caps the granted option set to whatever the *first* request ever asked for, with no re-prompt — so if this badge-only call ever won the race against `PushNotificationManager`'s broader `[.alert, .badge, .sound]` request, alert/sound notifications could be silently capped forever. **Fix:** `projectNativeBadge` now calls `Badge.checkPermissions()` first (reads status without prompting) and only proceeds to `Badge.set()` once already `'granted'` — structurally impossible for the badge call to ever be the first-ever authorization request.
3. Badge.set() failures are now logged (`console.error`) instead of silently swallowed, so a genuinely broken native plugin is diagnosable instead of reproducing the exact "badge silently wrong" class of bug this PR fixes.

## ⚠️ Requires a new build

Unlike the prior three push-notification PRs (web-only), **this one adds a native Capacitor plugin** and needs a fresh Xcode archive + TestFlight build to take effect:

```
bun install && npx cap sync ios
```

then archive in Xcode and ship to TestFlight.

## Test plan

- [x] `deriveBadgeCount` unit tests (0 / positive / negative-clamped / truncated)
- [x] `useIosBadgeSync` hook tests: not-iOS no-op, mount projection, count-change re-projection, resume refresh+reproject, unhydrated-zero suppression, hydration-transition projection, permission-gated projection (granted/prompt/denied), `Badge.set` failure logged+swallowed, listener cleanup on unmount
- [x] `packages/lib` notifications suite green (144 tests)
- [x] `apps/web` touched hook/store suites green (87 tests across useIosBadgeSync, useNotificationStore, useAppStateRecovery, useCapacitor, useDesktopNotifications, useNotificationToasts)
- [x] `bun run typecheck` green across all 16 workspace packages
- [x] `bun run build` (web) green — confirms the client bundle no longer pulls in server-only push-notification code
- [ ] Manual device verification post-TestFlight build (native plugin can't be exercised in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

