### PR TITLE
fix(ai): stop global-assistant streams from flashing/clobbering on send, reload, or switch

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -972,19 +972,29 @@ const GlobalAssistantView: React.FC = () => {
   useEffect(() => {
     if (agentConversationLoadSignal === prevAgentLoadSignalRef.current) return;
     prevAgentLoadSignalRef.current = agentConversationLoadSignal;
-    if (selectedAgent && agentConversationId) {
+    // Guarded the same way as the global-mode load-on-select effect below: the load-signal
+    // indirection already avoids re-firing on every streamed token, but it still fires
+    // unconditionally on a fresh mount (seeded to `null`) — so a reload mid-stream needs this
+    // guard too, or it clobbers the in-progress bubble with the pre-reply snapshot.
+    if (selectedAgent && agentConversationId && !effectiveIsStreaming) {
       setAgentMessages(agentInitialMessages);
     }
-  }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, setAgentMessages]);
+  }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, effectiveIsStreaming, setAgentMessages]);
 
   // Global-mode load-on-select guarantee: apply messages from context whenever
   // they change (loadConversation or createNewConversation ran). With a stable
   // useChat id, setMessages is the sole writer — no race with store recreation.
+  //
+  // Guarded on !effectiveIsStreaming: without it, a mount/reload/conversation-switch that lands
+  // while this surface is actively streaming (locally or via a bootstrapped own stream)
+  // overwrites the in-progress assistant bubble with a stale snapshot that predates the reply —
+  // the live text itself keeps rendering separately via `remoteStreams` regardless, so this
+  // effect only ever needs to apply the persisted snapshot once streaming has stopped.
   useEffect(() => {
     if (selectedAgent) return;
-    if (!globalIsInitialized || !globalConversationId) return;
+    if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return;
     setGlobalLocalMessages(globalInitialMessages);
-  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, setGlobalLocalMessages]);
+  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, effectiveIsStreaming, setGlobalLocalMessages]);
 
   // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
   // is null. Encapsulates page-room subscription, stream bootstrap/socket

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -435,6 +435,18 @@ const GlobalAssistantView: React.FC = () => {
     liveValue: globalLiveId,
   });
 
+  // Whether MY OWN local Chat is producing live content for the conversation about to be
+  // loaded/refreshed — narrower than effectiveIsStreaming (which folds in contextIsStreaming/
+  // agentBootstrapIsStreaming, other already conversation-scoped streams this surface merely
+  // shows a Stop button for). `agentStatus`/`globalStatus` belong to a stable-id useChat
+  // instance that keeps reporting streaming across a conversation switch, for the OLD
+  // conversation's still-in-flight request — comparing against the held stream-start id is the
+  // only way to know whether that live stream actually belongs to the conversation now being
+  // loaded. Used by the load-on-select/refresh effects below so a switch to an idle conversation
+  // isn't blocked by an unrelated stream still running elsewhere for the same agent/global chat.
+  const isOwnAgentStreamForCurrentConversation = isAgentStreamingNow && streamConvIdRef.current === agentConversationId;
+  const isOwnGlobalStreamForCurrentConversation = globalStreamingNow && globalStreamConvIdRef.current === globalConversationId;
+
   // THE STOP BUTTON THE USER ACTUALLY CLICKS aborts by the HELD id, not the live one.
   //
   // `liveAssistantMessageId` is derived from the live `messages` array, and "New Chat" (and
@@ -745,18 +757,20 @@ const GlobalAssistantView: React.FC = () => {
   const prevRefreshSignalRef = useRef(refreshSignal);
   useEffect(() => {
     if (refreshSignal === prevRefreshSignalRef.current) return;
-    // Guarded on !effectiveIsStreaming for the same reason as the load-on-select effects
-    // below: handlePullUpRefresh calls setGlobalLocalMessages/setAgentMessages directly with
-    // no reconciliation against an in-flight stream, so running it while this surface is
-    // actively streaming would clobber the in-progress assistant bubble with a stale DB
-    // snapshot. The ref is only advanced once the refresh actually runs, so a refreshSignal
-    // bump that arrives mid-stream is retried once streaming ends instead of being marked
-    // "seen" and permanently dropped.
-    if (!selectedAgent && isInitializedRef.current && !effectiveIsStreaming) {
+    // Guarded on isOwnGlobalStreamForCurrentConversation, not the broader effectiveIsStreaming:
+    // handlePullUpRefresh calls setGlobalLocalMessages directly with no reconciliation against
+    // an in-flight stream, so running it while THIS conversation is actively streaming would
+    // clobber the in-progress assistant bubble with a stale DB snapshot. effectiveIsStreaming
+    // would also stay true here for an unrelated conversation's still-in-flight send (stable
+    // useChat id survives a conversation switch), which would wrongly block this refresh for a
+    // conversation the user already left. The ref is only advanced once the refresh actually
+    // runs, so a refreshSignal bump that arrives mid-stream is retried once streaming ends
+    // instead of being marked "seen" and permanently dropped.
+    if (!selectedAgent && isInitializedRef.current && !isOwnGlobalStreamForCurrentConversation) {
       prevRefreshSignalRef.current = refreshSignal;
       handlePullUpRefresh();
     }
-  }, [refreshSignal, selectedAgent, effectiveIsStreaming, handlePullUpRefresh]);
+  }, [refreshSignal, selectedAgent, isOwnGlobalStreamForCurrentConversation, handlePullUpRefresh]);
 
   // Sync streaming status to global context (global mode only)
   useEffect(() => {
@@ -983,45 +997,55 @@ const GlobalAssistantView: React.FC = () => {
     // unconditionally on a fresh mount (seeded to `null`) — so a reload mid-stream needs this
     // guard too, or it clobbers the in-progress bubble with the pre-reply snapshot.
     //
-    // The ref is only advanced INSIDE the guard, not before it. If a load lands while
-    // effectiveIsStreaming is true, the guard skips applying it — and if the ref had already
-    // been marked "seen" at that point, the pending load would never be retried: the signal
-    // isn't going to change again on its own, so once streaming ends this effect would keep
-    // seeing "no change" and skip forever, stranding the dashboard on stale/empty history.
-    // Leaving the ref stale means the next re-run (streaming flag flipping is itself a
-    // dependency) still sees this signal as unapplied and retries it correctly.
-    if (selectedAgent && agentConversationId && !effectiveIsStreaming) {
+    // Guarded on isOwnAgentStreamForCurrentConversation, not the broader effectiveIsStreaming:
+    // switching to a different conversation for the same agent does not abort the old
+    // conversation's in-flight send (stable useChat id), so effectiveIsStreaming stays true for
+    // a conversation the user already left. Blocking on it would strand the newly-selected,
+    // idle conversation behind that unrelated stream instead of loading its messages.
+    //
+    // The ref is only advanced INSIDE the guard, not before it. If a load lands while the guard
+    // blocks, the ref stays stale — and if it had already been marked "seen" at that point, the
+    // pending load would never be retried: the signal isn't going to change again on its own, so
+    // once streaming ends this effect would keep seeing "no change" and skip forever, stranding
+    // the dashboard on stale/empty history. Leaving the ref stale means the next re-run
+    // (isOwnAgentStreamForCurrentConversation flipping is itself a dependency) still sees this
+    // signal as unapplied and retries it correctly.
+    if (selectedAgent && agentConversationId && !isOwnAgentStreamForCurrentConversation) {
       prevAgentLoadSignalRef.current = agentConversationLoadSignal;
       setAgentMessages(agentInitialMessages);
     }
-  }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, effectiveIsStreaming, setAgentMessages]);
+  }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, isOwnAgentStreamForCurrentConversation, setAgentMessages]);
 
   // Global-mode load-on-select guarantee: apply messages from context whenever
   // they change (loadConversation or createNewConversation ran). With a stable
   // useChat id, setMessages is the sole writer — no race with store recreation.
   //
-  // Guarded on !effectiveIsStreaming: without it, a mount/reload/conversation-switch that lands
-  // while this surface is actively streaming (locally or via a bootstrapped own stream)
-  // overwrites the in-progress assistant bubble with a stale snapshot that predates the reply —
-  // the live text itself keeps rendering separately via `remoteStreams` regardless, so this
-  // effect only ever needs to apply the persisted snapshot once streaming has stopped.
+  // Guarded on isOwnGlobalStreamForCurrentConversation, not the broader effectiveIsStreaming:
+  // without it, a mount/reload/conversation-switch that lands while THIS conversation is
+  // actively streaming overwrites the in-progress assistant bubble with a stale snapshot that
+  // predates the reply — the live text itself keeps rendering separately via `remoteStreams`
+  // regardless, so this effect only ever needs to apply the persisted snapshot once streaming
+  // has stopped for this conversation. effectiveIsStreaming also folds in contextIsStreaming/a
+  // bootstrapped stream elsewhere and, more importantly, stays true for an unrelated
+  // conversation's still-in-flight send after a mid-stream conversation switch (stable useChat
+  // id) — blocking on it would strand a newly-selected, idle conversation behind that stream.
   //
   // Dedup'd on a prevRef (CodeRabbit caught this): `globalInitialMessages` is NOT refreshed for
   // a fresh own send/completion in this surface (onStreamComplete deliberately no-ops — "surface's
   // useChat already has the message"), so without the reference check this effect would re-fire on
-  // every effectiveIsStreaming transition, including the streaming -> not-streaming edge at the end
-  // of every ordinary send — reapplying the SAME STALE pre-send snapshot and wiping the
-  // just-completed reply straight back out of view. The ref advances only inside the guard (see
-  // the load-on-select effects above) so a load skipped mid-stream is still retried once
-  // streaming ends, rather than being marked "seen" and dropped.
+  // every isOwnGlobalStreamForCurrentConversation transition, including the streaming -> not-
+  // streaming edge at the end of every ordinary send — reapplying the SAME STALE pre-send
+  // snapshot and wiping the just-completed reply straight back out of view. The ref advances
+  // only inside the guard (see the load-on-select effects above) so a load skipped mid-stream is
+  // still retried once streaming ends, rather than being marked "seen" and dropped.
   const prevGlobalInitialMessagesRef = useRef<import('ai').UIMessage[] | null>(null);
   useEffect(() => {
     if (selectedAgent) return;
     if (globalInitialMessages === prevGlobalInitialMessagesRef.current) return;
-    if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return;
+    if (!globalIsInitialized || !globalConversationId || isOwnGlobalStreamForCurrentConversation) return;
     prevGlobalInitialMessagesRef.current = globalInitialMessages;
     setGlobalLocalMessages(globalInitialMessages);
-  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, effectiveIsStreaming, setGlobalLocalMessages]);
+  }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, isOwnGlobalStreamForCurrentConversation, setGlobalLocalMessages]);
 
   // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
   // is null. Encapsulates page-room subscription, stream bootstrap/socket

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -745,11 +745,18 @@ const GlobalAssistantView: React.FC = () => {
   const prevRefreshSignalRef = useRef(refreshSignal);
   useEffect(() => {
     if (refreshSignal === prevRefreshSignalRef.current) return;
-    prevRefreshSignalRef.current = refreshSignal;
-    if (!selectedAgent && isInitializedRef.current) {
+    // Guarded on !effectiveIsStreaming for the same reason as the load-on-select effects
+    // below: handlePullUpRefresh calls setGlobalLocalMessages/setAgentMessages directly with
+    // no reconciliation against an in-flight stream, so running it while this surface is
+    // actively streaming would clobber the in-progress assistant bubble with a stale DB
+    // snapshot. The ref is only advanced once the refresh actually runs, so a refreshSignal
+    // bump that arrives mid-stream is retried once streaming ends instead of being marked
+    // "seen" and permanently dropped.
+    if (!selectedAgent && isInitializedRef.current && !effectiveIsStreaming) {
+      prevRefreshSignalRef.current = refreshSignal;
       handlePullUpRefresh();
     }
-  }, [refreshSignal, selectedAgent, handlePullUpRefresh]);
+  }, [refreshSignal, selectedAgent, effectiveIsStreaming, handlePullUpRefresh]);
 
   // Sync streaming status to global context (global mode only)
   useEffect(() => {
@@ -971,12 +978,20 @@ const GlobalAssistantView: React.FC = () => {
   const prevAgentLoadSignalRef = useRef<number | null>(null);
   useEffect(() => {
     if (agentConversationLoadSignal === prevAgentLoadSignalRef.current) return;
-    prevAgentLoadSignalRef.current = agentConversationLoadSignal;
     // Guarded the same way as the global-mode load-on-select effect below: the load-signal
     // indirection already avoids re-firing on every streamed token, but it still fires
     // unconditionally on a fresh mount (seeded to `null`) — so a reload mid-stream needs this
     // guard too, or it clobbers the in-progress bubble with the pre-reply snapshot.
+    //
+    // The ref is only advanced INSIDE the guard, not before it. If a load lands while
+    // effectiveIsStreaming is true, the guard skips applying it — and if the ref had already
+    // been marked "seen" at that point, the pending load would never be retried: the signal
+    // isn't going to change again on its own, so once streaming ends this effect would keep
+    // seeing "no change" and skip forever, stranding the dashboard on stale/empty history.
+    // Leaving the ref stale means the next re-run (streaming flag flipping is itself a
+    // dependency) still sees this signal as unapplied and retries it correctly.
     if (selectedAgent && agentConversationId && !effectiveIsStreaming) {
+      prevAgentLoadSignalRef.current = agentConversationLoadSignal;
       setAgentMessages(agentInitialMessages);
     }
   }, [agentConversationLoadSignal, selectedAgent, agentConversationId, agentInitialMessages, effectiveIsStreaming, setAgentMessages]);

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -1005,9 +1005,21 @@ const GlobalAssistantView: React.FC = () => {
   // overwrites the in-progress assistant bubble with a stale snapshot that predates the reply —
   // the live text itself keeps rendering separately via `remoteStreams` regardless, so this
   // effect only ever needs to apply the persisted snapshot once streaming has stopped.
+  //
+  // Dedup'd on a prevRef (CodeRabbit caught this): `globalInitialMessages` is NOT refreshed for
+  // a fresh own send/completion in this surface (onStreamComplete deliberately no-ops — "surface's
+  // useChat already has the message"), so without the reference check this effect would re-fire on
+  // every effectiveIsStreaming transition, including the streaming -> not-streaming edge at the end
+  // of every ordinary send — reapplying the SAME STALE pre-send snapshot and wiping the
+  // just-completed reply straight back out of view. The ref advances only inside the guard (see
+  // the load-on-select effects above) so a load skipped mid-stream is still retried once
+  // streaming ends, rather than being marked "seen" and dropped.
+  const prevGlobalInitialMessagesRef = useRef<import('ai').UIMessage[] | null>(null);
   useEffect(() => {
     if (selectedAgent) return;
+    if (globalInitialMessages === prevGlobalInitialMessagesRef.current) return;
     if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return;
+    prevGlobalInitialMessagesRef.current = globalInitialMessages;
     setGlobalLocalMessages(globalInitialMessages);
   }, [globalInitialMessages, globalIsInitialized, globalConversationId, selectedAgent, effectiveIsStreaming, setGlobalLocalMessages]);
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -42,6 +42,41 @@ function shouldApplyAgentMessagesOnLoadSignal(
   return Boolean(selectedAgent) && Boolean(agentConversationId) && !effectiveIsStreaming;
 }
 
+/**
+ * Mirrors the refreshSignal effect (~line 745-757): remote events (reconnect,
+ * cross-tab edit/delete) bump refreshSignal, and this surface reacts by
+ * calling handlePullUpRefresh — but only in global mode, and (as of this PR)
+ * only while not actively streaming, since handlePullUpRefresh overwrites
+ * local messages with no reconciliation against an in-flight stream.
+ */
+function shouldHandlePullUpRefresh(
+  selectedAgent: { id: string } | null,
+  isInitialized: boolean,
+  effectiveIsStreaming: boolean,
+): boolean {
+  return !selectedAgent && isInitialized && !effectiveIsStreaming;
+}
+
+/**
+ * Stateful simulator for the "ref-advances-only-on-apply" discipline — see
+ * the identical helper and rationale in SidebarChatTab.test.tsx. Both the
+ * agent load-signal effect and the refreshSignal effect in this file use a
+ * "seen" ref alongside a streaming guard; a Codex review on this PR found the
+ * first version advanced the ref before checking the guard, permanently
+ * losing a load skipped mid-stream.
+ */
+function createRefAdvancesOnlyOnApplySimulator<X>() {
+  let prevRef: X | null = null;
+  return {
+    step(x: X, guardPasses: boolean): boolean {
+      if (x === prevRef) return false;
+      if (!guardPasses) return false;
+      prevRef = x;
+      return true;
+    },
+  };
+}
+
 const mockAgent = { id: 'agent-123' };
 
 describe('GlobalAssistantView load-on-select effects', () => {
@@ -86,6 +121,61 @@ describe('GlobalAssistantView load-on-select effects', () => {
     // still be guarded, or it clobbers the in-progress bubble with the pre-reply snapshot.
     it('given effectiveIsStreaming=true (e.g. reload mid-stream), should NOT apply', () => {
       expect(shouldApplyAgentMessagesOnLoadSignal(mockAgent, 'conv-1', true)).toBe(false);
+    });
+  });
+
+  describe('shouldHandlePullUpRefresh (refreshSignal effect)', () => {
+    it('given global mode, initialized, and not streaming, should refresh', () => {
+      expect(shouldHandlePullUpRefresh(null, true, false)).toBe(true);
+    });
+
+    it('given agent mode, should NOT refresh (agent mode has its own multiplayer wiring)', () => {
+      expect(shouldHandlePullUpRefresh(mockAgent, true, false)).toBe(false);
+    });
+
+    it('given not yet initialized, should NOT refresh', () => {
+      expect(shouldHandlePullUpRefresh(null, false, false)).toBe(false);
+    });
+
+    // Regression coverage: this effect previously had NO streaming guard at all (a gap
+    // missed in the first version of this PR) — handlePullUpRefresh overwrites local
+    // messages unconditionally, so running it mid-stream clobbers the in-progress reply.
+    it('given effectiveIsStreaming=true, should NOT refresh (would clobber the live reply)', () => {
+      expect(shouldHandlePullUpRefresh(null, true, true)).toBe(false);
+    });
+  });
+
+  // ============================================
+  // Ref-advances-only-on-apply regression tests (Codex review on PR #2061)
+  //
+  // Pins the multi-render sequence the single-call boolean tests above can't
+  // express: a load/refresh skipped while streaming must be retried once
+  // streaming ends, even though the underlying reference/signal never
+  // changed again in the meantime. Applies identically to the agent
+  // load-signal effect (~972) and the refreshSignal effect (~745) in this
+  // file — both use a "seen" ref alongside the streaming guard.
+  // ============================================
+
+  describe('ref-advances-only-on-apply (retry-after-guard-lifts)', () => {
+    it('given the guard blocks (streaming) then later passes with the SAME reference, should apply on the later render instead of being lost', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<number>();
+      const signal = 1;
+      expect(sim.step(signal, false)).toBe(false); // streaming — blocked
+      expect(sim.step(signal, true)).toBe(true); // streaming ended, same signal — must still apply
+    });
+
+    it('given the guard passes immediately, should apply once and not re-apply on a redundant re-render with the same reference', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<number>();
+      const signal = 1;
+      expect(sim.step(signal, true)).toBe(true);
+      expect(sim.step(signal, true)).toBe(false); // already applied — no-op
+    });
+
+    it('given a NEW signal arrives while still blocked, should keep deferring until the guard passes, then apply the latest', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<number>();
+      expect(sim.step(1, false)).toBe(false); // streaming — blocked
+      expect(sim.step(2, false)).toBe(false); // still streaming — newer signal also deferred
+      expect(sim.step(2, true)).toBe(true); // guard lifts — applies the latest signal
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -16,15 +16,20 @@
 import { describe, it, expect } from 'vitest';
 
 /**
- * Mirrors the global-mode load-on-select effect (~line 1008-1023):
- * `if (selectedAgent) return; if (globalInitialMessages === prevRef) return; if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return; prevRef = globalInitialMessages; setGlobalLocalMessages(globalInitialMessages);`
+ * Mirrors the global-mode load-on-select effect (~line 1019-1044):
+ * `if (selectedAgent) return; if (globalInitialMessages === prevRef) return; if (!globalIsInitialized || !globalConversationId || isOwnGlobalStreamForCurrentConversation) return; prevRef = globalInitialMessages; setGlobalLocalMessages(globalInitialMessages);`
  *
  * The prevRef/dedup check is load-bearing (CodeRabbit review on this PR): without it, this
- * effect re-fires on EVERY effectiveIsStreaming transition, including the streaming -> not
- * -streaming edge at the end of an ordinary send. `globalInitialMessages` is not refreshed for a
- * fresh own completion (GlobalChatContext's onStreamComplete deliberately no-ops for that case),
- * so re-firing without the dedup would reapply the stale pre-send snapshot and wipe the
- * just-completed reply straight back out of the surface's own useChat state.
+ * effect re-fires on EVERY isOwnGlobalStreamForCurrentConversation transition, including the
+ * streaming -> not-streaming edge at the end of an ordinary send. `globalInitialMessages` is not
+ * refreshed for a fresh own completion (GlobalChatContext's onStreamComplete deliberately
+ * no-ops for that case), so re-firing without the dedup would reapply the stale pre-send
+ * snapshot and wipe the just-completed reply straight back out of the surface's own useChat
+ * state.
+ *
+ * The guard is `isOwnGlobalStreamForCurrentConversation`, not the broader `effectiveIsStreaming`
+ * (found via proactive review, not a reviewer comment) — see `isOwnStreamForConversation` below
+ * for why the raw flag is wrong here.
  */
 function shouldApplyGlobalLocalMessages<T>(
   selectedAgent: { id: string } | null,
@@ -32,39 +37,58 @@ function shouldApplyGlobalLocalMessages<T>(
   globalConversationId: string | null,
   globalInitialMessages: T[],
   prevGlobalInitialMessages: T[] | null,
-  effectiveIsStreaming: boolean,
+  isOwnGlobalStreamForCurrentConversation: boolean,
 ): boolean {
   if (selectedAgent) return false;
   if (globalInitialMessages === prevGlobalInitialMessages) return false;
-  if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return false;
+  if (!globalIsInitialized || !globalConversationId || isOwnGlobalStreamForCurrentConversation) return false;
   return true;
 }
 
 /**
- * Mirrors the agent-mode load-signal effect (~line 972-981):
- * `if (selectedAgent && agentConversationId && !effectiveIsStreaming) setAgentMessages(...)`
+ * Mirrors the agent-mode load-signal effect (~line 993-1017):
+ * `if (selectedAgent && agentConversationId && !isOwnAgentStreamForCurrentConversation) setAgentMessages(...)`
  */
 function shouldApplyAgentMessagesOnLoadSignal(
   selectedAgent: { id: string } | null,
   agentConversationId: string | null,
-  effectiveIsStreaming: boolean,
+  isOwnAgentStreamForCurrentConversation: boolean,
 ): boolean {
-  return Boolean(selectedAgent) && Boolean(agentConversationId) && !effectiveIsStreaming;
+  return Boolean(selectedAgent) && Boolean(agentConversationId) && !isOwnAgentStreamForCurrentConversation;
 }
 
 /**
- * Mirrors the refreshSignal effect (~line 745-757): remote events (reconnect,
+ * Mirrors the refreshSignal effect (~line 758-772): remote events (reconnect,
  * cross-tab edit/delete) bump refreshSignal, and this surface reacts by
  * calling handlePullUpRefresh — but only in global mode, and (as of this PR)
- * only while not actively streaming, since handlePullUpRefresh overwrites
- * local messages with no reconciliation against an in-flight stream.
+ * only while this conversation isn't the one MY OWN stream is running against,
+ * since handlePullUpRefresh overwrites local messages with no reconciliation
+ * against an in-flight stream.
  */
 function shouldHandlePullUpRefresh(
   selectedAgent: { id: string } | null,
   isInitialized: boolean,
-  effectiveIsStreaming: boolean,
+  isOwnGlobalStreamForCurrentConversation: boolean,
 ): boolean {
-  return !selectedAgent && isInitialized && !effectiveIsStreaming;
+  return !selectedAgent && isInitialized && !isOwnGlobalStreamForCurrentConversation;
+}
+
+/**
+ * Mirrors `isOwnAgentStreamForCurrentConversation`/`isOwnGlobalStreamForCurrentConversation` in
+ * GlobalAssistantView.tsx (identical shape to SidebarChatTab.tsx's `isOwnStreamForConversation`,
+ * see that file for the full rationale): whether MY OWN local Chat is producing live content for
+ * the conversation about to be loaded/refreshed. `agentStatus`/`globalStatus` belong to a
+ * stable-id useChat instance that keeps reporting streaming across a conversation switch, for
+ * the OLD conversation's still-in-flight request — comparing against the held stream-start id
+ * (streamConvIdRef/globalStreamConvIdRef) is the only way to tell whether a currently-true
+ * streaming flag actually belongs to the conversation now being loaded.
+ */
+function isOwnStreamForConversation(
+  isStreamingNow: boolean,
+  heldStreamConvId: string | null,
+  targetConversationId: string | null,
+): boolean {
+  return isStreamingNow && heldStreamConvId === targetConversationId;
 }
 
 /**
@@ -224,6 +248,38 @@ describe('GlobalAssistantView load-on-select effects', () => {
       expect(sim.step(1, false)).toBe(false); // streaming — blocked
       expect(sim.step(2, false)).toBe(false); // still streaming — newer signal also deferred
       expect(sim.step(2, true)).toBe(true); // guard lifts — applies the latest signal
+    });
+  });
+
+  // ============================================
+  // isOwnStreamForConversation regression tests
+  //
+  // Found via proactive review, not a reviewer comment: the load-on-select/refresh effects
+  // originally guarded on the raw effectiveIsStreaming flag, which reflects a stable-id useChat
+  // instance that keeps reporting "streaming" across a conversation/agent switch — for the OLD
+  // conversation's still-in-flight request, not the one now being loaded. Switching
+  // conversations mid-stream does not abort the running POST (documented at length elsewhere in
+  // this file, e.g. the streamConvIdRef/globalStreamConvIdRef comments). Guarding on the raw
+  // flag would strand a newly-selected, idle conversation behind an unrelated stream still
+  // running in a conversation the user already left, until that unrelated stream finished.
+  // ============================================
+
+  describe('isOwnStreamForConversation (conversation-scoped streaming guard)', () => {
+    it('given streaming and the held stream conversation matches the target, should report true (blocks — this IS the conversation being clobbered)', () => {
+      expect(isOwnStreamForConversation(true, 'conv-A', 'conv-A')).toBe(true);
+    });
+
+    it('given streaming but the held stream conversation is a DIFFERENT one than the target, should report false (does not block)', () => {
+      expect(isOwnStreamForConversation(true, 'conv-A', 'conv-B')).toBe(false);
+    });
+
+    it('given not streaming at all, should report false regardless of conversation ids', () => {
+      expect(isOwnStreamForConversation(false, 'conv-A', 'conv-A')).toBe(false);
+    });
+
+    it('given the exact regression scenario — sending in conv-A (or agent conversation A), then switching to idle conv-B while A keeps streaming — the load-on-select guard for conv-B must NOT be blocked', () => {
+      const blocked = isOwnStreamForConversation(true, 'conv-A', 'conv-B');
+      expect(blocked).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * GlobalAssistantView load-on-select regression tests
+ *
+ * Pure-function mirrors of the two load-on-select effects in
+ * GlobalAssistantView.tsx (global-mode and agent-mode), following the same
+ * extraction pattern used in SidebarChatTab.test.tsx — the component itself
+ * is too hook-heavy to render cheaply in a unit test.
+ *
+ * Both effects previously fired unconditionally on a messages-reference
+ * change (mount, reload, conversation/agent switch), which clobbers an
+ * actively-streaming local Chat instance's messages with a stale snapshot
+ * that predates the in-progress reply. This file pins the fix: both must
+ * skip while this surface is actively streaming.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Mirrors the global-mode load-on-select effect (~line 983-991):
+ * `if (selectedAgent) return; if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return; setGlobalLocalMessages(globalInitialMessages);`
+ */
+function shouldApplyGlobalLocalMessages(
+  selectedAgent: { id: string } | null,
+  globalIsInitialized: boolean,
+  globalConversationId: string | null,
+  effectiveIsStreaming: boolean,
+): boolean {
+  if (selectedAgent) return false;
+  if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return false;
+  return true;
+}
+
+/**
+ * Mirrors the agent-mode load-signal effect (~line 972-981):
+ * `if (selectedAgent && agentConversationId && !effectiveIsStreaming) setAgentMessages(...)`
+ */
+function shouldApplyAgentMessagesOnLoadSignal(
+  selectedAgent: { id: string } | null,
+  agentConversationId: string | null,
+  effectiveIsStreaming: boolean,
+): boolean {
+  return Boolean(selectedAgent) && Boolean(agentConversationId) && !effectiveIsStreaming;
+}
+
+const mockAgent = { id: 'agent-123' };
+
+describe('GlobalAssistantView load-on-select effects', () => {
+  describe('shouldApplyGlobalLocalMessages (global mode)', () => {
+    it('given global mode, initialized, with a conversation id, and not streaming, should apply', () => {
+      expect(shouldApplyGlobalLocalMessages(null, true, 'conv-1', false)).toBe(true);
+    });
+
+    it('given agent selected, should never apply (agent mode owns its own effect)', () => {
+      expect(shouldApplyGlobalLocalMessages(mockAgent, true, 'conv-1', false)).toBe(false);
+    });
+
+    it('given not yet initialized, should NOT apply', () => {
+      expect(shouldApplyGlobalLocalMessages(null, false, 'conv-1', false)).toBe(false);
+    });
+
+    it('given no conversation id, should NOT apply', () => {
+      expect(shouldApplyGlobalLocalMessages(null, true, null, false)).toBe(false);
+    });
+
+    // Regression coverage for the clobber bug fixed in this PR.
+    it('given effectiveIsStreaming=true (e.g. reload/switch mid-stream), should NOT apply', () => {
+      expect(shouldApplyGlobalLocalMessages(null, true, 'conv-1', true)).toBe(false);
+    });
+  });
+
+  describe('shouldApplyAgentMessagesOnLoadSignal (agent mode)', () => {
+    it('given an agent selected, a conversation id, and not streaming, should apply', () => {
+      expect(shouldApplyAgentMessagesOnLoadSignal(mockAgent, 'conv-1', false)).toBe(true);
+    });
+
+    it('given global mode (no agent selected), should NOT apply', () => {
+      expect(shouldApplyAgentMessagesOnLoadSignal(null, 'conv-1', false)).toBe(false);
+    });
+
+    it('given no agent conversation id yet, should NOT apply', () => {
+      expect(shouldApplyAgentMessagesOnLoadSignal(mockAgent, null, false)).toBe(false);
+    });
+
+    // Regression coverage: the load-signal indirection avoids re-firing on every streamed
+    // token, but still fires unconditionally on a fresh mount — a reload mid-stream must
+    // still be guarded, or it clobbers the in-progress bubble with the pre-reply snapshot.
+    it('given effectiveIsStreaming=true (e.g. reload mid-stream), should NOT apply', () => {
+      expect(shouldApplyAgentMessagesOnLoadSignal(mockAgent, 'conv-1', true)).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -16,16 +16,26 @@
 import { describe, it, expect } from 'vitest';
 
 /**
- * Mirrors the global-mode load-on-select effect (~line 983-991):
- * `if (selectedAgent) return; if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return; setGlobalLocalMessages(globalInitialMessages);`
+ * Mirrors the global-mode load-on-select effect (~line 1008-1023):
+ * `if (selectedAgent) return; if (globalInitialMessages === prevRef) return; if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return; prevRef = globalInitialMessages; setGlobalLocalMessages(globalInitialMessages);`
+ *
+ * The prevRef/dedup check is load-bearing (CodeRabbit review on this PR): without it, this
+ * effect re-fires on EVERY effectiveIsStreaming transition, including the streaming -> not
+ * -streaming edge at the end of an ordinary send. `globalInitialMessages` is not refreshed for a
+ * fresh own completion (GlobalChatContext's onStreamComplete deliberately no-ops for that case),
+ * so re-firing without the dedup would reapply the stale pre-send snapshot and wipe the
+ * just-completed reply straight back out of the surface's own useChat state.
  */
-function shouldApplyGlobalLocalMessages(
+function shouldApplyGlobalLocalMessages<T>(
   selectedAgent: { id: string } | null,
   globalIsInitialized: boolean,
   globalConversationId: string | null,
+  globalInitialMessages: T[],
+  prevGlobalInitialMessages: T[] | null,
   effectiveIsStreaming: boolean,
 ): boolean {
   if (selectedAgent) return false;
+  if (globalInitialMessages === prevGlobalInitialMessages) return false;
   if (!globalIsInitialized || !globalConversationId || effectiveIsStreaming) return false;
   return true;
 }
@@ -78,28 +88,66 @@ function createRefAdvancesOnlyOnApplySimulator<X>() {
 }
 
 const mockAgent = { id: 'agent-123' };
+const mockPreSendSnapshot = [{ id: 'msg-1', role: 'user', content: 'Hello' }] as never[];
+const mockPostLoadSnapshot = [
+  { id: 'msg-1', role: 'user', content: 'Hello' },
+  { id: 'msg-2', role: 'assistant', content: 'Hi there' },
+] as never[];
 
 describe('GlobalAssistantView load-on-select effects', () => {
   describe('shouldApplyGlobalLocalMessages (global mode)', () => {
-    it('given global mode, initialized, with a conversation id, and not streaming, should apply', () => {
-      expect(shouldApplyGlobalLocalMessages(null, true, 'conv-1', false)).toBe(true);
+    it('given global mode, initialized, with a conversation id, a new snapshot, and not streaming, should apply', () => {
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, 'conv-1', mockPostLoadSnapshot, null, false)
+      ).toBe(true);
     });
 
     it('given agent selected, should never apply (agent mode owns its own effect)', () => {
-      expect(shouldApplyGlobalLocalMessages(mockAgent, true, 'conv-1', false)).toBe(false);
+      expect(
+        shouldApplyGlobalLocalMessages(mockAgent, true, 'conv-1', mockPostLoadSnapshot, null, false)
+      ).toBe(false);
     });
 
     it('given not yet initialized, should NOT apply', () => {
-      expect(shouldApplyGlobalLocalMessages(null, false, 'conv-1', false)).toBe(false);
+      expect(
+        shouldApplyGlobalLocalMessages(null, false, 'conv-1', mockPostLoadSnapshot, null, false)
+      ).toBe(false);
     });
 
     it('given no conversation id, should NOT apply', () => {
-      expect(shouldApplyGlobalLocalMessages(null, true, null, false)).toBe(false);
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, null, mockPostLoadSnapshot, null, false)
+      ).toBe(false);
+    });
+
+    it('given the snapshot reference is unchanged, should NOT re-apply (no-op)', () => {
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, 'conv-1', mockPostLoadSnapshot, mockPostLoadSnapshot, false)
+      ).toBe(false);
     });
 
     // Regression coverage for the clobber bug fixed in this PR.
     it('given effectiveIsStreaming=true (e.g. reload/switch mid-stream), should NOT apply', () => {
-      expect(shouldApplyGlobalLocalMessages(null, true, 'conv-1', true)).toBe(false);
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, 'conv-1', mockPostLoadSnapshot, null, true)
+      ).toBe(false);
+    });
+
+    // Regression coverage for the CodeRabbit-flagged bug: without the prevRef dedup, this
+    // effect re-fires on every effectiveIsStreaming transition — including the moment an
+    // ordinary send finishes — and `globalInitialMessages` is never refreshed for that case
+    // (GlobalChatContext's onStreamComplete deliberately no-ops for an own fresh stream), so it
+    // would reapply the stale PRE-SEND snapshot and wipe the just-completed reply straight back
+    // out of the surface's own useChat state. The already-applied snapshot (prevRef === current
+    // reference) must short-circuit at the dedup check regardless of how the streaming flag
+    // transitions around it.
+    it('given the snapshot was already applied and effectiveIsStreaming flips from true to false (stream just completed), should NOT re-apply the stale pre-send snapshot', () => {
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, 'conv-1', mockPreSendSnapshot, mockPreSendSnapshot, true)
+      ).toBe(false);
+      expect(
+        shouldApplyGlobalLocalMessages(null, true, 'conv-1', mockPreSendSnapshot, mockPreSendSnapshot, false)
+      ).toBe(false);
     });
   });
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -281,6 +281,20 @@ const SidebarChatTab: React.FC = () => {
   // Derived State
   // ============================================
   const currentConversationId = selectedAgent ? agentConversationId : globalConversationId;
+  // The conversation the CURRENT stream belongs to, held from when it starts. The surface moves
+  // independently of the stream — switching conversation mid-stream does NOT abort the POST — so
+  // the abort must name the conversation the generation is actually running on. Moved up here
+  // (out of its original spot further down, next to heldStreamMsgIdRef) because the load-on-select
+  // effects below also need it: `isStreaming` reflects a stable-id useChat instance that keeps
+  // running across a conversation switch, so it cannot answer "is MY OWN stream for the
+  // conversation I'm about to load" on its own — only comparing against the conversation the
+  // stream actually started in (this ref) can.
+  const heldStreamConvIdRef = useRef<string | null>(null);
+  heldStreamConvIdRef.current = holdForStream({
+    current: heldStreamConvIdRef.current,
+    isStreaming,
+    liveValue: currentConversationId,
+  });
   const isInitialized = selectedAgent ? agentIsInitialized : globalIsInitialized;
   // Identity can be 'ready' (isInitialized true) while messages for the
   // conversation just switched to are still in flight — decoupled from
@@ -291,6 +305,16 @@ const SidebarChatTab: React.FC = () => {
   const displayIsStreaming = selectedAgent
     ? (isStreaming || dashboardIsStreaming)
     : (isStreaming || contextIsStreaming);
+  // Whether MY OWN local useChat is currently producing live content for the conversation I'm
+  // about to load/refresh — narrower than displayIsStreaming, which also includes
+  // dashboardIsStreaming/contextIsStreaming (other, already conversation-scoped, streams this
+  // surface merely displays a Stop button for). `isStreaming`'s Chat instance has a stable id
+  // per surface, so it keeps reporting true across a conversation switch for the OLD
+  // conversation's still-in-flight request — comparing against `heldStreamConvIdRef` (latched
+  // when the stream started) is the only way to know whether that live stream actually belongs
+  // to the conversation now being loaded. Used by the load-on-select/refresh effects below so a
+  // switch to an idle conversation isn't blocked by an unrelated stream still running elsewhere.
+  const isOwnStreamForCurrentConversation = isStreaming && heldStreamConvIdRef.current === currentConversationId;
 
   // ============================================
   // Remote Streams (multiplayer rendering)
@@ -616,11 +640,17 @@ const SidebarChatTab: React.FC = () => {
     // must be retried once streaming ends, not marked "seen" and dropped. Without this, a
     // remote event that fires while this surface happens to be streaming for an unrelated
     // reason would be silently lost if no further remote event bumps refreshSignal again.
-    if (!selectedAgent && globalIsInitializedRef.current && globalConversationId && !displayIsStreaming) {
+    //
+    // Guarded on `isOwnStreamForCurrentConversation`, NOT the broader `displayIsStreaming` —
+    // switching to a different global conversation does not abort an in-flight send in the old
+    // one (stable useChat id), so displayIsStreaming can stay true for a conversation that is no
+    // longer the one being loaded. Blocking on that would strand this refetch behind an
+    // unrelated stream in a conversation the user already left.
+    if (!selectedAgent && globalIsInitializedRef.current && globalConversationId && !isOwnStreamForCurrentConversation) {
       prevSidebarRefreshSignalRef.current = refreshSignal;
       loadGlobalMessages(globalConversationId);
     }
-  }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, loadGlobalMessages]);
+  }, [refreshSignal, selectedAgent, globalConversationId, isOwnStreamForCurrentConversation, loadGlobalMessages]);
 
   // ============================================
   // Effects: UI State
@@ -752,23 +782,29 @@ const SidebarChatTab: React.FC = () => {
   const prevSidebarGlobalMessagesRef = useRef<UIMessage[] | null>(null);
   useEffect(() => {
     if (globalInitialMessages === prevSidebarGlobalMessagesRef.current) return;
-    // Guarded the same way as the refreshSignal effect above (line ~615) — without this, a
+    // Guarded the same way as the refreshSignal effect above — without this, a
     // mount/reload/conversation-switch that lands while this surface's own send is already
     // streaming clobbers the in-progress assistant bubble with a stale DB snapshot that
     // predates the reply.
     //
+    // `isOwnStreamForCurrentConversation`, not the broader `displayIsStreaming`: a conversation
+    // switch does not abort an in-flight send in the conversation just left (stable useChat id),
+    // so displayIsStreaming can stay true there while `globalConversationId` has already moved
+    // on to an idle conversation — blocking on it would strand the newly-selected conversation
+    // behind an unrelated stream.
+    //
     // The ref is only advanced INSIDE the guard. If the guard blocks (streaming), the ref
-    // stays stale on purpose — every dependency change (including displayIsStreaming
+    // stays stale on purpose — every dependency change (including isOwnStreamForCurrentConversation
     // flipping false) re-runs the effect, and while the ref is stale this same
     // `globalInitialMessages` reference still reads as "changed," so the load is retried
     // instead of permanently lost. Advancing the ref unconditionally (before the guard) would
     // mark this reference as seen even though it was never applied, silently stranding the
     // sidebar on stale/empty history once streaming ends.
-    if (!selectedAgent && globalIsInitialized && globalConversationId && !displayIsStreaming) {
+    if (!selectedAgent && globalIsInitialized && globalConversationId && !isOwnStreamForCurrentConversation) {
       prevSidebarGlobalMessagesRef.current = globalInitialMessages;
       loadGlobalMessages(globalConversationId);
     }
-  }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, displayIsStreaming, loadGlobalMessages]);
+  }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, isOwnStreamForCurrentConversation, loadGlobalMessages]);
 
   // Load-on-select guarantee for agent mode: with a stable useChat id, the
   // sidebar's agent Chat instance is never recreated on conversation switch,
@@ -778,15 +814,17 @@ const SidebarChatTab: React.FC = () => {
   const prevSidebarAgentMessagesRef = useRef<UIMessage[] | null>(null);
   useEffect(() => {
     if (agentInitialMessages === prevSidebarAgentMessagesRef.current) return;
-    // Same guard as the global-mode load-on-select effect above, and the same ref-advances-
-    // only-on-apply discipline: a mount/reload/agent-switch that lands mid-stream must not
-    // clobber the in-progress assistant bubble, but it also must not be forgotten once the
-    // stream ends — advancing the ref here regardless of the guard would do exactly that.
-    if (selectedAgent && !displayIsStreaming) {
+    // Same guard as the global-mode load-on-select effect above (conversation-scoped, not the
+    // broader displayIsStreaming — switching agent conversations doesn't abort the old one's
+    // in-flight send either), and the same ref-advances-only-on-apply discipline: a
+    // mount/reload/agent-switch that lands mid-stream must not clobber the in-progress
+    // assistant bubble, but it also must not be forgotten once the stream ends — advancing the
+    // ref here regardless of the guard would do exactly that.
+    if (selectedAgent && !isOwnStreamForCurrentConversation) {
       prevSidebarAgentMessagesRef.current = agentInitialMessages;
       setMessages(agentInitialMessages);
     }
-  }, [agentInitialMessages, selectedAgent, displayIsStreaming, setMessages]);
+  }, [agentInitialMessages, selectedAgent, isOwnStreamForCurrentConversation, setMessages]);
 
   const handleNewConversation = useCallback(async () => {
     try {
@@ -992,15 +1030,6 @@ const SidebarChatTab: React.FC = () => {
   // Stop abort a message that finished minutes ago while the real generation kept running and
   // kept billing — on every turn after the first.
   const isActuallyStreaming = status === 'streaming';
-  // The conversation the CURRENT stream belongs to, held from when it starts. The surface moves
-  // independently of the stream — switching conversation mid-stream does NOT abort the POST — so
-  // the abort must name the conversation the generation is actually running on.
-  const heldStreamConvIdRef = useRef<string | null>(null);
-  heldStreamConvIdRef.current = holdForStream({
-    current: heldStreamConvIdRef.current,
-    isStreaming,
-    liveValue: currentConversationId,
-  });
   const heldStreamMsgIdRef = useRef<string | null>(null);
   heldStreamMsgIdRef.current = holdForStream({
     current: heldStreamMsgIdRef.current,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -748,10 +748,14 @@ const SidebarChatTab: React.FC = () => {
   useEffect(() => {
     if (globalInitialMessages === prevSidebarGlobalMessagesRef.current) return;
     prevSidebarGlobalMessagesRef.current = globalInitialMessages;
-    if (!selectedAgent && globalIsInitialized && globalConversationId) {
+    // Guarded the same way as the refreshSignal effect above (line ~615) — without this, a
+    // mount/reload/conversation-switch that lands while this surface's own send is already
+    // streaming clobbers the in-progress assistant bubble with a stale DB snapshot that
+    // predates the reply.
+    if (!selectedAgent && globalIsInitialized && globalConversationId && !displayIsStreaming) {
       loadGlobalMessages(globalConversationId);
     }
-  }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, loadGlobalMessages]);
+  }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, displayIsStreaming, loadGlobalMessages]);
 
   // Load-on-select guarantee for agent mode: with a stable useChat id, the
   // sidebar's agent Chat instance is never recreated on conversation switch,
@@ -762,10 +766,13 @@ const SidebarChatTab: React.FC = () => {
   useEffect(() => {
     if (agentInitialMessages === prevSidebarAgentMessagesRef.current) return;
     prevSidebarAgentMessagesRef.current = agentInitialMessages;
-    if (selectedAgent) {
+    // Same guard as the global-mode load-on-select effect above: a mount/reload/agent-switch
+    // that lands mid-stream must not clobber the in-progress assistant bubble with a stale
+    // conversation snapshot.
+    if (selectedAgent && !displayIsStreaming) {
       setMessages(agentInitialMessages);
     }
-  }, [agentInitialMessages, selectedAgent, setMessages]);
+  }, [agentInitialMessages, selectedAgent, displayIsStreaming, setMessages]);
 
   const handleNewConversation = useCallback(async () => {
     try {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -611,8 +611,13 @@ const SidebarChatTab: React.FC = () => {
   globalIsInitializedRef.current = globalIsInitialized;
   useEffect(() => {
     if (refreshSignal === prevSidebarRefreshSignalRef.current) return;
-    prevSidebarRefreshSignalRef.current = refreshSignal;
+    // The ref is only advanced when the refetch actually runs (see the load-on-select
+    // effects below for the full rationale) — a refreshSignal bump that arrives mid-stream
+    // must be retried once streaming ends, not marked "seen" and dropped. Without this, a
+    // remote event that fires while this surface happens to be streaming for an unrelated
+    // reason would be silently lost if no further remote event bumps refreshSignal again.
     if (!selectedAgent && globalIsInitializedRef.current && globalConversationId && !displayIsStreaming) {
+      prevSidebarRefreshSignalRef.current = refreshSignal;
       loadGlobalMessages(globalConversationId);
     }
   }, [refreshSignal, selectedAgent, globalConversationId, displayIsStreaming, loadGlobalMessages]);
@@ -747,12 +752,20 @@ const SidebarChatTab: React.FC = () => {
   const prevSidebarGlobalMessagesRef = useRef<UIMessage[] | null>(null);
   useEffect(() => {
     if (globalInitialMessages === prevSidebarGlobalMessagesRef.current) return;
-    prevSidebarGlobalMessagesRef.current = globalInitialMessages;
     // Guarded the same way as the refreshSignal effect above (line ~615) — without this, a
     // mount/reload/conversation-switch that lands while this surface's own send is already
     // streaming clobbers the in-progress assistant bubble with a stale DB snapshot that
     // predates the reply.
+    //
+    // The ref is only advanced INSIDE the guard. If the guard blocks (streaming), the ref
+    // stays stale on purpose — every dependency change (including displayIsStreaming
+    // flipping false) re-runs the effect, and while the ref is stale this same
+    // `globalInitialMessages` reference still reads as "changed," so the load is retried
+    // instead of permanently lost. Advancing the ref unconditionally (before the guard) would
+    // mark this reference as seen even though it was never applied, silently stranding the
+    // sidebar on stale/empty history once streaming ends.
     if (!selectedAgent && globalIsInitialized && globalConversationId && !displayIsStreaming) {
+      prevSidebarGlobalMessagesRef.current = globalInitialMessages;
       loadGlobalMessages(globalConversationId);
     }
   }, [globalInitialMessages, selectedAgent, globalIsInitialized, globalConversationId, displayIsStreaming, loadGlobalMessages]);
@@ -765,11 +778,12 @@ const SidebarChatTab: React.FC = () => {
   const prevSidebarAgentMessagesRef = useRef<UIMessage[] | null>(null);
   useEffect(() => {
     if (agentInitialMessages === prevSidebarAgentMessagesRef.current) return;
-    prevSidebarAgentMessagesRef.current = agentInitialMessages;
-    // Same guard as the global-mode load-on-select effect above: a mount/reload/agent-switch
-    // that lands mid-stream must not clobber the in-progress assistant bubble with a stale
-    // conversation snapshot.
+    // Same guard as the global-mode load-on-select effect above, and the same ref-advances-
+    // only-on-apply discipline: a mount/reload/agent-switch that lands mid-stream must not
+    // clobber the in-progress assistant bubble, but it also must not be forgotten once the
+    // stream ends — advancing the ref here regardless of the guard would do exactly that.
     if (selectedAgent && !displayIsStreaming) {
+      prevSidebarAgentMessagesRef.current = agentInitialMessages;
       setMessages(agentInitialMessages);
     }
   }, [agentInitialMessages, selectedAgent, displayIsStreaming, setMessages]);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -110,6 +110,25 @@ function createRefAdvancesOnlyOnApplySimulator<X>() {
   };
 }
 
+/**
+ * Mirrors `isOwnStreamForCurrentConversation` in SidebarChatTab.tsx: whether MY OWN local
+ * useChat is producing live content for the conversation about to be loaded/refreshed.
+ *
+ * Found via proactive review (not a reviewer comment): the raw `isStreaming`/`displayIsStreaming`
+ * flag belongs to a stable-id useChat instance that keeps reporting true across a conversation
+ * switch, for the OLD conversation's still-in-flight request — switching conversations does not
+ * abort it. Comparing against `heldStreamConvId` (latched to the conversation the stream actually
+ * started in) is the only way to tell whether a currently-true streaming flag actually belongs to
+ * the conversation now being loaded, or to one the user has already left.
+ */
+function isOwnStreamForConversation(
+  isStreaming: boolean,
+  heldStreamConvId: string | null,
+  targetConversationId: string | null,
+): boolean {
+  return isStreaming && heldStreamConvId === targetConversationId;
+}
+
 // ============================================
 // Test Data
 // ============================================
@@ -503,20 +522,43 @@ describe('SidebarChatTab Display Logic', () => {
       expect(sim.step(second, false)).toBe(false); // still streaming — newer snapshot also deferred
       expect(sim.step(second, true)).toBe(true); // guard lifts — applies the latest snapshot
     });
+  });
 
-    it('given the buggy pre-fix ordering (ref advances unconditionally), demonstrates the lost-load failure this test suite guards against', () => {
-      // Inlined here (not exported) — this is the shape review flagged, kept only to
-      // document the failure mode the simulator above is designed to prevent.
-      let prevRef: string[] | null = null;
-      const buggyStep = (x: string[], guardPasses: boolean): boolean => {
-        if (x === prevRef) return false;
-        prevRef = x; // <-- advances BEFORE checking the guard: the bug
-        if (!guardPasses) return false;
-        return true;
-      };
-      const snapshot = ['a'];
-      expect(buggyStep(snapshot, false)).toBe(false); // streaming — blocked, but ref already marked "seen"
-      expect(buggyStep(snapshot, true)).toBe(false); // streaming ended — same reference reads as "already seen", load lost
+  // ============================================
+  // isOwnStreamForConversation regression tests
+  //
+  // Found via proactive review, not a reviewer comment: the load-on-select/refresh effects
+  // originally guarded on the raw `displayIsStreaming` flag, which reflects a stable-id useChat
+  // instance that keeps reporting "streaming" across a conversation switch — for the OLD
+  // conversation's still-in-flight request, not the one now being loaded. Switching
+  // conversations does not abort an in-flight send (documented at length in both this file and
+  // GlobalAssistantView.tsx). Guarding on the raw flag would strand a newly-selected, idle
+  // conversation behind an unrelated stream still running in a conversation the user already
+  // left, until that unrelated stream happened to finish.
+  // ============================================
+
+  describe('isOwnStreamForConversation (conversation-scoped streaming guard)', () => {
+    it('given streaming and the held stream conversation matches the target, should report true (blocks the load — correct, this IS the conversation being clobbered)', () => {
+      expect(isOwnStreamForConversation(true, 'conv-A', 'conv-A')).toBe(true);
+    });
+
+    it('given streaming but the held stream conversation is a DIFFERENT one than the target, should report false (does not block — the target conversation has no stream of its own)', () => {
+      expect(isOwnStreamForConversation(true, 'conv-A', 'conv-B')).toBe(false);
+    });
+
+    it('given not streaming at all, should report false regardless of conversation ids', () => {
+      expect(isOwnStreamForConversation(false, 'conv-A', 'conv-A')).toBe(false);
+    });
+
+    it('given no stream has ever started (held id is null) and not streaming, should report false', () => {
+      expect(isOwnStreamForConversation(false, null, 'conv-A')).toBe(false);
+    });
+
+    it('given the exact regression scenario — send in conv-A, switch to idle conv-B while A keeps streaming — the load-on-select guard for conv-B must NOT be blocked', () => {
+      // isStreaming stays true (stable useChat id survives the switch); heldStreamConvId is
+      // latched to 'conv-A' (where the stream actually started); the surface has moved to 'conv-B'.
+      const blocked = isOwnStreamForConversation(true, 'conv-A', 'conv-B');
+      expect(blocked).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -51,15 +51,37 @@ function getStopFunction(
  * SidebarChatTab: with a stable useChat id, the agent Chat instance is never
  * recreated on conversation switch, so usePageAgentSidebarState's fetched
  * messages must be explicitly applied via setMessages whenever the reference
- * changes — but only while in agent mode.
+ * changes — but only while in agent mode, and never while this surface is
+ * actively streaming (a mount/reload/agent-switch landing mid-stream must not
+ * clobber the in-progress assistant bubble with a stale conversation snapshot).
  */
 function shouldApplySidebarAgentMessages<T>(
   selectedAgent: { id: string } | null,
   agentInitialMessages: T[],
-  prevAgentInitialMessages: T[] | null
+  prevAgentInitialMessages: T[] | null,
+  displayIsStreaming: boolean
 ): boolean {
   if (agentInitialMessages === prevAgentInitialMessages) return false;
-  return Boolean(selectedAgent);
+  return Boolean(selectedAgent) && !displayIsStreaming;
+}
+
+/**
+ * Pure function that mirrors the global-mode load-on-select effect in
+ * SidebarChatTab: GlobalChatContext's `initialMessages` reference changes on
+ * mount/loadConversation/createNewConversation, and must be explicitly
+ * re-fetched via loadGlobalMessages — but never while this surface is
+ * actively streaming, for the same clobber reason as the agent-mode twin.
+ */
+function shouldLoadSidebarGlobalMessages<T>(
+  selectedAgent: { id: string } | null,
+  globalIsInitialized: boolean,
+  globalConversationId: string | null,
+  globalInitialMessages: T[],
+  prevGlobalInitialMessages: T[] | null,
+  displayIsStreaming: boolean
+): boolean {
+  if (globalInitialMessages === prevGlobalInitialMessages) return false;
+  return !selectedAgent && globalIsInitialized && Boolean(globalConversationId) && !displayIsStreaming;
 }
 
 // ============================================
@@ -326,25 +348,97 @@ describe('SidebarChatTab Display Logic', () => {
 
   describe('shouldApplySidebarAgentMessages (agent-mode load-on-select)', () => {
     it('given an agent selected and a new messages reference, should apply', () => {
-      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, null)).toBe(true);
+      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, null, false)).toBe(true);
     });
 
     it('given an agent selected and conversation switch fetches a new reference, should apply', () => {
       const firstConversation = [mockUserMessage] as never[];
       const secondConversation = [mockAssistantMessage] as never[];
-      expect(shouldApplySidebarAgentMessages(mockAgent, secondConversation, firstConversation)).toBe(true);
+      expect(shouldApplySidebarAgentMessages(mockAgent, secondConversation, firstConversation, false)).toBe(true);
     });
 
     it('given an agent selected but the messages reference is unchanged, should NOT re-apply (no-op)', () => {
-      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, mockAgentMessages)).toBe(false);
+      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, mockAgentMessages, false)).toBe(false);
     });
 
     it('given global mode (no agent selected), should never apply agent messages even on a new reference', () => {
-      expect(shouldApplySidebarAgentMessages(null, mockAgentMessages, null)).toBe(false);
+      expect(shouldApplySidebarAgentMessages(null, mockAgentMessages, null, false)).toBe(false);
     });
 
     it('given a new empty-array reference (new conversation created), should still apply', () => {
-      expect(shouldApplySidebarAgentMessages(mockAgent, [], null)).toBe(true);
+      expect(shouldApplySidebarAgentMessages(mockAgent, [], null, false)).toBe(true);
+    });
+
+    // Regression coverage for the clobber bug fixed in this PR: a mount/reload/agent-switch
+    // landing while this surface is actively streaming must NOT overwrite the in-progress
+    // assistant bubble with a stale conversation snapshot, even though the messages
+    // reference did change (this is exactly the condition a reload produces).
+    it('given a new messages reference while streaming, should NOT apply (would clobber the live reply)', () => {
+      expect(shouldApplySidebarAgentMessages(mockAgent, mockAgentMessages, null, true)).toBe(false);
+    });
+
+    it('given a conversation switch fetch lands mid-stream, should NOT apply', () => {
+      const firstConversation = [mockUserMessage] as never[];
+      const secondConversation = [mockAssistantMessage] as never[];
+      expect(shouldApplySidebarAgentMessages(mockAgent, secondConversation, firstConversation, true)).toBe(false);
+    });
+  });
+
+  // ============================================
+  // Global-mode load-on-select regression tests
+  //
+  // Regression coverage for the same clobber bug as the agent-mode twin above,
+  // but on the global-assistant path: GlobalChatContext's `initialMessages`
+  // changes reference on mount/loadConversation/createNewConversation, and
+  // SidebarChatTab re-fetches via loadGlobalMessages whenever it does — but
+  // must skip that re-fetch while this surface is actively streaming, or a
+  // reload/conversation-switch mid-stream clobbers the in-progress reply with
+  // a DB snapshot that predates it (the flash + "invisible streaming" bug).
+  // ============================================
+
+  describe('shouldLoadSidebarGlobalMessages (global-mode load-on-select)', () => {
+    it('given global mode, initialized, with a new messages reference, should load', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(null, true, 'conv-1', mockContextMessages, null, false)
+      ).toBe(true);
+    });
+
+    it('given the messages reference is unchanged, should NOT re-load (no-op)', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(null, true, 'conv-1', mockContextMessages, mockContextMessages, false)
+      ).toBe(false);
+    });
+
+    it('given agent mode (agent selected), should never load global messages', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(mockAgent, true, 'conv-1', mockContextMessages, null, false)
+      ).toBe(false);
+    });
+
+    it('given not yet initialized, should NOT load', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(null, false, 'conv-1', mockContextMessages, null, false)
+      ).toBe(false);
+    });
+
+    it('given no conversation id, should NOT load', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(null, true, null, mockContextMessages, null, false)
+      ).toBe(false);
+    });
+
+    it('given a new messages reference while streaming (e.g. reload mid-stream), should NOT load (would clobber the live reply)', () => {
+      expect(
+        shouldLoadSidebarGlobalMessages(null, true, 'conv-1', mockContextMessages, null, true)
+      ).toBe(false);
+    });
+
+    it('given a conversation switch lands mid-stream, should NOT load', () => {
+      const firstConversation = [mockUserMessage] as never[];
+      const secondConversation = [mockAssistantMessage] as never[];
+      expect(
+        shouldLoadSidebarGlobalMessages(null, true, 'conv-1', secondConversation, firstConversation, true)
+      ).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -84,6 +84,32 @@ function shouldLoadSidebarGlobalMessages<T>(
   return !selectedAgent && globalIsInitialized && Boolean(globalConversationId) && !displayIsStreaming;
 }
 
+/**
+ * Stateful simulator for the "ref-advances-only-on-apply" discipline used by
+ * every load-on-select / refreshSignal effect in this file (global
+ * load-on-select, agent load-on-select, and the refreshSignal effect). A
+ * CodeRabbit/Codex review on this PR found that the first version of these
+ * fixes advanced the "seen" ref BEFORE checking the streaming guard: when the
+ * guard blocked (streaming), the ref was still marked as seen, so once
+ * streaming ended the effect would keep seeing "no change" on the same
+ * reference and permanently skip the deferred load. This simulator mirrors
+ * the corrected effect body across multiple renders so that retry-after-
+ * guard-lifts behavior can be pinned directly, not just checked as a single
+ * boolean call.
+ */
+function createRefAdvancesOnlyOnApplySimulator<X>() {
+  let prevRef: X | null = null;
+  return {
+    /** Simulates one render/effect run. Returns true if the apply ran. */
+    step(x: X, guardPasses: boolean): boolean {
+      if (x === prevRef) return false;
+      if (!guardPasses) return false;
+      prevRef = x;
+      return true;
+    },
+  };
+}
+
 // ============================================
 // Test Data
 // ============================================
@@ -439,6 +465,58 @@ describe('SidebarChatTab Display Logic', () => {
       expect(
         shouldLoadSidebarGlobalMessages(null, true, 'conv-1', secondConversation, firstConversation, true)
       ).toBe(false);
+    });
+  });
+
+  // ============================================
+  // Ref-advances-only-on-apply regression tests (Codex review on PR #2061)
+  //
+  // Pins the multi-render sequence the single-call boolean tests above can't
+  // express: a load skipped while streaming must be retried once streaming
+  // ends, even though the underlying reference never changed again in the
+  // meantime. This is the actual defect class flagged in review — the fix is
+  // "only advance the ref when the apply runs," applied identically to the
+  // global load-on-select effect (~747), the agent load-on-select effect
+  // (~765), and the pre-existing refreshSignal effect (~612) in this file.
+  // ============================================
+
+  describe('ref-advances-only-on-apply (retry-after-guard-lifts)', () => {
+    it('given the guard blocks (streaming) then later passes with the SAME reference, should apply on the later render instead of being lost', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<string[]>();
+      const snapshot = ['a'];
+      expect(sim.step(snapshot, false)).toBe(false); // streaming — blocked
+      expect(sim.step(snapshot, true)).toBe(true); // streaming ended, same reference — must still apply
+    });
+
+    it('given the guard passes immediately, should apply once and not re-apply on a redundant re-render with the same reference', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<string[]>();
+      const snapshot = ['a'];
+      expect(sim.step(snapshot, true)).toBe(true);
+      expect(sim.step(snapshot, true)).toBe(false); // already applied — no-op
+    });
+
+    it('given a NEW reference arrives while still blocked, should keep deferring until the guard passes, then apply the latest', () => {
+      const sim = createRefAdvancesOnlyOnApplySimulator<string[]>();
+      const first = ['a'];
+      const second = ['b'];
+      expect(sim.step(first, false)).toBe(false); // streaming — blocked
+      expect(sim.step(second, false)).toBe(false); // still streaming — newer snapshot also deferred
+      expect(sim.step(second, true)).toBe(true); // guard lifts — applies the latest snapshot
+    });
+
+    it('given the buggy pre-fix ordering (ref advances unconditionally), demonstrates the lost-load failure this test suite guards against', () => {
+      // Inlined here (not exported) — this is the shape review flagged, kept only to
+      // document the failure mode the simulator above is designed to prevent.
+      let prevRef: string[] | null = null;
+      const buggyStep = (x: string[], guardPasses: boolean): boolean => {
+        if (x === prevRef) return false;
+        prevRef = x; // <-- advances BEFORE checking the guard: the bug
+        if (!guardPasses) return false;
+        return true;
+      };
+      const snapshot = ['a'];
+      expect(buggyStep(snapshot, false)).toBe(false); // streaming — blocked, but ref already marked "seen"
+      expect(buggyStep(snapshot, true)).toBe(false); // streaming ended — same reference reads as "already seen", load lost
     });
   });
 });


### PR DESCRIPTION
## Summary

After #2018 (server-owned AI streams), per-page chat (`AiChatView.tsx`) reattaches cleanly to live streams on reload/reconnect. The **global assistant** — which exists as two independently-mounted surfaces, `GlobalAssistantView.tsx` (dashboard) and `SidebarChatTab.tsx` (right sidebar) — didn't get equivalent treatment:

- Sending a message caused a visible screen flash.
- The reply became invisible while generating, even though it was clearly running (activity feed, file edits).
- Reloading or switching conversations mid-stream never reattached the surface to the live content.
- The message appeared correctly once generation finished.

## Root cause

Both files have "load-on-select" effects (one for global mode, one for agent mode, in each file — four total) that reapply a conversation's persisted messages into the surface's own local `useChat` state whenever the reference changes (mount, reload, `loadConversation`, conversation/agent switch). All four were missing the streaming guard their sibling refresh-effects already have, so a mount/reload/switch landing while the surface was actively streaming unconditionally overwrote the in-progress assistant bubble with a stale DB snapshot that predated the reply.

Two theories I ruled out while investigating (kept here so a reviewer doesn't rediscover them):
- **Not** a shared `useChat` instance — I read the installed `@ai-sdk/react` source directly; `useChat`'s `id` option only controls when a given call site recreates its *own* local `Chat` ref, it is not a cross-component registry. `GlobalAssistantView` and `SidebarChatTab` have always had fully independent Chat instances.
- **Not** a missing own-tab filter on `GlobalChatContext`'s `onUserMessage` — `useChannelStreamSocket.ts`'s `handleUserMessage` already filters `isOwnStream` before invoking that callback.

## Fix

Added a streaming guard to all four load-on-select effects, matching the pattern their sibling refresh-effects already used. No new rendering path was needed — the existing `remoteStreams` → `inflightRemoteStreams`/`ChatMessagesArea` pipeline already renders any not-yet-local stream's accumulated content regardless of ownership, so once the clobber is prevented, that pipeline already covers reattachment.

### Update 1: ref-ordering defect (Codex review)

Codex flagged (3 P1 threads) that the guards advanced their "seen" ref **before** checking the streaming condition, so a load skipped mid-stream was marked seen and permanently dropped once streaming ended. Fixed by moving the ref assignment inside the guarded branch in all three flagged effects, plus the identical pre-existing shape in `SidebarChatTab.tsx`'s `refreshSignal` effect, plus a related gap this surfaced: `GlobalAssistantView.tsx`'s `refreshSignal` effect had no streaming guard at all.

### Update 2: missing dedup regression (CodeRabbit review)

CodeRabbit caught that `GlobalAssistantView.tsx`'s global-mode load-on-select effect had a streaming guard but no prevRef/dedup, so it re-fired on every streaming transition — including the streaming → not-streaming edge at the end of an **ordinary, successful send** — reapplying the stale pre-send snapshot and wiping the just-completed reply. Fixed with the same `prevGlobalInitialMessagesRef` dedup used elsewhere.

### Update 3: conversation-scoping regression (found via proactive review, not a reviewer comment)

Ran this repo's `code-review` skill (8 parallel finder angles + verification) against the diff after the first two rounds landed. Two independent finders converged on a real regression I'd introduced: all six streaming guards checked `displayIsStreaming`/`effectiveIsStreaming` — a flag scoped to *the surface*, not *the conversation*. Both `useChat` instances in these files use a stable id per surface (not per conversation), so switching to a different conversation for the same agent (or a different global conversation) does **not** abort the old conversation's in-flight send — the flag stays true for a conversation the user has already left. The guard would then block loading the *newly selected* conversation's messages until that unrelated stream happened to finish, stranding the UI on stale/previous-conversation content. The codebase's own existing comments confirm this is a real, previously-encountered scenario ("switching conversation mid-stream does NOT abort the POST").

Fixed by reusing the existing `streamConvIdRef`/`globalStreamConvIdRef` (GlobalAssistantView) and `heldStreamConvIdRef` (SidebarChatTab) — refs that already exist for the Stop/abort path, latching the conversation a stream actually started in — to scope each guard to "is *my own* stream, for *this specific* conversation" rather than "is anything streaming." All six effects updated.

Added regression tests pinning the conversation-scoping property directly (own stream in conversation A + switch to idle conversation B must not block B's load) in both test files. Also removed a test that inlined a standalone reimplementation of a bug no longer present anywhere in production code, so it could never actually regress (documentation dressed as an assertion, flagged by the same review pass).

**Noted, not fixed (out of scope for this PR):**
- The proactive review also surfaced that 6 call sites across both files now hand-roll a very similar "dedup + guard" pattern with no shared hook. This is a legitimate DRY observation, but I did not extract a shared hook: this PR is a targeted bug fix, two rounds of external review are already anchored to the current code shape, and introducing a new abstraction this late adds risk without a concrete reviewer request. Worth a dedicated follow-up PR if desired.
- Two related, pre-existing request-sequencing gaps in `SidebarChatTab.tsx`'s `loadGlobalMessages`/`shouldApplyLoadedMessages`, neither introduced by this PR (both predate it — I only changed which boolean gates the *dispatch* of this pre-existing function, not its internal request handling): (1) the streaming guard is checked at dispatch time but the fetch's `.then()` callback doesn't re-check it before writing, so a new send starting in the ~0.5-3s window before the pending-stream store registers it could still have its optimistic content overwritten; (2) `shouldApplyLoadedMessages` compares only conversationId, not a per-request sequence number, so if two of this file's independently-guarded effects (refreshSignal and the globalInitialMessages load-on-select) both happen to fire in the same render for the same conversation, their two concurrent fetches aren't ordered — whichever HTTP response resolves last wins, not whichever was requested last. Both are narrow (require rare event coincidences) and would need new request-generation-counter infrastructure in shared code to close properly; flagging for awareness/a future follow-up rather than expanding this PR's scope further.

## Known, separate, out-of-scope limitation

Prod runs multiple web instances. `streamMulticastRegistry` is single-process (documented in #2011/#2018, reconfirmed in #2022's "out of scope: multicast cross-instance join"). If a reload/switch reconnects to a *different* instance than the one running the generation, there's no live-token source available — with or without this fix. That's a known, deliberately-deferred, larger effort, not something this PR attempts.

## Test plan

- [x] `bun run typecheck` clean (apps/web)
- [x] `eslint` clean on touched files
- [x] 158 tests pass across `right-sidebar/ai-assistant`, `dashboard`, `contexts/GlobalChatContext`, `ai-page/AiChatView`
- [x] Regression tests pin every streaming guard, the ref-advances-only-on-apply ordering, the dedup-on-unrelated-dependency-change fix, and the conversation-scoping fix — `SidebarChatTab.test.tsx`, `GlobalAssistantView.test.tsx`
- [x] All Codex (3) and CodeRabbit (1) review threads replied to with the specific fix commit, left open for reviewer verification
- [x] Proactively ran this repo's `code-review` skill (8 finder angles) against the diff and fixed the one confirmed correctness regression it surfaced (conversation-scoping)
- [ ] Manual: dock the global assistant in the sidebar, send a message, confirm no flash and continuous live tokens through completion
- [ ] Manual: send a message, reload immediately, confirm the sidebar reattaches and shows accumulating text rather than a blank composer-disabled state
- [ ] Manual: repeat both with `GlobalAssistantView` (dashboard) as the active surface, and confirm the reply stays visible after it finishes (the CodeRabbit-flagged regression)
- [ ] Manual: send a message in conversation A, switch to a different idle conversation B (same agent, or a different global conversation) before A finishes streaming, confirm B's messages load immediately rather than waiting for A's stream to end (the conversation-scoping regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U8GPExjBCyxrXDtaJVYoWk
