### PR TITLE
feat(machines): unify MachineTree's two + icons into one add-palette

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -342,10 +342,8 @@ function MachineTreeSection({
   );
 
   const renderNodeExtra = useCallback(
-    (node: MachineTreeNode) => (
-      <WorkspaceNodeExtras machineId={machineId} node={node} onWorkspaceCreated={onSelectWorkspace} />
-    ),
-    [machineId, onSelectWorkspace],
+    (node: MachineTreeNode) => <WorkspaceNodeExtras machineId={machineId} node={node} />,
+    [machineId],
   );
 
   return (
@@ -362,6 +360,7 @@ function MachineTreeSection({
       selectedNode={selected ? MACHINE_NODE : null}
       renderNodeChildren={renderNodeChildren}
       renderNodeExtra={renderNodeExtra}
+      onWorkspaceCreated={onSelectWorkspace}
     />
   );
 }

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -9,7 +9,7 @@
  * and navigate.
  */
 import { describe, test, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const mockPush = vi.fn();
@@ -78,6 +78,12 @@ vi.mock('@/hooks/useGithubRepos', () => ({
   useGithubRepos: () => ({ repos: [], connected: true, isLoading: false, error: undefined, mutate: vi.fn() }),
 }));
 vi.mock('@/hooks/useIntegrations', () => ({ useProviders: () => ({ providers: [] }) }));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
+  post: vi.fn(async () => ({ agentTerminal: { name: 'claude-a1b2c3', agentType: 'claude', resumed: false } })),
+  del: vi.fn(async () => new Response(null, { status: 204 })),
+}));
 
 // Sidebar chrome that isn't under test.
 vi.mock('@/components/layout/navbar/DriveSwitcher', () => ({ default: () => <div /> }));
@@ -173,19 +179,23 @@ describe('DevelopmentSidebar', () => {
     expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/development/machine-1');
   });
 
-  test('the machine row\'s new-workspace trigger creates a workspace and drives the same click flow', async () => {
+  test('the machine row\'s single "+" palette spawns a new terminal and drives the same click flow', async () => {
     const user = userEvent.setup();
     render(<DevelopmentSidebar />);
 
-    await user.click(await screen.findByRole('button', { name: 'New workspace' }));
+    await user.click(await screen.findByTitle('Add…'));
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await user.click(await screen.findByRole('button', { name: 'Spawn agent' }));
 
-    const machine = selectMachine('machine-1')(useMachineWorkspaceStore.getState())!;
-    expect(Object.keys(machine.workspaces).length).toBe(2);
-    expect(usePendingWorkspaceStore.getState().pending).toEqual({
-      machineId: 'machine-1',
-      workspaceId: machine.activeWorkspaceId,
+    await waitFor(() => {
+      const machine = selectMachine('machine-1')(useMachineWorkspaceStore.getState())!;
+      expect(Object.keys(machine.workspaces).length).toBe(2);
+      expect(usePendingWorkspaceStore.getState().pending).toEqual({
+        machineId: 'machine-1',
+        workspaceId: machine.activeWorkspaceId,
+      });
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/development/machine-1');
     });
-    expect(mockPush).toHaveBeenCalledWith('/dashboard/drive-1/development/machine-1');
   });
 
   test('clicking the machine itself drops a stale workspace intent', async () => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
@@ -24,6 +24,11 @@ vi.mock('@/hooks/useGithubRepos', () => ({
   useGithubRepos: () => ({ repos: [], connected: true, isLoading: false, error: undefined, mutate: vi.fn() }),
 }));
 vi.mock('@/hooks/useIntegrations', () => ({ useProviders: () => ({ providers: [] }) }));
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
+  post: vi.fn(async () => ({ agentTerminal: { name: 'claude-a1b2c3', agentType: 'claude', resumed: false } })),
+  del: vi.fn(async () => new Response(null, { status: 204 })),
+}));
 
 import TerminalTab from './TerminalTab';
 
@@ -75,21 +80,25 @@ describe('TerminalTab', () => {
     });
   });
 
-  test('the machine row\'s new-workspace button creates and activates a fresh workspace', async () => {
+  test('the machine row\'s single "+" palette spawns a new terminal into a fresh, now-active workspace', async () => {
     render(<TerminalTab machineId="machine-1" />);
 
     await screen.findByText('Machine');
-    await userEvent.click(screen.getByRole('button', { name: 'New workspace' }));
+    await userEvent.click(screen.getByTitle('Add…'));
+    await userEvent.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Spawn agent' }));
 
-    const machine = selectMachine('machine-1')(store())!;
-    assert({
-      given: 'the machine row\'s new-workspace trigger clicked',
-      should: 'create a second, now-active workspace at machine scope',
-      actual: {
-        count: Object.keys(machine.workspaces).length,
-        activeScope: machine.workspaces[machine.activeWorkspaceId].scope,
-      },
-      expected: { count: 2, activeScope: {} },
+    await waitFor(() => {
+      const machine = selectMachine('machine-1')(store())!;
+      assert({
+        given: 'the machine row\'s single "+" trigger used to spawn a new terminal',
+        should: 'create a second, now-active workspace at machine scope',
+        actual: {
+          count: Object.keys(machine.workspaces).length,
+          activeScope: machine.workspaces[machine.activeWorkspaceId].scope,
+        },
+        expected: { count: 2, activeScope: {} },
+      });
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.tsx
@@ -76,11 +76,16 @@ function WorkspaceTree({ machineId, onSelected }: { machineId: string; onSelecte
   );
 
   const renderNodeExtra = useCallback(
-    (node: MachineTreeNode) => (
-      <WorkspaceNodeExtras machineId={machineId} node={node} onWorkspaceCreated={onSelectWorkspace} />
-    ),
-    [machineId, onSelectWorkspace],
+    (node: MachineTreeNode) => <WorkspaceNodeExtras machineId={machineId} node={node} />,
+    [machineId],
   );
 
-  return <MachineTree machineId={machineId} renderNodeChildren={renderNodeChildren} renderNodeExtra={renderNodeExtra} />;
+  return (
+    <MachineTree
+      machineId={machineId}
+      renderNodeChildren={renderNodeChildren}
+      renderNodeExtra={renderNodeExtra}
+      onWorkspaceCreated={onSelectWorkspace}
+    />
+  );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.test.tsx
@@ -321,15 +321,27 @@ describe('MachineTree', () => {
     });
   });
 
-  test('the machine row\'s "add project" trigger is hover-revealed on the row, not a separate header line', async () => {
+  test('the machine row\'s single "+" trigger is hover-revealed on the row, not a separate header line', async () => {
     renderTree();
 
     const machineRow = (await waitFor(() => screen.getByText('Machine'))).closest('.group') as HTMLElement;
     assert({
       given: 'the machine row',
-      should: 'offer an "Add project" trigger inside the row itself',
-      actual: within(machineRow).getByTitle('Add project') !== null,
+      should: 'offer exactly one "+" action-palette trigger inside the row itself',
+      actual: within(machineRow).getByTitle('Add…') !== null,
       expected: true,
+    });
+  });
+
+  test('a node offers ONE "+" trigger, not two — the old add-project/add-branch dialog trigger and the new-workspace trigger are unified', async () => {
+    renderTree();
+
+    const machineRow = (await waitFor(() => screen.getByText('Machine'))).closest('.group') as HTMLElement;
+    assert({
+      given: 'the machine row, which used to carry a structural "Add project" trigger AND a separate new-workspace trigger',
+      should: 'render exactly one hover-revealed add trigger',
+      actual: within(machineRow).getAllByTitle('Add…').length,
+      expected: 1,
     });
   });
 
@@ -360,7 +372,7 @@ describe('MachineTree', () => {
   // sidebar must not fire N fetches on mount). Before the `enabled` split,
   // addProject/addBranch shared that same gated key and threw "No active
   // machine"/"No active project" until the row was expanded once.
-  test('"Add project" submits successfully from a COLLAPSED machine row', async () => {
+  test('"Add project" (via the single "+" palette) submits successfully from a COLLAPSED machine row', async () => {
     const user = userEvent.setup();
     vi.mocked(post).mockResolvedValueOnce({
       project: { name: 'new-repo', repoUrl: 'https://github.com/org/new-repo.git', path: '/workspace/projects/new-repo' },
@@ -368,7 +380,8 @@ describe('MachineTree', () => {
     renderTree({ defaultExpanded: false });
 
     // Never expanded — the machine row's chevron is never clicked.
-    await user.click(screen.getByTitle('Add project'));
+    await user.click(screen.getByTitle('Add…'));
+    await user.click(await screen.findByRole('option', { name: 'Add project' }));
     await user.click(await screen.findByRole('button', { name: 'Enter a repo URL manually' }));
     await user.type(screen.getByPlaceholderText('Project name'), 'new-repo');
     await user.type(screen.getByPlaceholderText(/Repo URL/), 'https://github.com/org/new-repo.git');
@@ -377,7 +390,7 @@ describe('MachineTree', () => {
 
     await waitFor(() => {
       assert({
-        given: 'the collapsed machine row\'s hover-revealed "Add project" trigger, used without expanding first',
+        given: 'the collapsed machine row\'s single "+" trigger, used without expanding first',
         should: 'POST the new project — not throw "No active machine"',
         actual: vi.mocked(post).mock.calls[0]?.[0],
         expected: '/api/machines/projects',
@@ -385,7 +398,25 @@ describe('MachineTree', () => {
     });
   });
 
-  test('"Add branch" submits successfully from a COLLAPSED project row', async () => {
+  test('the machine node\'s palette does not offer "Add branch" — that only applies to a project', async () => {
+    const user = userEvent.setup();
+    renderTree();
+
+    const machineRow = (await waitFor(() => screen.getByText('Machine'))).closest('.group') as HTMLElement;
+    await user.click(within(machineRow).getByTitle('Add…'));
+
+    assert({
+      given: 'the machine node\'s "+" palette opened',
+      should: 'offer "Add project" but not "Add branch"',
+      actual: {
+        addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+      },
+      expected: { addProject: true, addBranch: false },
+    });
+  });
+
+  test('"Add branch" (via the single "+" palette) submits successfully from a COLLAPSED project row', async () => {
     const user = userEvent.setup();
     vi.mocked(post).mockResolvedValueOnce({
       branch: { branchName: 'feat-y', resumed: false },
@@ -398,18 +429,61 @@ describe('MachineTree', () => {
     // regression: clicking my-repo's chevron is what sets `expanded=true` on
     // THAT ProjectNode, which is the exact state this test must avoid.
     const projectRow = (await screen.findByText('my-repo')).closest('.group') as HTMLElement;
-    await user.click(within(projectRow).getByTitle('Add branch-terminal'));
+    await user.click(within(projectRow).getByTitle('Add…'));
+    await user.click(await screen.findByRole('option', { name: 'Add branch' }));
     await user.type(screen.getByPlaceholderText('Branch name'), 'feat-y');
     const dialog = screen.getByRole('dialog');
     await user.click(within(dialog).getByRole('button', { name: 'Add branch' }));
 
     await waitFor(() => {
       assert({
-        given: 'the collapsed project row\'s hover-revealed "Add branch" trigger, used without expanding first',
+        given: 'the collapsed project row\'s single "+" trigger, used without expanding first',
         should: 'POST the new branch — not throw "No active project"',
         actual: vi.mocked(post).mock.calls[0]?.[0],
         expected: '/api/machines/branches',
       });
+    });
+  });
+
+  test('the project node\'s palette does not offer "New terminal" when the tree is BARE (no onWorkspaceCreated)', async () => {
+    const user = userEvent.setup();
+    renderTree();
+
+    const projectRow = (await screen.findByText('my-repo')).closest('.group') as HTMLElement;
+    await user.click(within(projectRow).getByTitle('Add…'));
+
+    assert({
+      given: 'a bare tree (Diff/Files-tab shape: no onWorkspaceCreated passed) with a project node\'s palette opened',
+      should: 'offer "Add branch" but not "New terminal" — no workspace concept to spawn into',
+      actual: {
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+      },
+      expected: { addBranch: true, newTerminal: false },
+    });
+  });
+
+  test('a branch row (no add-child action of its own) still offers a "+" trigger once onWorkspaceCreated is wired', async () => {
+    const onWorkspaceCreated = vi.fn();
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <MachineTree machineId={TERMINAL_ID} onWorkspaceCreated={onWorkspaceCreated} />
+      </SWRConfig>,
+    );
+
+    await expandRowFor('my-repo');
+    const branchRow = (await screen.findByText('main')).closest('.group') as HTMLElement;
+    await userEvent.click(within(branchRow).getByTitle('Add…'));
+
+    assert({
+      given: 'a branch row with onWorkspaceCreated wired in',
+      should: 'offer "New terminal" only — a branch has no structural add-child action',
+      actual: {
+        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+      },
+      expected: { newTerminal: true, addProject: false, addBranch: false },
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.tsx
@@ -1,50 +1,13 @@
 "use client";
 
 import { useState, type ReactNode } from 'react';
-import { usePathname } from 'next/navigation';
-import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import {
-  ChevronRight,
-  ChevronDown,
-  Cpu,
-  FolderGit2,
-  Github,
-  GitBranch,
-  Plus,
-} from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
+import { ChevronRight, ChevronDown, Cpu, FolderGit2, GitBranch } from 'lucide-react';
 import { useMachineProjects } from '@/hooks/useMachineProjects';
 import { useMachineBranches } from '@/hooks/useMachineBranches';
-import { useGithubRepos, type GithubRepo } from '@/hooks/useGithubRepos';
-import { useProviders } from '@/hooks/useIntegrations';
-import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
-import { normalizeProjectName } from '@pagespace/lib/services/machines/project-name';
-import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-name';
 import ConfirmRemoveDialog from './ConfirmRemoveDialog';
 import RemoveButton from './RemoveButton';
+import NodeActionPalette from './NodeActionPalette';
 import { SidebarLoading } from '../tabs/tab-states';
 
 /** A node in the Machine → Project → Branch tree, passed to `onSelectNode` and `renderNodeChildren`. */
@@ -94,6 +57,14 @@ interface MachineTreeProps {
    * have no workspace to count or create, so they simply omit this prop.
    */
   renderNodeExtra?: (node: MachineTreeNode) => ReactNode;
+  /**
+   * When provided, every node's single "+" action palette offers a "New
+   * terminal" action that spawns an agent into a freshly created workspace
+   * at that node's scope, reporting the new workspace's id here. Omit for
+   * trees with no workspace concept (the Diff and Files tabs render this
+   * same tree BARE) — their palette then offers only Add project/Add branch.
+   */
+  onWorkspaceCreated?: (workspaceId: string) => void;
 }
 
 /**
@@ -121,7 +92,7 @@ export function isSameMachineTreeNode(a: MachineTreeNode | null | undefined, b: 
 }
 
 /** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */
-export default function MachineTree({ machineId, machineLabel, defaultExpanded, onSelectNode, isNodeSelectable, selectedNode, renderNodeChildren, renderNodeExtra }: MachineTreeProps) {
+export default function MachineTree({ machineId, machineLabel, defaultExpanded, onSelectNode, isNodeSelectable, selectedNode, renderNodeChildren, renderNodeExtra, onWorkspaceCreated }: MachineTreeProps) {
   return (
     <div className="p-1 text-sm">
       <MachineNode
@@ -133,6 +104,7 @@ export default function MachineTree({ machineId, machineLabel, defaultExpanded, 
         selectedNode={selectedNode}
         renderNodeChildren={renderNodeChildren}
         renderNodeExtra={renderNodeExtra}
+        onWorkspaceCreated={onWorkspaceCreated}
       />
     </div>
   );
@@ -227,6 +199,7 @@ interface TreeLevelProps {
   selectedNode?: MachineTreeNode | null;
   renderNodeChildren?: (node: MachineTreeNode) => ReactNode;
   renderNodeExtra?: (node: MachineTreeNode) => ReactNode;
+  onWorkspaceCreated?: (workspaceId: string) => void;
 }
 
 function MachineNode({
@@ -238,10 +211,11 @@ function MachineNode({
   selectedNode,
   renderNodeChildren,
   renderNodeExtra,
+  onWorkspaceCreated,
 }: TreeLevelProps & { machineId: string; machineLabel?: string; defaultExpanded?: boolean }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const node: MachineTreeNode = { level: 'machine' };
-  // The row's "Add project" trigger is always mounted (hover-revealed on the
+  // The row's "+" action palette is always mounted (hover-revealed on the
   // row itself, not gated by expansion — see MachineTree's header-ectomy), so
   // `addProject` must work before the row is ever expanded. Only the list
   // FETCH is gated on `expanded`.
@@ -259,7 +233,7 @@ function MachineNode({
         extra={
           <>
             {renderNodeExtra?.(node)}
-            <AddProjectDialog onAdd={addProject} />
+            <NodeActionPalette machineId={machineId} node={node} onAddProject={addProject} onWorkspaceCreated={onWorkspaceCreated} />
           </>
         }
       />
@@ -277,6 +251,7 @@ function MachineNode({
               selectedNode={selectedNode}
               renderNodeChildren={renderNodeChildren}
               renderNodeExtra={renderNodeExtra}
+              onWorkspaceCreated={onWorkspaceCreated}
               onRemoveProject={() => removeProject(project.name)}
             />
           ))}
@@ -294,6 +269,7 @@ function ProjectNode({
   selectedNode,
   renderNodeChildren,
   renderNodeExtra,
+  onWorkspaceCreated,
   onRemoveProject,
 }: TreeLevelProps & {
   machineId: string;
@@ -303,7 +279,7 @@ function ProjectNode({
   const [expanded, setExpanded] = useState(false);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const node: MachineTreeNode = { level: 'project', projectName };
-  // Same reasoning as the machine row's "Add project" trigger above: "Add
+  // Same reasoning as the machine row's "+" action palette above: "Add
   // branch" is always mounted, so `addBranch` must work before the row is
   // ever expanded. Only the list FETCH is gated on `expanded`.
   const { branches, isLoading: branchesLoading, addBranch, removeBranch } = useMachineBranches(machineId, projectName, { enabled: expanded });
@@ -320,7 +296,7 @@ function ProjectNode({
         extra={
           <>
             {renderNodeExtra?.(node)}
-            <AddBranchDialog onAdd={addBranch} />
+            <NodeActionPalette machineId={machineId} node={node} onAddBranch={addBranch} onWorkspaceCreated={onWorkspaceCreated} />
           </>
         }
         onRemove={() => setConfirmingRemove(true)}
@@ -340,6 +316,7 @@ function ProjectNode({
           {branches.map((branch) => (
             <BranchNode
               key={branch.branchName}
+              machineId={machineId}
               projectName={projectName}
               branchName={branch.branchName}
               onSelectNode={onSelectNode}
@@ -347,6 +324,7 @@ function ProjectNode({
               selectedNode={selectedNode}
               renderNodeChildren={renderNodeChildren}
               renderNodeExtra={renderNodeExtra}
+              onWorkspaceCreated={onWorkspaceCreated}
               onRemoveBranch={() => removeBranch(branch.branchName)}
             />
           ))}
@@ -357,6 +335,7 @@ function ProjectNode({
 }
 
 function BranchNode({
+  machineId,
   projectName,
   branchName,
   onSelectNode,
@@ -364,8 +343,10 @@ function BranchNode({
   selectedNode,
   renderNodeChildren,
   renderNodeExtra,
+  onWorkspaceCreated,
   onRemoveBranch,
 }: TreeLevelProps & {
+  machineId: string;
   projectName: string;
   branchName: string;
   onRemoveBranch(): Promise<unknown>;
@@ -384,7 +365,12 @@ function BranchNode({
         selected={isSameMachineTreeNode(node, selectedNode)}
         icon={<GitBranch className="size-3 shrink-0" />}
         label={branchName}
-        extra={renderNodeExtra?.(node)}
+        extra={
+          <>
+            {renderNodeExtra?.(node)}
+            <NodeActionPalette machineId={machineId} node={node} onWorkspaceCreated={onWorkspaceCreated} />
+          </>
+        }
         onRemove={() => setConfirmingRemove(true)}
         removeTitle="Remove branch-terminal"
       />
@@ -397,230 +383,5 @@ function BranchNode({
       />
       {expandable && expanded && <div className="pl-4">{renderNodeChildren?.(node)}</div>}
     </div>
-  );
-}
-
-function GithubRepoPicker({
-  repos,
-  isLoading,
-  error,
-  selectedLabel,
-  onSelect,
-}: {
-  repos: GithubRepo[];
-  isLoading: boolean;
-  error?: Error;
-  selectedLabel?: string;
-  onSelect(repo: GithubRepo): void;
-}) {
-  const [pickerOpen, setPickerOpen] = useState(false);
-
-  return (
-    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-      <PopoverTrigger asChild>
-        <Button type="button" variant="outline" role="combobox" aria-expanded={pickerOpen} className="w-full justify-between font-normal">
-          <span className="flex min-w-0 items-center gap-2">
-            <Github className="size-3.5 shrink-0 text-muted-foreground" />
-            <span className={cn('truncate', !selectedLabel && 'text-muted-foreground')}>
-              {selectedLabel || 'Select a repo…'}
-            </span>
-          </span>
-          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-        <Command>
-          <CommandInput placeholder="Search your repos…" />
-          <CommandList onWheel={(e) => e.stopPropagation()}>
-            <CommandEmpty>
-              {error ? `Failed to load repos: ${error.message}` : isLoading ? 'Loading repos…' : 'No repos found.'}
-            </CommandEmpty>
-            {repos.map((repo) => (
-              <CommandItem key={repo.full_name} value={repo.full_name} onSelect={() => { onSelect(repo); setPickerOpen(false); }}>
-                <FolderGit2 className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate text-sm">{repo.full_name}</span>
-                {repo.private && (
-                  <span className="ml-auto shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">private</span>
-                )}
-              </CommandItem>
-            ))}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-/** Short project name from a GitHub `full_name` (e.g. "org/my-repo" -> "my-repo"), and the ready-to-clone URL. */
-export function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
-  const segments = repo.full_name.split('/');
-  return { name: segments[segments.length - 1] || repo.full_name, repoUrl: repo.clone_url };
-}
-
-/** Hover-revealed trigger chrome shared by the two "add a child node" dialogs
- * (project, branch) — the non-destructive sibling of `RemoveButton`'s reveal
- * pattern, built on `Button` (rather than the plain `AddButton`) because a
- * `DialogTrigger asChild` needs a ref-forwarding child. */
-const ADD_DIALOG_TRIGGER_CLASSNAME =
-  'size-4 opacity-0 hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100';
-
-/** What the user's raw input will actually be saved as, shown live as they
- * type — the client-side half of "normalize-and-accept": `normalize` never
- * rejects, so this is purely informational and never blocks submission. */
-function NamePreview({ value, normalize }: { value: string; normalize(input: string): string }) {
-  const trimmed = value.trim();
-  if (!trimmed) return null;
-  const normalized = normalize(trimmed);
-  if (normalized === trimmed) return null;
-  return (
-    <p className="text-xs text-muted-foreground">
-      Will be saved as <span className="font-mono">{normalized}</span>
-    </p>
-  );
-}
-
-function AddProjectDialog({ onAdd }: { onAdd(name: string, repoUrl: string): Promise<unknown> }) {
-  const pathname = usePathname();
-  const [open, setOpen] = useState(false);
-  const [name, setName] = useState('');
-  const [repoUrl, setRepoUrl] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [manualMode, setManualMode] = useState(false);
-  const [connectDialogOpen, setConnectDialogOpen] = useState(false);
-
-  const { repos, connected, isLoading: reposLoading, error: reposError, mutate: refetchRepos } = useGithubRepos(open && !manualMode);
-  // Only needed to resolve the github provider for the "Connect GitHub" fallback CTA, so it's gated the same as useGithubRepos rather than fetched on every mount.
-  const { providers } = useProviders(open);
-  const githubProvider = providers.find((p) => p.slug === 'github') ?? null;
-
-  const mode: 'manual' | 'connect' | 'picker' = manualMode ? 'manual' : connected === false ? 'connect' : 'picker';
-
-  const resetAndClose = () => {
-    setOpen(false);
-    setName('');
-    setRepoUrl('');
-    setManualMode(false);
-  };
-
-  const handleSubmit = async () => {
-    setSubmitting(true);
-    try {
-      await onAdd(name.trim(), repoUrl.trim());
-      resetAndClose();
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to add project');
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  const handleSelectRepo = (repo: GithubRepo) => {
-    const fields = deriveProjectFieldsFromRepo(repo);
-    setName(fields.name);
-    setRepoUrl(fields.repoUrl);
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) resetAndClose(); }}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" size="icon" className={ADD_DIALOG_TRIGGER_CLASSNAME} title="Add project">
-          <Plus className="size-3" />
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add project</DialogTitle>
-          <DialogDescription>Clone a git repo onto this machine&apos;s persistent filesystem.</DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-3">
-          <div>
-            <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
-            <NamePreview value={name} normalize={normalizeProjectName} />
-          </div>
-
-          {mode === 'manual' && (
-            <Input placeholder="Repo URL (https://github.com/org/repo.git)" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} />
-          )}
-          {mode === 'connect' && (
-            <Button type="button" variant="outline" onClick={() => setConnectDialogOpen(true)} className="justify-start gap-2 font-normal text-muted-foreground">
-              <Github className="size-3.5 shrink-0" />
-              Connect GitHub to browse your repos
-            </Button>
-          )}
-          {mode === 'picker' && (
-            <GithubRepoPicker repos={repos} isLoading={reposLoading} error={reposError} selectedLabel={name} onSelect={handleSelectRepo} />
-          )}
-
-          <Button
-            type="button"
-            variant="link"
-            size="sm"
-            className="h-auto justify-start p-0 text-xs text-muted-foreground"
-            onClick={() => setManualMode((m) => !m)}
-          >
-            {manualMode ? 'Pick from your GitHub repos instead' : 'Enter a repo URL manually'}
-          </Button>
-        </div>
-        <DialogFooter>
-          <Button onClick={handleSubmit} disabled={submitting || !name.trim() || !repoUrl.trim()}>
-            {submitting ? 'Adding…' : 'Add project'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-      <ConnectIntegrationDialog
-        provider={githubProvider}
-        open={connectDialogOpen}
-        onOpenChange={setConnectDialogOpen}
-        onConnected={() => {
-          setConnectDialogOpen(false);
-          refetchRepos();
-        }}
-        returnUrl={pathname}
-      />
-    </Dialog>
-  );
-}
-
-function AddBranchDialog({ onAdd }: { onAdd(branchName: string): Promise<unknown> }) {
-  const [open, setOpen] = useState(false);
-  const [branchName, setBranchName] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-
-  const handleSubmit = async () => {
-    setSubmitting(true);
-    try {
-      await onAdd(branchName.trim());
-      setOpen(false);
-      setBranchName('');
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to add branch');
-    } finally {
-      setSubmitting(false);
-    }
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" size="icon" className={ADD_DIALOG_TRIGGER_CLASSNAME} title="Add branch-terminal">
-          <Plus className="size-3" />
-        </Button>
-      </DialogTrigger>
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>Add branch-terminal</DialogTitle>
-          <DialogDescription>Checks out this branch in its own isolated Sprite.</DialogDescription>
-        </DialogHeader>
-        <div>
-          <Input placeholder="Branch name" value={branchName} onChange={(e) => setBranchName(e.target.value)} />
-          <NamePreview value={branchName} normalize={normalizeBranchName} />
-        </div>
-        <DialogFooter>
-          <Button onClick={handleSubmit} disabled={submitting || !branchName.trim()}>
-            {submitting ? 'Spawning…' : 'Add branch'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.tsx
@@ -91,7 +91,22 @@ export function isSameMachineTreeNode(a: MachineTreeNode | null | undefined, b: 
   return a != null && b != null && nodeKey(a) === nodeKey(b);
 }
 
-/** Presentation-only Machine → Project → Branch tree, reusable across any tab that needs this navigation shape (Terminal, Diff, …). Has no opinion on what a row click does — callers own that via `onSelectNode`. */
+/**
+ * Machine → Project → Branch tree, reusable across any tab that needs this
+ * navigation shape (Terminal, Diff, …). Has no opinion on what a row CLICK
+ * does — callers own that via `onSelectNode` — and no opinion on workspaces:
+ * the "N running" badge and the workspace-item leaves under an expanded node
+ * are entirely caller-owned too, via `renderNodeExtra`/`renderNodeChildren`.
+ *
+ * It does own one thing directly: every row's single "+" action palette
+ * (`NodeActionPalette`), because "Add project"/"Add branch" are structural to
+ * THIS tree (backed by `useMachineProjects`/`useMachineBranches`, called
+ * here) — that part predates this file's workspace-agnosticism and was never
+ * caller-injected. "New terminal" rides along in the same palette rather than
+ * getting a second `+`, so it's real when `onWorkspaceCreated` is passed and
+ * simply absent (the palette then offers only Add project/Add branch) for
+ * the Diff/Files tabs that render this tree bare.
+ */
 export default function MachineTree({ machineId, machineLabel, defaultExpanded, onSelectNode, isNodeSelectable, selectedNode, renderNodeChildren, renderNodeExtra, onWorkspaceCreated }: MachineTreeProps) {
   return (
     <div className="p-1 text-sm">

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -222,4 +222,40 @@ describe('NodeActionPalette', () => {
       });
     });
   });
+
+  // Regression (Codex P2): a successful submit closes the palette via `close()`,
+  // which sets `open` false directly rather than through Radix's onOpenChange —
+  // so the phase-reset that onOpenChange triggers on an Escape/backdrop close
+  // must ALSO happen on this path, or reopening the "+" drops the user straight
+  // back into the just-completed form instead of the action list.
+  test('reopening the "+" after a successful "Add branch" shows the action list again, not the same form', async () => {
+    const onAddBranch = vi.fn().mockResolvedValue(undefined);
+    renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={onAddBranch} onWorkspaceCreated={vi.fn()} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'Add branch' }));
+    await user.type(screen.getByPlaceholderText('Branch name'), 'feat/z');
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Add branch' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a successful "Add branch" submit',
+        should: 'close the palette dialog',
+        actual: screen.queryByRole('dialog'),
+        expected: null,
+      });
+    });
+    await user.click(screen.getByTitle('Add…'));
+
+    assert({
+      given: 'the palette reopened right after a successful "Add branch" submit',
+      should: 'show the action list (New terminal / Add branch), not the branch-name form left over from last time',
+      actual: {
+        actionList: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+        staleForm: screen.queryByPlaceholderText('Branch name') !== null,
+      },
+      expected: { actionList: true, staleForm: false },
+    });
+  });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -162,6 +162,25 @@ describe('NodeActionPalette', () => {
     });
   });
 
+  test('"New terminal" offers shell, claude, and codex — not pagespace-cli — with shell first/default', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    const agentTypeTrigger = await screen.findByLabelText('Agent type');
+    const defaultSelected = agentTypeTrigger.textContent;
+
+    await user.click(agentTypeTrigger);
+    const optionTexts = (await screen.findAllByRole('option')).map((o) => o.textContent);
+
+    assert({
+      given: 'the "New terminal" agent-type picker, opened',
+      should: 'offer exactly shell, claude, and codex (never pagespace-cli), defaulting to shell',
+      actual: { optionTexts, defaultSelected },
+      expected: { optionTexts: ['shell', 'claude', 'codex'], defaultSelected: 'shell' },
+    });
+  });
+
   test('"Add project" submits the trimmed name (server-side normalizes it; the field only previews that)', async () => {
     const onAddProject = vi.fn().mockResolvedValue(undefined);
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onAddProject={onAddProject} />);

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -162,6 +162,45 @@ describe('NodeActionPalette', () => {
     });
   });
 
+  // Regression: submit() used to call onSpawned(workspaceId) unconditionally,
+  // even if the user backed out (Escape/backdrop) while the addAgentTerminal
+  // network call was still in flight. A late-resolving spawn would then still
+  // report "success" to a caller no longer listening — in DevelopmentSidebar
+  // that meant navigating the user to a workspace they explicitly cancelled.
+  test('cancelling "New terminal" (Escape) while the spawn is in flight never reports success once it resolves', async () => {
+    let resolveSpawn: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementationOnce(() => new Promise((resolve) => { resolveSpawn = resolve; }));
+    const onWorkspaceCreated = vi.fn();
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    // Still awaiting the network — back out before it resolves.
+    await user.keyboard('{Escape}');
+    await waitFor(() => {
+      assert({
+        given: 'Escape pressed while a "New terminal" spawn is awaiting the network',
+        should: 'close the palette immediately rather than wait for the in-flight spawn',
+        actual: screen.queryByRole('dialog'),
+        expected: null,
+      });
+    });
+
+    resolveSpawn({ agentTerminal: { name: 'claude-late', agentType: 'claude', resumed: false } });
+    // Let the now-resolved promise chain (addAgentTerminal -> cancelledRef
+    // check -> removeAgentTerminal cleanup) finish draining.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert({
+      given: 'the spawn resolving AFTER the user cancelled it',
+      should: 'never call onWorkspaceCreated for a spawn the user backed out of',
+      actual: onWorkspaceCreated.mock.calls.length,
+      expected: 0,
+    });
+  });
+
   test('"New terminal" offers shell, claude, and codex — not pagespace-cli — with shell first/default', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -1,0 +1,206 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SWRConfig } from 'swr';
+import type { ReactElement } from 'react';
+import { assert } from '@/stores/__tests__/riteway';
+import { useMachineWorkspaceStore, selectMachine } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import NodeActionPalette from './NodeActionPalette';
+import type { MachineTreeNode } from './MachineTree';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
+  post: vi.fn(),
+  del: vi.fn(async () => new Response(null, { status: 204 })),
+}));
+
+vi.mock('@/hooks/useGithubRepos', () => ({
+  useGithubRepos: () => ({ repos: [], connected: true, isLoading: false, error: undefined, mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useIntegrations', () => ({
+  useProviders: () => ({ providers: [] }),
+}));
+
+import { post } from '@/lib/auth/auth-fetch';
+
+const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
+const PROJECT_NODE: MachineTreeNode = { level: 'project', projectName: 'app' };
+const BRANCH_NODE: MachineTreeNode = { level: 'branch', projectName: 'app', branchName: 'main' };
+
+const store = () => useMachineWorkspaceStore.getState();
+
+const renderPalette = (ui: ReactElement) =>
+  render(<SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{ui}</SWRConfig>);
+
+const openPalette = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByTitle('Add…'));
+  return user;
+};
+
+describe('NodeActionPalette', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    useMachineWorkspaceStore.setState({ machines: {} });
+  });
+
+  test('a single "+" trigger opens the palette', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onAddProject={vi.fn()} />);
+
+    assert({
+      given: 'the row not yet interacted with',
+      should: 'show exactly one "+" trigger and no open dialog',
+      actual: { triggers: screen.getAllByTitle('Add…').length, dialog: screen.queryByRole('dialog') },
+      expected: { triggers: 1, dialog: null },
+    });
+
+    await openPalette();
+    assert({
+      given: 'the "+" trigger clicked',
+      should: 'open the action palette',
+      actual: screen.queryByRole('dialog') !== null,
+      expected: true,
+    });
+  });
+
+  test('the machine node offers New terminal + Add project, not Add branch', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onAddProject={vi.fn()} onWorkspaceCreated={vi.fn()} />);
+    await openPalette();
+
+    assert({
+      given: 'a machine node\'s palette, with onWorkspaceCreated wired in',
+      should: 'offer New terminal and Add project, but not Add branch',
+      actual: {
+        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+      },
+      expected: { newTerminal: true, addProject: true, addBranch: false },
+    });
+  });
+
+  test('the project node offers New terminal + Add branch, not Add project', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={vi.fn()} onWorkspaceCreated={vi.fn()} />);
+    await openPalette();
+
+    assert({
+      given: 'a project node\'s palette, with onWorkspaceCreated wired in',
+      should: 'offer New terminal and Add branch, but not Add project',
+      actual: {
+        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+        addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
+      },
+      expected: { newTerminal: true, addBranch: true, addProject: false },
+    });
+  });
+
+  test('the branch node offers New terminal only', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={vi.fn()} />);
+    await openPalette();
+
+    assert({
+      given: 'a branch node\'s palette, with onWorkspaceCreated wired in',
+      should: 'offer New terminal only — a branch has no structural add-child action',
+      actual: {
+        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
+        addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
+      },
+      expected: { newTerminal: true, addProject: false, addBranch: false },
+    });
+  });
+
+  test('a bare tree (no onWorkspaceCreated) renders no "+" at all for a branch node — it has no other action', () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} />);
+
+    assert({
+      given: 'a branch node with no onAddProject/onAddBranch/onWorkspaceCreated (the Diff/Files-tab shape)',
+      should: 'render nothing — a branch offers no structural add-child action and no workspace concept',
+      actual: screen.queryByTitle('Add…'),
+      expected: null,
+    });
+  });
+
+  test('"New terminal" creates a workspace at the node\'s scope, spawns the picked agent into it with the typed prompt, and reports the new workspace id', async () => {
+    vi.mocked(post).mockResolvedValueOnce({
+      agentTerminal: { name: 'claude-mocked', agentType: 'pagespace-cli', resumed: false },
+    });
+    const onWorkspaceCreated = vi.fn();
+    renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={vi.fn()} onWorkspaceCreated={onWorkspaceCreated} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await user.type(await screen.findByLabelText('Starting prompt'), 'hello agent');
+    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    await waitFor(() => {
+      const workspaceId = onWorkspaceCreated.mock.calls[0]?.[0];
+      const machine = selectMachine('m1')(store());
+      const workspace = workspaceId ? machine?.workspaces[workspaceId] : undefined;
+      const pane = workspace?.columns[0]?.panes[0];
+      assert({
+        given: '"New terminal" submitted with a starting prompt, on a project node',
+        should: 'create a workspace scoped to that project, bind the spawned agent into its first pane with the prompt pending, and report the workspace id',
+        actual: {
+          reported: workspaceId !== undefined,
+          scope: workspace?.scope,
+          paneAgentName: pane?.scope?.name,
+          pendingPrompt: pane?.pendingPrompt,
+        },
+        expected: {
+          reported: true,
+          scope: { projectName: 'app' },
+          paneAgentName: 'claude-mocked',
+          pendingPrompt: 'hello agent',
+        },
+      });
+    });
+  });
+
+  test('"Add project" submits the trimmed name (server-side normalizes it; the field only previews that)', async () => {
+    const onAddProject = vi.fn().mockResolvedValue(undefined);
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onAddProject={onAddProject} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'Add project' }));
+    await user.click(await screen.findByRole('button', { name: 'Enter a repo URL manually' }));
+    await user.type(screen.getByPlaceholderText('Project name'), 'My Repo');
+    await user.type(screen.getByPlaceholderText(/Repo URL/), 'https://github.com/org/my-repo.git');
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Add project' }));
+
+    await waitFor(() => {
+      assert({
+        given: '"Add project" submitted with an un-normalized name',
+        should: 'call onAddProject with the raw (trimmed) name — normalization is server-side, this only PREVIEWS it',
+        actual: onAddProject.mock.calls[0],
+        expected: ['My Repo', 'https://github.com/org/my-repo.git'],
+      });
+    });
+  });
+
+  test('"Add branch" submits the trimmed branch name', async () => {
+    const onAddBranch = vi.fn().mockResolvedValue(undefined);
+    renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={onAddBranch} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'Add branch' }));
+    await user.type(screen.getByPlaceholderText('Branch name'), '  feat/y  ');
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Add branch' }));
+
+    await waitFor(() => {
+      assert({
+        given: '"Add branch" submitted with surrounding whitespace',
+        should: 'call onAddBranch with the trimmed name',
+        actual: onAddBranch.mock.calls[0]?.[0],
+        expected: 'feat/y',
+      });
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -56,13 +56,21 @@ import { useAgentTerminals } from '@/hooks/useAgentTerminals';
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
 import { normalizeProjectName } from '@pagespace/lib/services/machines/project-name';
 import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-name';
-import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import { useMachineWorkspaceStore, autoSessionName } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { AddButton } from './RemoveButton';
 import { nodeScopeOf } from './WorkspaceLeaves';
 import type { MachineTreeNode } from './MachineTree';
 
-const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
+/**
+ * The "New terminal" agent choices — a fixed, local list rather than
+ * `Object.keys(AGENT_LAUNCH_SPECS)`, for two reasons: `pagespace-cli` is
+ * being removed as an agent type by a sibling change, and `shell` must be
+ * offered and listed FIRST (a plain shell is a first-class choice here,
+ * arguably the default — not an afterthought). Defined locally so this
+ * palette can't silently inherit some other list that (buggily) excludes it.
+ */
+const PICKABLE_AGENT_TYPES: AgentRuntimeType[] = ['shell', 'claude', 'codex'];
 
 /** Short project name from a GitHub `full_name` (e.g. "org/my-repo" -> "my-repo"), and the ready-to-clone URL. */
 export function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
@@ -231,7 +239,7 @@ function TerminalSpawnForm({
   const createWorkspace = useMachineWorkspaceStore((state) => state.createWorkspace);
   const bindPaneTerminal = useMachineWorkspaceStore((state) => state.bindPaneTerminal);
 
-  const [agentType, setAgentType] = useState<AgentRuntimeType>(AGENT_TYPES[0]);
+  const [agentType, setAgentType] = useState<AgentRuntimeType>(PICKABLE_AGENT_TYPES[0]);
   const [prompt, setPrompt] = useState('');
   const [spawning, setSpawning] = useState(false);
   const promptRef = useRef<HTMLTextAreaElement>(null);
@@ -275,7 +283,7 @@ function TerminalSpawnForm({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {AGENT_TYPES.map((type) => (
+            {PICKABLE_AGENT_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
                 {type}
               </SelectItem>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -152,8 +152,12 @@ export default function NodeActionPalette({ machineId, node, onAddProject, onAdd
   const actions = actionsFor(node, onWorkspaceCreated !== undefined);
   if (actions.length === 0) return null;
 
-  const close = () => setOpen(false);
   const reset = () => setPhase('select');
+  // Also resets the phase: this is called on SUCCESS (a spawn/add completing),
+  // not via Radix's onOpenChange — setting `open` false ourselves doesn't fire
+  // that callback, so without resetting here too, the palette would reopen
+  // straight back into the just-completed action's form instead of the list.
+  const close = () => { setOpen(false); reset(); };
 
   return (
     <>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -247,6 +247,14 @@ function TerminalSpawnForm({
   const [prompt, setPrompt] = useState('');
   const [spawning, setSpawning] = useState(false);
   const promptRef = useRef<HTMLTextAreaElement>(null);
+  // Backs out of an in-flight spawn cleanly: the palette can close (Escape,
+  // backdrop click) while `submit` is still awaiting the network. Without
+  // this, a spawn that resolves after the user backed out would still call
+  // `onSpawned` — reporting success to a caller that isn't listening for it
+  // anymore (e.g. DevelopmentSidebar would still navigate to the Terminal tab
+  // for a spawn the user explicitly cancelled).
+  const cancelledRef = useRef(false);
+  useEffect(() => () => { cancelledRef.current = true; }, []);
 
   useEffect(() => {
     const timer = setTimeout(() => promptRef.current?.focus(), 50);
@@ -255,8 +263,18 @@ function TerminalSpawnForm({
 
   const submit = async () => {
     setSpawning(true);
+    // May end up set even on a path that throws before assignment finishes —
+    // tracked outside the try so the catch below knows whether there's a
+    // session to clean up, regardless of which step failed.
+    let created: Awaited<ReturnType<typeof addAgentTerminal>> | undefined;
     try {
-      const created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
+      created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
+
+      if (cancelledRef.current) {
+        if (!created.resumed) await removeAgentTerminal(created.name).catch(() => {});
+        return;
+      }
+
       const workspaceId = createWorkspace(machineId, scope);
       const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
       const bound = workspace
@@ -268,13 +286,29 @@ function TerminalSpawnForm({
             created.resumed ? undefined : prompt.trim() || undefined,
           )
         : false;
-      if (!bound && !created.resumed) {
-        await removeAgentTerminal(created.name).catch(() => {});
+
+      if (!bound) {
+        // The pane went away (or never existed) before the bind landed. Take
+        // back only what THIS call created — a resumed session may already be
+        // open in someone else's pane — and report failure, not success.
+        if (!created.resumed) await removeAgentTerminal(created.name).catch(() => {});
+        toast.error('Failed to spawn agent');
+        setSpawning(false);
+        return;
       }
+
       onSpawned(workspaceId);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
-      setSpawning(false);
+      // `created` may be set even though we're here (e.g. createWorkspace
+      // itself threw) — clean up a session that was made but never
+      // successfully handed off, the same guard as the `!bound` path above.
+      if (created && !created.resumed) {
+        await removeAgentTerminal(created.name).catch(() => {});
+      }
+      if (!cancelledRef.current) {
+        toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
+        setSpawning(false);
+      }
     }
   };
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -1,0 +1,503 @@
+"use client";
+
+/**
+ * The single "+" per Machine/Project/Branch row (Terminal UX redesign,
+ * add-palette consolidation). Before this, a row could carry up to TWO plus
+ * icons that did different things — the structural "Add project"/"Add branch"
+ * dialog trigger (this file's predecessor lived in MachineTree.tsx) and the
+ * separate "New workspace" trigger injected via `renderNodeExtra`
+ * (WorkspaceLeaves.tsx's `WorkspaceNodeExtras`). One `+` per row, one
+ * Raycast-style palette, actions scoped to what that node can actually do:
+ *
+ * - Machine node: New terminal + Add project.
+ * - Project node: New terminal + Add branch.
+ * - Branch node: New terminal only.
+ *
+ * "New terminal" only appears when `onWorkspaceCreated` is passed — the
+ * Diff/Files tabs render the shared {@link MachineTree} BARE, with no
+ * workspace concept at all, and must not pay for one. Its spawn step
+ * (`TerminalSpawnForm`) is its own component, mounted only once the user
+ * actually opens that phase, so `useAgentTerminals`/the workspace store are
+ * never subscribed to for a row that only ever shows Add project/Add branch.
+ *
+ * Two-phase flow mirrors {@link QuickCreatePalette}: pick the action, then
+ * fill in its details. Follows that file's CommandDialog/back-button/phase
+ * shape closely rather than inventing a new palette pattern.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import { toast } from 'sonner';
+import { ArrowLeft, ChevronDown, FolderGit2, Github, GitBranch, Plus, TerminalSquare } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import {
+  Command,
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { useGithubRepos, type GithubRepo } from '@/hooks/useGithubRepos';
+import { useProviders } from '@/hooks/useIntegrations';
+import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
+import { normalizeProjectName } from '@pagespace/lib/services/machines/project-name';
+import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-name';
+import { AGENT_LAUNCH_SPECS, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { useMachineWorkspaceStore, autoSessionName } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import { AddButton } from './RemoveButton';
+import { nodeScopeOf } from './WorkspaceLeaves';
+import type { MachineTreeNode } from './MachineTree';
+
+const AGENT_TYPES = Object.keys(AGENT_LAUNCH_SPECS) as AgentRuntimeType[];
+
+/** Short project name from a GitHub `full_name` (e.g. "org/my-repo" -> "my-repo"), and the ready-to-clone URL. */
+export function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
+  const segments = repo.full_name.split('/');
+  return { name: segments[segments.length - 1] || repo.full_name, repoUrl: repo.clone_url };
+}
+
+/** Spawn is one act, so the session name is minted rather than asked for — same reasoning as TerminalPanes' split-and-pick. */
+function freshNameSuffix(): string {
+  return crypto.randomUUID().replace(/-/g, '');
+}
+
+type PaletteAction = 'new-terminal' | 'add-project' | 'add-branch';
+type Phase = 'select' | PaletteAction;
+
+const ACTION_LABEL: Record<PaletteAction, string> = {
+  'new-terminal': 'New terminal',
+  'add-project': 'Add project',
+  'add-branch': 'Add branch',
+};
+
+function actionsFor(node: MachineTreeNode, hasTerminalSupport: boolean): PaletteAction[] {
+  const actions: PaletteAction[] = [];
+  if (hasTerminalSupport) actions.push('new-terminal');
+  if (node.level === 'machine') actions.push('add-project');
+  if (node.level === 'project') actions.push('add-branch');
+  return actions;
+}
+
+/** What the user's raw input will actually be saved as, shown live as they
+ * type — the client-side half of "normalize-and-accept": `normalize` never
+ * rejects, so this is purely informational and never blocks submission. */
+function NamePreview({ value, normalize }: { value: string; normalize(input: string): string }) {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const normalized = normalize(trimmed);
+  if (normalized === trimmed) return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      Will be saved as <span className="font-mono">{normalized}</span>
+    </p>
+  );
+}
+
+function PhaseHeader({ title, onBack }: { title: string; onBack(): void }) {
+  return (
+    <div className="flex items-center gap-2 border-b px-3 py-2.5">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-muted-foreground transition-colors hover:text-foreground"
+        aria-label="Back to actions"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+      </button>
+      <span className="text-sm font-medium">{title}</span>
+    </div>
+  );
+}
+
+export interface NodeActionPaletteProps {
+  machineId: string;
+  node: MachineTreeNode;
+  /** Only offered at the machine node. */
+  onAddProject?(name: string, repoUrl: string): Promise<unknown>;
+  /** Only offered at project nodes. */
+  onAddBranch?(branchName: string): Promise<unknown>;
+  /** When provided, offers "New terminal" at every level — spawns an agent
+   * into a freshly created workspace at this node's scope and reports its
+   * id. Omitted by the Diff/Files tabs (bare trees, no workspace concept). */
+  onWorkspaceCreated?(workspaceId: string): void;
+}
+
+/** The row's single hover-revealed "+" and the context-aware palette it opens. */
+export default function NodeActionPalette({ machineId, node, onAddProject, onAddBranch, onWorkspaceCreated }: NodeActionPaletteProps) {
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>('select');
+
+  const actions = actionsFor(node, onWorkspaceCreated !== undefined);
+  if (actions.length === 0) return null;
+
+  const close = () => setOpen(false);
+  const reset = () => setPhase('select');
+
+  return (
+    <>
+      <AddButton onClick={() => setOpen(true)} label="Add…" icon={<Plus className="mx-auto size-3" />} />
+
+      {phase === 'select' && (
+        <CommandDialog
+          open={open}
+          onOpenChange={(o) => { setOpen(o); if (!o) reset(); }}
+          title="Add…"
+          description="Choose an action"
+          showCloseButton={false}
+          className="max-w-[380px]"
+        >
+          <CommandInput placeholder="Search actions…" autoFocus />
+          <CommandList>
+            <CommandEmpty>No matching actions.</CommandEmpty>
+            <CommandGroup>
+              {actions.map((action) => (
+                <CommandItem key={action} value={ACTION_LABEL[action]} onSelect={() => setPhase(action)}>
+                  {action === 'new-terminal' && <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />}
+                  {action === 'add-project' && <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />}
+                  {action === 'add-branch' && <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />}
+                  {ACTION_LABEL[action]}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </CommandDialog>
+      )}
+
+      {phase === 'new-terminal' && onWorkspaceCreated && (
+        <CommandDialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }} title="New terminal" description="Spawn an agent" showCloseButton={false} className="max-w-[380px]">
+          <TerminalSpawnForm
+            machineId={machineId}
+            node={node}
+            onBack={reset}
+            onSpawned={(workspaceId) => {
+              close();
+              onWorkspaceCreated(workspaceId);
+            }}
+          />
+        </CommandDialog>
+      )}
+
+      {phase === 'add-project' && onAddProject && (
+        <CommandDialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }} title="Add project" description="Clone a git repo" showCloseButton={false} className="max-w-[380px]">
+          <AddProjectForm onAdd={onAddProject} onBack={reset} onDone={close} />
+        </CommandDialog>
+      )}
+
+      {phase === 'add-branch' && onAddBranch && (
+        <CommandDialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }} title="Add branch" description="Check out a branch" showCloseButton={false} className="max-w-[380px]">
+          <AddBranchForm onAdd={onAddBranch} onBack={reset} onDone={close} />
+        </CommandDialog>
+      )}
+    </>
+  );
+}
+
+/**
+ * Split-and-pick, retargeted at a fresh workspace instead of an existing
+ * empty pane: create the session AND place it, in one act. Mirrors
+ * TerminalPanes' `spawnIntoPane` closely — same upsert/`resumed` handling,
+ * same "only clean up what we created" guard — but binds into the new
+ * workspace's first pane rather than a pane the user picked by clicking into
+ * it, since there is no pane yet: the palette action IS the "give me an
+ * agent" click.
+ */
+function TerminalSpawnForm({
+  machineId,
+  node,
+  onSpawned,
+  onBack,
+}: {
+  machineId: string;
+  node: MachineTreeNode;
+  onSpawned(workspaceId: string): void;
+  onBack(): void;
+}) {
+  const scope = nodeScopeOf(node);
+  const { addAgentTerminal, removeAgentTerminal } = useAgentTerminals(machineId, scope.projectName ?? null, scope.branchName ?? null);
+  const createWorkspace = useMachineWorkspaceStore((state) => state.createWorkspace);
+  const bindPaneTerminal = useMachineWorkspaceStore((state) => state.bindPaneTerminal);
+
+  const [agentType, setAgentType] = useState<AgentRuntimeType>(AGENT_TYPES[0]);
+  const [prompt, setPrompt] = useState('');
+  const [spawning, setSpawning] = useState(false);
+  const promptRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => promptRef.current?.focus(), 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const submit = async () => {
+    setSpawning(true);
+    try {
+      const created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
+      const workspaceId = createWorkspace(machineId, scope);
+      const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
+      const bound = workspace
+        ? bindPaneTerminal(
+            machineId,
+            workspaceId,
+            workspace.activePaneId,
+            { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
+            created.resumed ? undefined : prompt.trim() || undefined,
+          )
+        : false;
+      if (!bound && !created.resumed) {
+        await removeAgentTerminal(created.name).catch(() => {});
+      }
+      onSpawned(workspaceId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
+      setSpawning(false);
+    }
+  };
+
+  return (
+    <>
+      <PhaseHeader title="New terminal" onBack={onBack} />
+      <div className="flex flex-col gap-3 px-4 py-4">
+        <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentRuntimeType)}>
+          <SelectTrigger aria-label="Agent type" className="h-9">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {AGENT_TYPES.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Textarea
+          ref={promptRef}
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Starting prompt (optional)"
+          aria-label="Starting prompt"
+          rows={2}
+          className="resize-none text-sm"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              if (!spawning) void submit();
+            }
+          }}
+        />
+        <div className="flex justify-end">
+          <Button size="sm" disabled={spawning} onClick={() => void submit()} className="h-7 px-3 text-xs">
+            {spawning ? 'Spawning…' : 'Spawn agent'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function GithubRepoPicker({
+  repos,
+  isLoading,
+  error,
+  selectedLabel,
+  onSelect,
+}: {
+  repos: GithubRepo[];
+  isLoading: boolean;
+  error?: Error;
+  selectedLabel?: string;
+  onSelect(repo: GithubRepo): void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  return (
+    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" role="combobox" aria-expanded={pickerOpen} className="w-full justify-between font-normal">
+          <span className="flex min-w-0 items-center gap-2">
+            <Github className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className={cn('truncate', !selectedLabel && 'text-muted-foreground')}>
+              {selectedLabel || 'Select a repo…'}
+            </span>
+          </span>
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search your repos…" />
+          <CommandList onWheel={(e) => e.stopPropagation()}>
+            <CommandEmpty>
+              {error ? `Failed to load repos: ${error.message}` : isLoading ? 'Loading repos…' : 'No repos found.'}
+            </CommandEmpty>
+            {repos.map((repo) => (
+              <CommandItem key={repo.full_name} value={repo.full_name} onSelect={() => { onSelect(repo); setPickerOpen(false); }}>
+                <FolderGit2 className="mr-2 size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm">{repo.full_name}</span>
+                {repo.private && (
+                  <span className="ml-auto shrink-0 rounded bg-muted px-1 py-0.5 text-[10px] text-muted-foreground">private</span>
+                )}
+              </CommandItem>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function AddProjectForm({
+  onAdd,
+  onBack,
+  onDone,
+}: {
+  onAdd(name: string, repoUrl: string): Promise<unknown>;
+  onBack(): void;
+  onDone(): void;
+}) {
+  const pathname = usePathname();
+  const [name, setName] = useState('');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [manualMode, setManualMode] = useState(false);
+  const [connectDialogOpen, setConnectDialogOpen] = useState(false);
+
+  const { repos, connected, isLoading: reposLoading, error: reposError, mutate: refetchRepos } = useGithubRepos(!manualMode);
+  const { providers } = useProviders(true);
+  const githubProvider = providers.find((p) => p.slug === 'github') ?? null;
+
+  const mode: 'manual' | 'connect' | 'picker' = manualMode ? 'manual' : connected === false ? 'connect' : 'picker';
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(name.trim(), repoUrl.trim());
+      onDone();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add project');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSelectRepo = (repo: GithubRepo) => {
+    const fields = deriveProjectFieldsFromRepo(repo);
+    setName(fields.name);
+    setRepoUrl(fields.repoUrl);
+  };
+
+  return (
+    <>
+      <PhaseHeader title="Add project" onBack={onBack} />
+      <div className="flex flex-col gap-3 px-4 py-4">
+        <div>
+          <Input placeholder="Project name" value={name} onChange={(e) => setName(e.target.value)} />
+          <NamePreview value={name} normalize={normalizeProjectName} />
+        </div>
+
+        {mode === 'manual' && (
+          <Input placeholder="Repo URL (https://github.com/org/repo.git)" value={repoUrl} onChange={(e) => setRepoUrl(e.target.value)} />
+        )}
+        {mode === 'connect' && (
+          <Button type="button" variant="outline" onClick={() => setConnectDialogOpen(true)} className="justify-start gap-2 font-normal text-muted-foreground">
+            <Github className="size-3.5 shrink-0" />
+            Connect GitHub to browse your repos
+          </Button>
+        )}
+        {mode === 'picker' && (
+          <GithubRepoPicker repos={repos} isLoading={reposLoading} error={reposError} selectedLabel={name} onSelect={handleSelectRepo} />
+        )}
+
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="h-auto justify-start p-0 text-xs text-muted-foreground"
+          onClick={() => setManualMode((m) => !m)}
+        >
+          {manualMode ? 'Pick from your GitHub repos instead' : 'Enter a repo URL manually'}
+        </Button>
+
+        <div className="flex justify-end">
+          <Button onClick={() => void handleSubmit()} disabled={submitting || !name.trim() || !repoUrl.trim()} className="h-7 px-3 text-xs">
+            {submitting ? 'Adding…' : 'Add project'}
+          </Button>
+        </div>
+      </div>
+      <ConnectIntegrationDialog
+        provider={githubProvider}
+        open={connectDialogOpen}
+        onOpenChange={setConnectDialogOpen}
+        onConnected={() => {
+          setConnectDialogOpen(false);
+          refetchRepos();
+        }}
+        returnUrl={pathname}
+      />
+    </>
+  );
+}
+
+function AddBranchForm({
+  onAdd,
+  onBack,
+  onDone,
+}: {
+  onAdd(branchName: string): Promise<unknown>;
+  onBack(): void;
+  onDone(): void;
+}) {
+  const [branchName, setBranchName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await onAdd(branchName.trim());
+      onDone();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to add branch');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <PhaseHeader title="Add branch" onBack={onBack} />
+      <div className="flex flex-col gap-3 px-4 py-4">
+        <div>
+          <Input
+            placeholder="Branch name"
+            value={branchName}
+            onChange={(e) => setBranchName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !submitting && branchName.trim()) {
+                e.preventDefault();
+                void handleSubmit();
+              }
+            }}
+          />
+          <NamePreview value={branchName} normalize={normalizeBranchName} />
+        </div>
+        <div className="flex justify-end">
+          <Button onClick={() => void handleSubmit()} disabled={submitting || !branchName.trim()} className="h-7 px-3 text-xs">
+            {submitting ? 'Spawning…' : 'Add branch'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -261,7 +261,7 @@ describe('WorkspaceNodeExtras', () => {
   });
 
   test('shows no running-count badge when nothing is running', () => {
-    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
+    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} />);
 
     assert({
       given: 'a machine with no running agents',
@@ -276,7 +276,7 @@ describe('WorkspaceNodeExtras', () => {
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
     store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'claude-a1b2c3' });
 
-    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
+    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} />);
 
     assert({
       given: 'one running pane at machine scope',
@@ -286,19 +286,17 @@ describe('WorkspaceNodeExtras', () => {
     });
   });
 
-  test('the new-workspace button creates a workspace at the node\'s scope and reports its id', async () => {
-    const onWorkspaceCreated = vi.fn();
-    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={PROJECT_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
+  // Regression: WorkspaceNodeExtras used to also render a "New workspace" +
+  // trigger — that's now the node row's single "+" action palette
+  // (NodeActionPalette, via MachineTree's onWorkspaceCreated prop) instead.
+  test('renders no add/create trigger of its own — that lives in the node row\'s single "+" palette now', () => {
+    renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'New workspace' }));
-
-    const machine = selectMachine('m1')(store())!;
-    const created = machine.workspaces[machine.activeWorkspaceId];
     assert({
-      given: 'the new-workspace button clicked on a project node',
-      should: 'create a workspace scoped to that project and report its id',
-      actual: { scope: created.scope, reportedId: onWorkspaceCreated.mock.calls[0]?.[0] },
-      expected: { scope: { projectName: 'app' }, reportedId: created.id },
+      given: 'WorkspaceNodeExtras rendered standalone',
+      should: 'expose no button — it is a read-only badge',
+      actual: screen.queryByRole('button'),
+      expected: null,
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -35,7 +35,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import { Plus, TerminalSquare } from 'lucide-react';
+import { TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   useMachineWorkspaceStore,
@@ -50,7 +50,7 @@ import {
 import { useAgentTerminals } from '@/hooks/useAgentTerminals';
 import type { MachineTreeNode } from './MachineTree';
 import ConfirmRemoveDialog from './ConfirmRemoveDialog';
-import RemoveButton, { AddButton } from './RemoveButton';
+import RemoveButton from './RemoveButton';
 
 /** A tree node's scope, minus the session/workspace name it might carry. */
 export function nodeScopeOf(node: MachineTreeNode): MachineNodeScope {
@@ -191,38 +191,32 @@ export default function WorkspaceLeaves({
 }
 
 /**
- * A node's hover-revealed "N running" badge + new-workspace `+` button — the
- * de-bloated replacement for the "Terminals" sub-label and its modal (Sidebar
- * chrome section). Injected via `MachineTree`'s `renderNodeExtra` slot, kept
- * out of `MachineTree` itself: Diff/Files-tab callers reuse the same tree for
- * branch/file navigation and have no workspace to count or create.
+ * A node's hover-revealed "N running" badge — the de-bloated replacement for
+ * the "Terminals" sub-label and its modal (Sidebar chrome section). Injected
+ * via `MachineTree`'s `renderNodeExtra` slot, kept out of `MachineTree`
+ * itself: Diff/Files-tab callers reuse the same tree for branch/file
+ * navigation and have no workspace to count.
+ *
+ * The new-workspace `+` that used to live here has moved into the node row's
+ * single "+" action palette (`NodeActionPalette`, via `MachineTree`'s
+ * `onWorkspaceCreated` prop) — a row previously carried this trigger AND the
+ * structural Add project/Add branch trigger as two separate plus icons.
  */
 export function WorkspaceNodeExtras({
   machineId,
   node,
-  onWorkspaceCreated,
 }: {
   machineId: string;
   node: MachineTreeNode;
-  /** Called with the new workspace's id right after it's created (and made active). */
-  onWorkspaceCreated(workspaceId: string): void;
 }) {
   const scope = nodeScopeOf(node);
   const runningCount = useMachineWorkspaceStore(selectRunningPaneCount(machineId, scope));
-  const createWorkspace = useMachineWorkspaceStore((state) => state.createWorkspace);
+
+  if (runningCount === 0) return null;
 
   return (
-    <span className="flex shrink-0 items-center gap-0.5">
-      {runningCount > 0 && (
-        <span className="rounded bg-muted px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground" title={`${runningCount} running`}>
-          {runningCount} running
-        </span>
-      )}
-      <AddButton
-        onClick={() => onWorkspaceCreated(createWorkspace(machineId, scope))}
-        label="New workspace"
-        icon={<Plus className="mx-auto size-3" />}
-      />
+    <span className="rounded bg-muted px-1 py-0.5 text-[10px] tabular-nums text-muted-foreground" title={`${runningCount} running`}>
+      {runningCount} running
     </span>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/deriveProjectFieldsFromRepo.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/deriveProjectFieldsFromRepo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveProjectFieldsFromRepo } from './MachineTree';
+import { deriveProjectFieldsFromRepo } from './NodeActionPalette';
 
 describe('deriveProjectFieldsFromRepo', () => {
   it('given a full_name with an owner, should derive the short repo name', () => {

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -52,6 +52,14 @@ if (typeof window !== 'undefined' && !window.HTMLElement.prototype.scrollIntoVie
   window.HTMLElement.prototype.scrollIntoView = () => {};
 }
 
+// jsdom does not implement the Pointer Events capture methods. Radix Select's
+// pointer-interaction internals call hasPointerCapture/releasePointerCapture
+// on open/close — without these, clicking a SelectTrigger throws.
+if (typeof window !== 'undefined' && !window.Element.prototype.hasPointerCapture) {
+  window.Element.prototype.hasPointerCapture = () => false;
+  window.Element.prototype.releasePointerCapture = () => {};
+}
+
 // jsdom does not implement matchMedia. Provide a permissive default that
 // returns false (i.e. desktop, non-touch) so hooks like useMobile / useTouchDevice
 // can boot during component tests without each test re-stubbing it.

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -44,6 +44,14 @@ if (typeof window !== 'undefined') {
   }
 }
 
+// jsdom does not implement scrollIntoView. cmdk (the Command/CommandDialog
+// primitives) calls it on the selected item whenever the list's selection
+// moves, including on mount — without this stub every cmdk-based component
+// throws in its mount effect the instant it renders.
+if (typeof window !== 'undefined' && !window.HTMLElement.prototype.scrollIntoView) {
+  window.HTMLElement.prototype.scrollIntoView = () => {};
+}
+
 // jsdom does not implement matchMedia. Provide a permissive default that
 // returns false (i.e. desktop, non-touch) so hooks like useMobile / useTouchDevice
 // can boot during component tests without each test re-stubbing it.


### PR DESCRIPTION
## Summary
- The shared `MachineTree` (Machine page Terminal tab + Development sidebar) rendered TWO plus icons per row that did different things: the structural "Add project"/"Add branch" dialog trigger and a separate "New workspace" trigger. Consolidates both into one hover-revealed `+` that opens a context-aware Raycast-style cmdk palette (`NodeActionPalette`), scoped to what the node can do — Machine: New terminal + Add project; Project: New terminal + Add branch; Branch: New terminal only.
- "New terminal" now creates a workspace *and* spawns the picked agent into it in one step (agent type + optional starting prompt), reusing the same `createWorkspace`/`bindPaneTerminal`/`useAgentTerminals` path `TerminalPanes`' split-and-pick already uses. It only appears when `MachineTree`'s new `onWorkspaceCreated` prop is passed — the Diff/Files tabs render the same tree BARE with no workspace concept, so their palette is unchanged (Add project/Add branch only). Agent choices are `shell`/`claude`/`codex` (shell first/default) — `pagespace-cli` is deliberately excluded, since a sibling change is removing it as an agent type.
- `WorkspaceNodeExtras` (`WorkspaceLeaves.tsx`) drops its "New workspace" button and is now a read-only "N running" badge.
- Adds jsdom `scrollIntoView` and `hasPointerCapture`/`releasePointerCapture` stubs to the shared test setup — cmdk and Radix Select need them, and no test in this codebase had exercised either before.

### Review-driven fixes (post-open)
- The palette used to leave its `phase` stuck on a just-completed action after a successful spawn/add — reopening the `+` on that same row dropped the user straight back into that form instead of the action list, since the programmatic `close()` path doesn't go through Radix's `onOpenChange`. Fixed: `close()` now resets phase too. ([review thread](https://github.com/2witstudios/PageSpace/pull/2059#discussion_r3572318430))
- The spawn flow reported success (`onSpawned`) unconditionally, even when the bind failed or the user backed out (Escape/backdrop) while the network call was still in flight — a late-resolving spawn could still fire `onWorkspaceCreated` and silently navigate the user in `DevelopmentSidebar`. Fixed: cancellation is tracked via a ref, failed binds report failure instead of success, and cleanup now covers any unexpected throw between create and bind, not just the explicit failure branch.

## Test plan
- [x] `bun run typecheck` (apps/web) — clean
- [x] `bunx eslint` on all touched files — clean
- [x] Colocated tests: `MachineTree.test.tsx`, `WorkspaceLeaves.test.tsx`, `NodeActionPalette.test.tsx` (new), `TerminalTab.test.tsx`, `DevelopmentSidebar.test.tsx`, `deriveProjectFieldsFromRepo.test.ts` — 220/220 passing
- [x] Confirms: single `+` opens the palette; palette offers scope-correct actions per node level; "New terminal" creates+spawns and reports the workspace id; "Add project"/"Add branch" submit with normalized-name preview intact; reopening the palette after a successful action shows the action list, not stale form state; cancelling an in-flight spawn never reports success
- [x] CI green on latest commit (`5ae7d3984`): Unit Tests, Lint & TypeScript Check, CodeRabbit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaNqUZfG7f6NdwVrZy2sJN
