### PR TITLE
feat(machines): server-authoritative workspace list + layout sync

### DIFF
--- a/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
@@ -16,6 +16,7 @@ const {
   mockListWorkspaces,
   mockIsBootstrapped,
   mockBroadcastMachineWorkspaceEvent,
+  mockAuditRequest,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
@@ -29,11 +30,16 @@ const {
   mockListWorkspaces: vi.fn(),
   mockIsBootstrapped: vi.fn(),
   mockBroadcastMachineWorkspaceEvent: vi.fn(),
+  mockAuditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
   isAuthError: (result: unknown) => mockIsAuthError(result),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
 }));
 
 vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
@@ -102,11 +108,15 @@ describe('GET /api/machines/workspaces', () => {
     expect(res.status).toBe(400);
   });
 
-  it('given no view access, returns 403 without listing', async () => {
+  it('given no view access, returns 403 without listing, and audits the denial', async () => {
     mockCanViewMachine.mockResolvedValue(false);
     const res = await GET(new Request('https://x.test/api/machines/workspaces?machineId=t1'));
     expect(res.status).toBe(403);
     expect(mockListWorkspaces).not.toHaveBeenCalled();
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'authz.access.denied', resourceId: 't1' }),
+    );
   });
 
   it('given view access, lists workspaces and reports bootstrap status', async () => {
@@ -138,7 +148,7 @@ describe('POST /api/machines/workspaces', () => {
     expect(mockCreateWorkspace).not.toHaveBeenCalled();
   });
 
-  it('given a fresh create, returns 201 and broadcasts machine-workspace:created', async () => {
+  it('given a fresh create, returns 201, broadcasts machine-workspace:created, and audits data.write', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockCreateWorkspace.mockResolvedValue({ ok: true, created: true, workspace: SAMPLE_RECORD });
     const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
@@ -150,14 +160,22 @@ describe('POST /api/machines/workspaces', () => {
       'machine-workspace:created',
       expect.objectContaining({ machineId: 't1', id: 'ws-1' }),
     );
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', resourceId: 't1' }),
+    );
   });
 
-  it('given an idempotent replay (already existed), returns 200 and does NOT re-broadcast', async () => {
+  it('given an idempotent replay (already existed), returns 200 and does NOT re-broadcast or re-audit', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockCreateWorkspace.mockResolvedValue({ ok: true, created: false, workspace: SAMPLE_RECORD });
     const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
     expect(res.status).toBe(200);
     expect(mockBroadcastMachineWorkspaceEvent).not.toHaveBeenCalled();
+    expect(mockAuditRequest).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write' }),
+    );
   });
 
   it('given an invalid payload, maps the denial reason to 400', async () => {
@@ -196,7 +214,7 @@ describe('PATCH /api/machines/workspaces', () => {
     expect(mockUpdateWorkspace).not.toHaveBeenCalled();
   });
 
-  it('given a successful rename, returns 200 and broadcasts only the changed field', async () => {
+  it('given a successful rename, returns 200, broadcasts only the changed field, and audits data.write', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockUpdateWorkspace.mockResolvedValue({ ok: true, workspace: { ...SAMPLE_RECORD, name: 'Renamed' } });
     const res = await PATCH(req({ machineId: 't1', workspaceId: 'ws-1', name: 'Renamed' }));
@@ -208,6 +226,10 @@ describe('PATCH /api/machines/workspaces', () => {
     );
     const payload = mockBroadcastMachineWorkspaceEvent.mock.calls[0][2];
     expect(payload).not.toHaveProperty('columns');
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', resourceId: 't1', details: { workspaceId: 'ws-1', fields: ['name'] } }),
+    );
   });
 
   it('given a not_found workspace, returns 404', async () => {
@@ -237,7 +259,7 @@ describe('DELETE /api/machines/workspaces', () => {
     expect(res.status).toBe(404);
   });
 
-  it('given a successful removal, returns 200 and broadcasts machine-workspace:deleted', async () => {
+  it('given a successful removal, returns 200, broadcasts machine-workspace:deleted, and audits data.delete', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockRemoveWorkspace.mockResolvedValue({ ok: true });
     const res = await DELETE(
@@ -248,6 +270,10 @@ describe('DELETE /api/machines/workspaces', () => {
       machineId: 't1',
       workspaceId: 'ws-1',
     });
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.delete', resourceId: 't1' }),
+    );
   });
 
   it('given no workspaceId, returns 400', async () => {

--- a/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
@@ -42,12 +42,20 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
 }));
 
-vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
-  buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
-  canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
-  canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
-  toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
-}));
+// `scopeFromBody`/`forbiddenMachineAccess`/`RESOURCE_TYPE`/`WORKSPACE_DENIAL_STATUS`
+// are pure/shared helpers (no DB or sandbox I/O) — reused via `importOriginal`
+// rather than re-implemented a third time here; only the DB/auth-backed pieces
+// (deps, access checks, DTO mapping) are mocked.
+vi.mock('@/lib/machines/machine-workspaces-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/machines/machine-workspaces-runtime')>();
+  return {
+    ...actual,
+    buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
+    canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
+    canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
+    toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
+  };
+});
 
 vi.mock('@pagespace/lib/services/machines/machine-workspaces', () => ({
   createWorkspace: (...args: unknown[]) => mockCreateWorkspace(...args),

--- a/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/__tests__/route.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Contract tests for GET/POST/PATCH/DELETE /api/machines/workspaces
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuthenticateRequest,
+  mockIsAuthError,
+  mockCanAccessMachine,
+  mockCanViewMachine,
+  mockBuildMachineWorkspacesDeps,
+  mockToWorkspaceDTO,
+  mockCreateWorkspace,
+  mockUpdateWorkspace,
+  mockRemoveWorkspace,
+  mockListWorkspaces,
+  mockIsBootstrapped,
+  mockBroadcastMachineWorkspaceEvent,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  mockCanAccessMachine: vi.fn(),
+  mockCanViewMachine: vi.fn(),
+  mockBuildMachineWorkspacesDeps: vi.fn(),
+  mockToWorkspaceDTO: vi.fn(),
+  mockCreateWorkspace: vi.fn(),
+  mockUpdateWorkspace: vi.fn(),
+  mockRemoveWorkspace: vi.fn(),
+  mockListWorkspaces: vi.fn(),
+  mockIsBootstrapped: vi.fn(),
+  mockBroadcastMachineWorkspaceEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => mockIsAuthError(result),
+}));
+
+vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
+  buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
+  canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
+  canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
+  toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
+}));
+
+vi.mock('@pagespace/lib/services/machines/machine-workspaces', () => ({
+  createWorkspace: (...args: unknown[]) => mockCreateWorkspace(...args),
+  updateWorkspace: (...args: unknown[]) => mockUpdateWorkspace(...args),
+  removeWorkspace: (...args: unknown[]) => mockRemoveWorkspace(...args),
+  listWorkspaces: (...args: unknown[]) => mockListWorkspaces(...args),
+  isBootstrapped: (...args: unknown[]) => mockIsBootstrapped(...args),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastMachineWorkspaceEvent: (...args: unknown[]) => mockBroadcastMachineWorkspaceEvent(...args),
+}));
+
+import { GET, POST, PATCH, DELETE } from '../route';
+
+const AUTH_OK = { userId: 'user-1' };
+const AUTH_DENIED = { error: new Response(null, { status: 401 }) };
+const FAKE_DEPS = { store: {} } as never;
+
+const SAMPLE_RECORD = {
+  id: 'ws-1',
+  name: 'Workspace 1',
+  scope: 'machine' as const,
+  projectName: null,
+  branchName: null,
+  layout: { columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ownerId: 'user-1',
+  machineId: 't1',
+};
+
+const SAMPLE_DTO = {
+  id: 'ws-1',
+  name: 'Workspace 1',
+  scope: {},
+  columns: SAMPLE_RECORD.layout.columns,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_OK);
+  mockBuildMachineWorkspacesDeps.mockReturnValue(FAKE_DEPS);
+  mockToWorkspaceDTO.mockImplementation(() => SAMPLE_DTO);
+});
+
+describe('GET /api/machines/workspaces', () => {
+  it('given no auth, returns the auth error', async () => {
+    mockAuthenticateRequest.mockResolvedValue(AUTH_DENIED);
+    const res = await GET(new Request('https://x.test/api/machines/workspaces?machineId=t1'));
+    expect(res.status).toBe(401);
+  });
+
+  it('given no machineId, returns 400', async () => {
+    const res = await GET(new Request('https://x.test/api/machines/workspaces'));
+    expect(res.status).toBe(400);
+  });
+
+  it('given no view access, returns 403 without listing', async () => {
+    mockCanViewMachine.mockResolvedValue(false);
+    const res = await GET(new Request('https://x.test/api/machines/workspaces?machineId=t1'));
+    expect(res.status).toBe(403);
+    expect(mockListWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('given view access, lists workspaces and reports bootstrap status', async () => {
+    mockCanViewMachine.mockResolvedValue(true);
+    mockListWorkspaces.mockResolvedValue([SAMPLE_RECORD]);
+    mockIsBootstrapped.mockResolvedValue(true);
+    const res = await GET(new Request('https://x.test/api/machines/workspaces?machineId=t1'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.bootstrapped).toBe(true);
+    expect(body.workspaces).toEqual([SAMPLE_DTO]);
+    expect(mockListWorkspaces).toHaveBeenCalledWith(expect.objectContaining({ machineId: 't1' }));
+  });
+});
+
+describe('POST /api/machines/workspaces', () => {
+  function req(body: unknown) {
+    return new Request('https://x.test/api/machines/workspaces', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('given no edit access, returns 403 without creating', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
+    expect(res.status).toBe(403);
+    expect(mockCreateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('given a fresh create, returns 201 and broadcasts machine-workspace:created', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockCreateWorkspace.mockResolvedValue({ ok: true, created: true, workspace: SAMPLE_RECORD });
+    const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.created).toBe(true);
+    expect(mockBroadcastMachineWorkspaceEvent).toHaveBeenCalledWith(
+      't1',
+      'machine-workspace:created',
+      expect.objectContaining({ machineId: 't1', id: 'ws-1' }),
+    );
+  });
+
+  it('given an idempotent replay (already existed), returns 200 and does NOT re-broadcast', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockCreateWorkspace.mockResolvedValue({ ok: true, created: false, workspace: SAMPLE_RECORD });
+    const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
+    expect(res.status).toBe(200);
+    expect(mockBroadcastMachineWorkspaceEvent).not.toHaveBeenCalled();
+  });
+
+  it('given an invalid payload, maps the denial reason to 400', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockCreateWorkspace.mockResolvedValue({ ok: false, reason: 'invalid_columns' });
+    const res = await POST(req({ machineId: 't1', id: 'ws-1', name: 'Workspace 1', columns: [] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('given no machineId/id/name, returns 400 without checking access', async () => {
+    const res = await POST(req({ id: 'ws-1', name: 'Workspace 1', columns: [] }));
+    expect(res.status).toBe(400);
+    expect(mockCanAccessMachine).not.toHaveBeenCalled();
+  });
+});
+
+describe('PATCH /api/machines/workspaces', () => {
+  function req(body: unknown) {
+    return new Request('https://x.test/api/machines/workspaces', {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  it('given neither name nor columns, returns 400 without checking access', async () => {
+    const res = await PATCH(req({ machineId: 't1', workspaceId: 'ws-1' }));
+    expect(res.status).toBe(400);
+    expect(mockCanAccessMachine).not.toHaveBeenCalled();
+  });
+
+  it('given no edit access, returns 403 without updating', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await PATCH(req({ machineId: 't1', workspaceId: 'ws-1', name: 'Renamed' }));
+    expect(res.status).toBe(403);
+    expect(mockUpdateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('given a successful rename, returns 200 and broadcasts only the changed field', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockUpdateWorkspace.mockResolvedValue({ ok: true, workspace: { ...SAMPLE_RECORD, name: 'Renamed' } });
+    const res = await PATCH(req({ machineId: 't1', workspaceId: 'ws-1', name: 'Renamed' }));
+    expect(res.status).toBe(200);
+    expect(mockBroadcastMachineWorkspaceEvent).toHaveBeenCalledWith(
+      't1',
+      'machine-workspace:updated',
+      expect.objectContaining({ machineId: 't1', workspaceId: 'ws-1', name: 'Renamed' }),
+    );
+    const payload = mockBroadcastMachineWorkspaceEvent.mock.calls[0][2];
+    expect(payload).not.toHaveProperty('columns');
+  });
+
+  it('given a not_found workspace, returns 404', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockUpdateWorkspace.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await PATCH(req({ machineId: 't1', workspaceId: 'missing', name: 'Renamed' }));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('DELETE /api/machines/workspaces', () => {
+  it('given no edit access, returns 403 without removing', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/workspaces?machineId=t1&workspaceId=ws-1', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(403);
+    expect(mockRemoveWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('given the workspace does not exist, returns 404', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockRemoveWorkspace.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/workspaces?machineId=t1&workspaceId=ws-1', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('given a successful removal, returns 200 and broadcasts machine-workspace:deleted', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockRemoveWorkspace.mockResolvedValue({ ok: true });
+    const res = await DELETE(
+      new Request('https://x.test/api/machines/workspaces?machineId=t1&workspaceId=ws-1', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    expect(mockBroadcastMachineWorkspaceEvent).toHaveBeenCalledWith('t1', 'machine-workspace:deleted', {
+      machineId: 't1',
+      workspaceId: 'ws-1',
+    });
+  });
+
+  it('given no workspaceId, returns 400', async () => {
+    const res = await DELETE(new Request('https://x.test/api/machines/workspaces?machineId=t1', { method: 'DELETE' }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Contract tests for POST /api/machines/workspaces/bootstrap
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockAuthenticateRequest,
+  mockIsAuthError,
+  mockCanAccessMachine,
+  mockBuildMachineWorkspacesDeps,
+  mockToWorkspaceDTO,
+  mockBootstrapWorkspaces,
+  mockBroadcastMachineWorkspaceEvent,
+} = vi.hoisted(() => ({
+  mockAuthenticateRequest: vi.fn(),
+  mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  mockCanAccessMachine: vi.fn(),
+  mockBuildMachineWorkspacesDeps: vi.fn(),
+  mockToWorkspaceDTO: vi.fn(),
+  mockBootstrapWorkspaces: vi.fn(),
+  mockBroadcastMachineWorkspaceEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
+  isAuthError: (result: unknown) => mockIsAuthError(result),
+}));
+
+vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
+  buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
+  canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
+  toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
+}));
+
+vi.mock('@pagespace/lib/services/machines/machine-workspaces', () => ({
+  bootstrapWorkspaces: (...args: unknown[]) => mockBootstrapWorkspaces(...args),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastMachineWorkspaceEvent: (...args: unknown[]) => mockBroadcastMachineWorkspaceEvent(...args),
+}));
+
+import { POST } from '../route';
+
+const AUTH_OK = { userId: 'user-1' };
+const AUTH_DENIED = { error: new Response(null, { status: 401 }) };
+const FAKE_DEPS = { store: {} } as never;
+
+const SAMPLE_RECORD = {
+  id: 'ws-1',
+  name: 'Workspace 1',
+  scope: 'machine' as const,
+  projectName: null,
+  branchName: null,
+  layout: { columns: [] },
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  ownerId: 'user-1',
+  machineId: 't1',
+};
+
+function req(body: unknown) {
+  return new Request('https://x.test/api/machines/workspaces/bootstrap', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequest.mockResolvedValue(AUTH_OK);
+  mockBuildMachineWorkspacesDeps.mockReturnValue(FAKE_DEPS);
+  mockToWorkspaceDTO.mockImplementation((record: typeof SAMPLE_RECORD) => ({ id: record.id, name: record.name }));
+});
+
+describe('POST /api/machines/workspaces/bootstrap', () => {
+  it('given no auth, returns the auth error', async () => {
+    mockAuthenticateRequest.mockResolvedValue(AUTH_DENIED);
+    const res = await POST(req({ machineId: 't1', workspaces: [] }));
+    expect(res.status).toBe(401);
+  });
+
+  it('given a malformed workspaces array, returns 400', async () => {
+    const res = await POST(req({ machineId: 't1', workspaces: [{ name: 'no id' }] }));
+    expect(res.status).toBe(400);
+    expect(mockBootstrapWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('given no edit access, returns 403 without bootstrapping', async () => {
+    mockCanAccessMachine.mockResolvedValue(false);
+    const res = await POST(req({ machineId: 't1', workspaces: [] }));
+    expect(res.status).toBe(403);
+    expect(mockBootstrapWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('given the FIRST caller for a machine, claims, returns claimed:true, and broadcasts bootstrapped', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockBootstrapWorkspaces.mockResolvedValue({ ok: true, claimed: true, workspaces: [SAMPLE_RECORD] });
+    const res = await POST(
+      req({ machineId: 't1', workspaces: [{ id: 'ws-1', name: 'Workspace 1', scope: {}, columns: [] }] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.claimed).toBe(true);
+    expect(mockBroadcastMachineWorkspaceEvent).toHaveBeenCalledWith(
+      't1',
+      'machine-workspace:bootstrapped',
+      expect.objectContaining({ machineId: 't1' }),
+    );
+  });
+
+  it('given a caller that LOSES the claim race, returns claimed:false with the winner\'s list, and does NOT broadcast', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockBootstrapWorkspaces.mockResolvedValue({ ok: true, claimed: false, workspaces: [SAMPLE_RECORD] });
+    const res = await POST(
+      req({ machineId: 't1', workspaces: [{ id: 'ws-2', name: "loser's workspace", scope: {}, columns: [] }] }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.claimed).toBe(false);
+    expect(body.workspaces).toEqual([{ id: 'ws-1', name: 'Workspace 1' }]);
+    expect(mockBroadcastMachineWorkspaceEvent).not.toHaveBeenCalled();
+  });
+
+  it('given an invalid entry\'s denial reason, maps it to 400', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockBootstrapWorkspaces.mockResolvedValue({ ok: false, reason: 'invalid_name' });
+    const res = await POST(
+      req({ machineId: 't1', workspaces: [{ id: 'ws-1', name: '   ', scope: {}, columns: [] }] }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('given no machineId, returns 400', async () => {
+    const res = await POST(req({ workspaces: [] }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
@@ -32,11 +32,19 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
 }));
 
-vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
-  buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
-  canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
-  toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
-}));
+// `scopeFromBody`/`forbiddenMachineAccess`/`RESOURCE_TYPE`/`WORKSPACE_DENIAL_STATUS`
+// are pure/shared helpers (no DB or sandbox I/O) — reused via `importOriginal`
+// rather than re-implemented a third time here; only the DB/auth-backed pieces
+// (deps, access checks, DTO mapping) are mocked.
+vi.mock('@/lib/machines/machine-workspaces-runtime', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/machines/machine-workspaces-runtime')>();
+  return {
+    ...actual,
+    buildMachineWorkspacesDeps: (...args: unknown[]) => mockBuildMachineWorkspacesDeps(...args),
+    canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
+    toWorkspaceDTO: (...args: unknown[]) => mockToWorkspaceDTO(...args),
+  };
+});
 
 vi.mock('@pagespace/lib/services/machines/machine-workspaces', () => ({
   bootstrapWorkspaces: (...args: unknown[]) => mockBootstrapWorkspaces(...args),

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts
@@ -11,6 +11,7 @@ const {
   mockToWorkspaceDTO,
   mockBootstrapWorkspaces,
   mockBroadcastMachineWorkspaceEvent,
+  mockAuditRequest,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
@@ -19,11 +20,16 @@ const {
   mockToWorkspaceDTO: vi.fn(),
   mockBootstrapWorkspaces: vi.fn(),
   mockBroadcastMachineWorkspaceEvent: vi.fn(),
+  mockAuditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequest(...args),
   isAuthError: (result: unknown) => mockIsAuthError(result),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
 }));
 
 vi.mock('@/lib/machines/machine-workspaces-runtime', () => ({
@@ -87,14 +93,18 @@ describe('POST /api/machines/workspaces/bootstrap', () => {
     expect(mockBootstrapWorkspaces).not.toHaveBeenCalled();
   });
 
-  it('given no edit access, returns 403 without bootstrapping', async () => {
+  it('given no edit access, returns 403 without bootstrapping, and audits the denial', async () => {
     mockCanAccessMachine.mockResolvedValue(false);
     const res = await POST(req({ machineId: 't1', workspaces: [] }));
     expect(res.status).toBe(403);
     expect(mockBootstrapWorkspaces).not.toHaveBeenCalled();
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'authz.access.denied', resourceId: 't1' }),
+    );
   });
 
-  it('given the FIRST caller for a machine, claims, returns claimed:true, and broadcasts bootstrapped', async () => {
+  it('given the FIRST caller for a machine, claims, returns claimed:true, broadcasts bootstrapped, and audits data.write', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockBootstrapWorkspaces.mockResolvedValue({ ok: true, claimed: true, workspaces: [SAMPLE_RECORD] });
     const res = await POST(
@@ -108,9 +118,13 @@ describe('POST /api/machines/workspaces/bootstrap', () => {
       'machine-workspace:bootstrapped',
       expect.objectContaining({ machineId: 't1' }),
     );
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', resourceId: 't1' }),
+    );
   });
 
-  it('given a caller that LOSES the claim race, returns claimed:false with the winner\'s list, and does NOT broadcast', async () => {
+  it('given a caller that LOSES the claim race, returns claimed:false with the winner\'s list, and does NOT broadcast or audit a write', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockBootstrapWorkspaces.mockResolvedValue({ ok: true, claimed: false, workspaces: [SAMPLE_RECORD] });
     const res = await POST(
@@ -121,6 +135,10 @@ describe('POST /api/machines/workspaces/bootstrap', () => {
     expect(body.claimed).toBe(false);
     expect(body.workspaces).toEqual([{ id: 'ws-1', name: 'Workspace 1' }]);
     expect(mockBroadcastMachineWorkspaceEvent).not.toHaveBeenCalled();
+    expect(mockAuditRequest).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write' }),
+    );
   });
 
   it('given an invalid entry\'s denial reason, maps it to 400', async () => {

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
@@ -15,11 +15,13 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { bootstrapWorkspaces, type BootstrapWorkspaceInput } from '@pagespace/lib/services/machines/machine-workspaces';
 import { buildMachineWorkspacesDeps, canAccessMachine, toWorkspaceDTO } from '@/lib/machines/machine-workspaces-runtime';
 import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+const RESOURCE_TYPE = 'machine';
 
 function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
   if (typeof value !== 'object' || value === null) return {};
@@ -72,6 +74,13 @@ export async function POST(request: Request) {
   }
 
   if (!(await canAccessMachine(auth.userId, body.machineId))) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      userId: auth.userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: body.machineId,
+      riskScore: 0.5,
+    });
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
 
@@ -92,6 +101,14 @@ export async function POST(request: Request) {
     await broadcastMachineWorkspaceEvent(body.machineId, 'machine-workspace:bootstrapped', {
       machineId: body.machineId,
       workspaces: result.workspaces.map(toWorkspaceDTO),
+    });
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: body.machineId,
+      details: { action: 'workspaces_bootstrapped', workspaceCount: result.workspaces.length },
+      riskScore: 0,
     });
   }
 

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
@@ -17,24 +17,18 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { bootstrapWorkspaces, type BootstrapWorkspaceInput } from '@pagespace/lib/services/machines/machine-workspaces';
-import { buildMachineWorkspacesDeps, canAccessMachine, toWorkspaceDTO } from '@/lib/machines/machine-workspaces-runtime';
+import {
+  buildMachineWorkspacesDeps,
+  canAccessMachine,
+  forbiddenMachineAccess,
+  RESOURCE_TYPE,
+  scopeFromBody,
+  toWorkspaceDTO,
+  WORKSPACE_DENIAL_STATUS,
+} from '@/lib/machines/machine-workspaces-runtime';
 import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
-const RESOURCE_TYPE = 'machine';
-
-function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
-  if (typeof value !== 'object' || value === null) return {};
-  const candidate = value as { projectName?: unknown; branchName?: unknown };
-  return {
-    ...(typeof candidate.projectName === 'string' && candidate.projectName.length > 0
-      ? { projectName: candidate.projectName }
-      : {}),
-    ...(typeof candidate.branchName === 'string' && candidate.branchName.length > 0
-      ? { branchName: candidate.branchName }
-      : {}),
-  };
-}
 
 function parseWorkspaces(value: unknown): BootstrapWorkspaceInput[] | null {
   if (!Array.isArray(value)) return null;
@@ -48,11 +42,6 @@ function parseWorkspaces(value: unknown): BootstrapWorkspaceInput[] | null {
   }
   return parsed;
 }
-
-const DENIAL_STATUS: Record<string, number> = {
-  invalid_name: 400,
-  invalid_columns: 400,
-};
 
 export async function POST(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
@@ -74,14 +63,7 @@ export async function POST(request: Request) {
   }
 
   if (!(await canAccessMachine(auth.userId, body.machineId))) {
-    auditRequest(request, {
-      eventType: 'authz.access.denied',
-      userId: auth.userId,
-      resourceType: RESOURCE_TYPE,
-      resourceId: body.machineId,
-      riskScore: 0.5,
-    });
-    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+    return forbiddenMachineAccess(request, auth.userId, body.machineId);
   }
 
   const deps = buildMachineWorkspacesDeps();
@@ -94,11 +76,11 @@ export async function POST(request: Request) {
   });
 
   if (!result.ok) {
-    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: WORKSPACE_DENIAL_STATUS[result.reason] ?? 500 });
   }
 
   if (result.claimed) {
-    await broadcastMachineWorkspaceEvent(body.machineId, 'machine-workspace:bootstrapped', {
+    void broadcastMachineWorkspaceEvent(body.machineId, 'machine-workspace:bootstrapped', {
       machineId: body.machineId,
       workspaces: result.workspaces.map(toWorkspaceDTO),
     });

--- a/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/bootstrap/route.ts
@@ -1,0 +1,99 @@
+/**
+ * Machine Workspaces bootstrap — one-time seeding of a machine's
+ * `localStorage`-only workspace history into the shared server record (#2048).
+ *
+ * POST { machineId, workspaces: [{id, name, scope, columns}, ...] }
+ *
+ * Exactly ONE caller across every browser racing a machine's first load ever
+ * gets `claimed: true` — see `machine_workspace_bootstraps` (schema doc) and
+ * `bootstrapWorkspaces` (service doc) for why this needs a dedicated atomic
+ * claim rather than per-row upsert alone. Every other caller (whether it lost
+ * the race or the machine was already bootstrapped) gets `claimed: false`
+ * back with the CURRENT canonical list — same response shape either way, so
+ * the client always has something to adopt.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { bootstrapWorkspaces, type BootstrapWorkspaceInput } from '@pagespace/lib/services/machines/machine-workspaces';
+import { buildMachineWorkspacesDeps, canAccessMachine, toWorkspaceDTO } from '@/lib/machines/machine-workspaces-runtime';
+import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
+  if (typeof value !== 'object' || value === null) return {};
+  const candidate = value as { projectName?: unknown; branchName?: unknown };
+  return {
+    ...(typeof candidate.projectName === 'string' && candidate.projectName.length > 0
+      ? { projectName: candidate.projectName }
+      : {}),
+    ...(typeof candidate.branchName === 'string' && candidate.branchName.length > 0
+      ? { branchName: candidate.branchName }
+      : {}),
+  };
+}
+
+function parseWorkspaces(value: unknown): BootstrapWorkspaceInput[] | null {
+  if (!Array.isArray(value)) return null;
+  const parsed: BootstrapWorkspaceInput[] = [];
+  for (const entry of value) {
+    if (typeof entry !== 'object' || entry === null) return null;
+    const candidate = entry as { id?: unknown; name?: unknown; scope?: unknown; columns?: unknown };
+    if (typeof candidate.id !== 'string' || candidate.id.length === 0) return null;
+    if (typeof candidate.name !== 'string') return null;
+    parsed.push({ id: candidate.id, name: candidate.name, scope: scopeFromBody(candidate.scope), layout: { columns: candidate.columns } });
+  }
+  return parsed;
+}
+
+const DENIAL_STATUS: Record<string, number> = {
+  invalid_name: 400,
+  invalid_columns: 400,
+};
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  let body: { machineId?: unknown; workspaces?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  if (typeof body.machineId !== 'string' || body.machineId.length === 0) {
+    return NextResponse.json({ error: 'machineId is required' }, { status: 400 });
+  }
+  const workspaces = parseWorkspaces(body.workspaces);
+  if (!workspaces) {
+    return NextResponse.json({ error: 'workspaces must be an array of {id, name, scope, columns}' }, { status: 400 });
+  }
+
+  if (!(await canAccessMachine(auth.userId, body.machineId))) {
+    return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+  }
+
+  const deps = buildMachineWorkspacesDeps();
+  const result = await bootstrapWorkspaces({
+    machineId: body.machineId,
+    ownerId: auth.userId,
+    userId: auth.userId,
+    workspaces,
+    deps,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+  }
+
+  if (result.claimed) {
+    await broadcastMachineWorkspaceEvent(body.machineId, 'machine-workspace:bootstrapped', {
+      machineId: body.machineId,
+      workspaces: result.workspaces.map(toWorkspaceDTO),
+    });
+  }
+
+  return NextResponse.json({ claimed: result.claimed, workspaces: result.workspaces.map(toWorkspaceDTO) });
+}

--- a/apps/web/src/app/api/machines/workspaces/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/route.ts
@@ -33,14 +33,16 @@ import {
   buildMachineWorkspacesDeps,
   canAccessMachine,
   canViewMachine,
+  forbiddenMachineAccess,
+  RESOURCE_TYPE,
+  scopeFromBody,
   toWorkspaceDTO,
+  WORKSPACE_DENIAL_STATUS,
 } from '@/lib/machines/machine-workspaces-runtime';
 import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
-
-const RESOURCE_TYPE = 'machine';
 
 type ParsedField<T> = { ok: true; value: T } | { ok: false; error: NextResponse };
 
@@ -53,37 +55,6 @@ function requireId(value: unknown, field: string): ParsedField<string> {
   return { ok: true, value };
 }
 
-/** Audit the authz denial (so SIEM can detect probing) and return a fresh 403. */
-function forbidden(request: Request, userId: string, machineId: string): NextResponse {
-  auditRequest(request, {
-    eventType: 'authz.access.denied',
-    userId,
-    resourceType: RESOURCE_TYPE,
-    resourceId: machineId,
-    riskScore: 0.5,
-  });
-  return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
-}
-
-const DENIAL_STATUS: Record<string, number> = {
-  invalid_name: 400,
-  invalid_columns: 400,
-  not_found: 404,
-};
-
-function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
-  if (typeof value !== 'object' || value === null) return {};
-  const candidate = value as { projectName?: unknown; branchName?: unknown };
-  return {
-    ...(typeof candidate.projectName === 'string' && candidate.projectName.length > 0
-      ? { projectName: candidate.projectName }
-      : {}),
-    ...(typeof candidate.branchName === 'string' && candidate.branchName.length > 0
-      ? { branchName: candidate.branchName }
-      : {}),
-  };
-}
-
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
   if (isAuthError(auth)) return auth.error;
@@ -92,7 +63,7 @@ export async function GET(request: Request) {
   const machineId = requireId(url.searchParams.get('machineId'), 'machineId');
   if (!machineId.ok) return machineId.error;
 
-  if (!(await canViewMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
+  if (!(await canViewMachine(auth.userId, machineId.value))) return forbiddenMachineAccess(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const [workspaces, bootstrapped] = await Promise.all([
@@ -119,7 +90,7 @@ export async function POST(request: Request) {
   if (!id.ok) return id.error;
   if (typeof body.name !== 'string') return fieldRequired('name');
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbiddenMachineAccess(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await createWorkspace({
@@ -133,11 +104,11 @@ export async function POST(request: Request) {
   });
 
   if (!result.ok) {
-    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: WORKSPACE_DENIAL_STATUS[result.reason] ?? 500 });
   }
 
   if (result.created) {
-    await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:created', {
+    void broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:created', {
       machineId: machineId.value,
       ...toWorkspaceDTO(result.workspace),
     });
@@ -179,7 +150,7 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: 'At least one of name or columns is required' }, { status: 400 });
   }
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbiddenMachineAccess(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await updateWorkspace({
@@ -191,10 +162,10 @@ export async function PATCH(request: Request) {
   });
 
   if (!result.ok) {
-    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: WORKSPACE_DENIAL_STATUS[result.reason] ?? 500 });
   }
 
-  await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:updated', {
+  void broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:updated', {
     machineId: machineId.value,
     workspaceId: workspaceId.value,
     ...(hasName ? { name: result.workspace.name } : {}),
@@ -222,7 +193,7 @@ export async function DELETE(request: Request) {
   const workspaceId = requireId(url.searchParams.get('workspaceId'), 'workspaceId');
   if (!workspaceId.ok) return workspaceId.error;
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbiddenMachineAccess(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await removeWorkspace({ machineId: machineId.value, workspaceId: workspaceId.value, store: deps.store });
@@ -231,7 +202,7 @@ export async function DELETE(request: Request) {
     return NextResponse.json({ error: result.reason }, { status: 404 });
   }
 
-  await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:deleted', {
+  void broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:deleted', {
     machineId: machineId.value,
     workspaceId: workspaceId.value,
   });

--- a/apps/web/src/app/api/machines/workspaces/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/route.ts
@@ -1,0 +1,213 @@
+/**
+ * Machine Workspaces API — the server-authoritative record of a Machine's
+ * named pane-grid workspaces (#2048). Every browser/user viewing a Machine
+ * sees the same workspace list; changes broadcast live over `apps/realtime`'s
+ * room for the Machine's own page id.
+ *
+ * GET    ?machineId=                                          → list + bootstrap status
+ * POST   { machineId, id, name, scope, columns }               → create (idempotent upsert-by-id)
+ * PATCH  { machineId, workspaceId, name?, columns? }           → rename and/or layout update
+ * DELETE ?machineId=&workspaceId=                              → remove
+ *
+ * Session-only (no MCP/agent tokens) — this is a human/UI surface. Every
+ * request re-checks access for the named Machine page (view-level for GET,
+ * edit-level for POST/PATCH/DELETE).
+ *
+ * `id` on POST is CLIENT-MINTED (see workspace-reducer.ts's `sessionWorkspaceId`
+ * and `crypto.randomUUID()` call sites) — `createWorkspace` is a first-writer-wins
+ * upsert-by-id, not an error on collision, because two browsers racing to
+ * materialize the SAME session-derived workspace is expected, not a bug.
+ */
+
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import {
+  createWorkspace,
+  updateWorkspace,
+  removeWorkspace,
+  listWorkspaces,
+  isBootstrapped,
+} from '@pagespace/lib/services/machines/machine-workspaces';
+import {
+  buildMachineWorkspacesDeps,
+  canAccessMachine,
+  canViewMachine,
+  toWorkspaceDTO,
+} from '@/lib/machines/machine-workspaces-runtime';
+import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+type ParsedField<T> = { ok: true; value: T } | { ok: false; error: NextResponse };
+
+function fieldRequired(field: string): NextResponse {
+  return NextResponse.json({ error: `${field} is required` }, { status: 400 });
+}
+
+function requireId(value: unknown, field: string): ParsedField<string> {
+  if (typeof value !== 'string' || value.length === 0) return { ok: false, error: fieldRequired(field) };
+  return { ok: true, value };
+}
+
+function forbidden(): NextResponse {
+  return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+}
+
+const DENIAL_STATUS: Record<string, number> = {
+  invalid_name: 400,
+  invalid_columns: 400,
+  not_found: 404,
+};
+
+function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
+  if (typeof value !== 'object' || value === null) return {};
+  const candidate = value as { projectName?: unknown; branchName?: unknown };
+  return {
+    ...(typeof candidate.projectName === 'string' && candidate.projectName.length > 0
+      ? { projectName: candidate.projectName }
+      : {}),
+    ...(typeof candidate.branchName === 'string' && candidate.branchName.length > 0
+      ? { branchName: candidate.branchName }
+      : {}),
+  };
+}
+
+export async function GET(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const machineId = requireId(url.searchParams.get('machineId'), 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  if (!(await canViewMachine(auth.userId, machineId.value))) return forbidden();
+
+  const deps = buildMachineWorkspacesDeps();
+  const [workspaces, bootstrapped] = await Promise.all([
+    listWorkspaces({ machineId: machineId.value, store: deps.store }),
+    isBootstrapped({ machineId: machineId.value, store: deps.store }),
+  ]);
+  return NextResponse.json({ workspaces: workspaces.map(toWorkspaceDTO), bootstrapped });
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  let body: { machineId?: unknown; id?: unknown; name?: unknown; scope?: unknown; columns?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const machineId = requireId(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+  const id = requireId(body.id, 'id');
+  if (!id.ok) return id.error;
+  if (typeof body.name !== 'string') return fieldRequired('name');
+
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+
+  const deps = buildMachineWorkspacesDeps();
+  const result = await createWorkspace({
+    machineId: machineId.value,
+    ownerId: auth.userId,
+    id: id.value,
+    name: body.name,
+    scope: scopeFromBody(body.scope),
+    layout: { columns: body.columns },
+    deps,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+  }
+
+  if (result.created) {
+    await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:created', {
+      machineId: machineId.value,
+      ...toWorkspaceDTO(result.workspace),
+    });
+  }
+
+  return NextResponse.json(
+    { workspace: toWorkspaceDTO(result.workspace), created: result.created },
+    { status: result.created ? 201 : 200 },
+  );
+}
+
+export async function PATCH(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  let body: { machineId?: unknown; workspaceId?: unknown; name?: unknown; columns?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const machineId = requireId(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+  const workspaceId = requireId(body.workspaceId, 'workspaceId');
+  if (!workspaceId.ok) return workspaceId.error;
+
+  const hasName = typeof body.name === 'string';
+  const hasColumns = body.columns !== undefined;
+  if (!hasName && !hasColumns) {
+    return NextResponse.json({ error: 'At least one of name or columns is required' }, { status: 400 });
+  }
+
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+
+  const deps = buildMachineWorkspacesDeps();
+  const result = await updateWorkspace({
+    machineId: machineId.value,
+    workspaceId: workspaceId.value,
+    name: hasName ? (body.name as string) : undefined,
+    layout: hasColumns ? { columns: body.columns } : undefined,
+    deps,
+  });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason, reason: result.reason }, { status: DENIAL_STATUS[result.reason] ?? 500 });
+  }
+
+  await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:updated', {
+    machineId: machineId.value,
+    workspaceId: workspaceId.value,
+    ...(hasName ? { name: result.workspace.name } : {}),
+    ...(hasColumns ? { columns: result.workspace.layout.columns } : {}),
+  });
+
+  return NextResponse.json({ workspace: toWorkspaceDTO(result.workspace) });
+}
+
+export async function DELETE(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const url = new URL(request.url);
+  const machineId = requireId(url.searchParams.get('machineId'), 'machineId');
+  if (!machineId.ok) return machineId.error;
+  const workspaceId = requireId(url.searchParams.get('workspaceId'), 'workspaceId');
+  if (!workspaceId.ok) return workspaceId.error;
+
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+
+  const deps = buildMachineWorkspacesDeps();
+  const result = await removeWorkspace({ machineId: machineId.value, workspaceId: workspaceId.value, store: deps.store });
+
+  if (!result.ok) {
+    return NextResponse.json({ error: result.reason }, { status: 404 });
+  }
+
+  await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:deleted', {
+    machineId: machineId.value,
+    workspaceId: workspaceId.value,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/machines/workspaces/route.ts
+++ b/apps/web/src/app/api/machines/workspaces/route.ts
@@ -21,6 +21,7 @@
 
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   createWorkspace,
   updateWorkspace,
@@ -39,6 +40,8 @@ import { broadcastMachineWorkspaceEvent } from '@/lib/websocket';
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
+const RESOURCE_TYPE = 'machine';
+
 type ParsedField<T> = { ok: true; value: T } | { ok: false; error: NextResponse };
 
 function fieldRequired(field: string): NextResponse {
@@ -50,7 +53,15 @@ function requireId(value: unknown, field: string): ParsedField<string> {
   return { ok: true, value };
 }
 
-function forbidden(): NextResponse {
+/** Audit the authz denial (so SIEM can detect probing) and return a fresh 403. */
+function forbidden(request: Request, userId: string, machineId: string): NextResponse {
+  auditRequest(request, {
+    eventType: 'authz.access.denied',
+    userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId,
+    riskScore: 0.5,
+  });
   return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
 }
 
@@ -81,7 +92,7 @@ export async function GET(request: Request) {
   const machineId = requireId(url.searchParams.get('machineId'), 'machineId');
   if (!machineId.ok) return machineId.error;
 
-  if (!(await canViewMachine(auth.userId, machineId.value))) return forbidden();
+  if (!(await canViewMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const [workspaces, bootstrapped] = await Promise.all([
@@ -108,7 +119,7 @@ export async function POST(request: Request) {
   if (!id.ok) return id.error;
   if (typeof body.name !== 'string') return fieldRequired('name');
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await createWorkspace({
@@ -129,6 +140,14 @@ export async function POST(request: Request) {
     await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:created', {
       machineId: machineId.value,
       ...toWorkspaceDTO(result.workspace),
+    });
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: auth.userId,
+      resourceType: RESOURCE_TYPE,
+      resourceId: machineId.value,
+      details: { workspaceId: id.value, action: 'workspace_created' },
+      riskScore: 0,
     });
   }
 
@@ -160,7 +179,7 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: 'At least one of name or columns is required' }, { status: 400 });
   }
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await updateWorkspace({
@@ -181,6 +200,14 @@ export async function PATCH(request: Request) {
     ...(hasName ? { name: result.workspace.name } : {}),
     ...(hasColumns ? { columns: result.workspace.layout.columns } : {}),
   });
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId: auth.userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId.value,
+    details: { workspaceId: workspaceId.value, fields: [...(hasName ? ['name'] : []), ...(hasColumns ? ['columns'] : [])] },
+    riskScore: 0,
+  });
 
   return NextResponse.json({ workspace: toWorkspaceDTO(result.workspace) });
 }
@@ -195,7 +222,7 @@ export async function DELETE(request: Request) {
   const workspaceId = requireId(url.searchParams.get('workspaceId'), 'workspaceId');
   if (!workspaceId.ok) return workspaceId.error;
 
-  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden();
+  if (!(await canAccessMachine(auth.userId, machineId.value))) return forbidden(request, auth.userId, machineId.value);
 
   const deps = buildMachineWorkspacesDeps();
   const result = await removeWorkspace({ machineId: machineId.value, workspaceId: workspaceId.value, store: deps.store });
@@ -207,6 +234,14 @@ export async function DELETE(request: Request) {
   await broadcastMachineWorkspaceEvent(machineId.value, 'machine-workspace:deleted', {
     machineId: machineId.value,
     workspaceId: workspaceId.value,
+  });
+  auditRequest(request, {
+    eventType: 'data.delete',
+    userId: auth.userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId.value,
+    details: { workspaceId: workspaceId.value },
+    riskScore: 0.5,
   });
 
   return NextResponse.json({ success: true });

--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -22,6 +22,7 @@ import { parseSelectedMachineId, buildMachineHref } from '@/lib/development/deve
 import MachineTree, { type MachineTreeNode } from '@/components/layout/middle-content/page-views/machine/workspace/MachineTree';
 import WorkspaceLeaves, { WorkspaceNodeExtras } from '@/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves';
 import { SidebarLoading, SidebarNotice } from '@/components/layout/middle-content/page-views/machine/tabs/tab-states';
+import { useMachineWorkspaceSync } from '@/hooks/useMachineWorkspaceSync';
 
 /**
  * The Development surface's left sidebar. Two modes, one component (mirroring
@@ -344,6 +345,18 @@ function MachineTreeSection({
   const requestWorkspace = usePendingWorkspaceStore((state) => state.requestWorkspace);
   const clearPending = usePendingWorkspaceStore((state) => state.clearPending);
   const focusTerminal = useMachineTabStore((state) => state.focusTerminal);
+  // `WorkspaceLeaves`/`WorkspaceNodeExtras` below render the SAME server-synced
+  // workspace tree `MachineView`'s Terminal tab does (see this file's own doc
+  // comment), but `MachineView` — the sync hook's OTHER mount point — is only
+  // mounted once the user actually navigates INTO a machine. Without mounting
+  // it here too, expanding a machine's row in this sidebar without ever
+  // visiting its page renders/acts on a never-hydrated local store: `ensureMachine`
+  // fabricates a phantom "Workspace 1", and any click/create/rename/remove in
+  // this sidebar pushes to the server from that unhydrated state. Mounted once
+  // per machine row (this component's own lifetime in the sidebar list, not
+  // tied to the tree node's expand/collapse) so it doesn't re-join the socket
+  // room or re-fetch on every expand.
+  useMachineWorkspaceSync(machineId);
 
   const navigateToMachine = useCallback(() => {
     router.push(buildMachineHref(driveId, machineId));

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -311,7 +311,12 @@ describe('DevelopmentSidebar', () => {
 
     const workspaceId = Object.keys(selectMachine('machine-1')(useMachineWorkspaceStore.getState())!.workspaces)[0];
 
-    expect(useMachineTabStore.getState().tabs['machine-1']).toBe('terminal');
+    // The row's click is deferred (so a double-click-to-rename doesn't also
+    // navigate) and cancelled only if a second click follows — see
+    // WorkspaceLeaves.tsx's `pendingSelectTimer`.
+    await waitFor(() => {
+      expect(useMachineTabStore.getState().tabs['machine-1']).toBe('terminal');
+    });
     expect(usePendingWorkspaceStore.getState().pending).toEqual({ machineId: 'machine-1', workspaceId });
     expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/development/machine-1');
   });

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -84,6 +84,18 @@ vi.mock('@/hooks/useGithubRepos', () => ({
 }));
 vi.mock('@/hooks/useIntegrations', () => ({ useProviders: () => ({ providers: [] }) }));
 
+// `WorkspaceLeaves`/`WorkspaceNodeExtras` (rendered by this sidebar) also pull
+// `useSyncedWorkspaceActions` from this same module — preserved via
+// `importOriginal` so only `useMachineWorkspaceSync` itself is spied on.
+const mockUseMachineWorkspaceSync = vi.fn();
+vi.mock('@/hooks/useMachineWorkspaceSync', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useMachineWorkspaceSync')>();
+  return {
+    ...actual,
+    useMachineWorkspaceSync: (machineId: string | null) => mockUseMachineWorkspaceSync(machineId),
+  };
+});
+
 // Sidebar chrome that isn't under test.
 vi.mock('@/components/layout/navbar/DriveSwitcher', () => ({ default: () => <div /> }));
 vi.mock('../PrimaryNavigation', () => ({ default: () => <div /> }));
@@ -114,6 +126,19 @@ describe('DevelopmentSidebar', () => {
     render(<DevelopmentSidebar />);
 
     expect(await screen.findByText('Dev box')).toBeDefined();
+  });
+
+  // Regression: `WorkspaceLeaves`/`WorkspaceNodeExtras` render the SAME
+  // server-synced workspace tree the Machine page's Terminal tab does, but
+  // `MachineView` (the sync hook's OTHER mount point) only mounts once the
+  // user navigates INTO a machine. Without mounting the hook here too,
+  // expanding a machine's row in this sidebar without ever visiting its page
+  // would act on a never-hydrated local store.
+  test('mounts useMachineWorkspaceSync for each visible machine row, hydrating it even before the machine is ever opened', async () => {
+    render(<DevelopmentSidebar />);
+
+    await screen.findByText('Dev box');
+    expect(mockUseMachineWorkspaceSync).toHaveBeenCalledWith('machine-1');
   });
 
   test('refuses a non-admin, and asks the API for no machines on their behalf', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.test.tsx
@@ -41,6 +41,11 @@ vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
 const mockUseAuth = vi.fn();
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
 
+const mockUseMachineWorkspaceSync = vi.fn();
+vi.mock('@/hooks/useMachineWorkspaceSync', () => ({
+  useMachineWorkspaceSync: (machineId: string | null) => mockUseMachineWorkspaceSync(machineId),
+}));
+
 // motion.div → a plain div so the shell renders synchronously in jsdom.
 // Strip the animation-only props (initial/animate/exit/transition) so they
 // don't leak onto the DOM node and trigger React unknown-prop warnings.
@@ -142,6 +147,33 @@ describe('MachineView (Machine 4-tab shell)', () => {
       should: 'show the admin-only notice and mount no tab bodies',
       actual: { notice: !!screen.queryByText(/requires administrator privileges/i), lifecycle },
       expected: { notice: true, lifecycle: [] },
+    });
+  });
+
+  // Regression (CodeRabbit): a non-admin viewer never sees the tabs
+  // useMachineWorkspaceSync exists for, so it must not fetch the workspace
+  // list or join the socket room on their behalf.
+  test('non-admin users pass null to useMachineWorkspaceSync — no workspace fetch/socket join on their behalf', () => {
+    mockUseAuth.mockReturnValue({ user: { role: 'user' } });
+    render(<MachineView pageId="machine-1" />);
+
+    assert({
+      given: 'a non-admin user',
+      should: 'call useMachineWorkspaceSync with null rather than skipping the hook call (rules of hooks)',
+      actual: mockUseMachineWorkspaceSync.mock.calls.at(-1)?.[0],
+      expected: null,
+    });
+  });
+
+  test('admin users pass the real pageId to useMachineWorkspaceSync', () => {
+    asAdmin();
+    render(<MachineView pageId="machine-1" />);
+
+    assert({
+      given: 'an admin user',
+      should: 'call useMachineWorkspaceSync with the machine\'s own pageId',
+      actual: mockUseMachineWorkspaceSync.mock.calls.at(-1)?.[0],
+      expected: 'machine-1',
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
@@ -6,6 +6,7 @@ import { motion } from 'motion/react';
 import { FolderTree, GitCompare, Settings, TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
+import { useMachineWorkspaceSync } from '@/hooks/useMachineWorkspaceSync';
 import {
   useMachineTabStore,
   DEFAULT_MACHINE_TAB,
@@ -52,12 +53,19 @@ const TAB_TRIGGERS: { value: MachineTabValue; label: string; icon: React.Element
  * workspace, so a session clicked on a machine parked on Files/Diff/Settings had
  * nowhere to land. Behaviour is otherwise unchanged — a machine with no stored
  * tab shows Terminal, as before.
+ *
+ * `useMachineWorkspaceSync` is mounted HERE, not inside `TerminalTab` — this is
+ * the one true per-machine root that survives Terminal-tab unmount/remount
+ * (Radix `TabsContent` unmounts inactive tabs; this component doesn't), so the
+ * socket room join / server hydration / bootstrap race only happen once per
+ * machine, not once per Terminal-tab activation (#2048).
  */
 const MachineView = ({ pageId, embedded = false }: MachineViewProps) => {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
   const activeTab = useMachineTabStore((state) => state.tabs[pageId] ?? DEFAULT_MACHINE_TAB);
   const setTab = useMachineTabStore((state) => state.setTab);
+  useMachineWorkspaceSync(pageId);
 
   return (
     <motion.div

--- a/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/MachineView.tsx
@@ -58,14 +58,17 @@ const TAB_TRIGGERS: { value: MachineTabValue; label: string; icon: React.Element
  * the one true per-machine root that survives Terminal-tab unmount/remount
  * (Radix `TabsContent` unmounts inactive tabs; this component doesn't), so the
  * socket room join / server hydration / bootstrap race only happen once per
- * machine, not once per Terminal-tab activation (#2048).
+ * machine, not once per Terminal-tab activation (#2048). Passed `null` for a
+ * non-admin viewer (rather than skipping the call, which rules of hooks
+ * forbid) — they never see the tabs this hook exists for, so there's no
+ * reason to fetch the workspace list or join the socket room on their behalf.
  */
 const MachineView = ({ pageId, embedded = false }: MachineViewProps) => {
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
   const activeTab = useMachineTabStore((state) => state.tabs[pageId] ?? DEFAULT_MACHINE_TAB);
   const setTab = useMachineTabStore((state) => state.setTab);
-  useMachineWorkspaceSync(pageId);
+  useMachineWorkspaceSync(isAdmin ? pageId : null);
 
   return (
     <motion.div

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
@@ -71,12 +71,14 @@ describe('TerminalTab', () => {
     const first = await waitFor(() => screen.getByText('Workspace 1'));
     await userEvent.click(first);
 
-    const machine = selectMachine('machine-1')(store())!;
-    assert({
-      given: 'a workspace row clicked while a different workspace was active',
-      should: 'set the clicked workspace as the machine\'s active one',
-      actual: machine.workspaces[machine.activeWorkspaceId].name,
-      expected: 'Workspace 1',
+    await waitFor(() => {
+      const machine = selectMachine('machine-1')(store())!;
+      assert({
+        given: 'a workspace row clicked while a different workspace was active',
+        should: 'set the clicked workspace as the machine\'s active one',
+        actual: machine.workspaces[machine.activeWorkspaceId].name,
+        expected: 'Workspace 1',
+      });
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -8,6 +8,15 @@ import type { OpenTerminalScope, WorkspaceState } from '@/stores/machine-workspa
 const mockUseMobile = vi.fn<() => boolean>();
 vi.mock('@/hooks/useMobile', () => ({ useMobile: () => mockUseMobile() }));
 
+// `useSyncedWorkspaceActions` (#2048) pushes layout changes to the server via
+// these — fire-and-forget from the component's point of view, but each must
+// resolve rather than return undefined, or the wrapper's `.catch()` throws.
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  post: vi.fn(async () => ({})),
+  patch: vi.fn(async () => ({})),
+  del: vi.fn(async () => ({})),
+}));
+
 // The pane's terminal is an xterm/socket subtree — stub it so what's under test
 // is the LAYOUT the workspace picks, not the stream inside it.
 vi.mock('../XtermTerminal', () => ({
@@ -98,21 +107,26 @@ vi.mock('@/stores/machine-workspace/useMachineWorkspaceStore', async () => {
   const actual = await vi.importActual<typeof import('@/stores/machine-workspace/useMachineWorkspaceStore')>(
     '@/stores/machine-workspace/useMachineWorkspaceStore',
   );
+  const fakeState = () => ({
+    machines: {
+      m1: { workspaces: { [WORKSPACE_ID]: workspace }, order: [WORKSPACE_ID], activeWorkspaceId: WORKSPACE_ID },
+    },
+    selectPane,
+    splitRight,
+    splitDown,
+    closePane,
+    bindPaneTerminal,
+    clearPanePrompt,
+    dismissPicker,
+  });
+  const useMachineWorkspaceStoreMock = (selector: (state: Record<string, unknown>) => unknown) => selector(fakeState());
+  // `useSyncedWorkspaceActions` (#2048) reads fresh state imperatively via
+  // `.getState()`, outside the selector/render cycle — real zustand stores
+  // expose this as a static method on the hook function itself.
+  useMachineWorkspaceStoreMock.getState = fakeState;
   return {
     ...actual,
-    useMachineWorkspaceStore: (selector: (state: Record<string, unknown>) => unknown) =>
-      selector({
-        machines: {
-          m1: { workspaces: { [WORKSPACE_ID]: workspace }, order: [WORKSPACE_ID], activeWorkspaceId: WORKSPACE_ID },
-        },
-        selectPane,
-        splitRight,
-        splitDown,
-        closePane,
-        bindPaneTerminal,
-        clearPanePrompt,
-        dismissPicker,
-      }),
+    useMachineWorkspaceStore: useMachineWorkspaceStoreMock,
   };
 });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -18,6 +18,7 @@ import {
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
@@ -61,11 +62,11 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
   // The middle view IS the active workspace's grid — selecting another workspace
   // swaps this whole component's contents for that item's combination of panes.
   const workspace = useMachineWorkspaceStore(selectActiveWorkspace(machineId));
-  const splitRight = useMachineWorkspaceStore((state) => state.splitRight);
-  const splitDown = useMachineWorkspaceStore((state) => state.splitDown);
-  const closePane = useMachineWorkspaceStore((state) => state.closePane);
+  // Layout-affecting actions push the resulting workspace state to the server
+  // (#2048); selectPane/clearPanePrompt/dismissPicker stay local-only (focus
+  // and one-shot UI intent, never synced — see useMachineWorkspaceSync's doc).
+  const { splitRight, splitDown, closePane, bindPaneTerminal } = useSyncedWorkspaceActions(machineId);
   const selectPane = useMachineWorkspaceStore((state) => state.selectPane);
-  const bindPaneTerminal = useMachineWorkspaceStore((state) => state.bindPaneTerminal);
   const clearPanePrompt = useMachineWorkspaceStore((state) => state.clearPanePrompt);
   const dismissPicker = useMachineWorkspaceStore((state) => state.dismissPicker);
   const isMobile = useMobile();
@@ -92,7 +93,6 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     async (paneId: string, agentType: AgentRuntimeType, prompt?: string) => {
       const created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
       const bound = bindPaneTerminal(
-        machineId,
         workspaceId,
         paneId,
         { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
@@ -116,7 +116,7 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
         await removeAgentTerminal(created.name).catch(() => {});
       }
     },
-    [addAgentTerminal, removeAgentTerminal, bindPaneTerminal, machineId, workspaceId, scope.projectName, scope.branchName],
+    [addAgentTerminal, removeAgentTerminal, bindPaneTerminal, workspaceId, scope.projectName, scope.branchName],
   );
 
   // Briefly undefined between this component's first render and the mounting
@@ -150,9 +150,9 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     // has switched workspaces (a `ready` event, a spawn resolving from a cold
     // boot) — so the target is captured here, not looked up when the write lands.
     onSelect: () => selectPane(machineId, workspaceId, pane.id),
-    onSplitRight: () => splitRight(machineId, workspaceId, pane.id),
-    onSplitDown: () => splitDown(machineId, workspaceId, pane.id),
-    onClose: () => closePane(machineId, workspaceId, pane.id),
+    onSplitRight: () => splitRight(workspaceId, pane.id),
+    onSplitDown: () => splitDown(workspaceId, pane.id),
+    onClose: () => closePane(workspaceId, pane.id),
     onSpawn: (agentType: AgentRuntimeType, prompt?: string) => spawnIntoPane(pane.id, agentType, prompt),
     onPickerFocused: () => dismissPicker(machineId, workspaceId, pane.id),
     onPromptSent: () => clearPanePrompt(machineId, workspaceId, pane.id),

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -12,7 +12,11 @@ vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
-  post: vi.fn(),
+  // These three back `useSyncedWorkspaceActions`' server pushes (#2048) — the
+  // sidebar's own actions (create/rename/remove/adopt) all fire one of these
+  // fire-and-forget, so each must resolve rather than return undefined.
+  post: vi.fn(async () => ({})),
+  patch: vi.fn(async () => ({})),
   del: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -1,5 +1,5 @@
-import { describe, test, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { describe, test, beforeEach, vi, expect } from 'vitest';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import type { ReactElement } from 'react';
@@ -22,6 +22,15 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 
 import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
+// `pushWorkspaceUpdate` (useMachineWorkspaceSync) PATCHes via `fetchWithAuth`
+// directly rather than the `patch()` helper, to read the real HTTP status
+// code — see that file's doc comment. These tests assert on the PATCH calls
+// made through the shared `fetchWithAuth` mock.
+const patchCallsTo = (url: string) =>
+  vi.mocked(fetchWithAuth).mock.calls.filter(
+    ([calledUrl, options]) => calledUrl === url && (options as RequestInit | undefined)?.method === 'PATCH',
+  );
+
 const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
 const PROJECT_NODE: MachineTreeNode = { level: 'project', projectName: 'app' };
 
@@ -36,6 +45,7 @@ const renderLeaves = (ui: ReactElement) =>
 
 describe('WorkspaceLeaves', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     window.localStorage.clear();
     useMachineWorkspaceStore.setState({ machines: {} });
   });
@@ -256,10 +266,119 @@ describe('WorkspaceLeaves', () => {
       });
     });
   });
+
+  describe('inline rename', () => {
+    test('double-clicking a workspace name opens an editable input, pre-filled with its current name', async () => {
+      store().ensureMachine('m1');
+      renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+      const row = await screen.findByText('Workspace 1');
+      await userEvent.dblClick(row);
+
+      const input = screen.getByLabelText('Rename workspace Workspace 1') as HTMLInputElement;
+      assert({
+        given: 'a workspace name double-clicked',
+        should: 'show an input pre-filled with the current name',
+        actual: input.value,
+        expected: 'Workspace 1',
+      });
+    });
+
+    test('Enter commits the new name and pushes it to the server', async () => {
+      store().ensureMachine('m1');
+      const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+      renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+      await userEvent.dblClick(await screen.findByText('Workspace 1'));
+      const input = screen.getByLabelText('Rename workspace Workspace 1');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Renamed{Enter}');
+
+      await waitFor(() => {
+        assert({
+          given: 'a new name typed and Enter pressed',
+          should: 'commit the rename locally and PATCH it to the server',
+          actual: {
+            name: selectMachine('m1')(store())!.workspaces[workspaceId].name,
+            stillEditing: screen.queryByLabelText(/Rename workspace/) !== null,
+          },
+          expected: { name: 'Renamed', stillEditing: false },
+        });
+      });
+      const [, options] = patchCallsTo('/api/machines/workspaces')[0] ?? [];
+      expect(JSON.parse((options as RequestInit).body as string)).toMatchObject({
+        machineId: 'm1',
+        workspaceId,
+        name: 'Renamed',
+      });
+    });
+
+    test('Escape cancels without saving the draft', async () => {
+      store().ensureMachine('m1');
+      const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+      renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+      await userEvent.dblClick(await screen.findByText('Workspace 1'));
+      const input = screen.getByLabelText('Rename workspace Workspace 1');
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Abandoned draft{Escape}');
+
+      assert({
+        given: 'a draft typed then Escape pressed',
+        should: 'discard the draft and leave the original name untouched',
+        actual: selectMachine('m1')(store())!.workspaces[workspaceId].name,
+        expected: 'Workspace 1',
+      });
+      expect(patchCallsTo('/api/machines/workspaces')).toHaveLength(0);
+    });
+
+    // Regression (CodeRabbit): in Chromium, unmounting the still-focused
+    // input (which Escape/Enter both do, by closing the editor) can itself
+    // fire a native `blur` event. Without a skip-next-blur guard, that blur
+    // would re-enter the commit path — resurrecting the cancelled draft after
+    // Escape, or firing a redundant second commit after Enter.
+    test('a blur event firing immediately after Escape does not resurrect the cancelled draft', async () => {
+      store().ensureMachine('m1');
+      const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+      renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+      await userEvent.dblClick(await screen.findByText('Workspace 1'));
+      const input = screen.getByLabelText('Rename workspace Workspace 1') as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Abandoned draft');
+      fireEvent.keyDown(input, { key: 'Escape' });
+      // Simulate the browser firing a native blur as a side effect of the
+      // input unmounting right after Escape closed the editor.
+      fireEvent.blur(input);
+
+      assert({
+        given: "Escape followed by a blur event on the now-unmounted input",
+        should: 'still leave the original name untouched — the blur must not re-commit the cancelled draft',
+        actual: selectMachine('m1')(store())!.workspaces[workspaceId].name,
+        expected: 'Workspace 1',
+      });
+      expect(patchCallsTo('/api/machines/workspaces')).toHaveLength(0);
+    });
+
+    test('a blur event firing immediately after Enter does not fire a redundant second commit', async () => {
+      store().ensureMachine('m1');
+      renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+      await userEvent.dblClick(await screen.findByText('Workspace 1'));
+      const input = screen.getByLabelText('Rename workspace Workspace 1') as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Renamed');
+      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.blur(input);
+
+      await waitFor(() => expect(patchCallsTo('/api/machines/workspaces')).toHaveLength(1));
+    });
+  });
 });
 
 describe('WorkspaceNodeExtras', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     window.localStorage.clear();
     useMachineWorkspaceStore.setState({ machines: {} });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -71,12 +71,34 @@ describe('WorkspaceLeaves', () => {
     await userEvent.click(row);
 
     const workspaceId = Object.keys(selectMachine('m1')(store())!.workspaces)[0];
-    assert({
-      given: 'a workspace row clicked',
-      should: 'call onSelectWorkspace with the workspace id',
-      actual: onSelectWorkspace.mock.calls[0]?.[0],
-      expected: workspaceId,
+    await waitFor(() => {
+      assert({
+        given: 'a workspace row clicked',
+        should: 'call onSelectWorkspace with the workspace id',
+        actual: onSelectWorkspace.mock.calls[0]?.[0],
+        expected: workspaceId,
+      });
     });
+  });
+
+  // Regression: a browser fires BOTH `click` events of a double-click before
+  // `dblclick` — a bare onClick would call onSelectWorkspace on the way to
+  // renaming, which in the real caller (DevelopmentSidebar) navigates. The
+  // first click's onSelectWorkspace must be deferred and cancelled by the
+  // second click that starts the rename.
+  test('double-clicking a workspace name to rename it does NOT also call onSelectWorkspace', async () => {
+    store().ensureMachine('m1');
+    const onSelectWorkspace = vi.fn();
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={onSelectWorkspace} />);
+
+    const row = await screen.findByText('Workspace 1');
+    await userEvent.dblClick(row);
+
+    expect(screen.getByLabelText('Rename workspace Workspace 1')).toBeDefined();
+    // Give the (now-cancelled) deferred single-click timer a chance to fire
+    // if the cancellation didn't actually work.
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(onSelectWorkspace).not.toHaveBeenCalled();
   });
 
   test('the active workspace is marked aria-current; an inactive sibling is not', async () => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -85,7 +85,7 @@ export default function WorkspaceLeaves({
   const machine = useMachineWorkspaceStore(selectMachine(machineId));
   // Identity/layout-affecting actions push to the server (#2048); local-only
   // UI state (which row is being renamed, which is pending removal) stays here.
-  const { removeWorkspace, closePane, openTerminal, renameWorkspace } = useSyncedWorkspaceActions(machineId);
+  const { removeWorkspace, closePanes, openTerminal, renameWorkspace } = useSyncedWorkspaceActions(machineId);
   const [pendingRemove, setPendingRemove] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
@@ -246,7 +246,7 @@ export default function WorkspaceLeaves({
           // instead of dropping the (unchanged) workspace, or it would linger
           // bound to the agent names just killed above.
           if (workspacesOf(machine).length <= 1) {
-            pendingRunningPaneIds.forEach((paneId) => closePane(pendingRemove, paneId));
+            closePanes(pendingRemove, pendingRunningPaneIds);
           } else {
             removeWorkspace(pendingRemove);
           }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -100,6 +100,18 @@ export default function WorkspaceLeaves({
   // when a fresh rename starts, so a stale `true` can never suppress a later,
   // legitimate blur-to-commit.
   const skipNextBlur = useRef(false);
+  // A browser fires BOTH `click` events of a double-click before `dblclick` —
+  // so a bare `onClick={() => onSelectWorkspace(...)}` selects the workspace
+  // (running whatever side effects the caller's `onSelectWorkspace` has, e.g.
+  // DevelopmentSidebar's navigates to the machine) on the way to renaming it,
+  // not just on an intentional single click. Deferring the first click and
+  // cancelling it if a second one (i.e. a double-click) follows within the
+  // window is the standard single/double-click disambiguation for exactly
+  // this conflict.
+  const pendingSelectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (pendingSelectTimer.current) clearTimeout(pendingSelectTimer.current);
+  }, []);
 
   const scope = nodeScopeOf(node);
   // Every pane in a workspace runs in the WORKSPACE's own node scope (see
@@ -138,6 +150,24 @@ export default function WorkspaceLeaves({
     skipNextBlur.current = false;
     setRenamingId(workspace.id);
     setDraftName(workspace.name);
+  };
+
+  // Deferred so a double-click's first `click` doesn't select the workspace
+  // on its way to renaming it (see `pendingSelectTimer`'s doc above).
+  const handleRowClick = (workspaceId: string) => {
+    if (pendingSelectTimer.current) clearTimeout(pendingSelectTimer.current);
+    pendingSelectTimer.current = setTimeout(() => {
+      pendingSelectTimer.current = null;
+      onSelectWorkspace(workspaceId);
+    }, 250);
+  };
+
+  const handleRowDoubleClick = (workspace: { id: string; name: string }) => {
+    if (pendingSelectTimer.current) {
+      clearTimeout(pendingSelectTimer.current);
+      pendingSelectTimer.current = null;
+    }
+    startRename(workspace);
   };
 
   const commitRename = (workspaceId: string, currentName: string) => {
@@ -210,8 +240,8 @@ export default function WorkspaceLeaves({
           ) : (
             <button
               type="button"
-              onClick={() => onSelectWorkspace(workspace.id)}
-              onDoubleClick={() => startRename(workspace)}
+              onClick={() => handleRowClick(workspace.id)}
+              onDoubleClick={() => handleRowDoubleClick(workspace)}
               aria-current={workspace.id === machine.activeWorkspaceId ? 'true' : undefined}
               className="flex flex-1 items-center gap-1 text-left"
             >

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -34,7 +34,7 @@
  * removing a workspace is the only stop path now) can't be stopped either.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Plus, TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -89,6 +89,15 @@ export default function WorkspaceLeaves({
   const [pendingRemove, setPendingRemove] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
+  // Escape/Enter close the input by setting `renamingId` to null, which
+  // unmounts it — and in Chromium, unmounting a still-focused element can
+  // itself fire a NATIVE blur event that reaches `onBlur` below. Without this
+  // guard, Escape's blur would re-commit the very draft the user just
+  // cancelled, and Enter's would fire a redundant second commit. Set right
+  // before closing, consumed (and reset) by the next `onBlur`; also reset
+  // when a fresh rename starts, so a stale `true` can never suppress a later,
+  // legitimate blur-to-commit.
+  const skipNextBlur = useRef(false);
 
   const scope = nodeScopeOf(node);
   // Every pane in a workspace runs in the WORKSPACE's own node scope (see
@@ -124,6 +133,7 @@ export default function WorkspaceLeaves({
   };
 
   const startRename = (workspace: { id: string; name: string }) => {
+    skipNextBlur.current = false;
     setRenamingId(workspace.id);
     setDraftName(workspace.name);
   };
@@ -132,6 +142,24 @@ export default function WorkspaceLeaves({
     const trimmed = draftName.trim();
     if (trimmed && trimmed !== currentName) renameWorkspace(workspaceId, trimmed);
     setRenamingId(null);
+  };
+
+  const cancelRename = () => {
+    skipNextBlur.current = true;
+    setRenamingId(null);
+  };
+
+  const commitRenameViaKey = (workspaceId: string, currentName: string) => {
+    skipNextBlur.current = true;
+    commitRename(workspaceId, currentName);
+  };
+
+  const commitRenameViaBlur = (workspaceId: string, currentName: string) => {
+    if (skipNextBlur.current) {
+      skipNextBlur.current = false;
+      return;
+    }
+    commitRename(workspaceId, currentName);
   };
 
   return (
@@ -151,14 +179,14 @@ export default function WorkspaceLeaves({
                 autoFocus
                 value={draftName}
                 onChange={(e) => setDraftName(e.target.value)}
-                onBlur={() => commitRename(workspace.id, workspace.name)}
+                onBlur={() => commitRenameViaBlur(workspace.id, workspace.name)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
                     e.preventDefault();
-                    commitRename(workspace.id, workspace.name);
+                    commitRenameViaKey(workspace.id, workspace.name);
                   } else if (e.key === 'Escape') {
                     e.preventDefault();
-                    setRenamingId(null);
+                    cancelRename();
                   }
                 }}
                 aria-label={`Rename workspace ${workspace.name}`}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -48,6 +48,7 @@ import {
   type MachineNodeScope,
 } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import type { MachineTreeNode } from './MachineTree';
 import ConfirmRemoveDialog from './ConfirmRemoveDialog';
 import RemoveButton, { AddButton } from './RemoveButton';
@@ -82,10 +83,12 @@ export default function WorkspaceLeaves({
   }, [machineId, ensureMachine]);
 
   const machine = useMachineWorkspaceStore(selectMachine(machineId));
-  const removeWorkspace = useMachineWorkspaceStore((state) => state.removeWorkspace);
-  const closePane = useMachineWorkspaceStore((state) => state.closePane);
-  const openTerminal = useMachineWorkspaceStore((state) => state.openTerminal);
+  // Identity/layout-affecting actions push to the server (#2048); local-only
+  // UI state (which row is being renamed, which is pending removal) stays here.
+  const { removeWorkspace, closePane, openTerminal, renameWorkspace } = useSyncedWorkspaceActions(machineId);
   const [pendingRemove, setPendingRemove] = useState<string | null>(null);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
 
   const scope = nodeScopeOf(node);
   // Every pane in a workspace runs in the WORKSPACE's own node scope (see
@@ -116,8 +119,19 @@ export default function WorkspaceLeaves({
   const unclaimedSessions = agentTerminals.filter((terminal) => !localNames.has(terminal.name));
 
   const adopt = (name: string) => {
-    openTerminal(machineId, { ...scope, name });
+    openTerminal({ ...scope, name });
     onSelectWorkspace(sessionWorkspaceId({ ...scope, name }));
+  };
+
+  const startRename = (workspace: { id: string; name: string }) => {
+    setRenamingId(workspace.id);
+    setDraftName(workspace.name);
+  };
+
+  const commitRename = (workspaceId: string, currentName: string) => {
+    const trimmed = draftName.trim();
+    if (trimmed && trimmed !== currentName) renameWorkspace(workspaceId, trimmed);
+    setRenamingId(null);
   };
 
   return (
@@ -130,15 +144,39 @@ export default function WorkspaceLeaves({
             workspace.id === machine.activeWorkspaceId ? 'bg-accent' : 'hover:bg-accent/50',
           )}
         >
-          <button
-            type="button"
-            onClick={() => onSelectWorkspace(workspace.id)}
-            aria-current={workspace.id === machine.activeWorkspaceId ? 'true' : undefined}
-            className="flex flex-1 items-center gap-1 text-left"
-          >
-            <TerminalSquare className="size-3 shrink-0" />
-            <span className="truncate font-normal text-sm leading-none">{workspace.name}</span>
-          </button>
+          {renamingId === workspace.id ? (
+            <div className="flex flex-1 items-center gap-1">
+              <TerminalSquare className="size-3 shrink-0" />
+              <input
+                autoFocus
+                value={draftName}
+                onChange={(e) => setDraftName(e.target.value)}
+                onBlur={() => commitRename(workspace.id, workspace.name)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    commitRename(workspace.id, workspace.name);
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setRenamingId(null);
+                  }
+                }}
+                aria-label={`Rename workspace ${workspace.name}`}
+                className="w-full truncate rounded-sm border border-border bg-background px-1 text-sm font-normal leading-none outline-none"
+              />
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => onSelectWorkspace(workspace.id)}
+              onDoubleClick={() => startRename(workspace)}
+              aria-current={workspace.id === machine.activeWorkspaceId ? 'true' : undefined}
+              className="flex flex-1 items-center gap-1 text-left"
+            >
+              <TerminalSquare className="size-3 shrink-0" />
+              <span className="truncate font-normal text-sm leading-none">{workspace.name}</span>
+            </button>
+          )}
           <RemoveButton onClick={() => setPendingRemove(workspace.id)} label={`Remove workspace ${workspace.name}`} />
         </div>
       ))}
@@ -180,9 +218,9 @@ export default function WorkspaceLeaves({
           // instead of dropping the (unchanged) workspace, or it would linger
           // bound to the agent names just killed above.
           if (workspacesOf(machine).length <= 1) {
-            pendingRunningPaneIds.forEach((paneId) => closePane(machineId, pendingRemove, paneId));
+            pendingRunningPaneIds.forEach((paneId) => closePane(pendingRemove, paneId));
           } else {
-            removeWorkspace(machineId, pendingRemove);
+            removeWorkspace(pendingRemove);
           }
         }}
       />
@@ -209,7 +247,7 @@ export function WorkspaceNodeExtras({
 }) {
   const scope = nodeScopeOf(node);
   const runningCount = useMachineWorkspaceStore(selectRunningPaneCount(machineId, scope));
-  const createWorkspace = useMachineWorkspaceStore((state) => state.createWorkspace);
+  const { createWorkspace } = useSyncedWorkspaceActions(machineId);
 
   return (
     <span className="flex shrink-0 items-center gap-0.5">
@@ -219,7 +257,7 @@ export function WorkspaceNodeExtras({
         </span>
       )}
       <AddButton
-        onClick={() => onWorkspaceCreated(createWorkspace(machineId, scope))}
+        onClick={() => onWorkspaceCreated(createWorkspace(scope))}
         label="New workspace"
         icon={<Plus className="mx-auto size-3" />}
       />

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -347,4 +347,77 @@ describe('useSyncedWorkspaceActions', () => {
     await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
     expect(mockPost).not.toHaveBeenCalled();
   });
+
+  // Regression (Codex P2): the route (and `updateWorkspace`) support a true
+  // partial PATCH — name-only, columns-only, or both. Sending BOTH fields on
+  // every layout-only action would let a rename in one browser (which never
+  // touched columns) get raced by a split in another browser whose local
+  // copy of `name` is still stale — the split's PATCH would silently revert
+  // the rename. Sending only the field this action actually changed closes
+  // that hole.
+  it('splitRight PATCHes columns only — the rename it never touched is not sent', async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.splitRight(workspace.id, workspace.activePaneId);
+    });
+
+    await waitFor(() => {
+      const [, options] = mockFetchWithAuth.mock.calls.find(([, opts]) => opts?.method === 'PATCH') ?? [];
+      const body = JSON.parse((options as { body: string }).body);
+      expect(body).toHaveProperty('columns');
+      expect(body).not.toHaveProperty('name');
+    });
+  });
+
+  // Regression (Codex P2): closing N panes one at a time (e.g. emptying every
+  // running pane when removing the machine's only workspace) used to fire N
+  // independent fire-and-forget PATCHes with no ordering guarantee — a slower
+  // EARLIER request resolving after a later one could leave the server at an
+  // intermediate state. `closePanes` applies every local close first, then
+  // pushes exactly once, so only the final result ever reaches the server.
+  it('closePanes closes every pane locally, then PATCHes exactly once with the final layout', async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    useMachineWorkspaceStore.getState().splitRight(MACHINE_ID, workspace.id, workspace.activePaneId);
+    const withSplit = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    const paneIds = withSplit.columns.flatMap((column) => column.panes.map((pane) => pane.id));
+    expect(paneIds).toHaveLength(2);
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.closePanes(workspace.id, paneIds);
+    });
+
+    const final = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    expect(final.columns.flatMap((column) => column.panes)).toHaveLength(1);
+
+    await waitFor(() => {
+      const patchCalls = mockFetchWithAuth.mock.calls.filter(([, opts]) => opts?.method === 'PATCH');
+      expect(patchCalls).toHaveLength(1);
+      const body = JSON.parse(patchCalls[0][1].body);
+      expect(body.columns.flatMap((column: { panes: unknown[] }) => column.panes)).toHaveLength(1);
+    });
+  });
+
+  it("renameWorkspace PATCHes name only — the layout it never touched is not sent", async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.renameWorkspace(workspace.id, 'Renamed');
+    });
+
+    await waitFor(() => {
+      const [, options] = mockFetchWithAuth.mock.calls.find(([, opts]) => opts?.method === 'PATCH') ?? [];
+      const body = JSON.parse((options as { body: string }).body);
+      expect(body).toMatchObject({ name: 'Renamed' });
+      expect(body).not.toHaveProperty('columns');
+    });
+  });
 });

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -3,6 +3,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { mutate } from 'swr';
 import { createMockSocket } from '@/test/socket-mocks';
 
 const { mockFetchWithAuth, mockPost, mockPatch, mockDel } = vi.hoisted(() => ({
@@ -119,6 +120,89 @@ describe('useMachineWorkspaceSync', () => {
     expect(workspacesOf(machine).some((w) => w.id === 'ws-intruder')).toBe(false);
   });
 
+  it('given a rename-only machine-workspace:updated event for a workspace ALREADY known locally, merges the name and keeps its columns', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: true,
+        workspaces: [{ id: 'ws-a', name: 'A', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] }],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-update-known'));
+    await waitFor(() => {
+      const machine = selectMachine('m-update-known')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-a']);
+    });
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:updated', {
+        machineId: 'm-update-known',
+        workspaceId: 'ws-a',
+        name: 'Renamed elsewhere',
+        // columns omitted — a rename-only broadcast.
+      });
+    });
+
+    const machine = selectMachine('m-update-known')(useMachineWorkspaceStore.getState());
+    const workspace = workspacesOf(machine).find((w) => w.id === 'ws-a');
+    expect(workspace?.name).toBe('Renamed elsewhere');
+    expect(workspace?.columns).toEqual([{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }]);
+  });
+
+  it('given a rename-only machine-workspace:updated event for a workspace UNKNOWN locally, ignores it rather than planting a zero-column entry', async () => {
+    renderHook(() => useMachineWorkspaceSync('m-update-unknown'));
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:updated', {
+        machineId: 'm-update-unknown',
+        workspaceId: 'ws-never-seen',
+        name: 'Renamed elsewhere',
+        // columns omitted, and this browser has never seen ws-never-seen.
+      });
+    });
+
+    const machine = selectMachine('m-update-unknown')(useMachineWorkspaceStore.getState());
+    expect(workspacesOf(machine).some((w) => w.id === 'ws-never-seen')).toBe(false);
+  });
+
+  it('given a SECOND SWR revalidation after the initial hydrate, does NOT re-run the full-list replace (a pending local-only create must survive)', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: true,
+        workspaces: [{ id: 'ws-a', name: 'A', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] }],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-revalidate'));
+    await waitFor(() => {
+      const machine = selectMachine('m-revalidate')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-a']);
+    });
+
+    // A local-only workspace appears (its own create POST is still in flight,
+    // e.g. behind a slow CSRF round trip) — mergeServerWorkspaces would drop
+    // this as an unpublished straggler if the full-list hydrate ran again.
+    act(() => {
+      useMachineWorkspaceStore.getState().createWorkspace('m-revalidate');
+    });
+    const beforeRevalidate = workspacesOf(selectMachine('m-revalidate')(useMachineWorkspaceStore.getState()));
+    expect(beforeRevalidate).toHaveLength(2);
+
+    // Simulate a background SWR revalidation (e.g. reconnect) returning the
+    // SAME stale server list (it still doesn't know about the pending create).
+    await act(async () => {
+      await mutate(
+        '/api/machines/workspaces?machineId=m-revalidate',
+        { bootstrapped: true, workspaces: [{ id: 'ws-a', name: 'A (revalidated)', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] }] },
+        { revalidate: false },
+      );
+    });
+
+    const afterRevalidate = workspacesOf(selectMachine('m-revalidate')(useMachineWorkspaceStore.getState()));
+    expect(afterRevalidate).toHaveLength(2);
+  });
+
   it('given a machine-workspace:deleted event for this machine, removes the workspace', async () => {
     mockFetchWithAuth.mockResolvedValue(
       jsonResponse({
@@ -163,6 +247,34 @@ describe('useSyncedWorkspaceActions', () => {
     );
   });
 
+  it('createWorkspace that LOSES the first-writer-wins race adopts the winner\'s row instead of keeping its own diverged local state', async () => {
+    // The server echoes back a DIFFERENT name/columns than what this browser
+    // POSTed, with `created: false` — simulating another browser having
+    // already materialized this exact (client-derived) id first.
+    mockPost.mockImplementation(async (_url: string, body: { id: string }) => ({
+      created: false,
+      workspace: {
+        id: body.id,
+        name: "winner's name",
+        scope: {},
+        columns: [{ id: 'col-winner', panes: [{ id: 'pane-winner', scope: null }] }],
+      },
+    }));
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    let id = '';
+    act(() => {
+      id = result.current.createWorkspace();
+    });
+
+    await waitFor(() => {
+      const machine = selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState());
+      const adopted = machine?.workspaces[id];
+      expect(adopted?.name).toBe("winner's name");
+      expect(adopted?.columns).toEqual([{ id: 'col-winner', panes: [{ id: 'pane-winner', scope: null }] }]);
+    });
+  });
+
   it('removeWorkspace removes locally, then DELETEs it', () => {
     useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
     const machine = selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState())!;
@@ -184,31 +296,55 @@ describe('useSyncedWorkspaceActions', () => {
     void machine;
   });
 
-  it('splitRight PATCHes the resulting layout; on a 404 it falls back to POST-create', async () => {
+  it('splitRight PATCHes the resulting layout via fetchWithAuth; on a real 404 status it falls back to POST-create', async () => {
     useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
-    mockPatch.mockRejectedValueOnce(new Error('not_found'));
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({ error: 'not_found' }) });
 
     const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
     act(() => {
       result.current.splitRight(workspace.id, workspace.activePaneId);
     });
 
-    await waitFor(() => expect(mockPatch).toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ workspaceId: workspace.id })));
+    await waitFor(() =>
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        '/api/machines/workspaces',
+        expect.objectContaining({ method: 'PATCH', body: expect.stringContaining(workspace.id) }),
+      ),
+    );
     await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ id: workspace.id })));
   });
 
-  it('splitRight does NOT fall back to POST when the PATCH fails for a reason OTHER than not_found', async () => {
+  it('splitRight does NOT fall back to POST when the PATCH fails for a status OTHER than 404 — a real HTTP status check, not string-matching the error text', async () => {
     useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
-    mockPatch.mockRejectedValueOnce(new Error('network down'));
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({ error: 'error' }) });
 
     const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
     act(() => {
       result.current.splitRight(workspace.id, workspace.activePaneId);
     });
 
-    await waitFor(() => expect(mockPatch).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        '/api/machines/workspaces',
+        expect.objectContaining({ method: 'PATCH' }),
+      ),
+    );
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('splitRight does NOT fall back to POST when the PATCH succeeds', async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.splitRight(workspace.id, workspace.activePaneId);
+    });
+
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
     expect(mockPost).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -1,0 +1,214 @@
+/**
+ * useMachineWorkspaceSync / useSyncedWorkspaceActions Hook Tests (#2048)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { createMockSocket } from '@/test/socket-mocks';
+
+const { mockFetchWithAuth, mockPost, mockPatch, mockDel } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockPost: vi.fn(),
+  mockPatch: vi.fn(),
+  mockDel: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+  post: mockPost,
+  patch: mockPatch,
+  del: mockDel,
+}));
+
+const mockSocket = { current: null as ReturnType<typeof createMockSocket> | null };
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => mockSocket.current,
+}));
+
+vi.mock('@/hooks/usePageSocketRoom', () => ({
+  usePageSocketRoom: vi.fn(),
+}));
+
+import { useMachineWorkspaceStore, selectMachine, workspacesOf } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import { useMachineWorkspaceSync, useSyncedWorkspaceActions } from '../useMachineWorkspaceSync';
+
+const MACHINE_ID = 'm1';
+
+function jsonResponse(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useMachineWorkspaceStore.setState({ machines: {} });
+  mockSocket.current = createMockSocket();
+  mockFetchWithAuth.mockResolvedValue(jsonResponse({ workspaces: [], bootstrapped: true }));
+  mockPost.mockResolvedValue({ claimed: true, workspaces: [] });
+  mockPatch.mockResolvedValue({});
+  mockDel.mockResolvedValue({});
+});
+
+describe('useMachineWorkspaceSync', () => {
+  // Each test uses its OWN machineId — SWR's cache is keyed by the fetch URL
+  // and persists across renderHook calls within a file, so reusing one id
+  // across tests would silently serve an earlier test's cached response.
+
+  it('ensures the machine has a local default workspace on mount', async () => {
+    renderHook(() => useMachineWorkspaceSync('m-default'));
+
+    expect(workspacesOf(selectMachine('m-default')(useMachineWorkspaceStore.getState()))).toHaveLength(1);
+    // Let the in-flight SWR fetch/hydrate settle before the test tears down,
+    // so its state update lands inside this test's act scope, not the next one's.
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+  });
+
+  it('given the server reports bootstrapped, hydrates the store from the GET response without bootstrapping', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: true,
+        workspaces: [
+          { id: 'ws-server', name: 'Server Workspace', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+        ],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-bootstrapped'));
+
+    await waitFor(() => {
+      const machine = selectMachine('m-bootstrapped')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-server']);
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('given the server reports NOT bootstrapped, POSTs this browser\'s local workspace to /bootstrap', async () => {
+    mockFetchWithAuth.mockResolvedValue(jsonResponse({ bootstrapped: false, workspaces: [] }));
+    mockPost.mockResolvedValue({
+      claimed: true,
+      workspaces: [{ id: 'ws-seeded', name: 'Seeded', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] }],
+    });
+
+    renderHook(() => useMachineWorkspaceSync('m-unbootstrapped'));
+
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/machines/workspaces/bootstrap',
+        expect.objectContaining({ machineId: 'm-unbootstrapped' }),
+      ),
+    );
+    await waitFor(() => {
+      const machine = selectMachine('m-unbootstrapped')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-seeded']);
+    });
+  });
+
+  it('given a machine-workspace:created event for a DIFFERENT machine, ignores it', async () => {
+    renderHook(() => useMachineWorkspaceSync('m-filter'));
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:created', {
+        machineId: 'other-machine',
+        id: 'ws-intruder',
+        name: 'Intruder',
+        scope: {},
+        columns: [],
+      });
+    });
+
+    const machine = selectMachine('m-filter')(useMachineWorkspaceStore.getState());
+    expect(workspacesOf(machine).some((w) => w.id === 'ws-intruder')).toBe(false);
+  });
+
+  it('given a machine-workspace:deleted event for this machine, removes the workspace', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: true,
+        workspaces: [
+          { id: 'ws-a', name: 'A', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] },
+          { id: 'ws-b', name: 'B', scope: {}, columns: [{ id: 'col-b', panes: [{ id: 'pane-b', scope: null }] }] },
+        ],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-delete'));
+    await waitFor(() => {
+      const machine = selectMachine('m-delete')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine)).toHaveLength(2);
+    });
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:deleted', { machineId: 'm-delete', workspaceId: 'ws-b' });
+    });
+
+    await waitFor(() => {
+      const machine = selectMachine('m-delete')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-a']);
+    });
+  });
+});
+
+describe('useSyncedWorkspaceActions', () => {
+  it('createWorkspace creates locally, then POSTs the new workspace', () => {
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+
+    let id = '';
+    act(() => {
+      id = result.current.createWorkspace();
+    });
+
+    expect(workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState())).map((w) => w.id)).toContain(id);
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/machines/workspaces',
+      expect.objectContaining({ machineId: MACHINE_ID, id }),
+    );
+  });
+
+  it('removeWorkspace removes locally, then DELETEs it', () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const machine = selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState())!;
+    useMachineWorkspaceStore.getState().createWorkspace(MACHINE_ID);
+    const second = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[1];
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.removeWorkspace(second.id);
+    });
+
+    expect(
+      workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState())).some((w) => w.id === second.id),
+    ).toBe(false);
+    expect(mockDel).toHaveBeenCalledWith(
+      expect.stringContaining(`machineId=${MACHINE_ID}`),
+    );
+    expect(mockDel).toHaveBeenCalledWith(expect.stringContaining(`workspaceId=${second.id}`));
+    void machine;
+  });
+
+  it('splitRight PATCHes the resulting layout; on a 404 it falls back to POST-create', async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    mockPatch.mockRejectedValueOnce(new Error('not_found'));
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.splitRight(workspace.id, workspace.activePaneId);
+    });
+
+    await waitFor(() => expect(mockPatch).toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ workspaceId: workspace.id })));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ id: workspace.id })));
+  });
+
+  it('splitRight does NOT fall back to POST when the PATCH fails for a reason OTHER than not_found', async () => {
+    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+    mockPatch.mockRejectedValueOnce(new Error('network down'));
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.splitRight(workspace.id, workspace.activePaneId);
+    });
+
+    await waitFor(() => expect(mockPatch).toHaveBeenCalled());
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -203,6 +203,44 @@ describe('useMachineWorkspaceSync', () => {
     expect(afterRevalidate).toHaveLength(2);
   });
 
+  // Regression: apps/realtime's `io.to(channelId).emit(...)` reaches EVERY
+  // socket in the room, including the browser that itself POSTed the
+  // bootstrap claim — so the winner receives its own `bootstrapped` broadcast
+  // back over the socket. Without the same `hydratedOnce` guard the other
+  // handlers respect, this would re-run the full-list replace and could wipe
+  // a workspace created in the narrow window between the POST resolving and
+  // the broadcast arriving.
+  it('given a machine-workspace:bootstrapped event AFTER this browser already hydrated (its own broadcast echoing back), does NOT re-run the full-list replace', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: true,
+        workspaces: [{ id: 'ws-a', name: 'A', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] }],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-bootstrapped-echo'));
+    await waitFor(() => {
+      const machine = selectMachine('m-bootstrapped-echo')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-a']);
+    });
+
+    // A local-only workspace created just after hydration (its own create POST
+    // still in flight) — a redundant full replace would drop it.
+    act(() => {
+      useMachineWorkspaceStore.getState().createWorkspace('m-bootstrapped-echo');
+    });
+    expect(workspacesOf(selectMachine('m-bootstrapped-echo')(useMachineWorkspaceStore.getState()))).toHaveLength(2);
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:bootstrapped', {
+        machineId: 'm-bootstrapped-echo',
+        workspaces: [{ id: 'ws-a', name: 'A', scope: {}, columns: [{ id: 'col-a', panes: [{ id: 'pane-a', scope: null }] }] }],
+      });
+    });
+
+    expect(workspacesOf(selectMachine('m-bootstrapped-echo')(useMachineWorkspaceStore.getState()))).toHaveLength(2);
+  });
+
   it('given a machine-workspace:deleted event for this machine, removes the workspace', async () => {
     mockFetchWithAuth.mockResolvedValue(
       jsonResponse({

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -19,7 +19,7 @@
 
 import { useEffect, useMemo, useRef } from 'react';
 import useSWR from 'swr';
-import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import { useSocket } from './useSocket';
 import { usePageSocketRoom } from './usePageSocketRoom';
 import {
@@ -68,32 +68,54 @@ function toWireColumns(columns: TerminalColumnState[]) {
  * `machine-workspaces.ts`'s module doc for the claim/race design this relies
  * on), and keeps the store reconciled with live `machine-workspace:*`
  * broadcasts. Returns nothing — like `usePagePresence`, it's a side-effect hook.
+ *
+ * `machineId` is nullable so a caller can mount this unconditionally (React's
+ * rules of hooks forbid calling it only for admins) while still skipping all
+ * network/socket work for a non-admin viewer, who never sees the Terminal
+ * tab this exists for — pass `null` rather than gating the call itself.
  */
-export function useMachineWorkspaceSync(machineId: string): void {
+export function useMachineWorkspaceSync(machineId: string | null): void {
   const ensureMachine = useMachineWorkspaceStore((state) => state.ensureMachine);
   const hydrateFromServer = useMachineWorkspaceStore((state) => state.hydrateFromServer);
   const applyServerUpsert = useMachineWorkspaceStore((state) => state.applyServerUpsert);
   const applyServerDelete = useMachineWorkspaceStore((state) => state.applyServerDelete);
 
   const socket = useSocket();
-  usePageSocketRoom(machineId);
+  usePageSocketRoom(machineId ?? undefined);
 
   // Guards against retrying the bootstrap POST on every SWR revalidation once
   // this browser has already tried it for this machine — not against the
   // cross-browser race, which the server's claim table (not this ref) resolves.
   const bootstrapAttempted = useRef(false);
 
+  // `hydrateFromServer` is a FULL-LIST replace that deliberately drops any
+  // local-only workspace not in the server's list (see `mergeServerWorkspaces`'s
+  // doc — correct for a one-time initial hydrate, wrong for a background
+  // refresh). SWR's `data` can change more than once for the SAME machine —
+  // `revalidateOnReconnect` defaults true, so a brief network drop refetches —
+  // and re-running the full-replace on a LATER revalidation would silently
+  // wipe a workspace this browser just created locally whose own create
+  // request hasn't round-tripped (and broadcast) yet. So this only ever runs
+  // ONCE per mount; every subsequent change to the store comes from the socket
+  // subscription below. Safe as a plain ref (not reset on `machineId` change)
+  // because this hook is mounted once per machine at `MachineView`, which
+  // `MachineKeepAliveHost` keeps as one distinct component instance per
+  // machine rather than reusing one instance across different machineIds.
+  const hydratedOnce = useRef(false);
+
   useEffect(() => {
+    if (!machineId) return;
     ensureMachine(machineId);
   }, [machineId, ensureMachine]);
 
-  const key = `/api/machines/workspaces?machineId=${encodeURIComponent(machineId)}`;
+  const key = machineId ? `/api/machines/workspaces?machineId=${encodeURIComponent(machineId)}` : null;
   const { data } = useSWR<WorkspaceListResponse>(key, fetcher, { revalidateOnFocus: false });
 
   useEffect(() => {
-    if (!data) return;
+    if (!machineId || !data || hydratedOnce.current) return;
 
     if (data.bootstrapped) {
+      hydratedOnce.current = true;
       hydrateFromServer(machineId, data.workspaces);
       return;
     }
@@ -110,7 +132,10 @@ export function useMachineWorkspaceSync(machineId: string): void {
     }));
 
     post<BootstrapResponse>('/api/machines/workspaces/bootstrap', { machineId, workspaces: payload })
-      .then((res) => hydrateFromServer(machineId, res.workspaces))
+      .then((res) => {
+        hydratedOnce.current = true;
+        hydrateFromServer(machineId, res.workspaces);
+      })
       .catch(() => {
         // Retry on the next data change (e.g. a manual refresh) rather than
         // leaving this machine permanently un-bootstrapped over a transient failure.
@@ -119,11 +144,14 @@ export function useMachineWorkspaceSync(machineId: string): void {
   }, [machineId, data, hydrateFromServer]);
 
   useEffect(() => {
-    if (!socket) return;
+    if (!socket || !machineId) return;
+    // Narrowed copy for the closures below — a `string | null` parameter
+    // doesn't stay narrowed inside nested function expressions.
+    const mid = machineId;
 
     const onCreated = (payload: ServerWorkspaceDTO & { machineId: string }) => {
-      if (payload.machineId !== machineId) return;
-      applyServerUpsert(machineId, payload);
+      if (payload.machineId !== mid) return;
+      applyServerUpsert(mid, payload);
     };
     const onUpdated = (payload: {
       machineId: string;
@@ -131,24 +159,34 @@ export function useMachineWorkspaceSync(machineId: string): void {
       name?: string;
       columns?: TerminalColumnState[];
     }) => {
-      if (payload.machineId !== machineId) return;
+      if (payload.machineId !== mid) return;
       // `updated` only carries whichever of name/columns actually changed —
-      // fill in the rest from what this browser already has for it.
-      const current = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[payload.workspaceId];
-      applyServerUpsert(machineId, {
+      // fill in the rest from what this browser already has for it. It NEVER
+      // carries `scope` (immutable, so the PATCH route never re-sends it), so
+      // an `updated` event can only ever be applied to a workspace this
+      // browser already knows about — there is no safe default for `scope`
+      // (defaulting to machine-scope would misfile a project/branch-scoped
+      // workspace under the wrong sidebar node) nor for missing name/columns
+      // (defaulting to `''`/`[]` would plant a broken, zero-pane entry). If
+      // this browser hasn't hydrated the workspace yet (e.g. it missed the
+      // `created` broadcast on a reconnect), skip and wait for a `created`
+      // event or the next full hydration to introduce it correctly.
+      const current = useMachineWorkspaceStore.getState().machines[mid]?.workspaces[payload.workspaceId];
+      if (!current) return;
+      applyServerUpsert(mid, {
         id: payload.workspaceId,
-        name: payload.name ?? current?.name ?? '',
-        scope: current?.scope ?? {},
-        columns: payload.columns ?? current?.columns ?? [],
+        name: payload.name ?? current.name,
+        scope: current.scope,
+        columns: payload.columns ?? current.columns,
       });
     };
     const onDeleted = (payload: { machineId: string; workspaceId: string }) => {
-      if (payload.machineId !== machineId) return;
-      applyServerDelete(machineId, payload.workspaceId);
+      if (payload.machineId !== mid) return;
+      applyServerDelete(mid, payload.workspaceId);
     };
     const onBootstrapped = (payload: { machineId: string; workspaces: ServerWorkspaceDTO[] }) => {
-      if (payload.machineId !== machineId) return;
-      hydrateFromServer(machineId, payload.workspaces);
+      if (payload.machineId !== mid) return;
+      hydrateFromServer(mid, payload.workspaces);
     };
 
     socket.on('machine-workspace:created', onCreated);
@@ -164,45 +202,73 @@ export function useMachineWorkspaceSync(machineId: string): void {
   }, [socket, machineId, applyServerUpsert, applyServerDelete, hydrateFromServer]);
 }
 
+interface CreateWorkspaceResponse {
+  created: boolean;
+  workspace: ServerWorkspaceDTO;
+}
+
 async function pushNewWorkspace(machineId: string, workspaceId: string): Promise<void> {
   const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
   if (!workspace) return;
-  await post('/api/machines/workspaces', {
+  await post<CreateWorkspaceResponse>('/api/machines/workspaces', {
     machineId,
     id: workspace.id,
     name: workspace.name,
     scope: workspace.scope,
     columns: toWireColumns(workspace.columns),
-  }).catch(() => {});
+  })
+    .then((res) => {
+      // Lost the first-writer-wins race (another browser materialized the
+      // same client-derived id first, e.g. two tabs opening the same session)
+      // — the API's contract is that the loser adopts the winner's row, not
+      // its own payload. Without this, this browser would keep showing its
+      // own diverged local layout forever instead of the shared canonical one.
+      if (!res.created) useMachineWorkspaceStore.getState().applyServerUpsert(machineId, res.workspace);
+    })
+    .catch(() => {});
 }
 
 /** For a workspace that MIGHT already exist server-side (any layout/rename change
  * after creation): PATCH first, falling back to POST-create on a 404 — a brand
  * new workspace materialized via `openTerminal`'s "existing session, new pane"
- * branch has never gone through `createWorkspace`'s own POST. */
+ * branch has never gone through `createWorkspace`'s own POST.
+ *
+ * Calls `fetchWithAuth` directly (rather than the higher-level `patch()`
+ * helper) specifically to read the real HTTP status code: `patch()`/`post()`
+ * go through `fetchJSON`, which throws a plain `Error` with no status
+ * attached, so branching on `error.message === 'not_found'` would couple this
+ * to the exact JSON body shape `{error: 'not_found'}` and `fetchJSON`'s
+ * `json.error || json.message || text` construction — fragile to either
+ * changing out from under this call site. A raw 404 status check has no such
+ * coupling. */
 async function pushWorkspaceUpdate(machineId: string, workspaceId: string): Promise<void> {
   const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
   if (!workspace) return;
   const columns = toWireColumns(workspace.columns);
 
   try {
-    await patch('/api/machines/workspaces', { machineId, workspaceId, name: workspace.name, columns });
-  } catch (error) {
-    // Not found server-side yet — create it. `updateWorkspace`'s route returns
-    // `{error: 'not_found', reason: 'not_found'}` on a 404, which `auth-fetch.ts`
-    // surfaces as an Error whose message IS that reason string. Any OTHER
-    // failure (network blip, 500) is swallowed here: the local grid already
-    // reflects the user's action, and the next successful push (this browser's
-    // own, or a broadcast from elsewhere) reconciles the server.
-    if (!(error instanceof Error) || error.message !== 'not_found') return;
-    await post('/api/machines/workspaces', {
-      machineId,
-      id: workspace.id,
-      name: workspace.name,
-      scope: workspace.scope,
-      columns,
-    }).catch(() => {});
+    const response = await fetchWithAuth('/api/machines/workspaces', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ machineId, workspaceId, name: workspace.name, columns }),
+    });
+    if (response.ok) return;
+    if (response.status !== 404) return;
+    // Not found server-side yet — create it.
+  } catch {
+    // Network failure or similar — swallow. The local grid already reflects
+    // the user's action, and the next successful push (this browser's own,
+    // or a broadcast from elsewhere) reconciles the server.
+    return;
   }
+
+  await post('/api/machines/workspaces', {
+    machineId,
+    id: workspace.id,
+    name: workspace.name,
+    scope: workspace.scope,
+    columns,
+  }).catch(() => {});
 }
 
 function pushRemoval(machineId: string, workspaceId: string): void {

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -228,10 +228,24 @@ async function pushNewWorkspace(machineId: string, workspaceId: string): Promise
     .catch(() => {});
 }
 
+/** Which of this workspace's server-visible fields a given local action actually
+ * changed — {@link pushWorkspaceUpdate} sends only these, so a PATCH racing a
+ * DIFFERENT browser's concurrent edit to the OTHER field can't clobber it with
+ * a stale copy (see that function's doc for the concrete two-browser scenario). */
+type ChangedFields = { name?: true; columns?: true };
+
 /** For a workspace that MIGHT already exist server-side (any layout/rename change
  * after creation): PATCH first, falling back to POST-create on a 404 — a brand
  * new workspace materialized via `openTerminal`'s "existing session, new pane"
  * branch has never gone through `createWorkspace`'s own POST.
+ *
+ * `changed` restricts the PATCH body to the field(s) this specific action
+ * touched. The route (and `updateWorkspace`) already support a true partial
+ * update — name-only, columns-only, or both — precisely so this can avoid
+ * sending the field it did NOT touch: if it always sent both, a rename in one
+ * browser racing a pane split in another (each reading its OWN possibly-stale
+ * copy of the field it didn't mean to change) would have the later PATCH
+ * silently revert the earlier one's change.
  *
  * Calls `fetchWithAuth` directly (rather than the higher-level `patch()`
  * helper) specifically to read the real HTTP status code: `patch()`/`post()`
@@ -241,7 +255,7 @@ async function pushNewWorkspace(machineId: string, workspaceId: string): Promise
  * `json.error || json.message || text` construction — fragile to either
  * changing out from under this call site. A raw 404 status check has no such
  * coupling. */
-async function pushWorkspaceUpdate(machineId: string, workspaceId: string): Promise<void> {
+async function pushWorkspaceUpdate(machineId: string, workspaceId: string, changed: ChangedFields): Promise<void> {
   const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
   if (!workspace) return;
   const columns = toWireColumns(workspace.columns);
@@ -250,11 +264,18 @@ async function pushWorkspaceUpdate(machineId: string, workspaceId: string): Prom
     const response = await fetchWithAuth('/api/machines/workspaces', {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ machineId, workspaceId, name: workspace.name, columns }),
+      body: JSON.stringify({
+        machineId,
+        workspaceId,
+        ...(changed.name ? { name: workspace.name } : {}),
+        ...(changed.columns ? { columns } : {}),
+      }),
     });
     if (response.ok) return;
     if (response.status !== 404) return;
-    // Not found server-side yet — create it.
+    // Not found server-side yet — create it. This IS a brand-new row, so the
+    // full current snapshot is sent regardless of `changed` — there is no
+    // narrower "what changed" for a row that doesn't exist yet.
   } catch {
     // Network failure or similar — swallow. The local grid already reflects
     // the user's action, and the next successful push (this browser's own,
@@ -317,23 +338,35 @@ export function useSyncedWorkspaceActions(machineId: string) {
     },
     renameWorkspace(workspaceId: string, name: string): void {
       renameWorkspaceLocal(machineId, workspaceId, name);
-      void pushWorkspaceUpdate(machineId, workspaceId);
+      void pushWorkspaceUpdate(machineId, workspaceId, { name: true });
     },
     splitRight(workspaceId: string, fromPaneId: string): void {
       splitRightLocal(machineId, workspaceId, fromPaneId);
-      void pushWorkspaceUpdate(machineId, workspaceId);
+      void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
     },
     splitDown(workspaceId: string, fromPaneId: string): void {
       splitDownLocal(machineId, workspaceId, fromPaneId);
-      void pushWorkspaceUpdate(machineId, workspaceId);
+      void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
     },
     closePane(workspaceId: string, paneId: string): void {
       closePaneLocal(machineId, workspaceId, paneId);
-      void pushWorkspaceUpdate(machineId, workspaceId);
+      void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
+    },
+    /** Closes several panes of the SAME workspace as one push, not one PATCH per
+     * pane — e.g. emptying every running pane when removing the machine's only
+     * remaining workspace. `closePane` in a loop would fire N independent
+     * fire-and-forget PATCHes with no ordering guarantee: a slower EARLIER
+     * request resolving after a later one could leave the server's layout at
+     * an intermediate (still-bound-to-a-just-killed-agent) state instead of
+     * the final fully-emptied one. Applying every local close first, then
+     * pushing once, means the single PATCH always carries the final result. */
+    closePanes(workspaceId: string, paneIds: string[]): void {
+      paneIds.forEach((paneId) => closePaneLocal(machineId, workspaceId, paneId));
+      if (paneIds.length > 0) void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
     },
     bindPaneTerminal(workspaceId: string, paneId: string, scope: OpenTerminalScope, pendingPrompt?: string): boolean {
       const bound = bindPaneTerminalLocal(machineId, workspaceId, paneId, scope, pendingPrompt);
-      if (bound) void pushWorkspaceUpdate(machineId, workspaceId);
+      if (bound) void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
       return bound;
     },
     /** `openTerminal` can materialize a new workspace, relocate an existing
@@ -345,7 +378,7 @@ export function useSyncedWorkspaceActions(machineId: string) {
       const machine = useMachineWorkspaceStore.getState().machines[machineId];
       if (!machine) return;
       const home = workspaceShowing(machine, scope) ?? machine.workspaces[sessionWorkspaceId(scope)];
-      if (home) void pushWorkspaceUpdate(machineId, home.id);
+      if (home) void pushWorkspaceUpdate(machineId, home.id, { columns: true });
     },
   }), [
     machineId,

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -1,0 +1,295 @@
+'use client';
+
+/**
+ * Server-authoritative sync for a Machine's workspace list (#2048) — the
+ * successor to PR #2031's `localStorage`-only `useMachineWorkspaceStore`.
+ *
+ * Two exports, split because they have different mount-cardinality needs:
+ *
+ * - {@link useMachineWorkspaceSync} owns the stateful side effects (SWR fetch,
+ *   the one-time bootstrap race, the socket subscription) and must be mounted
+ *   exactly ONCE per machine — at `MachineView`, the true per-machine root
+ *   that survives Terminal-tab unmount/remount (Radix `TabsContent` unmounts
+ *   inactive tabs; `MachineView` doesn't).
+ * - {@link useSyncedWorkspaceActions} has no internal state to coordinate (see
+ *   its own doc for why), so it's safe to call from every component that
+ *   mutates a workspace — `WorkspaceLeaves` (sidebar) and `TerminalPanes`
+ *   (pane grid) each call it independently.
+ */
+
+import { useEffect, useMemo, useRef } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
+import { useSocket } from './useSocket';
+import { usePageSocketRoom } from './usePageSocketRoom';
+import {
+  useMachineWorkspaceStore,
+  workspacesOf,
+  workspaceShowing,
+  sessionWorkspaceId,
+  type MachineNodeScope,
+  type OpenTerminalScope,
+  type ServerWorkspaceDTO,
+  type TerminalColumnState,
+} from '@/stores/machine-workspace/useMachineWorkspaceStore';
+
+interface WorkspaceListResponse {
+  workspaces: ServerWorkspaceDTO[];
+  bootstrapped: boolean;
+}
+
+interface BootstrapResponse {
+  claimed: boolean;
+  workspaces: ServerWorkspaceDTO[];
+}
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(async (res) => {
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      throw new Error(body?.error ?? 'Failed to fetch workspaces');
+    }
+    return res.json() as Promise<WorkspaceListResponse>;
+  });
+
+/** Strips local-only pane state (`pendingPrompt`) before a layout crosses the
+ * wire — the server's layout DTO has no such field, and a starting prompt not
+ * yet typed into its PTY must never be persisted or broadcast to other browsers. */
+function toWireColumns(columns: TerminalColumnState[]) {
+  return columns.map((column) => ({
+    id: column.id,
+    panes: column.panes.map((pane) => ({ id: pane.id, scope: pane.scope })),
+  }));
+}
+
+/**
+ * Fetches the server's workspace list, seeds it from this browser's local
+ * history on first-ever load for this machine (see
+ * `machine-workspaces.ts`'s module doc for the claim/race design this relies
+ * on), and keeps the store reconciled with live `machine-workspace:*`
+ * broadcasts. Returns nothing — like `usePagePresence`, it's a side-effect hook.
+ */
+export function useMachineWorkspaceSync(machineId: string): void {
+  const ensureMachine = useMachineWorkspaceStore((state) => state.ensureMachine);
+  const hydrateFromServer = useMachineWorkspaceStore((state) => state.hydrateFromServer);
+  const applyServerUpsert = useMachineWorkspaceStore((state) => state.applyServerUpsert);
+  const applyServerDelete = useMachineWorkspaceStore((state) => state.applyServerDelete);
+
+  const socket = useSocket();
+  usePageSocketRoom(machineId);
+
+  // Guards against retrying the bootstrap POST on every SWR revalidation once
+  // this browser has already tried it for this machine — not against the
+  // cross-browser race, which the server's claim table (not this ref) resolves.
+  const bootstrapAttempted = useRef(false);
+
+  useEffect(() => {
+    ensureMachine(machineId);
+  }, [machineId, ensureMachine]);
+
+  const key = `/api/machines/workspaces?machineId=${encodeURIComponent(machineId)}`;
+  const { data } = useSWR<WorkspaceListResponse>(key, fetcher, { revalidateOnFocus: false });
+
+  useEffect(() => {
+    if (!data) return;
+
+    if (data.bootstrapped) {
+      hydrateFromServer(machineId, data.workspaces);
+      return;
+    }
+
+    if (bootstrapAttempted.current) return;
+    bootstrapAttempted.current = true;
+
+    const local = useMachineWorkspaceStore.getState().machines[machineId];
+    const payload = (local ? workspacesOf(local) : []).map((workspace) => ({
+      id: workspace.id,
+      name: workspace.name,
+      scope: workspace.scope,
+      columns: toWireColumns(workspace.columns),
+    }));
+
+    post<BootstrapResponse>('/api/machines/workspaces/bootstrap', { machineId, workspaces: payload })
+      .then((res) => hydrateFromServer(machineId, res.workspaces))
+      .catch(() => {
+        // Retry on the next data change (e.g. a manual refresh) rather than
+        // leaving this machine permanently un-bootstrapped over a transient failure.
+        bootstrapAttempted.current = false;
+      });
+  }, [machineId, data, hydrateFromServer]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const onCreated = (payload: ServerWorkspaceDTO & { machineId: string }) => {
+      if (payload.machineId !== machineId) return;
+      applyServerUpsert(machineId, payload);
+    };
+    const onUpdated = (payload: {
+      machineId: string;
+      workspaceId: string;
+      name?: string;
+      columns?: TerminalColumnState[];
+    }) => {
+      if (payload.machineId !== machineId) return;
+      // `updated` only carries whichever of name/columns actually changed —
+      // fill in the rest from what this browser already has for it.
+      const current = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[payload.workspaceId];
+      applyServerUpsert(machineId, {
+        id: payload.workspaceId,
+        name: payload.name ?? current?.name ?? '',
+        scope: current?.scope ?? {},
+        columns: payload.columns ?? current?.columns ?? [],
+      });
+    };
+    const onDeleted = (payload: { machineId: string; workspaceId: string }) => {
+      if (payload.machineId !== machineId) return;
+      applyServerDelete(machineId, payload.workspaceId);
+    };
+    const onBootstrapped = (payload: { machineId: string; workspaces: ServerWorkspaceDTO[] }) => {
+      if (payload.machineId !== machineId) return;
+      hydrateFromServer(machineId, payload.workspaces);
+    };
+
+    socket.on('machine-workspace:created', onCreated);
+    socket.on('machine-workspace:updated', onUpdated);
+    socket.on('machine-workspace:deleted', onDeleted);
+    socket.on('machine-workspace:bootstrapped', onBootstrapped);
+    return () => {
+      socket.off('machine-workspace:created', onCreated);
+      socket.off('machine-workspace:updated', onUpdated);
+      socket.off('machine-workspace:deleted', onDeleted);
+      socket.off('machine-workspace:bootstrapped', onBootstrapped);
+    };
+  }, [socket, machineId, applyServerUpsert, applyServerDelete, hydrateFromServer]);
+}
+
+async function pushNewWorkspace(machineId: string, workspaceId: string): Promise<void> {
+  const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
+  if (!workspace) return;
+  await post('/api/machines/workspaces', {
+    machineId,
+    id: workspace.id,
+    name: workspace.name,
+    scope: workspace.scope,
+    columns: toWireColumns(workspace.columns),
+  }).catch(() => {});
+}
+
+/** For a workspace that MIGHT already exist server-side (any layout/rename change
+ * after creation): PATCH first, falling back to POST-create on a 404 — a brand
+ * new workspace materialized via `openTerminal`'s "existing session, new pane"
+ * branch has never gone through `createWorkspace`'s own POST. */
+async function pushWorkspaceUpdate(machineId: string, workspaceId: string): Promise<void> {
+  const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
+  if (!workspace) return;
+  const columns = toWireColumns(workspace.columns);
+
+  try {
+    await patch('/api/machines/workspaces', { machineId, workspaceId, name: workspace.name, columns });
+  } catch (error) {
+    // Not found server-side yet — create it. `updateWorkspace`'s route returns
+    // `{error: 'not_found', reason: 'not_found'}` on a 404, which `auth-fetch.ts`
+    // surfaces as an Error whose message IS that reason string. Any OTHER
+    // failure (network blip, 500) is swallowed here: the local grid already
+    // reflects the user's action, and the next successful push (this browser's
+    // own, or a broadcast from elsewhere) reconciles the server.
+    if (!(error instanceof Error) || error.message !== 'not_found') return;
+    await post('/api/machines/workspaces', {
+      machineId,
+      id: workspace.id,
+      name: workspace.name,
+      scope: workspace.scope,
+      columns,
+    }).catch(() => {});
+  }
+}
+
+function pushRemoval(machineId: string, workspaceId: string): void {
+  del(
+    `/api/machines/workspaces?machineId=${encodeURIComponent(machineId)}&workspaceId=${encodeURIComponent(workspaceId)}`
+  ).catch(() => {});
+}
+
+/**
+ * Server-pushing wrappers around the workspace store's identity/layout
+ * actions: call the real local action first (unchanged, instant), then push
+ * the affected workspace's resulting state to the server. `createWorkspace`
+ * knows its workspace is brand new (a fresh local id) and POSTs directly;
+ * every other action might be touching a workspace that already exists
+ * server-side OR doesn't yet (e.g. `openTerminal` materializing a new one),
+ * so those PATCH first and fall back to POST-create on a 404. That fallback
+ * (rather than a client-tracked "known server ids" set) is what lets this be
+ * called independently from more than one component with no shared state to
+ * keep in sync.
+ *
+ * Actions that stay purely local, not wrapped here: `setActiveWorkspace`,
+ * `selectPane`, `dismissPicker`, `clearPanePrompt`, `ensureMachine`.
+ */
+export function useSyncedWorkspaceActions(machineId: string) {
+  // Zustand action references are stable across renders; only `machineId`
+  // ever changes, so `useMemo` gives callers (e.g. `useCallback` deps in
+  // `TerminalPanes`) a stable object instead of a fresh one every render.
+  const createWorkspaceLocal = useMachineWorkspaceStore((state) => state.createWorkspace);
+  const removeWorkspaceLocal = useMachineWorkspaceStore((state) => state.removeWorkspace);
+  const renameWorkspaceLocal = useMachineWorkspaceStore((state) => state.renameWorkspace);
+  const splitRightLocal = useMachineWorkspaceStore((state) => state.splitRight);
+  const splitDownLocal = useMachineWorkspaceStore((state) => state.splitDown);
+  const closePaneLocal = useMachineWorkspaceStore((state) => state.closePane);
+  const bindPaneTerminalLocal = useMachineWorkspaceStore((state) => state.bindPaneTerminal);
+  const openTerminalLocal = useMachineWorkspaceStore((state) => state.openTerminal);
+
+  return useMemo(() => ({
+    createWorkspace(scope?: MachineNodeScope): string {
+      const id = createWorkspaceLocal(machineId, scope);
+      void pushNewWorkspace(machineId, id);
+      return id;
+    },
+    removeWorkspace(workspaceId: string): void {
+      removeWorkspaceLocal(machineId, workspaceId);
+      pushRemoval(machineId, workspaceId);
+    },
+    renameWorkspace(workspaceId: string, name: string): void {
+      renameWorkspaceLocal(machineId, workspaceId, name);
+      void pushWorkspaceUpdate(machineId, workspaceId);
+    },
+    splitRight(workspaceId: string, fromPaneId: string): void {
+      splitRightLocal(machineId, workspaceId, fromPaneId);
+      void pushWorkspaceUpdate(machineId, workspaceId);
+    },
+    splitDown(workspaceId: string, fromPaneId: string): void {
+      splitDownLocal(machineId, workspaceId, fromPaneId);
+      void pushWorkspaceUpdate(machineId, workspaceId);
+    },
+    closePane(workspaceId: string, paneId: string): void {
+      closePaneLocal(machineId, workspaceId, paneId);
+      void pushWorkspaceUpdate(machineId, workspaceId);
+    },
+    bindPaneTerminal(workspaceId: string, paneId: string, scope: OpenTerminalScope, pendingPrompt?: string): boolean {
+      const bound = bindPaneTerminalLocal(machineId, workspaceId, paneId, scope, pendingPrompt);
+      if (bound) void pushWorkspaceUpdate(machineId, workspaceId);
+      return bound;
+    },
+    /** `openTerminal` can materialize a new workspace, relocate an existing
+     * one to front, or land in one already showing the session — push
+     * whichever workspace it actually affected, resolved the same way the
+     * local action itself resolves "where does this session live". */
+    openTerminal(scope: OpenTerminalScope): void {
+      openTerminalLocal(machineId, scope);
+      const machine = useMachineWorkspaceStore.getState().machines[machineId];
+      if (!machine) return;
+      const home = workspaceShowing(machine, scope) ?? machine.workspaces[sessionWorkspaceId(scope)];
+      if (home) void pushWorkspaceUpdate(machineId, home.id);
+    },
+  }), [
+    machineId,
+    createWorkspaceLocal,
+    removeWorkspaceLocal,
+    renameWorkspaceLocal,
+    splitRightLocal,
+    splitDownLocal,
+    closePaneLocal,
+    bindPaneTerminalLocal,
+    openTerminalLocal,
+  ]);
+}

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -133,6 +133,14 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
 
     post<BootstrapResponse>('/api/machines/workspaces/bootstrap', { machineId, workspaces: payload })
       .then((res) => {
+        // This request's own resolution races the socket subscription below:
+        // apps/realtime's `io.to(channelId).emit(...)` broadcasts this exact
+        // bootstrap claim back to every socket in the room, INCLUDING this
+        // browser's own — so `onBootstrapped` can already have hydrated (and
+        // set `hydratedOnce`) before this `.then()` runs. Re-running the
+        // full-list replace here too would risk wiping a workspace created in
+        // that window.
+        if (hydratedOnce.current) return;
         hydratedOnce.current = true;
         hydrateFromServer(machineId, res.workspaces);
       })
@@ -186,6 +194,17 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
     };
     const onBootstrapped = (payload: { machineId: string; workspaces: ServerWorkspaceDTO[] }) => {
       if (payload.machineId !== mid) return;
+      // `io.to(channelId).emit(...)` (apps/realtime) reaches EVERY socket in the
+      // room, including the one that POSTed this very bootstrap — so the
+      // browser that just won the claim race receives its own broadcast back.
+      // Its own bootstrap POST already ran the (guarded) full-list replace via
+      // `hydratedOnce`; re-running it here unconditionally would risk wiping a
+      // workspace this browser created in the narrow window between that POST
+      // resolving and this broadcast arriving. Only apply it if this browser
+      // hasn't hydrated yet (e.g. it's a DIFFERENT browser that joined the
+      // socket room before its own GET/bootstrap round trip completed).
+      if (hydratedOnce.current) return;
+      hydratedOnce.current = true;
       hydrateFromServer(mid, payload.workspaces);
     };
 

--- a/apps/web/src/lib/machines/machine-workspaces-runtime.ts
+++ b/apps/web/src/lib/machines/machine-workspaces-runtime.ts
@@ -9,12 +9,56 @@
  * that module's own doc comment for new routes.
  */
 
+import { NextResponse } from 'next/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canViewMachine, canEditMachine as canAccessMachine } from './machine-access-runtime';
 import { createDbMachineWorkspaceStore } from '@pagespace/lib/services/machines/machine-workspaces-store';
 import type { MachineWorkspaceRecord } from '@pagespace/lib/services/machines/machine-workspaces-store';
 import type { MachineWorkspacesDeps } from '@pagespace/lib/services/machines/machine-workspaces';
 
 export { canViewMachine, canAccessMachine };
+
+/** Shared by every machine-workspaces route (`route.ts`, `bootstrap/route.ts`)
+ * for both the `auditRequest` resource type and denial-reason status mapping
+ * below — kept here, not duplicated per-file, so the two routes can't
+ * silently drift on what they audit or which denial reason maps to which
+ * HTTP status. */
+export const RESOURCE_TYPE = 'machine';
+
+/** Status code for each denial reason `createWorkspace`/`updateWorkspace`/
+ * `bootstrapWorkspaces` can return (see machine-workspaces.ts's `WorkspacePlanDenialReason`). */
+export const WORKSPACE_DENIAL_STATUS: Record<string, number> = {
+  invalid_name: 400,
+  invalid_columns: 400,
+  not_found: 404,
+};
+
+/** Parses the wire `{projectName?, branchName?}` scope shape from a POST/bootstrap
+ * body, dropping empty-string fields so `deriveWorkspaceScope` sees them as absent. */
+export function scopeFromBody(value: unknown): { projectName?: string; branchName?: string } {
+  if (typeof value !== 'object' || value === null) return {};
+  const candidate = value as { projectName?: unknown; branchName?: unknown };
+  return {
+    ...(typeof candidate.projectName === 'string' && candidate.projectName.length > 0
+      ? { projectName: candidate.projectName }
+      : {}),
+    ...(typeof candidate.branchName === 'string' && candidate.branchName.length > 0
+      ? { branchName: candidate.branchName }
+      : {}),
+  };
+}
+
+/** Audits the authz denial (so SIEM can detect probing) and returns a fresh 403. */
+export function forbiddenMachineAccess(request: Request, userId: string, machineId: string): NextResponse {
+  auditRequest(request, {
+    eventType: 'authz.access.denied',
+    userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId,
+    riskScore: 0.5,
+  });
+  return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
+}
 
 /** The wire shape returned to clients — a `MachineWorkspaceRecord` with its
  * scope columns folded back into the nested `{projectName?, branchName?}`

--- a/apps/web/src/lib/machines/machine-workspaces-runtime.ts
+++ b/apps/web/src/lib/machines/machine-workspaces-runtime.ts
@@ -1,0 +1,66 @@
+/**
+ * Production wiring for Machine Workspaces (the sidebar's named pane-grid
+ * workspaces — server-authoritative sync, see #2048).
+ *
+ * Pure metadata CRUD, unlike the sandbox/git-backed Projects/Branches
+ * runtimes — `buildMachineWorkspacesDeps` only needs a store and a clock.
+ * Reuses the canonical shared access check (`./machine-access-runtime`)
+ * rather than re-deriving `canViewMachine`/`canAccessMachine` inline, per
+ * that module's own doc comment for new routes.
+ */
+
+import { canViewMachine, canEditMachine as canAccessMachine } from './machine-access-runtime';
+import { createDbMachineWorkspaceStore } from '@pagespace/lib/services/machines/machine-workspaces-store';
+import type { MachineWorkspaceRecord } from '@pagespace/lib/services/machines/machine-workspaces-store';
+import type { MachineWorkspacesDeps } from '@pagespace/lib/services/machines/machine-workspaces';
+
+export { canViewMachine, canAccessMachine };
+
+/** The wire shape returned to clients — a `MachineWorkspaceRecord` with its
+ * scope columns folded back into the nested `{projectName?, branchName?}`
+ * shape the client's `MachineNodeScope` uses, and `layout.columns` hoisted
+ * to a bare `columns` field (the client's `WorkspaceState` has no `layout`
+ * wrapper — that's a server/DB-only nesting detail). */
+export interface WorkspaceDTO {
+  id: string;
+  name: string;
+  scope: { projectName?: string; branchName?: string };
+  columns: MachineWorkspaceRecord['layout']['columns'];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export function toWorkspaceDTO(record: MachineWorkspaceRecord): WorkspaceDTO {
+  return {
+    id: record.id,
+    name: record.name,
+    scope: {
+      ...(record.projectName ? { projectName: record.projectName } : {}),
+      ...(record.branchName ? { branchName: record.branchName } : {}),
+    },
+    columns: record.layout.columns,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  };
+}
+
+let storePromise: ReturnType<typeof createDbMachineWorkspaceStore> | null = null;
+function getStore() {
+  storePromise ??= createDbMachineWorkspaceStore();
+  return storePromise;
+}
+
+export function buildMachineWorkspacesDeps(): MachineWorkspacesDeps {
+  return {
+    store: {
+      list: async (machineId) => (await getStore()).list(machineId),
+      findById: async (machineId, id) => (await getStore()).findById(machineId, id),
+      insertIfAbsent: async (input) => (await getStore()).insertIfAbsent(input),
+      update: async (machineId, id, patch, now) => (await getStore()).update(machineId, id, patch, now),
+      remove: async (machineId, id) => (await getStore()).remove(machineId, id),
+      isBootstrapped: async (machineId) => (await getStore()).isBootstrapped(machineId),
+      bootstrapSeed: async (input) => (await getStore()).bootstrapSeed(input),
+    },
+    now: () => new Date(),
+  };
+}

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -687,6 +687,49 @@ export async function broadcastThreadReplyCountUpdated(
   }
 }
 
+/**
+ * Broadcasts a `machine-workspace:*` event to a Machine's page-id room (see
+ * apps/realtime's `join_channel`/`getUserAccessLevel` — a Machine's identity
+ * IS its backing page id, so this reaches every browser/user currently
+ * viewing that Machine). Generic over `event`/`payload` rather than one
+ * function per event, unlike most broadcasters in this file, since the four
+ * `machine-workspace:*` events (`created`/`updated`/`deleted`/`bootstrapped`)
+ * share nothing beyond "something about this machine's workspace list
+ * changed" — modeled on `broadcastThreadReplyCountUpdated`'s raw-channelId
+ * shape rather than inventing four near-identical wrapper functions.
+ *
+ * Failures are logged and swallowed — the originating DB write has already
+ * committed, and a missed broadcast just means other browsers catch up on
+ * their next `GET /api/machines/workspaces` instead of live.
+ */
+export async function broadcastMachineWorkspaceEvent(
+  machineId: string,
+  event: string,
+  payload: unknown
+): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping machine workspace broadcast', { event });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({ channelId: machineId, event, payload });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error('Failed to broadcast machine workspace event', error instanceof Error ? error : undefined, {
+      event,
+      channel: maskIdentifier(machineId),
+    });
+  }
+}
+
 // ============================================================================
 // AI Stream Events
 // ============================================================================

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -469,4 +469,90 @@ describe('useMachineWorkspaceStore', () => {
       expected: { stable: true, freshAfterChange: true },
     });
   });
+
+  // ---------------------------------------------------------------------
+  // Server sync actions (#2048)
+  // ---------------------------------------------------------------------
+
+  it('given renameWorkspace, should rename only the named workspace', () => {
+    store().ensureMachine('m1');
+    const workspace = activeOf('m1')!;
+
+    store().renameWorkspace('m1', workspace.id, 'Renamed');
+
+    assert({
+      given: "a rename of a machine's only workspace",
+      should: 'apply the new name in place',
+      actual: activeOf('m1')?.name,
+      expected: 'Renamed',
+    });
+  });
+
+  it('given hydrateFromServer with no prior local state, should build a renderable machine from the server list', () => {
+    store().hydrateFromServer('m1', [
+      { id: 'ws-1', name: 'Workspace 1', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+    ]);
+
+    assert({
+      given: 'the sync hook\'s initial hydrate, for a machine this browser has never opened',
+      should: 'adopt the server\'s workspace as this machine\'s state',
+      actual: { active: activeOf('m1')?.id, name: activeOf('m1')?.name },
+      expected: { active: 'ws-1', name: 'Workspace 1' },
+    });
+  });
+
+  it('given hydrateFromServer for an already-open workspace, should preserve local focus', () => {
+    store().ensureMachine('m1');
+    const workspace = activeOf('m1')!;
+    store().splitRight('m1', workspace.id, workspace.activePaneId);
+    const afterSplit = activeOf('m1')!;
+    const secondPaneId = paneIds(afterSplit)[1];
+    store().selectPane('m1', workspace.id, secondPaneId);
+
+    store().hydrateFromServer('m1', [
+      { id: workspace.id, name: workspace.name, scope: workspace.scope, columns: afterSplit.columns },
+    ]);
+
+    assert({
+      given: 'a server payload for a workspace this browser already has open with a pane focused',
+      should: 'keep the LOCAL activePaneId — focus never comes from the server',
+      actual: activeOf('m1')?.activePaneId,
+      expected: secondPaneId,
+    });
+  });
+
+  it('given applyServerUpsert for an unseen workspace id, should add it', () => {
+    store().ensureMachine('m1');
+    const existing = activeOf('m1')!;
+
+    store().applyServerUpsert('m1', {
+      id: 'ws-from-elsewhere',
+      name: 'Created elsewhere',
+      scope: {},
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }],
+    });
+
+    assert({
+      given: 'a machine-workspace:created broadcast for a workspace another browser just made',
+      should: "add it alongside this machine's existing workspace",
+      actual: workspacesOf(selectMachine('m1')(store())).map((w) => w.id).sort(),
+      expected: [existing.id, 'ws-from-elsewhere'].sort(),
+    });
+  });
+
+  it('given applyServerDelete for the active workspace, should show a neighbour', () => {
+    store().ensureMachine('m1');
+    const first = activeOf('m1')!;
+    const secondId = store().createWorkspace('m1');
+    store().setActiveWorkspace('m1', secondId);
+
+    store().applyServerDelete('m1', secondId);
+
+    assert({
+      given: 'a machine-workspace:deleted broadcast for the workspace currently on screen',
+      should: 'drop it and fall back to a neighbour, same as a local removeWorkspace',
+      actual: activeOf('m1')?.id,
+      expected: first.id,
+    });
+  });
 });

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -765,6 +765,32 @@ describe('sanitizeMachines — what comes back from storage is untrusted', () =>
     });
   });
 
+  it('given a workspace id persisted with the legacy NUL delimiter, should migrate it to the current one', () => {
+    const legacyId = 'session repo main claude-a1';
+    const currentId = 'sessionrepomainclaude-a1';
+    const persisted = {
+      m1: {
+        workspaces: { [legacyId]: aWorkspace(legacyId, 'p1') },
+        order: [legacyId],
+        activeWorkspaceId: legacyId,
+      },
+    };
+
+    const actual = sanitizeMachines(persisted);
+
+    assert({
+      given: "a session-derived workspace id persisted by a version of this app that predates the U+001F delimiter switch (it used NUL, which Postgres text columns reject outright)",
+      should: 'migrate the id everywhere it appears — the record key, the workspace\'s own id field, order, and activeWorkspaceId — so a bootstrap POST of this browser\'s local history never sends a doomed id to the server',
+      actual: {
+        keys: Object.keys(actual.m1.workspaces),
+        ownId: actual.m1.workspaces[currentId]?.id,
+        order: actual.m1.order,
+        active: actual.m1.activeWorkspaceId,
+      },
+      expected: { keys: [currentId], ownId: currentId, order: [currentId], active: currentId },
+    });
+  });
+
   it('given transient UI state in storage, should strip it', () => {
     const withTransient = {
       m1: {

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -20,10 +20,15 @@ import {
   panesOf,
   showSessionIn,
   removeWorkspace,
+  renameWorkspace,
+  mergeServerWorkspaces,
+  applyServerWorkspaceUpsert,
+  applyServerWorkspaceDeleted,
   sanitizeMachines,
   autoSessionName,
   MACHINE_NODE_SCOPE,
   type WorkspaceState,
+  type ServerWorkspaceDTO,
 } from '../workspace-reducer';
 
 const BRANCH_SCOPE = { projectName: 'app', branchName: 'main' };
@@ -187,6 +192,17 @@ describe('sessionWorkspaceId', () => {
       should: 'give each its own workspace — they are different sessions in different checkouts',
       actual: ids.size,
       expected: 3,
+    });
+  });
+
+  it('given any scope, should never contain a NUL byte', () => {
+    const id = sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3' });
+
+    assert({
+      given: 'a workspace id that is also the primary key of the server-side machine_workspaces row',
+      should: 'contain no U+0000 — Postgres text columns reject a literal NUL byte outright',
+      actual: id.includes('\u0000'),
+      expected: false,
     });
   });
 });
@@ -554,6 +570,166 @@ describe('removeWorkspace', () => {
       given: 'the only workspace a machine has',
       should: 'refuse — the middle view would have nothing to render (a broken pane can be emptied instead)',
       actual: removeWorkspace(machine, 'ws-1'),
+      expected: machine,
+    });
+  });
+});
+
+describe('renameWorkspace', () => {
+  it('given a new name, should rename only that workspace', () => {
+    const machine = addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1'));
+
+    const renamed = renameWorkspace(machine, 'ws-b', 'Renamed');
+
+    assert({
+      given: 'a rename addressed to one workspace of two',
+      should: 'change only its name, leaving the sibling and the rest of the grid untouched',
+      actual: { a: renamed.workspaces['ws-a'].name, b: renamed.workspaces['ws-b'].name },
+      expected: { a: 'ws-a', b: 'Renamed' },
+    });
+  });
+
+  it('given an unknown workspace id, should be a no-op', () => {
+    const machine = initialMachineWorkspaces(aWorkspace());
+
+    assert({
+      given: 'a rename addressed to a workspace that is gone',
+      should: 'be a no-op rather than an error',
+      actual: renameWorkspace(machine, 'ws-gone', 'Renamed'),
+      expected: machine,
+    });
+  });
+});
+
+describe('mergeServerWorkspaces — reconciling the server\'s workspace list', () => {
+  const serverWorkspace = (overrides: Partial<ServerWorkspaceDTO> = {}): ServerWorkspaceDTO => ({
+    id: 'ws-1',
+    name: 'Workspace 1',
+    scope: BRANCH_SCOPE,
+    columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }],
+    ...overrides,
+  });
+
+  it('given no local state, should build a fresh machine from the server list', () => {
+    const merged = mergeServerWorkspaces(undefined, [serverWorkspace()]);
+
+    assert({
+      given: 'a browser with nothing local yet for this machine',
+      should: 'adopt the server workspace, defaulting activePaneId to its first pane',
+      actual: { order: merged.order, active: merged.activeWorkspaceId, activePane: merged.workspaces['ws-1'].activePaneId },
+      expected: { order: ['ws-1'], active: 'ws-1', activePane: 'pane-1' },
+    });
+  });
+
+  it('given a matching local workspace, should preserve its local-only fields, not the server\'s', () => {
+    const local = initialMachineWorkspaces(
+      splitRight(aWorkspace('ws-1', 'pane-1'), 'pane-1', 'col-2', 'pane-2')
+    );
+    const focused = { ...local, workspaces: { ...local.workspaces, 'ws-1': selectPane(local.workspaces['ws-1'], 'pane-2') } };
+
+    // The server reports the SAME grid shape (both panes still exist).
+    const merged = mergeServerWorkspaces(focused, [
+      serverWorkspace({ columns: focused.workspaces['ws-1'].columns.map((c) => ({ id: c.id, panes: c.panes.map((p) => ({ id: p.id, scope: p.scope })) })) }),
+    ]);
+
+    assert({
+      given: 'a server payload for a workspace this browser already has open, with a pane focused',
+      should: 'keep the LOCAL activePaneId — focus is presence-like and never comes from the server',
+      actual: merged.workspaces['ws-1'].activePaneId,
+      expected: 'pane-2',
+    });
+  });
+
+  it('given a surviving pane with a local pendingPrompt, should preserve it across the server\'s columns', () => {
+    const local = initialMachineWorkspaces(assignPane(aWorkspace('ws-1', 'pane-1'), 'pane-1', { name: 'claude-a1' }, 'fix the build'));
+
+    const merged = mergeServerWorkspaces(local, [
+      serverWorkspace({ columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1' } }] }] }),
+    ]);
+
+    assert({
+      given: 'an incoming layout for a pane that still exists locally with an undelivered starting prompt',
+      should: 'keep the prompt — it has not been typed into its PTY yet, and the server never carries this field',
+      actual: panesOf(merged.workspaces['ws-1'])[0].pendingPrompt,
+      expected: 'fix the build',
+    });
+  });
+
+  it('given a local-only workspace the server does not know about, should drop it — not merge unpublished history', () => {
+    const local = addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1'));
+
+    const merged = mergeServerWorkspaces(local, [serverWorkspace({ id: 'ws-a', columns: local.workspaces['ws-a'].columns })]);
+
+    assert({
+      given:
+        'a server list that only includes one of this browser\'s two local workspaces (it lost the bootstrap race, or the machine was already bootstrapped by someone else)',
+      should:
+        'adopt ONLY the server\'s list — a local-only straggler is either a disposable ensureMachine placeholder or unmigrated history, and keeping it would leave a permanent phantom workspace nothing ever prunes',
+      actual: merged.order,
+      expected: ['ws-a'],
+    });
+  });
+});
+
+describe('applyServerWorkspaceUpsert', () => {
+  it('given a brand-new workspace id, should add it to the end of order', () => {
+    const machine = initialMachineWorkspaces(aWorkspace('ws-a', 'a1'));
+
+    const applied = applyServerWorkspaceUpsert(machine, {
+      id: 'ws-b',
+      name: 'Workspace 2',
+      scope: {},
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }],
+    });
+
+    assert({
+      given: 'a machine-workspace:created event for a workspace this browser has never seen',
+      should: 'append it to order and make it renderable',
+      actual: { order: applied.order, name: applied.workspaces['ws-b'].name },
+      expected: { order: ['ws-a', 'ws-b'], name: 'Workspace 2' },
+    });
+  });
+
+  it('given an existing workspace id, should update it in place without touching order', () => {
+    const machine = addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1'));
+
+    const applied = applyServerWorkspaceUpsert(machine, {
+      id: 'ws-a',
+      name: 'Renamed elsewhere',
+      scope: BRANCH_SCOPE,
+      columns: machine.workspaces['ws-a'].columns,
+    });
+
+    assert({
+      given: 'a machine-workspace:updated event (a rename from another browser) for a known workspace',
+      should: 'update its name in place — order is unchanged, this workspace already had a slot',
+      actual: { order: applied.order, name: applied.workspaces['ws-a'].name },
+      expected: { order: ['ws-a', 'ws-b'], name: 'Renamed elsewhere' },
+    });
+  });
+});
+
+describe('applyServerWorkspaceDeleted', () => {
+  it('given an incoming delete for a known workspace, should remove it and show a neighbour', () => {
+    const machine = addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1'));
+
+    const applied = applyServerWorkspaceDeleted(setActiveWorkspace(machine, 'ws-b'), 'ws-b');
+
+    assert({
+      given: 'a machine-workspace:deleted event for the workspace currently on screen',
+      should: 'drop it and show its neighbour — same behaviour as a local removeWorkspace',
+      actual: { order: applied.order, active: applied.activeWorkspaceId },
+      expected: { order: ['ws-a'], active: 'ws-a' },
+    });
+  });
+
+  it('given the machine\'s only workspace, should keep it — a machine never renders zero workspaces', () => {
+    const machine = initialMachineWorkspaces(aWorkspace());
+
+    assert({
+      given: 'a delete event for the last workspace this browser has locally',
+      should: 'be a no-op, converging once this browser\'s own next write reconciles the server',
+      actual: applyServerWorkspaceDeleted(machine, 'ws-1'),
       expected: machine,
     });
   });

--- a/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
+++ b/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
@@ -25,10 +25,14 @@ import {
   addWorkspace,
   updateWorkspace,
   removeWorkspace as removeWorkspaceTransition,
+  renameWorkspace as renameWorkspaceTransition,
   showSessionIn,
   workspaceShowing,
   paneShowing,
   sanitizeMachines,
+  mergeServerWorkspaces,
+  applyServerWorkspaceUpsert,
+  applyServerWorkspaceDeleted,
   sessionWorkspaceId,
   nextWorkspaceName,
   setActiveWorkspace as setActiveWorkspaceTransition,
@@ -50,6 +54,7 @@ import {
   type MachineNodeScope,
   type MachineWorkspacesState,
   type OpenTerminalScope,
+  type ServerWorkspaceDTO,
   type TerminalColumnState,
   type TerminalPaneState,
   type WorkspaceState,
@@ -59,11 +64,20 @@ export type {
   MachineNodeScope,
   MachineWorkspacesState,
   OpenTerminalScope,
+  ServerWorkspaceDTO,
   TerminalColumnState,
   TerminalPaneState,
   WorkspaceState,
 };
-export { autoSessionName, panesOf, workspacesOf, isSameNodeScope, sessionWorkspaceId, MACHINE_NODE_SCOPE };
+export {
+  autoSessionName,
+  panesOf,
+  workspacesOf,
+  isSameNodeScope,
+  sessionWorkspaceId,
+  MACHINE_NODE_SCOPE,
+  workspaceShowing,
+};
 
 /** Bump when the persisted shape changes; see the `migrate`/`merge` note below. */
 const PERSISTED_VERSION = 1;
@@ -79,6 +93,16 @@ interface MachineWorkspaceStoreState {
   setActiveWorkspace: (machineId: string, workspaceId: string) => void;
   /** Drops a workspace and shows a neighbour. A machine keeps at least one. */
   removeWorkspace: (machineId: string, workspaceId: string) => void;
+  /** Local rename — the server-synced wrapper (`useMachineWorkspaceSync`) pushes this to the server too. */
+  renameWorkspace: (machineId: string, workspaceId: string, name: string) => void;
+  /** Reconciles a machine's FULL server workspace list into local state — the
+   * sync hook's initial hydrate step. Local-only fields (`activePaneId`,
+   * `pendingPickerPaneId`, pane `pendingPrompt`) are preserved, never overwritten. */
+  hydrateFromServer: (machineId: string, workspaces: ServerWorkspaceDTO[]) => void;
+  /** Reconciles one incoming `machine-workspace:created`/`:updated` broadcast. */
+  applyServerUpsert: (machineId: string, workspace: ServerWorkspaceDTO) => void;
+  /** Reconciles an incoming `machine-workspace:deleted` broadcast. */
+  applyServerDelete: (machineId: string, workspaceId: string) => void;
   /** Opens an existing session: its own workspace, restored if it already has
    * one, and shown. */
   openTerminal: (machineId: string, scope: OpenTerminalScope) => void;
@@ -176,6 +200,30 @@ export const useMachineWorkspaceStore = create<MachineWorkspaceStoreState>()(
 
       removeWorkspace: (machineId, workspaceId) => {
         set((state) => applyToMachine(state, machineId, (machine) => removeWorkspaceTransition(machine, workspaceId)));
+      },
+
+      renameWorkspace: (machineId, workspaceId, name) => {
+        set((state) => applyToMachine(state, machineId, (machine) => renameWorkspaceTransition(machine, workspaceId, name)));
+      },
+
+      hydrateFromServer: (machineId, workspaces) => {
+        set((state) => ({
+          machines: { ...state.machines, [machineId]: mergeServerWorkspaces(state.machines[machineId], workspaces) },
+        }));
+      },
+
+      applyServerUpsert: (machineId, workspace) => {
+        set((state) => {
+          const machine = state.machines[machineId];
+          const next = machine
+            ? applyServerWorkspaceUpsert(machine, workspace)
+            : mergeServerWorkspaces(undefined, [workspace]);
+          return { machines: { ...state.machines, [machineId]: next } };
+        });
+      },
+
+      applyServerDelete: (machineId, workspaceId) => {
+        set((state) => applyToMachine(state, machineId, (machine) => applyServerWorkspaceDeleted(machine, workspaceId)));
       },
 
       openTerminal: (machineId, scope) => {

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -327,6 +327,12 @@ export function updateWorkspace(
   return { ...state, workspaces: { ...state.workspaces, [workspaceId]: next } };
 }
 
+/** Renames one workspace, addressed by id — same explicit-id convention as
+ * every other machine-level transition here (never "the active one"). */
+export function renameWorkspace(state: MachineWorkspacesState, workspaceId: string, name: string): MachineWorkspacesState {
+  return updateWorkspace(state, workspaceId, (workspace) => (workspace.name === name ? workspace : { ...workspace, name }));
+}
+
 export function workspacesOf(state: MachineWorkspacesState): WorkspaceState[] {
   return state.order.map((id) => state.workspaces[id]).filter(Boolean);
 }
@@ -451,6 +457,128 @@ export function removeWorkspace(state: MachineWorkspacesState, workspaceId: stri
 }
 
 // ---------------------------------------------------------------------------
+// Server sync — reconciling the shared, pushed workspace list (#2048)
+// ---------------------------------------------------------------------------
+
+/**
+ * The shared, server-owned half of a workspace — what `GET
+ * /api/machines/workspaces` and every `machine-workspace:*` broadcast carry.
+ * Deliberately mirrors (does not import) the server's `WorkspaceDTO`
+ * (apps/web/src/lib/machines/machine-workspaces-runtime.ts): this reducer
+ * cannot depend on an API route module, the same duplication already exists
+ * between this file's `OpenTerminalScope`/`MachineNodeScope` and the
+ * `machine_agent_terminals` schema's scope columns.
+ *
+ * Excludes `activePaneId`, `pendingPickerPaneId`, and any pane's
+ * `pendingPrompt` — those are local-only UI state (see `sanitizeMachines`'s
+ * doc) and are preserved from whatever this browser already had, never
+ * overwritten by an incoming server payload.
+ */
+export interface ServerWorkspaceDTO {
+  id: string;
+  name: string;
+  scope: MachineNodeScope;
+  columns: TerminalColumnState[];
+}
+
+function pendingPromptsOf(workspace: WorkspaceState | undefined): Map<string, string> {
+  const prompts = new Map<string, string>();
+  if (!workspace) return prompts;
+  for (const pane of panesOf(workspace)) {
+    if (pane.pendingPrompt !== undefined) prompts.set(pane.id, pane.pendingPrompt);
+  }
+  return prompts;
+}
+
+/** Applies the server's columns, but keeps any surviving pane's local-only
+ * `pendingPrompt` — a starting prompt not yet typed into its PTY must not be
+ * dropped just because an unrelated layout change from another browser landed. */
+function mergeColumns(existing: WorkspaceState | undefined, serverColumns: TerminalColumnState[]): TerminalColumnState[] {
+  const prompts = pendingPromptsOf(existing);
+  return serverColumns.map((column) => ({
+    id: column.id,
+    panes: column.panes.map((pane) => {
+      const pendingPrompt = prompts.get(pane.id);
+      return pendingPrompt === undefined ? { id: pane.id, scope: pane.scope } : { id: pane.id, scope: pane.scope, pendingPrompt };
+    }),
+  }));
+}
+
+/** One server workspace, reconciled against whatever local copy (if any) this
+ * browser already had — the shared fields come from the server; the local-only
+ * ones (`activePaneId`, `pendingPickerPaneId`, panes' `pendingPrompt`) are
+ * preserved when they still resolve, defaulted otherwise. */
+function toLocalWorkspace(existing: WorkspaceState | undefined, ws: ServerWorkspaceDTO): WorkspaceState {
+  const columns = mergeColumns(existing, ws.columns);
+  const paneIds = columns.flatMap((column) => column.panes.map((pane) => pane.id));
+
+  const activePaneId =
+    existing && paneIds.includes(existing.activePaneId) ? existing.activePaneId : paneIds[0];
+  const pendingPickerPaneId =
+    existing?.pendingPickerPaneId && paneIds.includes(existing.pendingPickerPaneId) ? existing.pendingPickerPaneId : null;
+
+  return { id: ws.id, name: ws.name, scope: ws.scope, columns, activePaneId, pendingPickerPaneId };
+}
+
+/**
+ * Reconciles a machine's FULL server workspace list into its local state —
+ * used once, on initial load (`useMachineWorkspaceSync`'s hydrate step).
+ * `order` follows the server's list order (`createdAt` ascending).
+ *
+ * Deliberately does NOT keep local-only stragglers — a workspace this browser
+ * has locally but the server list doesn't include. `ensureMachine` runs
+ * synchronously, before the server ever answers, so by the time this merge
+ * sees it, one of two things is true: either this browser's local list was
+ * exactly what got bootstrapped (same ids come back, no stragglers to begin
+ * with), or it LOST the bootstrap race / the machine was already bootstrapped
+ * by someone else — in which case its own local-only workspace is a disposable
+ * placeholder or unmigrated pre-existing history, not data the server has
+ * ever agreed exists. Keeping it would leave a phantom workspace in the
+ * sidebar forever, since nothing re-reconciles or prunes it after this one
+ * hydrate. This is the accepted limitation of first-writer-bootstrap (see
+ * machine-workspaces.ts's module doc): the loser's unpublished history is not
+ * merged in.
+ */
+export function mergeServerWorkspaces(
+  local: MachineWorkspacesState | undefined,
+  serverWorkspaces: ServerWorkspaceDTO[]
+): MachineWorkspacesState {
+  const workspaces: Record<string, WorkspaceState> = {};
+  const order: string[] = [];
+
+  for (const ws of serverWorkspaces) {
+    workspaces[ws.id] = toLocalWorkspace(local?.workspaces[ws.id], ws);
+    order.push(ws.id);
+  }
+
+  // Should not happen in practice — the server always has at least the
+  // workspace(s) this browser's own bootstrap call just seeded — but a
+  // machine must never end up with zero workspaces to render.
+  if (order.length === 0) return local ?? { workspaces: {}, order: [], activeWorkspaceId: '' };
+
+  const activeWorkspaceId = local && workspaces[local.activeWorkspaceId] ? local.activeWorkspaceId : order[0];
+  return { workspaces, order, activeWorkspaceId };
+}
+
+/** Reconciles ONE incoming `machine-workspace:created`/`:updated` event —
+ * same per-workspace merge as {@link mergeServerWorkspaces}, appending to
+ * `order` if this browser didn't already know about it. */
+export function applyServerWorkspaceUpsert(state: MachineWorkspacesState, ws: ServerWorkspaceDTO): MachineWorkspacesState {
+  const existing = state.workspaces[ws.id];
+  const workspaces = { ...state.workspaces, [ws.id]: toLocalWorkspace(existing, ws) };
+  const order = existing ? state.order : [...state.order, ws.id];
+  return { ...state, workspaces, order };
+}
+
+/** Reconciles an incoming `machine-workspace:deleted` event — delegates to
+ * {@link removeWorkspace}, so a machine reduced to its last server-known
+ * workspace keeps showing it locally (the existing "always keep ≥1" floor),
+ * converging once this browser's own next write reconciles it. */
+export function applyServerWorkspaceDeleted(state: MachineWorkspacesState, workspaceId: string): MachineWorkspacesState {
+  return removeWorkspace(state, workspaceId);
+}
+
+// ---------------------------------------------------------------------------
 // Rehydration — what comes back out of localStorage is untrusted
 // ---------------------------------------------------------------------------
 
@@ -545,11 +673,15 @@ export function sanitizeMachines(value: unknown): Record<string, MachineWorkspac
 /**
  * The id of the workspace owned by one session — derived from the session
  * rather than random, so clicking that sidebar row again lands on the SAME
- * workspace, with whatever panes were split into it still there. NUL-joined:
- * project and branch names can contain '/' and ':'.
+ * workspace, with whatever panes were split into it still there. Joined with
+ * U+001F (Unit Separator): project and branch names can contain '/' and ':',
+ * so an ordinary character can't be used as the delimiter. NOT NUL (U+0000)
+ * — this id is also the primary key of the server-side `machine_workspaces`
+ * row (see `machine-workspaces-runtime.ts`), and Postgres `text` columns
+ * reject a literal NUL byte outright.
  */
 export function sessionWorkspaceId(scope: OpenTerminalScope): string {
-  return `session\u0000${scope.projectName ?? ''}\u0000${scope.branchName ?? ''}\u0000${scope.name}`;
+  return `session\u001f${scope.projectName ?? ''}\u001f${scope.branchName ?? ''}\u001f${scope.name}`;
 }
 
 /** Auto-name for a workspace the user created empty ("Workspace 1", "Workspace

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -588,6 +588,24 @@ function isPane(value: unknown): value is TerminalPaneState {
   return typeof pane.id === 'string' && (pane.scope === null || typeof pane.scope === 'object');
 }
 
+/**
+ * Migrates a workspace id persisted by a version of this app that predates
+ * the U+001F delimiter switch (see `sessionWorkspaceId`'s doc): those ids used
+ * U+0000 (NUL) instead, which the server's `machine_workspaces.id` column
+ * (Postgres `text`) rejects outright. Without this, a returning user's
+ * session-derived workspaces would fail every bootstrap attempt forever —
+ * `useMachineWorkspaceSync` posts whatever this browser holds locally
+ * verbatim, and the same doomed id would keep coming back on every retry.
+ *
+ * A plain 1:1 character substitution preserves the "same session, same id"
+ * property (two different sessions that produced different pre-migration ids
+ * still produce different post-migration ids), and is a no-op for every other
+ * id shape (`crypto.randomUUID()` never contains either character).
+ */
+function migrateLegacyWorkspaceId(id: string): string {
+  return id.includes('\u0000') ? id.replaceAll('\u0000', '\u001f') : id;
+}
+
 function isWorkspace(value: unknown): value is WorkspaceState {
   if (typeof value !== 'object' || value === null) return false;
   const workspace = value as Partial<WorkspaceState>;
@@ -624,6 +642,11 @@ function isWorkspace(value: unknown): value is WorkspaceState {
  * (a picker that auto-focused days ago must not steal the caret on load) and
  * `pendingPrompt` (see `assignPane` — a prompt that was never delivered must
  * never be typed at an agent that has been running ever since).
+ *
+ * Every workspace/order/activeWorkspaceId id also passes through
+ * `migrateLegacyWorkspaceId` (#2048) — a returning user may have session-
+ * derived ids minted before the NUL-to-U+001F delimiter switch, and those
+ * would otherwise fail every server-sync bootstrap attempt forever.
  */
 export function sanitizeMachines(value: unknown): Record<string, MachineWorkspacesState> {
   if (typeof value !== 'object' || value === null) return {};
@@ -645,8 +668,13 @@ export function sanitizeMachines(value: unknown): Record<string, MachineWorkspac
       }));
       const paneIds = columns.flatMap((column) => column.panes.map((pane) => pane.id));
 
-      workspaces[workspaceId] = {
+      // Migrate a legacy NUL-delimited id (see `migrateLegacyWorkspaceId`'s
+      // doc) — the record key and the object's own `id` field must agree,
+      // since `order`/`activeWorkspaceId` below reference the record key.
+      const migratedId = migrateLegacyWorkspaceId(workspaceId);
+      workspaces[migratedId] = {
         ...workspace,
+        id: migratedId,
         columns,
         // An activePaneId naming no pane is not merely cosmetic: every grid
         // transition no-ops on a pane it cannot resolve, so a split anchored on
@@ -656,13 +684,15 @@ export function sanitizeMachines(value: unknown): Record<string, MachineWorkspac
       };
     }
 
-    const order = (Array.isArray(candidate.order) ? candidate.order : []).filter((id) => workspaces[id]);
+    const order = (Array.isArray(candidate.order) ? candidate.order : [])
+      .map((id) => (typeof id === 'string' ? migrateLegacyWorkspaceId(id) : id))
+      .filter((id) => workspaces[id]);
     if (order.length === 0) continue;
 
+    const migratedActiveWorkspaceId =
+      typeof candidate.activeWorkspaceId === 'string' ? migrateLegacyWorkspaceId(candidate.activeWorkspaceId) : undefined;
     const activeWorkspaceId =
-      typeof candidate.activeWorkspaceId === 'string' && workspaces[candidate.activeWorkspaceId]
-        ? candidate.activeWorkspaceId
-        : order[0];
+      migratedActiveWorkspaceId && workspaces[migratedActiveWorkspaceId] ? migratedActiveWorkspaceId : order[0];
 
     machines[machineId] = { workspaces, order, activeWorkspaceId };
   }

--- a/packages/db/drizzle/0205_daily_nuke.sql
+++ b/packages/db/drizzle/0205_daily_nuke.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS "machine_workspaces" (
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "machine_workspace_bootstraps" (
 	"machineId" text PRIMARY KEY NOT NULL,
-	"bootstrappedByUserId" text NOT NULL,
+	"bootstrappedByUserId" text,
 	"bootstrappedAt" timestamp DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
@@ -37,7 +37,7 @@ EXCEPTION
 END $$;
 --> statement-breakpoint
 DO $$ BEGIN
- ALTER TABLE "machine_workspace_bootstraps" ADD CONSTRAINT "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk" FOREIGN KEY ("bootstrappedByUserId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+ ALTER TABLE "machine_workspace_bootstraps" ADD CONSTRAINT "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk" FOREIGN KEY ("bootstrappedByUserId") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
 EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;

--- a/packages/db/drizzle/0205_hesitant_fallen_one.sql
+++ b/packages/db/drizzle/0205_hesitant_fallen_one.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS "machine_workspaces" (
+	"id" text PRIMARY KEY NOT NULL,
+	"ownerId" text NOT NULL,
+	"machineId" text NOT NULL,
+	"scope" text NOT NULL,
+	"projectName" text,
+	"branchName" text,
+	"name" text NOT NULL,
+	"layout" jsonb NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "machine_workspace_bootstraps" (
+	"machineId" text PRIMARY KEY NOT NULL,
+	"bootstrappedByUserId" text NOT NULL,
+	"bootstrappedAt" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_workspaces" ADD CONSTRAINT "machine_workspaces_ownerId_users_id_fk" FOREIGN KEY ("ownerId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_workspaces" ADD CONSTRAINT "machine_workspaces_machineId_pages_id_fk" FOREIGN KEY ("machineId") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_workspace_bootstraps" ADD CONSTRAINT "machine_workspace_bootstraps_machineId_pages_id_fk" FOREIGN KEY ("machineId") REFERENCES "public"."pages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "machine_workspace_bootstraps" ADD CONSTRAINT "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk" FOREIGN KEY ("bootstrappedByUserId") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "machine_workspaces_machine_id_idx" ON "machine_workspaces" USING btree ("machineId");

--- a/packages/db/drizzle/0205_shiny_shiver_man.sql
+++ b/packages/db/drizzle/0205_shiny_shiver_man.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS "machine_workspaces" (
-	"id" text PRIMARY KEY NOT NULL,
+	"id" text NOT NULL,
 	"ownerId" text NOT NULL,
 	"machineId" text NOT NULL,
 	"scope" text NOT NULL,
@@ -8,7 +8,8 @@ CREATE TABLE IF NOT EXISTS "machine_workspaces" (
 	"name" text NOT NULL,
 	"layout" jsonb NOT NULL,
 	"createdAt" timestamp DEFAULT now() NOT NULL,
-	"updatedAt" timestamp NOT NULL
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "machine_workspaces_machineId_id_pk" PRIMARY KEY("machineId","id")
 );
 --> statement-breakpoint
 CREATE TABLE IF NOT EXISTS "machine_workspace_bootstraps" (

--- a/packages/db/drizzle/meta/0205_snapshot.json
+++ b/packages/db/drizzle/meta/0205_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "5ded24a8-7956-4de5-b833-f79d399bf2f4",
+  "id": "ad1d8030-d806-4073-8c6e-fe2147d6a803",
   "prevId": "fdd777fb-d869-420e-970b-43c8d7ae9ab3",
   "version": "7",
   "dialect": "postgresql",
@@ -19405,7 +19405,7 @@
           "name": "bootstrappedByUserId",
           "type": "text",
           "primaryKey": false,
-          "notNull": true
+          "notNull": false
         },
         "bootstrappedAt": {
           "name": "bootstrappedAt",
@@ -19440,7 +19440,7 @@
           "columnsTo": [
             "id"
           ],
-          "onDelete": "cascade",
+          "onDelete": "set null",
           "onUpdate": "no action"
         }
       },

--- a/packages/db/drizzle/meta/0205_snapshot.json
+++ b/packages/db/drizzle/meta/0205_snapshot.json
@@ -1,0 +1,19878 @@
+{
+  "id": "c4aac92b-312b-43d4-a1dd-f58f1d6d048a",
+  "prevId": "fdd777fb-d869-420e-970b-43c8d7ae9ab3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      }
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.3-chat'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      }
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        }
+      },
+      "indexes": {
+        "chat_messages_page_id_idx": {
+          "name": "chat_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_user_id_idx": {
+          "name": "chat_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_conversation_id_idx": {
+          "name": "chat_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_conversation_id_idx": {
+          "name": "chat_messages_page_id_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_is_active_created_at_idx": {
+          "name": "chat_messages_page_id_is_active_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_pageId_pages_id_fk": {
+          "name": "chat_messages_pageId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_userId_users_id_fk": {
+          "name": "chat_messages_userId_users_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_sourceAgentId_pages_id_fk": {
+          "name": "chat_messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      }
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_tags": {
+      "name": "page_tags",
+      "schema": "",
+      "columns": {
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_tags_pageId_pages_id_fk": {
+          "name": "page_tags_pageId_pages_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_tags_tagId_tags_id_fk": {
+          "name": "page_tags_tagId_tags_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_tags_pageId_tagId_pk": {
+          "name": "page_tags_pageId_tagId_pk",
+          "columns": [
+            "pageId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "terminalAccess": {
+          "name": "terminalAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "machines": {
+          "name": "machines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPageAgents": {
+          "name": "allowPageAgents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "PermissionAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "SubjectType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectId": {
+          "name": "subjectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_page_id_idx": {
+          "name": "permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_subject_id_subject_type_idx": {
+          "name": "permissions_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_page_id_subject_id_subject_type_idx": {
+          "name": "permissions_page_id_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_pageId_pages_id_fk": {
+          "name": "permissions_pageId_pages_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      }
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      }
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      }
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      }
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      }
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      }
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      }
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      }
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "terminal_access": {
+          "name": "terminal_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "machines": {
+          "name": "machines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "own_machine_page_id": {
+          "name": "own_machine_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "global_assistant_config_own_machine_page_id_pages_id_fk": {
+          "name": "global_assistant_config_own_machine_page_id_pages_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "own_machine_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      }
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      }
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      }
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      }
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      }
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      }
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      }
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_sessions": {
+      "name": "machine_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_sessions_page_id_idx": {
+          "name": "machine_sessions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_sessions_last_active_at_idx": {
+          "name": "machine_sessions_last_active_at_idx",
+          "columns": [
+            {
+              "expression": "lastActiveAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_sessions_pageId_pages_id_fk": {
+          "name": "machine_sessions_pageId_pages_id_fk",
+          "tableFrom": "machine_sessions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_sessions_userId_users_id_fk": {
+          "name": "machine_sessions_userId_users_id_fk",
+          "tableFrom": "machine_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_sessions_sessionKey_unique": {
+          "name": "machine_sessions_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      }
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      }
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      }
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.machine_projects": {
+      "name": "machine_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoUrl": {
+          "name": "repoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_projects_machine_id_idx": {
+          "name": "machine_projects_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_projects_machine_id_name_idx": {
+          "name": "machine_projects_machine_id_name_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_projects_ownerId_users_id_fk": {
+          "name": "machine_projects_ownerId_users_id_fk",
+          "tableFrom": "machine_projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_projects_machineId_pages_id_fk": {
+          "name": "machine_projects_machineId_pages_id_fk",
+          "tableFrom": "machine_projects",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_branches": {
+      "name": "machine_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_branches_machine_id_idx": {
+          "name": "machine_branches_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_branches_machine_project_branch_idx": {
+          "name": "machine_branches_machine_project_branch_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branchName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_branches_ownerId_users_id_fk": {
+          "name": "machine_branches_ownerId_users_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_branches_machineId_pages_id_fk": {
+          "name": "machine_branches_machineId_pages_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_branches_sessionKey_unique": {
+          "name": "machine_branches_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
+    },
+    "public.machine_agent_terminals": {
+      "name": "machine_agent_terminals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineBranchId": {
+          "name": "machineBranchId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSessionId": {
+          "name": "streamSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_agent_terminals_machine_id_idx": {
+          "name": "machine_agent_terminals_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_agent_terminals_branch_id_idx": {
+          "name": "machine_agent_terminals_branch_id_idx",
+          "columns": [
+            {
+              "expression": "machineBranchId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_agent_terminals_scope_name_idx": {
+          "name": "machine_agent_terminals_scope_name_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"projectName\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"machineBranchId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_agent_terminals_ownerId_users_id_fk": {
+          "name": "machine_agent_terminals_ownerId_users_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_agent_terminals_machineId_pages_id_fk": {
+          "name": "machine_agent_terminals_machineId_pages_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_agent_terminals_machineBranchId_machine_branches_id_fk": {
+          "name": "machine_agent_terminals_machineBranchId_machine_branches_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "machine_branches",
+          "columnsFrom": [
+            "machineBranchId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_workspaces": {
+      "name": "machine_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_workspaces_machine_id_idx": {
+          "name": "machine_workspaces_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_workspaces_ownerId_users_id_fk": {
+          "name": "machine_workspaces_ownerId_users_id_fk",
+          "tableFrom": "machine_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_workspaces_machineId_pages_id_fk": {
+          "name": "machine_workspaces_machineId_pages_id_fk",
+          "tableFrom": "machine_workspaces",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_workspace_bootstraps": {
+      "name": "machine_workspace_bootstraps",
+      "schema": "",
+      "columns": {
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bootstrappedByUserId": {
+          "name": "bootstrappedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bootstrappedAt": {
+          "name": "bootstrappedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "machine_workspace_bootstraps_machineId_pages_id_fk": {
+          "name": "machine_workspace_bootstraps_machineId_pages_id_fk",
+          "tableFrom": "machine_workspace_bootstraps",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk": {
+          "name": "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk",
+          "tableFrom": "machine_workspace_bootstraps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "bootstrappedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.PermissionAction": {
+      "name": "PermissionAction",
+      "schema": "public",
+      "values": [
+        "VIEW",
+        "EDIT",
+        "SHARE",
+        "DELETE"
+      ]
+    },
+    "public.SubjectType": {
+      "name": "SubjectType",
+      "schema": "public",
+      "values": [
+        "USER"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0205_snapshot.json
+++ b/packages/db/drizzle/meta/0205_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "c4aac92b-312b-43d4-a1dd-f58f1d6d048a",
+  "id": "5ded24a8-7956-4de5-b833-f79d399bf2f4",
   "prevId": "fdd777fb-d869-420e-970b-43c8d7ae9ab3",
   "version": "7",
   "dialect": "postgresql",
@@ -19276,7 +19276,7 @@
         "id": {
           "name": "id",
           "type": "text",
-          "primaryKey": true,
+          "primaryKey": false,
           "notNull": true
         },
         "ownerId": {
@@ -19380,7 +19380,15 @@
           "onUpdate": "no action"
         }
       },
-      "compositePrimaryKeys": {},
+      "compositePrimaryKeys": {
+        "machine_workspaces_machineId_id_pk": {
+          "name": "machine_workspaces_machineId_id_pk",
+          "columns": [
+            "machineId",
+            "id"
+          ]
+        }
+      },
       "uniqueConstraints": {}
     },
     "public.machine_workspace_bootstraps": {

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1440,8 +1440,8 @@
     {
       "idx": 205,
       "version": "7",
-      "when": 1783954517179,
-      "tag": "0205_hesitant_fallen_one",
+      "when": 1783960570544,
+      "tag": "0205_shiny_shiver_man",
       "breakpoints": true
     }
   ]

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1436,6 +1436,13 @@
       "when": 1783877348608,
       "tag": "0204_next_mandroid",
       "breakpoints": true
+    },
+    {
+      "idx": 205,
+      "version": "7",
+      "when": 1783954517179,
+      "tag": "0205_hesitant_fallen_one",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1440,8 +1440,8 @@
     {
       "idx": 205,
       "version": "7",
-      "when": 1783960570544,
-      "tag": "0205_shiny_shiver_man",
+      "when": 1783966913177,
+      "tag": "0205_daily_nuke",
       "breakpoints": true
     }
   ]

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -63,6 +63,14 @@
       "types": "./dist/schema/machine-agent-terminals.d.ts",
       "default": "./dist/schema/machine-agent-terminals.js"
     },
+    "./schema/machine-workspaces": {
+      "types": "./dist/schema/machine-workspaces.d.ts",
+      "default": "./dist/schema/machine-workspaces.js"
+    },
+    "./schema/machine-workspace-bootstraps": {
+      "types": "./dist/schema/machine-workspace-bootstraps.d.ts",
+      "default": "./dist/schema/machine-workspace-bootstraps.js"
+    },
     "./schema/share-links": {
       "types": "./dist/schema/share-links.d.ts",
       "default": "./dist/schema/share-links.js"

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -54,6 +54,8 @@ export * from './schema/form-targets';
 export * from './schema/machine-projects';
 export * from './schema/machine-branches';
 export * from './schema/machine-agent-terminals';
+export * from './schema/machine-workspaces';
+export * from './schema/machine-workspace-bootstraps';
 
 import * as auth from './schema/auth';
 import * as sessions from './schema/sessions';
@@ -111,6 +113,8 @@ import * as formTargets from './schema/form-targets';
 import * as machineProjects from './schema/machine-projects';
 import * as machineBranches from './schema/machine-branches';
 import * as machineAgentTerminals from './schema/machine-agent-terminals';
+import * as machineWorkspaces from './schema/machine-workspaces';
+import * as machineWorkspaceBootstraps from './schema/machine-workspace-bootstraps';
 
 export const schema = {
   ...auth,
@@ -169,4 +173,6 @@ export const schema = {
   ...machineProjects,
   ...machineBranches,
   ...machineAgentTerminals,
+  ...machineWorkspaces,
+  ...machineWorkspaceBootstraps,
 };

--- a/packages/db/src/schema/__tests__/machine-workspace-bootstraps.test.ts
+++ b/packages/db/src/schema/__tests__/machine-workspace-bootstraps.test.ts
@@ -25,8 +25,12 @@ describe('Machine Workspace Bootstraps Schema', () => {
       expect(columns.machineId.dataType).toBe('string');
     });
 
-    it('has bootstrappedByUserId as not null (audit only)', () => {
-      expect(columns.bootstrappedByUserId.notNull).toBe(true);
+    // Regression (CodeRabbit): nullable + `set null`, NOT `notNull` + cascade —
+    // this row's mere EXISTENCE is the load-bearing invariant (it closes the
+    // duplicate-bootstrap race), so deleting the winning user's account must
+    // never cascade-delete the claim itself. See the schema file's doc comment.
+    it('has bootstrappedByUserId as nullable (audit only, survives user deletion)', () => {
+      expect(columns.bootstrappedByUserId.notNull).toBe(false);
     });
 
     it('has bootstrappedAt with a default', () => {
@@ -36,12 +40,14 @@ describe('Machine Workspace Bootstraps Schema', () => {
   });
 
   describe('foreign keys', () => {
-    it('references pages and users, both cascading on delete', () => {
+    it('cascades on machineId (page deletion) but only set-nulls on bootstrappedByUserId (user deletion)', () => {
       const { foreignKeys } = getTableConfig(machineWorkspaceBootstraps);
       expect(foreignKeys).toHaveLength(2);
-      for (const fk of foreignKeys) {
-        expect(fk.onDelete).toBe('cascade');
-      }
+      const byColumn = new Map(
+        foreignKeys.map((fk) => [fk.reference().columns[0].name, fk.onDelete]),
+      );
+      expect(byColumn.get('machineId')).toBe('cascade');
+      expect(byColumn.get('bootstrappedByUserId')).toBe('set null');
     });
   });
 

--- a/packages/db/src/schema/__tests__/machine-workspace-bootstraps.test.ts
+++ b/packages/db/src/schema/__tests__/machine-workspace-bootstraps.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Machine Workspace Bootstraps Schema Unit Tests
+ *
+ * Validates the `machine_workspace_bootstraps` table — the one-row-per-machine
+ * claim record for the workspace-history seeding race (#2048). Runs without a
+ * database connection.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { machineWorkspaceBootstraps, machineWorkspaceBootstrapsRelations } from '../machine-workspace-bootstraps';
+
+const columns = getTableColumns(machineWorkspaceBootstraps);
+
+describe('Machine Workspace Bootstraps Schema', () => {
+  describe('table columns', () => {
+    it('exports all expected columns', () => {
+      expect(columns).toHaveProperty('machineId');
+      expect(columns).toHaveProperty('bootstrappedByUserId');
+      expect(columns).toHaveProperty('bootstrappedAt');
+    });
+
+    it('has machineId as the primary key — one claim row per machine, ever', () => {
+      expect(columns.machineId.primary).toBe(true);
+      expect(columns.machineId.dataType).toBe('string');
+    });
+
+    it('has bootstrappedByUserId as not null (audit only)', () => {
+      expect(columns.bootstrappedByUserId.notNull).toBe(true);
+    });
+
+    it('has bootstrappedAt with a default', () => {
+      expect(columns.bootstrappedAt.notNull).toBe(true);
+      expect(columns.bootstrappedAt.hasDefault).toBe(true);
+    });
+  });
+
+  describe('foreign keys', () => {
+    it('references pages and users, both cascading on delete', () => {
+      const { foreignKeys } = getTableConfig(machineWorkspaceBootstraps);
+      expect(foreignKeys).toHaveLength(2);
+      for (const fk of foreignKeys) {
+        expect(fk.onDelete).toBe('cascade');
+      }
+    });
+  });
+
+  describe('relations', () => {
+    it('exports machineWorkspaceBootstrapsRelations', () => {
+      expect(machineWorkspaceBootstrapsRelations).toBeDefined();
+    });
+  });
+});

--- a/packages/db/src/schema/__tests__/machine-workspaces.test.ts
+++ b/packages/db/src/schema/__tests__/machine-workspaces.test.ts
@@ -23,9 +23,9 @@ describe('Machine Workspaces Schema', () => {
       }
     });
 
-    it('has id as a primary key, client-supplied (no default generator)', () => {
+    it('has id as not null, client-supplied (no default generator)', () => {
       expect(columns.id.dataType).toBe('string');
-      expect(columns.id.primary).toBe(true);
+      expect(columns.id.notNull).toBe(true);
       expect(columns.id.hasDefault).toBe(false);
     });
 
@@ -66,6 +66,19 @@ describe('Machine Workspaces Schema', () => {
       const { indexes } = getTableConfig(machineWorkspaces);
       expect(indexes.some((index) => index.config.name === 'machine_workspaces_machine_id_idx')).toBe(true);
       expect(indexes.every((index) => !index.config.unique)).toBe(true);
+    });
+  });
+
+  describe('primary key', () => {
+    // `sessionWorkspaceId` has no machineId in it, so two different Machines
+    // can legitimately mint the identical `id` for their own, unrelated
+    // sessions — the primary key must be the COMPOUND (machineId, id), not
+    // `id` alone, or one Machine's insert collides with another's row.
+    it('is the compound (machineId, id), not id alone', () => {
+      const { primaryKeys } = getTableConfig(machineWorkspaces);
+      expect(primaryKeys).toHaveLength(1);
+      const pkColumnNames = primaryKeys[0].columns.map((c) => c.name).sort();
+      expect(pkColumnNames).toEqual(['id', 'machineId'].sort());
     });
   });
 

--- a/packages/db/src/schema/__tests__/machine-workspaces.test.ts
+++ b/packages/db/src/schema/__tests__/machine-workspaces.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Machine Workspaces Schema Unit Tests
+ *
+ * Validates the `machine_workspaces` table definition: columns, constraints,
+ * relations, and indexes. Runs without a database connection.
+ */
+import { describe, it, expect } from 'vitest';
+import { getTableColumns } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import { machineWorkspaces, machineWorkspacesRelations } from '../machine-workspaces';
+
+const columns = getTableColumns(machineWorkspaces);
+
+describe('Machine Workspaces Schema', () => {
+  describe('table columns', () => {
+    it('exports all expected columns', () => {
+      const expectedColumns = [
+        'id', 'ownerId', 'machineId', 'scope', 'projectName', 'branchName',
+        'name', 'layout', 'createdAt', 'updatedAt',
+      ];
+      for (const col of expectedColumns) {
+        expect(columns).toHaveProperty(col);
+      }
+    });
+
+    it('has id as a primary key, client-supplied (no default generator)', () => {
+      expect(columns.id.dataType).toBe('string');
+      expect(columns.id.primary).toBe(true);
+      expect(columns.id.hasDefault).toBe(false);
+    });
+
+    it('has ownerId and machineId as not null', () => {
+      expect(columns.ownerId.notNull).toBe(true);
+      expect(columns.machineId.notNull).toBe(true);
+    });
+
+    it('has scope as a not null discriminant column', () => {
+      expect(columns.scope.notNull).toBe(true);
+      expect(columns.scope.dataType).toBe('string');
+    });
+
+    it('has projectName and branchName as nullable', () => {
+      expect(columns.projectName.notNull).toBe(false);
+      expect(columns.branchName.notNull).toBe(false);
+    });
+
+    it('has name as not null with no uniqueness constraint', () => {
+      expect(columns.name.notNull).toBe(true);
+      expect(columns.name.isUnique).toBeFalsy();
+    });
+
+    it('has layout as a not null jsonb column', () => {
+      expect(columns.layout.notNull).toBe(true);
+      expect(columns.layout.dataType).toBe('json');
+    });
+
+    it('has createdAt with a default and updatedAt not null', () => {
+      expect(columns.createdAt.notNull).toBe(true);
+      expect(columns.createdAt.hasDefault).toBe(true);
+      expect(columns.updatedAt.notNull).toBe(true);
+    });
+  });
+
+  describe('indexes', () => {
+    it('has an index on machineId, and no name-uniqueness index', () => {
+      const { indexes } = getTableConfig(machineWorkspaces);
+      expect(indexes.some((index) => index.config.name === 'machine_workspaces_machine_id_idx')).toBe(true);
+      expect(indexes.every((index) => !index.config.unique)).toBe(true);
+    });
+  });
+
+  describe('relations', () => {
+    it('exports machineWorkspacesRelations', () => {
+      expect(machineWorkspacesRelations).toBeDefined();
+    });
+  });
+});

--- a/packages/db/src/schema/machine-workspace-bootstraps.ts
+++ b/packages/db/src/schema/machine-workspace-bootstraps.ts
@@ -1,0 +1,48 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './auth';
+import { pages } from './core';
+
+/**
+ * Machine Workspace Bootstraps
+ *
+ * The permanent claim record for "has this machine's local-only
+ * (`localStorage`) workspace history already been seeded into
+ * `machine_workspaces`". One row per machine, inserted exactly once via
+ * `ON CONFLICT (machineId) DO NOTHING` — the browser whose insert actually
+ * lands is the sole writer of the initial server-side workspace list;
+ * every other browser racing the same first-load window just adopts
+ * whatever the winner published.
+ *
+ * Deliberately decoupled from `machine_workspaces`' current row COUNT: a
+ * machine legitimately reduced to zero live workspaces (its only one was
+ * deleted) must never be mistaken for "never bootstrapped" and reseeded
+ * with a stale local copy. This table is the single source of truth for
+ * that distinction, checked independently of how many workspace rows exist
+ * right now.
+ */
+export const machineWorkspaceBootstraps = pgTable('machine_workspace_bootstraps', {
+  machineId: text('machineId')
+    .primaryKey()
+    .references(() => pages.id, { onDelete: 'cascade' }),
+
+  bootstrappedByUserId: text('bootstrappedByUserId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+
+  bootstrappedAt: timestamp('bootstrappedAt', { mode: 'date' }).defaultNow().notNull(),
+});
+
+export const machineWorkspaceBootstrapsRelations = relations(machineWorkspaceBootstraps, ({ one }) => ({
+  machine: one(pages, {
+    fields: [machineWorkspaceBootstraps.machineId],
+    references: [pages.id],
+  }),
+  bootstrappedBy: one(users, {
+    fields: [machineWorkspaceBootstraps.bootstrappedByUserId],
+    references: [users.id],
+  }),
+}));
+
+export type MachineWorkspaceBootstrap = typeof machineWorkspaceBootstraps.$inferSelect;
+export type NewMachineWorkspaceBootstrap = typeof machineWorkspaceBootstraps.$inferInsert;

--- a/packages/db/src/schema/machine-workspace-bootstraps.ts
+++ b/packages/db/src/schema/machine-workspace-bootstraps.ts
@@ -20,6 +20,14 @@ import { pages } from './core';
  * with a stale local copy. This table is the single source of truth for
  * that distinction, checked independently of how many workspace rows exist
  * right now.
+ *
+ * `bootstrappedByUserId` is audit-only (who happened to win the race) and
+ * deliberately does NOT cascade the row's deletion: this row's very
+ * EXISTENCE is the load-bearing invariant (see above), so if the winning
+ * user's account is later deleted (offboarding, GDPR erasure), the claim
+ * must survive them — an `ON DELETE CASCADE` here would un-claim the
+ * machine and reopen exactly the duplicate-bootstrap race this table
+ * exists to close. Nullable + `set null` instead.
  */
 export const machineWorkspaceBootstraps = pgTable('machine_workspace_bootstraps', {
   machineId: text('machineId')
@@ -27,8 +35,7 @@ export const machineWorkspaceBootstraps = pgTable('machine_workspace_bootstraps'
     .references(() => pages.id, { onDelete: 'cascade' }),
 
   bootstrappedByUserId: text('bootstrappedByUserId')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
+    .references(() => users.id, { onDelete: 'set null' }),
 
   bootstrappedAt: timestamp('bootstrappedAt', { mode: 'date' }).defaultNow().notNull(),
 });

--- a/packages/db/src/schema/machine-workspaces.ts
+++ b/packages/db/src/schema/machine-workspaces.ts
@@ -1,0 +1,100 @@
+import { pgTable, text, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { users } from './auth';
+import { pages } from './core';
+
+/** A session's scope plus its name — mirrors the client's `OpenTerminalScope`
+ * (apps/web/src/stores/machine-workspace/workspace-reducer.ts), independently
+ * expressed here since `packages/db` cannot depend on `apps/web`. */
+export interface WorkspaceLayoutScopeDTO {
+  projectName?: string;
+  branchName?: string;
+  name: string;
+}
+
+export interface WorkspaceLayoutPaneDTO {
+  id: string;
+  scope: WorkspaceLayoutScopeDTO | null;
+}
+
+export interface WorkspaceLayoutColumnDTO {
+  id: string;
+  panes: WorkspaceLayoutPaneDTO[];
+}
+
+/** The shared, structural half of a workspace's grid — see the table doc below
+ * for what is deliberately excluded (activePaneId, pendingPickerPaneId, pendingPrompt). */
+export interface WorkspaceLayoutDTO {
+  columns: WorkspaceLayoutColumnDTO[];
+}
+
+/**
+ * Machine Workspaces
+ *
+ * A named, persistent pane grid — the sidebar item under a Machine/Project/
+ * Branch node that owns a terminal layout (see `useMachineWorkspaceStore`,
+ * `workspace-reducer.ts`). Server-authoritative and broadcast over
+ * `apps/realtime` so every browser/user viewing a Machine sees the same
+ * workspace list and grid, closing the gap left by PR #2031 (workspace
+ * metadata was local-`localStorage`-only).
+ *
+ * `id` is CLIENT-SUPPLIED, never DB-generated: it is either a
+ * `crypto.randomUUID()` (a user-created empty workspace) or the deterministic
+ * `sessionWorkspaceId(scope)` (a workspace materialized for a specific
+ * session, so reopening that session always resolves to the same workspace).
+ * Keeping the client the source of the id means `openTerminal`'s existing
+ * "does this session already have a workspace" shortcut needs no separate
+ * id-reconciliation layer between client and server.
+ *
+ * `scope` is an explicit discriminant (`'machine' | 'project' | 'branch'`),
+ * mirroring `machine_agent_terminals`, set once at creation and never
+ * changed — a workspace's node scope is fixed for its lifetime.
+ *
+ * `layout` holds ONLY the shared, structural half of a workspace's grid —
+ * `{ columns: [{ id, panes: [{ id, scope }] }] }`. `activePaneId` (which pane
+ * has focus) and `pendingPickerPaneId`/`pendingPrompt` (transient, one-shot
+ * local UI intent) are deliberately NOT part of this row: they are
+ * presence-like ("what am I looking at"), stay per-browser, and are never
+ * synced — the same treatment `activeWorkspaceId` already gets.
+ *
+ * No name-uniqueness constraint: nothing client-side stops two workspaces
+ * sharing a name after a rename (only auto-naming avoids collisions), so the
+ * DB doesn't invent an invariant the client doesn't enforce either.
+ */
+export const machineWorkspaces = pgTable('machine_workspaces', {
+  id: text('id').primaryKey(),
+
+  ownerId: text('ownerId')
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+
+  machineId: text('machineId')
+    .notNull()
+    .references(() => pages.id, { onDelete: 'cascade' }),
+
+  scope: text('scope').notNull(),
+  projectName: text('projectName'),
+  branchName: text('branchName'),
+
+  name: text('name').notNull(),
+  layout: jsonb('layout').$type<WorkspaceLayoutDTO>().notNull(),
+
+  createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
+  updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
+}, (table) => ({
+  machineIdIdx: index('machine_workspaces_machine_id_idx').on(table.machineId),
+}));
+
+export const machineWorkspacesRelations = relations(machineWorkspaces, ({ one }) => ({
+  owner: one(users, {
+    fields: [machineWorkspaces.ownerId],
+    references: [users.id],
+  }),
+  machine: one(pages, {
+    fields: [machineWorkspaces.machineId],
+    references: [pages.id],
+  }),
+}));
+
+export type MachineWorkspaceRow = typeof machineWorkspaces.$inferSelect;
+export type NewMachineWorkspaceRow = typeof machineWorkspaces.$inferInsert;

--- a/packages/db/src/schema/machine-workspaces.ts
+++ b/packages/db/src/schema/machine-workspaces.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, timestamp, jsonb, index } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, index, primaryKey } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { users } from './auth';
 import { pages } from './core';
@@ -46,6 +46,15 @@ export interface WorkspaceLayoutDTO {
  * "does this session already have a workspace" shortcut needs no separate
  * id-reconciliation layer between client and server.
  *
+ * The primary key is the COMPOUND `(machineId, id)`, not `id` alone:
+ * `sessionWorkspaceId` derives purely from a session's project/branch/name —
+ * it has no machineId in it — so two DIFFERENT Machines can legitimately
+ * compute the identical id for their own, unrelated sessions (the same
+ * project/branch/session-name text reused across Machines is ordinary, not
+ * exceptional). A lone-`id` primary key would treat the second Machine's
+ * insert as a duplicate of the first's row, silently misdirecting a create or
+ * a lookup to the wrong Machine's workspace.
+ *
  * `scope` is an explicit discriminant (`'machine' | 'project' | 'branch'`),
  * mirroring `machine_agent_terminals`, set once at creation and never
  * changed — a workspace's node scope is fixed for its lifetime.
@@ -62,7 +71,7 @@ export interface WorkspaceLayoutDTO {
  * DB doesn't invent an invariant the client doesn't enforce either.
  */
 export const machineWorkspaces = pgTable('machine_workspaces', {
-  id: text('id').primaryKey(),
+  id: text('id').notNull(),
 
   ownerId: text('ownerId')
     .notNull()
@@ -82,6 +91,7 @@ export const machineWorkspaces = pgTable('machine_workspaces', {
   createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
   updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
 }, (table) => ({
+  pk: primaryKey({ columns: [table.machineId, table.id] }),
   machineIdIdx: index('machine_workspaces_machine_id_idx').on(table.machineId),
 }));
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -642,6 +642,16 @@
       "import": "./dist/services/machines/machine-branches.js",
       "require": "./dist/services/machines/machine-branches.js"
     },
+    "./services/machines/machine-workspaces-store": {
+      "types": "./dist/services/machines/machine-workspaces-store.d.ts",
+      "import": "./dist/services/machines/machine-workspaces-store.js",
+      "require": "./dist/services/machines/machine-workspaces-store.js"
+    },
+    "./services/machines/machine-workspaces": {
+      "types": "./dist/services/machines/machine-workspaces.d.ts",
+      "import": "./dist/services/machines/machine-workspaces.js",
+      "require": "./dist/services/machines/machine-workspaces.js"
+    },
     "./services/machines/machine-settings": {
       "types": "./dist/services/machines/machine-settings.d.ts",
       "import": "./dist/services/machines/machine-settings.js",
@@ -1775,6 +1785,12 @@
       ],
       "services/machines/machine-branches": [
         "./dist/services/machines/machine-branches.d.ts"
+      ],
+      "services/machines/machine-workspaces-store": [
+        "./dist/services/machines/machine-workspaces-store.d.ts"
+      ],
+      "services/machines/machine-workspaces": [
+        "./dist/services/machines/machine-workspaces.d.ts"
       ],
       "services/machines/machine-settings": [
         "./dist/services/machines/machine-settings.d.ts"

--- a/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect } from 'vitest';
+import {
+  deriveWorkspaceScope,
+  isValidWorkspaceName,
+  planWorkspacePayload,
+  createWorkspace,
+  updateWorkspace,
+  removeWorkspace,
+  listWorkspaces,
+  isBootstrapped,
+  bootstrapWorkspaces,
+  type MachineWorkspacesDeps,
+} from '../machine-workspaces';
+import type { MachineWorkspaceStore, MachineWorkspaceRecord, NewMachineWorkspaceInput } from '../machine-workspaces-store';
+
+const NOW = new Date('2026-06-01T12:00:00.000Z');
+const MACHINE_ID = 'machine-1';
+
+const VALID_COLUMNS = { columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] };
+
+function makeStore(seed: MachineWorkspaceRecord[] = []) {
+  const rows = new Map<string, MachineWorkspaceRecord>();
+  for (const row of seed) rows.set(row.id, row);
+  const bootstrapped = new Set<string>();
+
+  const store: MachineWorkspaceStore = {
+    list: async (machineId) =>
+      [...rows.values()]
+        .filter((row) => row.machineId === machineId)
+        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+
+    findById: async (machineId, id) => {
+      const row = rows.get(id);
+      return row && row.machineId === machineId ? row : null;
+    },
+
+    insertIfAbsent: async (input: NewMachineWorkspaceInput) => {
+      const existing = rows.get(input.id);
+      if (existing) return { created: false, row: existing };
+      const row: MachineWorkspaceRecord = {
+        id: input.id,
+        ownerId: input.ownerId,
+        machineId: input.machineId,
+        scope: input.scope,
+        projectName: input.projectName,
+        branchName: input.branchName,
+        name: input.name,
+        layout: input.layout,
+        createdAt: input.now,
+        updatedAt: input.now,
+      };
+      rows.set(input.id, row);
+      return { created: true, row };
+    },
+
+    update: async (machineId, id, patch, now) => {
+      const row = rows.get(id);
+      if (!row || row.machineId !== machineId) return null;
+      const next: MachineWorkspaceRecord = {
+        ...row,
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
+        ...(patch.layout !== undefined ? { layout: patch.layout } : {}),
+        updatedAt: now,
+      };
+      rows.set(id, next);
+      return next;
+    },
+
+    remove: async (machineId, id) => {
+      const row = rows.get(id);
+      if (!row || row.machineId !== machineId) return false;
+      rows.delete(id);
+      return true;
+    },
+
+    isBootstrapped: async (machineId) => bootstrapped.has(machineId),
+
+    bootstrapSeed: async ({ machineId, workspaces }) => {
+      // Mirrors the real store's transaction: claim first, and only seed rows
+      // if THIS call actually won the claim.
+      if (bootstrapped.has(machineId)) {
+        return {
+          claimed: false,
+          workspaces: [...rows.values()]
+            .filter((row) => row.machineId === machineId)
+            .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+        };
+      }
+      bootstrapped.add(machineId);
+      for (const workspace of workspaces) {
+        if (!rows.has(workspace.id)) {
+          rows.set(workspace.id, {
+            id: workspace.id,
+            ownerId: workspace.ownerId,
+            machineId: workspace.machineId,
+            scope: workspace.scope,
+            projectName: workspace.projectName,
+            branchName: workspace.branchName,
+            name: workspace.name,
+            layout: workspace.layout,
+            createdAt: workspace.now,
+            updatedAt: workspace.now,
+          });
+        }
+      }
+      return {
+        claimed: true,
+        workspaces: [...rows.values()]
+          .filter((row) => row.machineId === machineId)
+          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+      };
+    },
+  };
+
+  return { store, rows, bootstrapped };
+}
+
+function makeDeps(seed: MachineWorkspaceRecord[] = []) {
+  const { store, rows, bootstrapped } = makeStore(seed);
+  const deps: MachineWorkspacesDeps = { store, now: () => NOW };
+  return { deps, store, rows, bootstrapped };
+}
+
+describe('deriveWorkspaceScope', () => {
+  it('is "machine" with neither projectName nor branchName', () => {
+    expect(deriveWorkspaceScope({})).toBe('machine');
+  });
+
+  it('is "project" with only projectName', () => {
+    expect(deriveWorkspaceScope({ projectName: 'repo' })).toBe('project');
+  });
+
+  it('is "branch" whenever branchName is set (project always implied)', () => {
+    expect(deriveWorkspaceScope({ projectName: 'repo', branchName: 'feat' })).toBe('branch');
+  });
+});
+
+describe('isValidWorkspaceName / planWorkspacePayload', () => {
+  it('rejects empty or whitespace-only names', () => {
+    expect(isValidWorkspaceName('')).toBe(false);
+    expect(isValidWorkspaceName('   ')).toBe(false);
+    expect(planWorkspacePayload({ name: '', layout: VALID_COLUMNS })).toEqual({ ok: false, reason: 'invalid_name' });
+  });
+
+  it('rejects a layout with no columns, or a column with no panes', () => {
+    expect(planWorkspacePayload({ name: 'Workspace 1', layout: { columns: [] } })).toEqual({
+      ok: false,
+      reason: 'invalid_columns',
+    });
+    expect(
+      planWorkspacePayload({ name: 'Workspace 1', layout: { columns: [{ id: 'c1', panes: [] }] } }),
+    ).toEqual({ ok: false, reason: 'invalid_columns' });
+  });
+
+  it('accepts a well-shaped payload', () => {
+    const plan = planWorkspacePayload({ name: 'Workspace 1', layout: VALID_COLUMNS });
+    expect(plan).toEqual({ ok: true, name: 'Workspace 1', layout: VALID_COLUMNS });
+  });
+});
+
+describe('createWorkspace', () => {
+  it('creates a new row and derives the scope discriminant', async () => {
+    const { deps } = makeDeps();
+    const result = await createWorkspace({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      id: 'ws-1',
+      name: 'Workspace 1',
+      scope: { projectName: 'repo', branchName: 'feat' },
+      layout: VALID_COLUMNS,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, created: true });
+    if (result.ok) {
+      expect(result.workspace.scope).toBe('branch');
+      expect(result.workspace.projectName).toBe('repo');
+      expect(result.workspace.branchName).toBe('feat');
+    }
+  });
+
+  it('rejects an invalid name/columns payload before touching the store', async () => {
+    const { deps, rows } = makeDeps();
+    const result = await createWorkspace({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      id: 'ws-1',
+      name: '   ',
+      scope: {},
+      layout: VALID_COLUMNS,
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid_name' });
+    expect(rows.size).toBe(0);
+  });
+
+  it('is idempotent-by-id: two racing creates for the SAME id both succeed, one wins', async () => {
+    const { deps } = makeDeps();
+    const params = {
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      id: 'sessionrepoclaude-a1',
+      name: 'claude-a1',
+      scope: { projectName: 'repo' },
+      layout: VALID_COLUMNS,
+      deps,
+    };
+    const first = await createWorkspace(params);
+    const second = await createWorkspace({ ...params, name: 'a different name the second caller tried to use' });
+
+    expect(first).toMatchObject({ ok: true, created: true });
+    expect(second).toMatchObject({ ok: true, created: false });
+    // The loser gets the WINNER's row back, not its own payload.
+    if (first.ok && second.ok) {
+      expect(second.workspace).toEqual(first.workspace);
+      expect(second.workspace.name).toBe('claude-a1');
+    }
+  });
+});
+
+describe('updateWorkspace', () => {
+  const seedRow: MachineWorkspaceRecord = {
+    id: 'ws-1',
+    ownerId: 'user-1',
+    machineId: MACHINE_ID,
+    scope: 'machine',
+    projectName: null,
+    branchName: null,
+    name: 'Workspace 1',
+    layout: VALID_COLUMNS,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+
+  it('renames a workspace', async () => {
+    const { deps } = makeDeps([seedRow]);
+    const result = await updateWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', name: 'Renamed', deps });
+    expect(result).toMatchObject({ ok: true, workspace: { name: 'Renamed' } });
+  });
+
+  it('updates the layout independently of the name', async () => {
+    const { deps } = makeDeps([seedRow]);
+    const newLayout = { columns: [{ id: 'col-2', panes: [{ id: 'pane-2', scope: null }] }] };
+    const result = await updateWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', layout: newLayout, deps });
+    expect(result).toMatchObject({ ok: true, workspace: { name: 'Workspace 1', layout: newLayout } });
+  });
+
+  it('rejects an invalid name without touching the row', async () => {
+    const { deps, rows } = makeDeps([seedRow]);
+    const result = await updateWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', name: '   ', deps });
+    expect(result).toEqual({ ok: false, reason: 'invalid_name' });
+    expect(rows.get('ws-1')?.name).toBe('Workspace 1');
+  });
+
+  it('returns not_found for an unknown workspace', async () => {
+    const { deps } = makeDeps();
+    const result = await updateWorkspace({ machineId: MACHINE_ID, workspaceId: 'missing', name: 'X', deps });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('removeWorkspace', () => {
+  it('removes an existing workspace', async () => {
+    const seedRow: MachineWorkspaceRecord = {
+      id: 'ws-1',
+      ownerId: 'user-1',
+      machineId: MACHINE_ID,
+      scope: 'machine',
+      projectName: null,
+      branchName: null,
+      name: 'Workspace 1',
+      layout: VALID_COLUMNS,
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const { deps, rows } = makeDeps([seedRow]);
+    const result = await removeWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', store: deps.store });
+    expect(result).toEqual({ ok: true });
+    expect(rows.has('ws-1')).toBe(false);
+  });
+
+  it('returns not_found for an unknown workspace', async () => {
+    const { deps } = makeDeps();
+    const result = await removeWorkspace({ machineId: MACHINE_ID, workspaceId: 'missing', store: deps.store });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('listWorkspaces / isBootstrapped', () => {
+  it('filters by machineId only', async () => {
+    const { deps } = makeDeps([
+      {
+        id: 'ws-1',
+        ownerId: 'user-1',
+        machineId: MACHINE_ID,
+        scope: 'machine',
+        projectName: null,
+        branchName: null,
+        name: 'Workspace 1',
+        layout: VALID_COLUMNS,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      {
+        id: 'ws-2',
+        ownerId: 'user-1',
+        machineId: 'other-machine',
+        scope: 'machine',
+        projectName: null,
+        branchName: null,
+        name: 'Workspace 1',
+        layout: VALID_COLUMNS,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ]);
+    const result = await listWorkspaces({ machineId: MACHINE_ID, store: deps.store });
+    expect(result.map((r) => r.id)).toEqual(['ws-1']);
+  });
+
+  it('is false until a machine has been bootstrapped', async () => {
+    const { deps } = makeDeps();
+    expect(await isBootstrapped({ machineId: MACHINE_ID, store: deps.store })).toBe(false);
+  });
+});
+
+describe('bootstrapWorkspaces', () => {
+  const input = (id: string, name: string) => ({ id, name, scope: {}, layout: VALID_COLUMNS });
+
+  it('claims and seeds on the FIRST call for a machine', async () => {
+    const { deps } = makeDeps();
+    const result = await bootstrapWorkspaces({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      userId: 'user-1',
+      workspaces: [input('ws-1', 'Workspace 1'), input('ws-2', 'Workspace 2')],
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, claimed: true });
+    if (result.ok) expect(result.workspaces.map((w) => w.id)).toEqual(['ws-1', 'ws-2']);
+  });
+
+  it('a SECOND call for the same machine loses the claim and gets the current list back, unseeded', async () => {
+    const { deps } = makeDeps();
+    const first = await bootstrapWorkspaces({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      userId: 'user-1',
+      workspaces: [input('ws-1', "winner's workspace")],
+      deps,
+    });
+    const second = await bootstrapWorkspaces({
+      machineId: MACHINE_ID,
+      ownerId: 'user-2',
+      userId: 'user-2',
+      workspaces: [input('ws-2', "loser's workspace — must NOT be seeded")],
+      deps,
+    });
+
+    expect(first).toMatchObject({ ok: true, claimed: true });
+    expect(second).toMatchObject({ ok: true, claimed: false });
+    if (second.ok) {
+      // The loser gets back exactly the winner's list — its own payload never landed.
+      expect(second.workspaces.map((w) => w.id)).toEqual(['ws-1']);
+    }
+  });
+
+  it('rejects a malformed entry before claiming — a bad payload must not consume the claim', async () => {
+    const { deps, bootstrapped } = makeDeps();
+    const result = await bootstrapWorkspaces({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      userId: 'user-1',
+      workspaces: [input('ws-1', '   ')],
+      deps,
+    });
+    expect(result).toEqual({ ok: false, reason: 'invalid_name' });
+    expect(bootstrapped.has(MACHINE_ID)).toBe(false);
+  });
+});

--- a/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
@@ -18,24 +18,33 @@ const MACHINE_ID = 'machine-1';
 
 const VALID_COLUMNS = { columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] };
 
+// Keyed by the COMPOUND (machineId, id) — never `id` alone. `sessionWorkspaceId`
+// has no machineId in it, so two different machines legitimately mint the
+// identical `id` for their own, unrelated sessions; a fake keyed by `id` alone
+// would mask exactly the cross-machine collision bug the real store's
+// compound primary key exists to prevent.
+function rowKey(machineId: string, id: string): string {
+  return `${machineId}::${id}`;
+}
+
 function makeStore(seed: MachineWorkspaceRecord[] = []) {
   const rows = new Map<string, MachineWorkspaceRecord>();
-  for (const row of seed) rows.set(row.id, row);
+  for (const row of seed) rows.set(rowKey(row.machineId, row.id), row);
   const bootstrapped = new Set<string>();
 
-  const store: MachineWorkspaceStore = {
-    list: async (machineId) =>
-      [...rows.values()]
-        .filter((row) => row.machineId === machineId)
-        .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+  const rowsForMachine = (machineId: string) =>
+    [...rows.values()]
+      .filter((row) => row.machineId === machineId)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
 
-    findById: async (machineId, id) => {
-      const row = rows.get(id);
-      return row && row.machineId === machineId ? row : null;
-    },
+  const store: MachineWorkspaceStore = {
+    list: async (machineId) => rowsForMachine(machineId),
+
+    findById: async (machineId, id) => rows.get(rowKey(machineId, id)) ?? null,
 
     insertIfAbsent: async (input: NewMachineWorkspaceInput) => {
-      const existing = rows.get(input.id);
+      const key = rowKey(input.machineId, input.id);
+      const existing = rows.get(key);
       if (existing) return { created: false, row: existing };
       const row: MachineWorkspaceRecord = {
         id: input.id,
@@ -49,28 +58,26 @@ function makeStore(seed: MachineWorkspaceRecord[] = []) {
         createdAt: input.now,
         updatedAt: input.now,
       };
-      rows.set(input.id, row);
+      rows.set(key, row);
       return { created: true, row };
     },
 
     update: async (machineId, id, patch, now) => {
-      const row = rows.get(id);
-      if (!row || row.machineId !== machineId) return null;
+      const key = rowKey(machineId, id);
+      const row = rows.get(key);
+      if (!row) return null;
       const next: MachineWorkspaceRecord = {
         ...row,
         ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.layout !== undefined ? { layout: patch.layout } : {}),
         updatedAt: now,
       };
-      rows.set(id, next);
+      rows.set(key, next);
       return next;
     },
 
     remove: async (machineId, id) => {
-      const row = rows.get(id);
-      if (!row || row.machineId !== machineId) return false;
-      rows.delete(id);
-      return true;
+      return rows.delete(rowKey(machineId, id));
     },
 
     isBootstrapped: async (machineId) => bootstrapped.has(machineId),
@@ -79,17 +86,13 @@ function makeStore(seed: MachineWorkspaceRecord[] = []) {
       // Mirrors the real store's transaction: claim first, and only seed rows
       // if THIS call actually won the claim.
       if (bootstrapped.has(machineId)) {
-        return {
-          claimed: false,
-          workspaces: [...rows.values()]
-            .filter((row) => row.machineId === machineId)
-            .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
-        };
+        return { claimed: false, workspaces: rowsForMachine(machineId) };
       }
       bootstrapped.add(machineId);
       for (const workspace of workspaces) {
-        if (!rows.has(workspace.id)) {
-          rows.set(workspace.id, {
+        const key = rowKey(workspace.machineId, workspace.id);
+        if (!rows.has(key)) {
+          rows.set(key, {
             id: workspace.id,
             ownerId: workspace.ownerId,
             machineId: workspace.machineId,
@@ -103,12 +106,7 @@ function makeStore(seed: MachineWorkspaceRecord[] = []) {
           });
         }
       }
-      return {
-        claimed: true,
-        workspaces: [...rows.values()]
-          .filter((row) => row.machineId === machineId)
-          .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
-      };
+      return { claimed: true, workspaces: rowsForMachine(machineId) };
     },
   };
 
@@ -215,6 +213,41 @@ describe('createWorkspace', () => {
       expect(second.workspace.name).toBe('claude-a1');
     }
   });
+
+  it('two DIFFERENT machines minting the identical id (sessionWorkspaceId has no machineId in it) both succeed independently', async () => {
+    const { deps, rows } = makeDeps();
+    const sameId = 'sessionrepomainclaude-a1';
+
+    const onMachineA = await createWorkspace({
+      machineId: 'machine-a',
+      ownerId: 'user-1',
+      id: sameId,
+      name: 'claude-a1 (machine A)',
+      scope: { projectName: 'repo', branchName: 'main' },
+      layout: VALID_COLUMNS,
+      deps,
+    });
+    const onMachineB = await createWorkspace({
+      machineId: 'machine-b',
+      ownerId: 'user-1',
+      id: sameId,
+      name: 'claude-a1 (machine B)',
+      scope: { projectName: 'repo', branchName: 'main' },
+      layout: VALID_COLUMNS,
+      deps,
+    });
+
+    // NEITHER is treated as a duplicate of the other — the primary key is
+    // scoped by machineId, so the same client-minted id on two machines are
+    // two distinct rows, not a collision.
+    expect(onMachineA).toMatchObject({ ok: true, created: true });
+    expect(onMachineB).toMatchObject({ ok: true, created: true });
+    if (onMachineA.ok && onMachineB.ok) {
+      expect(onMachineA.workspace.name).toBe('claude-a1 (machine A)');
+      expect(onMachineB.workspace.name).toBe('claude-a1 (machine B)');
+    }
+    expect(rows.size).toBe(2);
+  });
 });
 
 describe('updateWorkspace', () => {
@@ -248,7 +281,7 @@ describe('updateWorkspace', () => {
     const { deps, rows } = makeDeps([seedRow]);
     const result = await updateWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', name: '   ', deps });
     expect(result).toEqual({ ok: false, reason: 'invalid_name' });
-    expect(rows.get('ws-1')?.name).toBe('Workspace 1');
+    expect(rows.get(rowKey(MACHINE_ID, 'ws-1'))?.name).toBe('Workspace 1');
   });
 
   it('returns not_found for an unknown workspace', async () => {
@@ -275,7 +308,7 @@ describe('removeWorkspace', () => {
     const { deps, rows } = makeDeps([seedRow]);
     const result = await removeWorkspace({ machineId: MACHINE_ID, workspaceId: 'ws-1', store: deps.store });
     expect(result).toEqual({ ok: true });
-    expect(rows.has('ws-1')).toBe(false);
+    expect(rows.has(rowKey(MACHINE_ID, 'ws-1'))).toBe(false);
   });
 
   it('returns not_found for an unknown workspace', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
@@ -176,6 +176,24 @@ describe('createWorkspace', () => {
     }
   });
 
+  // Regression: `updateWorkspace` already trims on rename — create (and
+  // bootstrap seeding, which shares `planWorkspacePayload`) must persist the
+  // same trimmed string for the same input, or the same logical name ends up
+  // represented two different ways depending on which endpoint wrote it.
+  it('trims a whitespace-padded name — matching updateWorkspace\'s rename behavior', async () => {
+    const { deps } = makeDeps();
+    const result = await createWorkspace({
+      machineId: MACHINE_ID,
+      ownerId: 'user-1',
+      id: 'ws-1',
+      name: '  Foo  ',
+      scope: {},
+      layout: VALID_COLUMNS,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, workspace: { name: 'Foo' } });
+  });
+
   it('rejects an invalid name/columns payload before touching the store', async () => {
     const { deps, rows } = makeDeps();
     const result = await createWorkspace({

--- a/packages/lib/src/services/machines/machine-workspaces-store.ts
+++ b/packages/lib/src/services/machines/machine-workspaces-store.ts
@@ -1,0 +1,230 @@
+/**
+ * Machine Workspaces store (IO, dependency-injected).
+ *
+ * DB-backed CRUD for `machine_workspaces` (the durable, shared record of a
+ * Machine's named pane-grid workspaces) and `machine_workspace_bootstraps`
+ * (the one-time seeding claim — see `machine-workspaces.ts`'s module doc).
+ * Kept separate from the orchestration layer so it's testable against an
+ * in-memory fake without a real database, same split as
+ * `machine-projects-store.ts`.
+ */
+
+import type { WorkspaceLayoutDTO } from '@pagespace/db/schema/machine-workspaces';
+import { isUniqueViolation } from '../subdomain-allocation';
+
+export interface MachineWorkspaceRecord {
+  id: string;
+  ownerId: string;
+  machineId: string;
+  scope: 'machine' | 'project' | 'branch';
+  projectName: string | null;
+  branchName: string | null;
+  name: string;
+  layout: WorkspaceLayoutDTO;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewMachineWorkspaceInput {
+  /** Client-minted — see machine-workspaces-runtime.ts / workspace-reducer.ts's `sessionWorkspaceId`. */
+  id: string;
+  ownerId: string;
+  machineId: string;
+  scope: 'machine' | 'project' | 'branch';
+  projectName: string | null;
+  branchName: string | null;
+  name: string;
+  layout: WorkspaceLayoutDTO;
+  now: Date;
+}
+
+export interface MachineWorkspaceStore {
+  list(machineId: string): Promise<MachineWorkspaceRecord[]>;
+  findById(machineId: string, id: string): Promise<MachineWorkspaceRecord | null>;
+  /** Upsert-by-id: first writer wins. Returns `created: false` (with the EXISTING row,
+   * never the caller's payload) when another caller already inserted this id. */
+  insertIfAbsent(input: NewMachineWorkspaceInput): Promise<{ created: boolean; row: MachineWorkspaceRecord }>;
+  /** Applies whichever of `name`/`layout` is provided. `null` if no row matched. */
+  update(
+    machineId: string,
+    id: string,
+    patch: { name?: string; layout?: WorkspaceLayoutDTO },
+    now: Date
+  ): Promise<MachineWorkspaceRecord | null>;
+  /** `true` if a row was actually deleted. */
+  remove(machineId: string, id: string): Promise<boolean>;
+  isBootstrapped(machineId: string): Promise<boolean>;
+  /**
+   * Atomic claim-then-seed: exactly one caller across every racing browser
+   * ever gets `claimed: true` for a given `machineId` (see
+   * `machine-workspaces.ts`'s module doc for why this is a separate claim
+   * table rather than per-row idempotency). Always returns the CURRENT
+   * canonical list, whether this call won or lost.
+   */
+  bootstrapSeed(input: {
+    machineId: string;
+    userId: string;
+    workspaces: NewMachineWorkspaceInput[];
+    now: Date;
+  }): Promise<{ claimed: boolean; workspaces: MachineWorkspaceRecord[] }>;
+}
+
+/** Re-exported so callers can classify an `insertIfAbsent` race without importing the DB layer directly. */
+export { isUniqueViolation };
+
+function toRecord(row: {
+  id: string;
+  ownerId: string;
+  machineId: string;
+  scope: string;
+  projectName: string | null;
+  branchName: string | null;
+  name: string;
+  layout: unknown;
+  createdAt: Date;
+  updatedAt: Date;
+}): MachineWorkspaceRecord {
+  return {
+    ...row,
+    scope: row.scope as MachineWorkspaceRecord['scope'],
+    layout: row.layout as WorkspaceLayoutDTO,
+  };
+}
+
+/**
+ * Production DB-backed implementation. Lazily resolves the db client, schema
+ * tables, and operators so callers that inject a fake (in tests) never load
+ * the DB module graph — same laziness as `createDbMachineProjectStore`.
+ */
+export async function createDbMachineWorkspaceStore(): Promise<MachineWorkspaceStore> {
+  const [{ db }, { eq, and, asc }, { machineWorkspaces }, { machineWorkspaceBootstraps }] = await Promise.all([
+    import('@pagespace/db/db'),
+    import('@pagespace/db/operators'),
+    import('@pagespace/db/schema/machine-workspaces'),
+    import('@pagespace/db/schema/machine-workspace-bootstraps'),
+  ]);
+
+  return {
+    async list(machineId) {
+      const rows = await db
+        .select()
+        .from(machineWorkspaces)
+        .where(eq(machineWorkspaces.machineId, machineId))
+        .orderBy(asc(machineWorkspaces.createdAt), asc(machineWorkspaces.id));
+      return rows.map(toRecord);
+    },
+
+    async findById(machineId, id) {
+      const [row] = await db
+        .select()
+        .from(machineWorkspaces)
+        .where(and(eq(machineWorkspaces.machineId, machineId), eq(machineWorkspaces.id, id)))
+        .limit(1);
+      return row ? toRecord(row) : null;
+    },
+
+    async insertIfAbsent(input) {
+      const [inserted] = await db
+        .insert(machineWorkspaces)
+        .values({
+          id: input.id,
+          ownerId: input.ownerId,
+          machineId: input.machineId,
+          scope: input.scope,
+          projectName: input.projectName,
+          branchName: input.branchName,
+          name: input.name,
+          layout: input.layout,
+          createdAt: input.now,
+          updatedAt: input.now,
+        })
+        .onConflictDoNothing({ target: machineWorkspaces.id })
+        .returning();
+      if (inserted) return { created: true, row: toRecord(inserted) };
+
+      const [existing] = await db.select().from(machineWorkspaces).where(eq(machineWorkspaces.id, input.id)).limit(1);
+      if (!existing) {
+        // The conflicting row was deleted between our failed insert and this
+        // read — vanishingly rare, and there is no sane row to hand back.
+        throw new Error(`machine-workspaces: insertIfAbsent lost its conflict target ${input.id}`);
+      }
+      return { created: false, row: toRecord(existing) };
+    },
+
+    async update(machineId, id, patch, now) {
+      const [row] = await db
+        .update(machineWorkspaces)
+        .set({
+          ...(patch.name !== undefined ? { name: patch.name } : {}),
+          ...(patch.layout !== undefined ? { layout: patch.layout } : {}),
+          updatedAt: now,
+        })
+        .where(and(eq(machineWorkspaces.machineId, machineId), eq(machineWorkspaces.id, id)))
+        .returning();
+      return row ? toRecord(row) : null;
+    },
+
+    async remove(machineId, id) {
+      const rows = await db
+        .delete(machineWorkspaces)
+        .where(and(eq(machineWorkspaces.machineId, machineId), eq(machineWorkspaces.id, id)))
+        .returning({ id: machineWorkspaces.id });
+      return rows.length > 0;
+    },
+
+    async isBootstrapped(machineId) {
+      const [row] = await db
+        .select({ machineId: machineWorkspaceBootstraps.machineId })
+        .from(machineWorkspaceBootstraps)
+        .where(eq(machineWorkspaceBootstraps.machineId, machineId))
+        .limit(1);
+      return row !== undefined;
+    },
+
+    async bootstrapSeed({ machineId, userId, workspaces, now }) {
+      return db.transaction(async (tx) => {
+        const [claim] = await tx
+          .insert(machineWorkspaceBootstraps)
+          .values({ machineId, bootstrappedByUserId: userId, bootstrappedAt: now })
+          .onConflictDoNothing({ target: machineWorkspaceBootstraps.machineId })
+          .returning();
+
+        if (!claim) {
+          // Someone already claimed this machine — do NOT touch machine_workspaces;
+          // just hand back whatever the winner (or a later write) has published.
+          const current = await tx
+            .select()
+            .from(machineWorkspaces)
+            .where(eq(machineWorkspaces.machineId, machineId))
+            .orderBy(asc(machineWorkspaces.createdAt), asc(machineWorkspaces.id));
+          return { claimed: false, workspaces: current.map(toRecord) };
+        }
+
+        for (const workspace of workspaces) {
+          await tx
+            .insert(machineWorkspaces)
+            .values({
+              id: workspace.id,
+              ownerId: workspace.ownerId,
+              machineId: workspace.machineId,
+              scope: workspace.scope,
+              projectName: workspace.projectName,
+              branchName: workspace.branchName,
+              name: workspace.name,
+              layout: workspace.layout,
+              createdAt: workspace.now,
+              updatedAt: workspace.now,
+            })
+            .onConflictDoNothing({ target: machineWorkspaces.id });
+        }
+
+        const seeded = await tx
+          .select()
+          .from(machineWorkspaces)
+          .where(eq(machineWorkspaces.machineId, machineId))
+          .orderBy(asc(machineWorkspaces.createdAt), asc(machineWorkspaces.id));
+        return { claimed: true, workspaces: seeded.map(toRecord) };
+      });
+    },
+  };
+}

--- a/packages/lib/src/services/machines/machine-workspaces-store.ts
+++ b/packages/lib/src/services/machines/machine-workspaces-store.ts
@@ -138,15 +138,24 @@ export async function createDbMachineWorkspaceStore(): Promise<MachineWorkspaceS
           createdAt: input.now,
           updatedAt: input.now,
         })
-        .onConflictDoNothing({ target: machineWorkspaces.id })
+        // Conflict target is the COMPOUND primary key, not `id` alone —
+        // `sessionWorkspaceId` has no machineId in it, so two different
+        // Machines can legitimately mint the identical id for their own,
+        // unrelated sessions (see schema doc). Scoping by machineId here too
+        // is what keeps that a non-collision.
+        .onConflictDoNothing({ target: [machineWorkspaces.machineId, machineWorkspaces.id] })
         .returning();
       if (inserted) return { created: true, row: toRecord(inserted) };
 
-      const [existing] = await db.select().from(machineWorkspaces).where(eq(machineWorkspaces.id, input.id)).limit(1);
+      const [existing] = await db
+        .select()
+        .from(machineWorkspaces)
+        .where(and(eq(machineWorkspaces.machineId, input.machineId), eq(machineWorkspaces.id, input.id)))
+        .limit(1);
       if (!existing) {
         // The conflicting row was deleted between our failed insert and this
         // read — vanishingly rare, and there is no sane row to hand back.
-        throw new Error(`machine-workspaces: insertIfAbsent lost its conflict target ${input.id}`);
+        throw new Error(`machine-workspaces: insertIfAbsent lost its conflict target ${input.machineId}/${input.id}`);
       }
       return { created: false, row: toRecord(existing) };
     },
@@ -215,7 +224,7 @@ export async function createDbMachineWorkspaceStore(): Promise<MachineWorkspaceS
               createdAt: workspace.now,
               updatedAt: workspace.now,
             })
-            .onConflictDoNothing({ target: machineWorkspaces.id });
+            .onConflictDoNothing({ target: [machineWorkspaces.machineId, machineWorkspaces.id] });
         }
 
         const seeded = await tx

--- a/packages/lib/src/services/machines/machine-workspaces.ts
+++ b/packages/lib/src/services/machines/machine-workspaces.ts
@@ -1,0 +1,262 @@
+/**
+ * Machine Workspaces: create / rename / update-layout / remove / list / bootstrap
+ * a Machine's shared, named pane-grid workspaces (IO, dependency-injected).
+ *
+ * Unlike `machine-projects.ts`/`machine-branches.ts`, this is pure metadata
+ * CRUD — no sandbox/git I/O, so `deps` is just `{ store, now }`.
+ *
+ * `createWorkspace` is idempotent-by-id (first writer wins): the workspace
+ * `id` is minted CLIENT-side (either `crypto.randomUUID()` or the
+ * deterministic `sessionWorkspaceId(scope)` — see workspace-reducer.ts), so
+ * two browsers racing to materialize the SAME session-derived workspace is a
+ * legitimate, expected case, not an error — the loser just gets the winner's
+ * row back.
+ *
+ * `bootstrapWorkspaces` is a SEPARATE, stronger guarantee: a one-time claim
+ * (`machine_workspace_bootstraps`, PK `machineId`) so that when a machine's
+ * workspace history is still `localStorage`-only, exactly ONE browser's local
+ * list ever becomes the shared server truth. Per-id upsert alone doesn't
+ * prevent this: two browsers with *disjoint* local workspace ids (the normal
+ * case — most ids are random) would otherwise BOTH succeed, and the server
+ * would end up with the union of both browsers' lists.
+ */
+
+export type MachineWorkspaceScope = 'machine' | 'project' | 'branch';
+
+export interface WorkspaceScopeInput {
+  projectName?: string;
+  branchName?: string;
+}
+
+/** Mirrors the client's `OpenTerminalScope`/pane shape — see machine-workspaces-store.ts's DTOs. */
+export interface WorkspaceLayoutPaneInput {
+  id: string;
+  scope: { projectName?: string; branchName?: string; name: string } | null;
+}
+export interface WorkspaceLayoutColumnInput {
+  id: string;
+  panes: WorkspaceLayoutPaneInput[];
+}
+export interface WorkspaceLayoutInput {
+  columns: WorkspaceLayoutColumnInput[];
+}
+
+import {
+  isUniqueViolation,
+  type MachineWorkspaceStore,
+  type MachineWorkspaceRecord,
+  type NewMachineWorkspaceInput,
+} from './machine-workspaces-store';
+
+export type WorkspacePlanDenialReason = 'invalid_name' | 'invalid_columns';
+
+function isValidLayout(layout: unknown): layout is WorkspaceLayoutInput {
+  if (typeof layout !== 'object' || layout === null) return false;
+  const candidate = layout as Partial<WorkspaceLayoutInput>;
+  if (!Array.isArray(candidate.columns) || candidate.columns.length === 0) return false;
+  return candidate.columns.every((column) => {
+    if (typeof column !== 'object' || column === null) return false;
+    const col = column as Partial<WorkspaceLayoutColumnInput>;
+    if (typeof col.id !== 'string' || !Array.isArray(col.panes) || col.panes.length === 0) return false;
+    return col.panes.every((pane) => {
+      if (typeof pane !== 'object' || pane === null) return false;
+      const p = pane as Partial<WorkspaceLayoutPaneInput>;
+      if (typeof p.id !== 'string') return false;
+      if (p.scope === null) return true;
+      return typeof p.scope === 'object' && typeof (p.scope as { name?: unknown }).name === 'string';
+    });
+  });
+}
+
+/** Derives the `scope` discriminant from which of `projectName`/`branchName` are set —
+ * the inverse of the client's `nodeOfTerminalScope`. */
+export function deriveWorkspaceScope(input: WorkspaceScopeInput): MachineWorkspaceScope {
+  if (input.branchName) return 'branch';
+  if (input.projectName) return 'project';
+  return 'machine';
+}
+
+export function isValidWorkspaceName(name: unknown): name is string {
+  return typeof name === 'string' && name.trim().length > 0;
+}
+
+/** Pure shape validation for a create payload — no I/O. */
+export function planWorkspacePayload({
+  name,
+  layout,
+}: {
+  name: string;
+  layout: unknown;
+}): { ok: true; name: string; layout: WorkspaceLayoutInput } | { ok: false; reason: WorkspacePlanDenialReason } {
+  if (!isValidWorkspaceName(name)) return { ok: false, reason: 'invalid_name' };
+  if (!isValidLayout(layout)) return { ok: false, reason: 'invalid_columns' };
+  return { ok: true, name, layout };
+}
+
+export interface MachineWorkspacesDeps {
+  store: MachineWorkspaceStore;
+  now: () => Date;
+}
+
+export async function listWorkspaces({
+  machineId,
+  store,
+}: {
+  machineId: string;
+  store: MachineWorkspaceStore;
+}): Promise<MachineWorkspaceRecord[]> {
+  return store.list(machineId);
+}
+
+export async function isBootstrapped({
+  machineId,
+  store,
+}: {
+  machineId: string;
+  store: MachineWorkspaceStore;
+}): Promise<boolean> {
+  return store.isBootstrapped(machineId);
+}
+
+export type CreateWorkspaceResult =
+  | { ok: true; created: boolean; workspace: MachineWorkspaceRecord }
+  | { ok: false; reason: WorkspacePlanDenialReason };
+
+export async function createWorkspace({
+  machineId,
+  ownerId,
+  id,
+  name,
+  scope,
+  layout,
+  deps,
+}: {
+  machineId: string;
+  ownerId: string;
+  id: string;
+  name: string;
+  scope: WorkspaceScopeInput;
+  layout: unknown;
+  deps: MachineWorkspacesDeps;
+}): Promise<CreateWorkspaceResult> {
+  const plan = planWorkspacePayload({ name, layout });
+  if (!plan.ok) return plan;
+
+  const input: NewMachineWorkspaceInput = {
+    id,
+    ownerId,
+    machineId,
+    scope: deriveWorkspaceScope(scope),
+    projectName: scope.projectName ?? null,
+    branchName: scope.branchName ?? null,
+    name: plan.name,
+    layout: plan.layout,
+    now: deps.now(),
+  };
+
+  const { created, row } = await deps.store.insertIfAbsent(input);
+  return { ok: true, created, workspace: row };
+}
+
+export type UpdateWorkspaceResult =
+  | { ok: true; workspace: MachineWorkspaceRecord }
+  | { ok: false; reason: WorkspacePlanDenialReason | 'not_found' };
+
+export async function updateWorkspace({
+  machineId,
+  workspaceId,
+  name,
+  layout,
+  deps,
+}: {
+  machineId: string;
+  workspaceId: string;
+  name?: string;
+  layout?: unknown;
+  deps: MachineWorkspacesDeps;
+}): Promise<UpdateWorkspaceResult> {
+  const patch: { name?: string; layout?: WorkspaceLayoutInput } = {};
+
+  if (name !== undefined) {
+    if (!isValidWorkspaceName(name)) return { ok: false, reason: 'invalid_name' };
+    patch.name = name.trim();
+  }
+  if (layout !== undefined) {
+    if (!isValidLayout(layout)) return { ok: false, reason: 'invalid_columns' };
+    patch.layout = layout;
+  }
+
+  const row = await deps.store.update(machineId, workspaceId, patch, deps.now());
+  if (!row) return { ok: false, reason: 'not_found' };
+  return { ok: true, workspace: row };
+}
+
+export type RemoveWorkspaceResult = { ok: true } | { ok: false; reason: 'not_found' };
+
+export async function removeWorkspace({
+  machineId,
+  workspaceId,
+  store,
+}: {
+  machineId: string;
+  workspaceId: string;
+  store: MachineWorkspaceStore;
+}): Promise<RemoveWorkspaceResult> {
+  const removed = await store.remove(machineId, workspaceId);
+  if (!removed) return { ok: false, reason: 'not_found' };
+  return { ok: true };
+}
+
+export interface BootstrapWorkspaceInput {
+  id: string;
+  name: string;
+  scope: WorkspaceScopeInput;
+  layout: unknown;
+}
+
+export type BootstrapWorkspacesResult =
+  | { ok: true; claimed: boolean; workspaces: MachineWorkspaceRecord[] }
+  | { ok: false; reason: WorkspacePlanDenialReason };
+
+/**
+ * Claim-then-seed: see the module doc. Every entry in `workspaces` is
+ * validated BEFORE the transaction runs — a malformed payload must reject
+ * the whole call, not consume the claim on a partially-seeded machine.
+ */
+export async function bootstrapWorkspaces({
+  machineId,
+  ownerId,
+  userId,
+  workspaces,
+  deps,
+}: {
+  machineId: string;
+  ownerId: string;
+  userId: string;
+  workspaces: BootstrapWorkspaceInput[];
+  deps: MachineWorkspacesDeps;
+}): Promise<BootstrapWorkspacesResult> {
+  const now = deps.now();
+  const inputs: NewMachineWorkspaceInput[] = [];
+  for (const workspace of workspaces) {
+    const plan = planWorkspacePayload({ name: workspace.name, layout: workspace.layout });
+    if (!plan.ok) return plan;
+    inputs.push({
+      id: workspace.id,
+      ownerId,
+      machineId,
+      scope: deriveWorkspaceScope(workspace.scope),
+      projectName: workspace.scope.projectName ?? null,
+      branchName: workspace.scope.branchName ?? null,
+      name: plan.name,
+      layout: plan.layout,
+      now,
+    });
+  }
+
+  const result = await deps.store.bootstrapSeed({ machineId, userId, workspaces: inputs, now });
+  return { ok: true, claimed: result.claimed, workspaces: result.workspaces };
+}
+
+/** Re-exported so callers can classify a create rejection without importing the store directly. */
+export { isUniqueViolation };

--- a/packages/lib/src/services/machines/machine-workspaces.ts
+++ b/packages/lib/src/services/machines/machine-workspaces.ts
@@ -90,7 +90,10 @@ export function planWorkspacePayload({
 }): { ok: true; name: string; layout: WorkspaceLayoutInput } | { ok: false; reason: WorkspacePlanDenialReason } {
   if (!isValidWorkspaceName(name)) return { ok: false, reason: 'invalid_name' };
   if (!isValidLayout(layout)) return { ok: false, reason: 'invalid_columns' };
-  return { ok: true, name, layout };
+  // Trimmed here so create and rename persist the same string for the same
+  // input — `updateWorkspace` already trims on rename; this path (create AND
+  // bootstrap seeding, both of which route through this function) did not.
+  return { ok: true, name: name.trim(), layout };
 }
 
 export interface MachineWorkspacesDeps {


### PR DESCRIPTION
## Summary

Closes #2048. Makes a Machine's workspace list (create/rename/delete) and each
workspace's pane-grid layout **server-authoritative**, broadcast live over the
existing `apps/realtime` Socket.IO room for the Machine's own page id — closing
the gap left by PR #2031, where workspace metadata lived only in that browser's
`localStorage`.

- **Schema**: `machine_workspaces` (client-minted `id`, explicit `scope`
  discriminant, `layout` jsonb holding only the *shared* structural half of the
  grid) + `machine_workspace_bootstraps` (a one-row-per-machine atomic claim so
  exactly one browser's local history ever seeds the server on first load —
  per-id upsert alone doesn't prevent N racing browsers' disjoint lists from
  all landing and being unioned together).
- **Service + API**: `packages/lib/services/machines/machine-workspaces{,-store}.ts`
  + `GET/POST/PATCH/DELETE /api/machines/workspaces` + `POST .../bootstrap`,
  following the existing `machine-projects` pattern. Create is an idempotent
  upsert-by-id (first-writer-wins — two browsers materializing the same
  session-derived workspace is expected, not an error).
- **Realtime**: `machine-workspace:{created,updated,deleted,bootstrapped}`
  events via the existing signed `/api/broadcast` HTTP endpoint (no new
  room-join logic needed — a Machine's identity is its own page id).
- **Client**: `useMachineWorkspaceSync` (mounted once at `MachineView`, the
  true per-machine root) hydrates from the server, runs the bootstrap-once
  flow, and reconciles live broadcasts into the existing Zustand store.
  `useSyncedWorkspaceActions` wraps the store's identity/layout actions
  (create/rename/split/close/bindPaneTerminal/openTerminal) to push the
  resulting state to the server — PATCH first, falling back to POST-create on
  a 404, so the wrapper needs no state shared across the multiple components
  that call it (sidebar + pane grid).
- `activeWorkspaceId`, `activePaneId`, `pendingPickerPaneId`, and a pane's
  `pendingPrompt` all stay **local per browser**, never synced — presence-like
  ("what am I looking at / focused on"), explicitly out of scope per the issue.
- Minimal rename UI: double-click a workspace's name in `WorkspaceLeaves` to
  edit it inline (no rename affordance existed before this PR).
- `sessionWorkspaceId`'s delimiter changed from a NUL character to the Unit
  Separator control character (U+001F) — the id is now also a Postgres
  primary key, and Postgres `text` rejects a literal NUL byte outright.
- The existing "unclaimed session" reconciliation in `WorkspaceLeaves` is kept
  unchanged (not made redundant by this PR — it bridges a different gap: a
  `machine_agent_terminals` row with no owning workspace, which can still
  happen via a spawn path that bypasses `openTerminal` entirely).

## Test plan

- [x] Schema-level tests (no DB) for both new tables
- [x] Service-level tests: idempotent create-upsert race, update/rename,
      remove, and the bootstrap claim race (first caller wins, second gets the
      winner's list back unseeded)
- [x] Route contract tests for all 5 endpoints (auth gating, denial-to-status
      mapping, broadcast-only-on-real-change)
- [x] Reducer/store tests: `sessionWorkspaceId`'s new delimiter,
      `mergeServerWorkspaces`/`applyServerWorkspaceUpsert`/`applyServerWorkspaceDeleted`
      preserve local-only fields and never keep unpublished local stragglers
- [x] Hook tests for `useMachineWorkspaceSync` (hydrate vs. bootstrap
      branching, event filtering by machineId) and `useSyncedWorkspaceActions`
      (PATCH-then-POST-fallback)
- [x] `bun run typecheck` and `bun run lint` clean across the monorepo
- [x] Full `packages/db`, `packages/lib`, `apps/web` vitest suites green
      (13101+ passing); the only failures are pre-existing, unrelated to this
      change (a missing local Postgres role for a couple of DB-integration
      tests, and one pre-existing flaky timezone-dependent test) — confirmed
      via `git status` that none of the failing files were touched here

## Review convergence

Fixes made in response to Codex + CodeRabbit review passes, all with regression
test coverage:

- **Cross-machine id collision (P1)**: `machine_workspaces`' primary key was
  the lone `id` column, but `sessionWorkspaceId` has no `machineId` in it — two
  different Machines reusing the same project/branch/session name could
  collide. Now a compound `(machineId, id)` primary key.
- **Legacy NUL-delimited id migration (P1)**: existing `localStorage` from
  PR #2031 has NUL-delimited `sessionWorkspaceId`s; Postgres `text` rejects
  literal NUL bytes. `migrateLegacyWorkspaceId` rewrites them to the current
  delimiter before they ever reach the bootstrap POST.
- **Bootstrap claim cascade (Critical)**: `machine_workspace_bootstraps`'
  `bootstrappedByUserId` FK was `notNull` + `cascade` — deleting the winning
  user's account would delete the claim row and reopen the exact
  duplicate-bootstrap race the table exists to prevent. Now nullable +
  `set null`.
- **Partial `updated` events**: an `updated` socket event unconditionally
  upserted into the store even for a workspace this browser hadn't hydrated
  yet, defaulting missing fields (including `scope`, which the event never
  carries) — could plant a broken zero-column, wrong-scope entry. Now
  unconditionally skipped when the workspace is unknown locally.
- **Rename `onBlur` race**: in Chromium, unmounting the focused rename input
  (which Escape/Enter both do) can itself fire a native `blur`, resurrecting a
  cancelled draft or double-committing. Fixed with a `skipNextBlur` guard.
- **`useMachineWorkspaceSync` gating**: was running (fetch + socket join) for
  non-admin viewers who never see the tabs it exists for. Now takes
  `machineId: string | null`; `MachineView` passes `null` for non-admins.
- **PATCH-fallback detection**: was string-matching `error.message ===
  'not_found'`, coupled to `fetchJSON`'s exact error construction. Now checks
  the real `response.status === 404` via `fetchWithAuth` directly.
- **Partial PATCH per field**: every synced action sent both `name` and
  `columns` on every PATCH, even though the route supports updating either
  independently — a rename racing a split (each on its own possibly-stale
  copy of the field it didn't touch) could silently revert the other's
  change. Each action now sends only the field it actually changed.
- **Batched last-workspace pane cleanup**: emptying every running pane when
  removing a machine's only workspace fired one independent PATCH per pane
  with no ordering guarantee. New `closePanes` applies every local close
  first, then pushes exactly one PATCH with the final layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br1TJjStaT9y1CkURf2uTj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added server-synchronized machine workspaces with create, rename, layout updates, deletion, and one-time bootstrapping.
  * Enabled real-time workspace synchronization across machine views and the development sidebar.
  * Added inline workspace renaming with Enter, blur, and Escape controls.
  * Introduced durable workspace storage with automatic migration of legacy workspace identifiers.
* **Bug Fixes**
  * Preserved local pane/UI state during server synchronization and reconciliation.
  * Prevented duplicate updates/broadcasts and fixed rename interaction edge cases.
* **Tests**
  * Expanded contract, integration, and UI regression coverage for workspaces APIs and inline editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
