### PR TITLE
fix(ai): sidebar agents lose awareness of the page in view

### DIFF
--- a/apps/web/scripts/redteam-sandbox-injection.ts
+++ b/apps/web/scripts/redteam-sandbox-injection.ts
@@ -197,7 +197,7 @@ function evaluateCompliance(
 }
 
 async function runPayload(model: Awaited<ReturnType<typeof buildModel>>, payload: Payload, index: number) {
-  const system = buildSystemPrompt('page', undefined, false, undefined, true);
+  const system = buildSystemPrompt(false, undefined, true);
 
   // Run the payload through the REAL production injection seam first, so the
   // model sees exactly what a live sandbox run would show it.

--- a/apps/web/src/app/api/admin/global-prompt/route.ts
+++ b/apps/web/src/app/api/admin/global-prompt/route.ts
@@ -21,6 +21,7 @@ import { buildSystemPrompt } from '@/lib/ai/core/system-prompt';
 import { buildAgentAwarenessPrompt } from '@/lib/ai/core/agent-awareness';
 import { getPageTreeContext, getDriveListSummary } from '@/lib/ai/core/page-tree-context';
 import { buildInlineInstructions, buildGlobalAssistantInstructions } from '@/lib/ai/core/inline-instructions';
+import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
 import { CORE_TOOL_NAMES } from '@/lib/ai/core/stub-tools';
 import { db } from '@pagespace/db/db'
 import { eq, and, asc } from '@pagespace/db/operators'
@@ -256,43 +257,26 @@ async function handleGlobalPrompt(
         includeExampleMessage: true,
       });
 
-      // Build system prompt for sections display
-      const systemPrompt = buildSystemPrompt(
-        contextType,
-        locationContext?.currentDrive ? {
-          driveName: locationContext.currentDrive.name,
-          driveSlug: locationContext.currentDrive.slug,
-          driveId: locationContext.currentDrive.id,
-          pagePath: locationContext.currentPage?.path,
-          pageType: locationContext.currentPage?.type,
-          breadcrumbs: locationContext.breadcrumbs?.map(b => b.title),
-        } : undefined,
-        isReadOnly
-      );
+      // Build system prompt for sections display. Location is turn-volatile —
+      // shown as its own "Location Context (volatile)" section below, not
+      // baked into this stable system prompt (mirrors production routes).
+      const systemPrompt = buildSystemPrompt(isReadOnly);
 
       // Build inline instructions based on context type
-      let inlineInstructions: string;
-      if (contextType === 'page' && locationContext?.currentPage) {
-        inlineInstructions = buildInlineInstructions({
-          pageTitle: locationContext.currentPage.title,
-          pageType: locationContext.currentPage.type,
-          isTaskLinked: locationContext.currentPage.isTaskLinked,
-          driveName: locationContext.currentDrive?.name,
-          pagePath: locationContext.currentPage.path,
-          driveSlug: locationContext.currentDrive?.slug,
-          driveId: locationContext.currentDrive?.id,
-        });
-      } else {
-        inlineInstructions = buildGlobalAssistantInstructions(
-          locationContext?.currentDrive
-            ? {
-                driveName: locationContext.currentDrive.name,
-                driveSlug: locationContext.currentDrive.slug,
-                driveId: locationContext.currentDrive.id,
-              }
-            : undefined
-        );
-      }
+      const inlineInstructions =
+        contextType === 'page' && locationContext?.currentPage
+          ? buildInlineInstructions()
+          : buildGlobalAssistantInstructions();
+
+      const locationPrompt = buildLocationTurnPrompt(
+        locationContext
+          ? {
+              currentPage: locationContext.currentPage,
+              currentDrive: locationContext.currentDrive,
+              breadcrumbs: locationContext.breadcrumbs?.map(b => b.title),
+            }
+          : undefined
+      );
 
       // Build detailed sections with source annotations for the breakdown view
       const sections: PromptSection[] = [
@@ -307,6 +291,12 @@ async function handleGlobalPrompt(
           content: inlineInstructions,
           source: 'apps/web/src/lib/ai/core/inline-instructions.ts',
           tokens: estimateSystemPromptTokens(inlineInstructions),
+        },
+        {
+          name: 'Location Context (volatile)',
+          content: locationPrompt,
+          source: 'apps/web/src/lib/ai/core/location-prompt.ts',
+          tokens: estimateSystemPromptTokens(locationPrompt),
         },
       ];
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1529,7 +1529,10 @@ export async function POST(request: Request) {
               conversationId, // Use actual conversation ID instead of pageId
               messageId,
               pageId: chatId,
-              driveId: pageContext?.driveId,
+              // Empty string (no drive in view) must read as "no drive", not a
+              // literal '' driveId — matches the truthy-guards used elsewhere
+              // in this file for the same pageContext.driveId field.
+              driveId: pageContext?.driveId || undefined,
               // 'exhausted' = retry shell gave up (failure); clean/terminal = a real
               // completion. Cost still settles regardless (the provider charged us).
               success: agentRun?.finalOutcome !== 'exhausted',

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -61,6 +61,7 @@ import { buildSystemPrompt, buildPersonalizationPrompt } from '@/lib/ai/core/sys
 import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { getAgentContextDrives } from '@pagespace/lib/services/drive-agent-service';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
+import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
 import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
 import { shouldExposeImageGen } from '@/lib/ai/core/image-gen-access';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
@@ -1010,14 +1011,14 @@ export async function POST(request: Request) {
     }
 
     // Build system prompt for Page AI - use custom system prompt if available, otherwise use default
+    // Note: "current page/drive" is turn-volatile — it's built separately as
+    // `locationPrompt` below and injected via buildVolatileTurnContext, NOT
+    // baked in here, so this string stays byte-identical across turns.
     let systemPrompt: string;
     if (customSystemPrompt) {
       // Use custom system prompt with page context injected
       // Prepend drive prompt if enabled and available
       systemPrompt = drivePromptPrefix + customSystemPrompt;
-      if (pageContext) {
-        systemPrompt += `\n\nYou are operating within the page "${pageContext.pageTitle}" in the "${pageContext.driveName}" drive. Your current location: ${pageContext.pagePath}`;
-      }
       // Add user personalization if enabled
       const personalizationPrompt = buildPersonalizationPrompt(personalization ?? undefined);
       if (personalizationPrompt) {
@@ -1030,33 +1031,28 @@ export async function POST(request: Request) {
     } else {
       // Fallback to default PageSpace system prompt with read-only mode and personalization
       systemPrompt = buildSystemPrompt(
-        'page',
-        pageContext ? {
-          driveName: pageContext.driveName,
-          driveSlug: pageContext.driveSlug,
-          driveId: pageContext.driveId,
-          pagePath: pageContext.pagePath,
-          pageType: pageContext.pageType,
-          breadcrumbs: pageContext.breadcrumbs,
-        } : undefined,
         readOnlyMode,
         personalization ?? undefined,
         isCodeExecutionEnabled()
       );
 
       // Append workspace knowledge (tool-aware). Custom systemPrompt = opt-out (blank slate).
-      systemPrompt += buildInlineInstructions(
-        {
-          pageTitle: pageContext?.pageTitle,
-          pageType: pageContext?.pageType,
-          driveName: pageContext?.driveName,
-          pagePath: pageContext?.pagePath,
-          driveSlug: pageContext?.driveSlug,
-          driveId: pageContext?.driveId,
-        },
-        allowedToolNames
-      );
+      systemPrompt += buildInlineInstructions(allowedToolNames);
     }
+
+    const locationPrompt = buildLocationTurnPrompt(pageContext ? {
+      currentPage: {
+        title: pageContext.pageTitle,
+        type: pageContext.pageType,
+        path: pageContext.pagePath,
+      },
+      currentDrive: pageContext.driveId ? {
+        id: pageContext.driveId,
+        name: pageContext.driveName,
+        slug: pageContext.driveSlug,
+      } : undefined,
+      breadcrumbs: pageContext.breadcrumbs,
+    } : undefined);
 
     // Cross-drive membership context applies uniformly regardless of whether
     // a custom system prompt is set (unlike drivePromptPrefix above, which is
@@ -1271,12 +1267,14 @@ export async function POST(request: Request) {
             startTimeMs: startTime,
             logger: loggers.ai,
             buildStreamText: (messages) => {
-              // Volatile per-turn data (timestamp/mention/command) is appended
-              // to the last user message so the system prefix stays byte-stable
-              // and provider prefix caches (Anthropic/OpenAI/Gemini) are not
-              // invalidated on every turn.
+              // Volatile per-turn data (timestamp/location/mention/command) is
+              // appended to the last user message so the system prefix stays
+              // byte-stable and provider prefix caches (Anthropic/OpenAI/Gemini)
+              // are not invalidated on every turn — including turns where only
+              // the user's current page/drive changed.
               const turnContext = buildVolatileTurnContext({
                 timestampPrompt: timestampSystemPrompt,
+                locationPrompt,
                 mentionPrompt: mentionSystemPrompt,
                 commandPrompt: commandSystemPrompt,
               });
@@ -1324,6 +1322,15 @@ export async function POST(request: Request) {
                     slug: pageContext.driveSlug,
                   } : undefined,
                   breadcrumbs: pageContext.breadcrumbs,
+                } : undefined,
+                // Turn-start snapshot of the agent's working page — tools that
+                // shift focus (e.g. create_page) mutate this in place so later
+                // tool calls in the same turn track the agent's own actions
+                // rather than staying pinned to the turn-start snapshot.
+                currentWorkingPage: pageContext ? {
+                  id: pageContext.pageId,
+                  title: pageContext.pageTitle,
+                  type: pageContext.pageType,
                 } : undefined,
                 modelCapabilities: modelCapabilitiesForTools,
                 isAdmin: isAdminUser,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -5,6 +5,7 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { askUserTools, ASK_USER_TOOL_NAME } from '@/lib/ai/tools/ask-user-tools';
 import { canUseAskUser } from '@/lib/ai/core/ask-user-gating';
 import { ASK_USER_SECTION } from '@/lib/ai/core/inline-instructions';
+import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
 import {
   extractClientAskUserResults,
   applyAskUserResultsToGlobalMessage,
@@ -657,25 +658,21 @@ export async function POST(
       });
     }
 
-    // Build system prompt with context
-    const contextType = locationContext?.currentPage ? 'page' :
-                       locationContext?.currentDrive ? 'drive' :
-                       'dashboard';
-
+    // Build system prompt. Note: "current page/drive" is turn-volatile — it's
+    // built separately as `locationPrompt` below and injected via
+    // buildVolatileTurnContext, NOT baked in here, so this string stays
+    // byte-identical across turns regardless of where the user navigates.
     const baseSystemPrompt = buildSystemPrompt(
-      contextType,
-      locationContext ? {
-        driveName: locationContext.currentDrive?.name,
-        driveSlug: locationContext.currentDrive?.slug,
-        driveId: locationContext.currentDrive?.id,
-        pagePath: locationContext.currentPage?.path,
-        pageType: locationContext.currentPage?.type,
-        breadcrumbs: locationContext.breadcrumbs,
-      } : undefined,
       readOnlyMode,
       personalization ?? undefined,
       isCodeExecutionEnabled()
     );
+
+    const locationPrompt = buildLocationTurnPrompt(locationContext ? {
+      currentPage: locationContext.currentPage,
+      currentDrive: locationContext.currentDrive,
+      breadcrumbs: locationContext.breadcrumbs,
+    } : undefined);
 
     // Build timestamp system prompt for temporal awareness (using user's timezone)
     const timestampSystemPrompt = buildTimestampSystemPrompt(userTimezone);
@@ -705,9 +702,10 @@ export async function POST(
 
     // Add global assistant specific instructions (including tool discovery — only this route has tool_search).
     // Stable order: base → TOOL_DISCOVERY → global instructions → drivePrompt → agentAwareness → pageTree → nonCoreToolNames.
-    // Volatile sections (timestamp/mention/command) are NOT concatenated here; they are
+    // Volatile sections (timestamp/location/mention/command) are NOT concatenated here; they are
     // appended to the last user message at assembly time so the system prefix stays
-    // byte-identical across turns and provider prefix caches are not invalidated.
+    // byte-identical across turns and provider prefix caches are not invalidated —
+    // including turns where only the user's current page/drive changed.
     const systemPrompt = baseSystemPrompt + '\n\n' + TOOL_DISCOVERY_PROMPT + `
 
 You are the Global Assistant for PageSpace - accessible from both the dashboard and sidebar.
@@ -722,40 +720,24 @@ CRITICAL NESTING PRINCIPLE:
 • NO RESTRICTIONS on what can contain what - organize based on logical user needs
 • Documents can contain AI chats, channels, folders, and canvas pages
 • AI chats can contain documents, other AI chats, folders, and any page type
-• Channels can contain any page type for organized discussion threads  
+• Channels can contain any page type for organized discussion threads
 • Canvas pages can contain any page type for custom navigation structures
 • Think creatively about nesting - optimize for user workflow, not type conventions
 
-${locationContext ? `
-CONTEXT-AWARE BEHAVIOR:
-• You are currently in: ${locationContext.currentDrive?.name || 'dashboard'} ${locationContext.currentPage ? `> ${locationContext.currentPage.title}` : ''}
-• Default scope: Operations should focus on this location unless user indicates otherwise
-• When user says "here" or "this", they mean the current location
-• Only explore other drives/areas when explicitly mentioned or necessary for the task
-• Start from current context, not from list_drives
-` : `
-DASHBOARD CONTEXT:
-• You are in the dashboard view - focus on cross-workspace tasks and overview
-• Use list_drives when you need to work across multiple workspaces
-• Help with personal productivity and workspace organization
-• create_drive: Use when user explicitly requests new workspace OR when their project clearly doesn't fit existing drives
-• Always check existing drives first via list_drives before suggesting new drive creation
-• Ask for confirmation unless user is explicit about creating new workspace
-`}
-
 SMART EXPLORATION RULES:
-1. When in a drive context - ALWAYS explore it first:
-   - If locationContext includes a drive, ALWAYS use list_pages on that drive when:
+1. When in a drive context (see your current LOCATION context for the driveId) - ALWAYS explore it first:
+   - ALWAYS use list_pages on the current drive when:
      • User asks about the drive, its contents, or what's available
      • User wants to create, write, or modify ANYTHING
      • User mentions something that MAY exist in the drive
      • User asks general questions about content or organization
      • You need to understand the workspace structure
-   - Start with list_pages(driveId: '${locationContext?.currentDrive?.id || 'current-drive-id'}') BEFORE other actions
+   - Start with list_pages on the current drive BEFORE other actions
 2. Context-first approach:
-   - Default scope: Current drive/location is your primary workspace
+   - Default scope: current drive/location (see LOCATION context) is your primary workspace
    - Only explore OTHER drives when explicitly mentioned
    - When user says "here" or "this", they mean current context
+   - If LOCATION context shows no drive, you're in the dashboard — use list_drives when you need to work across multiple workspaces; always check existing drives before suggesting new drive creation
 3. Efficient exploration pattern:
    - FIRST: list_pages with driveId on current drive (if in a drive)
    - THEN: read specific pages as needed
@@ -1153,11 +1135,13 @@ MENTION PROCESSING:
           startTimeMs: startTime,
           logger: loggers.api,
           buildStreamText: (messages) => {
-            // Volatile per-turn data (timestamp/mention/command) is appended
-            // to the last user message so the stable system prefix stays
-            // byte-identical across turns and provider prefix caches survive.
+            // Volatile per-turn data (timestamp/location/mention/command) is
+            // appended to the last user message so the stable system prefix
+            // stays byte-identical across turns and provider prefix caches
+            // survive — including turns where only the user's page changed.
             const turnContext = buildVolatileTurnContext({
               timestampPrompt: timestampSystemPrompt,
+              locationPrompt,
               mentionPrompt: mentionSystemPrompt,
               commandPrompt: commandSystemPrompt,
             });
@@ -1183,6 +1167,15 @@ MENTION PROCESSING:
               aiModel: currentModel,
               conversationId,
               locationContext,
+              // Turn-start snapshot of the agent's working page — tools that
+              // shift focus (e.g. create_page) mutate this in place so later
+              // tool calls in the same turn track the agent's own actions
+              // rather than staying pinned to the turn-start snapshot.
+              currentWorkingPage: locationContext?.currentPage ? {
+                id: locationContext.currentPage.id,
+                title: locationContext.currentPage.title,
+                type: locationContext.currentPage.type,
+              } : undefined,
               modelCapabilities: modelCapabilitiesForTools,
               isAdmin: auth.role === 'admin',
               subscriptionTier: userSubscriptionTier,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -251,7 +251,7 @@ export async function POST(request: Request): Promise<Response> {
   try {
     // 7. Build system prompt from agent page config
     const systemPrompt = page.systemPrompt
-      ?? buildSystemPrompt('page', undefined, false);
+      ?? buildSystemPrompt(false);
 
     // 7b. Build the final tool set and stop conditions based on the request mode:
     //   server-only (useServerTools && !hasClientTools)  — full PageSpace tools + finish tool (default)

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -32,7 +32,8 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
-import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
+import { resolveLocationContext } from '@/lib/ai/shared/resolveLocationContext';
+import { locationContextToPageContext } from '@/lib/ai/shared/buildPageContext';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId, reportAbortOutcome } from '@/lib/ai/core/client';
 import { resolveActiveAssistantMessageId } from '@/lib/ai/streams/resolveActiveAssistantMessageId';
 import { holdForStream } from '@/lib/ai/streams/holdForStream';
@@ -412,136 +413,30 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
   // Effects: Location Context Extraction
   // ============================================
+  // This effect drives the UI display only (the composer's location chip).
+  // Message sends must NOT read `locationContext` state here — it can lag a
+  // fast navigate-then-send by one async round trip. Sends call
+  // `buildFreshLocationContext()` (below) instead, which resolves fresh at
+  // send time from the current pathname/drives, same pattern as
+  // AiChatView's `buildFreshPageContext()`.
   useEffect(() => {
-    // Capture the pathname this run is resolving for, so async branches can
-    // bail if the user navigated away before they completed.
-    const activePathname = pathname;
     let ignore = false;
 
-    const resolveDrive = (driveId: string | undefined) => {
-      if (!driveId) return null;
-      const driveData = drives.find(d => d.id === driveId);
-      return driveData
-        ? { id: driveData.id, slug: driveData.slug, name: driveData.name }
-        : null;
-    };
-
-    const fetchPageContext = async (
-      pageId: string,
-      currentDrive: { id: string; slug: string; name: string } | null
-    ) => {
-      try {
-        const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
-        if (!pageResponse.ok) return null;
-        const pageData = (await pageResponse.json()) as { id: string; title: string; type: string };
-
-        // Only prefix the drive slug when we actually have one — channel routes
-        // resolve no drive, so a bare `/${slug}` would bake "/undefined/..." into
-        // the path that gets sent to the AI.
-        const slugPrefix = currentDrive?.slug ? `/${currentDrive.slug}` : '';
-        let path = `${slugPrefix}/${pageData.title}`;
-        try {
-          const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
-          if (breadcrumbsResponse.ok) {
-            const breadcrumbsData = (await breadcrumbsResponse.json()) as Array<{ title: string }>;
-            const pathSegments = breadcrumbsData.map((crumb) => crumb.title);
-            path = `${slugPrefix}/${pathSegments.join('/')}`;
-          }
-        } catch {
-          // Keep the simple path fallback.
-        }
-
-        return {
-          id: pageData.id,
-          title: pageData.title,
-          type: pageData.type,
-          path,
-        };
-      } catch {
-        return null;
-      }
-    };
-
-    const extractLocationContext = async () => {
-      const parsed = parseTabPath(activePathname);
-
-      let label: string | null = null;
-      let currentPage: LocationContext['currentPage'] = null;
-      let currentDrive: LocationContext['currentDrive'] = null;
-
-      try {
-        switch (parsed.type) {
-          // Real page routes — fetch the page so the AI keeps page context.
-          case 'page':
-          case 'channel': {
-            currentDrive = parsed.type === 'page' ? resolveDrive(parsed.driveId) : null;
-            if (parsed.pageId) {
-              currentPage = await fetchPageContext(parsed.pageId, currentDrive);
-            }
-            label = currentPage?.title ?? null;
-            break;
-          }
-
-          // A whole drive — use the drive name from the store.
-          case 'drive': {
-            currentDrive = resolveDrive(parsed.driveId);
-            label = currentDrive?.name ?? null;
-            break;
-          }
-
-          // A specific DM — show the other person's name (DMs are not pages).
-          case 'dm': {
-            if (parsed.conversationId) {
-              try {
-                const res = await fetchWithAuth(`/api/messages/conversations/${parsed.conversationId}`);
-                if (res.ok) {
-                  const data = (await res.json()) as {
-                    conversation?: { otherUser?: { displayName?: string | null; name?: string | null } };
-                  };
-                  const otherUser = data?.conversation?.otherUser;
-                  label = otherUser?.displayName || otherUser?.name || null;
-                }
-              } catch {
-                // Fall through to the generic DM label below.
-              }
-            }
-            if (!label) label = 'Direct Message';
-            break;
-          }
-
-          // Everything else with a known static title (dms, channels, tasks,
-          // calendar, files/drives, activity, drive-scoped variants, …).
-          // 'unknown' routes have no meaningful label (getStaticTabMeta would
-          // echo the raw path), so fall back to the generic prompt.
-          default: {
-            label = parsed.type === 'unknown' ? null : getStaticTabMeta(parsed)?.title ?? null;
-            break;
-          }
-        }
-      } catch {
-        label = null;
-      }
-
+    resolveLocationContext(pathname, drives).then(({ label, locationContext }) => {
       if (ignore) return;
-
-      const breadcrumbs: string[] = [];
-      if (currentDrive) breadcrumbs.push(currentDrive.name);
-      if (currentPage?.path) {
-        breadcrumbs.push(...currentPage.path.split('/').filter(Boolean).slice(1));
-      }
-
       setContextLabel(label);
-      setLocationContext(
-        currentPage || currentDrive ? { currentPage, currentDrive, breadcrumbs } : null
-      );
-    };
-
-    extractLocationContext();
+      setLocationContext(locationContext);
+    });
 
     return () => {
       ignore = true;
     };
   }, [pathname, drives]);
+
+  const buildFreshLocationContext = useCallback(
+    () => resolveLocationContext(pathname, drives).then((r) => r.locationContext),
+    [pathname, drives],
+  );
 
   // ============================================
   // Effects: Global Mode Sync to Context
@@ -787,34 +682,43 @@ const SidebarChatTab: React.FC = () => {
     // Derive isReadOnly from writeMode (inverted)
     const isReadOnly = !writeMode;
 
-    const body = selectedAgent
-      ? {
-          chatId: selectedAgent.id,
-          conversationId: agentConversationId,
-          isReadOnly,
-          webSearchEnabled,
-          imageGenEnabled,
-          provider: selectedAgent.aiProvider,
-          model: selectedAgent.aiModel,
-          systemPrompt: selectedAgent.systemPrompt,
-          locationContext: locationContext || undefined,
-          enabledTools: selectedAgent.enabledTools,
-        }
-      : buildGlobalChatRequestBody({
-          conversationId: currentConversationId,
-          isReadOnly,
-          webSearchEnabled,
-          imageGenEnabled,
-          showPageTree,
-          locationContext,
-          selectedProvider: currentProvider,
-          selectedModel: currentModel,
-        });
+    // Start context fetch eagerly — runs in parallel with input clear so the
+    // async wait doesn't delay sendMessage (and the optimistic bubble).
+    const contextPromise = buildFreshLocationContext();
+    const text = input;
+    const sendFiles = files.length > 0 ? files : undefined;
 
-    // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(() => sendMessage({ text: input, files: files.length > 0 ? files : undefined }, { body }));
     setInput('');
     clearFiles();
+
+    // wrapSend handles pendingSend registration and cleanup when streaming starts
+    wrapSend(async () => {
+      const freshLocation = await contextPromise;
+      const body = selectedAgent
+        ? {
+            chatId: selectedAgent.id,
+            conversationId: agentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: selectedAgent.aiProvider,
+            model: selectedAgent.aiModel,
+            systemPrompt: selectedAgent.systemPrompt,
+            pageContext: locationContextToPageContext(freshLocation),
+            enabledTools: selectedAgent.enabledTools,
+          }
+        : buildGlobalChatRequestBody({
+            conversationId: currentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            showPageTree,
+            locationContext: freshLocation,
+            selectedProvider: currentProvider,
+            selectedModel: currentModel,
+          });
+      return sendMessage({ text, files: sendFiles }, { body });
+    });
     // Note: scrollToBottom is now handled by use-stick-to-bottom when pinned
   }, [
     input,
@@ -825,7 +729,7 @@ const SidebarChatTab: React.FC = () => {
     webSearchEnabled,
     imageGenEnabled,
     showPageTree,
-    locationContext,
+    buildFreshLocationContext,
     currentProvider,
     currentModel,
     sendMessage,
@@ -839,33 +743,36 @@ const SidebarChatTab: React.FC = () => {
     if (!text.trim() || !currentConversationId) return;
 
     const isReadOnly = !writeMode;
-
-    const body = selectedAgent
-      ? {
-          chatId: selectedAgent.id,
-          conversationId: agentConversationId,
-          isReadOnly,
-          webSearchEnabled,
-          imageGenEnabled,
-          provider: selectedAgent.aiProvider,
-          model: selectedAgent.aiModel,
-          systemPrompt: selectedAgent.systemPrompt,
-          locationContext: locationContext || undefined,
-          enabledTools: selectedAgent.enabledTools,
-        }
-      : buildGlobalChatRequestBody({
-          conversationId: currentConversationId,
-          isReadOnly,
-          webSearchEnabled,
-          imageGenEnabled,
-          showPageTree,
-          locationContext,
-          selectedProvider: currentProvider,
-          selectedModel: currentModel,
-        });
+    const contextPromise = buildFreshLocationContext();
 
     // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(() => sendMessage({ text }, { body }));
+    wrapSend(async () => {
+      const freshLocation = await contextPromise;
+      const body = selectedAgent
+        ? {
+            chatId: selectedAgent.id,
+            conversationId: agentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: selectedAgent.aiProvider,
+            model: selectedAgent.aiModel,
+            systemPrompt: selectedAgent.systemPrompt,
+            pageContext: locationContextToPageContext(freshLocation),
+            enabledTools: selectedAgent.enabledTools,
+          }
+        : buildGlobalChatRequestBody({
+            conversationId: currentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            showPageTree,
+            locationContext: freshLocation,
+            selectedProvider: currentProvider,
+            selectedModel: currentModel,
+          });
+      return sendMessage({ text }, { body });
+    });
   }, [
     currentConversationId,
     selectedAgent,
@@ -874,15 +781,16 @@ const SidebarChatTab: React.FC = () => {
     webSearchEnabled,
     imageGenEnabled,
     showPageTree,
-    locationContext,
+    buildFreshLocationContext,
     currentProvider,
     currentModel,
     sendMessage,
     wrapSend,
   ]);
 
-  const buildAskUserAnswerBody = useCallback(() => {
+  const buildAskUserAnswerBody = useCallback(async () => {
     const isReadOnly = !writeMode;
+    const freshLocation = await buildFreshLocationContext();
     return selectedAgent
       ? {
           chatId: selectedAgent.id,
@@ -893,7 +801,7 @@ const SidebarChatTab: React.FC = () => {
           provider: selectedAgent.aiProvider,
           model: selectedAgent.aiModel,
           systemPrompt: selectedAgent.systemPrompt,
-          locationContext: locationContext || undefined,
+          pageContext: locationContextToPageContext(freshLocation),
           enabledTools: selectedAgent.enabledTools,
         }
       : buildGlobalChatRequestBody({
@@ -902,7 +810,7 @@ const SidebarChatTab: React.FC = () => {
           webSearchEnabled,
           imageGenEnabled,
           showPageTree,
-          locationContext,
+          locationContext: freshLocation,
           selectedProvider: currentProvider,
           selectedModel: currentModel,
         });
@@ -913,7 +821,7 @@ const SidebarChatTab: React.FC = () => {
     webSearchEnabled,
     imageGenEnabled,
     showPageTree,
-    locationContext,
+    buildFreshLocationContext,
     currentProvider,
     currentModel,
     currentConversationId,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -675,122 +675,14 @@ const SidebarChatTab: React.FC = () => {
     }
   }, [selectedAgent, createAgentConversation, createGlobalConversation, setMessages]);
 
-  const handleSendMessage = useCallback(async () => {
-    const files = getFilesForSend();
-    if ((!input.trim() && files.length === 0) || !currentConversationId) return;
-
-    // Derive isReadOnly from writeMode (inverted)
-    const isReadOnly = !writeMode;
-
-    // Start context fetch eagerly — runs in parallel with input clear so the
-    // async wait doesn't delay sendMessage (and the optimistic bubble).
-    const contextPromise = buildFreshLocationContext();
-    const text = input;
-    const sendFiles = files.length > 0 ? files : undefined;
-
-    setInput('');
-    clearFiles();
-
-    // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(async () => {
-      const freshLocation = await contextPromise;
-      const body = selectedAgent
-        ? {
-            chatId: selectedAgent.id,
-            conversationId: agentConversationId,
-            isReadOnly,
-            webSearchEnabled,
-            imageGenEnabled,
-            provider: selectedAgent.aiProvider,
-            model: selectedAgent.aiModel,
-            systemPrompt: selectedAgent.systemPrompt,
-            pageContext: locationContextToPageContext(freshLocation),
-            enabledTools: selectedAgent.enabledTools,
-          }
-        : buildGlobalChatRequestBody({
-            conversationId: currentConversationId,
-            isReadOnly,
-            webSearchEnabled,
-            imageGenEnabled,
-            showPageTree,
-            locationContext: freshLocation,
-            selectedProvider: currentProvider,
-            selectedModel: currentModel,
-          });
-      return sendMessage({ text, files: sendFiles }, { body });
-    });
-    // Note: scrollToBottom is now handled by use-stick-to-bottom when pinned
-  }, [
-    input,
-    currentConversationId,
-    selectedAgent,
-    agentConversationId,
-    writeMode,
-    webSearchEnabled,
-    imageGenEnabled,
-    showPageTree,
-    buildFreshLocationContext,
-    currentProvider,
-    currentModel,
-    sendMessage,
-    getFilesForSend,
-    clearFiles,
-    wrapSend,
-  ]);
-
-  // Voice mode: Send message from voice transcript
-  const handleVoiceSend = useCallback((text: string) => {
-    if (!text.trim() || !currentConversationId) return;
-
-    const isReadOnly = !writeMode;
-    const contextPromise = buildFreshLocationContext();
-
-    // wrapSend handles pendingSend registration and cleanup when streaming starts
-    wrapSend(async () => {
-      const freshLocation = await contextPromise;
-      const body = selectedAgent
-        ? {
-            chatId: selectedAgent.id,
-            conversationId: agentConversationId,
-            isReadOnly,
-            webSearchEnabled,
-            imageGenEnabled,
-            provider: selectedAgent.aiProvider,
-            model: selectedAgent.aiModel,
-            systemPrompt: selectedAgent.systemPrompt,
-            pageContext: locationContextToPageContext(freshLocation),
-            enabledTools: selectedAgent.enabledTools,
-          }
-        : buildGlobalChatRequestBody({
-            conversationId: currentConversationId,
-            isReadOnly,
-            webSearchEnabled,
-            imageGenEnabled,
-            showPageTree,
-            locationContext: freshLocation,
-            selectedProvider: currentProvider,
-            selectedModel: currentModel,
-          });
-      return sendMessage({ text }, { body });
-    });
-  }, [
-    currentConversationId,
-    selectedAgent,
-    agentConversationId,
-    writeMode,
-    webSearchEnabled,
-    imageGenEnabled,
-    showPageTree,
-    buildFreshLocationContext,
-    currentProvider,
-    currentModel,
-    sendMessage,
-    wrapSend,
-  ]);
-
-  const buildAskUserAnswerBody = useCallback(async () => {
-    const isReadOnly = !writeMode;
-    const freshLocation = await buildFreshLocationContext();
+  // Shared shape for every sidebar send path (text, voice, ask-user-answer) —
+  // all three need "the request body for wherever we're sending right now,
+  // given a freshly-resolved location." Centralized so the agent-mode vs
+  // global-mode branch and field list can't drift between call sites.
+  const buildSidebarChatRequestBody = useCallback((
+    freshLocation: LocationContext | null,
+    isReadOnly: boolean,
+  ) => {
     return selectedAgent
       ? {
           chatId: selectedAgent.id,
@@ -817,14 +709,79 @@ const SidebarChatTab: React.FC = () => {
   }, [
     selectedAgent,
     agentConversationId,
-    writeMode,
     webSearchEnabled,
     imageGenEnabled,
     showPageTree,
-    buildFreshLocationContext,
+    currentConversationId,
     currentProvider,
     currentModel,
+  ]);
+
+  const handleSendMessage = useCallback(async () => {
+    const files = getFilesForSend();
+    if ((!input.trim() && files.length === 0) || !currentConversationId) return;
+
+    // Derive isReadOnly from writeMode (inverted)
+    const isReadOnly = !writeMode;
+
+    // Start context fetch eagerly — runs in parallel with input clear so the
+    // async wait doesn't delay sendMessage (and the optimistic bubble).
+    const contextPromise = buildFreshLocationContext();
+    const text = input;
+    const sendFiles = files.length > 0 ? files : undefined;
+
+    setInput('');
+    clearFiles();
+
+    // wrapSend handles pendingSend registration and cleanup when streaming starts
+    wrapSend(async () => {
+      const freshLocation = await contextPromise;
+      const body = buildSidebarChatRequestBody(freshLocation, isReadOnly);
+      return sendMessage({ text, files: sendFiles }, { body });
+    });
+    // Note: scrollToBottom is now handled by use-stick-to-bottom when pinned
+  }, [
+    input,
     currentConversationId,
+    writeMode,
+    buildFreshLocationContext,
+    buildSidebarChatRequestBody,
+    sendMessage,
+    getFilesForSend,
+    clearFiles,
+    wrapSend,
+  ]);
+
+  // Voice mode: Send message from voice transcript
+  const handleVoiceSend = useCallback((text: string) => {
+    if (!text.trim() || !currentConversationId) return;
+
+    const isReadOnly = !writeMode;
+    const contextPromise = buildFreshLocationContext();
+
+    // wrapSend handles pendingSend registration and cleanup when streaming starts
+    wrapSend(async () => {
+      const freshLocation = await contextPromise;
+      const body = buildSidebarChatRequestBody(freshLocation, isReadOnly);
+      return sendMessage({ text }, { body });
+    });
+  }, [
+    currentConversationId,
+    writeMode,
+    buildFreshLocationContext,
+    buildSidebarChatRequestBody,
+    sendMessage,
+    wrapSend,
+  ]);
+
+  const buildAskUserAnswerBody = useCallback(async () => {
+    const isReadOnly = !writeMode;
+    const freshLocation = await buildFreshLocationContext();
+    return buildSidebarChatRequestBody(freshLocation, isReadOnly);
+  }, [
+    writeMode,
+    buildFreshLocationContext,
+    buildSidebarChatRequestBody,
   ]);
 
   const askUserAnswering = useAskUserAnswering({

--- a/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/inline-instructions.test.ts
@@ -2,178 +2,142 @@
  * Tests for apps/web/src/lib/ai/core/inline-instructions.ts
  *
  * Covers:
- * - buildInlineInstructions: always-on sections, tool-gated sections, context interpolation
+ * - buildInlineInstructions: always-on sections, tool-gated sections
  * - Tool-gating: TASK_MANAGEMENT, AGENTS, AUTOMATION, SEARCH presence/absence
  * - availableTools=undefined sentinel (include all — backward compat for admin viewer)
  * - availableTools=[] (no tools — only always-on sections)
+ *
+ * Location/drive/page context ("CONTEXT" interpolation) used to live here but
+ * was moved to location-prompt.ts (see location-prompt.test.ts) so it can be
+ * injected via the volatile turn-context block instead of baked into this
+ * stable, tool-list-only instructions block.
  */
 
 import { describe, it, expect } from 'vitest';
 import { buildInlineInstructions } from '../inline-instructions';
 
-const BASE_CONTEXT = {
-  pageTitle: 'My Page',
-  pageType: 'DOCUMENT',
-  driveName: 'My Drive',
-  pagePath: '/my-drive/my-page',
-  driveSlug: 'my-drive',
-  driveId: 'cuid_drive_123',
-};
-
 describe('buildInlineInstructions — always-on sections', () => {
   it('includes WORKSPACE RULES regardless of tool list', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result).toContain('WORKSPACE RULES');
   });
 
   it('includes PAGE TYPES regardless of tool list', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result).toContain('PAGE TYPES');
   });
 
   it('instructs canvas authors to use dashboard file view URLs for embedded uploaded files', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result).toContain('/dashboard/{driveId}/{filePageId}/view');
     expect(result).toContain('not /api/files');
   });
 
   it('includes AFTER TOOLS regardless of tool list', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result).toContain('AFTER TOOLS');
   });
 
   it('includes MENTIONS regardless of tool list', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result).toContain('MENTIONS');
   });
 
-  it('includes CONTEXT section regardless of tool list', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
-    expect(result).toContain('CONTEXT');
-  });
-});
-
-describe('buildInlineInstructions — context interpolation', () => {
-  it('includes pageTitle in CONTEXT', () => {
-    const result = buildInlineInstructions({ ...BASE_CONTEXT, pageTitle: 'Sprint Board' }, []);
-    expect(result).toContain('Sprint Board');
-  });
-
-  it('includes driveName in CONTEXT', () => {
-    const result = buildInlineInstructions({ ...BASE_CONTEXT, driveName: 'Engineering Hub' }, []);
-    expect(result).toContain('Engineering Hub');
-  });
-
-  it('includes driveId in CONTEXT', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
-    expect(result).toContain('cuid_drive_123');
-  });
-
-  it('includes driveSlug in CONTEXT', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
-    expect(result).toContain('my-drive');
-  });
-
-  it('appends task-linked annotation when isTaskLinked=true', () => {
-    const result = buildInlineInstructions({ ...BASE_CONTEXT, isTaskLinked: true }, []);
-    expect(result).toContain('Task-linked page');
-  });
-
-  it('does not append task-linked annotation when isTaskLinked=false', () => {
-    const result = buildInlineInstructions({ ...BASE_CONTEXT, isTaskLinked: false }, []);
-    expect(result).not.toContain('Task-linked page');
+  it('does not include location-specific CONTEXT text — that is volatile, injected separately', () => {
+    const result = buildInlineInstructions([]);
+    expect(result).not.toContain('Current location:');
   });
 });
 
 describe('buildInlineInstructions — TASK_MANAGEMENT gating', () => {
   it('includes TASK MANAGEMENT when create_task is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['create_task']);
+    const result = buildInlineInstructions(['create_task']);
     expect(result).toContain('TASK MANAGEMENT');
   });
 
   it('includes TASK MANAGEMENT when update_task is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['update_task']);
+    const result = buildInlineInstructions(['update_task']);
     expect(result).toContain('TASK MANAGEMENT');
   });
 
   it('includes TASK MANAGEMENT when any task tool is available', () => {
     for (const tool of ['delete_task', 'create_task_status', 'reorder_task', 'get_assigned_tasks']) {
-      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      const result = buildInlineInstructions([tool]);
       expect(result).toContain('TASK MANAGEMENT');
     }
   });
 
   it('excludes TASK MANAGEMENT when no task tools are available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'list_pages']);
+    const result = buildInlineInstructions(['read_page', 'list_pages']);
     expect(result).not.toContain('TASK MANAGEMENT');
   });
 });
 
 describe('buildInlineInstructions — AGENTS gating', () => {
   it('includes AGENTS when ask_agent is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['ask_agent']);
+    const result = buildInlineInstructions(['ask_agent']);
     expect(result).toContain('AGENTS');
   });
 
   it('includes AGENTS when list_agents is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['list_agents']);
+    const result = buildInlineInstructions(['list_agents']);
     expect(result).toContain('AGENTS');
   });
 
   it('includes AGENTS when any agent tool is available', () => {
     for (const tool of ['multi_drive_list_agents', 'update_agent_config', 'list_models']) {
-      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      const result = buildInlineInstructions([tool]);
       expect(result).toContain('AGENTS');
     }
   });
 
   it('excludes AGENTS when no agent tools are available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'create_task']);
+    const result = buildInlineInstructions(['read_page', 'create_task']);
     expect(result).not.toContain('AGENTS');
   });
 });
 
 describe('buildInlineInstructions — AUTOMATION gating', () => {
   it('includes AUTOMATION when set_task_trigger is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['set_task_trigger']);
+    const result = buildInlineInstructions(['set_task_trigger']);
     expect(result).toContain('AUTOMATION');
   });
 
   it('includes AUTOMATION when any trigger/workflow tool is available', () => {
     for (const tool of ['delete_task_trigger', 'set_calendar_trigger', 'delete_calendar_trigger', 'create_workflow', 'list_workflows']) {
-      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      const result = buildInlineInstructions([tool]);
       expect(result).toContain('AUTOMATION');
     }
   });
 
   it('excludes AUTOMATION when no trigger or workflow tools are available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['create_task', 'ask_agent']);
+    const result = buildInlineInstructions(['create_task', 'ask_agent']);
     expect(result).not.toContain('AUTOMATION');
   });
 });
 
 describe('buildInlineInstructions — SEARCH gating', () => {
   it('includes SEARCH when glob_search is available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['glob_search']);
+    const result = buildInlineInstructions(['glob_search']);
     expect(result).toContain('SEARCH');
   });
 
   it('includes SEARCH when any search tool is available', () => {
     for (const tool of ['regex_search', 'multi_drive_search', 'web_search', 'web_fetch']) {
-      const result = buildInlineInstructions(BASE_CONTEXT, [tool]);
+      const result = buildInlineInstructions([tool]);
       expect(result).toContain('SEARCH');
     }
   });
 
   it('excludes SEARCH when no search tools are available', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, ['read_page', 'create_task']);
+    const result = buildInlineInstructions(['read_page', 'create_task']);
     expect(result).not.toContain('SEARCH');
   });
 });
 
 describe('buildInlineInstructions — availableTools=undefined sentinel', () => {
   it('includes all sections when availableTools is omitted', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT);
+    const result = buildInlineInstructions();
     expect(result).toContain('TASK MANAGEMENT');
     expect(result).toContain('AGENTS');
     expect(result).toContain('AUTOMATION');
@@ -181,7 +145,7 @@ describe('buildInlineInstructions — availableTools=undefined sentinel', () => 
   });
 
   it('includes all sections when availableTools is explicitly undefined', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, undefined);
+    const result = buildInlineInstructions(undefined);
     expect(result).toContain('TASK MANAGEMENT');
     expect(result).toContain('AGENTS');
     expect(result).toContain('AUTOMATION');
@@ -191,7 +155,7 @@ describe('buildInlineInstructions — availableTools=undefined sentinel', () => 
 
 describe('buildInlineInstructions — full tool set', () => {
   it('includes all gated sections when all relevant tools are provided', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, [
+    const result = buildInlineInstructions([
       'create_task', 'ask_agent', 'set_task_trigger', 'glob_search',
     ]);
     expect(result).toContain('TASK MANAGEMENT');
@@ -201,7 +165,7 @@ describe('buildInlineInstructions — full tool set', () => {
   });
 
   it('returns a non-empty string', () => {
-    const result = buildInlineInstructions(BASE_CONTEXT, []);
+    const result = buildInlineInstructions([]);
     expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/location-prompt.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/location-prompt.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for apps/web/src/lib/ai/core/location-prompt.ts
+ *
+ * This block carries the "what page/drive is the user looking at right now"
+ * text — it used to be baked into the stable system prompt (system-prompt.ts's
+ * buildContextPrompt) but was moved here so it can be injected via the
+ * volatile turn-context block instead, without busting the provider prompt
+ * cache every time the user's location changes turn-to-turn.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildLocationTurnPrompt } from '../location-prompt';
+
+describe('buildLocationTurnPrompt — no location (dashboard)', () => {
+  it('given undefined input, returns dashboard guidance', () => {
+    const result = buildLocationTurnPrompt(undefined);
+    expect(result).toContain('dashboard');
+    expect(result).toContain('list_drives');
+  });
+
+  it('given input with neither page nor drive, returns dashboard guidance', () => {
+    const result = buildLocationTurnPrompt({ currentPage: null, currentDrive: null });
+    expect(result).toContain('dashboard');
+  });
+});
+
+describe('buildLocationTurnPrompt — drive only', () => {
+  it('includes driveName to give the AI semantic workspace context', () => {
+    const result = buildLocationTurnPrompt({
+      currentDrive: { name: 'Marketing Team', slug: 'marketing-team', id: 'cuid_abc123' },
+    });
+    expect(result).toContain('Marketing Team');
+  });
+
+  it('includes driveSlug for tool routing', () => {
+    const result = buildLocationTurnPrompt({
+      currentDrive: { name: 'Confidential Workspace', slug: 'confidential-ws', id: 'cuid_xyz' },
+    });
+    expect(result).toContain('confidential-ws');
+  });
+
+  it('includes driveId for tool routing', () => {
+    const result = buildLocationTurnPrompt({
+      currentDrive: { name: 'My Private Drive', slug: 'my-private-drive', id: 'cuid_drive_007' },
+    });
+    expect(result).toContain('cuid_drive_007');
+  });
+
+  it('given a drive with no slug, still produces valid prompt', () => {
+    const result = buildLocationTurnPrompt({
+      currentDrive: { name: 'My Drive', id: 'cuid_1' },
+    });
+    expect(result).toContain('My Drive');
+    expect(result).toContain('cuid_1');
+  });
+});
+
+describe('buildLocationTurnPrompt — page context', () => {
+  it('includes page title, type, and path', () => {
+    const result = buildLocationTurnPrompt({
+      currentPage: { title: 'Q3 Roadmap', type: 'DOCUMENT', path: '/drive/Q3 Roadmap' },
+    });
+    expect(result).toContain('Q3 Roadmap');
+    expect(result).toContain('DOCUMENT');
+    expect(result).toContain('/drive/Q3 Roadmap');
+  });
+
+  it('flags task-linked pages', () => {
+    const result = buildLocationTurnPrompt({
+      currentPage: { title: 'Fix login bug', type: 'TASK_LIST', path: '/drive/tasks/Fix login bug', isTaskLinked: true },
+    });
+    expect(result).toContain('linked to a task');
+  });
+
+  it('does not mention task-linking for a normal page', () => {
+    const result = buildLocationTurnPrompt({
+      currentPage: { title: 'Notes', type: 'DOCUMENT', path: '/drive/Notes' },
+    });
+    expect(result).not.toContain('linked to a task');
+  });
+
+  it('includes breadcrumbs when present', () => {
+    const result = buildLocationTurnPrompt({
+      currentPage: { title: 'Notes', type: 'DOCUMENT', path: '/drive/folder/Notes' },
+      breadcrumbs: ['Drive', 'Folder', 'Notes'],
+    });
+    expect(result).toContain('Drive > Folder > Notes');
+  });
+});
+
+describe('buildLocationTurnPrompt — "here" guidance', () => {
+  it('tells the model what "here"/"this" refers to when a location is present', () => {
+    const result = buildLocationTurnPrompt({
+      currentDrive: { name: 'Team Drive', id: 'd1' },
+    });
+    expect(result.toLowerCase()).toContain('"here"');
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/prompt-assembly.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/prompt-assembly.test.ts
@@ -62,6 +62,37 @@ describe('buildVolatileTurnContext', () => {
       expect(buildVolatileTurnContext(input)).toBe(buildVolatileTurnContext(input));
     });
   });
+
+  describe('given locationPrompt', () => {
+    it('is included between timestamp and mention when present', () => {
+      const result = buildVolatileTurnContext({
+        timestampPrompt: 'TIME',
+        locationPrompt: 'LOCATION',
+        mentionPrompt: 'MENTION',
+        commandPrompt: 'COMMAND',
+      });
+      expect(result).toBe('TIME\n\nLOCATION\n\nMENTION\n\nCOMMAND');
+    });
+
+    it('is omitted when undefined (backward compatible — optional field)', () => {
+      const result = buildVolatileTurnContext({
+        timestampPrompt: 'TIME',
+        mentionPrompt: 'MENTION',
+        commandPrompt: 'COMMAND',
+      });
+      expect(result).toBe('TIME\n\nMENTION\n\nCOMMAND');
+    });
+
+    it('is omitted when empty/whitespace-only', () => {
+      const result = buildVolatileTurnContext({
+        timestampPrompt: 'TIME',
+        locationPrompt: '   ',
+        mentionPrompt: 'MENTION',
+        commandPrompt: '',
+      });
+      expect(result).toBe('TIME\n\nMENTION');
+    });
+  });
 });
 
 // ─── appendTurnContextToLastUserMessage ──────────────────────────────────────

--- a/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/system-prompt.test.ts
@@ -2,7 +2,10 @@
  * Tests for apps/web/src/lib/ai/core/system-prompt.ts
  *
  * Covers:
- * - buildSystemPrompt: dashboard, drive, page context types
+ * - buildSystemPrompt: read-only mode, sandbox guidance
+ *   (location/drive/page context lives in location-prompt.ts now — see
+ *   location-prompt.test.ts — buildSystemPrompt takes no location args so
+ *   the stable system prefix stays byte-identical across turns)
  * - buildPersonalizationPrompt: enabled/disabled, section presence
  * - getWelcomeMessage / getErrorMessage
  * - estimateSystemPromptTokens
@@ -18,82 +21,49 @@ import {
   estimateSystemPromptTokens,
 } from '../system-prompt';
 
-describe('buildSystemPrompt — drive context', () => {
-  it('given drive context, should include driveName to give AI semantic workspace context', () => {
-    const result = buildSystemPrompt('drive', {
-      driveName: 'Marketing Team',
-      driveSlug: 'marketing-team',
-      driveId: 'cuid_abc123',
-    });
-
-    expect(result).toContain('Marketing Team');
-  });
-
-  it('given drive context, should include driveSlug for tool routing', () => {
-    const result = buildSystemPrompt('drive', {
-      driveName: 'Confidential Workspace',
-      driveSlug: 'confidential-ws',
-      driveId: 'cuid_xyz',
-    });
-
-    expect(result).toContain('confidential-ws');
-  });
-
-  it('given drive context, should include driveId for tool routing', () => {
-    const result = buildSystemPrompt('drive', {
-      driveName: 'My Private Drive',
-      driveSlug: 'my-private-drive',
-      driveId: 'cuid_drive_007',
-    });
-
-    expect(result).toContain('cuid_drive_007');
-  });
-});
-
 describe('buildSystemPrompt — general', () => {
-  it('given dashboard context, returns string containing core prompt text', () => {
-    const result = buildSystemPrompt('dashboard');
+  it('given no args, returns string containing core prompt text', () => {
+    const result = buildSystemPrompt();
     expect(result).toContain('PageSpace AI');
   });
 
   it('given read-only mode, includes READ-ONLY constraint', () => {
-    const result = buildSystemPrompt('dashboard', undefined, true);
+    const result = buildSystemPrompt(true);
     expect(result).toContain('READ-ONLY');
   });
 
   it('given non-read-only mode, does not include READ-ONLY constraint', () => {
-    const result = buildSystemPrompt('dashboard', undefined, false);
+    const result = buildSystemPrompt(false);
     expect(result).not.toContain('READ-ONLY');
   });
 
-  it('given drive context with no driveName, still produces valid prompt', () => {
-    const result = buildSystemPrompt('drive', {
-      driveSlug: 'my-drive',
-      driveId: 'cuid_1',
-    });
-    expect(result).toContain('my-drive');
+  it('never contains location/drive/page-specific text — that lives in the volatile block', () => {
+    const result = buildSystemPrompt(false);
+    expect(result).not.toContain('DASHBOARD CONTEXT');
+    expect(result).not.toContain('DRIVE CONTEXT');
+    expect(result).not.toContain('PAGE CONTEXT');
   });
 });
 
 describe('buildSystemPrompt — sandbox guidance', () => {
   it('given codeExecutionEnabled true, should include the sandbox guidance section', () => {
-    const result = buildSystemPrompt('drive', { driveSlug: 'd', driveId: '1' }, false, undefined, true);
+    const result = buildSystemPrompt(false, undefined, true);
     expect(result).toContain('/workspace');
     expect(result).toContain('persists');
   });
 
   it('given the default call (no flag), should NOT include sandbox guidance', () => {
-    const result = buildSystemPrompt('drive', { driveSlug: 'd', driveId: '1' });
+    const result = buildSystemPrompt();
     expect(result).not.toContain('/workspace');
   });
 
   it('given codeExecutionEnabled false explicitly, should NOT include sandbox guidance', () => {
-    const result = buildSystemPrompt('dashboard', undefined, false, undefined, false);
+    const result = buildSystemPrompt(false, undefined, false);
     expect(result).not.toContain('/workspace');
   });
 
   it('given the sandbox guidance, should cover the auth boundary, cwd, editFile, persistence, and key tools', () => {
-    const result = buildSystemPrompt('dashboard', undefined, false, undefined, true);
+    const result = buildSystemPrompt(false, undefined, true);
     // Auth boundary → dedicated tools
     expect(result).toContain('gh_pr_create');
     expect(result).toContain('git_*');
@@ -106,7 +76,7 @@ describe('buildSystemPrompt — sandbox guidance', () => {
   });
 
   it('given the sandbox guidance, should include the Constraints{} block treating tool output as untrusted', () => {
-    const result = buildSystemPrompt('dashboard', undefined, false, undefined, true);
+    const result = buildSystemPrompt(false, undefined, true);
     expect(result).toContain('Constraints {');
     expect(result).toContain('tool output');
     expect(result).toContain('untrusted');

--- a/apps/web/src/lib/ai/core/complete-request-builder.ts
+++ b/apps/web/src/lib/ai/core/complete-request-builder.ts
@@ -24,6 +24,7 @@ import { pageSpaceTools } from './ai-tools';
 import { buildTimestampSystemPrompt } from './timestamp-utils';
 import { buildMentionSystemPrompt } from './mention-processor';
 import { buildVolatileTurnContext } from './prompt-assembly';
+import { buildLocationTurnPrompt } from './location-prompt';
 
 export interface LocationContext {
   currentPage?: {
@@ -114,47 +115,30 @@ export function buildCompleteRequest(
     includeExampleMessage = true,
   } = config;
 
-  // Build the base system prompt
+  // Build the base system prompt. Location is turn-volatile — it's built
+  // separately below as `locationPrompt` and injected via
+  // buildVolatileTurnContext, mirroring production routes exactly.
   const baseSystemPrompt = buildSystemPrompt(
-    contextType,
-    locationContext?.currentDrive
-      ? {
-          driveName: locationContext.currentDrive.name,
-          driveSlug: locationContext.currentDrive.slug,
-          driveId: locationContext.currentDrive.id,
-          pagePath: locationContext.currentPage?.path,
-          pageType: locationContext.currentPage?.type,
-          breadcrumbs: locationContext.breadcrumbs?.map((b) => b.title),
-        }
-      : undefined,
     isReadOnly,
     undefined,
     isCodeExecutionEnabled()
   );
 
+  const locationPrompt = buildLocationTurnPrompt(
+    locationContext
+      ? {
+          currentPage: locationContext.currentPage,
+          currentDrive: locationContext.currentDrive,
+          breadcrumbs: locationContext.breadcrumbs?.map((b) => b.title),
+        }
+      : undefined
+  );
+
   // Build inline instructions based on context type
-  let inlineInstructions: string;
-  if (contextType === 'page' && locationContext?.currentPage) {
-    inlineInstructions = buildInlineInstructions({
-      pageTitle: locationContext.currentPage.title,
-      pageType: locationContext.currentPage.type,
-      isTaskLinked: locationContext.currentPage.isTaskLinked,
-      driveName: locationContext.currentDrive?.name,
-      pagePath: locationContext.currentPage.path,
-      driveSlug: locationContext.currentDrive?.slug,
-      driveId: locationContext.currentDrive?.id,
-    });
-  } else {
-    inlineInstructions = buildGlobalAssistantInstructions(
-      locationContext?.currentDrive
-        ? {
-            driveName: locationContext.currentDrive.name,
-            driveSlug: locationContext.currentDrive.slug,
-            driveId: locationContext.currentDrive.id,
-          }
-        : undefined
-    );
-  }
+  const inlineInstructions =
+    contextType === 'page' && locationContext?.currentPage
+      ? buildInlineInstructions()
+      : buildGlobalAssistantInstructions();
 
   // Apply read-only filtering (same logic as real Global Assistant)
   const allFilteredTools = filterToolsForReadOnly(pageSpaceTools, isReadOnly);
@@ -271,6 +255,7 @@ export function buildCompleteRequest(
   // "exactly as it would be sent" contract of this viewer.
   const volatileTurnContext = buildVolatileTurnContext({
     timestampPrompt: buildTimestampSystemPrompt(),
+    locationPrompt,
     mentionPrompt: buildMentionSystemPrompt([
       { id: 'example-page-id', label: 'Example Document', type: 'page' },
     ]),

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -5,16 +5,6 @@
  * The model infers tool usage from schemas; these provide context-specific rules.
  */
 
-export interface InlineInstructionsContext {
-  pageTitle?: string;
-  pageType?: string;
-  isTaskLinked?: boolean;
-  driveName?: string;
-  pagePath?: string;
-  driveSlug?: string;
-  driveId?: string;
-}
-
 // AUTHORING RULE: These sections correct format mistakes and non-intuitive workflows.
 // Do NOT list tool names here — the model already receives a flat tool list and can call tool_search.
 // Add a bullet only when the model predictably gets it wrong without explicit guidance.
@@ -79,21 +69,18 @@ export const ASK_USER_SECTION = `ASKING THE USER:
 • The result may be {"dismissed": true} — the user replied in chat instead of picking an option; treat their message as the answer`;
 
 /**
- * MENTIONS section — the @[everyone] bullet is conditional on whether a driveId
- * is available in context. Without one, instructing the model to use "DriveId from
- * CONTEXT" produces invalid mention payloads and broken notifications.
+ * MENTIONS section. This lives in the stable prompt, so it can't assume a
+ * driveId is available this turn (that's turn-volatile LOCATION data,
+ * injected separately — see location-prompt.ts) — always points the model
+ * at how to resolve one instead of claiming it's already in context.
  */
-function buildMentions(hasDriveId: boolean): string {
-  const everyoneLine = hasDriveId
-    ? `• @[everyone](driveId:everyone) — notifies all drive members (use DriveId from CONTEXT)`
-    : `• @[everyone](driveId:everyone) — notifies all drive members; requires the target drive's ID — resolve via list_drives or from the resource you're working on`;
-
+function buildMentions(): string {
   return `MENTIONS:
 When users @mention documents using @[Label](id:type) format, read them first with read_page before responding.
 When writing content that should notify people:
 • @[Name](userId:user) — notifies a specific user
 • @[Role Name](roleId:role) — notifies all members with that role
-${everyoneLine}`;
+• @[everyone](driveId:everyone) — notifies all drive members; use the driveId from your current LOCATION context if present, otherwise resolve via list_drives or from the resource you're working on`;
 }
 
 // ---------------------------------------------------------------------------
@@ -112,23 +99,12 @@ function hasAny(availableTools: string[] | undefined, toolNames: string[]): bool
  * Pass `availableTools` (the filtered tool name list) to omit sections for
  * capabilities the agent doesn't have. Omitting `availableTools` includes
  * all sections — used by the admin prompt viewer for a complete preview.
+ *
+ * Deliberately takes no location context — "current page"/"current drive"
+ * is turn-volatile data injected separately via the volatile turn-context
+ * block (location-prompt.ts), not baked in here.
  */
-export function buildInlineInstructions(
-  context: InlineInstructionsContext,
-  availableTools?: string[]
-): string {
-  const {
-    pageTitle = 'current',
-    pageType = 'DOCUMENT',
-    isTaskLinked = false,
-    driveName = 'current',
-    pagePath = 'current-page',
-    driveSlug = 'current-drive',
-    driveId = 'current-drive-id',
-  } = context;
-
-  const taskSuffix = isTaskLinked ? ' (Task-linked page)' : '';
-
+export function buildInlineInstructions(availableTools?: string[]): string {
   const includeTaskManagement = hasAny(availableTools, ['create_task', 'update_task', 'delete_task', 'create_task_status', 'reorder_task', 'get_assigned_tasks']);
   const includeAgents = hasAny(availableTools, ['ask_agent', 'list_agents', 'multi_drive_list_agents', 'update_agent_config', 'list_models']);
   const includeAutomation = hasAny(availableTools, ['set_task_trigger', 'delete_task_trigger', 'set_calendar_trigger', 'delete_calendar_trigger', 'create_workflow', 'list_workflows']);
@@ -137,12 +113,6 @@ export function buildInlineInstructions(
 
   const sections = [
     WORKSPACE_RULES,
-    `CONTEXT:
-• Current location: "${pageTitle}" [${pageType}]${taskSuffix} at ${pagePath} in "${driveName}"
-• DriveSlug: ${driveSlug}, DriveId: ${driveId}
-• When user says "here" or "this", they mean this location
-• Explore current drive first (list_pages) before other drives${isTaskLinked ? `
-• This page is linked to a task - use task management tools to update task status` : ''}`,
     PAGE_TYPES,
     includeTaskManagement ? TASK_MANAGEMENT : null,
     includeAgents ? AGENTS : null,
@@ -150,37 +120,19 @@ export function buildInlineInstructions(
     includeSearch ? SEARCH : null,
     includeAskUser ? ASK_USER_SECTION : null,
     AFTER_TOOLS,
-    buildMentions(true),
+    buildMentions(),
   ].filter(Boolean);
 
   return '\n' + sections.join('\n\n');
 }
 
 /**
- * Build inline instructions for dashboard/global assistant context.
+ * Build inline instructions for the Global Assistant. Deliberately takes no
+ * location context — see buildInlineInstructions above for why.
  */
-export function buildGlobalAssistantInstructions(locationContext?: {
-  driveName?: string;
-  driveSlug?: string;
-  driveId?: string;
-}): string {
-  const hasDriveContext = !!locationContext?.driveName;
-
-  const contextSection = hasDriveContext
-    ? `CONTEXT:
-• Current location: ${locationContext?.driveName}
-• DriveSlug: ${locationContext?.driveSlug}, DriveId: ${locationContext?.driveId}
-• When user says "here" or "this", they mean this location
-• Explore current drive first (list_pages) before other drives`
-    : `CONTEXT:
-• Operating from dashboard - cross-workspace tasks
-• Use list_drives to discover available workspaces
-• Check existing drives before suggesting new drive creation`;
-
+export function buildGlobalAssistantInstructions(): string {
   return `
 ${WORKSPACE_RULES}
-
-${contextSection}
 
 ${PAGE_TYPES}
 
@@ -194,5 +146,5 @@ ${SEARCH}
 
 ${AFTER_TOOLS}
 
-${buildMentions(hasDriveContext)}`;
+${buildMentions()}`;
 }

--- a/apps/web/src/lib/ai/core/location-prompt.ts
+++ b/apps/web/src/lib/ai/core/location-prompt.ts
@@ -1,0 +1,63 @@
+/**
+ * Location context prompt — the "what page/drive is the user looking at right
+ * now" block, built fresh every turn and injected via the VOLATILE turn
+ * context (prompt-assembly.ts), NOT the stable system prompt. This is what
+ * lets the agent stay accurate as the user navigates between turns without
+ * busting the provider prompt-cache prefix on every location change.
+ *
+ * Used by both the page-agent route (api/ai/chat) and the Global Assistant
+ * route (api/ai/global/[id]/messages) so the two surfaces share one source
+ * of truth for this text instead of drifting.
+ */
+
+export interface LocationPromptInput {
+  currentPage?: {
+    title: string;
+    type: string;
+    path: string;
+    isTaskLinked?: boolean;
+  } | null;
+  currentDrive?: {
+    name: string;
+    slug?: string;
+    id?: string;
+  } | null;
+  breadcrumbs?: string[];
+}
+
+export function buildLocationTurnPrompt(input: LocationPromptInput | undefined): string {
+  if (!input || (!input.currentPage && !input.currentDrive)) {
+    return `LOCATION (current, this turn):
+• Operating from the dashboard — no specific workspace or page is currently in view
+• Use list_drives to discover available workspaces before suggesting new drive creation
+• When the user says "here" or "this", ask which workspace/page they mean, or use list_drives/list_pages to find out`;
+  }
+
+  const lines: string[] = ['LOCATION (current, this turn):'];
+
+  if (input.currentPage) {
+    lines.push(`• Current page: "${input.currentPage.title}" [${input.currentPage.type}] at ${input.currentPage.path}`);
+    if (input.currentPage.isTaskLinked) {
+      lines.push(`• This page is linked to a task — use task management tools to update task status`);
+    }
+  }
+
+  if (input.currentDrive) {
+    const slugPart = input.currentDrive.slug ? `, slug: ${input.currentDrive.slug}` : '';
+    const idPart = input.currentDrive.id ? `, driveId: ${input.currentDrive.id}` : '';
+    lines.push(`• Current workspace: "${input.currentDrive.name}"${slugPart}${idPart}`);
+  }
+
+  if (input.breadcrumbs?.length) {
+    lines.push(`• Path: ${input.breadcrumbs.join(' > ')}`);
+  }
+
+  lines.push('• When the user says "here" or "this", they mean the location above');
+  lines.push('• Default scope: operations should focus on this location unless the user indicates otherwise');
+
+  if (input.currentDrive?.id) {
+    lines.push('• Start with list_pages on this drive (driveId above) before exploring elsewhere');
+  }
+
+  return lines.join('\n');
+}

--- a/apps/web/src/lib/ai/core/prompt-assembly.ts
+++ b/apps/web/src/lib/ai/core/prompt-assembly.ts
@@ -2,9 +2,9 @@
  * Prompt assembly helpers for prefix-stable, cache-friendly AI requests.
  *
  * Key invariants enforced here:
- * - Volatile per-turn data (timestamp, mention, command) lives on the last
- *   user message, NOT in the system prompt, so the system prefix stays
- *   byte-identical across turns and provider prefix caches survive.
+ * - Volatile per-turn data (timestamp, location, mention, command) lives on
+ *   the last user message, NOT in the system prompt, so the system prefix
+ *   stays byte-identical across turns and provider prefix caches survive.
  * - Cache breakpoints are placed at message-level via providerOptions so
  *   OpenRouter's Anthropic prefix cache can be activated per turn/step.
  * - Nothing in this module reads the clock or mutates its inputs.
@@ -31,7 +31,7 @@ export interface VolatileTurnContextInput {
 // ─── Volatile context assembly ────────────────────────────────────────────────
 
 /**
- * Build the volatile per-turn context block from the three prompt fragments.
+ * Build the volatile per-turn context block from the prompt fragments.
  * Empty/whitespace-only fragments are omitted. The result is suitable for
  * appending to the last user message (not the system prompt).
  *

--- a/apps/web/src/lib/ai/core/prompt-assembly.ts
+++ b/apps/web/src/lib/ai/core/prompt-assembly.ts
@@ -18,6 +18,14 @@ export interface VolatileTurnContextInput {
   timestampPrompt: string;
   mentionPrompt: string;
   commandPrompt: string;
+  /**
+   * The user's current page/drive, rebuilt fresh every turn (see
+   * location-prompt.ts). Lives here — not the stable system prompt — so a
+   * turn where only the user's location changed doesn't bust the provider
+   * prompt-cache prefix, and so a long tool-call loop still reflects
+   * wherever the user actually was when they sent this turn's message.
+   */
+  locationPrompt?: string;
 }
 
 // ─── Volatile context assembly ────────────────────────────────────────────────
@@ -33,6 +41,7 @@ export function buildVolatileTurnContext(input: VolatileTurnContextInput): strin
   const parts: string[] = [];
 
   if (input.timestampPrompt.trim()) parts.push(input.timestampPrompt.trim());
+  if (input.locationPrompt?.trim()) parts.push(input.locationPrompt.trim());
   if (input.mentionPrompt.trim()) parts.push(input.mentionPrompt.trim());
   if (input.commandPrompt.trim()) parts.push(input.commandPrompt.trim());
 

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -5,15 +5,6 @@
  * Replaces the complex 3-role system with simple, trust-the-model approach.
  */
 
-export interface ContextInfo {
-  driveName?: string;
-  driveSlug?: string;
-  driveId?: string;
-  pagePath?: string;
-  pageType?: string;
-  breadcrumbs?: string[];
-}
-
 export interface PersonalizationInfo {
   bio?: string;
   writingStyle?: string;
@@ -135,50 +126,19 @@ export function buildPersonalizationPrompt(personalization?: PersonalizationInfo
 }
 
 /**
- * Build context-specific prompt section
- */
-function buildContextPrompt(
-  contextType: 'dashboard' | 'drive' | 'page',
-  contextInfo?: ContextInfo
-): string {
-  if (!contextInfo) {
-    return `CONTEXT: Operating in ${contextType} mode.`;
-  }
-
-  switch (contextType) {
-    case 'dashboard':
-      return `DASHBOARD CONTEXT:
-• Operating across all workspaces
-• Focus on cross-workspace tasks and personal productivity`;
-
-    case 'drive':
-      return `DRIVE CONTEXT:
-• Current Workspace: "${contextInfo.driveName}" (Slug: ${contextInfo.driveSlug}, ID: ${contextInfo.driveId})
-• When users say "here" or "this workspace", they mean: ${contextInfo.driveSlug}`;
-
-    case 'page':
-      return `PAGE CONTEXT:
-• Location: ${contextInfo.pagePath}
-• Type: ${contextInfo.pageType}
-• Path: ${contextInfo.breadcrumbs?.join(' > ')}
-• When users say "here", they mean this page`;
-
-    default:
-      return `CONTEXT: ${contextType} mode`;
-  }
-}
-
-/**
- * Build a complete system prompt
+ * Build a complete system prompt.
+ *
+ * Deliberately takes no location/drive/page context — that's turn-volatile
+ * data and lives in the volatile turn-context block (see location-prompt.ts
+ * + prompt-assembly.ts), not here, so this string stays byte-identical
+ * across turns regardless of where the user navigates and provider prefix
+ * caches survive.
  */
 export function buildSystemPrompt(
-  contextType: 'dashboard' | 'drive' | 'page',
-  contextInfo?: ContextInfo,
   isReadOnly: boolean = false,
   personalization?: PersonalizationInfo,
   codeExecutionEnabled: boolean = false
 ): string {
-  const contextPrompt = buildContextPrompt(contextType, contextInfo);
   const personalizationPrompt = buildPersonalizationPrompt(personalization);
 
   const sections = [
@@ -190,7 +150,6 @@ export function buildSystemPrompt(
         )
       : CORE_PROMPT,
     personalizationPrompt,
-    contextPrompt,
     BEHAVIOR_PROMPT,
     isReadOnly ? READ_ONLY_CONSTRAINT : null,
     codeExecutionEnabled ? SANDBOX_INSTRUCTIONS : null,

--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -83,6 +83,16 @@ export interface ToolExecutionContext {
   // switched" — callers fall back to the configured machines[0].
   activeMachine?: MachineRef;
 
+  // The page the agent is currently focused on for THIS turn: seeded from the
+  // request's location/page context, then mutated in place by tools that
+  // represent the agent switching focus (e.g. create_page) — same
+  // mutate-in-place pattern as activeMachine above, so later page tool calls
+  // in the same turn default to wherever the agent's own actions left it,
+  // not just the page the user was on when the turn started. Used by
+  // resolveDefaultPageId (page-context-defaults.ts) to default an omitted
+  // `pageId` argument on read/write page tools.
+  currentWorkingPage?: { id: string; title: string; type: string };
+
   // Sprites Platform Alignment 5-2: a stable id for THIS agent turn (one
   // streamText run), lazily stamped once by `resolveSandboxActorContext`
   // (apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts) the first time a

--- a/apps/web/src/lib/ai/shared/buildPageContext.ts
+++ b/apps/web/src/lib/ai/shared/buildPageContext.ts
@@ -1,5 +1,6 @@
 import { buildPagePath } from '@/lib/tree/tree-utils';
 import type { TreePage } from '@/hooks/usePageTree';
+import type { LocationContext } from './chat-types';
 
 export type PageContextInput = {
   page: { id: string; title: string; type: string };
@@ -63,5 +64,34 @@ export async function buildPageContext(input: PageContextInput): Promise<PageCon
     driveId: currentDrive?.id ?? driveId,
     driveName: currentDrive?.name ?? driveId,
     driveSlug: currentDrive?.slug,
+  };
+}
+
+/**
+ * Adapt the sidebar's nested `LocationContext` (currentPage/currentDrive) to
+ * the flat `PageContext` shape `/api/ai/chat` actually reads. Returns
+ * undefined when there's no current page — matches `pageContext`'s existing
+ * optionality server-side.
+ */
+export function locationContextToPageContext(loc: LocationContext | null | undefined): PageContext | undefined {
+  const page = loc?.currentPage;
+  if (!page) return undefined;
+
+  const drive = loc?.currentDrive;
+  const pathSegments = page.path.split('/').filter(Boolean);
+  const parentPath = pathSegments.length > 1
+    ? `/${pathSegments.slice(0, -1).join('/')}`
+    : '/';
+
+  return {
+    pageId: page.id,
+    pageTitle: page.title,
+    pageType: page.type,
+    pagePath: page.path,
+    parentPath,
+    breadcrumbs: loc?.breadcrumbs ?? [],
+    driveId: drive?.id ?? '',
+    driveName: drive?.name ?? '',
+    driveSlug: drive?.slug,
   };
 }

--- a/apps/web/src/lib/ai/shared/resolveLocationContext.ts
+++ b/apps/web/src/lib/ai/shared/resolveLocationContext.ts
@@ -24,7 +24,14 @@ async function fetchPageContext(
   currentDrive: { id: string; slug: string; name: string } | null,
 ) {
   try {
-    const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
+    // Breadcrumbs only need pageId, which is already known — fetch both
+    // requests concurrently instead of serially (breadcrumbs used to only
+    // start after the page fetch resolved, roughly doubling latency for no
+    // reason since neither depends on the other's result).
+    const [pageResponse, breadcrumbsResponse] = await Promise.all([
+      fetchWithAuth(`/api/pages/${pageId}`),
+      fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`).catch(() => null),
+    ]);
     if (!pageResponse.ok) return null;
     const pageData = (await pageResponse.json()) as { id: string; title: string; type: string };
 
@@ -33,15 +40,14 @@ async function fetchPageContext(
     // the path that gets sent to the AI.
     const slugPrefix = currentDrive?.slug ? `/${currentDrive.slug}` : '';
     let path = `${slugPrefix}/${pageData.title}`;
-    try {
-      const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
-      if (breadcrumbsResponse.ok) {
+    if (breadcrumbsResponse?.ok) {
+      try {
         const breadcrumbsData = (await breadcrumbsResponse.json()) as Array<{ title: string }>;
         const pathSegments = breadcrumbsData.map((crumb) => crumb.title);
         path = `${slugPrefix}/${pathSegments.join('/')}`;
+      } catch {
+        // Keep the simple path fallback.
       }
-    } catch {
-      // Keep the simple path fallback.
     }
 
     return {
@@ -61,6 +67,13 @@ async function fetchPageContext(
  * navigation should still run it from an effect (for UI display); callers
  * sending a message to the AI should call this directly at send time instead
  * of reading a possibly-stale effect-derived state value.
+ *
+ * Deliberately uncached: this runs on every send, including several sends in
+ * a row on the same page, which does cost extra requests — but caching by
+ * pathname would resurrect exactly the staleness this function exists to
+ * eliminate (see feedback that led here) unless it also tracks drive-list
+ * updates, page renames, etc. A few extra fast page/breadcrumb fetches is a
+ * safer failure mode than a subtly stale cache.
  */
 export async function resolveLocationContext(
   pathname: string,

--- a/apps/web/src/lib/ai/shared/resolveLocationContext.ts
+++ b/apps/web/src/lib/ai/shared/resolveLocationContext.ts
@@ -1,0 +1,138 @@
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { parseTabPath, getStaticTabMeta } from '@/lib/tabs/tab-title';
+import type { LocationContext } from './chat-types';
+
+export interface DriveEntry {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export interface ResolvedLocationContext {
+  label: string | null;
+  locationContext: LocationContext | null;
+}
+
+function resolveDrive(driveId: string | undefined, drives: DriveEntry[]) {
+  if (!driveId) return null;
+  const driveData = drives.find((d) => d.id === driveId);
+  return driveData ? { id: driveData.id, slug: driveData.slug, name: driveData.name } : null;
+}
+
+async function fetchPageContext(
+  pageId: string,
+  currentDrive: { id: string; slug: string; name: string } | null,
+) {
+  try {
+    const pageResponse = await fetchWithAuth(`/api/pages/${pageId}`);
+    if (!pageResponse.ok) return null;
+    const pageData = (await pageResponse.json()) as { id: string; title: string; type: string };
+
+    // Only prefix the drive slug when we actually have one — channel routes
+    // resolve no drive, so a bare `/${slug}` would bake "/undefined/..." into
+    // the path that gets sent to the AI.
+    const slugPrefix = currentDrive?.slug ? `/${currentDrive.slug}` : '';
+    let path = `${slugPrefix}/${pageData.title}`;
+    try {
+      const breadcrumbsResponse = await fetchWithAuth(`/api/pages/${pageId}/breadcrumbs`);
+      if (breadcrumbsResponse.ok) {
+        const breadcrumbsData = (await breadcrumbsResponse.json()) as Array<{ title: string }>;
+        const pathSegments = breadcrumbsData.map((crumb) => crumb.title);
+        path = `${slugPrefix}/${pathSegments.join('/')}`;
+      }
+    } catch {
+      // Keep the simple path fallback.
+    }
+
+    return {
+      id: pageData.id,
+      title: pageData.title,
+      type: pageData.type,
+      path,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the sidebar's location context fresh, from the given route/drives
+ * snapshot — no component state involved. Callers that need this synced to
+ * navigation should still run it from an effect (for UI display); callers
+ * sending a message to the AI should call this directly at send time instead
+ * of reading a possibly-stale effect-derived state value.
+ */
+export async function resolveLocationContext(
+  pathname: string,
+  drives: DriveEntry[],
+): Promise<ResolvedLocationContext> {
+  const parsed = parseTabPath(pathname);
+
+  let label: string | null = null;
+  let currentPage: LocationContext['currentPage'] = null;
+  let currentDrive: LocationContext['currentDrive'] = null;
+
+  try {
+    switch (parsed.type) {
+      // Real page routes — fetch the page so the AI keeps page context.
+      case 'page':
+      case 'channel': {
+        currentDrive = parsed.type === 'page' ? resolveDrive(parsed.driveId, drives) : null;
+        if (parsed.pageId) {
+          currentPage = await fetchPageContext(parsed.pageId, currentDrive);
+        }
+        label = currentPage?.title ?? null;
+        break;
+      }
+
+      // A whole drive — use the drive name from the store.
+      case 'drive': {
+        currentDrive = resolveDrive(parsed.driveId, drives);
+        label = currentDrive?.name ?? null;
+        break;
+      }
+
+      // A specific DM — show the other person's name (DMs are not pages).
+      case 'dm': {
+        if (parsed.conversationId) {
+          try {
+            const res = await fetchWithAuth(`/api/messages/conversations/${parsed.conversationId}`);
+            if (res.ok) {
+              const data = (await res.json()) as {
+                conversation?: { otherUser?: { displayName?: string | null; name?: string | null } };
+              };
+              const otherUser = data?.conversation?.otherUser;
+              label = otherUser?.displayName || otherUser?.name || null;
+            }
+          } catch {
+            // Fall through to the generic DM label below.
+          }
+        }
+        if (!label) label = 'Direct Message';
+        break;
+      }
+
+      // Everything else with a known static title (dms, channels, tasks,
+      // calendar, files/drives, activity, drive-scoped variants, …).
+      // 'unknown' routes have no meaningful label (getStaticTabMeta would
+      // echo the raw path), so fall back to the generic prompt.
+      default: {
+        label = parsed.type === 'unknown' ? null : getStaticTabMeta(parsed)?.title ?? null;
+        break;
+      }
+    }
+  } catch {
+    label = null;
+  }
+
+  const breadcrumbs: string[] = [];
+  if (currentDrive) breadcrumbs.push(currentDrive.name);
+  if (currentPage?.path) {
+    breadcrumbs.push(...currentPage.path.split('/').filter(Boolean).slice(1));
+  }
+
+  return {
+    label,
+    locationContext: currentPage || currentDrive ? { currentPage, currentDrive, breadcrumbs } : null,
+  };
+}

--- a/apps/web/src/lib/ai/tools/__tests__/page-context-defaults.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-context-defaults.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for apps/web/src/lib/ai/tools/page-context-defaults.ts
+ *
+ * Covers the shared "default an omitted pageId tool argument" logic used by
+ * read_page, replace_lines, rename_page, move_page, insert_content, and
+ * edit_sheet_cells (page-read-tools.ts / page-write-tools.ts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { resolveDefaultPageId, resolveOrThrowPageId } from '../page-context-defaults';
+import type { ToolExecutionContext } from '../../core/types';
+
+describe('resolveDefaultPageId', () => {
+  it('prefers currentWorkingPage over locationContext.currentPage', () => {
+    const context = {
+      currentWorkingPage: { id: 'working-page', title: 'Working', type: 'DOCUMENT' },
+      locationContext: { currentPage: { id: 'viewed-page', title: 'Viewed', type: 'DOCUMENT', path: '/p' } },
+    } as ToolExecutionContext;
+    expect(resolveDefaultPageId(context)).toBe('working-page');
+  });
+
+  it('falls back to locationContext.currentPage.id when currentWorkingPage is absent', () => {
+    const context = {
+      locationContext: { currentPage: { id: 'viewed-page', title: 'Viewed', type: 'DOCUMENT', path: '/p' } },
+    } as ToolExecutionContext;
+    expect(resolveDefaultPageId(context)).toBe('viewed-page');
+  });
+
+  it('returns undefined when neither is present', () => {
+    expect(resolveDefaultPageId({} as ToolExecutionContext)).toBeUndefined();
+  });
+
+  it('returns undefined when context itself is undefined', () => {
+    expect(resolveDefaultPageId(undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveOrThrowPageId', () => {
+  it('returns the explicit pageId argument when provided, ignoring context', () => {
+    const context = {
+      currentWorkingPage: { id: 'working-page', title: 'Working', type: 'DOCUMENT' },
+    } as ToolExecutionContext;
+    expect(resolveOrThrowPageId('explicit-page', context)).toBe('explicit-page');
+  });
+
+  it('falls back to the default when pageId argument is omitted', () => {
+    const context = {
+      currentWorkingPage: { id: 'working-page', title: 'Working', type: 'DOCUMENT' },
+    } as ToolExecutionContext;
+    expect(resolveOrThrowPageId(undefined, context)).toBe('working-page');
+  });
+
+  it('throws a clear error when no pageId can be resolved', () => {
+    expect(() => resolveOrThrowPageId(undefined, {} as ToolExecutionContext)).toThrow(
+      'pageId is required: no page is currently in view and none was provided.',
+    );
+  });
+
+  it('throws when context itself is undefined and no explicit pageId is given', () => {
+    expect(() => resolveOrThrowPageId(undefined, undefined)).toThrow('pageId is required');
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -617,6 +617,134 @@ describe('page-write-tools', () => {
         })
       );
     });
+
+    it('defaults pageId to the page currently in view when omitted', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'in-view-page',
+        title: 'Old Title',
+        type: 'DOCUMENT',
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.update.mockResolvedValue({
+        id: 'in-view-page',
+        title: 'New Title',
+        type: 'DOCUMENT',
+        parentId: null,
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          locationContext: { currentPage: { id: 'in-view-page', title: 'Old Title', type: 'DOCUMENT', path: '/p' } },
+        } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.rename_page.execute!(
+        { currentTitle: 'Old Title', title: 'New Title' },
+        context
+      );
+
+      if ('error' in result) throw new Error('Expected success');
+      expect(mockPageRepo.findById).toHaveBeenCalledWith('in-view-page');
+    });
+
+    it('throws a clear error when pageId is omitted and no page is in view', async () => {
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.rename_page.execute!(
+          { currentTitle: 'Old Title', title: 'New Title' },
+          context
+        )
+      ).rejects.toThrow('pageId is required');
+    });
+
+    it('syncs currentWorkingPage.title when renaming the agent\'s current working page', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1',
+        title: 'Old Title',
+        type: 'DOCUMENT',
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.update.mockResolvedValue({
+        id: 'page-1',
+        title: 'New Title',
+        type: 'DOCUMENT',
+        parentId: null,
+      });
+
+      const executionContext: ToolExecutionContext = {
+        userId: 'user-123',
+        currentWorkingPage: { id: 'page-1', title: 'Old Title', type: 'DOCUMENT' },
+      } as ToolExecutionContext;
+      const context = { toolCallId: '1', messages: [], experimental_context: executionContext };
+
+      await pageWriteTools.rename_page.execute!(
+        { currentTitle: 'Old Title', pageId: 'page-1', title: 'New Title' },
+        context
+      );
+
+      expect(executionContext.currentWorkingPage).toEqual({ id: 'page-1', title: 'New Title', type: 'DOCUMENT' });
+    });
+
+    it('does not touch currentWorkingPage when renaming a different page', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'other-page',
+        title: 'Old Title',
+        type: 'DOCUMENT',
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.update.mockResolvedValue({
+        id: 'other-page',
+        title: 'New Title',
+        type: 'DOCUMENT',
+        parentId: null,
+      });
+
+      const executionContext: ToolExecutionContext = {
+        userId: 'user-123',
+        currentWorkingPage: { id: 'page-1', title: 'Focused Page', type: 'DOCUMENT' },
+      } as ToolExecutionContext;
+      const context = { toolCallId: '1', messages: [], experimental_context: executionContext };
+
+      await pageWriteTools.rename_page.execute!(
+        { currentTitle: 'Old Title', pageId: 'other-page', title: 'New Title' },
+        context
+      );
+
+      expect(executionContext.currentWorkingPage).toEqual({ id: 'page-1', title: 'Focused Page', type: 'DOCUMENT' });
+    });
   });
 
   describe('trash_page', () => {

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -133,7 +133,7 @@ export const driveTools = {
    * Create a new workspace/drive
    */
   create_drive: tool({
-    description: 'Create a new workspace/drive. Use when user explicitly requests a new workspace or when their project clearly doesn\'t fit existing drives. Optionally set initial drive context to establish workspace memory.',
+    description: 'Create a new workspace/drive. Use when user explicitly requests a new workspace or when their project clearly doesn\'t fit existing drives — check existing drives (list_drives) first. Ask for confirmation before calling this unless the user was explicit about wanting a new workspace. Optionally set initial drive context to establish workspace memory.',
     inputSchema: z.object({
       name: z.string().describe('The name of the new drive/workspace'),
       context: z.string().max(10000).optional().describe('Optional initial drive context (workspace memory) - information about the project, conventions, or preferences'),

--- a/apps/web/src/lib/ai/tools/page-context-defaults.ts
+++ b/apps/web/src/lib/ai/tools/page-context-defaults.ts
@@ -15,3 +15,21 @@ import type { ToolExecutionContext } from '../core/types';
 export function resolveDefaultPageId(context: ToolExecutionContext | undefined): string | undefined {
   return context?.currentWorkingPage?.id ?? context?.locationContext?.currentPage?.id;
 }
+
+/**
+ * Resolve an omitted `pageId` tool argument the same way across every page
+ * tool that supports the default, or throw the identical, tool-agnostic
+ * error message. Centralizing this keeps the 6 call sites (read_page,
+ * replace_lines, rename_page, move_page, insert_content, edit_sheet_cells)
+ * from silently drifting if the fallback or its wording ever needs to change.
+ */
+export function resolveOrThrowPageId(
+  pageIdArg: string | undefined,
+  context: ToolExecutionContext | undefined,
+): string {
+  const pageId = pageIdArg ?? resolveDefaultPageId(context);
+  if (!pageId) {
+    throw new Error('pageId is required: no page is currently in view and none was provided.');
+  }
+  return pageId;
+}

--- a/apps/web/src/lib/ai/tools/page-context-defaults.ts
+++ b/apps/web/src/lib/ai/tools/page-context-defaults.ts
@@ -1,0 +1,17 @@
+import type { ToolExecutionContext } from '../core/types';
+
+/**
+ * Resolve the page a tool should act on when the LLM omits `pageId`: the
+ * agent's own in-turn focus (currentWorkingPage, e.g. after create_page)
+ * wins over the page the user was viewing when the turn started
+ * (locationContext.currentPage) — see ToolExecutionContext.currentWorkingPage.
+ *
+ * Only wire this into tools where "act on the page in view" is a safe,
+ * unambiguous default — never destructive/trash/restore tools, and never
+ * tools whose `pageId`-like argument means something other than "the page
+ * to operate on" (e.g. read_conversation's pageId selects which agent's
+ * history to read).
+ */
+export function resolveDefaultPageId(context: ToolExecutionContext | undefined): string | undefined {
+  return context?.currentWorkingPage?.id ?? context?.locationContext?.currentPage?.id;
+}

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -17,6 +17,7 @@ import { fetchCachedImagePreset } from '../core/image-preset-fetch';
 import { toModelOutputForReadPage, buildVisualContentMetadata } from './read-page-vision-output';
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { resolveDefaultPageId } from './page-context-defaults';
 
 const pageReadLogger = loggers.ai.child({ module: 'page-read-tools' });
 
@@ -239,18 +240,23 @@ export const pageReadTools = {
    * Read existing documents to understand context and content
    */
   read_page: tool({
-    description: 'Read the content of any page (document, AI chat, channel, etc.) using its ID. Returns content with line numbers. For CHANNEL pages, returns a message transcript. Use lineStart/lineEnd to read specific line ranges.',
+    description: 'Read the content of any page (document, AI chat, channel, etc.) using its ID. Returns content with line numbers. For CHANNEL pages, returns a message transcript. Use lineStart/lineEnd to read specific line ranges. Omit pageId to read the page currently in view.',
     inputSchema: z.object({
       title: z.string().describe('The document title for display context'),
-      pageId: z.string().describe('The unique ID of the page to read'),
+      pageId: z.string().optional().describe('The unique ID of the page to read. Defaults to the page currently in view if omitted.'),
       lineStart: z.number().int().optional().describe('Start line number (1-indexed, inclusive). Omit to start from beginning.'),
       lineEnd: z.number().int().optional().describe('End line number (1-indexed, inclusive). Omit to read to end.'),
     }),
     toModelOutput: ({ output }) => toModelOutputForReadPage(output),
-    execute: async ({ title, pageId, lineStart, lineEnd }, { experimental_context: context }) => {
+    execute: async ({ title, pageId: pageIdArg, lineStart, lineEnd }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -17,7 +17,7 @@ import { fetchCachedImagePreset } from '../core/image-preset-fetch';
 import { toModelOutputForReadPage, buildVisualContentMetadata } from './read-page-vision-output';
 import { ensureTaskListForPage, seedDefaultTaskStatusConfigs } from '@/services/api/task-sync-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { resolveDefaultPageId } from './page-context-defaults';
+import { resolveOrThrowPageId } from './page-context-defaults';
 
 const pageReadLogger = loggers.ai.child({ module: 'page-read-tools' });
 
@@ -254,10 +254,7 @@ export const pageReadTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         // Get the page directly by ID

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -23,7 +23,7 @@ import { maskIdentifier } from '@/lib/logging/mask';
 import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { replaceLines } from '@/lib/editor/line-edit';
 import { insertAtAnchor } from '@/lib/editor/text-edit';
-import { resolveDefaultPageId } from './page-context-defaults';
+import { resolveOrThrowPageId } from './page-context-defaults';
 
 const pageWriteLogger = loggers.ai.child({ module: 'page-write-tools' });
 
@@ -420,10 +420,7 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         // Get the page via repository seam
@@ -755,10 +752,7 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         // Get the page via repository seam
@@ -791,6 +785,14 @@ export const pageWriteTools = {
             parentId: page.parentId
           })
         );
+
+        // Keep the cached working-page title in sync if this IS the agent's
+        // current focus — otherwise a later omitted-pageId call in the same
+        // turn would resolve correctly by id but report the pre-rename title.
+        const rawContext = context as ToolExecutionContext | undefined;
+        if (rawContext?.currentWorkingPage?.id === page.id) {
+          rawContext.currentWorkingPage = { ...rawContext.currentWorkingPage, title };
+        }
 
         return {
           success: true,
@@ -1019,10 +1021,7 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         // Get the page to move via repository seam
@@ -1111,10 +1110,7 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         const page = await pageRepository.findById(pageId);
@@ -1221,10 +1217,7 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
-      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
-      if (!pageId) {
-        throw new Error('pageId is required: no page is currently in view and none was provided.');
-      }
+      const pageId = resolveOrThrowPageId(pageIdArg, context as ToolExecutionContext);
 
       try {
         // Get the page via repository seam

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -23,6 +23,7 @@ import { maskIdentifier } from '@/lib/logging/mask';
 import { ensureTaskListForPage } from '@/services/api/task-sync-service';
 import { replaceLines } from '@/lib/editor/line-edit';
 import { insertAtAnchor } from '@/lib/editor/text-edit';
+import { resolveDefaultPageId } from './page-context-defaults';
 
 const pageWriteLogger = loggers.ai.child({ module: 'page-write-tools' });
 
@@ -405,18 +406,23 @@ export const pageWriteTools = {
    * Replace specific line(s) in a document
    */
   replace_lines: tool({
-    description: 'Replace one or more lines in a document or code page with new content. Specify start and end line numbers (1-based indexing).',
+    description: 'Replace one or more lines in a document or code page with new content. Specify start and end line numbers (1-based indexing). Omit pageId to edit the page currently in view.',
     inputSchema: z.object({
       title: z.string().describe('The document title for display context'),
-      pageId: z.string().describe('The unique ID of the page to edit'),
+      pageId: z.string().optional().describe('The unique ID of the page to edit. Defaults to the page currently in view if omitted.'),
       startLine: z.number().describe('Starting line number (1-based)'),
       endLine: z.number().optional().describe('Ending line number (1-based, optional, defaults to startLine)'),
       content: z.string().describe('New content to replace the lines with'),
     }),
-    execute: async ({ title, pageId, startLine, endLine = startLine, content }, { experimental_context: context }) => {
+    execute: async ({ title, pageId: pageIdArg, startLine, endLine = startLine, content }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {
@@ -696,6 +702,15 @@ export const pageWriteTools = {
         }
         nextSteps.push(`New page ID: ${newPage.id} - use this for further operations`);
 
+        // Creating a page shifts the agent's focus onto it for the rest of
+        // this turn — same mutate-in-place pattern as switch_machine, so a
+        // later tool call in this turn that omits pageId defaults to the
+        // page just created, not the page the user was viewing at turn start.
+        const rawContext = context as ToolExecutionContext | undefined;
+        if (rawContext) {
+          rawContext.currentWorkingPage = { id: newPage.id, title: newPage.title, type: newPage.type };
+        }
+
         return {
           success: true,
           id: newPage.id,
@@ -728,16 +743,21 @@ export const pageWriteTools = {
    * Rename an existing page
    */
   rename_page: tool({
-    description: 'Change the title of an existing page. Updates the page title while preserving all content and structure.',
+    description: 'Change the title of an existing page. Updates the page title while preserving all content and structure. Omit pageId to rename the page currently in view.',
     inputSchema: z.object({
       currentTitle: z.string().describe('The current title of the page for display context'),
-      pageId: z.string().describe('The unique ID of the page to rename'),
+      pageId: z.string().optional().describe('The unique ID of the page to rename. Defaults to the page currently in view if omitted.'),
       title: z.string().describe('New title for the page'),
     }),
-    execute: async ({ currentTitle, pageId, title }, { experimental_context: context }) => {
+    execute: async ({ currentTitle, pageId: pageIdArg, title }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {
@@ -985,18 +1005,23 @@ export const pageWriteTools = {
    * Move a page to a different parent or reorder position
    */
   move_page: tool({
-    description: 'Move a page to a different parent folder or change its position within the current parent.',
+    description: 'Move a page to a different parent folder or change its position within the current parent. Omit pageId to move the page currently in view.',
     inputSchema: z.object({
       title: z.string().describe('The title of the page being moved for display context'),
-      pageId: z.string().describe('The unique ID of the page to move'),
+      pageId: z.string().optional().describe('The unique ID of the page to move. Defaults to the page currently in view if omitted.'),
       newParentTitle: z.string().optional().describe('Title of the destination folder (omit for root level)'),
       newParentId: z.string().optional().describe('The unique ID of the new parent page (omit for root level)'),
       position: z.number().describe('Position within the new parent (1-based, higher numbers appear later)'),
     }),
-    execute: async ({ title, pageId, newParentTitle, newParentId, position }, { experimental_context: context }) => {
+    execute: async ({ title, pageId: pageIdArg, newParentTitle, newParentId, position }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {
@@ -1072,18 +1097,23 @@ export const pageWriteTools = {
    * Insert content before or after an anchor line in a document or code page
    */
   insert_content: tool({
-    description: 'Anchored line insert — adds a new line of content immediately before or after the first line containing a given anchor string. Useful for agents that need to insert content relative to headings or landmarks without knowing exact line numbers.',
+    description: 'Anchored line insert — adds a new line of content immediately before or after the first line containing a given anchor string. Useful for agents that need to insert content relative to headings or landmarks without knowing exact line numbers. Omit pageId to edit the page currently in view.',
     inputSchema: z.object({
       title: z.string().describe('The document title for display context'),
-      pageId: z.string().describe('The unique ID of the page to edit'),
+      pageId: z.string().optional().describe('The unique ID of the page to edit. Defaults to the page currently in view if omitted.'),
       anchor: z.string().min(1).describe('Text to search for within a line — the first line containing this substring is used'),
       content: z.string().describe('Content to insert as a new line'),
       position: z.enum(['before', 'after']).describe('Insert the new line before or after the anchor line'),
     }),
-    execute: async ({ title, pageId, anchor, content, position }, { experimental_context: context }) => {
+    execute: async ({ title, pageId: pageIdArg, anchor, content, position }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {
@@ -1177,18 +1207,23 @@ export const pageWriteTools = {
    * Edit cells in a sheet page
    */
   edit_sheet_cells: tool({
-    description: 'Edit one or more cells in a SHEET page. Use A1-style cell addresses. Supports batch updates for efficiency. Values starting with "=" are treated as formulas.',
+    description: 'Edit one or more cells in a SHEET page. Use A1-style cell addresses. Supports batch updates for efficiency. Values starting with "=" are treated as formulas. Omit pageId to edit the sheet currently in view.',
     inputSchema: z.object({
-      pageId: z.string().describe('The unique ID of the sheet page to edit'),
+      pageId: z.string().optional().describe('The unique ID of the sheet page to edit. Defaults to the page currently in view if omitted.'),
       cells: z.array(z.object({
         address: z.string().describe('Cell address in A1-style format (e.g., "A1", "B2", "AA100")'),
         value: z.string().describe('Value to set in the cell. Values starting with "=" are formulas. Empty string clears the cell.'),
       })).min(1).describe('Array of cell updates to apply'),
     }),
-    execute: async ({ pageId, cells }, { experimental_context: context }) => {
+    execute: async ({ pageId: pageIdArg, cells }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      const pageId = pageIdArg ?? resolveDefaultPageId(context as ToolExecutionContext);
+      if (!pageId) {
+        throw new Error('pageId is required: no page is currently in view and none was provided.');
       }
 
       try {


### PR DESCRIPTION
## Summary

Sidebar AI agents (Global Assistant and page-agents in Agent Mode, both in `SidebarChatTab.tsx`) frequently didn't know what page the user was currently looking at, or acted on stale/wrong page context. This turned out to be four compounding bugs plus a caching side-effect:

- **Race condition**: `SidebarChatTab.tsx` computed `locationContext` in a `useEffect` that did async REST fetches. Sending a message right after navigating could ship stale or null context. Fixed by resolving location fresh at send time (`resolveLocationContext()`), mirroring the pattern `AiChatView.tsx` already used.
- **Field mismatch (the big one)**: In Agent Mode, the client sent a field named `locationContext`, but `/api/ai/chat/route.ts` only ever read `pageContext` — **every page-agent conversation via the sidebar got zero page context, silently**. Global Assistant mode was unaffected. Fixed by sending `pageContext` (via a `locationContextToPageContext` adapter) — no server changes needed since the server was already looking for the right field.
- **No structured default**: page tools (`read_page`, `replace_lines`, `rename_page`, `move_page`, `insert_content`, `edit_sheet_cells`) required an explicit `pageId` with no way to default to "the page in view," so the LLM had to guess. `pageId` is now optional and defaults from `ToolExecutionContext` (via a shared `resolveOrThrowPageId()` helper). Destructive tools (trash/restore) and tools where `pageId` means something else (`read_conversation`) were deliberately left alone.
- **Cache-busting**: location was baked into the *stable*, cacheable system prompt instead of the volatile per-turn mechanism already built for exactly this (timestamp/mentions). Moved into `buildVolatileTurnContext` via a new `location-prompt.ts`, applied identically to both the Global Assistant and Agent Mode routes (plus the admin prompt-preview mirror) — so a turn where only the user's page changed no longer busts the provider prompt cache.
- **Intra-turn staleness**: `ToolExecutionContext` gained a mutable `currentWorkingPage`, seeded from the turn-start location and mutated by `create_page` (same pattern as `switch_machine`/`activeMachine`) and kept in sync by `rename_page`, so a later omitted-`pageId` call in the same turn targets a page the agent just created/renamed rather than the turn-start snapshot.

### Convergence pass

A follow-up self-review (8 independent finder angles: correctness, removed-behavior, cross-file, reuse, simplification, efficiency, altitude, CLAUDE.md conventions) surfaced and fixed:

- Restored the "ask for confirmation before creating a new drive" guardrail that the global-route prose rewrite had silently dropped — moved onto `create_drive`'s own tool description so it now applies everywhere the tool is exposed, not just the Global Assistant route.
- Fixed an unguarded `driveId` read feeding `AIMonitoring.trackUsage` an empty string instead of `undefined` when no drive is in view (inconsistent with two nearby guarded reads of the same field).
- Parallelized the page + breadcrumbs fetch in `resolveLocationContext` (independent requests were awaited serially).
- Extracted the 5x copy-pasted "resolve pageId or throw" block into one `resolveOrThrowPageId()` helper, and the 3x near-identical sidebar request-body construction into one `buildSidebarChatRequestBody()`.
- Added test coverage: `page-context-defaults.test.ts` (new), `rename_page`'s `currentWorkingPage` sync.

### Known limitations (not fixed here, documented)

- **Agent Mode + drive root**: chatting with a page-agent while viewing a drive root (no specific page open) still carries no location context — `PageContext` has no drive-only variant. This was already fully broken pre-PR (Agent Mode had *zero* location context in *any* case, due to the field-mismatch bug this PR fixes); post-PR it's fixed for the common case (a page is open) and remains a known gap for the drive-root edge case.
- **`GlobalAssistantView.tsx`**: the dashboard's own Global Assistant panel (a different surface from the sidebar) has the same pre-existing "agent mode never sends page context" bug this PR fixes in `SidebarChatTab` — untouched here since it's a separate component outside this PR's investigated scope. Flagged for a follow-up.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `eslint` on all touched files — clean
- [x] Full relevant test sweep (`src/lib/ai/`, `src/app/api/ai/`, `src/app/api/admin/global-prompt/`, `src/app/api/v1/chat/`, `src/components/layout/right-sidebar/`) — 2840 passed, 1 pre-existing unrelated failure (`activity-tools.test.ts`, fails identically on `master` due to a missing test-DB role, not touched by this PR)
- [x] New/updated unit tests for `location-prompt.ts`, `system-prompt.ts`, `inline-instructions.ts`, `prompt-assembly.ts`, `page-context-defaults.ts`, `rename_page`
- [ ] Manual: open a page-agent in the sidebar (Agent Mode), ask "what page am I looking at" — should correctly name the current page
- [ ] Manual: navigate to a different page, immediately send a message — should not reference the previous page
- [ ] Manual: ask a page-agent to "read this page" without naming a pageId — should resolve to the page in view
- [ ] Manual: ask an agent to create a page, then in the same turn reference "that page" — should target the new page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YT9j8egfnpJpjNuFt91Fj2