### PR TITLE
fix(ai): deterministic stream recovery for global assistant on mobile

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -739,11 +739,15 @@ const GlobalAssistantView: React.FC = () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
       if (action === 'noop') return;
       if (action === 'rejoin-and-refresh') {
+        // rawStop is the local-only useChat stop; it does NOT signal the server (that is
+        // done separately via abortActiveStreamByMessageId). We only clear the local
+        // streaming state so the rejoin can attach cleanly.
+        rawStop();
+        // Agent rejoin goes through the ref: useAgentChannelMultiplayer is called further
+        // down, so the callback would otherwise close over a temporal-dead-zone binding.
         if (selectedAgent) {
-          agentStop();
-          rejoinAgentStream();
+          rejoinAgentStreamRef.current();
         } else {
-          globalStop();
           rejoinGlobalStream();
         }
       }
@@ -751,9 +755,7 @@ const GlobalAssistantView: React.FC = () => {
     }, [
       effectiveIsStreaming,
       selectedAgent,
-      agentStop,
-      rejoinAgentStream,
-      globalStop,
+      rawStop,
       rejoinGlobalStream,
       handlePullUpRefresh,
     ]),

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -86,7 +86,8 @@ import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemote
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
-import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
+import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
+import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
   ProviderSetupCard,
@@ -651,41 +652,28 @@ const GlobalAssistantView: React.FC = () => {
           stillOnThisConversation() &&
           decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
         ) {
-          // Evict the half-streamed assistant bubble useChat is still holding for this run.
-          //
-          // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
-          // dropped fetch leaves them too — so `messages` still contains an assistant message
-          // whose id IS the live stream's messageId (the server mints one id and uses it for both
-          // the UI message and the stream registry row). The rejoin re-adds that same stream to
-          // the pending store, and BOTH surfaces drop a pending stream whose messageId already
-          // appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams) —
-          // so the rejoined stream would be filtered straight back out and not one token of it
-          // would ever render. The user would sit in front of a frozen partial reply.
-          //
-          // Only when the server has something to put in its place, though. `parts` here is the
-          // registry's DEBOUNCED checkpoint (persisted every N parts), so it is empty for a stream
-          // that is only a few parts old. Evict against an empty checkpoint and, if the SSE join
-          // then fails — the documented multi-instance case, where the multicast lives in another
-          // process — the bootstrap removes the stream and the user is left with NOTHING, which is
-          // strictly worse than the frozen partial we started with. In that case keep the partial:
-          // the rejoin can still attach and take over, and if it cannot, the user keeps what they
-          // had.
+          // Evict the half-streamed assistant bubble useChat is still holding for this run — see
+          // evictStalePartial for why that is load-bearing (without it the rejoined stream is
+          // deduped straight back out and renders nothing) and why it is conditional.
           const staleId = liveStream.messageId;
-          // Counted with isValidPartFrame, the SAME predicate the bootstrap seeds with — it is
-          // `persistedParts.length` (post-filter) that becomes skipReplayCount, and a
-          // skipReplayCount of 0 is what makes a failed join drop the stream. A raw
-          // `parts.length > 0` would say "safe to evict" for a checkpoint of malformed frames
-          // that seeds nothing.
-          const hasServerParts = (liveStream.parts ?? []).filter(isValidPartFrame).length > 0;
-          const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
-          // Via agentSetMessages / globalSetMessages, not the raw useChat setters: agent mode
-          // must drop the stale partial from the dashboard store as well, or the store keeps
+          // evictStalePartial owns BOTH halves of the rule — why the stale bubble must go, and why
+          // only when the server's (debounced, isValidPartFrame-filtered) checkpoint can render in
+          // its place. It returns the same array reference when it is not safe, so this is a no-op
+          // write in that case.
+          const before = currentMessagesRef.current;
+          const evicted = evictStalePartial(before, staleId, liveStream.parts);
+          // Written via agentSetMessages / globalSetMessages, not the raw useChat setters: agent
+          // mode must drop the stale partial from the dashboard store as well, or the store keeps
           // serving it back to a co-mounted surface (and hands it to the sidebar on navigation).
+          // Skipped entirely when the helper declined to evict — it returns the same reference,
+          // and there is no reason to push an identical array through two setters.
+          if (evicted !== before) {
+            if (selectedAgent) agentSetMessages(evicted);
+            else globalSetMessages(evicted);
+          }
           if (selectedAgent) {
-            if (hasServerParts) agentSetMessages(evictStale);
             rejoinAgentStreamRef.current();
           } else {
-            if (hasServerParts) globalSetMessages(evictStale);
             rejoinGlobalStream();
           }
           return { recovered: true, probeAnswered, dbAnswered };
@@ -863,7 +851,7 @@ const GlobalAssistantView: React.FC = () => {
   //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
   //   neither            → falls through to handlePullUpRefresh below
   const resumeEnabled = useCallback(
-    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    () => canResumeRecovery(currentConversationId, useEditingStore.getState().isAnyEditing()),
     [currentConversationId],
   );
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -200,6 +200,12 @@ const GlobalAssistantView: React.FC = () => {
   // Populated after useAgentChannelMultiplayer runs (called further down); used
   // in tryRecover via ref so the callback doesn't depend on hook ordering.
   const rejoinAgentStreamRef = useRef<() => void>(() => {});
+  // Whether the LAST /active-streams probe actually reached the server and answered.
+  //
+  // tryRecover returns false for two semantically opposite outcomes — "the server says nothing is
+  // live" and "the probe never got an answer" — and the resume path must not treat silence as an
+  // answer. See the regenerate gate in useAppStateRecovery below.
+  const probeAnsweredRef = useRef(false);
   // The conversation currently on screen, mirrored on every render. Read after an await to
   // decide whether a response that just resolved is still wanted.
   //
@@ -611,10 +617,14 @@ const GlobalAssistantView: React.FC = () => {
     if (!channelId) return false;
 
     // Step 1: live stream check
+    probeAnsweredRef.current = false;
     try {
       const res = await fetchWithAuth(
         `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
       );
+      // Reachability, recorded separately from the verdict: only a 2xx means the server actually
+      // TOLD us what is live. A throw or a non-ok leaves us knowing nothing.
+      probeAnsweredRef.current = res.ok;
       if (res.ok) {
         const data = (await res.json()) as {
           streams?: Array<{
@@ -851,22 +861,37 @@ const GlobalAssistantView: React.FC = () => {
       rawStop();
       if (await tryRecover()) return;
 
-      // Nothing live on the server, and nothing persisted for this turn. Deliberately NOT a DB
-      // refresh — that is unsafe here (the probe may simply have failed, in which case a stream
-      // could still be live and the DB snapshot, which cannot contain an unpersisted reply, would
-      // erase the in-progress bubble; or the DB is behind our local state, where it would erase
-      // the user's own prompt).
+      // tryRecover came up empty — but that means one of two OPPOSITE things, and only one of them
+      // is an answer:
       //
-      // Regenerate instead — the same fallback useStreamRecovery applies when its probe comes up
-      // empty on a network error. It is needed BECAUSE of the stop above: aborting the fetch
-      // settles useChat at `ready` with no `error`, and useStreamRecovery only fires on
-      // `status === 'error'`. Without this, a turn whose POST died on the background transition
-      // (a radio drop right then is common) would find no stream, no reply, and no error — and
-      // the user's prompt would sit unanswered forever.
+      //   "the server says nothing is live"  → the run died; regenerating is the recovery.
+      //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
       //
-      // Gated on a turn actually having been in flight, so an ordinary resume on an idle
-      // conversation can never fire a spurious generation.
-      if (hadTurnInFlight) await handleRetry();
+      // The first request after a foreground is the one most likely to fail (cold radio), so on
+      // this path the second case is common. Re-probe a couple of times before concluding: the
+      // radio comes back well inside a few seconds.
+      for (let attempt = 1; !probeAnsweredRef.current && attempt <= 2; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+        if (await tryRecover()) return;
+      }
+
+      // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
+      //
+      // The regenerate is needed BECAUSE of the stop above: aborting the fetch settles useChat at
+      // `ready` with NO `error`, and useStreamRecovery only fires on `status === 'error'`. Without
+      // it, a turn whose POST died on the background transition would find no stream, no reply and
+      // no error, and the user's prompt would sit unanswered forever.
+      //
+      // But regenerating on SILENCE would be far worse than doing nothing. Every generation start
+      // calls takeOverConversationStreams, so a regenerate issued while the run is in fact still
+      // live does not race it — it ABORTS it. We would kill a healthy, possibly nearly-finished
+      // generation, re-run any write tools it had already executed, bill the discarded tokens, and
+      // strand its partial in the DB. Silence is not an answer.
+      //
+      // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
+      // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
+      // leaves the user their prompt and the retry action on it.
+      if (hadTurnInFlight && probeAnsweredRef.current) await handleRetry();
     }, [
       effectiveIsStreaming,
       selectedAgent,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -40,6 +40,7 @@
  */
 
 import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
+import type { UIMessage } from 'ai';
 import { useChat } from '@ai-sdk/react';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
@@ -82,6 +83,8 @@ import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
+import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
+import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
@@ -197,6 +200,9 @@ const GlobalAssistantView: React.FC = () => {
   // Populated after useAgentChannelMultiplayer runs (called further down); used
   // in tryRecover via ref so the callback doesn't depend on hook ordering.
   const rejoinAgentStreamRef = useRef<() => void>(() => {});
+  // The conversation the most recent message load was requested for. Lets a response that
+  // resolves after the user switched conversation be dropped instead of clobbering the new one.
+  const loadRequestedIdRef = useRef<string | null>(null);
 
   // ============================================
   // SHARED HOOKS
@@ -690,22 +696,48 @@ const GlobalAssistantView: React.FC = () => {
     setGlobalLocalMessages,
   ]);
 
-  // Pull-up refresh to check for missed messages (when real-time may have failed)
+  // Pull-up / resume refresh: check for messages this surface missed (real-time may have failed,
+  // or the app was backgrounded).
+  //
+  // This runs DURING an active own stream on the resume path (see useAppStateRecovery below:
+  // native resume rejoins the live server stream and then refreshes). A raw
+  // `setMessages(serverMessages)` would clobber the in-progress assistant bubble with a snapshot
+  // that predates the reply — the reply is not persisted until the run completes. So this funnels
+  // through the same two guards as the authoritative loaders elsewhere in the app
+  // (AiChatView.loadMessagesForConversation, SidebarChatTab.loadGlobalMessages):
+  //
+  //   1. shouldApplyLoadedMessages — drop the response if the user switched conversation while
+  //      the fetch was in flight, so it cannot clobber the conversation they moved to.
+  //   2. mergeServerAndPending — re-attach the in-flight own stream's bubble, which by definition
+  //      is absent from the DB snapshot while the run is still generating.
   const handlePullUpRefresh = useCallback(async () => {
-    if (!currentConversationId) return;
+    const conversationId = currentConversationId;
+    if (!conversationId) return;
+    loadRequestedIdRef.current = conversationId;
     try {
       const url = selectedAgent
-        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
-        : `/api/ai/global/${currentConversationId}/messages`;
+        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${conversationId}/messages`
+        : `/api/ai/global/${conversationId}/messages`;
       const res = await fetchWithAuth(url);
-      if (res.ok) {
-        const data = await res.json();
-        if (selectedAgent) {
-          setAgentMessages(data.messages);
-          setAgentStoreMessages(data.messages);
-        } else {
-          setGlobalLocalMessages(data.messages);
-        }
+      if (!res.ok) return;
+      // Stale check after the await — the user may have switched conversation/agent.
+      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+      const data = await res.json();
+      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+
+      const serverMessages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
+      const ownStream = Array.from(usePendingStreamsStore.getState().streams.values()).find(
+        (s) => s.isOwn && s.conversationId === conversationId,
+      );
+      const merged = ownStream
+        ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
+        : serverMessages;
+
+      if (selectedAgent) {
+        setAgentMessages(merged);
+        setAgentStoreMessages(merged);
+      } else {
+        setGlobalLocalMessages(merged);
       }
     } catch (error) {
       console.error('Failed to refresh messages:', error);
@@ -726,9 +758,19 @@ const GlobalAssistantView: React.FC = () => {
   // for — `!isStreaming` was false (streaming), and the recovery hook was gated off.
   //
   // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
-  // (the local fetch is dead after backgrounding), so we stop the local useChat state,
-  // rejoin the server-owned stream, then refresh from DB to catch a stream that finished
-  // while backgrounded.
+  // (the local fetch is dead after backgrounding).
+  //
+  // ORDER IS LOAD-BEARING: stop → await refresh → rejoin.
+  //
+  // The refresh must be AWAITED BEFORE the rejoin, not fired after it. The reply is not
+  // persisted until the run completes, so a refresh issued alongside a live stream returns a
+  // snapshot with no assistant message. If that request were still in flight when the rejoined
+  // stream completed, its response would land last and overwrite the freshly-completed reply
+  // with the pre-reply snapshot — and in agent mode nothing would heal it (there is no
+  // completion-triggered refetch there), leaving the reply invisible until the user reselects
+  // the conversation. Awaiting the refresh first means no DB request is ever outstanding when
+  // the stream completes: the refresh catches a run that finished while backgrounded, and the
+  // rejoin then attaches to one that is still live.
   const resumeEnabled = useCallback(
     () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
     [currentConversationId],
@@ -738,20 +780,22 @@ const GlobalAssistantView: React.FC = () => {
     onResume: useCallback(async () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
       if (action === 'noop') return;
-      if (action === 'rejoin-and-refresh') {
-        // rawStop is the local-only useChat stop; it does NOT signal the server (that is
-        // done separately via abortActiveStreamByMessageId). We only clear the local
-        // streaming state so the rejoin can attach cleanly.
-        rawStop();
-        // Agent rejoin goes through the ref: useAgentChannelMultiplayer is called further
-        // down, so the callback would otherwise close over a temporal-dead-zone binding.
-        if (selectedAgent) {
-          rejoinAgentStreamRef.current();
-        } else {
-          rejoinGlobalStream();
-        }
+      if (action !== 'rejoin-and-refresh') {
+        await handlePullUpRefresh();
+        return;
       }
+      // rawStop is the local-only useChat stop; it does NOT signal the server (that is
+      // done separately via abortActiveStreamByMessageId). We only clear the local
+      // streaming state so the refresh and rejoin can write cleanly.
+      rawStop();
       await handlePullUpRefresh();
+      // Agent rejoin goes through the ref: useAgentChannelMultiplayer is called further
+      // down, so the callback would otherwise close over a temporal-dead-zone binding.
+      if (selectedAgent) {
+        rejoinAgentStreamRef.current();
+      } else {
+        rejoinGlobalStream();
+      }
     }, [
       effectiveIsStreaming,
       selectedAgent,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -85,6 +85,7 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
+import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
   ProviderSetupCard,
@@ -647,7 +648,12 @@ const GlobalAssistantView: React.FC = () => {
           // the rejoin can still attach and take over, and if it cannot, the user keeps what they
           // had.
           const staleId = liveStream.messageId;
-          const hasServerParts = (liveStream.parts?.length ?? 0) > 0;
+          // Counted with isValidPartFrame, the SAME predicate the bootstrap seeds with — it is
+          // `persistedParts.length` (post-filter) that becomes skipReplayCount, and a
+          // skipReplayCount of 0 is what makes a failed join drop the stream. A raw
+          // `parts.length > 0` would say "safe to evict" for a checkpoint of malformed frames
+          // that seeds nothing.
+          const hasServerParts = (liveStream.parts ?? []).filter(isValidPartFrame).length > 0;
           const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           // Via agentSetMessages / globalSetMessages, not the raw useChat setters: agent mode
           // must drop the stale partial from the dashboard store as well, or the store keeps
@@ -822,25 +828,37 @@ const GlobalAssistantView: React.FC = () => {
         await handlePullUpRefresh();
         return;
       }
-      // Native. Local-only useChat stop: it does NOT signal the server (that is done separately
-      // via abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
-      // also ends the dead response body, which releases this channel's `consuming` mark —
-      // without that the rejoin's bootstrap would classify the stream as one we are already
-      // reading off the POST and skip attaching it.
+      // Native. Whether a turn was actually in flight when we went away. iOS froze JS at that
+      // moment, so this render-time value is a faithful record of it — which is exactly what it
+      // is used for here, and why it is safe even though it is useless for deciding whether the
+      // TRANSPORT is still alive (that is resolveResumeAction's job, and the answer is "no").
+      const hadTurnInFlight = effectiveIsStreaming;
+
+      // Local-only useChat stop: it does NOT signal the server (that is done separately via
+      // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
+      // ends the dead response body, which releases this channel's `consuming` mark — without
+      // that the rejoin's bootstrap would classify the stream as one we are already reading off
+      // the POST and skip attaching it.
       rawStop();
-      // tryRecover is the whole recovery here, and there is deliberately NO DB-refresh fallback
-      // after it. It already refetches when the run finished while we were away (its step 2). A
-      // fallback refresh would only run in the cases where a DB write is UNSAFE:
-      //   - the /active-streams probe failed (first request after a foreground is the likeliest
-      //     to, with the radio still coming up) — a stream may well be live, and the DB snapshot,
-      //     which cannot contain an unpersisted reply, would erase the in-progress bubble;
-      //   - the DB is behind our local state (step 2's dbUserCount >= localUserCount guard
-      //     rejected it) — e.g. a send whose POST never reached the server, where refreshing
-      //     would erase the user's own prompt.
-      // In both, doing nothing is correct: local state is newer than anything we could fetch, and
-      // the socket reconnect / refreshSignal path heals it.
-      await tryRecover();
-    }, [effectiveIsStreaming, rawStop, tryRecover, handlePullUpRefresh]),
+      if (await tryRecover()) return;
+
+      // Nothing live on the server, and nothing persisted for this turn. Deliberately NOT a DB
+      // refresh — that is unsafe here (the probe may simply have failed, in which case a stream
+      // could still be live and the DB snapshot, which cannot contain an unpersisted reply, would
+      // erase the in-progress bubble; or the DB is behind our local state, where it would erase
+      // the user's own prompt).
+      //
+      // Regenerate instead — the same fallback useStreamRecovery applies when its probe comes up
+      // empty on a network error. It is needed BECAUSE of the stop above: aborting the fetch
+      // settles useChat at `ready` with no `error`, and useStreamRecovery only fires on
+      // `status === 'error'`. Without this, a turn whose POST died on the background transition
+      // (a radio drop right then is common) would find no stream, no reply, and no error — and
+      // the user's prompt would sit unanswered forever.
+      //
+      // Gated on a turn actually having been in flight, so an ordinary resume on an idle
+      // conversation can never fire a spurious generation.
+      if (hadTurnInFlight) await handleRetry();
+    }, [effectiveIsStreaming, rawStop, tryRecover, handlePullUpRefresh, handleRetry]),
     enabled: resumeEnabled,
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -84,7 +84,6 @@ import { useEditingStore } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
-import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
@@ -617,7 +616,12 @@ const GlobalAssistantView: React.FC = () => {
       );
       if (res.ok) {
         const data = (await res.json()) as {
-          streams?: Array<{ messageId: string; conversationId: string; triggeredBy: { userId: string } }>;
+          streams?: Array<{
+            messageId: string;
+            conversationId: string;
+            parts?: unknown[];
+            triggeredBy: { userId: string };
+          }>;
         };
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
@@ -634,19 +638,25 @@ const GlobalAssistantView: React.FC = () => {
           // so the rejoined stream would be filtered straight back out and not one token of it
           // would ever render. The user would sit in front of a frozen partial reply.
           //
-          // Nothing is lost by dropping it: the bootstrap seeds the stream from the server's
-          // registry buffer, which holds every part pushed so far — strictly more than the
-          // partial we froze with.
+          // Only when the server has something to put in its place, though. `parts` here is the
+          // registry's DEBOUNCED checkpoint (persisted every N parts), so it is empty for a stream
+          // that is only a few parts old. Evict against an empty checkpoint and, if the SSE join
+          // then fails — the documented multi-instance case, where the multicast lives in another
+          // process — the bootstrap removes the stream and the user is left with NOTHING, which is
+          // strictly worse than the frozen partial we started with. In that case keep the partial:
+          // the rejoin can still attach and take over, and if it cannot, the user keeps what they
+          // had.
           const staleId = liveStream.messageId;
+          const hasServerParts = (liveStream.parts?.length ?? 0) > 0;
           const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           // Via agentSetMessages / globalSetMessages, not the raw useChat setters: agent mode
           // must drop the stale partial from the dashboard store as well, or the store keeps
-          // serving it back to a co-mounted surface.
+          // serving it back to a co-mounted surface (and hands it to the sidebar on navigation).
           if (selectedAgent) {
-            agentSetMessages(evictStale);
+            if (hasServerParts) agentSetMessages(evictStale);
             rejoinAgentStreamRef.current();
           } else {
-            globalSetMessages(evictStale);
+            if (hasServerParts) globalSetMessages(evictStale);
             rejoinGlobalStream();
           }
           return true;
@@ -733,20 +743,18 @@ const GlobalAssistantView: React.FC = () => {
   // Pull-up / resume refresh: check for messages this surface missed (real-time may have failed,
   // or the app was backgrounded and no live stream was found to rejoin).
   //
-  // Carries the two guards the authoritative loaders elsewhere in the app use
-  // (AiChatView.loadMessagesForConversation, SidebarChatTab.loadGlobalMessages), because a
-  // message load that lands late can otherwise overwrite state it knows nothing about:
+  // Guarded by shouldApplyLoadedMessages against the LIVE conversation (currentConversationIdRef):
+  // drop the response if the user switched conversation or agent while the fetch was in flight, so
+  // it cannot clobber the conversation they moved to.
   //
-  //   1. shouldApplyLoadedMessages, against the LIVE conversation (currentConversationIdRef) —
-  //      drop the response if the user switched conversation or agent while the fetch was in
-  //      flight, so it cannot clobber the conversation they moved to.
-  //   2. mergeServerAndPending — keep a bootstrap-restored stream's in-flight bubble, which is
-  //      absent from the DB snapshot until the run persists its reply.
-  //
-  // Note this is NOT the mid-stream write path: the resume handler below reaches this only when
-  // /active-streams reported nothing live to rejoin. Guard 2 covers a stream restored into the
-  // pending store by a bootstrap (after a refresh mid-stream) — an OWN stream being read off the
-  // POST body is deliberately never in that store, so it is not what this protects.
+  // NOTE — deliberately does NOT reconcile with the pending-streams store the way
+  // AiChatView.loadMessagesForConversation does. On this surface the pending store IS the live
+  // bubble: an in-flight stream renders from `remoteStreams`, and both renderers drop a pending
+  // stream whose messageId already appears in `messages` (dedupRemoteStreams /
+  // ChatMessagesArea.visibleRemoteStreams). mergeServerAndPending synthesizes a message under
+  // exactly that id, so merging here would FREEZE the live bubble at the merged snapshot — the
+  // rejoined stream would be deduped away and stop updating until completion. Leaving the DB
+  // snapshot alone keeps the id absent from `messages`, and the stream keeps rendering live.
   const handlePullUpRefresh = useCallback(async () => {
     const conversationId = currentConversationId;
     if (!conversationId) return;
@@ -763,26 +771,11 @@ const GlobalAssistantView: React.FC = () => {
       if (!shouldApplyLoadedMessages(conversationId, currentConversationIdRef.current)) return;
 
       const serverMessages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-      // Scoped by channel AND conversation, the same way AiChatView scopes its own lookup.
-      // A conversation id is only unique within its channel, and this surface switches between
-      // the global channel and per-agent channels, so matching on `isOwn && conversationId`
-      // alone could splice a different agent's in-flight bubble into this conversation.
-      const channelId = agentId ?? (user?.id ? globalChannelId(user.id) : null);
-      const ownStream = channelId
-        ? usePendingStreamsStore
-            .getState()
-            .getOwnStreams(channelId)
-            .find((s) => s.conversationId === conversationId)
-        : undefined;
-      const merged = ownStream
-        ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
-        : serverMessages;
-
       if (agentId) {
-        setAgentMessages(merged);
-        setAgentStoreMessages(merged);
+        setAgentMessages(serverMessages);
+        setAgentStoreMessages(serverMessages);
       } else {
-        setGlobalLocalMessages(merged);
+        setGlobalLocalMessages(serverMessages);
       }
     } catch (error) {
       console.error('Failed to refresh messages:', error);
@@ -790,7 +783,6 @@ const GlobalAssistantView: React.FC = () => {
   }, [
     currentConversationId,
     selectedAgent,
-    user,
     setAgentMessages,
     setAgentStoreMessages,
     setGlobalLocalMessages,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -617,15 +617,33 @@ const GlobalAssistantView: React.FC = () => {
       );
       if (res.ok) {
         const data = (await res.json()) as {
-          streams?: Array<{ conversationId: string; triggeredBy: { userId: string } }>;
+          streams?: Array<{ messageId: string; conversationId: string; triggeredBy: { userId: string } }>;
         };
-        const hasLiveStream = (data.streams ?? []).some(
+        const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
         );
-        if (decideRecovery({ hasLiveStream, hasPersistedReply: false }) === 'rejoin') {
+        if (liveStream && decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin') {
+          // Evict the half-streamed assistant bubble useChat is still holding for this run.
+          //
+          // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
+          // dropped fetch leaves them too — so `messages` still contains an assistant message
+          // whose id IS the live stream's messageId (the server mints one id and uses it for both
+          // the UI message and the stream registry row). The rejoin re-adds that same stream to
+          // the pending store, and BOTH surfaces drop a pending stream whose messageId already
+          // appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams) —
+          // so the rejoined stream would be filtered straight back out and not one token of it
+          // would ever render. The user would sit in front of a frozen partial reply.
+          //
+          // Nothing is lost by dropping it: the bootstrap seeds the stream from the server's
+          // registry buffer, which holds every part pushed so far — strictly more than the
+          // partial we froze with.
+          const staleId = liveStream.messageId;
+          const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           if (selectedAgent) {
+            setAgentMessages(evictStale);
             rejoinAgentStreamRef.current();
           } else {
+            setGlobalLocalMessages(evictStale);
             rejoinGlobalStream();
           }
           return true;
@@ -802,16 +820,29 @@ const GlobalAssistantView: React.FC = () => {
     onResume: useCallback(async () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
       if (action === 'noop') return;
-      if (action === 'rejoin-and-refresh') {
-        // Local-only useChat stop. It does NOT signal the server (that is done separately via
-        // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
-        // also ends the dead response body, which releases this channel's `consuming` mark —
-        // without that the rejoin's bootstrap would classify the stream as one we are already
-        // reading off the POST and skip attaching it.
-        rawStop();
-        if (await tryRecover()) return;
+      if (action === 'refresh') {
+        // Web, no live fetch of our own: a plain DB refresh is safe and is all we need.
+        await handlePullUpRefresh();
+        return;
       }
-      await handlePullUpRefresh();
+      // Native. Local-only useChat stop: it does NOT signal the server (that is done separately
+      // via abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
+      // also ends the dead response body, which releases this channel's `consuming` mark —
+      // without that the rejoin's bootstrap would classify the stream as one we are already
+      // reading off the POST and skip attaching it.
+      rawStop();
+      // tryRecover is the whole recovery here, and there is deliberately NO DB-refresh fallback
+      // after it. It already refetches when the run finished while we were away (its step 2). A
+      // fallback refresh would only run in the cases where a DB write is UNSAFE:
+      //   - the /active-streams probe failed (first request after a foreground is the likeliest
+      //     to, with the radio still coming up) — a stream may well be live, and the DB snapshot,
+      //     which cannot contain an unpersisted reply, would erase the in-progress bubble;
+      //   - the DB is behind our local state (step 2's dbUserCount >= localUserCount guard
+      //     rejected it) — e.g. a send whose POST never reached the server, where refreshing
+      //     would erase the user's own prompt.
+      // In both, doing nothing is correct: local state is newer than anything we could fetch, and
+      // the socket reconnect / refreshSignal path heals it.
+      await tryRecover();
     }, [effectiveIsStreaming, rawStop, tryRecover, handlePullUpRefresh]),
     enabled: resumeEnabled,
   });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -890,6 +890,12 @@ const GlobalAssistantView: React.FC = () => {
       const hadTurnInFlight = selectedAgent
         ? isOwnAgentStreamForCurrentConversation
         : isOwnGlobalStreamForCurrentConversation;
+      // The conversation that turn belongs to. The recovery below spans up to a few seconds of
+      // network, and the user can switch conversation inside that window — at which point
+      // regenerating would fire a generation for the turn they moved TO, not the one that was
+      // interrupted. `handleRetry` always acts on the live conversation, so the only way to keep
+      // it honest is to re-check that we are still on the one we started from.
+      const conversationAtResume = currentConversationId;
 
       // Local-only useChat stop: it does NOT signal the server (that is done separately via
       // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
@@ -937,9 +943,14 @@ const GlobalAssistantView: React.FC = () => {
       // live run is picked up by the socket-reconnect bootstrap once the network returns, a
       // persisted reply is picked up by the next load, and a genuinely dead turn leaves the user
       // their prompt and the retry action on it.
-      if (hadTurnInFlight && canConcludeTurnIsLost(attempt)) await handleRetry();
+      const stillOnTheInterruptedConversation =
+        currentConversationIdRef.current === conversationAtResume;
+      if (hadTurnInFlight && stillOnTheInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+        await handleRetry();
+      }
     }, [
       effectiveIsStreaming,
+      currentConversationId,
       selectedAgent,
       isOwnAgentStreamForCurrentConversation,
       isOwnGlobalStreamForCurrentConversation,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -708,20 +708,22 @@ const GlobalAssistantView: React.FC = () => {
   ]);
 
   // Pull-up / resume refresh: check for messages this surface missed (real-time may have failed,
-  // or the app was backgrounded).
+  // or the app was backgrounded and no live stream was found to rejoin).
   //
-  // This runs DURING an active own stream on the resume path (see useAppStateRecovery below:
-  // native resume rejoins the live server stream and then refreshes). A raw
-  // `setMessages(serverMessages)` would clobber the in-progress assistant bubble with a snapshot
-  // that predates the reply — the reply is not persisted until the run completes. So this funnels
-  // through the same two guards as the authoritative loaders elsewhere in the app
-  // (AiChatView.loadMessagesForConversation, SidebarChatTab.loadGlobalMessages):
+  // Carries the two guards the authoritative loaders elsewhere in the app use
+  // (AiChatView.loadMessagesForConversation, SidebarChatTab.loadGlobalMessages), because a
+  // message load that lands late can otherwise overwrite state it knows nothing about:
   //
   //   1. shouldApplyLoadedMessages, against the LIVE conversation (currentConversationIdRef) —
   //      drop the response if the user switched conversation or agent while the fetch was in
   //      flight, so it cannot clobber the conversation they moved to.
-  //   2. mergeServerAndPending — re-attach the in-flight own stream's bubble, which by definition
-  //      is absent from the DB snapshot while the run is still generating.
+  //   2. mergeServerAndPending — keep a bootstrap-restored stream's in-flight bubble, which is
+  //      absent from the DB snapshot until the run persists its reply.
+  //
+  // Note this is NOT the mid-stream write path: the resume handler below reaches this only when
+  // /active-streams reported nothing live to rejoin. Guard 2 covers a stream restored into the
+  // pending store by a bootstrap (after a refresh mid-stream) — an OWN stream being read off the
+  // POST body is deliberately never in that store, so it is not what this protects.
   const handlePullUpRefresh = useCallback(async () => {
     const conversationId = currentConversationId;
     if (!conversationId) return;
@@ -781,17 +783,16 @@ const GlobalAssistantView: React.FC = () => {
   // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
   // (the local fetch is dead after backgrounding).
   //
-  // ORDER IS LOAD-BEARING: stop → await refresh → rejoin.
+  // It then delegates to `tryRecover`, the same rejoin-first probe useStreamRecovery uses on a
+  // network error — because a background/foreground cycle IS a network error on iOS, just one we
+  // are told about. Do NOT blind-refresh from the DB here: the reply is not persisted until the
+  // run completes, so while a stream is still live a DB snapshot contains no assistant message
+  // and writing it would wipe the in-progress bubble. `tryRecover` asks /active-streams first —
+  // the server's authoritative answer — and only touches the DB when nothing is live:
   //
-  // The refresh must be AWAITED BEFORE the rejoin, not fired after it. The reply is not
-  // persisted until the run completes, so a refresh issued alongside a live stream returns a
-  // snapshot with no assistant message. If that request were still in flight when the rejoined
-  // stream completed, its response would land last and overwrite the freshly-completed reply
-  // with the pre-reply snapshot — and in agent mode nothing would heal it (there is no
-  // completion-triggered refetch there), leaving the reply invisible until the user reselects
-  // the conversation. Awaiting the refresh first means no DB request is ever outstanding when
-  // the stream completes: the refresh catches a run that finished while backgrounded, and the
-  // rejoin then attaches to one that is still live.
+  //   live stream        → rejoin it, no DB read at all
+  //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
+  //   neither            → falls through to handlePullUpRefresh below
   const resumeEnabled = useCallback(
     () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
     [currentConversationId],
@@ -801,29 +802,17 @@ const GlobalAssistantView: React.FC = () => {
     onResume: useCallback(async () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
       if (action === 'noop') return;
-      if (action !== 'rejoin-and-refresh') {
-        await handlePullUpRefresh();
-        return;
+      if (action === 'rejoin-and-refresh') {
+        // Local-only useChat stop. It does NOT signal the server (that is done separately via
+        // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
+        // also ends the dead response body, which releases this channel's `consuming` mark —
+        // without that the rejoin's bootstrap would classify the stream as one we are already
+        // reading off the POST and skip attaching it.
+        rawStop();
+        if (await tryRecover()) return;
       }
-      // rawStop is the local-only useChat stop; it does NOT signal the server (that is
-      // done separately via abortActiveStreamByMessageId). We only clear the local
-      // streaming state so the refresh and rejoin can write cleanly.
-      rawStop();
       await handlePullUpRefresh();
-      // Agent rejoin goes through the ref: useAgentChannelMultiplayer is called further
-      // down, so the callback would otherwise close over a temporal-dead-zone binding.
-      if (selectedAgent) {
-        rejoinAgentStreamRef.current();
-      } else {
-        rejoinGlobalStream();
-      }
-    }, [
-      effectiveIsStreaming,
-      selectedAgent,
-      rawStop,
-      rejoinGlobalStream,
-      handlePullUpRefresh,
-    ]),
+    }, [effectiveIsStreaming, rawStop, tryRecover, handlePullUpRefresh]),
     enabled: resumeEnabled,
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -85,7 +85,7 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
-import type { RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
+import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
 import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
@@ -612,9 +612,17 @@ const GlobalAssistantView: React.FC = () => {
     // flight together. A single shared slot would let one caller's probe answer the other's
     // question, which on this path means regenerating over a run we never actually asked about.
     let probeAnswered = false;
-    if (!currentConversationId) return { recovered: false, probeAnswered };
+    let dbAnswered = false;
+    const conversationId = currentConversationId;
+    if (!conversationId) return { recovered: false, probeAnswered, dbAnswered };
     const channelId = selectedAgent?.id ?? (user?.id ? globalChannelId(user.id) : null);
-    if (!channelId) return { recovered: false, probeAnswered };
+    if (!channelId) return { recovered: false, probeAnswered, dbAnswered };
+    // Every write below happens after an await, into a useChat instance whose id is constant
+    // across conversation switches. Re-check the LIVE conversation before each one, exactly as
+    // handlePullUpRefresh and loadGlobalMessages do — otherwise a recovery for the conversation
+    // the user just left lands in the one they moved to.
+    const stillOnThisConversation = () =>
+      shouldApplyLoadedMessages(conversationId, currentConversationIdRef.current);
 
     // Step 1: live stream check
     try {
@@ -636,9 +644,13 @@ const GlobalAssistantView: React.FC = () => {
         // swallow it while we went on believing we had an answer.
         probeAnswered = true;
         const liveStream = (data.streams ?? []).find(
-          (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
+          (s) => s.conversationId === conversationId && s.triggeredBy.userId === user?.id,
         );
-        if (liveStream && decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin') {
+        if (
+          liveStream &&
+          stillOnThisConversation() &&
+          decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
+        ) {
           // Evict the half-streamed assistant bubble useChat is still holding for this run.
           //
           // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
@@ -676,33 +688,51 @@ const GlobalAssistantView: React.FC = () => {
             if (hasServerParts) globalSetMessages(evictStale);
             rejoinGlobalStream();
           }
-          return { recovered: true, probeAnswered };
+          return { recovered: true, probeAnswered, dbAnswered };
         }
       }
     } catch { /* network error — fall through to DB check */ }
 
-    // Step 2: DB check for persisted reply for the CURRENT turn.
-    // Only accept when the DB has at least as many user messages as we have locally —
-    // this guards against the case where the network error fired before the user's
-    // message reached the server, making the DB end with the PREVIOUS turn's
-    // assistant reply and causing us to silently drop the new user prompt.
+    // Step 2: DB check for a persisted reply to the CURRENT turn.
     try {
       const url = selectedAgent
-        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
-        : `/api/ai/global/${currentConversationId}/messages`;
+        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${conversationId}/messages`
+        : `/api/ai/global/${conversationId}/messages`;
       const res = await fetchWithAuth(url);
       if (res.ok) {
         const data = await res.json();
-        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
-        const localUserCount = currentMessagesRef.current.filter((m) => m.role === 'user').length;
-        const dbUserCount = msgs.filter((m) => m.role === 'user').length;
-        // DB must have at least as many user messages as local (the user's turn
-        // was persisted) AND end with an assistant reply (the run completed).
+        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{
+          id: string;
+          role: string;
+        }>;
+        // Only NOW do we know what is persisted. As with the probe above, a throw or a non-ok
+        // leaves us knowing nothing — and treating that silence as "no reply exists" would let the
+        // caller regenerate over a reply that had in fact completed, which DELETES it (handleRetry
+        // removes the trailing assistant by the very id the server persisted it under).
+        dbAnswered = true;
+
+        // "Was the user's turn persisted?" asked by IDENTITY, not by counting.
+        //
+        // It used to compare user-message counts (dbUserCount >= localUserCount). That silently
+        // breaks on any conversation longer than one page: this GET is unpaginated, so the route
+        // applies its default limit of 50 and returns only the newest 50 rows, while local
+        // `messages` is the initial 50 PLUS every turn since. Past that boundary the count guard
+        // is permanently false, step 2 can never recover, and every interrupted turn on a long
+        // conversation would fall through to a regenerate that deletes the reply it should have
+        // refetched. The last local user message is by definition the newest, so it is always
+        // inside the returned window — checking for its id is both correct and pagination-proof.
+        const lastLocalUserId = [...currentMessagesRef.current]
+          .reverse()
+          .find((m) => m.role === 'user')?.id;
+        const ourTurnIsPersisted =
+          lastLocalUserId === undefined || msgs.some((m) => m.id === lastLocalUserId);
         const hasPersistedReply =
-          msgs.length > 0 &&
-          msgs[msgs.length - 1].role === 'assistant' &&
-          dbUserCount >= localUserCount;
-        if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant' && ourTurnIsPersisted;
+
+        if (
+          stillOnThisConversation() &&
+          decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch'
+        ) {
           // Write the SAME normalized array the guards above were computed from. Reading
           // defensively and then writing `data.messages` raw would blank the surface outright if
           // the route ever answered with a bare array.
@@ -713,12 +743,12 @@ const GlobalAssistantView: React.FC = () => {
           } else {
             setGlobalLocalMessages(serverMessages);
           }
-          return { recovered: true, probeAnswered };
+          return { recovered: true, probeAnswered, dbAnswered };
         }
       }
-    } catch { /* network error — fall through to regenerate */ }
+    } catch { /* network error — the caller must not treat this as "nothing is persisted" */ }
 
-    return { recovered: false, probeAnswered };
+    return { recovered: false, probeAnswered, dbAnswered };
   }, [
     currentConversationId,
     selectedAgent,
@@ -870,38 +900,44 @@ const GlobalAssistantView: React.FC = () => {
       let attempt = await tryRecover();
       if (attempt.recovered) return;
 
-      // Came up empty — but that means one of two OPPOSITE things, and only one of them is an
-      // answer:
+      // Came up empty — but "we recovered nothing" is NOT "there was nothing to recover". Each of
+      // tryRecover's two questions can come back UNANSWERED, and silence from either one means the
+      // work we would be about to destroy might still exist:
       //
-      //   "the server says nothing is live"    → the run died; regenerating is the recovery.
-      //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
+      //   /active-streams silent → a run may still be LIVE.       Regenerating aborts it.
+      //   messages GET silent    → the reply may already be SAVED. Regenerating deletes it.
       //
-      // The first request after a foreground is the one most likely to fail (cold radio), so on
-      // this path the second case is common. Re-probe a couple of times before concluding: the
-      // radio comes back well inside a few seconds.
-      for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+      // The first request after a foreground is the one most likely to fail (cold radio), so this
+      // is common on exactly this path. Re-ask until both questions come back, bounded — the radio
+      // returns well inside a few seconds.
+      for (let i = 1; !(attempt.probeAnswered && attempt.dbAnswered) && i <= 2; i++) {
         await new Promise((resolve) => setTimeout(resolve, i * 1000));
         attempt = await tryRecover();
         if (attempt.recovered) return;
       }
 
-      // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
+      // Regenerate ONLY once BOTH questions came back, and only for a turn of ours that really was
+      // in flight (canConcludeTurnIsLost).
       //
       // The regenerate is needed BECAUSE of the stop above: aborting the fetch settles useChat at
       // `ready` with NO `error`, and useStreamRecovery only fires on `status === 'error'`. Without
       // it, a turn whose POST died on the background transition would find no stream, no reply and
       // no error, and the user's prompt would sit unanswered forever.
       //
-      // But regenerating on SILENCE would be far worse than doing nothing. Every generation start
-      // calls takeOverConversationStreams, so a regenerate issued while the run is in fact still
-      // live does not race it — it ABORTS it. We would kill a healthy, possibly nearly-finished
-      // generation, re-run any write tools it had already executed, bill the discarded tokens, and
-      // strand its partial in the DB. Silence is not an answer.
+      // But regenerating on SILENCE would be far worse than doing nothing, because regenerating is
+      // destructive twice over:
+      //   - takeOverConversationStreams runs on every generation start, so a regenerate issued
+      //     while the run is in fact still live ABORTS it — re-running write tools it had already
+      //     executed, billing its discarded tokens, stranding its partial in the DB.
+      //   - handleRetry DELETEs the trailing assistant by id before re-requesting, and that is the
+      //     same id the server persisted the reply under — so a regenerate issued when the reply
+      //     had in fact completed deletes the finished reply and pays for it again.
       //
-      // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
-      // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
-      // leaves the user their prompt and the retry action on it.
-      if (hadTurnInFlight && attempt.probeAnswered) await handleRetry();
+      // Doing nothing on silence is safe: the stop released this channel's `consuming` mark, so a
+      // live run is picked up by the socket-reconnect bootstrap once the network returns, a
+      // persisted reply is picked up by the next load, and a genuinely dead turn leaves the user
+      // their prompt and the retry action on it.
+      if (hadTurnInFlight && canConcludeTurnIsLost(attempt)) await handleRetry();
     }, [
       effectiveIsStreaming,
       selectedAgent,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -85,6 +85,7 @@ import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
+import type { RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
 import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
@@ -200,12 +201,6 @@ const GlobalAssistantView: React.FC = () => {
   // Populated after useAgentChannelMultiplayer runs (called further down); used
   // in tryRecover via ref so the callback doesn't depend on hook ordering.
   const rejoinAgentStreamRef = useRef<() => void>(() => {});
-  // Whether the LAST /active-streams probe actually reached the server and answered.
-  //
-  // tryRecover returns false for two semantically opposite outcomes — "the server says nothing is
-  // live" and "the probe never got an answer" — and the resume path must not treat silence as an
-  // answer. See the regenerate gate in useAppStateRecovery below.
-  const probeAnsweredRef = useRef(false);
   // The conversation currently on screen, mirrored on every render. Read after an await to
   // decide whether a response that just resolved is still wanted.
   //
@@ -611,20 +606,21 @@ const GlobalAssistantView: React.FC = () => {
   //   1. Check /api/ai/chat/active-streams — if the original run is still live, rejoin it.
   //   2. Else fetch messages from the DB — if the run already persisted a reply, surface it.
   //   3. Only fall through to regenerate() when neither path finds anything to recover.
-  const tryRecover = useCallback(async (): Promise<boolean> => {
-    if (!currentConversationId) return false;
+  const tryRecover = useCallback(async (): Promise<RecoveryAttempt> => {
+    // `probeAnswered` is RETURNED, never stashed in a ref. tryRecover has two callers — this
+    // surface's resume handler and useStreamRecovery's network-error retry — and they can be in
+    // flight together. A single shared slot would let one caller's probe answer the other's
+    // question, which on this path means regenerating over a run we never actually asked about.
+    let probeAnswered = false;
+    if (!currentConversationId) return { recovered: false, probeAnswered };
     const channelId = selectedAgent?.id ?? (user?.id ? globalChannelId(user.id) : null);
-    if (!channelId) return false;
+    if (!channelId) return { recovered: false, probeAnswered };
 
     // Step 1: live stream check
-    probeAnsweredRef.current = false;
     try {
       const res = await fetchWithAuth(
         `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
       );
-      // Reachability, recorded separately from the verdict: only a 2xx means the server actually
-      // TOLD us what is live. A throw or a non-ok leaves us knowing nothing.
-      probeAnsweredRef.current = res.ok;
       if (res.ok) {
         const data = (await res.json()) as {
           streams?: Array<{
@@ -634,6 +630,11 @@ const GlobalAssistantView: React.FC = () => {
             triggeredBy: { userId: string };
           }>;
         };
+        // Only NOW do we know the server told us something. Setting this off `res.ok` alone would
+        // be a lie: res.json() can still throw on a body that dies mid-read — which is exactly the
+        // cold-radio-after-foreground case this whole path exists for — and the catch below would
+        // swallow it while we went on believing we had an answer.
+        probeAnswered = true;
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
         );
@@ -675,7 +676,7 @@ const GlobalAssistantView: React.FC = () => {
             if (hasServerParts) globalSetMessages(evictStale);
             rejoinGlobalStream();
           }
-          return true;
+          return { recovered: true, probeAnswered };
         }
       }
     } catch { /* network error — fall through to DB check */ }
@@ -702,18 +703,22 @@ const GlobalAssistantView: React.FC = () => {
           msgs[msgs.length - 1].role === 'assistant' &&
           dbUserCount >= localUserCount;
         if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          // Write the SAME normalized array the guards above were computed from. Reading
+          // defensively and then writing `data.messages` raw would blank the surface outright if
+          // the route ever answered with a bare array.
+          const serverMessages = msgs as unknown as UIMessage[];
           if (selectedAgent) {
-            setAgentMessages(data.messages);
-            setAgentStoreMessages(data.messages);
+            setAgentMessages(serverMessages);
+            setAgentStoreMessages(serverMessages);
           } else {
-            setGlobalLocalMessages(data.messages);
+            setGlobalLocalMessages(serverMessages);
           }
-          return true;
+          return { recovered: true, probeAnswered };
         }
       }
     } catch { /* network error — fall through to regenerate */ }
 
-    return false;
+    return { recovered: false, probeAnswered };
   }, [
     currentConversationId,
     selectedAgent,
@@ -727,7 +732,10 @@ const GlobalAssistantView: React.FC = () => {
   ]);
 
   // Auto-retry on network errors — rejoin-first, regenerate only as last resort
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover });
+  // useStreamRecovery only asks "did you recover?" — the probe-reachability half of the answer is
+  // for the resume path, which is the one that would otherwise regenerate over a live run.
+  const tryRecoverForError = useCallback(async () => (await tryRecover()).recovered, [tryRecover]);
+  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover: tryRecoverForError });
 
   const handleUndoSuccess = useCallback(async () => {
     if (!currentConversationId) return;
@@ -859,20 +867,22 @@ const GlobalAssistantView: React.FC = () => {
       // that the rejoin's bootstrap would classify the stream as one we are already reading off
       // the POST and skip attaching it.
       rawStop();
-      if (await tryRecover()) return;
+      let attempt = await tryRecover();
+      if (attempt.recovered) return;
 
-      // tryRecover came up empty — but that means one of two OPPOSITE things, and only one of them
-      // is an answer:
+      // Came up empty — but that means one of two OPPOSITE things, and only one of them is an
+      // answer:
       //
-      //   "the server says nothing is live"  → the run died; regenerating is the recovery.
+      //   "the server says nothing is live"    → the run died; regenerating is the recovery.
       //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
       //
       // The first request after a foreground is the one most likely to fail (cold radio), so on
       // this path the second case is common. Re-probe a couple of times before concluding: the
       // radio comes back well inside a few seconds.
-      for (let attempt = 1; !probeAnsweredRef.current && attempt <= 2; attempt++) {
-        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
-        if (await tryRecover()) return;
+      for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+        await new Promise((resolve) => setTimeout(resolve, i * 1000));
+        attempt = await tryRecover();
+        if (attempt.recovered) return;
       }
 
       // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
@@ -891,7 +901,7 @@ const GlobalAssistantView: React.FC = () => {
       // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
       // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
       // leaves the user their prompt and the retry action on it.
-      if (hadTurnInFlight && probeAnsweredRef.current) await handleRetry();
+      if (hadTurnInFlight && attempt.probeAnswered) await handleRetry();
     }, [
       effectiveIsStreaming,
       selectedAgent,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -77,6 +77,8 @@ import { buildContextRef, type ContextRef } from '@/lib/ai/shared/buildContextRe
 import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { abortActiveStream, abortActiveStreamByMessageId, clearActiveStreamId, reportAbortOutcome } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
+import { isCapacitorApp } from '@/hooks/useCapacitor';
+import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
@@ -716,12 +718,46 @@ const GlobalAssistantView: React.FC = () => {
     setGlobalLocalMessages,
   ]);
 
-  // App state recovery - refresh messages when returning from background
-  // This catches completed AI responses that finished while the app was backgrounded
+  // App state recovery — deterministic stream rejoin on mobile.
+  //
+  // The `enabled` gate MUST be a callback, not a render-time boolean: iOS freezes JS the
+  // moment the app backgrounds, so a boolean captured at render is whatever was true when
+  // the app went away. That is how this path was dead in exactly the case it was written
+  // for — `!isStreaming` was false (streaming), and the recovery hook was gated off.
+  //
+  // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
+  // (the local fetch is dead after backgrounding), so we stop the local useChat state,
+  // rejoin the server-owned stream, then refresh from DB to catch a stream that finished
+  // while backgrounded.
+  const resumeEnabled = useCallback(
+    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    [currentConversationId],
+  );
+
   useAppStateRecovery({
-    onResume: handlePullUpRefresh,
-    // Block recovery if streaming OR pending send OR any editing active
-    enabled: !isStreaming && currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    onResume: useCallback(async () => {
+      const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
+      if (action === 'noop') return;
+      if (action === 'rejoin-and-refresh') {
+        if (selectedAgent) {
+          agentStop();
+          rejoinAgentStream();
+        } else {
+          globalStop();
+          rejoinGlobalStream();
+        }
+      }
+      await handlePullUpRefresh();
+    }, [
+      effectiveIsStreaming,
+      selectedAgent,
+      agentStop,
+      rejoinAgentStream,
+      globalStop,
+      rejoinGlobalStream,
+      handlePullUpRefresh,
+    ]),
+    enabled: resumeEnabled,
   });
 
   // Clean up stream tracking on unmount / conversation change.

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -756,7 +756,33 @@ const GlobalAssistantView: React.FC = () => {
   // useStreamRecovery only asks "did you recover?" — the probe-reachability half of the answer is
   // for the resume path, which is the one that would otherwise regenerate over a live run.
   const tryRecoverForError = useCallback(async () => (await tryRecover()).recovered, [tryRecover]);
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover: tryRecoverForError });
+
+  // ONE mutex across BOTH recovery paths.
+  //
+  // useStreamRecovery watches this same failure from the other side (it fires on
+  // `status === 'error'`) and regenerates too, and the two shared no lock. Either could decide to
+  // regenerate the turn while the other was still deciding — useStreamRecovery calls clearError()
+  // BEFORE running its own probes, so for the whole of its decision window the status reads
+  // `ready` and looks idle to us. Two regenerates for one turn is the double destruction the
+  // resume gate exists to prevent: the server takes over the conversation on every generation
+  // start, so the second aborts the first, and handleRetry deletes its assistant message on the
+  // way in.
+  //
+  // The lock is held across the whole of handleRetry — its message DELETEs are a network
+  // round-trip — after which the restarted generation's own `submitted` status keeps the other
+  // path out (see `nothingHasRestarted` below).
+  const regenerationInFlightRef = useRef(false);
+  const regenerateTurnOnce = useCallback(async () => {
+    if (regenerationInFlightRef.current) return;
+    regenerationInFlightRef.current = true;
+    try {
+      await handleRetry();
+    } finally {
+      regenerationInFlightRef.current = false;
+    }
+  }, [handleRetry]);
+
+  useStreamRecovery({ error, status, clearError, handleRetry: regenerateTurnOnce, maxRetries: 2, tryRecover: tryRecoverForError });
 
   const handleUndoSuccess = useCallback(async () => {
     if (!currentConversationId) return;
@@ -937,15 +963,11 @@ const GlobalAssistantView: React.FC = () => {
       // their prompt and the retry action on it.
       const stillOnTheInterruptedConversation =
         currentConversationIdRef.current === conversationAtResume;
-      // Nothing has restarted the turn in the meantime. useStreamRecovery watches the SAME failure
-      // from the other side (it fires on `status === 'error'`) and regenerates too, and the two
-      // share no lock. If iOS delivers the dead fetch's rejection as an error before this listener
-      // runs, useStreamRecovery may already have retried — and `rawStop()` above would have been a
-      // no-op, since Chat.stop() returns early unless the status is streaming/submitted, so it
-      // cannot have cancelled that. Regenerating on top would be exactly the double destruction the
-      // gate below exists to prevent: takeOverConversationStreams aborts the run that just started,
-      // and handleRetry deletes its assistant message on the way in. Read through a ref because the
-      // closure's copy is the value captured before we were frozen.
+      // Belt to regenerateTurnOnce's braces. The mutex stops the two paths regenerating at the
+      // same moment; this stops us regenerating on top of a turn that has ALREADY restarted and
+      // moved on — the mutex is released as soon as handleRetry returns, but the generation it
+      // kicked off is still running. Read through a ref because the closure's copy of `isStreaming`
+      // is the value captured before we were frozen.
       const nothingHasRestarted = !isStreamingRef.current;
       if (
         hadTurnInFlight &&
@@ -953,7 +975,7 @@ const GlobalAssistantView: React.FC = () => {
         nothingHasRestarted &&
         canConcludeTurnIsLost(attempt)
       ) {
-        await handleRetry();
+        await regenerateTurnOnce();
       }
     }, [
       effectiveIsStreaming,
@@ -964,7 +986,7 @@ const GlobalAssistantView: React.FC = () => {
       rawStop,
       tryRecover,
       handlePullUpRefresh,
-      handleRetry,
+      regenerateTurnOnce,
     ]),
     enabled: resumeEnabled,
   });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -639,11 +639,14 @@ const GlobalAssistantView: React.FC = () => {
           // partial we froze with.
           const staleId = liveStream.messageId;
           const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
+          // Via agentSetMessages / globalSetMessages, not the raw useChat setters: agent mode
+          // must drop the stale partial from the dashboard store as well, or the store keeps
+          // serving it back to a co-mounted surface.
           if (selectedAgent) {
-            setAgentMessages(evictStale);
+            agentSetMessages(evictStale);
             rejoinAgentStreamRef.current();
           } else {
-            setGlobalLocalMessages(evictStale);
+            globalSetMessages(evictStale);
             rejoinGlobalStream();
           }
           return true;
@@ -690,6 +693,8 @@ const GlobalAssistantView: React.FC = () => {
     selectedAgent,
     user,
     rejoinGlobalStream,
+    agentSetMessages,
+    globalSetMessages,
     setAgentMessages,
     setAgentStoreMessages,
     setGlobalLocalMessages,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -828,11 +828,20 @@ const GlobalAssistantView: React.FC = () => {
         await handlePullUpRefresh();
         return;
       }
-      // Native. Whether a turn was actually in flight when we went away. iOS froze JS at that
-      // moment, so this render-time value is a faithful record of it — which is exactly what it
-      // is used for here, and why it is safe even though it is useless for deciding whether the
-      // TRANSPORT is still alive (that is resolveResumeAction's job, and the answer is "no").
-      const hadTurnInFlight = effectiveIsStreaming;
+      // Native. Whether a turn of OUR OWN was in flight, for the conversation on screen, when we
+      // went away. iOS froze JS at that moment, so this render-time value is a faithful record of
+      // it — which is exactly what it is used for here, and why it is safe even though it is
+      // useless for deciding whether the TRANSPORT is still alive (that is resolveResumeAction's
+      // job, and the answer is "no").
+      //
+      // Conversation-scoped, NOT the broader effectiveIsStreaming: that also reports true for a
+      // stream still running against a conversation the user has since navigated away from (the
+      // useChat id is stable across a switch), and regenerating on the strength of it would fire
+      // a generation for the turn the user is now LOOKING at rather than the one that was
+      // actually interrupted.
+      const hadTurnInFlight = selectedAgent
+        ? isOwnAgentStreamForCurrentConversation
+        : isOwnGlobalStreamForCurrentConversation;
 
       // Local-only useChat stop: it does NOT signal the server (that is done separately via
       // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
@@ -858,7 +867,16 @@ const GlobalAssistantView: React.FC = () => {
       // Gated on a turn actually having been in flight, so an ordinary resume on an idle
       // conversation can never fire a spurious generation.
       if (hadTurnInFlight) await handleRetry();
-    }, [effectiveIsStreaming, rawStop, tryRecover, handlePullUpRefresh, handleRetry]),
+    }, [
+      effectiveIsStreaming,
+      selectedAgent,
+      isOwnAgentStreamForCurrentConversation,
+      isOwnGlobalStreamForCurrentConversation,
+      rawStop,
+      tryRecover,
+      handlePullUpRefresh,
+      handleRetry,
+    ]),
     enabled: resumeEnabled,
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -86,7 +86,7 @@ import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemote
 import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMessages';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
-import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
+import { evictStalePartial, canEvictStalePartial } from '@/lib/ai/streams/evictStalePartial';
 import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
@@ -652,24 +652,23 @@ const GlobalAssistantView: React.FC = () => {
           stillOnThisConversation() &&
           decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
         ) {
-          // Evict the half-streamed assistant bubble useChat is still holding for this run — see
-          // evictStalePartial for why that is load-bearing (without it the rejoined stream is
-          // deduped straight back out and renders nothing) and why it is conditional.
-          const staleId = liveStream.messageId;
-          // evictStalePartial owns BOTH halves of the rule — why the stale bubble must go, and why
-          // only when the server's (debounced, isValidPartFrame-filtered) checkpoint can render in
-          // its place. It returns the same array reference when it is not safe, so this is a no-op
-          // write in that case.
-          const before = currentMessagesRef.current;
-          const evicted = evictStalePartial(before, staleId, liveStream.parts);
+          // Evict the half-streamed assistant bubble useChat is still holding for this run. See
+          // evictStalePartial: without it the rejoined stream is deduped straight back out and
+          // renders nothing, and it is safe only when the server's checkpoint has frames the
+          // bootstrap can actually seed in its place.
+          //
+          // Ask before writing, so an unsafe checkpoint costs no state write at all; then evict
+          // through the UPDATER form, so the filter runs against the freshest message list rather
+          // than one captured before the awaits above.
+          //
           // Written via agentSetMessages / globalSetMessages, not the raw useChat setters: agent
           // mode must drop the stale partial from the dashboard store as well, or the store keeps
           // serving it back to a co-mounted surface (and hands it to the sidebar on navigation).
-          // Skipped entirely when the helper declined to evict — it returns the same reference,
-          // and there is no reason to push an identical array through two setters.
-          if (evicted !== before) {
-            if (selectedAgent) agentSetMessages(evicted);
-            else globalSetMessages(evicted);
+          const staleId = liveStream.messageId;
+          if (canEvictStalePartial(liveStream.parts)) {
+            const evict = (prev: UIMessage[]) => evictStalePartial(prev, staleId, liveStream.parts);
+            if (selectedAgent) agentSetMessages(evict);
+            else globalSetMessages(evict);
           }
           if (selectedAgent) {
             rejoinAgentStreamRef.current();

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -373,6 +373,10 @@ const GlobalAssistantView: React.FC = () => {
   const rawStop = selectedAgent ? agentStop : globalStop;
   const addToolResult = selectedAgent ? agentAddToolResult : globalAddToolResult;
   const isStreaming = status === 'submitted' || status === 'streaming';
+  // Mirrored so the resume handler can read it AFTER its awaits. Its own closure captured the
+  // pre-background value, which cannot tell it whether a generation has since restarted.
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current = isStreaming;
   const { wrapSend } = useSendHandoff(currentConversationId, status);
 
   const streamingAssistantText = useMemo(() => {
@@ -647,11 +651,11 @@ const GlobalAssistantView: React.FC = () => {
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === conversationId && s.triggeredBy.userId === user?.id,
         );
-        if (
-          liveStream &&
-          stillOnThisConversation() &&
-          decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
-        ) {
+        // decideRecovery's priority (rejoin > refetch > regenerate) is expressed by the ORDER of
+        // these steps, not by a call here: with hasLiveStream hardcoded true it could only ever
+        // answer 'rejoin', so asking would be decoration. Step 2 below is where it genuinely
+        // decides. A live stream is always rejoined, never read around.
+        if (liveStream && stillOnThisConversation()) {
           // Evict the half-streamed assistant bubble useChat is still holding for this run. See
           // evictStalePartial: without it the rejoined stream is deduped straight back out and
           // renders nothing, and it is safe only when the server's checkpoint has frames the
@@ -848,7 +852,8 @@ const GlobalAssistantView: React.FC = () => {
   //
   //   live stream        → rejoin it, no DB read at all
   //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
-  //   neither            → falls through to handlePullUpRefresh below
+  //   neither            → regenerate — but ONLY once both questions actually came back
+  //                         (canConcludeTurnIsLost). Never a DB refresh: see the gate below.
   const resumeEnabled = useCallback(
     () => canResumeRecovery(currentConversationId, useEditingStore.getState().isAnyEditing()),
     [currentConversationId],
@@ -932,7 +937,22 @@ const GlobalAssistantView: React.FC = () => {
       // their prompt and the retry action on it.
       const stillOnTheInterruptedConversation =
         currentConversationIdRef.current === conversationAtResume;
-      if (hadTurnInFlight && stillOnTheInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+      // Nothing has restarted the turn in the meantime. useStreamRecovery watches the SAME failure
+      // from the other side (it fires on `status === 'error'`) and regenerates too, and the two
+      // share no lock. If iOS delivers the dead fetch's rejection as an error before this listener
+      // runs, useStreamRecovery may already have retried — and `rawStop()` above would have been a
+      // no-op, since Chat.stop() returns early unless the status is streaming/submitted, so it
+      // cannot have cancelled that. Regenerating on top would be exactly the double destruction the
+      // gate below exists to prevent: takeOverConversationStreams aborts the run that just started,
+      // and handleRetry deletes its assistant message on the way in. Read through a ref because the
+      // closure's copy is the value captured before we were frozen.
+      const nothingHasRestarted = !isStreamingRef.current;
+      if (
+        hadTurnInFlight &&
+        stillOnTheInterruptedConversation &&
+        nothingHasRestarted &&
+        canConcludeTurnIsLost(attempt)
+      ) {
         await handleRetry();
       }
     }, [

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -200,14 +200,25 @@ const GlobalAssistantView: React.FC = () => {
   // Populated after useAgentChannelMultiplayer runs (called further down); used
   // in tryRecover via ref so the callback doesn't depend on hook ordering.
   const rejoinAgentStreamRef = useRef<() => void>(() => {});
-  // The conversation the most recent message load was requested for. Lets a response that
-  // resolves after the user switched conversation be dropped instead of clobbering the new one.
-  const loadRequestedIdRef = useRef<string | null>(null);
+  // The conversation currently on screen, mirrored on every render. Read after an await to
+  // decide whether a response that just resolved is still wanted.
+  //
+  // Deliberately NOT the "id the load was requested for" ref that AiChatView and
+  // SidebarChatTab use. That pattern only works because in those components every load path
+  // funnels through the one loader that advances the ref, so switching conversation advances
+  // it. Here it would not: this surface loads on select via the globalInitialMessages /
+  // agent-load-signal effects, which do NOT go through handlePullUpRefresh. A
+  // "requested id" ref written only by handlePullUpRefresh would still equal the id its own
+  // in-flight fetch was issued for, so the guard would always pass and a response for the
+  // conversation the user just left would be applied to the one they switched to. Comparing
+  // against the LIVE conversation is the invariant that actually holds here.
+  const currentConversationIdRef = useRef<string | null>(null);
 
   // ============================================
   // SHARED HOOKS
   // ============================================
   const currentConversationId = selectedAgent ? agentConversationId : globalConversationId;
+  currentConversationIdRef.current = currentConversationId;
 
   const { isLoading: isLoadingProviders, isAnyProviderConfigured, needsSetup } =
     useProviderSettings();
@@ -706,34 +717,43 @@ const GlobalAssistantView: React.FC = () => {
   // through the same two guards as the authoritative loaders elsewhere in the app
   // (AiChatView.loadMessagesForConversation, SidebarChatTab.loadGlobalMessages):
   //
-  //   1. shouldApplyLoadedMessages — drop the response if the user switched conversation while
-  //      the fetch was in flight, so it cannot clobber the conversation they moved to.
+  //   1. shouldApplyLoadedMessages, against the LIVE conversation (currentConversationIdRef) —
+  //      drop the response if the user switched conversation or agent while the fetch was in
+  //      flight, so it cannot clobber the conversation they moved to.
   //   2. mergeServerAndPending — re-attach the in-flight own stream's bubble, which by definition
   //      is absent from the DB snapshot while the run is still generating.
   const handlePullUpRefresh = useCallback(async () => {
     const conversationId = currentConversationId;
     if (!conversationId) return;
-    loadRequestedIdRef.current = conversationId;
+    const agentId = selectedAgent?.id ?? null;
     try {
-      const url = selectedAgent
-        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${conversationId}/messages`
+      const url = agentId
+        ? `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages`
         : `/api/ai/global/${conversationId}/messages`;
       const res = await fetchWithAuth(url);
       if (!res.ok) return;
       // Stale check after the await — the user may have switched conversation/agent.
-      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+      if (!shouldApplyLoadedMessages(conversationId, currentConversationIdRef.current)) return;
       const data = await res.json();
-      if (!shouldApplyLoadedMessages(conversationId, loadRequestedIdRef.current)) return;
+      if (!shouldApplyLoadedMessages(conversationId, currentConversationIdRef.current)) return;
 
       const serverMessages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-      const ownStream = Array.from(usePendingStreamsStore.getState().streams.values()).find(
-        (s) => s.isOwn && s.conversationId === conversationId,
-      );
+      // Scoped by channel AND conversation, the same way AiChatView scopes its own lookup.
+      // A conversation id is only unique within its channel, and this surface switches between
+      // the global channel and per-agent channels, so matching on `isOwn && conversationId`
+      // alone could splice a different agent's in-flight bubble into this conversation.
+      const channelId = agentId ?? (user?.id ? globalChannelId(user.id) : null);
+      const ownStream = channelId
+        ? usePendingStreamsStore
+            .getState()
+            .getOwnStreams(channelId)
+            .find((s) => s.conversationId === conversationId)
+        : undefined;
       const merged = ownStream
         ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
         : serverMessages;
 
-      if (selectedAgent) {
+      if (agentId) {
         setAgentMessages(merged);
         setAgentStoreMessages(merged);
       } else {
@@ -745,6 +765,7 @@ const GlobalAssistantView: React.FC = () => {
   }, [
     currentConversationId,
     selectedAgent,
+    user,
     setAgentMessages,
     setAgentStoreMessages,
     setGlobalLocalMessages,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -147,12 +147,25 @@ type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 function planResume({
   native,
   isStreaming,
+  ownTurnInFlight = isStreaming,
   recovered = true,
+  probeAnswered = true,
 }: {
   native: boolean;
+  /** The broad display/effective streaming flag — what resolveResumeAction sees. */
   isStreaming: boolean;
+  /**
+   * Whether a stream of OUR OWN was running for the conversation ON SCREEN. Distinct from
+   * `isStreaming`, which stays true for a stream still running against a conversation the user has
+   * since navigated away from (the useChat id is stable across a switch). Only this may gate a
+   * regenerate — otherwise we would fire a generation for the turn the user is now LOOKING at
+   * rather than the one that was interrupted.
+   */
+  ownTurnInFlight?: boolean;
   /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
   recovered?: boolean;
+  /** Whether the /active-streams probe actually reached the server and answered. */
+  probeAnswered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -162,12 +175,10 @@ function planResume({
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
   if (recovered) return effects;
-  // Nothing live, nothing persisted. NOT a DB refresh (unsafe: the probe may merely have failed
-  // and a stream still be live, or the DB may be behind local state). Regenerate — but only if a
-  // turn was actually in flight when we backgrounded, so an idle resume never fires a spurious
-  // generation. `isStreaming` here is the render-time value iOS froze at background, which is a
-  // faithful record of exactly that.
-  if (isStreaming) effects.push('regenerate');
+  // Nothing recovered. NOT a DB refresh (unsafe: it would erase an in-progress bubble or the
+  // user's own prompt). Regenerate — but only on an ANSWERED probe, and only if a turn of ours was
+  // really in flight for this conversation.
+  if (ownTurnInFlight && probeAnswered) effects.push('regenerate');
   return effects;
 }
 
@@ -419,7 +430,34 @@ function evictStalePartial<T extends { id: string }>(
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
       });
 
-      it('given native, a turn in flight, and NOTHING to recover, should regenerate — never a DB refresh', () => {
+      it('given native, a stream for a DIFFERENT conversation, and nothing to recover, should NOT regenerate', () => {
+        // The broad flag stays true for a stream still running against a conversation the user has
+        // navigated away from. Regenerating on it would fire a generation for the turn now on
+        // screen rather than the interrupted one — a spurious reply, and a spurious charge, on an
+        // untouched conversation.
+        expect(
+          planResume({ native: true, isStreaming: true, ownTurnInFlight: false, recovered: false }),
+        ).toEqual(['stop', 'try-recover']);
+      });
+
+      it('given native and the probe never ANSWERED, should NOT regenerate', () => {
+        // Silence is not an answer. Every generation start calls takeOverConversationStreams, so a
+        // regenerate issued while the run is in fact still live does not race it — it ABORTS it.
+        // We would kill a healthy generation, re-run write tools it had already executed, bill the
+        // discarded tokens, and strand its partial in the DB. Doing nothing is safe: the stop
+        // released the `consuming` mark, so the socket-reconnect bootstrap picks a live run up.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            recovered: false,
+            probeAnswered: false,
+          }),
+        ).toEqual(['stop', 'try-recover']);
+      });
+
+      it('given native, a turn in flight, an ANSWERED probe, and NOTHING to recover, should regenerate — never a DB refresh', () => {
         // The stop above settles useChat at `ready` with no `error`, and useStreamRecovery only
         // fires on `status === 'error'` — so aborting the fetch destroys the very signal that
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -142,14 +142,17 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
  */
-type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
+type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
 function planResume({
   native,
   isStreaming,
+  recovered = true,
 }: {
   native: boolean;
   isStreaming: boolean;
+  /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
+  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -157,7 +160,15 @@ function planResume({
   // The stop is local-only. It clears useChat state and — critically — ends the dead response
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
-  return ['stop', 'try-recover'];
+  const effects: ResumeEffect[] = ['stop', 'try-recover'];
+  if (recovered) return effects;
+  // Nothing live, nothing persisted. NOT a DB refresh (unsafe: the probe may merely have failed
+  // and a stream still be live, or the DB may be behind local state). Regenerate — but only if a
+  // turn was actually in flight when we backgrounded, so an idle resume never fires a spurious
+  // generation. `isStreaming` here is the render-time value iOS froze at background, which is a
+  // faithful record of exactly that.
+  if (isStreaming) effects.push('regenerate');
+  return effects;
 }
 
 const mockAgent = { id: 'agent-123' };
@@ -406,6 +417,25 @@ function evictStalePartial<T extends { id: string }>(
 
       it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
+      });
+
+      it('given native, a turn in flight, and NOTHING to recover, should regenerate — never a DB refresh', () => {
+        // The stop above settles useChat at `ready` with no `error`, and useStreamRecovery only
+        // fires on `status === 'error'` — so aborting the fetch destroys the very signal that
+        // used to drive the fallback. Without regenerating here, a turn whose POST died on the
+        // background transition (a radio drop right then is common) finds no stream, no reply and
+        // no error, and the user's prompt sits unanswered forever.
+        const plan = planResume({ native: true, isStreaming: true, recovered: false });
+        expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
+        expect(plan).not.toContain('refresh');
+      });
+
+      it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
+        // An ordinary resume on an idle conversation must never fire a spurious generation.
+        expect(planResume({ native: true, isStreaming: false, recovered: false })).toEqual([
+          'stop',
+          'try-recover',
+        ]);
       });
     });
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -131,33 +131,35 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
  * real policy.
  *
- * The critical property: on the rejoin path we stop the local fetch and hand off to
- * `tryRecover` (the /active-streams-first probe), and we DO NOT touch the DB unless
- * tryRecover comes back empty. A blind DB refresh while a run is still generating would
- * write a snapshot with no assistant message over the in-progress bubble.
+ * Two invariants worth stating plainly, because both were bugs:
+ *
+ *  - On the native path we stop the local fetch and hand off to `tryRecover`, and there is NO
+ *    DB-refresh fallback afterwards. tryRecover already refetches when the run finished while
+ *    we were away. A fallback would only fire in the cases where a DB write is UNSAFE: the
+ *    /active-streams probe failed (a stream may still be live, and the DB cannot contain an
+ *    unpersisted reply), or the DB is behind local state (a send whose POST never landed).
+ *
+ *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
  * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
- * persisted reply; false = nothing live, nothing persisted.
+ * persisted reply; false = nothing live, nothing persisted, or the probe failed.
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
 function planResume({
   native,
   isStreaming,
-  recovered = false,
 }: {
   native: boolean;
   isStreaming: boolean;
-  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
-  if (action !== 'rejoin-and-refresh') return ['refresh'];
-  // rawStop is local-only — it clears useChat state and releases the channel's `consuming`
-  // mark so the rejoin's bootstrap will attach. It does NOT signal the server; the run keeps
-  // generating and stays rejoinable.
-  if (recovered) return ['stop', 'try-recover'];
-  return ['stop', 'try-recover', 'refresh'];
+  if (action === 'refresh') return ['refresh'];
+  // The stop is local-only. It clears useChat state and — critically — ends the dead response
+  // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
+  // treats the stream as one we are already reading off the POST and skips attaching it.
+  return ['stop', 'try-recover'];
 }
 
 const mockAgent = { id: 'agent-123' };
@@ -332,6 +334,23 @@ describe('GlobalAssistantView load-on-select effects', () => {
     });
   });
 
+/**
+ * Mirrors the rejoin branch of `tryRecover`: the live stream's messageId is used to evict the
+ * half-streamed assistant bubble useChat is still holding, so the rejoined pending stream is not
+ * deduped away.
+ *
+ * `Chat.stop()` "keeps the generated tokens", and a dropped fetch leaves them too — so `messages`
+ * still holds an assistant message whose id IS the live stream's messageId (the server mints one
+ * id and uses it for BOTH the UI message and the stream registry row). The rejoin re-adds that
+ * same stream to the pending store, and the surfaces drop a pending stream whose messageId
+ * already appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams).
+ * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
+ * token renders, and the user stares at a frozen partial.
+ */
+function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageId: string): T[] {
+  return messages.filter((m) => m.id !== liveMessageId);
+}
+
   describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
     describe('resumeEnabled (the gate)', () => {
       it('given a conversation and no active editing, should enable recovery', () => {
@@ -349,23 +368,22 @@ describe('GlobalAssistantView load-on-select effects', () => {
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream and a live stream to rejoin, should stop the local fetch and hand off to tryRecover — and NOT touch the DB', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch and hand off to tryRecover — and NOT read the DB', () => {
         // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB
         // snapshot taken while the stream is still generating contains no assistant message.
         // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
-        // and rejoins; the DB is never read on this path.
-        expect(planResume({ native: true, isStreaming: true, recovered: true })).toEqual([
-          'stop',
-          'try-recover',
-        ]);
+        // and rejoins; the DB is never read while a run is live.
+        expect(planResume({ native: true, isStreaming: true })).toEqual(['stop', 'try-recover']);
       });
 
-      it('given native and tryRecover finds nothing live or persisted, should fall back to a DB refresh', () => {
-        expect(planResume({ native: true, isStreaming: true, recovered: false })).toEqual([
-          'stop',
-          'try-recover',
-          'refresh',
-        ]);
+      it('given native, should NOT fall back to a DB refresh when tryRecover comes back empty', () => {
+        // tryRecover returns false in exactly the two cases where a DB write is unsafe: the
+        // probe failed (a stream may still be live — and the first request after a foreground
+        // is the likeliest to fail, radio still coming up), or the DB is behind local state
+        // (a send whose POST never reached the server; refreshing would erase the user's own
+        // prompt). Doing nothing is correct in both; the socket reconnect path heals it.
+        expect(planResume({ native: true, isStreaming: true })).not.toContain('refresh');
+        expect(planResume({ native: true, isStreaming: false })).not.toContain('refresh');
       });
 
       it('given native, should always stop BEFORE recovering', () => {
@@ -373,7 +391,7 @@ describe('GlobalAssistantView load-on-select effects', () => {
         // the channel's `consuming` mark. Without that, the rejoin's bootstrap classifies the
         // stream as one we are already reading off the POST body and skips attaching it — the
         // rejoin would silently do nothing.
-        const plan = planResume({ native: true, isStreaming: true, recovered: true });
+        const plan = planResume({ native: true, isStreaming: true });
         expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('try-recover'));
       });
 
@@ -381,10 +399,7 @@ describe('GlobalAssistantView load-on-select effects', () => {
         // The local fetch is dead after backgrounding regardless of what useChat still
         // reports, so native always probes. /active-streams is the authoritative answer
         // on whether a stream is actually live; no client flag gates the rejoin.
-        expect(planResume({ native: true, isStreaming: false, recovered: true })).toEqual([
-          'stop',
-          'try-recover',
-        ]);
+        expect(planResume({ native: true, isStreaming: false })).toEqual(['stop', 'try-recover']);
       });
 
       it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
@@ -393,6 +408,35 @@ describe('GlobalAssistantView load-on-select effects', () => {
 
       it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
+      });
+    });
+
+    describe('evictStalePartial (why the rejoin renders at all)', () => {
+      const liveId = 'srv-msg-1';
+      const messages = [
+        { id: 'u1', role: 'user' },
+        { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
+      ];
+
+      it('given a rejoined live stream, should drop the local partial carrying that same messageId', () => {
+        // Without this the pending stream the rejoin adds under `liveId` is deduped away,
+        // because `liveId` is still present in `messages`. The bubble would never update.
+        expect(evictStalePartial(messages, liveId)).toEqual([{ id: 'u1', role: 'user' }]);
+      });
+
+      it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
+        const remaining = evictStalePartial(messages, liveId);
+        const seen = new Set(remaining.map((m) => m.id));
+        expect(seen.has(liveId)).toBe(false);
+      });
+
+      it('given messages with no matching id, should leave them untouched', () => {
+        expect(evictStalePartial(messages, 'some-other-id')).toEqual(messages);
+      });
+
+      it('should only ever drop the ONE message the server named — never the user turn', () => {
+        const out = evictStalePartial(messages, liveId);
+        expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -166,6 +166,7 @@ function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
+  stillOnInterruptedConversation = true,
   attempts = [RECOVERED],
 }: {
   native: boolean;
@@ -179,6 +180,13 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
+  /**
+   * Whether we are still on the conversation the interrupted turn belongs to. The recovery spans
+   * seconds of network and the user can switch conversation inside that window; handleRetry always
+   * acts on the LIVE conversation, so regenerating after a switch would fire a generation for the
+   * turn they moved TO rather than the one that was interrupted.
+   */
+  stillOnInterruptedConversation?: boolean;
   /** Successive tryRecover outcomes, one per attempt the resume handler makes (up to 3). */
   attempts?: Attempt[];
 }): ResumeEffect[] {
@@ -201,7 +209,9 @@ function planResume({
   }
 
   // The REAL predicate, not a copy of it.
-  if (ownTurnInFlight && canConcludeTurnIsLost(attempt)) effects.push('regenerate');
+  if (ownTurnInFlight && stillOnInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+    effects.push('regenerate');
+  }
   return effects;
 }
 
@@ -482,6 +492,21 @@ function evictStalePartial<T extends { id: string }>(
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
         expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the user switched conversation during the recovery, should NOT regenerate', () => {
+        // handleRetry acts on the LIVE conversation. The recovery spans seconds of network, so a
+        // switch inside that window would make it fire a generation for the turn the user moved
+        // TO, not the interrupted one.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            stillOnInterruptedConversation: false,
+            attempts: [ANSWERED_NOTHING],
+          }),
+        ).toEqual(['stop', 'try-recover']);
       });
 
       it('given the probe answered but the DB GET did NOT, should NOT regenerate', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -144,12 +144,20 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
+/**
+ * One tryRecover outcome. `recovered` and `probeAnswered` are separate because "we recovered
+ * nothing" is NOT the same claim as "the server told us there was nothing to recover".
+ */
+interface Attempt {
+  recovered: boolean;
+  probeAnswered: boolean;
+}
+
 function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
-  recovered = true,
-  probeAnswered = true,
+  attempts = [{ recovered: true, probeAnswered: true }],
 }: {
   native: boolean;
   /** The broad display/effective streaming flag — what resolveResumeAction sees. */
@@ -162,10 +170,8 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
-  /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
-  recovered?: boolean;
-  /** Whether the /active-streams probe actually reached the server and answered. */
-  probeAnswered?: boolean;
+  /** Successive tryRecover outcomes, one per probe the resume handler makes (up to 3). */
+  attempts?: Attempt[];
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -174,11 +180,18 @@ function planResume({
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
-  if (recovered) return effects;
-  // Nothing recovered. NOT a DB refresh (unsafe: it would erase an in-progress bubble or the
-  // user's own prompt). Regenerate — but only on an ANSWERED probe, and only if a turn of ours was
-  // really in flight for this conversation.
-  if (ownTurnInFlight && probeAnswered) effects.push('regenerate');
+  let attempt: Attempt = attempts[0] ?? { recovered: false, probeAnswered: false };
+  if (attempt.recovered) return effects;
+
+  // An unanswered probe is not an answer. Re-probe (bounded) before concluding anything.
+  for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+    effects.push('try-recover');
+    attempt = attempts[i] ?? { recovered: false, probeAnswered: false };
+    if (attempt.recovered) return effects;
+  }
+
+  // Regenerate only on an ANSWERED probe, and only for a turn of ours on this conversation.
+  if (ownTurnInFlight && attempt.probeAnswered) effects.push('regenerate');
   return effects;
 }
 
@@ -436,25 +449,64 @@ function evictStalePartial<T extends { id: string }>(
         // screen rather than the interrupted one — a spurious reply, and a spurious charge, on an
         // untouched conversation.
         expect(
-          planResume({ native: true, isStreaming: true, ownTurnInFlight: false, recovered: false }),
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: false,
+            attempts: [{ recovered: false, probeAnswered: true }],
+          }),
         ).toEqual(['stop', 'try-recover']);
       });
 
-      it('given native and the probe never ANSWERED, should NOT regenerate', () => {
+      it('given native and the probe never ANSWERED, should re-probe and then NOT regenerate', () => {
         // Silence is not an answer. Every generation start calls takeOverConversationStreams, so a
         // regenerate issued while the run is in fact still live does not race it — it ABORTS it.
         // We would kill a healthy generation, re-run write tools it had already executed, bill the
         // discarded tokens, and strand its partial in the DB. Doing nothing is safe: the stop
         // released the `consuming` mark, so the socket-reconnect bootstrap picks a live run up.
+        const plan = planResume({
+          native: true,
+          isStreaming: true,
+          ownTurnInFlight: true,
+          attempts: [
+            { recovered: false, probeAnswered: false },
+            { recovered: false, probeAnswered: false },
+            { recovered: false, probeAnswered: false },
+          ],
+        });
+        expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
+        expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the probe answers only on a LATER attempt, should still regenerate — a cold radio must not strand the turn', () => {
+        // The first request after a foreground is the one most likely to fail. Concluding from that
+        // single silence would leave the user's prompt unanswered forever; re-probing lets the
+        // radio come back and gives us a real answer to act on.
         expect(
           planResume({
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            recovered: false,
-            probeAnswered: false,
+            attempts: [
+              { recovered: false, probeAnswered: false },
+              { recovered: false, probeAnswered: true },
+            ],
           }),
-        ).toEqual(['stop', 'try-recover']);
+        ).toEqual(['stop', 'try-recover', 'try-recover', 'regenerate']);
+      });
+
+      it('given a re-probe finds the live stream, should rejoin and never regenerate', () => {
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            attempts: [
+              { recovered: false, probeAnswered: false },
+              { recovered: true, probeAnswered: true },
+            ],
+          }),
+        ).toEqual(['stop', 'try-recover', 'try-recover']);
       });
 
       it('given native, a turn in flight, an ANSWERED probe, and NOTHING to recover, should regenerate — never a DB refresh', () => {
@@ -463,14 +515,14 @@ function evictStalePartial<T extends { id: string }>(
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the
         // background transition (a radio drop right then is common) finds no stream, no reply and
         // no error, and the user's prompt sits unanswered forever.
-        const plan = planResume({ native: true, isStreaming: true, recovered: false });
+        const plan = planResume({ native: true, isStreaming: true, attempts: [{ recovered: false, probeAnswered: true }] });
         expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
         expect(plan).not.toContain('refresh');
       });
 
       it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
         // An ordinary resume on an idle conversation must never fire a spurious generation.
-        expect(planResume({ native: true, isStreaming: false, recovered: false })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, attempts: [{ recovered: false, probeAnswered: true }] })).toEqual([
           'stop',
           'try-recover',
         ]);

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -15,6 +15,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
+import { canConcludeTurnIsLost } from '@/lib/ai/streams/recoveryAttempt';
 
 /**
  * Mirrors the global-mode load-on-select effect (~line 1019-1044):
@@ -145,19 +146,27 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
 /**
- * One tryRecover outcome. `recovered` and `probeAnswered` are separate because "we recovered
- * nothing" is NOT the same claim as "the server told us there was nothing to recover".
+ * One tryRecover outcome. `recovered` and the two "answered" flags are separate because "we
+ * recovered nothing" is NOT the same claim as "the server told us there was nothing to recover" —
+ * and regenerating on the latter is destructive twice over (it aborts a still-live run, and it
+ * DELETEs an already-persisted reply, since handleRetry removes the trailing assistant by the very
+ * id the server saved it under).
  */
 interface Attempt {
   recovered: boolean;
   probeAnswered: boolean;
+  dbAnswered: boolean;
 }
+
+const ANSWERED_NOTHING: Attempt = { recovered: false, probeAnswered: true, dbAnswered: true };
+const SILENT: Attempt = { recovered: false, probeAnswered: false, dbAnswered: false };
+const RECOVERED: Attempt = { recovered: true, probeAnswered: true, dbAnswered: true };
 
 function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
-  attempts = [{ recovered: true, probeAnswered: true }],
+  attempts = [RECOVERED],
 }: {
   native: boolean;
   /** The broad display/effective streaming flag — what resolveResumeAction sees. */
@@ -170,7 +179,7 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
-  /** Successive tryRecover outcomes, one per probe the resume handler makes (up to 3). */
+  /** Successive tryRecover outcomes, one per attempt the resume handler makes (up to 3). */
   attempts?: Attempt[];
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
@@ -180,18 +189,19 @@ function planResume({
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
-  let attempt: Attempt = attempts[0] ?? { recovered: false, probeAnswered: false };
+  let attempt: Attempt = attempts[0] ?? SILENT;
   if (attempt.recovered) return effects;
 
-  // An unanswered probe is not an answer. Re-probe (bounded) before concluding anything.
-  for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+  // Re-ask until BOTH questions come back. Silence from either means the work we would destroy
+  // might still exist.
+  for (let i = 1; !(attempt.probeAnswered && attempt.dbAnswered) && i <= 2; i++) {
     effects.push('try-recover');
-    attempt = attempts[i] ?? { recovered: false, probeAnswered: false };
+    attempt = attempts[i] ?? SILENT;
     if (attempt.recovered) return effects;
   }
 
-  // Regenerate only on an ANSWERED probe, and only for a turn of ours on this conversation.
-  if (ownTurnInFlight && attempt.probeAnswered) effects.push('regenerate');
+  // The REAL predicate, not a copy of it.
+  if (ownTurnInFlight && canConcludeTurnIsLost(attempt)) effects.push('regenerate');
   return effects;
 }
 
@@ -453,7 +463,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: false,
-            attempts: [{ recovered: false, probeAnswered: true }],
+            attempts: [ANSWERED_NOTHING],
           }),
         ).toEqual(['stop', 'try-recover']);
       });
@@ -468,13 +478,24 @@ function evictStalePartial<T extends { id: string }>(
           native: true,
           isStreaming: true,
           ownTurnInFlight: true,
-          attempts: [
-            { recovered: false, probeAnswered: false },
-            { recovered: false, probeAnswered: false },
-            { recovered: false, probeAnswered: false },
-          ],
+          attempts: [SILENT, SILENT, SILENT],
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
+        expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the probe answered but the DB GET did NOT, should NOT regenerate', () => {
+        // The other half of "silence is not an answer", and the more destructive half. If the
+        // messages GET failed we do not know whether the reply is already persisted — and
+        // handleRetry DELETEs the trailing assistant by the very id the server saved it under, so
+        // regenerating here would delete a COMPLETED reply and pay for it a second time.
+        const dbSilent = { recovered: false, probeAnswered: true, dbAnswered: false };
+        const plan = planResume({
+          native: true,
+          isStreaming: true,
+          ownTurnInFlight: true,
+          attempts: [dbSilent, dbSilent, dbSilent],
+        });
         expect(plan).not.toContain('regenerate');
       });
 
@@ -487,10 +508,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            attempts: [
-              { recovered: false, probeAnswered: false },
-              { recovered: false, probeAnswered: true },
-            ],
+            attempts: [SILENT, ANSWERED_NOTHING],
           }),
         ).toEqual(['stop', 'try-recover', 'try-recover', 'regenerate']);
       });
@@ -501,10 +519,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            attempts: [
-              { recovered: false, probeAnswered: false },
-              { recovered: true, probeAnswered: true },
-            ],
+            attempts: [SILENT, RECOVERED],
           }),
         ).toEqual(['stop', 'try-recover', 'try-recover']);
       });
@@ -515,14 +530,14 @@ function evictStalePartial<T extends { id: string }>(
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the
         // background transition (a radio drop right then is common) finds no stream, no reply and
         // no error, and the user's prompt sits unanswered forever.
-        const plan = planResume({ native: true, isStreaming: true, attempts: [{ recovered: false, probeAnswered: true }] });
+        const plan = planResume({ native: true, isStreaming: true, attempts: [ANSWERED_NOTHING] });
         expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
         expect(plan).not.toContain('refresh');
       });
 
       it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
         // An ordinary resume on an idle conversation must never fire a spurious generation.
-        expect(planResume({ native: true, isStreaming: false, attempts: [{ recovered: false, probeAnswered: true }] })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, attempts: [ANSWERED_NOTHING] })).toEqual([
           'stop',
           'try-recover',
         ]);

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -639,7 +639,7 @@ describe('GlobalAssistantView load-on-select effects', () => {
       });
 
       it('given the server checkpoint is EMPTY, should KEEP the local partial', () => {
-        // The debounced checkpoint is empty for a stream only a few parts old. If we evicted here
+        // The checkpoint lags the live stream, so it is empty for a stream in its first moments. If we evicted here
         // and the SSE join then failed (multi-instance: the multicast lives in another process),
         // the bootstrap removes the stream and the user is left with nothing at all — worse than
         // the frozen partial. Keep what they had; the rejoin can still attach and take over.

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -14,6 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 
 /**
  * Mirrors the global-mode load-on-select effect (~line 1019-1044):
@@ -109,6 +110,44 @@ function createRefAdvancesOnlyOnApplySimulator<X>() {
       return true;
     },
   };
+}
+
+/**
+ * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
+ *
+ * Deliberately takes NO streaming argument. The gate must be a callback (evaluated at
+ * fire time, on resume) and must gate on user-editing only. See the regression test below.
+ */
+function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
+  return currentConversationId !== null && !isAnyEditing;
+}
+
+/**
+ * Mirrors the side effects of the `onResume` body, in order. The decision itself is NOT
+ * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring (which stop,
+ * which rejoin, and that the DB refresh runs last) against the real policy.
+ */
+type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
+
+function planResume({
+  native,
+  isStreaming,
+  selectedAgent,
+}: {
+  native: boolean;
+  isStreaming: boolean;
+  selectedAgent: { id: string } | null;
+}): ResumeEffect[] {
+  const action = resolveResumeAction({ native, isStreaming });
+  if (action === 'noop') return [];
+  const effects: ResumeEffect[] = [];
+  if (action === 'rejoin-and-refresh') {
+    // rawStop is local-only — it clears useChat state so the rejoin attaches cleanly.
+    // It does NOT signal the server; the run keeps generating and is rejoined below.
+    effects.push('stop', selectedAgent ? 'rejoin-agent' : 'rejoin-global');
+  }
+  effects.push('refresh');
+  return effects;
 }
 
 const mockAgent = { id: 'agent-123' };
@@ -280,6 +319,73 @@ describe('GlobalAssistantView load-on-select effects', () => {
     it('given the exact regression scenario — sending in conv-A (or agent conversation A), then switching to idle conv-B while A keeps streaming — the load-on-select guard for conv-B must NOT be blocked', () => {
       const blocked = isOwnStreamForConversation(true, 'conv-A', 'conv-B');
       expect(blocked).toBe(false);
+    });
+  });
+
+  describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
+    describe('resumeEnabled (the gate)', () => {
+      it('given a conversation and no active editing, should enable recovery', () => {
+        expect(resumeEnabled('conv-A', false)).toBe(true);
+      });
+
+      it('given no conversation, should NOT enable recovery (nothing to rejoin)', () => {
+        expect(resumeEnabled(null, false)).toBe(false);
+      });
+
+      it('given the user is actively editing, should NOT enable recovery (would clobber their edit)', () => {
+        expect(resumeEnabled('conv-A', true)).toBe(false);
+      });
+
+      it('given a stream is in flight, should STILL enable recovery — streaming is not an input to the gate', () => {
+        // THE REGRESSION. The gate used to be a render-time boolean that folded in
+        // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
+        // that gated the resume was whatever was true when the app went away — i.e.
+        // streaming — which disabled recovery in exactly the case it was written for.
+        // The gate takes no streaming argument at all now; there is no way to express
+        // that bug in this signature. The streaming decision belongs to
+        // resolveResumeAction, at fire time.
+        expect(resumeEnabled('conv-A', false)).toBe(true);
+      });
+    });
+
+    describe('planResume (the onResume body)', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, rejoin the global stream, then refresh', () => {
+        expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
+          'stop',
+          'rejoin-global',
+          'refresh',
+        ]);
+      });
+
+      it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
+        expect(planResume({ native: true, isStreaming: true, selectedAgent: { id: 'agent-1' } })).toEqual([
+          'stop',
+          'rejoin-agent',
+          'refresh',
+        ]);
+      });
+
+      it('given native and NOT streaming, should still rejoin — the recovery is deterministic, not flag-gated', () => {
+        // The local fetch is dead after backgrounding regardless of what useChat still
+        // reports, so native always rejoins. /active-streams is the authoritative answer
+        // on whether a stream is actually live; no client flag gates the rejoin.
+        expect(planResume({ native: false, isStreaming: false, selectedAgent: null })).toEqual(['refresh']);
+        expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
+          'stop',
+          'rejoin-global',
+          'refresh',
+        ]);
+      });
+
+      it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
+        expect(planResume({ native: false, isStreaming: true, selectedAgent: null })).toEqual([]);
+      });
+
+      it('given web with no live fetch, should refresh only (no stop, no rejoin)', () => {
+        expect(planResume({ native: false, isStreaming: false, selectedAgent: { id: 'agent-1' } })).toEqual([
+          'refresh',
+        ]);
+      });
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -16,6 +16,8 @@
 import { describe, it, expect } from 'vitest';
 import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { canConcludeTurnIsLost } from '@/lib/ai/streams/recoveryAttempt';
+import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
+import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
 
 /**
  * Mirrors the global-mode load-on-select effect (~line 1019-1044):
@@ -111,20 +113,6 @@ function createRefAdvancesOnlyOnApplySimulator<X>() {
       return true;
     },
   };
-}
-
-/**
- * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
- *
- * Deliberately takes NO streaming argument, which is the whole point. The gate used to be a
- * render-time boolean folding in `!isStreaming`; iOS freezes JS the moment the app backgrounds,
- * so the value that gated the resume was whatever was true when the app went away — streaming —
- * and recovery was disabled in exactly the case it was written for. The gate must be a callback
- * (evaluated at fire time) considering only the conversation and user-editing; the streaming
- * decision belongs to resolveResumeAction.
- */
-function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
-  return currentConversationId !== null && !isAnyEditing;
 }
 
 /**
@@ -387,45 +375,18 @@ describe('GlobalAssistantView load-on-select effects', () => {
     });
   });
 
-/**
- * Mirrors the rejoin branch of `tryRecover`: the live stream's messageId is used to evict the
- * half-streamed assistant bubble useChat is still holding, so the rejoined pending stream is not
- * deduped away.
- *
- * `Chat.stop()` "keeps the generated tokens", and a dropped fetch leaves them too — so `messages`
- * still holds an assistant message whose id IS the live stream's messageId (the server mints one
- * id and uses it for BOTH the UI message and the stream registry row). The rejoin re-adds that
- * same stream to the pending store, and the surfaces drop a pending stream whose messageId
- * already appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams).
- * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
- * token renders, and the user stares at a frozen partial.
- */
-function evictStalePartial<T extends { id: string }>(
-  messages: T[],
-  liveMessageId: string,
-  serverPartsCount: number,
-): T[] {
-  // Only when the server has something to put in its place. `parts` from /active-streams is the
-  // registry's DEBOUNCED checkpoint, so it is empty for a stream only a few parts old. Evicting
-  // against an empty checkpoint and then failing the SSE join (the multi-instance case, where the
-  // multicast lives in another process) removes the stream and leaves the user with NOTHING —
-  // strictly worse than the frozen partial we started with.
-  if (serverPartsCount === 0) return messages;
-  return messages.filter((m) => m.id !== liveMessageId);
-}
-
   describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
     describe('resumeEnabled (the gate)', () => {
       it('given a conversation and no active editing, should enable recovery', () => {
-        expect(resumeEnabled('conv-A', false)).toBe(true);
+        expect(canResumeRecovery('conv-A', false)).toBe(true);
       });
 
       it('given no conversation, should NOT enable recovery (nothing to rejoin)', () => {
-        expect(resumeEnabled(null, false)).toBe(false);
+        expect(canResumeRecovery(null, false)).toBe(false);
       });
 
       it('given the user is actively editing, should NOT enable recovery (would clobber their edit)', () => {
-        expect(resumeEnabled('conv-A', true)).toBe(false);
+        expect(canResumeRecovery('conv-A', true)).toBe(false);
       });
 
     });
@@ -571,6 +532,8 @@ function evictStalePartial<T extends { id: string }>(
 
     describe('evictStalePartial (why the rejoin renders at all)', () => {
       const liveId = 'srv-msg-1';
+      // A checkpoint the bootstrap would actually seed from (survives isValidPartFrame).
+      const SEEDED_PARTS = [{ type: 'text', text: 'partial reply' }];
       const messages = [
         { id: 'u1', role: 'user' },
         { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
@@ -579,11 +542,11 @@ function evictStalePartial<T extends { id: string }>(
       it('given a rejoined live stream the server has parts for, should drop the local partial carrying that same messageId', () => {
         // Without this the pending stream the rejoin adds under `liveId` is deduped away,
         // because `liveId` is still present in `messages`. The bubble would never update.
-        expect(evictStalePartial(messages, liveId, 12)).toEqual([{ id: 'u1', role: 'user' }]);
+        expect(evictStalePartial(messages, liveId, SEEDED_PARTS)).toEqual([{ id: 'u1', role: 'user' }]);
       });
 
       it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
-        const remaining = evictStalePartial(messages, liveId, 12);
+        const remaining = evictStalePartial(messages, liveId, SEEDED_PARTS);
         const seen = new Set(remaining.map((m) => m.id));
         expect(seen.has(liveId)).toBe(false);
       });
@@ -593,15 +556,15 @@ function evictStalePartial<T extends { id: string }>(
         // and the SSE join then failed (multi-instance: the multicast lives in another process),
         // the bootstrap removes the stream and the user is left with nothing at all — worse than
         // the frozen partial. Keep what they had; the rejoin can still attach and take over.
-        expect(evictStalePartial(messages, liveId, 0)).toEqual(messages);
+        expect(evictStalePartial(messages, liveId, [])).toEqual(messages);
       });
 
       it('given messages with no matching id, should leave them untouched', () => {
-        expect(evictStalePartial(messages, 'some-other-id', 12)).toEqual(messages);
+        expect(evictStalePartial(messages, 'some-other-id', SEEDED_PARTS)).toEqual(messages);
       });
 
       it('should only ever drop the ONE message the server named — never the user turn', () => {
-        const out = evictStalePartial(messages, liveId, 12);
+        const out = evictStalePartial(messages, liveId, SEEDED_PARTS);
         expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -141,8 +141,6 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  *
  *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
- * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
- * persisted reply; false = nothing live, nothing persisted, or the probe failed.
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
@@ -347,7 +345,17 @@ describe('GlobalAssistantView load-on-select effects', () => {
  * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
  * token renders, and the user stares at a frozen partial.
  */
-function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageId: string): T[] {
+function evictStalePartial<T extends { id: string }>(
+  messages: T[],
+  liveMessageId: string,
+  serverPartsCount: number,
+): T[] {
+  // Only when the server has something to put in its place. `parts` from /active-streams is the
+  // registry's DEBOUNCED checkpoint, so it is empty for a stream only a few parts old. Evicting
+  // against an empty checkpoint and then failing the SSE join (the multi-instance case, where the
+  // multicast lives in another process) removes the stream and leaves the user with NOTHING —
+  // strictly worse than the frozen partial we started with.
+  if (serverPartsCount === 0) return messages;
   return messages.filter((m) => m.id !== liveMessageId);
 }
 
@@ -374,16 +382,6 @@ function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageI
         // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
         // and rejoins; the DB is never read while a run is live.
         expect(planResume({ native: true, isStreaming: true })).toEqual(['stop', 'try-recover']);
-      });
-
-      it('given native, should NOT fall back to a DB refresh when tryRecover comes back empty', () => {
-        // tryRecover returns false in exactly the two cases where a DB write is unsafe: the
-        // probe failed (a stream may still be live — and the first request after a foreground
-        // is the likeliest to fail, radio still coming up), or the DB is behind local state
-        // (a send whose POST never reached the server; refreshing would erase the user's own
-        // prompt). Doing nothing is correct in both; the socket reconnect path heals it.
-        expect(planResume({ native: true, isStreaming: true })).not.toContain('refresh');
-        expect(planResume({ native: true, isStreaming: false })).not.toContain('refresh');
       });
 
       it('given native, should always stop BEFORE recovering', () => {
@@ -418,24 +416,32 @@ function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageI
         { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
       ];
 
-      it('given a rejoined live stream, should drop the local partial carrying that same messageId', () => {
+      it('given a rejoined live stream the server has parts for, should drop the local partial carrying that same messageId', () => {
         // Without this the pending stream the rejoin adds under `liveId` is deduped away,
         // because `liveId` is still present in `messages`. The bubble would never update.
-        expect(evictStalePartial(messages, liveId)).toEqual([{ id: 'u1', role: 'user' }]);
+        expect(evictStalePartial(messages, liveId, 12)).toEqual([{ id: 'u1', role: 'user' }]);
       });
 
       it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
-        const remaining = evictStalePartial(messages, liveId);
+        const remaining = evictStalePartial(messages, liveId, 12);
         const seen = new Set(remaining.map((m) => m.id));
         expect(seen.has(liveId)).toBe(false);
       });
 
+      it('given the server checkpoint is EMPTY, should KEEP the local partial', () => {
+        // The debounced checkpoint is empty for a stream only a few parts old. If we evicted here
+        // and the SSE join then failed (multi-instance: the multicast lives in another process),
+        // the bootstrap removes the stream and the user is left with nothing at all — worse than
+        // the frozen partial. Keep what they had; the rejoin can still attach and take over.
+        expect(evictStalePartial(messages, liveId, 0)).toEqual(messages);
+      });
+
       it('given messages with no matching id, should leave them untouched', () => {
-        expect(evictStalePartial(messages, 'some-other-id')).toEqual(messages);
+        expect(evictStalePartial(messages, 'some-other-id', 12)).toEqual(messages);
       });
 
       it('should only ever drop the ONE message the server named — never the user turn', () => {
-        const out = evictStalePartial(messages, liveId);
+        const out = evictStalePartial(messages, liveId, 12);
         expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -154,6 +154,7 @@ function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
+  somethingRestarted = false,
   stillOnInterruptedConversation = true,
   attempts = [RECOVERED],
 }: {
@@ -168,6 +169,12 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
+  /**
+   * Whether something has ALREADY restarted the turn while we were recovering — useStreamRecovery
+   * watches the same failure from the other side (it fires on `status === 'error'`) and regenerates
+   * too, and the two share no lock.
+   */
+  somethingRestarted?: boolean;
   /**
    * Whether we are still on the conversation the interrupted turn belongs to. The recovery spans
    * seconds of network and the user can switch conversation inside that window; handleRetry always
@@ -197,7 +204,12 @@ function planResume({
   }
 
   // The REAL predicate, not a copy of it.
-  if (ownTurnInFlight && stillOnInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+  if (
+    ownTurnInFlight &&
+    stillOnInterruptedConversation &&
+    !somethingRestarted &&
+    canConcludeTurnIsLost(attempt)
+  ) {
     effects.push('regenerate');
   }
   return effects;
@@ -453,6 +465,23 @@ describe('GlobalAssistantView load-on-select effects', () => {
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
         expect(plan).not.toContain('regenerate');
+      });
+
+      it('given useStreamRecovery already restarted the turn, should NOT regenerate again', () => {
+        // The two paths watch the same failure and share no lock: useStreamRecovery fires on
+        // `status === 'error'`, and rawStop() cannot have cancelled it (Chat.stop returns early
+        // unless the status is streaming/submitted). Regenerating on top would be exactly the
+        // double destruction the gate exists to prevent — takeOverConversationStreams aborts the
+        // run that just started, and handleRetry deletes its assistant message on the way in.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            somethingRestarted: true,
+            attempts: [ANSWERED_NOTHING],
+          }),
+        ).toEqual(['stop', 'try-recover']);
       });
 
       it('given the user switched conversation during the recovery, should NOT regenerate', () => {

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -123,9 +123,13 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
 }
 
 /**
- * Mirrors the side effects of the `onResume` body, in order. The decision itself is NOT
- * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring (which stop,
- * which rejoin, and that the DB refresh runs last) against the real policy.
+ * Mirrors the side effects of the `onResume` body, IN ORDER. The decision itself is NOT
+ * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
+ * real policy.
+ *
+ * The order is the point: stop → refresh → rejoin. The refresh is awaited BEFORE the rejoin
+ * so that no DB request is outstanding when the rejoined stream completes; see the
+ * ordering tests below.
  */
 type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
 
@@ -140,14 +144,10 @@ function planResume({
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
-  const effects: ResumeEffect[] = [];
-  if (action === 'rejoin-and-refresh') {
-    // rawStop is local-only — it clears useChat state so the rejoin attaches cleanly.
-    // It does NOT signal the server; the run keeps generating and is rejoined below.
-    effects.push('stop', selectedAgent ? 'rejoin-agent' : 'rejoin-global');
-  }
-  effects.push('refresh');
-  return effects;
+  if (action !== 'rejoin-and-refresh') return ['refresh'];
+  // rawStop is local-only — it clears useChat state so the refresh and rejoin write cleanly.
+  // It does NOT signal the server; the run keeps generating and is rejoined below.
+  return ['stop', 'refresh', selectedAgent ? 'rejoin-agent' : 'rejoin-global'];
 }
 
 const mockAgent = { id: 'agent-123' };
@@ -336,44 +336,55 @@ describe('GlobalAssistantView load-on-select effects', () => {
         expect(resumeEnabled('conv-A', true)).toBe(false);
       });
 
-      it('given a stream is in flight, should STILL enable recovery — streaming is not an input to the gate', () => {
+      it('given the gate signature, streaming must not be an input at all', () => {
         // THE REGRESSION. The gate used to be a render-time boolean that folded in
         // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
         // that gated the resume was whatever was true when the app went away — i.e.
         // streaming — which disabled recovery in exactly the case it was written for.
-        // The gate takes no streaming argument at all now; there is no way to express
-        // that bug in this signature. The streaming decision belongs to
-        // resolveResumeAction, at fire time.
-        expect(resumeEnabled('conv-A', false)).toBe(true);
+        // The streaming decision belongs to resolveResumeAction, evaluated at fire time;
+        // the gate must only ever consider the conversation and user-editing. Pinned on
+        // arity so a third `isStreaming` parameter cannot be reintroduced silently.
+        expect(resumeEnabled.length).toBe(2);
       });
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, rejoin the global stream, then refresh', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, refresh, then rejoin the global stream', () => {
         expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
           'stop',
-          'rejoin-global',
           'refresh',
+          'rejoin-global',
         ]);
       });
 
       it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
         expect(planResume({ native: true, isStreaming: true, selectedAgent: { id: 'agent-1' } })).toEqual([
           'stop',
-          'rejoin-agent',
           'refresh',
+          'rejoin-agent',
         ]);
       });
 
-      it('given native and NOT streaming, should still rejoin — the recovery is deterministic, not flag-gated', () => {
+      it('given native, should await the refresh BEFORE the rejoin — never after it', () => {
+        // Order is the fix for a reply-wiping race. The reply is not persisted until the run
+        // completes, so a refresh issued alongside a live stream returns a snapshot with no
+        // assistant message. Fired AFTER the rejoin, that request could still be in flight when
+        // the rejoined stream completed — landing last and overwriting the just-completed reply
+        // with the pre-reply snapshot. In agent mode nothing heals that (no completion-triggered
+        // refetch), so the reply would stay invisible until the conversation was reselected.
+        const plan = planResume({ native: true, isStreaming: true, selectedAgent: { id: 'agent-1' } });
+        expect(plan.indexOf('refresh')).toBeLessThan(plan.indexOf('rejoin-agent'));
+        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('refresh'));
+      });
+
+      it('given native and NOT streaming, should still stop and rejoin — the recovery is deterministic, not flag-gated', () => {
         // The local fetch is dead after backgrounding regardless of what useChat still
         // reports, so native always rejoins. /active-streams is the authoritative answer
         // on whether a stream is actually live; no client flag gates the rejoin.
-        expect(planResume({ native: false, isStreaming: false, selectedAgent: null })).toEqual(['refresh']);
         expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
           'stop',
-          'rejoin-global',
           'refresh',
+          'rejoin-global',
         ]);
       });
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -403,6 +403,64 @@ describe('GlobalAssistantView load-on-select effects', () => {
 
     });
 
+    describe('regenerateTurnOnce (the mutex both recovery paths share)', () => {
+      // Mirrors the component's wrapper. useStreamRecovery and the resume handler watch the same
+      // failure from opposite sides and would otherwise regenerate the same turn twice — and
+      // useStreamRecovery calls clearError() BEFORE its own probes, so for its whole decision
+      // window the chat looks idle to us. Two regenerates for one turn is the double destruction
+      // the resume gate exists to prevent: the server takes over the conversation on every
+      // generation start, so the second aborts the first, and handleRetry deletes its assistant
+      // message on the way in.
+      function makeRegenerateTurnOnce(handleRetry: () => Promise<void>) {
+        let inFlight = false;
+        return async () => {
+          if (inFlight) return;
+          inFlight = true;
+          try {
+            await handleRetry();
+          } finally {
+            inFlight = false;
+          }
+        };
+      }
+
+      it('given both paths fire while the first is still running, should regenerate ONCE', async () => {
+        let calls = 0;
+        let release!: () => void;
+        const blocked = new Promise<void>((r) => { release = r; });
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => {
+          calls += 1;
+          await blocked; // handleRetry's message DELETEs are a network round-trip
+        });
+
+        const first = regenerateTurnOnce();  // useStreamRecovery's retry
+        const second = regenerateTurnOnce(); // the resume handler, deciding concurrently
+        release();
+        await Promise.all([first, second]);
+
+        expect(calls).toBe(1);
+      });
+
+      it('given the lock was released, should allow a LATER regenerate (it is a mutex, not a one-shot latch)', async () => {
+        let calls = 0;
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => { calls += 1; });
+        await regenerateTurnOnce();
+        await regenerateTurnOnce();
+        expect(calls).toBe(2);
+      });
+
+      it('given handleRetry throws, should still release the lock', async () => {
+        let calls = 0;
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => {
+          calls += 1;
+          throw new Error('regenerate failed');
+        });
+        await expect(regenerateTurnOnce()).rejects.toThrow('regenerate failed');
+        await expect(regenerateTurnOnce()).rejects.toThrow('regenerate failed');
+        expect(calls).toBe(2); // not wedged shut
+      });
+    });
+
     describe('planResume (the onResume body)', () => {
       it('given native mid-stream (the orphaned-stream bug), should stop the local fetch and hand off to tryRecover — and NOT read the DB', () => {
         // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/GlobalAssistantView.test.tsx
@@ -115,8 +115,12 @@ function createRefAdvancesOnlyOnApplySimulator<X>() {
 /**
  * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
  *
- * Deliberately takes NO streaming argument. The gate must be a callback (evaluated at
- * fire time, on resume) and must gate on user-editing only. See the regression test below.
+ * Deliberately takes NO streaming argument, which is the whole point. The gate used to be a
+ * render-time boolean folding in `!isStreaming`; iOS freezes JS the moment the app backgrounds,
+ * so the value that gated the resume was whatever was true when the app went away — streaming —
+ * and recovery was disabled in exactly the case it was written for. The gate must be a callback
+ * (evaluated at fire time) considering only the conversation and user-editing; the streaming
+ * decision belongs to resolveResumeAction.
  */
 function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
   return currentConversationId !== null && !isAnyEditing;
@@ -127,27 +131,33 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
  * real policy.
  *
- * The order is the point: stop → refresh → rejoin. The refresh is awaited BEFORE the rejoin
- * so that no DB request is outstanding when the rejoined stream completes; see the
- * ordering tests below.
+ * The critical property: on the rejoin path we stop the local fetch and hand off to
+ * `tryRecover` (the /active-streams-first probe), and we DO NOT touch the DB unless
+ * tryRecover comes back empty. A blind DB refresh while a run is still generating would
+ * write a snapshot with no assistant message over the in-progress bubble.
+ *
+ * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
+ * persisted reply; false = nothing live, nothing persisted.
  */
-type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
+type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
 function planResume({
   native,
   isStreaming,
-  selectedAgent,
+  recovered = false,
 }: {
   native: boolean;
   isStreaming: boolean;
-  selectedAgent: { id: string } | null;
+  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
   if (action !== 'rejoin-and-refresh') return ['refresh'];
-  // rawStop is local-only — it clears useChat state so the refresh and rejoin write cleanly.
-  // It does NOT signal the server; the run keeps generating and is rejoined below.
-  return ['stop', 'refresh', selectedAgent ? 'rejoin-agent' : 'rejoin-global'];
+  // rawStop is local-only — it clears useChat state and releases the channel's `consuming`
+  // mark so the rejoin's bootstrap will attach. It does NOT signal the server; the run keeps
+  // generating and stays rejoinable.
+  if (recovered) return ['stop', 'try-recover'];
+  return ['stop', 'try-recover', 'refresh'];
 }
 
 const mockAgent = { id: 'agent-123' };
@@ -336,66 +346,53 @@ describe('GlobalAssistantView load-on-select effects', () => {
         expect(resumeEnabled('conv-A', true)).toBe(false);
       });
 
-      it('given the gate signature, streaming must not be an input at all', () => {
-        // THE REGRESSION. The gate used to be a render-time boolean that folded in
-        // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
-        // that gated the resume was whatever was true when the app went away — i.e.
-        // streaming — which disabled recovery in exactly the case it was written for.
-        // The streaming decision belongs to resolveResumeAction, evaluated at fire time;
-        // the gate must only ever consider the conversation and user-editing. Pinned on
-        // arity so a third `isStreaming` parameter cannot be reintroduced silently.
-        expect(resumeEnabled.length).toBe(2);
-      });
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, refresh, then rejoin the global stream', () => {
-        expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
+      it('given native mid-stream and a live stream to rejoin, should stop the local fetch and hand off to tryRecover — and NOT touch the DB', () => {
+        // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB
+        // snapshot taken while the stream is still generating contains no assistant message.
+        // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
+        // and rejoins; the DB is never read on this path.
+        expect(planResume({ native: true, isStreaming: true, recovered: true })).toEqual([
           'stop',
-          'refresh',
-          'rejoin-global',
+          'try-recover',
         ]);
       });
 
-      it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
-        expect(planResume({ native: true, isStreaming: true, selectedAgent: { id: 'agent-1' } })).toEqual([
+      it('given native and tryRecover finds nothing live or persisted, should fall back to a DB refresh', () => {
+        expect(planResume({ native: true, isStreaming: true, recovered: false })).toEqual([
           'stop',
+          'try-recover',
           'refresh',
-          'rejoin-agent',
         ]);
       });
 
-      it('given native, should await the refresh BEFORE the rejoin — never after it', () => {
-        // Order is the fix for a reply-wiping race. The reply is not persisted until the run
-        // completes, so a refresh issued alongside a live stream returns a snapshot with no
-        // assistant message. Fired AFTER the rejoin, that request could still be in flight when
-        // the rejoined stream completed — landing last and overwriting the just-completed reply
-        // with the pre-reply snapshot. In agent mode nothing heals that (no completion-triggered
-        // refetch), so the reply would stay invisible until the conversation was reselected.
-        const plan = planResume({ native: true, isStreaming: true, selectedAgent: { id: 'agent-1' } });
-        expect(plan.indexOf('refresh')).toBeLessThan(plan.indexOf('rejoin-agent'));
-        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('refresh'));
+      it('given native, should always stop BEFORE recovering', () => {
+        // The stop is local-only, but it is what ends the dead response body and so releases
+        // the channel's `consuming` mark. Without that, the rejoin's bootstrap classifies the
+        // stream as one we are already reading off the POST body and skips attaching it — the
+        // rejoin would silently do nothing.
+        const plan = planResume({ native: true, isStreaming: true, recovered: true });
+        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('try-recover'));
       });
 
-      it('given native and NOT streaming, should still stop and rejoin — the recovery is deterministic, not flag-gated', () => {
+      it('given native and NOT streaming, should still stop and probe — the recovery is deterministic, not flag-gated', () => {
         // The local fetch is dead after backgrounding regardless of what useChat still
-        // reports, so native always rejoins. /active-streams is the authoritative answer
+        // reports, so native always probes. /active-streams is the authoritative answer
         // on whether a stream is actually live; no client flag gates the rejoin.
-        expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, recovered: true })).toEqual([
           'stop',
-          'refresh',
-          'rejoin-global',
+          'try-recover',
         ]);
       });
 
       it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
-        expect(planResume({ native: false, isStreaming: true, selectedAgent: null })).toEqual([]);
+        expect(planResume({ native: false, isStreaming: true })).toEqual([]);
       });
 
-      it('given web with no live fetch, should refresh only (no stop, no rejoin)', () => {
-        expect(planResume({ native: false, isStreaming: false, selectedAgent: { id: 'agent-1' } })).toEqual([
-          'refresh',
-        ]);
+      it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
+        expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
       });
     });
   });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -906,7 +906,12 @@ const SidebarChatTab: React.FC = () => {
       );
       if (res.ok) {
         const data = (await res.json()) as {
-          streams?: Array<{ messageId: string; conversationId: string; triggeredBy: { userId: string } }>;
+          streams?: Array<{
+            messageId: string;
+            conversationId: string;
+            parts?: unknown[];
+            triggeredBy: { userId: string };
+          }>;
         };
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
@@ -923,16 +928,22 @@ const SidebarChatTab: React.FC = () => {
           // straight back out and not one token of it would ever render. The user would sit in
           // front of a frozen partial reply.
           //
-          // Nothing is lost by dropping it: the bootstrap seeds the stream from the server's
-          // registry buffer, which holds every part pushed so far — strictly more than the
-          // partial we froze with.
+          // Only when the server has something to put in its place, though. `parts` here is the
+          // registry's DEBOUNCED checkpoint (persisted every N parts), so it is empty for a stream
+          // that is only a few parts old. Evict against an empty checkpoint and, if the SSE join
+          // then fails — the documented multi-instance case, where the multicast lives in another
+          // process — the bootstrap removes the stream and the user is left with NOTHING, which is
+          // strictly worse than the frozen partial we started with. In that case keep the partial:
+          // the rejoin can still attach and take over, and if it cannot, the user keeps what they
+          // had.
           const staleId = liveStream.messageId;
+          const hasServerParts = (liveStream.parts?.length ?? 0) > 0;
           const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           if (selectedAgent) {
-            setMessages(evictStale);
+            if (hasServerParts) setMessages(evictStale);
             rejoinAgentStream();
           } else {
-            setGlobalMessages(evictStale);
+            if (hasServerParts) setGlobalMessages(evictStale);
             rejoinGlobalStream();
           }
           return true;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -1039,11 +1039,18 @@ const SidebarChatTab: React.FC = () => {
         await handleAppResume();
         return;
       }
-      // Native. Whether a turn was actually in flight when we went away. iOS froze JS at that
-      // moment, so this render-time value is a faithful record of it — which is exactly what it
-      // is used for here, and why it is safe even though it is useless for deciding whether the
-      // TRANSPORT is still alive (that is resolveResumeAction's job, and the answer is "no").
-      const hadTurnInFlight = displayIsStreaming;
+      // Native. Whether a turn of OUR OWN was in flight, for the conversation on screen, when we
+      // went away. iOS froze JS at that moment, so this render-time value is a faithful record of
+      // it — which is exactly what it is used for here, and why it is safe even though it is
+      // useless for deciding whether the TRANSPORT is still alive (that is resolveResumeAction's
+      // job, and the answer is "no").
+      //
+      // Conversation-scoped, NOT the broader displayIsStreaming: that also reports true for a
+      // stream still running against a conversation the user has since navigated away from (the
+      // useChat id is stable across a switch), and regenerating on the strength of it would fire
+      // a generation for the turn the user is now LOOKING at rather than the one that was
+      // actually interrupted.
+      const hadTurnInFlight = isOwnStreamForCurrentConversation;
 
       // Local-only useChat stop: it does NOT signal the server (that is done separately via
       // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
@@ -1069,7 +1076,14 @@ const SidebarChatTab: React.FC = () => {
       // Gated on a turn actually having been in flight, so an ordinary resume on an idle
       // conversation can never fire a spurious generation.
       if (hadTurnInFlight) await handleRetry();
-    }, [displayIsStreaming, stop, tryRecover, handleAppResume, handleRetry]),
+    }, [
+      displayIsStreaming,
+      isOwnStreamForCurrentConversation,
+      stop,
+      tryRecover,
+      handleAppResume,
+      handleRetry,
+    ]),
     enabled: resumeEnabled,
   });
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -51,6 +51,7 @@ import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMes
 import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode';
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
+import type { RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
 import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
@@ -400,12 +401,6 @@ const SidebarChatTab: React.FC = () => {
   const [globalMessagesLoadError, setGlobalMessagesLoadError] = useState<Error | null>(null);
   // Stale-request guard: holds the conversationId of the most recent load request.
   const globalLoadRequestedIdRef = useRef<string | null>(null);
-  // Whether the LAST /active-streams probe actually reached the server and answered.
-  //
-  // tryRecover returns false for two semantically opposite outcomes — "the server says nothing is
-  // live" and "the probe never got an answer" — and the resume path must not treat silence as an
-  // answer. See the regenerate gate in useAppStateRecovery below.
-  const probeAnsweredRef = useRef(false);
   // Synchronously updated each render — lets tryRecover read the live message
   // count without adding messages to its useCallback deps.
   const currentMessagesRef = useRef(messages);
@@ -901,20 +896,21 @@ const SidebarChatTab: React.FC = () => {
   //   1. Check /api/ai/chat/active-streams — if the original run is still live, rejoin it.
   //   2. Else fetch messages from the DB — if the run persisted a reply, surface it.
   //   3. Only fall through to regenerate() when neither path finds anything to recover.
-  const tryRecover = useCallback(async (): Promise<boolean> => {
-    if (!currentConversationId) return false;
+  const tryRecover = useCallback(async (): Promise<RecoveryAttempt> => {
+    // `probeAnswered` is RETURNED, never stashed in a ref. tryRecover has two callers — this
+    // surface's resume handler and useStreamRecovery's network-error retry — and they can be in
+    // flight together. A single shared slot would let one caller's probe answer the other's
+    // question, which on this path means regenerating over a run we never actually asked about.
+    let probeAnswered = false;
+    if (!currentConversationId) return { recovered: false, probeAnswered };
     const channelId = selectedAgent?.id ?? channelIdForGlobal;
-    if (!channelId) return false;
+    if (!channelId) return { recovered: false, probeAnswered };
 
     // Step 1: live stream check
-    probeAnsweredRef.current = false;
     try {
       const res = await fetchWithAuth(
         `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
       );
-      // Reachability, recorded separately from the verdict: only a 2xx means the server actually
-      // TOLD us what is live. A throw or a non-ok leaves us knowing nothing.
-      probeAnsweredRef.current = res.ok;
       if (res.ok) {
         const data = (await res.json()) as {
           streams?: Array<{
@@ -924,6 +920,11 @@ const SidebarChatTab: React.FC = () => {
             triggeredBy: { userId: string };
           }>;
         };
+        // Only NOW do we know the server told us something. Setting this off `res.ok` alone would
+        // be a lie: res.json() can still throw on a body that dies mid-read — which is exactly the
+        // cold-radio-after-foreground case this whole path exists for — and the catch below would
+        // swallow it while we went on believing we had an answer.
+        probeAnswered = true;
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
         );
@@ -962,7 +963,7 @@ const SidebarChatTab: React.FC = () => {
             if (hasServerParts) setGlobalMessages(evictStale);
             rejoinGlobalStream();
           }
-          return true;
+          return { recovered: true, probeAnswered };
         }
       }
     } catch { /* network error — fall through to DB check */ }
@@ -987,17 +988,21 @@ const SidebarChatTab: React.FC = () => {
           msgs[msgs.length - 1].role === 'assistant' &&
           dbUserCount >= localUserCount;
         if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          // Write the SAME normalized array the guards above were computed from. Reading
+          // defensively and then writing `data.messages` raw would blank the surface outright if
+          // the route ever answered with a bare array.
+          const serverMessages = msgs as unknown as UIMessage[];
           if (selectedAgent) {
-            setMessages(data.messages);
+            setMessages(serverMessages);
           } else {
-            setGlobalMessages(data.messages);
+            setGlobalMessages(serverMessages);
           }
-          return true;
+          return { recovered: true, probeAnswered };
         }
       }
     } catch { /* network error — fall through to regenerate */ }
 
-    return false;
+    return { recovered: false, probeAnswered };
   }, [
     currentConversationId,
     selectedAgent,
@@ -1010,7 +1015,10 @@ const SidebarChatTab: React.FC = () => {
   ]);
 
   // Auto-retry on network errors — rejoin-first, regenerate only as last resort
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover });
+  // useStreamRecovery only asks "did you recover?" — the probe-reachability half of the answer is
+  // for the resume path, which is the one that would otherwise regenerate over a live run.
+  const tryRecoverForError = useCallback(async () => (await tryRecover()).recovered, [tryRecover]);
+  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover: tryRecoverForError });
 
   // App state recovery — deterministic stream rejoin on mobile.
   //
@@ -1068,20 +1076,22 @@ const SidebarChatTab: React.FC = () => {
       // that the rejoin's bootstrap would classify the stream as one we are already reading off
       // the POST and skip attaching it.
       stop();
-      if (await tryRecover()) return;
+      let attempt = await tryRecover();
+      if (attempt.recovered) return;
 
-      // tryRecover came up empty — but that means one of two OPPOSITE things, and only one of them
-      // is an answer:
+      // Came up empty — but that means one of two OPPOSITE things, and only one of them is an
+      // answer:
       //
-      //   "the server says nothing is live"  → the run died; regenerating is the recovery.
+      //   "the server says nothing is live"    → the run died; regenerating is the recovery.
       //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
       //
       // The first request after a foreground is the one most likely to fail (cold radio), so on
       // this path the second case is common. Re-probe a couple of times before concluding: the
       // radio comes back well inside a few seconds.
-      for (let attempt = 1; !probeAnsweredRef.current && attempt <= 2; attempt++) {
-        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
-        if (await tryRecover()) return;
+      for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+        await new Promise((resolve) => setTimeout(resolve, i * 1000));
+        attempt = await tryRecover();
+        if (attempt.recovered) return;
       }
 
       // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
@@ -1100,7 +1110,7 @@ const SidebarChatTab: React.FC = () => {
       // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
       // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
       // leaves the user their prompt and the retry action on it.
-      if (hadTurnInFlight && probeAnsweredRef.current) await handleRetry();
+      if (hadTurnInFlight && attempt.probeAnswered) await handleRetry();
     }, [
       displayIsStreaming,
       isOwnStreamForCurrentConversation,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -1045,7 +1045,33 @@ const SidebarChatTab: React.FC = () => {
   // useStreamRecovery only asks "did you recover?" — the probe-reachability half of the answer is
   // for the resume path, which is the one that would otherwise regenerate over a live run.
   const tryRecoverForError = useCallback(async () => (await tryRecover()).recovered, [tryRecover]);
-  useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover: tryRecoverForError });
+
+  // ONE mutex across BOTH recovery paths.
+  //
+  // useStreamRecovery watches this same failure from the other side (it fires on
+  // `status === 'error'`) and regenerates too, and the two shared no lock. Either could decide to
+  // regenerate the turn while the other was still deciding — useStreamRecovery calls clearError()
+  // BEFORE running its own probes, so for the whole of its decision window the status reads
+  // `ready` and looks idle to us. Two regenerates for one turn is the double destruction the
+  // resume gate exists to prevent: the server takes over the conversation on every generation
+  // start, so the second aborts the first, and handleRetry deletes its assistant message on the
+  // way in.
+  //
+  // The lock is held across the whole of handleRetry — its message DELETEs are a network
+  // round-trip — after which the restarted generation's own `submitted` status keeps the other
+  // path out (see `nothingHasRestarted` below).
+  const regenerationInFlightRef = useRef(false);
+  const regenerateTurnOnce = useCallback(async () => {
+    if (regenerationInFlightRef.current) return;
+    regenerationInFlightRef.current = true;
+    try {
+      await handleRetry();
+    } finally {
+      regenerationInFlightRef.current = false;
+    }
+  }, [handleRetry]);
+
+  useStreamRecovery({ error, status, clearError, handleRetry: regenerateTurnOnce, maxRetries: 2, tryRecover: tryRecoverForError });
 
   // App state recovery — deterministic stream rejoin on mobile.
   //
@@ -1152,15 +1178,11 @@ const SidebarChatTab: React.FC = () => {
       // their prompt and the retry action on it.
       const stillOnTheInterruptedConversation =
         currentConversationIdRef.current === conversationAtResume;
-      // Nothing has restarted the turn in the meantime. useStreamRecovery watches the SAME failure
-      // from the other side (it fires on `status === 'error'`) and regenerates too, and the two
-      // share no lock. If iOS delivers the dead fetch's rejection as an error before this listener
-      // runs, useStreamRecovery may already have retried — and `rawStop()` above would have been a
-      // no-op, since Chat.stop() returns early unless the status is streaming/submitted, so it
-      // cannot have cancelled that. Regenerating on top would be exactly the double destruction the
-      // gate below exists to prevent: takeOverConversationStreams aborts the run that just started,
-      // and handleRetry deletes its assistant message on the way in. Read through a ref because the
-      // closure's copy is the value captured before we were frozen.
+      // Belt to regenerateTurnOnce's braces. The mutex stops the two paths regenerating at the
+      // same moment; this stops us regenerating on top of a turn that has ALREADY restarted and
+      // moved on — the mutex is released as soon as handleRetry returns, but the generation it
+      // kicked off is still running. Read through a ref because the closure's copy of `isStreaming`
+      // is the value captured before we were frozen.
       const nothingHasRestarted = !isStreamingRef.current;
       if (
         hadTurnInFlight &&
@@ -1168,7 +1190,7 @@ const SidebarChatTab: React.FC = () => {
         nothingHasRestarted &&
         canConcludeTurnIsLost(attempt)
       ) {
-        await handleRetry();
+        await regenerateTurnOnce();
       }
     }, [
       displayIsStreaming,
@@ -1177,7 +1199,7 @@ const SidebarChatTab: React.FC = () => {
       stop,
       tryRecover,
       handleAppResume,
-      handleRetry,
+      regenerateTurnOnce,
     ]),
     enabled: resumeEnabled,
   });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -628,59 +628,6 @@ const SidebarChatTab: React.FC = () => {
     }
   }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, loadGlobalMessages]);
 
-  // App state recovery — deterministic stream rejoin on mobile.
-  //
-  // The `enabled` gate MUST be a callback, not a render-time boolean: iOS freezes JS the
-  // moment the app backgrounds, so a boolean captured at render is whatever was true when
-  // the app went away. That is how this path was dead in exactly the case it was written
-  // for — `!isStreaming` was false (streaming), and the recovery hook was gated off.
-  //
-  // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
-  // (the local fetch is dead after backgrounding).
-  //
-  // ORDER IS LOAD-BEARING: stop → await refresh → rejoin.
-  //
-  // The refresh must be AWAITED BEFORE the rejoin, not fired after it. The reply is not
-  // persisted until the run completes, so a refresh issued alongside a live stream returns a
-  // snapshot with no assistant message. If that request were still in flight when the rejoined
-  // stream completed, its response would land last and overwrite the freshly-completed reply
-  // with the pre-reply snapshot. Awaiting the refresh first means no DB request is ever
-  // outstanding when the stream completes: the refresh catches a run that finished while
-  // backgrounded, and the rejoin then attaches to one that is still live.
-  const resumeEnabled = useCallback(
-    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
-    [currentConversationId],
-  );
-
-  useAppStateRecovery({
-    onResume: useCallback(async () => {
-      const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
-      if (action === 'noop') return;
-      if (action !== 'rejoin-and-refresh') {
-        await handleAppResume();
-        return;
-      }
-      // `stop` is the local-only useChat stop; it does NOT signal the server (that is
-      // done separately via abortActiveStreamByMessageId). We only clear the local
-      // streaming state so the refresh and rejoin can write cleanly.
-      stop();
-      await handleAppResume();
-      if (selectedAgent) {
-        rejoinAgentStream();
-      } else {
-        rejoinGlobalStream();
-      }
-    }, [
-      displayIsStreaming,
-      stop,
-      selectedAgent,
-      rejoinAgentStream,
-      rejoinGlobalStream,
-      handleAppResume,
-    ]),
-    enabled: resumeEnabled,
-  });
-
   // Clean up stream tracking on unmount or conversation change.
   //
   // Keyed by `sidebarChatId` — THE KEY THIS SURFACE ACTUALLY REGISTERED. It used to clear the bare
@@ -1026,6 +973,52 @@ const SidebarChatTab: React.FC = () => {
 
   // Auto-retry on network errors — rejoin-first, regenerate only as last resort
   useStreamRecovery({ error, status, clearError, handleRetry, maxRetries: 2, tryRecover });
+
+  // App state recovery — deterministic stream rejoin on mobile.
+  //
+  // Placed HERE, below tryRecover, rather than up with the other effects: it delegates to
+  // tryRecover, and a resume callback declared above it would close over a temporal-dead-zone
+  // binding.
+  //
+  // The `enabled` gate MUST be a callback, not a render-time boolean: iOS freezes JS the moment
+  // the app backgrounds, so a boolean captured at render is whatever was true when the app went
+  // away. That is how this path was dead in exactly the case it was written for — `!isStreaming`
+  // was false (streaming), and the recovery hook was gated off.
+  //
+  // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh' (the
+  // local fetch is dead after backgrounding) — and then delegates to `tryRecover`, the same
+  // rejoin-first probe useStreamRecovery uses on a network error, because a background/foreground
+  // cycle IS a network error on iOS, just one we are told about. Do NOT blind-refresh from the DB
+  // here: the reply is not persisted until the run completes, so while a stream is still live a DB
+  // snapshot contains no assistant message and writing it would wipe the in-progress bubble.
+  // tryRecover asks /active-streams first — the server's authoritative answer — and only touches
+  // the DB when nothing is live:
+  //
+  //   live stream        → rejoin it, no DB read at all
+  //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
+  //   neither            → falls through to handleAppResume
+  const resumeEnabled = useCallback(
+    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    [currentConversationId],
+  );
+
+  useAppStateRecovery({
+    onResume: useCallback(async () => {
+      const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
+      if (action === 'noop') return;
+      if (action === 'rejoin-and-refresh') {
+        // Local-only useChat stop. It does NOT signal the server (that is done separately via
+        // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
+        // also ends the dead response body, which releases this channel's `consuming` mark —
+        // without that the rejoin's bootstrap would classify the stream as one we are already
+        // reading off the POST and skip attaching it.
+        stop();
+        if (await tryRecover()) return;
+      }
+      await handleAppResume();
+    }, [displayIsStreaming, stop, tryRecover, handleAppResume]),
+    enabled: resumeEnabled,
+  });
 
   // Adapter for AgentSelector (converts SidebarAgentInfo to AgentInfo shape)
   const handleSelectAgent = useCallback((agent: SidebarAgentInfo | null) => {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -604,21 +604,23 @@ const SidebarChatTab: React.FC = () => {
 
   // App state recovery - refresh messages when returning from background
   // This catches completed AI responses that finished while the app was backgrounded
+  // Refresh this surface from the DB after a background resume.
+  //
+  // Global mode funnels through `loadGlobalMessages` — the single writer for the global-mode
+  // server→view path — rather than doing its own fetch. This runs DURING an active own stream
+  // on the resume path (see useAppStateRecovery below), and only that loader carries the two
+  // guards that make a mid-stream DB read safe: a stale-response check (so a response arriving
+  // after a conversation switch cannot clobber the conversation the user moved to) and
+  // `mergeServerAndPending` (which re-attaches the in-flight assistant bubble, absent from the
+  // DB snapshot because the reply is not persisted until the run completes). The raw fetch this
+  // replaced had neither, so it wrote a pre-reply snapshot straight over the live bubble.
   const handleAppResume = useCallback(async () => {
     if (selectedAgent) {
       await refreshAgentConversation();
     } else if (globalConversationId && globalIsInitialized) {
-      try {
-        const res = await fetchWithAuth(`/api/ai/global/${globalConversationId}/messages`);
-        if (res.ok) {
-          const data = await res.json();
-          setGlobalMessages(data.messages);
-        }
-      } catch (err) {
-        console.error('Failed to refresh global messages after resume:', err);
-      }
+      loadGlobalMessages(globalConversationId);
     }
-  }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, setGlobalMessages]);
+  }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, loadGlobalMessages]);
 
   // App state recovery — deterministic stream rejoin on mobile.
   //
@@ -628,9 +630,17 @@ const SidebarChatTab: React.FC = () => {
   // for — `!isStreaming` was false (streaming), and the recovery hook was gated off.
   //
   // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
-  // (the local fetch is dead after backgrounding), so we stop the local useChat state,
-  // rejoin the server-owned stream, then refresh from DB to catch a stream that finished
-  // while backgrounded.
+  // (the local fetch is dead after backgrounding).
+  //
+  // ORDER IS LOAD-BEARING: stop → await refresh → rejoin.
+  //
+  // The refresh must be AWAITED BEFORE the rejoin, not fired after it. The reply is not
+  // persisted until the run completes, so a refresh issued alongside a live stream returns a
+  // snapshot with no assistant message. If that request were still in flight when the rejoined
+  // stream completed, its response would land last and overwrite the freshly-completed reply
+  // with the pre-reply snapshot. Awaiting the refresh first means no DB request is ever
+  // outstanding when the stream completes: the refresh catches a run that finished while
+  // backgrounded, and the rejoin then attaches to one that is still live.
   const resumeEnabled = useCallback(
     () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
     [currentConversationId],
@@ -640,18 +650,20 @@ const SidebarChatTab: React.FC = () => {
     onResume: useCallback(async () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
       if (action === 'noop') return;
-      if (action === 'rejoin-and-refresh') {
-        // `stop` is the local-only useChat stop; it does NOT signal the server (that is
-        // done separately via abortActiveStreamByMessageId). We only clear the local
-        // streaming state so the rejoin can attach cleanly.
-        stop();
-        if (selectedAgent) {
-          rejoinAgentStream();
-        } else {
-          rejoinGlobalStream();
-        }
+      if (action !== 'rejoin-and-refresh') {
+        await handleAppResume();
+        return;
       }
+      // `stop` is the local-only useChat stop; it does NOT signal the server (that is
+      // done separately via abortActiveStreamByMessageId). We only clear the local
+      // streaming state so the refresh and rejoin can write cleanly.
+      stop();
       await handleAppResume();
+      if (selectedAgent) {
+        rejoinAgentStream();
+      } else {
+        rejoinGlobalStream();
+      }
     }, [
       displayIsStreaming,
       stop,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -327,6 +327,10 @@ const SidebarChatTab: React.FC = () => {
   // to the conversation now being loaded. Used by the load-on-select/refresh effects below so a
   // switch to an idle conversation isn't blocked by an unrelated stream still running elsewhere.
   const isOwnStreamForCurrentConversation = isStreaming && heldStreamConvIdRef.current === currentConversationId;
+  // Mirrored so the resume handler can read it AFTER its awaits. Its own closure captured the
+  // pre-background value, which cannot tell it whether a generation has since restarted.
+  const isStreamingRef = useRef(false);
+  isStreamingRef.current = isStreaming;
 
   // ============================================
   // Remote Streams (multiplayer rendering)
@@ -942,11 +946,11 @@ const SidebarChatTab: React.FC = () => {
         const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === conversationId && s.triggeredBy.userId === user?.id,
         );
-        if (
-          liveStream &&
-          stillOnThisConversation() &&
-          decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
-        ) {
+        // decideRecovery's priority (rejoin > refetch > regenerate) is expressed by the ORDER of
+        // these steps, not by a call here: with hasLiveStream hardcoded true it could only ever
+        // answer 'rejoin', so asking would be decoration. Step 2 below is where it genuinely
+        // decides. A live stream is always rejoined, never read around.
+        if (liveStream && stillOnThisConversation()) {
           // Evict the half-streamed assistant bubble useChat is still holding for this run. See
           // evictStalePartial: without it the rejoined stream is deduped straight back out and
           // renders nothing, and it is safe only when the server's checkpoint has frames the
@@ -1065,7 +1069,8 @@ const SidebarChatTab: React.FC = () => {
   //
   //   live stream        → rejoin it, no DB read at all
   //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
-  //   neither            → falls through to handleAppResume
+  //   neither            → regenerate — but ONLY once both questions actually came back
+  //                         (canConcludeTurnIsLost). Never a DB refresh: see the gate below.
   const resumeEnabled = useCallback(
     () => canResumeRecovery(currentConversationId, useEditingStore.getState().isAnyEditing()),
     [currentConversationId],
@@ -1147,7 +1152,22 @@ const SidebarChatTab: React.FC = () => {
       // their prompt and the retry action on it.
       const stillOnTheInterruptedConversation =
         currentConversationIdRef.current === conversationAtResume;
-      if (hadTurnInFlight && stillOnTheInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+      // Nothing has restarted the turn in the meantime. useStreamRecovery watches the SAME failure
+      // from the other side (it fires on `status === 'error'`) and regenerates too, and the two
+      // share no lock. If iOS delivers the dead fetch's rejection as an error before this listener
+      // runs, useStreamRecovery may already have retried — and `rawStop()` above would have been a
+      // no-op, since Chat.stop() returns early unless the status is streaming/submitted, so it
+      // cannot have cancelled that. Regenerating on top would be exactly the double destruction the
+      // gate below exists to prevent: takeOverConversationStreams aborts the run that just started,
+      // and handleRetry deletes its assistant message on the way in. Read through a ref because the
+      // closure's copy is the value captured before we were frozen.
+      const nothingHasRestarted = !isStreamingRef.current;
+      if (
+        hadTurnInFlight &&
+        stillOnTheInterruptedConversation &&
+        nothingHasRestarted &&
+        canConcludeTurnIsLost(attempt)
+      ) {
         await handleRetry();
       }
     }, [

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -1106,6 +1106,12 @@ const SidebarChatTab: React.FC = () => {
       // a generation for the turn the user is now LOOKING at rather than the one that was
       // actually interrupted.
       const hadTurnInFlight = isOwnStreamForCurrentConversation;
+      // The conversation that turn belongs to. The recovery below spans up to a few seconds of
+      // network, and the user can switch conversation inside that window — at which point
+      // regenerating would fire a generation for the turn they moved TO, not the one that was
+      // interrupted. `handleRetry` always acts on the live conversation, so the only way to keep
+      // it honest is to re-check that we are still on the one we started from.
+      const conversationAtResume = currentConversationId;
 
       // Local-only useChat stop: it does NOT signal the server (that is done separately via
       // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
@@ -1153,9 +1159,14 @@ const SidebarChatTab: React.FC = () => {
       // live run is picked up by the socket-reconnect bootstrap once the network returns, a
       // persisted reply is picked up by the next load, and a genuinely dead turn leaves the user
       // their prompt and the retry action on it.
-      if (hadTurnInFlight && canConcludeTurnIsLost(attempt)) await handleRetry();
+      const stillOnTheInterruptedConversation =
+        currentConversationIdRef.current === conversationAtResume;
+      if (hadTurnInFlight && stillOnTheInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+        await handleRetry();
+      }
     }, [
       displayIsStreaming,
+      currentConversationId,
       isOwnStreamForCurrentConversation,
       stop,
       tryRecover,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -52,7 +52,7 @@ import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode'
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
-import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
+import { evictStalePartial, canEvictStalePartial } from '@/lib/ai/streams/evictStalePartial';
 import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
@@ -947,21 +947,19 @@ const SidebarChatTab: React.FC = () => {
           stillOnThisConversation() &&
           decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
         ) {
-          // Evict the half-streamed assistant bubble useChat is still holding for this run — see
-          // evictStalePartial for why that is load-bearing (without it the rejoined stream is
-          // deduped straight back out and renders nothing) and why it is conditional.
+          // Evict the half-streamed assistant bubble useChat is still holding for this run. See
+          // evictStalePartial: without it the rejoined stream is deduped straight back out and
+          // renders nothing, and it is safe only when the server's checkpoint has frames the
+          // bootstrap can actually seed in its place.
+          //
+          // Ask before writing, so an unsafe checkpoint costs no state write at all; then evict
+          // through the UPDATER form, so the filter runs against the freshest message list rather
+          // than one captured before the awaits above.
           const staleId = liveStream.messageId;
-          // evictStalePartial owns BOTH halves of the rule — why the stale bubble must go, and why
-          // only when the server's (debounced, isValidPartFrame-filtered) checkpoint can render in
-          // its place. It returns the same array reference when it is not safe, so this is a no-op
-          // write in that case.
-          const before = currentMessagesRef.current;
-          const evicted = evictStalePartial(before, staleId, liveStream.parts);
-          // Skipped entirely when the helper declined to evict — it returns the same reference,
-          // and there is no reason to push an identical array back through setMessages.
-          if (evicted !== before) {
-            if (selectedAgent) setMessages(evicted);
-            else setGlobalMessages(evicted);
+          if (canEvictStalePartial(liveStream.parts)) {
+            const evict = (prev: UIMessage[]) => evictStalePartial(prev, staleId, liveStream.parts);
+            if (selectedAgent) setMessages(evict);
+            else setGlobalMessages(evict);
           }
           if (selectedAgent) {
             rejoinAgentStream();

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -489,12 +489,17 @@ const SidebarChatTab: React.FC = () => {
   // NOTE: prod runs multiple web instances — live tokens from a stream on another
   // instance won't be in the pending store; the persisted message still shows up
   // on the next DB load. Cross-instance live-token rejoin is a known follow-up.
-  const loadGlobalMessages = useCallback((conversationId: string) => {
+  // Returns the in-flight promise so callers that must sequence against it can await it —
+  // the resume handler below has to know the load has LANDED before it rejoins the stream,
+  // or the response could still be outstanding when the rejoined stream completes and would
+  // overwrite the finished reply with its pre-reply snapshot. Callers that just want to kick
+  // off a refresh (load-on-select, refreshSignal, retry) can keep ignoring the result.
+  const loadGlobalMessages = useCallback((conversationId: string): Promise<void> => {
     globalLoadRequestedIdRef.current = conversationId;
     setIsLoadingGlobalMessages(true);
     setGlobalMessagesLoadError(null);
 
-    fetchWithAuth(`/api/ai/global/${conversationId}/messages`)
+    return fetchWithAuth(`/api/ai/global/${conversationId}/messages`)
       .then(async (res) => {
         if (!shouldApplyLoadedMessages(conversationId, globalLoadRequestedIdRef.current)) return;
         if (!res.ok) throw new Error(`Failed to load messages (${res.status})`);
@@ -618,7 +623,8 @@ const SidebarChatTab: React.FC = () => {
     if (selectedAgent) {
       await refreshAgentConversation();
     } else if (globalConversationId && globalIsInitialized) {
-      loadGlobalMessages(globalConversationId);
+      // Awaited, not fire-and-forget: the resume handler sequences the rejoin after this.
+      await loadGlobalMessages(globalConversationId);
     }
   }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, loadGlobalMessages]);
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -618,10 +618,44 @@ const SidebarChatTab: React.FC = () => {
     }
   }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, setGlobalMessages]);
 
+  // App state recovery — deterministic stream rejoin on mobile.
+  //
+  // The `enabled` gate MUST be a callback, not a render-time boolean: iOS freezes JS the
+  // moment the app backgrounds, so a boolean captured at render is whatever was true when
+  // the app went away. That is how this path was dead in exactly the case it was written
+  // for — `!isStreaming` was false (streaming), and the recovery hook was gated off.
+  //
+  // `onResume` uses `resolveResumeAction` — on native it always returns 'rejoin-and-refresh'
+  // (the local fetch is dead after backgrounding), so we stop the local useChat state,
+  // rejoin the server-owned stream, then refresh from DB to catch a stream that finished
+  // while backgrounded.
+  const resumeEnabled = useCallback(
+    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    [currentConversationId],
+  );
+
   useAppStateRecovery({
-    onResume: handleAppResume,
-    // Block recovery if streaming OR pending send OR any editing active
-    enabled: !isStreaming && currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    onResume: useCallback(async () => {
+      const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
+      if (action === 'noop') return;
+      if (action === 'rejoin-and-refresh') {
+        stop();
+        if (selectedAgent) {
+          rejoinAgentStream();
+        } else {
+          rejoinGlobalStream();
+        }
+      }
+      await handleAppResume();
+    }, [
+      displayIsStreaming,
+      stop,
+      selectedAgent,
+      rejoinAgentStream,
+      rejoinGlobalStream,
+      handleAppResume,
+    ]),
+    enabled: resumeEnabled,
   });
 
   // Clean up stream tracking on unmount or conversation change.

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -489,11 +489,9 @@ const SidebarChatTab: React.FC = () => {
   // NOTE: prod runs multiple web instances — live tokens from a stream on another
   // instance won't be in the pending store; the persisted message still shows up
   // on the next DB load. Cross-instance live-token rejoin is a known follow-up.
-  // Returns the in-flight promise so callers that must sequence against it can await it —
-  // the resume handler below has to know the load has LANDED before it rejoins the stream,
-  // or the response could still be outstanding when the rejoined stream completes and would
-  // overwrite the finished reply with its pre-reply snapshot. Callers that just want to kick
-  // off a refresh (load-on-select, refreshSignal, retry) can keep ignoring the result.
+  // Returns the in-flight promise so callers that need to know the load has LANDED can await it
+  // (the resume handler does). Callers that just want to kick a refresh off — load-on-select,
+  // refreshSignal, retry — can keep ignoring the result.
   const loadGlobalMessages = useCallback((conversationId: string): Promise<void> => {
     globalLoadRequestedIdRef.current = conversationId;
     setIsLoadingGlobalMessages(true);
@@ -607,23 +605,18 @@ const SidebarChatTab: React.FC = () => {
     );
   }, [messages, displayIsStreaming, isVoiceModeActive]);
 
-  // App state recovery - refresh messages when returning from background
-  // This catches completed AI responses that finished while the app was backgrounded
-  // Refresh this surface from the DB after a background resume.
+  // Refresh this surface from the DB after a background resume, catching a reply that landed
+  // while we were away. Reached on the WEB resume path only (an idle tab coming back); the
+  // native path recovers through tryRecover, which never reads the DB while a run is live.
   //
-  // Global mode funnels through `loadGlobalMessages` — the single writer for the global-mode
-  // server→view path — rather than doing its own fetch. This runs DURING an active own stream
-  // on the resume path (see useAppStateRecovery below), and only that loader carries the two
-  // guards that make a mid-stream DB read safe: a stale-response check (so a response arriving
-  // after a conversation switch cannot clobber the conversation the user moved to) and
-  // `mergeServerAndPending` (which re-attaches the in-flight assistant bubble, absent from the
-  // DB snapshot because the reply is not persisted until the run completes). The raw fetch this
-  // replaced had neither, so it wrote a pre-reply snapshot straight over the live bubble.
+  // Global mode funnels through `loadGlobalMessages` — the documented single writer for the
+  // global-mode server→view path — rather than doing its own fetch. That loader carries the
+  // stale-response check, so a response arriving after the user switched conversation cannot
+  // clobber the conversation they moved to. The raw fetch this replaced had no such guard.
   const handleAppResume = useCallback(async () => {
     if (selectedAgent) {
       await refreshAgentConversation();
     } else if (globalConversationId && globalIsInitialized) {
-      // Awaited, not fire-and-forget: the resume handler sequences the rejoin after this.
       await loadGlobalMessages(globalConversationId);
     }
   }, [selectedAgent, refreshAgentConversation, globalConversationId, globalIsInitialized, loadGlobalMessages]);
@@ -913,15 +906,33 @@ const SidebarChatTab: React.FC = () => {
       );
       if (res.ok) {
         const data = (await res.json()) as {
-          streams?: Array<{ conversationId: string; triggeredBy: { userId: string } }>;
+          streams?: Array<{ messageId: string; conversationId: string; triggeredBy: { userId: string } }>;
         };
-        const hasLiveStream = (data.streams ?? []).some(
+        const liveStream = (data.streams ?? []).find(
           (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
         );
-        if (decideRecovery({ hasLiveStream, hasPersistedReply: false }) === 'rejoin') {
+        if (liveStream && decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin') {
+          // Evict the half-streamed assistant bubble useChat is still holding for this run.
+          //
+          // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
+          // dropped fetch leaves them too — so `messages` still contains an assistant message
+          // whose id IS the live stream's messageId (the server mints one id and uses it for both
+          // the UI message and the stream registry row). The rejoin re-adds that same stream to
+          // the pending store, and this surface drops a pending stream whose messageId already
+          // appears in `messages` (dedupRemoteStreams) — so the rejoined stream would be filtered
+          // straight back out and not one token of it would ever render. The user would sit in
+          // front of a frozen partial reply.
+          //
+          // Nothing is lost by dropping it: the bootstrap seeds the stream from the server's
+          // registry buffer, which holds every part pushed so far — strictly more than the
+          // partial we froze with.
+          const staleId = liveStream.messageId;
+          const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           if (selectedAgent) {
+            setMessages(evictStale);
             rejoinAgentStream();
           } else {
+            setGlobalMessages(evictStale);
             rejoinGlobalStream();
           }
           return true;
@@ -1006,16 +1017,29 @@ const SidebarChatTab: React.FC = () => {
     onResume: useCallback(async () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
       if (action === 'noop') return;
-      if (action === 'rejoin-and-refresh') {
-        // Local-only useChat stop. It does NOT signal the server (that is done separately via
-        // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
-        // also ends the dead response body, which releases this channel's `consuming` mark —
-        // without that the rejoin's bootstrap would classify the stream as one we are already
-        // reading off the POST and skip attaching it.
-        stop();
-        if (await tryRecover()) return;
+      if (action === 'refresh') {
+        // Web, no live fetch of our own: a plain DB refresh is safe and is all we need.
+        await handleAppResume();
+        return;
       }
-      await handleAppResume();
+      // Native. Local-only useChat stop: it does NOT signal the server (that is done separately
+      // via abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
+      // also ends the dead response body, which releases this channel's `consuming` mark —
+      // without that the rejoin's bootstrap would classify the stream as one we are already
+      // reading off the POST and skip attaching it.
+      stop();
+      // tryRecover is the whole recovery here, and there is deliberately NO DB-refresh fallback
+      // after it. It already refetches when the run finished while we were away (its step 2). A
+      // fallback refresh would only run in the cases where a DB write is UNSAFE:
+      //   - the /active-streams probe failed (first request after a foreground is the likeliest
+      //     to, with the radio still coming up) — a stream may well be live, and the DB snapshot,
+      //     which cannot contain an unpersisted reply, would erase the in-progress bubble;
+      //   - the DB is behind our local state (step 2's dbUserCount >= localUserCount guard
+      //     rejected it) — e.g. a send whose POST never reached the server, where refreshing
+      //     would erase the user's own prompt.
+      // In both, doing nothing is correct: local state is newer than anything we could fetch, and
+      // the socket reconnect / refreshSignal path heals it.
+      await tryRecover();
     }, [displayIsStreaming, stop, tryRecover, handleAppResume]),
     enabled: resumeEnabled,
   });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -400,6 +400,12 @@ const SidebarChatTab: React.FC = () => {
   const [globalMessagesLoadError, setGlobalMessagesLoadError] = useState<Error | null>(null);
   // Stale-request guard: holds the conversationId of the most recent load request.
   const globalLoadRequestedIdRef = useRef<string | null>(null);
+  // Whether the LAST /active-streams probe actually reached the server and answered.
+  //
+  // tryRecover returns false for two semantically opposite outcomes — "the server says nothing is
+  // live" and "the probe never got an answer" — and the resume path must not treat silence as an
+  // answer. See the regenerate gate in useAppStateRecovery below.
+  const probeAnsweredRef = useRef(false);
   // Synchronously updated each render — lets tryRecover read the live message
   // count without adding messages to its useCallback deps.
   const currentMessagesRef = useRef(messages);
@@ -901,10 +907,14 @@ const SidebarChatTab: React.FC = () => {
     if (!channelId) return false;
 
     // Step 1: live stream check
+    probeAnsweredRef.current = false;
     try {
       const res = await fetchWithAuth(
         `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
       );
+      // Reachability, recorded separately from the verdict: only a 2xx means the server actually
+      // TOLD us what is live. A throw or a non-ok leaves us knowing nothing.
+      probeAnsweredRef.current = res.ok;
       if (res.ok) {
         const data = (await res.json()) as {
           streams?: Array<{
@@ -1060,22 +1070,37 @@ const SidebarChatTab: React.FC = () => {
       stop();
       if (await tryRecover()) return;
 
-      // Nothing live on the server, and nothing persisted for this turn. Deliberately NOT a DB
-      // refresh — that is unsafe here (the probe may simply have failed, in which case a stream
-      // could still be live and the DB snapshot, which cannot contain an unpersisted reply, would
-      // erase the in-progress bubble; or the DB is behind our local state, where it would erase
-      // the user's own prompt).
+      // tryRecover came up empty — but that means one of two OPPOSITE things, and only one of them
+      // is an answer:
       //
-      // Regenerate instead — the same fallback useStreamRecovery applies when its probe comes up
-      // empty on a network error. It is needed BECAUSE of the stop above: aborting the fetch
-      // settles useChat at `ready` with no `error`, and useStreamRecovery only fires on
-      // `status === 'error'`. Without this, a turn whose POST died on the background transition
-      // (a radio drop right then is common) would find no stream, no reply, and no error — and
-      // the user's prompt would sit unanswered forever.
+      //   "the server says nothing is live"  → the run died; regenerating is the recovery.
+      //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
       //
-      // Gated on a turn actually having been in flight, so an ordinary resume on an idle
-      // conversation can never fire a spurious generation.
-      if (hadTurnInFlight) await handleRetry();
+      // The first request after a foreground is the one most likely to fail (cold radio), so on
+      // this path the second case is common. Re-probe a couple of times before concluding: the
+      // radio comes back well inside a few seconds.
+      for (let attempt = 1; !probeAnsweredRef.current && attempt <= 2; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+        if (await tryRecover()) return;
+      }
+
+      // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
+      //
+      // The regenerate is needed BECAUSE of the stop above: aborting the fetch settles useChat at
+      // `ready` with NO `error`, and useStreamRecovery only fires on `status === 'error'`. Without
+      // it, a turn whose POST died on the background transition would find no stream, no reply and
+      // no error, and the user's prompt would sit unanswered forever.
+      //
+      // But regenerating on SILENCE would be far worse than doing nothing. Every generation start
+      // calls takeOverConversationStreams, so a regenerate issued while the run is in fact still
+      // live does not race it — it ABORTS it. We would kill a healthy, possibly nearly-finished
+      // generation, re-run any write tools it had already executed, bill the discarded tokens, and
+      // strand its partial in the DB. Silence is not an answer.
+      //
+      // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
+      // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
+      // leaves the user their prompt and the retry action on it.
+      if (hadTurnInFlight && probeAnsweredRef.current) await handleRetry();
     }, [
       displayIsStreaming,
       isOwnStreamForCurrentConversation,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -41,6 +41,8 @@ import { useChatTransport, useStreamingRegistration, useSendHandoff, useMessageA
 import { AskUserAnswerProvider } from '@/components/ai/shared/chat/ask-user/AskUserAnswerContext';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
+import { isCapacitorApp } from '@/hooks/useCapacitor';
+import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
 import { useEditingStore } from '@/stores/useEditingStore';
@@ -639,6 +641,9 @@ const SidebarChatTab: React.FC = () => {
       const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: displayIsStreaming });
       if (action === 'noop') return;
       if (action === 'rejoin-and-refresh') {
+        // `stop` is the local-only useChat stop; it does NOT signal the server (that is
+        // done separately via abortActiveStreamByMessageId). We only clear the local
+        // streaming state so the rejoin can attach cleanly.
         stop();
         if (selectedAgent) {
           rejoinAgentStream();

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -52,7 +52,8 @@ import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode'
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
 import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
-import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
+import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
+import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
 
@@ -946,38 +947,25 @@ const SidebarChatTab: React.FC = () => {
           stillOnThisConversation() &&
           decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
         ) {
-          // Evict the half-streamed assistant bubble useChat is still holding for this run.
-          //
-          // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
-          // dropped fetch leaves them too — so `messages` still contains an assistant message
-          // whose id IS the live stream's messageId (the server mints one id and uses it for both
-          // the UI message and the stream registry row). The rejoin re-adds that same stream to
-          // the pending store, and this surface drops a pending stream whose messageId already
-          // appears in `messages` (dedupRemoteStreams) — so the rejoined stream would be filtered
-          // straight back out and not one token of it would ever render. The user would sit in
-          // front of a frozen partial reply.
-          //
-          // Only when the server has something to put in its place, though. `parts` here is the
-          // registry's DEBOUNCED checkpoint (persisted every N parts), so it is empty for a stream
-          // that is only a few parts old. Evict against an empty checkpoint and, if the SSE join
-          // then fails — the documented multi-instance case, where the multicast lives in another
-          // process — the bootstrap removes the stream and the user is left with NOTHING, which is
-          // strictly worse than the frozen partial we started with. In that case keep the partial:
-          // the rejoin can still attach and take over, and if it cannot, the user keeps what they
-          // had.
+          // Evict the half-streamed assistant bubble useChat is still holding for this run — see
+          // evictStalePartial for why that is load-bearing (without it the rejoined stream is
+          // deduped straight back out and renders nothing) and why it is conditional.
           const staleId = liveStream.messageId;
-          // Counted with isValidPartFrame, the SAME predicate the bootstrap seeds with — it is
-          // `persistedParts.length` (post-filter) that becomes skipReplayCount, and a
-          // skipReplayCount of 0 is what makes a failed join drop the stream. A raw
-          // `parts.length > 0` would say "safe to evict" for a checkpoint of malformed frames
-          // that seeds nothing.
-          const hasServerParts = (liveStream.parts ?? []).filter(isValidPartFrame).length > 0;
-          const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
+          // evictStalePartial owns BOTH halves of the rule — why the stale bubble must go, and why
+          // only when the server's (debounced, isValidPartFrame-filtered) checkpoint can render in
+          // its place. It returns the same array reference when it is not safe, so this is a no-op
+          // write in that case.
+          const before = currentMessagesRef.current;
+          const evicted = evictStalePartial(before, staleId, liveStream.parts);
+          // Skipped entirely when the helper declined to evict — it returns the same reference,
+          // and there is no reason to push an identical array back through setMessages.
+          if (evicted !== before) {
+            if (selectedAgent) setMessages(evicted);
+            else setGlobalMessages(evicted);
+          }
           if (selectedAgent) {
-            if (hasServerParts) setMessages(evictStale);
             rejoinAgentStream();
           } else {
-            if (hasServerParts) setGlobalMessages(evictStale);
             rejoinGlobalStream();
           }
           return { recovered: true, probeAnswered, dbAnswered };
@@ -1081,7 +1069,7 @@ const SidebarChatTab: React.FC = () => {
   //   already persisted  → refetch the completed reply (the stream finished while backgrounded)
   //   neither            → falls through to handleAppResume
   const resumeEnabled = useCallback(
-    () => currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
+    () => canResumeRecovery(currentConversationId, useEditingStore.getState().isAnyEditing()),
     [currentConversationId],
   );
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -51,7 +51,7 @@ import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMes
 import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode';
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
-import type { RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
+import { canConcludeTurnIsLost, type RecoveryAttempt } from '@/lib/ai/streams/recoveryAttempt';
 import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
@@ -287,6 +287,11 @@ const SidebarChatTab: React.FC = () => {
   // Derived State
   // ============================================
   const currentConversationId = selectedAgent ? agentConversationId : globalConversationId;
+  // The conversation on screen, mirrored every render. Read after an await to decide whether a
+  // response that just resolved is still wanted — the useChat id is constant across a conversation
+  // switch, so a late write would otherwise land in whatever conversation the user moved to.
+  const currentConversationIdRef = useRef<string | null>(null);
+  currentConversationIdRef.current = currentConversationId;
   // The conversation the CURRENT stream belongs to, held from when it starts. The surface moves
   // independently of the stream — switching conversation mid-stream does NOT abort the POST — so
   // the abort must name the conversation the generation is actually running on. Moved up here
@@ -902,9 +907,17 @@ const SidebarChatTab: React.FC = () => {
     // flight together. A single shared slot would let one caller's probe answer the other's
     // question, which on this path means regenerating over a run we never actually asked about.
     let probeAnswered = false;
-    if (!currentConversationId) return { recovered: false, probeAnswered };
+    let dbAnswered = false;
+    const conversationId = currentConversationId;
+    if (!conversationId) return { recovered: false, probeAnswered, dbAnswered };
     const channelId = selectedAgent?.id ?? channelIdForGlobal;
-    if (!channelId) return { recovered: false, probeAnswered };
+    if (!channelId) return { recovered: false, probeAnswered, dbAnswered };
+    // Every write below happens after an await, into a useChat instance whose id is constant
+    // across conversation switches. Re-check the LIVE conversation before each one, exactly as
+    // loadGlobalMessages does — otherwise a recovery for the conversation the user just left
+    // lands in the one they moved to.
+    const stillOnThisConversation = () =>
+      shouldApplyLoadedMessages(conversationId, currentConversationIdRef.current);
 
     // Step 1: live stream check
     try {
@@ -926,9 +939,13 @@ const SidebarChatTab: React.FC = () => {
         // swallow it while we went on believing we had an answer.
         probeAnswered = true;
         const liveStream = (data.streams ?? []).find(
-          (s) => s.conversationId === currentConversationId && s.triggeredBy.userId === user?.id,
+          (s) => s.conversationId === conversationId && s.triggeredBy.userId === user?.id,
         );
-        if (liveStream && decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin') {
+        if (
+          liveStream &&
+          stillOnThisConversation() &&
+          decideRecovery({ hasLiveStream: true, hasPersistedReply: false }) === 'rejoin'
+        ) {
           // Evict the half-streamed assistant bubble useChat is still holding for this run.
           //
           // This is load-bearing, not tidy-up. `Chat.stop()` "keeps the generated tokens", and a
@@ -963,31 +980,51 @@ const SidebarChatTab: React.FC = () => {
             if (hasServerParts) setGlobalMessages(evictStale);
             rejoinGlobalStream();
           }
-          return { recovered: true, probeAnswered };
+          return { recovered: true, probeAnswered, dbAnswered };
         }
       }
     } catch { /* network error — fall through to DB check */ }
 
-    // Step 2: DB check for persisted reply for the CURRENT turn.
-    // Only accept when the DB has at least as many user messages as we have locally —
-    // this guards against the case where the network error fired before the user's
-    // message reached the server, making the DB end with the PREVIOUS turn's
-    // assistant reply and causing us to silently drop the new user prompt.
+    // Step 2: DB check for a persisted reply to the CURRENT turn.
     try {
       const url = selectedAgent
-        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${currentConversationId}/messages`
-        : `/api/ai/global/${currentConversationId}/messages`;
+        ? `/api/ai/page-agents/${selectedAgent.id}/conversations/${conversationId}/messages`
+        : `/api/ai/global/${conversationId}/messages`;
       const res = await fetchWithAuth(url);
       if (res.ok) {
         const data = await res.json();
-        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{ role: string }>;
-        const localUserCount = currentMessagesRef.current.filter((m) => m.role === 'user').length;
-        const dbUserCount = msgs.filter((m) => m.role === 'user').length;
+        const msgs = (Array.isArray(data) ? data : (data.messages ?? [])) as Array<{
+          id: string;
+          role: string;
+        }>;
+        // Only NOW do we know what is persisted. As with the probe above, a throw or a non-ok
+        // leaves us knowing nothing — and treating that silence as "no reply exists" would let the
+        // caller regenerate over a reply that had in fact completed, which DELETES it (handleRetry
+        // removes the trailing assistant by the very id the server persisted it under).
+        dbAnswered = true;
+
+        // "Was the user's turn persisted?" asked by IDENTITY, not by counting.
+        //
+        // It used to compare user-message counts (dbUserCount >= localUserCount). That silently
+        // breaks on any conversation longer than one page: this GET is unpaginated, so the route
+        // applies its default limit of 50 and returns only the newest 50 rows, while local
+        // `messages` is the initial 50 PLUS every turn since. Past that boundary the count guard
+        // is permanently false, step 2 can never recover, and every interrupted turn on a long
+        // conversation would fall through to a regenerate that deletes the reply it should have
+        // refetched. The last local user message is by definition the newest, so it is always
+        // inside the returned window — checking for its id is both correct and pagination-proof.
+        const lastLocalUserId = [...currentMessagesRef.current]
+          .reverse()
+          .find((m) => m.role === 'user')?.id;
+        const ourTurnIsPersisted =
+          lastLocalUserId === undefined || msgs.some((m) => m.id === lastLocalUserId);
         const hasPersistedReply =
-          msgs.length > 0 &&
-          msgs[msgs.length - 1].role === 'assistant' &&
-          dbUserCount >= localUserCount;
-        if (decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch') {
+          msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant' && ourTurnIsPersisted;
+
+        if (
+          stillOnThisConversation() &&
+          decideRecovery({ hasLiveStream: false, hasPersistedReply }) === 'refetch'
+        ) {
           // Write the SAME normalized array the guards above were computed from. Reading
           // defensively and then writing `data.messages` raw would blank the surface outright if
           // the route ever answered with a bare array.
@@ -997,12 +1034,12 @@ const SidebarChatTab: React.FC = () => {
           } else {
             setGlobalMessages(serverMessages);
           }
-          return { recovered: true, probeAnswered };
+          return { recovered: true, probeAnswered, dbAnswered };
         }
       }
-    } catch { /* network error — fall through to regenerate */ }
+    } catch { /* network error — the caller must not treat this as "nothing is persisted" */ }
 
-    return { recovered: false, probeAnswered };
+    return { recovered: false, probeAnswered, dbAnswered };
   }, [
     currentConversationId,
     selectedAgent,
@@ -1079,38 +1116,44 @@ const SidebarChatTab: React.FC = () => {
       let attempt = await tryRecover();
       if (attempt.recovered) return;
 
-      // Came up empty — but that means one of two OPPOSITE things, and only one of them is an
-      // answer:
+      // Came up empty — but "we recovered nothing" is NOT "there was nothing to recover". Each of
+      // tryRecover's two questions can come back UNANSWERED, and silence from either one means the
+      // work we would be about to destroy might still exist:
       //
-      //   "the server says nothing is live"    → the run died; regenerating is the recovery.
-      //   "the probe never reached the server" → we know NOTHING; a run may well still be live.
+      //   /active-streams silent → a run may still be LIVE.       Regenerating aborts it.
+      //   messages GET silent    → the reply may already be SAVED. Regenerating deletes it.
       //
-      // The first request after a foreground is the one most likely to fail (cold radio), so on
-      // this path the second case is common. Re-probe a couple of times before concluding: the
-      // radio comes back well inside a few seconds.
-      for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+      // The first request after a foreground is the one most likely to fail (cold radio), so this
+      // is common on exactly this path. Re-ask until both questions come back, bounded — the radio
+      // returns well inside a few seconds.
+      for (let i = 1; !(attempt.probeAnswered && attempt.dbAnswered) && i <= 2; i++) {
         await new Promise((resolve) => setTimeout(resolve, i * 1000));
         attempt = await tryRecover();
         if (attempt.recovered) return;
       }
 
-      // Regenerate ONLY on an answered probe, and only if a turn of ours really was in flight.
+      // Regenerate ONLY once BOTH questions came back, and only for a turn of ours that really was
+      // in flight (canConcludeTurnIsLost).
       //
       // The regenerate is needed BECAUSE of the stop above: aborting the fetch settles useChat at
       // `ready` with NO `error`, and useStreamRecovery only fires on `status === 'error'`. Without
       // it, a turn whose POST died on the background transition would find no stream, no reply and
       // no error, and the user's prompt would sit unanswered forever.
       //
-      // But regenerating on SILENCE would be far worse than doing nothing. Every generation start
-      // calls takeOverConversationStreams, so a regenerate issued while the run is in fact still
-      // live does not race it — it ABORTS it. We would kill a healthy, possibly nearly-finished
-      // generation, re-run any write tools it had already executed, bill the discarded tokens, and
-      // strand its partial in the DB. Silence is not an answer.
+      // But regenerating on SILENCE would be far worse than doing nothing, because regenerating is
+      // destructive twice over:
+      //   - takeOverConversationStreams runs on every generation start, so a regenerate issued
+      //     while the run is in fact still live ABORTS it — re-running write tools it had already
+      //     executed, billing its discarded tokens, stranding its partial in the DB.
+      //   - handleRetry DELETEs the trailing assistant by id before re-requesting, and that is the
+      //     same id the server persisted the reply under — so a regenerate issued when the reply
+      //     had in fact completed deletes the finished reply and pays for it again.
       //
-      // Doing nothing there is safe: the stop released this channel's `consuming` mark, so a live
-      // run is picked up by the socket-reconnect bootstrap once the network returns, and a dead one
-      // leaves the user their prompt and the retry action on it.
-      if (hadTurnInFlight && attempt.probeAnswered) await handleRetry();
+      // Doing nothing on silence is safe: the stop released this channel's `consuming` mark, so a
+      // live run is picked up by the socket-reconnect bootstrap once the network returns, a
+      // persisted reply is picked up by the next load, and a genuinely dead turn leaves the user
+      // their prompt and the retry action on it.
+      if (hadTurnInFlight && canConcludeTurnIsLost(attempt)) await handleRetry();
     }, [
       displayIsStreaming,
       isOwnStreamForCurrentConversation,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -51,6 +51,7 @@ import { shouldApplyLoadedMessages } from '@/lib/ai/streams/shouldApplyLoadedMes
 import { selectMessagesAreaMode } from '@/lib/ai/streams/selectMessagesAreaMode';
 import { mergeServerAndPending } from '@/lib/ai/streams/mergeServerAndPending';
 import { decideRecovery } from '@/lib/ai/streams/decideRecovery';
+import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 
 const VOICE_OWNER: VoiceModeOwner = 'sidebar-chat';
 
@@ -937,7 +938,12 @@ const SidebarChatTab: React.FC = () => {
           // the rejoin can still attach and take over, and if it cannot, the user keeps what they
           // had.
           const staleId = liveStream.messageId;
-          const hasServerParts = (liveStream.parts?.length ?? 0) > 0;
+          // Counted with isValidPartFrame, the SAME predicate the bootstrap seeds with — it is
+          // `persistedParts.length` (post-filter) that becomes skipReplayCount, and a
+          // skipReplayCount of 0 is what makes a failed join drop the stream. A raw
+          // `parts.length > 0` would say "safe to evict" for a checkpoint of malformed frames
+          // that seeds nothing.
+          const hasServerParts = (liveStream.parts ?? []).filter(isValidPartFrame).length > 0;
           const evictStale = (prev: UIMessage[]) => prev.filter((m) => m.id !== staleId);
           if (selectedAgent) {
             if (hasServerParts) setMessages(evictStale);
@@ -1033,25 +1039,37 @@ const SidebarChatTab: React.FC = () => {
         await handleAppResume();
         return;
       }
-      // Native. Local-only useChat stop: it does NOT signal the server (that is done separately
-      // via abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It
-      // also ends the dead response body, which releases this channel's `consuming` mark —
-      // without that the rejoin's bootstrap would classify the stream as one we are already
-      // reading off the POST and skip attaching it.
+      // Native. Whether a turn was actually in flight when we went away. iOS froze JS at that
+      // moment, so this render-time value is a faithful record of it — which is exactly what it
+      // is used for here, and why it is safe even though it is useless for deciding whether the
+      // TRANSPORT is still alive (that is resolveResumeAction's job, and the answer is "no").
+      const hadTurnInFlight = displayIsStreaming;
+
+      // Local-only useChat stop: it does NOT signal the server (that is done separately via
+      // abortActiveStreamByMessageId), so the run keeps generating and stays rejoinable. It also
+      // ends the dead response body, which releases this channel's `consuming` mark — without
+      // that the rejoin's bootstrap would classify the stream as one we are already reading off
+      // the POST and skip attaching it.
       stop();
-      // tryRecover is the whole recovery here, and there is deliberately NO DB-refresh fallback
-      // after it. It already refetches when the run finished while we were away (its step 2). A
-      // fallback refresh would only run in the cases where a DB write is UNSAFE:
-      //   - the /active-streams probe failed (first request after a foreground is the likeliest
-      //     to, with the radio still coming up) — a stream may well be live, and the DB snapshot,
-      //     which cannot contain an unpersisted reply, would erase the in-progress bubble;
-      //   - the DB is behind our local state (step 2's dbUserCount >= localUserCount guard
-      //     rejected it) — e.g. a send whose POST never reached the server, where refreshing
-      //     would erase the user's own prompt.
-      // In both, doing nothing is correct: local state is newer than anything we could fetch, and
-      // the socket reconnect / refreshSignal path heals it.
-      await tryRecover();
-    }, [displayIsStreaming, stop, tryRecover, handleAppResume]),
+      if (await tryRecover()) return;
+
+      // Nothing live on the server, and nothing persisted for this turn. Deliberately NOT a DB
+      // refresh — that is unsafe here (the probe may simply have failed, in which case a stream
+      // could still be live and the DB snapshot, which cannot contain an unpersisted reply, would
+      // erase the in-progress bubble; or the DB is behind our local state, where it would erase
+      // the user's own prompt).
+      //
+      // Regenerate instead — the same fallback useStreamRecovery applies when its probe comes up
+      // empty on a network error. It is needed BECAUSE of the stop above: aborting the fetch
+      // settles useChat at `ready` with no `error`, and useStreamRecovery only fires on
+      // `status === 'error'`. Without this, a turn whose POST died on the background transition
+      // (a radio drop right then is common) would find no stream, no reply, and no error — and
+      // the user's prompt would sit unanswered forever.
+      //
+      // Gated on a turn actually having been in flight, so an ordinary resume on an idle
+      // conversation can never fire a spurious generation.
+      if (hadTurnInFlight) await handleRetry();
+    }, [displayIsStreaming, stop, tryRecover, handleAppResume, handleRetry]),
     enabled: resumeEnabled,
   });
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -160,14 +160,17 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
  */
-type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
+type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
 function planResume({
   native,
   isStreaming,
+  recovered = true,
 }: {
   native: boolean;
   isStreaming: boolean;
+  /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
+  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -175,7 +178,15 @@ function planResume({
   // The stop is local-only. It clears useChat state and — critically — ends the dead response
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
-  return ['stop', 'try-recover'];
+  const effects: ResumeEffect[] = ['stop', 'try-recover'];
+  if (recovered) return effects;
+  // Nothing live, nothing persisted. NOT a DB refresh (unsafe: the probe may merely have failed
+  // and a stream still be live, or the DB may be behind local state). Regenerate — but only if a
+  // turn was actually in flight when we backgrounded, so an idle resume never fires a spurious
+  // generation. `isStreaming` here is the render-time value iOS froze at background, which is a
+  // faithful record of exactly that.
+  if (isStreaming) effects.push('regenerate');
+  return effects;
 }
 
 // ============================================
@@ -685,6 +696,25 @@ function evictStalePartial<T extends { id: string }>(
 
       it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
+      });
+
+      it('given native, a turn in flight, and NOTHING to recover, should regenerate — never a DB refresh', () => {
+        // The stop above settles useChat at `ready` with no `error`, and useStreamRecovery only
+        // fires on `status === 'error'` — so aborting the fetch destroys the very signal that
+        // used to drive the fallback. Without regenerating here, a turn whose POST died on the
+        // background transition (a radio drop right then is common) finds no stream, no reply and
+        // no error, and the user's prompt sits unanswered forever.
+        const plan = planResume({ native: true, isStreaming: true, recovered: false });
+        expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
+        expect(plan).not.toContain('refresh');
+      });
+
+      it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
+        // An ordinary resume on an idle conversation must never fire a spurious generation.
+        expect(planResume({ native: true, isStreaming: false, recovered: false })).toEqual([
+          'stop',
+          'try-recover',
+        ]);
       });
     });
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -133,8 +133,12 @@ function isOwnStreamForConversation(
 /**
  * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
  *
- * Deliberately takes NO streaming argument. The gate must be a callback (evaluated at
- * fire time, on resume) and must gate on user-editing only. See the regression test below.
+ * Deliberately takes NO streaming argument, which is the whole point. The gate used to be a
+ * render-time boolean folding in `!isStreaming`; iOS freezes JS the moment the app backgrounds,
+ * so the value that gated the resume was whatever was true when the app went away — streaming —
+ * and recovery was disabled in exactly the case it was written for. The gate must be a callback
+ * (evaluated at fire time) considering only the conversation and user-editing; the streaming
+ * decision belongs to resolveResumeAction.
  */
 function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
   return currentConversationId !== null && !isAnyEditing;
@@ -145,27 +149,33 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
  * real policy.
  *
- * The order is the point: stop → refresh → rejoin. The refresh is awaited BEFORE the rejoin
- * so that no DB request is outstanding when the rejoined stream completes; see the
- * ordering tests below.
+ * The critical property: on the rejoin path we stop the local fetch and hand off to
+ * `tryRecover` (the /active-streams-first probe), and we DO NOT touch the DB unless
+ * tryRecover comes back empty. A blind DB refresh while a run is still generating would
+ * write a snapshot with no assistant message over the in-progress bubble.
+ *
+ * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
+ * persisted reply; false = nothing live, nothing persisted.
  */
-type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
+type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
 function planResume({
   native,
   isStreaming,
-  selectedAgent,
+  recovered = false,
 }: {
   native: boolean;
   isStreaming: boolean;
-  selectedAgent: { id: string } | null;
+  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
   if (action !== 'rejoin-and-refresh') return ['refresh'];
-  // `stop` is local-only — it clears useChat state so the refresh and rejoin write cleanly.
-  // It does NOT signal the server; the run keeps generating and is rejoined below.
-  return ['stop', 'refresh', selectedAgent ? 'rejoin-agent' : 'rejoin-global'];
+  // `stop` is local-only — it clears useChat state and releases the channel's `consuming`
+  // mark so the rejoin's bootstrap will attach. It does NOT signal the server; the run keeps
+  // generating and stays rejoinable.
+  if (recovered) return ['stop', 'try-recover'];
+  return ['stop', 'try-recover', 'refresh'];
 }
 
 // ============================================
@@ -615,65 +625,53 @@ describe('SidebarChatTab Display Logic', () => {
         expect(resumeEnabled('conv-A', true)).toBe(false);
       });
 
-      it('given the gate signature, streaming must not be an input at all', () => {
-        // THE REGRESSION. The gate used to be a render-time boolean that folded in
-        // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
-        // that gated the resume was whatever was true when the app went away — i.e.
-        // streaming — which disabled recovery in exactly the case it was written for.
-        // The streaming decision belongs to resolveResumeAction, evaluated at fire time;
-        // the gate must only ever consider the conversation and user-editing. Pinned on
-        // arity so a third `isStreaming` parameter cannot be reintroduced silently.
-        expect(resumeEnabled.length).toBe(2);
-      });
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, refresh, then rejoin the global stream', () => {
-        expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
+      it('given native mid-stream and a live stream to rejoin, should stop the local fetch and hand off to tryRecover — and NOT touch the DB', () => {
+        // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB
+        // snapshot taken while the stream is still generating contains no assistant message.
+        // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
+        // and rejoins; the DB is never read on this path.
+        expect(planResume({ native: true, isStreaming: true, recovered: true })).toEqual([
           'stop',
-          'refresh',
-          'rejoin-global',
+          'try-recover',
         ]);
       });
 
-      it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
-        expect(planResume({ native: true, isStreaming: true, selectedAgent: mockAgent })).toEqual([
+      it('given native and tryRecover finds nothing live or persisted, should fall back to a DB refresh', () => {
+        expect(planResume({ native: true, isStreaming: true, recovered: false })).toEqual([
           'stop',
+          'try-recover',
           'refresh',
-          'rejoin-agent',
         ]);
       });
 
-      it('given native, should await the refresh BEFORE the rejoin — never after it', () => {
-        // Order is the fix for a reply-wiping race. The reply is not persisted until the run
-        // completes, so a refresh issued alongside a live stream returns a snapshot with no
-        // assistant message. Fired AFTER the rejoin, that request could still be in flight when
-        // the rejoined stream completed — landing last and overwriting the just-completed reply
-        // with the pre-reply snapshot.
-        const plan = planResume({ native: true, isStreaming: true, selectedAgent: mockAgent });
-        expect(plan.indexOf('refresh')).toBeLessThan(plan.indexOf('rejoin-agent'));
-        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('refresh'));
+      it('given native, should always stop BEFORE recovering', () => {
+        // The stop is local-only, but it is what ends the dead response body and so releases
+        // the channel's `consuming` mark. Without that, the rejoin's bootstrap classifies the
+        // stream as one we are already reading off the POST body and skips attaching it — the
+        // rejoin would silently do nothing.
+        const plan = planResume({ native: true, isStreaming: true, recovered: true });
+        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('try-recover'));
       });
 
-      it('given native and NOT streaming, should still stop and rejoin — the recovery is deterministic, not flag-gated', () => {
+      it('given native and NOT streaming, should still stop and probe — the recovery is deterministic, not flag-gated', () => {
         // The local fetch is dead after backgrounding regardless of what useChat still
-        // reports, so native always rejoins. /active-streams is the authoritative answer
+        // reports, so native always probes. /active-streams is the authoritative answer
         // on whether a stream is actually live; no client flag gates the rejoin.
-        expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, recovered: true })).toEqual([
           'stop',
-          'refresh',
-          'rejoin-global',
+          'try-recover',
         ]);
       });
 
       it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
-        expect(planResume({ native: false, isStreaming: true, selectedAgent: null })).toEqual([]);
+        expect(planResume({ native: false, isStreaming: true })).toEqual([]);
       });
 
-      it('given web with no live fetch, should refresh only (no stop, no rejoin)', () => {
-        expect(planResume({ native: false, isStreaming: false, selectedAgent: mockAgent })).toEqual([
-          'refresh',
-        ]);
+      it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
+        expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
       });
     });
   });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
+import { canConcludeTurnIsLost } from '@/lib/ai/streams/recoveryAttempt';
 
 // ============================================
 // Test Helpers - Display Logic Extraction
@@ -163,19 +164,27 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
 /**
- * One tryRecover outcome. `recovered` and `probeAnswered` are separate because "we recovered
- * nothing" is NOT the same claim as "the server told us there was nothing to recover".
+ * One tryRecover outcome. `recovered` and the two "answered" flags are separate because "we
+ * recovered nothing" is NOT the same claim as "the server told us there was nothing to recover" —
+ * and regenerating on the latter is destructive twice over (it aborts a still-live run, and it
+ * DELETEs an already-persisted reply, since handleRetry removes the trailing assistant by the very
+ * id the server saved it under).
  */
 interface Attempt {
   recovered: boolean;
   probeAnswered: boolean;
+  dbAnswered: boolean;
 }
+
+const ANSWERED_NOTHING: Attempt = { recovered: false, probeAnswered: true, dbAnswered: true };
+const SILENT: Attempt = { recovered: false, probeAnswered: false, dbAnswered: false };
+const RECOVERED: Attempt = { recovered: true, probeAnswered: true, dbAnswered: true };
 
 function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
-  attempts = [{ recovered: true, probeAnswered: true }],
+  attempts = [RECOVERED],
 }: {
   native: boolean;
   /** The broad display/effective streaming flag — what resolveResumeAction sees. */
@@ -188,7 +197,7 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
-  /** Successive tryRecover outcomes, one per probe the resume handler makes (up to 3). */
+  /** Successive tryRecover outcomes, one per attempt the resume handler makes (up to 3). */
   attempts?: Attempt[];
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
@@ -198,18 +207,19 @@ function planResume({
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
-  let attempt: Attempt = attempts[0] ?? { recovered: false, probeAnswered: false };
+  let attempt: Attempt = attempts[0] ?? SILENT;
   if (attempt.recovered) return effects;
 
-  // An unanswered probe is not an answer. Re-probe (bounded) before concluding anything.
-  for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+  // Re-ask until BOTH questions come back. Silence from either means the work we would destroy
+  // might still exist.
+  for (let i = 1; !(attempt.probeAnswered && attempt.dbAnswered) && i <= 2; i++) {
     effects.push('try-recover');
-    attempt = attempts[i] ?? { recovered: false, probeAnswered: false };
+    attempt = attempts[i] ?? SILENT;
     if (attempt.recovered) return effects;
   }
 
-  // Regenerate only on an ANSWERED probe, and only for a turn of ours on this conversation.
-  if (ownTurnInFlight && attempt.probeAnswered) effects.push('regenerate');
+  // The REAL predicate, not a copy of it.
+  if (ownTurnInFlight && canConcludeTurnIsLost(attempt)) effects.push('regenerate');
   return effects;
 }
 
@@ -732,7 +742,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: false,
-            attempts: [{ recovered: false, probeAnswered: true }],
+            attempts: [ANSWERED_NOTHING],
           }),
         ).toEqual(['stop', 'try-recover']);
       });
@@ -747,13 +757,24 @@ function evictStalePartial<T extends { id: string }>(
           native: true,
           isStreaming: true,
           ownTurnInFlight: true,
-          attempts: [
-            { recovered: false, probeAnswered: false },
-            { recovered: false, probeAnswered: false },
-            { recovered: false, probeAnswered: false },
-          ],
+          attempts: [SILENT, SILENT, SILENT],
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
+        expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the probe answered but the DB GET did NOT, should NOT regenerate', () => {
+        // The other half of "silence is not an answer", and the more destructive half. If the
+        // messages GET failed we do not know whether the reply is already persisted — and
+        // handleRetry DELETEs the trailing assistant by the very id the server saved it under, so
+        // regenerating here would delete a COMPLETED reply and pay for it a second time.
+        const dbSilent = { recovered: false, probeAnswered: true, dbAnswered: false };
+        const plan = planResume({
+          native: true,
+          isStreaming: true,
+          ownTurnInFlight: true,
+          attempts: [dbSilent, dbSilent, dbSilent],
+        });
         expect(plan).not.toContain('regenerate');
       });
 
@@ -766,10 +787,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            attempts: [
-              { recovered: false, probeAnswered: false },
-              { recovered: false, probeAnswered: true },
-            ],
+            attempts: [SILENT, ANSWERED_NOTHING],
           }),
         ).toEqual(['stop', 'try-recover', 'try-recover', 'regenerate']);
       });
@@ -780,10 +798,7 @@ function evictStalePartial<T extends { id: string }>(
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            attempts: [
-              { recovered: false, probeAnswered: false },
-              { recovered: true, probeAnswered: true },
-            ],
+            attempts: [SILENT, RECOVERED],
           }),
         ).toEqual(['stop', 'try-recover', 'try-recover']);
       });
@@ -794,14 +809,14 @@ function evictStalePartial<T extends { id: string }>(
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the
         // background transition (a radio drop right then is common) finds no stream, no reply and
         // no error, and the user's prompt sits unanswered forever.
-        const plan = planResume({ native: true, isStreaming: true, attempts: [{ recovered: false, probeAnswered: true }] });
+        const plan = planResume({ native: true, isStreaming: true, attempts: [ANSWERED_NOTHING] });
         expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
         expect(plan).not.toContain('refresh');
       });
 
       it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
         // An ordinary resume on an idle conversation must never fire a spurious generation.
-        expect(planResume({ native: true, isStreaming: false, attempts: [{ recovered: false, probeAnswered: true }] })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, attempts: [ANSWERED_NOTHING] })).toEqual([
           'stop',
           'try-recover',
         ]);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -141,9 +141,13 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
 }
 
 /**
- * Mirrors the side effects of the `onResume` body, in order. The decision itself is NOT
- * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring (which stop,
- * which rejoin, and that the DB refresh runs last) against the real policy.
+ * Mirrors the side effects of the `onResume` body, IN ORDER. The decision itself is NOT
+ * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
+ * real policy.
+ *
+ * The order is the point: stop → refresh → rejoin. The refresh is awaited BEFORE the rejoin
+ * so that no DB request is outstanding when the rejoined stream completes; see the
+ * ordering tests below.
  */
 type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
 
@@ -158,14 +162,10 @@ function planResume({
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
-  const effects: ResumeEffect[] = [];
-  if (action === 'rejoin-and-refresh') {
-    // `stop` is local-only — it clears useChat state so the rejoin attaches cleanly.
-    // It does NOT signal the server; the run keeps generating and is rejoined below.
-    effects.push('stop', selectedAgent ? 'rejoin-agent' : 'rejoin-global');
-  }
-  effects.push('refresh');
-  return effects;
+  if (action !== 'rejoin-and-refresh') return ['refresh'];
+  // `stop` is local-only — it clears useChat state so the refresh and rejoin write cleanly.
+  // It does NOT signal the server; the run keeps generating and is rejoined below.
+  return ['stop', 'refresh', selectedAgent ? 'rejoin-agent' : 'rejoin-global'];
 }
 
 // ============================================
@@ -615,33 +615,44 @@ describe('SidebarChatTab Display Logic', () => {
         expect(resumeEnabled('conv-A', true)).toBe(false);
       });
 
-      it('given a stream is in flight, should STILL enable recovery — streaming is not an input to the gate', () => {
+      it('given the gate signature, streaming must not be an input at all', () => {
         // THE REGRESSION. The gate used to be a render-time boolean that folded in
         // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
         // that gated the resume was whatever was true when the app went away — i.e.
         // streaming — which disabled recovery in exactly the case it was written for.
-        // The gate takes no streaming argument at all now; there is no way to express
-        // that bug in this signature. The streaming decision belongs to
-        // resolveResumeAction, at fire time.
-        expect(resumeEnabled('conv-A', false)).toBe(true);
+        // The streaming decision belongs to resolveResumeAction, evaluated at fire time;
+        // the gate must only ever consider the conversation and user-editing. Pinned on
+        // arity so a third `isStreaming` parameter cannot be reintroduced silently.
+        expect(resumeEnabled.length).toBe(2);
       });
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, rejoin the global stream, then refresh', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, refresh, then rejoin the global stream', () => {
         expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
           'stop',
-          'rejoin-global',
           'refresh',
+          'rejoin-global',
         ]);
       });
 
       it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
         expect(planResume({ native: true, isStreaming: true, selectedAgent: mockAgent })).toEqual([
           'stop',
-          'rejoin-agent',
           'refresh',
+          'rejoin-agent',
         ]);
+      });
+
+      it('given native, should await the refresh BEFORE the rejoin — never after it', () => {
+        // Order is the fix for a reply-wiping race. The reply is not persisted until the run
+        // completes, so a refresh issued alongside a live stream returns a snapshot with no
+        // assistant message. Fired AFTER the rejoin, that request could still be in flight when
+        // the rejoined stream completed — landing last and overwriting the just-completed reply
+        // with the pre-reply snapshot.
+        const plan = planResume({ native: true, isStreaming: true, selectedAgent: mockAgent });
+        expect(plan.indexOf('refresh')).toBeLessThan(plan.indexOf('rejoin-agent'));
+        expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('refresh'));
       });
 
       it('given native and NOT streaming, should still stop and rejoin — the recovery is deterministic, not flag-gated', () => {
@@ -650,8 +661,8 @@ describe('SidebarChatTab Display Logic', () => {
         // on whether a stream is actually live; no client flag gates the rejoin.
         expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
           'stop',
-          'rejoin-global',
           'refresh',
+          'rejoin-global',
         ]);
       });
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -6,6 +6,8 @@
 import { describe, it, expect, vi } from 'vitest';
 import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 import { canConcludeTurnIsLost } from '@/lib/ai/streams/recoveryAttempt';
+import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
+import { evictStalePartial } from '@/lib/ai/streams/evictStalePartial';
 
 // ============================================
 // Test Helpers - Display Logic Extraction
@@ -129,20 +131,6 @@ function isOwnStreamForConversation(
   targetConversationId: string | null,
 ): boolean {
   return isStreaming && heldStreamConvId === targetConversationId;
-}
-
-/**
- * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
- *
- * Deliberately takes NO streaming argument, which is the whole point. The gate used to be a
- * render-time boolean folding in `!isStreaming`; iOS freezes JS the moment the app backgrounds,
- * so the value that gated the resume was whatever was true when the app went away — streaming —
- * and recovery was disabled in exactly the case it was written for. The gate must be a callback
- * (evaluated at fire time) considering only the conversation and user-editing; the streaming
- * decision belongs to resolveResumeAction.
- */
-function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
-  return currentConversationId !== null && !isAnyEditing;
 }
 
 /**
@@ -666,45 +654,18 @@ describe('SidebarChatTab Display Logic', () => {
     });
   });
 
-/**
- * Mirrors the rejoin branch of `tryRecover`: the live stream's messageId is used to evict the
- * half-streamed assistant bubble useChat is still holding, so the rejoined pending stream is not
- * deduped away.
- *
- * `Chat.stop()` "keeps the generated tokens", and a dropped fetch leaves them too — so `messages`
- * still holds an assistant message whose id IS the live stream's messageId (the server mints one
- * id and uses it for BOTH the UI message and the stream registry row). The rejoin re-adds that
- * same stream to the pending store, and the surfaces drop a pending stream whose messageId
- * already appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams).
- * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
- * token renders, and the user stares at a frozen partial.
- */
-function evictStalePartial<T extends { id: string }>(
-  messages: T[],
-  liveMessageId: string,
-  serverPartsCount: number,
-): T[] {
-  // Only when the server has something to put in its place. `parts` from /active-streams is the
-  // registry's DEBOUNCED checkpoint, so it is empty for a stream only a few parts old. Evicting
-  // against an empty checkpoint and then failing the SSE join (the multi-instance case, where the
-  // multicast lives in another process) removes the stream and leaves the user with NOTHING —
-  // strictly worse than the frozen partial we started with.
-  if (serverPartsCount === 0) return messages;
-  return messages.filter((m) => m.id !== liveMessageId);
-}
-
   describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
     describe('resumeEnabled (the gate)', () => {
       it('given a conversation and no active editing, should enable recovery', () => {
-        expect(resumeEnabled('conv-A', false)).toBe(true);
+        expect(canResumeRecovery('conv-A', false)).toBe(true);
       });
 
       it('given no conversation, should NOT enable recovery (nothing to rejoin)', () => {
-        expect(resumeEnabled(null, false)).toBe(false);
+        expect(canResumeRecovery(null, false)).toBe(false);
       });
 
       it('given the user is actively editing, should NOT enable recovery (would clobber their edit)', () => {
-        expect(resumeEnabled('conv-A', true)).toBe(false);
+        expect(canResumeRecovery('conv-A', true)).toBe(false);
       });
 
     });
@@ -850,6 +811,8 @@ function evictStalePartial<T extends { id: string }>(
 
     describe('evictStalePartial (why the rejoin renders at all)', () => {
       const liveId = 'srv-msg-1';
+      // A checkpoint the bootstrap would actually seed from (survives isValidPartFrame).
+      const SEEDED_PARTS = [{ type: 'text', text: 'partial reply' }];
       const messages = [
         { id: 'u1', role: 'user' },
         { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
@@ -858,11 +821,11 @@ function evictStalePartial<T extends { id: string }>(
       it('given a rejoined live stream the server has parts for, should drop the local partial carrying that same messageId', () => {
         // Without this the pending stream the rejoin adds under `liveId` is deduped away,
         // because `liveId` is still present in `messages`. The bubble would never update.
-        expect(evictStalePartial(messages, liveId, 12)).toEqual([{ id: 'u1', role: 'user' }]);
+        expect(evictStalePartial(messages, liveId, SEEDED_PARTS)).toEqual([{ id: 'u1', role: 'user' }]);
       });
 
       it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
-        const remaining = evictStalePartial(messages, liveId, 12);
+        const remaining = evictStalePartial(messages, liveId, SEEDED_PARTS);
         const seen = new Set(remaining.map((m) => m.id));
         expect(seen.has(liveId)).toBe(false);
       });
@@ -872,15 +835,15 @@ function evictStalePartial<T extends { id: string }>(
         // and the SSE join then failed (multi-instance: the multicast lives in another process),
         // the bootstrap removes the stream and the user is left with nothing at all — worse than
         // the frozen partial. Keep what they had; the rejoin can still attach and take over.
-        expect(evictStalePartial(messages, liveId, 0)).toEqual(messages);
+        expect(evictStalePartial(messages, liveId, [])).toEqual(messages);
       });
 
       it('given messages with no matching id, should leave them untouched', () => {
-        expect(evictStalePartial(messages, 'some-other-id', 12)).toEqual(messages);
+        expect(evictStalePartial(messages, 'some-other-id', SEEDED_PARTS)).toEqual(messages);
       });
 
       it('should only ever drop the ONE message the server named — never the user turn', () => {
-        const out = evictStalePartial(messages, liveId, 12);
+        const out = evictStalePartial(messages, liveId, SEEDED_PARTS);
         expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -159,8 +159,6 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  *
  *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
- * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
- * persisted reply; false = nothing live, nothing persisted, or the probe failed.
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
@@ -626,7 +624,17 @@ describe('SidebarChatTab Display Logic', () => {
  * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
  * token renders, and the user stares at a frozen partial.
  */
-function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageId: string): T[] {
+function evictStalePartial<T extends { id: string }>(
+  messages: T[],
+  liveMessageId: string,
+  serverPartsCount: number,
+): T[] {
+  // Only when the server has something to put in its place. `parts` from /active-streams is the
+  // registry's DEBOUNCED checkpoint, so it is empty for a stream only a few parts old. Evicting
+  // against an empty checkpoint and then failing the SSE join (the multi-instance case, where the
+  // multicast lives in another process) removes the stream and leaves the user with NOTHING —
+  // strictly worse than the frozen partial we started with.
+  if (serverPartsCount === 0) return messages;
   return messages.filter((m) => m.id !== liveMessageId);
 }
 
@@ -653,16 +661,6 @@ function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageI
         // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
         // and rejoins; the DB is never read while a run is live.
         expect(planResume({ native: true, isStreaming: true })).toEqual(['stop', 'try-recover']);
-      });
-
-      it('given native, should NOT fall back to a DB refresh when tryRecover comes back empty', () => {
-        // tryRecover returns false in exactly the two cases where a DB write is unsafe: the
-        // probe failed (a stream may still be live — and the first request after a foreground
-        // is the likeliest to fail, radio still coming up), or the DB is behind local state
-        // (a send whose POST never reached the server; refreshing would erase the user's own
-        // prompt). Doing nothing is correct in both; the socket reconnect path heals it.
-        expect(planResume({ native: true, isStreaming: true })).not.toContain('refresh');
-        expect(planResume({ native: true, isStreaming: false })).not.toContain('refresh');
       });
 
       it('given native, should always stop BEFORE recovering', () => {
@@ -697,24 +695,32 @@ function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageI
         { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
       ];
 
-      it('given a rejoined live stream, should drop the local partial carrying that same messageId', () => {
+      it('given a rejoined live stream the server has parts for, should drop the local partial carrying that same messageId', () => {
         // Without this the pending stream the rejoin adds under `liveId` is deduped away,
         // because `liveId` is still present in `messages`. The bubble would never update.
-        expect(evictStalePartial(messages, liveId)).toEqual([{ id: 'u1', role: 'user' }]);
+        expect(evictStalePartial(messages, liveId, 12)).toEqual([{ id: 'u1', role: 'user' }]);
       });
 
       it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
-        const remaining = evictStalePartial(messages, liveId);
+        const remaining = evictStalePartial(messages, liveId, 12);
         const seen = new Set(remaining.map((m) => m.id));
         expect(seen.has(liveId)).toBe(false);
       });
 
+      it('given the server checkpoint is EMPTY, should KEEP the local partial', () => {
+        // The debounced checkpoint is empty for a stream only a few parts old. If we evicted here
+        // and the SSE join then failed (multi-instance: the multicast lives in another process),
+        // the bootstrap removes the stream and the user is left with nothing at all — worse than
+        // the frozen partial. Keep what they had; the rejoin can still attach and take over.
+        expect(evictStalePartial(messages, liveId, 0)).toEqual(messages);
+      });
+
       it('given messages with no matching id, should leave them untouched', () => {
-        expect(evictStalePartial(messages, 'some-other-id')).toEqual(messages);
+        expect(evictStalePartial(messages, 'some-other-id', 12)).toEqual(messages);
       });
 
       it('should only ever drop the ONE message the server named — never the user turn', () => {
-        const out = evictStalePartial(messages, liveId);
+        const out = evictStalePartial(messages, liveId, 12);
         expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -918,7 +918,7 @@ describe('SidebarChatTab Display Logic', () => {
       });
 
       it('given the server checkpoint is EMPTY, should KEEP the local partial', () => {
-        // The debounced checkpoint is empty for a stream only a few parts old. If we evicted here
+        // The checkpoint lags the live stream, so it is empty for a stream in its first moments. If we evicted here
         // and the SSE join then failed (multi-instance: the multicast lives in another process),
         // the bootstrap removes the stream and the user is left with nothing at all — worse than
         // the frozen partial. Keep what they had; the rejoin can still attach and take over.

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -4,6 +4,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
+import { resolveResumeAction } from '@/lib/ai/streams/resolveResumeAction';
 
 // ============================================
 // Test Helpers - Display Logic Extraction
@@ -127,6 +128,44 @@ function isOwnStreamForConversation(
   targetConversationId: string | null,
 ): boolean {
   return isStreaming && heldStreamConvId === targetConversationId;
+}
+
+/**
+ * Mirrors `resumeEnabled` — the `enabled` gate passed to useAppStateRecovery.
+ *
+ * Deliberately takes NO streaming argument. The gate must be a callback (evaluated at
+ * fire time, on resume) and must gate on user-editing only. See the regression test below.
+ */
+function resumeEnabled(currentConversationId: string | null, isAnyEditing: boolean): boolean {
+  return currentConversationId !== null && !isAnyEditing;
+}
+
+/**
+ * Mirrors the side effects of the `onResume` body, in order. The decision itself is NOT
+ * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring (which stop,
+ * which rejoin, and that the DB refresh runs last) against the real policy.
+ */
+type ResumeEffect = 'stop' | 'rejoin-agent' | 'rejoin-global' | 'refresh';
+
+function planResume({
+  native,
+  isStreaming,
+  selectedAgent,
+}: {
+  native: boolean;
+  isStreaming: boolean;
+  selectedAgent: { id: string } | null;
+}): ResumeEffect[] {
+  const action = resolveResumeAction({ native, isStreaming });
+  if (action === 'noop') return [];
+  const effects: ResumeEffect[] = [];
+  if (action === 'rejoin-and-refresh') {
+    // `stop` is local-only — it clears useChat state so the rejoin attaches cleanly.
+    // It does NOT signal the server; the run keeps generating and is rejoined below.
+    effects.push('stop', selectedAgent ? 'rejoin-agent' : 'rejoin-global');
+  }
+  effects.push('refresh');
+  return effects;
 }
 
 // ============================================
@@ -559,6 +598,72 @@ describe('SidebarChatTab Display Logic', () => {
       // latched to 'conv-A' (where the stream actually started); the surface has moved to 'conv-B'.
       const blocked = isOwnStreamForConversation(true, 'conv-A', 'conv-B');
       expect(blocked).toBe(false);
+    });
+  });
+
+  describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
+    describe('resumeEnabled (the gate)', () => {
+      it('given a conversation and no active editing, should enable recovery', () => {
+        expect(resumeEnabled('conv-A', false)).toBe(true);
+      });
+
+      it('given no conversation, should NOT enable recovery (nothing to rejoin)', () => {
+        expect(resumeEnabled(null, false)).toBe(false);
+      });
+
+      it('given the user is actively editing, should NOT enable recovery (would clobber their edit)', () => {
+        expect(resumeEnabled('conv-A', true)).toBe(false);
+      });
+
+      it('given a stream is in flight, should STILL enable recovery — streaming is not an input to the gate', () => {
+        // THE REGRESSION. The gate used to be a render-time boolean that folded in
+        // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value
+        // that gated the resume was whatever was true when the app went away — i.e.
+        // streaming — which disabled recovery in exactly the case it was written for.
+        // The gate takes no streaming argument at all now; there is no way to express
+        // that bug in this signature. The streaming decision belongs to
+        // resolveResumeAction, at fire time.
+        expect(resumeEnabled('conv-A', false)).toBe(true);
+      });
+    });
+
+    describe('planResume (the onResume body)', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch, rejoin the global stream, then refresh', () => {
+        expect(planResume({ native: true, isStreaming: true, selectedAgent: null })).toEqual([
+          'stop',
+          'rejoin-global',
+          'refresh',
+        ]);
+      });
+
+      it('given native mid-stream with an agent selected, should rejoin the AGENT stream', () => {
+        expect(planResume({ native: true, isStreaming: true, selectedAgent: mockAgent })).toEqual([
+          'stop',
+          'rejoin-agent',
+          'refresh',
+        ]);
+      });
+
+      it('given native and NOT streaming, should still stop and rejoin — the recovery is deterministic, not flag-gated', () => {
+        // The local fetch is dead after backgrounding regardless of what useChat still
+        // reports, so native always rejoins. /active-streams is the authoritative answer
+        // on whether a stream is actually live; no client flag gates the rejoin.
+        expect(planResume({ native: true, isStreaming: false, selectedAgent: null })).toEqual([
+          'stop',
+          'rejoin-global',
+          'refresh',
+        ]);
+      });
+
+      it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
+        expect(planResume({ native: false, isStreaming: true, selectedAgent: null })).toEqual([]);
+      });
+
+      it('given web with no live fetch, should refresh only (no stop, no rejoin)', () => {
+        expect(planResume({ native: false, isStreaming: false, selectedAgent: mockAgent })).toEqual([
+          'refresh',
+        ]);
+      });
     });
   });
 });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -682,6 +682,64 @@ describe('SidebarChatTab Display Logic', () => {
 
     });
 
+    describe('regenerateTurnOnce (the mutex both recovery paths share)', () => {
+      // Mirrors the component's wrapper. useStreamRecovery and the resume handler watch the same
+      // failure from opposite sides and would otherwise regenerate the same turn twice — and
+      // useStreamRecovery calls clearError() BEFORE its own probes, so for its whole decision
+      // window the chat looks idle to us. Two regenerates for one turn is the double destruction
+      // the resume gate exists to prevent: the server takes over the conversation on every
+      // generation start, so the second aborts the first, and handleRetry deletes its assistant
+      // message on the way in.
+      function makeRegenerateTurnOnce(handleRetry: () => Promise<void>) {
+        let inFlight = false;
+        return async () => {
+          if (inFlight) return;
+          inFlight = true;
+          try {
+            await handleRetry();
+          } finally {
+            inFlight = false;
+          }
+        };
+      }
+
+      it('given both paths fire while the first is still running, should regenerate ONCE', async () => {
+        let calls = 0;
+        let release!: () => void;
+        const blocked = new Promise<void>((r) => { release = r; });
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => {
+          calls += 1;
+          await blocked; // handleRetry's message DELETEs are a network round-trip
+        });
+
+        const first = regenerateTurnOnce();  // useStreamRecovery's retry
+        const second = regenerateTurnOnce(); // the resume handler, deciding concurrently
+        release();
+        await Promise.all([first, second]);
+
+        expect(calls).toBe(1);
+      });
+
+      it('given the lock was released, should allow a LATER regenerate (it is a mutex, not a one-shot latch)', async () => {
+        let calls = 0;
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => { calls += 1; });
+        await regenerateTurnOnce();
+        await regenerateTurnOnce();
+        expect(calls).toBe(2);
+      });
+
+      it('given handleRetry throws, should still release the lock', async () => {
+        let calls = 0;
+        const regenerateTurnOnce = makeRegenerateTurnOnce(async () => {
+          calls += 1;
+          throw new Error('regenerate failed');
+        });
+        await expect(regenerateTurnOnce()).rejects.toThrow('regenerate failed');
+        await expect(regenerateTurnOnce()).rejects.toThrow('regenerate failed');
+        expect(calls).toBe(2); // not wedged shut
+      });
+    });
+
     describe('planResume (the onResume body)', () => {
       it('given native mid-stream (the orphaned-stream bug), should stop the local fetch and hand off to tryRecover — and NOT read the DB', () => {
         // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -149,33 +149,35 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  * mirrored — it calls the real `resolveResumeAction`, so this pins the wiring against the
  * real policy.
  *
- * The critical property: on the rejoin path we stop the local fetch and hand off to
- * `tryRecover` (the /active-streams-first probe), and we DO NOT touch the DB unless
- * tryRecover comes back empty. A blind DB refresh while a run is still generating would
- * write a snapshot with no assistant message over the in-progress bubble.
+ * Two invariants worth stating plainly, because both were bugs:
+ *
+ *  - On the native path we stop the local fetch and hand off to `tryRecover`, and there is NO
+ *    DB-refresh fallback afterwards. tryRecover already refetches when the run finished while
+ *    we were away. A fallback would only fire in the cases where a DB write is UNSAFE: the
+ *    /active-streams probe failed (a stream may still be live, and the DB cannot contain an
+ *    unpersisted reply), or the DB is behind local state (a send whose POST never landed).
+ *
+ *  - The web path never stops or probes: a live fetch survives a tab switch.
  *
  * `recovered` models tryRecover's return: true = it rejoined a live stream or refetched a
- * persisted reply; false = nothing live, nothing persisted.
+ * persisted reply; false = nothing live, nothing persisted, or the probe failed.
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh';
 
 function planResume({
   native,
   isStreaming,
-  recovered = false,
 }: {
   native: boolean;
   isStreaming: boolean;
-  recovered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
-  if (action !== 'rejoin-and-refresh') return ['refresh'];
-  // `stop` is local-only — it clears useChat state and releases the channel's `consuming`
-  // mark so the rejoin's bootstrap will attach. It does NOT signal the server; the run keeps
-  // generating and stays rejoinable.
-  if (recovered) return ['stop', 'try-recover'];
-  return ['stop', 'try-recover', 'refresh'];
+  if (action === 'refresh') return ['refresh'];
+  // The stop is local-only. It clears useChat state and — critically — ends the dead response
+  // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
+  // treats the stream as one we are already reading off the POST and skips attaching it.
+  return ['stop', 'try-recover'];
 }
 
 // ============================================
@@ -611,6 +613,23 @@ describe('SidebarChatTab Display Logic', () => {
     });
   });
 
+/**
+ * Mirrors the rejoin branch of `tryRecover`: the live stream's messageId is used to evict the
+ * half-streamed assistant bubble useChat is still holding, so the rejoined pending stream is not
+ * deduped away.
+ *
+ * `Chat.stop()` "keeps the generated tokens", and a dropped fetch leaves them too — so `messages`
+ * still holds an assistant message whose id IS the live stream's messageId (the server mints one
+ * id and uses it for BOTH the UI message and the stream registry row). The rejoin re-adds that
+ * same stream to the pending store, and the surfaces drop a pending stream whose messageId
+ * already appears in `messages` (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams).
+ * Leave the stale bubble in place and the rejoined stream is filtered straight back out — not one
+ * token renders, and the user stares at a frozen partial.
+ */
+function evictStalePartial<T extends { id: string }>(messages: T[], liveMessageId: string): T[] {
+  return messages.filter((m) => m.id !== liveMessageId);
+}
+
   describe('app-state resume recovery (useAppStateRecovery wiring)', () => {
     describe('resumeEnabled (the gate)', () => {
       it('given a conversation and no active editing, should enable recovery', () => {
@@ -628,23 +647,22 @@ describe('SidebarChatTab Display Logic', () => {
     });
 
     describe('planResume (the onResume body)', () => {
-      it('given native mid-stream and a live stream to rejoin, should stop the local fetch and hand off to tryRecover — and NOT touch the DB', () => {
+      it('given native mid-stream (the orphaned-stream bug), should stop the local fetch and hand off to tryRecover — and NOT read the DB', () => {
         // THE KEY INVARIANT. The reply is not persisted until the run completes, so a DB
         // snapshot taken while the stream is still generating contains no assistant message.
         // Writing it would wipe the in-progress bubble. tryRecover asks /active-streams first
-        // and rejoins; the DB is never read on this path.
-        expect(planResume({ native: true, isStreaming: true, recovered: true })).toEqual([
-          'stop',
-          'try-recover',
-        ]);
+        // and rejoins; the DB is never read while a run is live.
+        expect(planResume({ native: true, isStreaming: true })).toEqual(['stop', 'try-recover']);
       });
 
-      it('given native and tryRecover finds nothing live or persisted, should fall back to a DB refresh', () => {
-        expect(planResume({ native: true, isStreaming: true, recovered: false })).toEqual([
-          'stop',
-          'try-recover',
-          'refresh',
-        ]);
+      it('given native, should NOT fall back to a DB refresh when tryRecover comes back empty', () => {
+        // tryRecover returns false in exactly the two cases where a DB write is unsafe: the
+        // probe failed (a stream may still be live — and the first request after a foreground
+        // is the likeliest to fail, radio still coming up), or the DB is behind local state
+        // (a send whose POST never reached the server; refreshing would erase the user's own
+        // prompt). Doing nothing is correct in both; the socket reconnect path heals it.
+        expect(planResume({ native: true, isStreaming: true })).not.toContain('refresh');
+        expect(planResume({ native: true, isStreaming: false })).not.toContain('refresh');
       });
 
       it('given native, should always stop BEFORE recovering', () => {
@@ -652,7 +670,7 @@ describe('SidebarChatTab Display Logic', () => {
         // the channel's `consuming` mark. Without that, the rejoin's bootstrap classifies the
         // stream as one we are already reading off the POST body and skips attaching it — the
         // rejoin would silently do nothing.
-        const plan = planResume({ native: true, isStreaming: true, recovered: true });
+        const plan = planResume({ native: true, isStreaming: true });
         expect(plan.indexOf('stop')).toBeLessThan(plan.indexOf('try-recover'));
       });
 
@@ -660,10 +678,7 @@ describe('SidebarChatTab Display Logic', () => {
         // The local fetch is dead after backgrounding regardless of what useChat still
         // reports, so native always probes. /active-streams is the authoritative answer
         // on whether a stream is actually live; no client flag gates the rejoin.
-        expect(planResume({ native: true, isStreaming: false, recovered: true })).toEqual([
-          'stop',
-          'try-recover',
-        ]);
+        expect(planResume({ native: true, isStreaming: false })).toEqual(['stop', 'try-recover']);
       });
 
       it('given web with a live fetch, should do nothing — the fetch survives a tab switch and must not be clobbered', () => {
@@ -672,6 +687,35 @@ describe('SidebarChatTab Display Logic', () => {
 
       it('given web with no live fetch, should refresh only (no stop, no probe)', () => {
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
+      });
+    });
+
+    describe('evictStalePartial (why the rejoin renders at all)', () => {
+      const liveId = 'srv-msg-1';
+      const messages = [
+        { id: 'u1', role: 'user' },
+        { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
+      ];
+
+      it('given a rejoined live stream, should drop the local partial carrying that same messageId', () => {
+        // Without this the pending stream the rejoin adds under `liveId` is deduped away,
+        // because `liveId` is still present in `messages`. The bubble would never update.
+        expect(evictStalePartial(messages, liveId)).toEqual([{ id: 'u1', role: 'user' }]);
+      });
+
+      it('given the partial is evicted, the rejoined stream is no longer deduped out', () => {
+        const remaining = evictStalePartial(messages, liveId);
+        const seen = new Set(remaining.map((m) => m.id));
+        expect(seen.has(liveId)).toBe(false);
+      });
+
+      it('given messages with no matching id, should leave them untouched', () => {
+        expect(evictStalePartial(messages, 'some-other-id')).toEqual(messages);
+      });
+
+      it('should only ever drop the ONE message the server named — never the user turn', () => {
+        const out = evictStalePartial(messages, liveId);
+        expect(out.some((m) => m.role === 'user')).toBe(true);
       });
     });
   });

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -172,6 +172,7 @@ function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
+  somethingRestarted = false,
   stillOnInterruptedConversation = true,
   attempts = [RECOVERED],
 }: {
@@ -186,6 +187,12 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
+  /**
+   * Whether something has ALREADY restarted the turn while we were recovering — useStreamRecovery
+   * watches the same failure from the other side (it fires on `status === 'error'`) and regenerates
+   * too, and the two share no lock.
+   */
+  somethingRestarted?: boolean;
   /**
    * Whether we are still on the conversation the interrupted turn belongs to. The recovery spans
    * seconds of network and the user can switch conversation inside that window; handleRetry always
@@ -215,7 +222,12 @@ function planResume({
   }
 
   // The REAL predicate, not a copy of it.
-  if (ownTurnInFlight && stillOnInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+  if (
+    ownTurnInFlight &&
+    stillOnInterruptedConversation &&
+    !somethingRestarted &&
+    canConcludeTurnIsLost(attempt)
+  ) {
     effects.push('regenerate');
   }
   return effects;
@@ -732,6 +744,23 @@ describe('SidebarChatTab Display Logic', () => {
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
         expect(plan).not.toContain('regenerate');
+      });
+
+      it('given useStreamRecovery already restarted the turn, should NOT regenerate again', () => {
+        // The two paths watch the same failure and share no lock: useStreamRecovery fires on
+        // `status === 'error'`, and rawStop() cannot have cancelled it (Chat.stop returns early
+        // unless the status is streaming/submitted). Regenerating on top would be exactly the
+        // double destruction the gate exists to prevent — takeOverConversationStreams aborts the
+        // run that just started, and handleRetry deletes its assistant message on the way in.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            somethingRestarted: true,
+            attempts: [ANSWERED_NOTHING],
+          }),
+        ).toEqual(['stop', 'try-recover']);
       });
 
       it('given the user switched conversation during the recovery, should NOT regenerate', () => {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -184,6 +184,7 @@ function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
+  stillOnInterruptedConversation = true,
   attempts = [RECOVERED],
 }: {
   native: boolean;
@@ -197,6 +198,13 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
+  /**
+   * Whether we are still on the conversation the interrupted turn belongs to. The recovery spans
+   * seconds of network and the user can switch conversation inside that window; handleRetry always
+   * acts on the LIVE conversation, so regenerating after a switch would fire a generation for the
+   * turn they moved TO rather than the one that was interrupted.
+   */
+  stillOnInterruptedConversation?: boolean;
   /** Successive tryRecover outcomes, one per attempt the resume handler makes (up to 3). */
   attempts?: Attempt[];
 }): ResumeEffect[] {
@@ -219,7 +227,9 @@ function planResume({
   }
 
   // The REAL predicate, not a copy of it.
-  if (ownTurnInFlight && canConcludeTurnIsLost(attempt)) effects.push('regenerate');
+  if (ownTurnInFlight && stillOnInterruptedConversation && canConcludeTurnIsLost(attempt)) {
+    effects.push('regenerate');
+  }
   return effects;
 }
 
@@ -761,6 +771,21 @@ function evictStalePartial<T extends { id: string }>(
         });
         expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
         expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the user switched conversation during the recovery, should NOT regenerate', () => {
+        // handleRetry acts on the LIVE conversation. The recovery spans seconds of network, so a
+        // switch inside that window would make it fire a generation for the turn the user moved
+        // TO, not the interrupted one.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            stillOnInterruptedConversation: false,
+            attempts: [ANSWERED_NOTHING],
+          }),
+        ).toEqual(['stop', 'try-recover']);
       });
 
       it('given the probe answered but the DB GET did NOT, should NOT regenerate', () => {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -162,12 +162,20 @@ function resumeEnabled(currentConversationId: string | null, isAnyEditing: boole
  */
 type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 
+/**
+ * One tryRecover outcome. `recovered` and `probeAnswered` are separate because "we recovered
+ * nothing" is NOT the same claim as "the server told us there was nothing to recover".
+ */
+interface Attempt {
+  recovered: boolean;
+  probeAnswered: boolean;
+}
+
 function planResume({
   native,
   isStreaming,
   ownTurnInFlight = isStreaming,
-  recovered = true,
-  probeAnswered = true,
+  attempts = [{ recovered: true, probeAnswered: true }],
 }: {
   native: boolean;
   /** The broad display/effective streaming flag — what resolveResumeAction sees. */
@@ -180,10 +188,8 @@ function planResume({
    * rather than the one that was interrupted.
    */
   ownTurnInFlight?: boolean;
-  /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
-  recovered?: boolean;
-  /** Whether the /active-streams probe actually reached the server and answered. */
-  probeAnswered?: boolean;
+  /** Successive tryRecover outcomes, one per probe the resume handler makes (up to 3). */
+  attempts?: Attempt[];
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -192,11 +198,18 @@ function planResume({
   // body, which releases the channel's `consuming` mark. Without that the rejoin's bootstrap
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
-  if (recovered) return effects;
-  // Nothing recovered. NOT a DB refresh (unsafe: it would erase an in-progress bubble or the
-  // user's own prompt). Regenerate — but only on an ANSWERED probe, and only if a turn of ours was
-  // really in flight for this conversation.
-  if (ownTurnInFlight && probeAnswered) effects.push('regenerate');
+  let attempt: Attempt = attempts[0] ?? { recovered: false, probeAnswered: false };
+  if (attempt.recovered) return effects;
+
+  // An unanswered probe is not an answer. Re-probe (bounded) before concluding anything.
+  for (let i = 1; !attempt.probeAnswered && i <= 2; i++) {
+    effects.push('try-recover');
+    attempt = attempts[i] ?? { recovered: false, probeAnswered: false };
+    if (attempt.recovered) return effects;
+  }
+
+  // Regenerate only on an ANSWERED probe, and only for a turn of ours on this conversation.
+  if (ownTurnInFlight && attempt.probeAnswered) effects.push('regenerate');
   return effects;
 }
 
@@ -715,25 +728,64 @@ function evictStalePartial<T extends { id: string }>(
         // screen rather than the interrupted one — a spurious reply, and a spurious charge, on an
         // untouched conversation.
         expect(
-          planResume({ native: true, isStreaming: true, ownTurnInFlight: false, recovered: false }),
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: false,
+            attempts: [{ recovered: false, probeAnswered: true }],
+          }),
         ).toEqual(['stop', 'try-recover']);
       });
 
-      it('given native and the probe never ANSWERED, should NOT regenerate', () => {
+      it('given native and the probe never ANSWERED, should re-probe and then NOT regenerate', () => {
         // Silence is not an answer. Every generation start calls takeOverConversationStreams, so a
         // regenerate issued while the run is in fact still live does not race it — it ABORTS it.
         // We would kill a healthy generation, re-run write tools it had already executed, bill the
         // discarded tokens, and strand its partial in the DB. Doing nothing is safe: the stop
         // released the `consuming` mark, so the socket-reconnect bootstrap picks a live run up.
+        const plan = planResume({
+          native: true,
+          isStreaming: true,
+          ownTurnInFlight: true,
+          attempts: [
+            { recovered: false, probeAnswered: false },
+            { recovered: false, probeAnswered: false },
+            { recovered: false, probeAnswered: false },
+          ],
+        });
+        expect(plan).toEqual(['stop', 'try-recover', 'try-recover', 'try-recover']);
+        expect(plan).not.toContain('regenerate');
+      });
+
+      it('given the probe answers only on a LATER attempt, should still regenerate — a cold radio must not strand the turn', () => {
+        // The first request after a foreground is the one most likely to fail. Concluding from that
+        // single silence would leave the user's prompt unanswered forever; re-probing lets the
+        // radio come back and gives us a real answer to act on.
         expect(
           planResume({
             native: true,
             isStreaming: true,
             ownTurnInFlight: true,
-            recovered: false,
-            probeAnswered: false,
+            attempts: [
+              { recovered: false, probeAnswered: false },
+              { recovered: false, probeAnswered: true },
+            ],
           }),
-        ).toEqual(['stop', 'try-recover']);
+        ).toEqual(['stop', 'try-recover', 'try-recover', 'regenerate']);
+      });
+
+      it('given a re-probe finds the live stream, should rejoin and never regenerate', () => {
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            attempts: [
+              { recovered: false, probeAnswered: false },
+              { recovered: true, probeAnswered: true },
+            ],
+          }),
+        ).toEqual(['stop', 'try-recover', 'try-recover']);
       });
 
       it('given native, a turn in flight, an ANSWERED probe, and NOTHING to recover, should regenerate — never a DB refresh', () => {
@@ -742,14 +794,14 @@ function evictStalePartial<T extends { id: string }>(
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the
         // background transition (a radio drop right then is common) finds no stream, no reply and
         // no error, and the user's prompt sits unanswered forever.
-        const plan = planResume({ native: true, isStreaming: true, recovered: false });
+        const plan = planResume({ native: true, isStreaming: true, attempts: [{ recovered: false, probeAnswered: true }] });
         expect(plan).toEqual(['stop', 'try-recover', 'regenerate']);
         expect(plan).not.toContain('refresh');
       });
 
       it('given native, NO turn in flight, and nothing to recover, should NOT regenerate', () => {
         // An ordinary resume on an idle conversation must never fire a spurious generation.
-        expect(planResume({ native: true, isStreaming: false, recovered: false })).toEqual([
+        expect(planResume({ native: true, isStreaming: false, attempts: [{ recovered: false, probeAnswered: true }] })).toEqual([
           'stop',
           'try-recover',
         ]);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarChatTab.test.tsx
@@ -165,12 +165,25 @@ type ResumeEffect = 'stop' | 'try-recover' | 'refresh' | 'regenerate';
 function planResume({
   native,
   isStreaming,
+  ownTurnInFlight = isStreaming,
   recovered = true,
+  probeAnswered = true,
 }: {
   native: boolean;
+  /** The broad display/effective streaming flag — what resolveResumeAction sees. */
   isStreaming: boolean;
+  /**
+   * Whether a stream of OUR OWN was running for the conversation ON SCREEN. Distinct from
+   * `isStreaming`, which stays true for a stream still running against a conversation the user has
+   * since navigated away from (the useChat id is stable across a switch). Only this may gate a
+   * regenerate — otherwise we would fire a generation for the turn the user is now LOOKING at
+   * rather than the one that was interrupted.
+   */
+  ownTurnInFlight?: boolean;
   /** What tryRecover returned: it rejoined a live stream, or refetched a persisted reply. */
   recovered?: boolean;
+  /** Whether the /active-streams probe actually reached the server and answered. */
+  probeAnswered?: boolean;
 }): ResumeEffect[] {
   const action = resolveResumeAction({ native, isStreaming });
   if (action === 'noop') return [];
@@ -180,12 +193,10 @@ function planResume({
   // treats the stream as one we are already reading off the POST and skips attaching it.
   const effects: ResumeEffect[] = ['stop', 'try-recover'];
   if (recovered) return effects;
-  // Nothing live, nothing persisted. NOT a DB refresh (unsafe: the probe may merely have failed
-  // and a stream still be live, or the DB may be behind local state). Regenerate — but only if a
-  // turn was actually in flight when we backgrounded, so an idle resume never fires a spurious
-  // generation. `isStreaming` here is the render-time value iOS froze at background, which is a
-  // faithful record of exactly that.
-  if (isStreaming) effects.push('regenerate');
+  // Nothing recovered. NOT a DB refresh (unsafe: it would erase an in-progress bubble or the
+  // user's own prompt). Regenerate — but only on an ANSWERED probe, and only if a turn of ours was
+  // really in flight for this conversation.
+  if (ownTurnInFlight && probeAnswered) effects.push('regenerate');
   return effects;
 }
 
@@ -698,7 +709,34 @@ function evictStalePartial<T extends { id: string }>(
         expect(planResume({ native: false, isStreaming: false })).toEqual(['refresh']);
       });
 
-      it('given native, a turn in flight, and NOTHING to recover, should regenerate — never a DB refresh', () => {
+      it('given native, a stream for a DIFFERENT conversation, and nothing to recover, should NOT regenerate', () => {
+        // The broad flag stays true for a stream still running against a conversation the user has
+        // navigated away from. Regenerating on it would fire a generation for the turn now on
+        // screen rather than the interrupted one — a spurious reply, and a spurious charge, on an
+        // untouched conversation.
+        expect(
+          planResume({ native: true, isStreaming: true, ownTurnInFlight: false, recovered: false }),
+        ).toEqual(['stop', 'try-recover']);
+      });
+
+      it('given native and the probe never ANSWERED, should NOT regenerate', () => {
+        // Silence is not an answer. Every generation start calls takeOverConversationStreams, so a
+        // regenerate issued while the run is in fact still live does not race it — it ABORTS it.
+        // We would kill a healthy generation, re-run write tools it had already executed, bill the
+        // discarded tokens, and strand its partial in the DB. Doing nothing is safe: the stop
+        // released the `consuming` mark, so the socket-reconnect bootstrap picks a live run up.
+        expect(
+          planResume({
+            native: true,
+            isStreaming: true,
+            ownTurnInFlight: true,
+            recovered: false,
+            probeAnswered: false,
+          }),
+        ).toEqual(['stop', 'try-recover']);
+      });
+
+      it('given native, a turn in flight, an ANSWERED probe, and NOTHING to recover, should regenerate — never a DB refresh', () => {
         // The stop above settles useChat at `ready` with no `error`, and useStreamRecovery only
         // fires on `status === 'error'` — so aborting the fetch destroys the very signal that
         // used to drive the fallback. Without regenerating here, a turn whose POST died on the

--- a/apps/web/src/lib/ai/streams/__tests__/canResumeRecovery.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/canResumeRecovery.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { canResumeRecovery } from '../canResumeRecovery';
+
+describe('canResumeRecovery', () => {
+  it('given a conversation and no active editing, should allow recovery', () => {
+    expect(canResumeRecovery('conv-A', false)).toBe(true);
+  });
+
+  it('given no conversation, should NOT allow recovery (nothing to rejoin)', () => {
+    expect(canResumeRecovery(null, false)).toBe(false);
+  });
+
+  it('given the user is mid-edit, should NOT allow recovery (it would clobber their work)', () => {
+    expect(canResumeRecovery('conv-A', true)).toBe(false);
+  });
+
+  it('should take no streaming argument at all — the regression is not expressible in the signature', () => {
+    // THE BUG THIS EXISTS TO PREVENT. The gate used to be a render-time boolean folding in
+    // `!isStreaming`. iOS freezes JS the moment the app backgrounds, so the value that ended up
+    // gating the resume was whatever was true when the app went AWAY — i.e. streaming — and
+    // recovery was disabled in exactly the case it was written for. Whether the transport survived
+    // is resolveResumeAction's question, asked at fire time; it must never be baked into this gate.
+    expect(canResumeRecovery.length).toBe(2);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/evictStalePartial.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/evictStalePartial.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { evictStalePartial } from '../evictStalePartial';
+
+const liveId = 'srv-msg-1';
+const messages = [
+  { id: 'u1', role: 'user' },
+  { id: liveId, role: 'assistant' }, // the frozen half-streamed bubble
+];
+const seededParts = [{ type: 'text', text: 'partial reply' }];
+
+describe('evictStalePartial', () => {
+  it('given a checkpoint the bootstrap can seed from, should drop the local partial carrying the live messageId', () => {
+    // Without this, the pending stream the rejoin adds under `liveId` is deduped straight back out
+    // (dedupRemoteStreams / ChatMessagesArea drop a stream whose messageId is already in
+    // `messages`), so the rejoined stream renders not one token and the user stares at a frozen
+    // partial.
+    expect(evictStalePartial(messages, liveId, seededParts)).toEqual([{ id: 'u1', role: 'user' }]);
+  });
+
+  it('should never touch the user turn — only the one message the server named', () => {
+    const out = evictStalePartial(messages, liveId, seededParts);
+    expect(out.some((m) => m.role === 'user')).toBe(true);
+  });
+
+  it('given an EMPTY checkpoint, should keep the partial and return the same reference', () => {
+    // The checkpoint is debounced, so it is empty for a stream only a few parts old. Evicting
+    // against it and then losing the SSE join (multi-instance: the multicast lives in another
+    // process) makes the bootstrap drop the stream — leaving the user with NOTHING, which is
+    // strictly worse than the frozen partial. Same reference so callers can pass this to a
+    // setMessages updater without forcing a needless write.
+    expect(evictStalePartial(messages, liveId, [])).toBe(messages);
+  });
+
+  it('given no checkpoint at all, should keep the partial', () => {
+    expect(evictStalePartial(messages, liveId, undefined)).toBe(messages);
+  });
+
+  it('given a checkpoint of MALFORMED frames, should keep the partial', () => {
+    // The gate must use the same predicate the bootstrap seeds with (isValidPartFrame). Counting
+    // raw array length would call this checkpoint "safe to evict" while it in fact seeds nothing —
+    // and a failed join would then leave an empty screen.
+    const junk = [{ nope: true }, 'not-a-frame', null, 42];
+    expect(evictStalePartial(messages, liveId, junk)).toBe(messages);
+  });
+
+  it('given a checkpoint that is only PARTLY malformed, should still evict — the valid frames will render', () => {
+    expect(evictStalePartial(messages, liveId, [{ bogus: 1 }, ...seededParts])).toEqual([
+      { id: 'u1', role: 'user' },
+    ]);
+  });
+
+  it('given no message matching the live id, should return the list unchanged', () => {
+    expect(evictStalePartial(messages, 'some-other-id', seededParts)).toEqual(messages);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/evictStalePartial.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/evictStalePartial.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { evictStalePartial } from '../evictStalePartial';
+import { evictStalePartial, canEvictStalePartial } from '../evictStalePartial';
 
 const liveId = 'srv-msg-1';
 const messages = [
@@ -51,5 +51,26 @@ describe('evictStalePartial', () => {
 
   it('given no message matching the live id, should return the list unchanged', () => {
     expect(evictStalePartial(messages, 'some-other-id', seededParts)).toEqual(messages);
+  });
+
+  describe('canEvictStalePartial (the gate the call sites ask before writing)', () => {
+    it('given a checkpoint with seedable frames, should allow the eviction', () => {
+      expect(canEvictStalePartial(seededParts)).toBe(true);
+    });
+
+    it('given an empty, absent, or all-malformed checkpoint, should refuse', () => {
+      expect(canEvictStalePartial([])).toBe(false);
+      expect(canEvictStalePartial(undefined)).toBe(false);
+      expect(canEvictStalePartial([{ nope: true }, 'junk', null])).toBe(false);
+    });
+
+    it('should agree with evictStalePartial — the helper self-guards on the same rule', () => {
+      // The gate exists so an unsafe checkpoint costs no state write; it must never disagree with
+      // the helper it is gating, or a caller could evict against a checkpoint that seeds nothing.
+      for (const parts of [seededParts, [], undefined, [{ bogus: 1 }]]) {
+        const evicted = evictStalePartial(messages, liveId, parts);
+        expect(evicted !== messages).toBe(canEvictStalePartial(parts));
+      }
+    });
   });
 });

--- a/apps/web/src/lib/ai/streams/canResumeRecovery.ts
+++ b/apps/web/src/lib/ai/streams/canResumeRecovery.ts
@@ -1,0 +1,19 @@
+/**
+ * The `enabled` gate for useAppStateRecovery on the AI chat surfaces.
+ *
+ * Deliberately takes NO streaming argument, and that is the whole point of it existing.
+ *
+ * The gate used to be a render-time boolean that folded in `!isStreaming`. iOS freezes JS the
+ * moment the app backgrounds, so the value that ended up gating the resume was whatever was true
+ * when the app went AWAY — i.e. streaming — and recovery was therefore disabled in exactly the
+ * case it was written for. Pass this as a callback (`enabled: () => canResumeRecovery(...)`) so it
+ * is evaluated at fire time, and keep streaming out of it: whether the transport is still alive is
+ * resolveResumeAction's question, asked on resume, not a flag captured before the freeze.
+ *
+ * Editing is the only thing that may suppress a resume — recovering underneath a user who is
+ * mid-edit would clobber their work.
+ */
+export const canResumeRecovery = (
+  currentConversationId: string | null,
+  isAnyEditing: boolean,
+): boolean => currentConversationId !== null && !isAnyEditing;

--- a/apps/web/src/lib/ai/streams/evictStalePartial.ts
+++ b/apps/web/src/lib/ai/streams/evictStalePartial.ts
@@ -1,6 +1,20 @@
 import { isValidPartFrame } from './isValidPartFrame';
 
 /**
+ * Whether the server's checkpoint for a live stream has anything the bootstrap could actually
+ * render — i.e. whether it is safe to evict the local partial in favour of it.
+ *
+ * Counted with `isValidPartFrame`, the SAME predicate the bootstrap seeds with: it is the
+ * post-filter count that becomes `skipReplayCount`, and a `skipReplayCount` of 0 is exactly what
+ * makes a failed SSE join drop the stream entirely. A raw `parts.length > 0` would call a
+ * checkpoint of malformed frames "safe" while it in fact seeds nothing.
+ *
+ * Exported so callers can decide whether to write at all, without having to reproduce the rule.
+ */
+export const canEvictStalePartial = (serverParts: readonly unknown[] | undefined): boolean =>
+  (serverParts ?? []).filter(isValidPartFrame).length > 0;
+
+/**
  * Drops the half-streamed assistant bubble useChat is still holding for a run we are about to
  * rejoin — but only when the server has something to render in its place.
  *
@@ -29,7 +43,7 @@ export const evictStalePartial = <T extends { id: string }>(
   liveMessageId: string,
   serverParts: readonly unknown[] | undefined,
 ): T[] => {
-  const seededParts = (serverParts ?? []).filter(isValidPartFrame);
-  if (seededParts.length === 0) return messages;
+  // Self-guarding, so the rule holds even if a caller forgets to ask canEvictStalePartial first.
+  if (!canEvictStalePartial(serverParts)) return messages;
   return messages.filter((m) => m.id !== liveMessageId);
 };

--- a/apps/web/src/lib/ai/streams/evictStalePartial.ts
+++ b/apps/web/src/lib/ai/streams/evictStalePartial.ts
@@ -27,13 +27,13 @@ export const canEvictStalePartial = (serverParts: readonly unknown[] | undefined
  * and the rejoined stream is filtered straight back out — not one token of it renders, and the
  * user sits in front of a frozen partial reply.
  *
- * WHY ONLY WHEN THE SERVER HAS PARTS. `serverParts` is the stream registry's DEBOUNCED checkpoint,
- * persisted every N parts, so it is empty for a stream that is only a few parts old. It is also
- * what the bootstrap seeds from — after the same isValidPartFrame filter — and a seed of zero
- * parts is exactly what makes a failed SSE join drop the stream entirely (the documented
- * multi-instance case, where the multicast lives in another process). Evict against an empty
- * checkpoint and lose the join, and the user is left with NOTHING: strictly worse than the frozen
- * partial. So the same predicate the bootstrap seeds with decides whether it is safe to evict.
+ * WHY ONLY WHEN THE SERVER HAS PARTS. `serverParts` is the stream registry's periodic checkpoint,
+ * which lags the live stream, so it is empty for a stream in its first moments. It is also what the
+ * bootstrap seeds from — after the same isValidPartFrame filter — and a seed of zero parts is
+ * exactly what makes a failed SSE join drop the stream entirely (the documented multi-instance
+ * case, where the multicast lives in another process). Evict against an empty checkpoint and lose
+ * the join, and the user is left with NOTHING: strictly worse than the frozen partial. So the same
+ * predicate the bootstrap seeds with decides whether it is safe to evict.
  *
  * Returns `messages` unchanged (same reference) when it is not safe, so callers can pass this
  * straight to a setMessages updater without forcing a needless write.

--- a/apps/web/src/lib/ai/streams/evictStalePartial.ts
+++ b/apps/web/src/lib/ai/streams/evictStalePartial.ts
@@ -1,0 +1,35 @@
+import { isValidPartFrame } from './isValidPartFrame';
+
+/**
+ * Drops the half-streamed assistant bubble useChat is still holding for a run we are about to
+ * rejoin — but only when the server has something to render in its place.
+ *
+ * WHY IT MUST BE DROPPED. `Chat.stop()` documents that it "keeps the generated tokens", and a
+ * dropped fetch leaves them too, so `messages` still holds an assistant message whose id IS the
+ * live stream's messageId (the server mints ONE id and uses it for the stream registry row, the
+ * UI message, and the DB row alike). The rejoin re-adds that same stream to the pending store, and
+ * both surfaces drop a pending stream whose messageId already appears in `messages`
+ * (dedupRemoteStreams / ChatMessagesArea.visibleRemoteStreams). Leave the stale bubble in place
+ * and the rejoined stream is filtered straight back out — not one token of it renders, and the
+ * user sits in front of a frozen partial reply.
+ *
+ * WHY ONLY WHEN THE SERVER HAS PARTS. `serverParts` is the stream registry's DEBOUNCED checkpoint,
+ * persisted every N parts, so it is empty for a stream that is only a few parts old. It is also
+ * what the bootstrap seeds from — after the same isValidPartFrame filter — and a seed of zero
+ * parts is exactly what makes a failed SSE join drop the stream entirely (the documented
+ * multi-instance case, where the multicast lives in another process). Evict against an empty
+ * checkpoint and lose the join, and the user is left with NOTHING: strictly worse than the frozen
+ * partial. So the same predicate the bootstrap seeds with decides whether it is safe to evict.
+ *
+ * Returns `messages` unchanged (same reference) when it is not safe, so callers can pass this
+ * straight to a setMessages updater without forcing a needless write.
+ */
+export const evictStalePartial = <T extends { id: string }>(
+  messages: T[],
+  liveMessageId: string,
+  serverParts: readonly unknown[] | undefined,
+): T[] => {
+  const seededParts = (serverParts ?? []).filter(isValidPartFrame);
+  if (seededParts.length === 0) return messages;
+  return messages.filter((m) => m.id !== liveMessageId);
+};

--- a/apps/web/src/lib/ai/streams/recoveryAttempt.ts
+++ b/apps/web/src/lib/ai/streams/recoveryAttempt.ts
@@ -1,0 +1,26 @@
+/**
+ * The outcome of one `tryRecover` attempt.
+ *
+ * `recovered` and `probeAnswered` are deliberately separate, because "we recovered nothing" is
+ * NOT the same claim as "the server told us there was nothing to recover":
+ *
+ *   probeAnswered: true,  recovered: false  → the server answered; no live run, nothing persisted.
+ *                                             The run really is gone. Regenerating is the recovery.
+ *   probeAnswered: false, recovered: false  → the probe never got an answer. We know NOTHING.
+ *                                             A run may well still be live.
+ *
+ * Collapsing those two into a single boolean is how a resume can end up regenerating over a
+ * healthy generation — which, because every generation start takes over the conversation's
+ * in-flight streams, ABORTS it: its already-executed write tools run a second time, its tokens are
+ * billed and discarded, and its partial is stranded in the DB. Silence is not an answer.
+ *
+ * Returned rather than stashed in a ref: `tryRecover` has two callers (the app-resume handler and
+ * useStreamRecovery's network-error retry) which can be in flight at once, and a single shared
+ * slot would let one caller's probe answer the other caller's question.
+ */
+export interface RecoveryAttempt {
+  /** A live stream was rejoined, or a persisted reply was refetched. Nothing further to do. */
+  recovered: boolean;
+  /** The /active-streams probe reached the server AND we parsed its answer. */
+  probeAnswered: boolean;
+}

--- a/apps/web/src/lib/ai/streams/recoveryAttempt.ts
+++ b/apps/web/src/lib/ai/streams/recoveryAttempt.ts
@@ -1,18 +1,25 @@
 /**
  * The outcome of one `tryRecover` attempt.
  *
- * `recovered` and `probeAnswered` are deliberately separate, because "we recovered nothing" is
- * NOT the same claim as "the server told us there was nothing to recover":
+ * The two "answered" flags are kept separate from `recovered` because **"we recovered nothing" is
+ * not the same claim as "the server told us there was nothing to recover"**:
  *
- *   probeAnswered: true,  recovered: false  → the server answered; no live run, nothing persisted.
- *                                             The run really is gone. Regenerating is the recovery.
- *   probeAnswered: false, recovered: false  → the probe never got an answer. We know NOTHING.
- *                                             A run may well still be live.
+ *   answered, recovered: false  → no live run, nothing persisted. The turn really is gone, and
+ *                                 regenerating it is the recovery.
+ *   unanswered              → we know NOTHING. A run may still be live, or its reply may already
+ *                                 be sitting in the DB.
  *
- * Collapsing those two into a single boolean is how a resume can end up regenerating over a
- * healthy generation — which, because every generation start takes over the conversation's
- * in-flight streams, ABORTS it: its already-executed write tools run a second time, its tokens are
- * billed and discarded, and its partial is stranded in the DB. Silence is not an answer.
+ * Collapsing those into one boolean is how a resume ends up regenerating over work that still
+ * exists — and regenerating is destructive here, twice over:
+ *
+ *   - Every generation start takes over the conversation's in-flight streams, so a regenerate
+ *     issued while a run is still live ABORTS it: its already-executed write tools run a second
+ *     time, its tokens are billed and discarded, and its partial is stranded in the DB.
+ *   - `handleRetry` DELETEs the trailing assistant message by id before re-requesting, and that id
+ *     is the same one the server persisted the reply under. So a regenerate issued when the reply
+ *     was in fact already persisted deletes the finished reply and pays for it again.
+ *
+ * Hence one flag per question we actually asked. Regenerating is only safe when BOTH came back.
  *
  * Returned rather than stashed in a ref: `tryRecover` has two callers (the app-resume handler and
  * useStreamRecovery's network-error retry) which can be in flight at once, and a single shared
@@ -21,6 +28,15 @@
 export interface RecoveryAttempt {
   /** A live stream was rejoined, or a persisted reply was refetched. Nothing further to do. */
   recovered: boolean;
-  /** The /active-streams probe reached the server AND we parsed its answer. */
+  /** GET /active-streams reached the server AND we parsed its answer: we know what is live. */
   probeAnswered: boolean;
+  /** The messages GET reached the server AND we parsed its answer: we know what is persisted. */
+  dbAnswered: boolean;
 }
+
+/**
+ * Regenerating is only safe once BOTH questions came back. Silence from either one means the work
+ * we would be destroying might still exist.
+ */
+export const canConcludeTurnIsLost = (attempt: RecoveryAttempt): boolean =>
+  !attempt.recovered && attempt.probeAnswered && attempt.dbAnswered;


### PR DESCRIPTION
## Summary

On mobile, when an AI stream is in progress and the app backgrounds, the stream keeps generating server-side (disconnect-immune by design). But the client couldn't rejoin it on foreground — both `GlobalAssistantView.tsx` and `SidebarChatTab.tsx` had defects in their `useAppStateRecovery` wiring that orphaned the stream.

This is the bug behind the "invisible AI stream on mobile" issue. PR #2061 fixed the flashing/clobbering on send/reload/switch (client-side state machine). This PR fixes the recovery path that never fired.

## Root cause

### Defect 1: `enabled` was a render-time boolean

```ts
enabled: !isStreaming && currentConversationId !== null && !useEditingStore.getState().isAnyEditing(),
```

iOS freezes JS the moment the app backgrounds. The boolean is captured at render — so when the app went away mid-stream, `!isStreaming` was `false`. The recovery hook was gated off in **exactly the case it was written for**.

The `useAppStateRecovery` docstring documents this exact failure:
> A boolean is captured at render, and iOS freezes JS the moment the app backgrounds — so the value that ends up gating the resume is whatever was true when the app went away.

That comment was written when `AiChatView.tsx` was fixed. `GlobalAssistantView` and `SidebarChatTab` were never updated.

### Defect 2: `onResume` was a dumb DB fetch

```ts
onResume: handlePullUpRefresh, // or handleAppResume
```

Both handlers just fetch messages from the DB and `setMessages`. But **the reply isn't persisted until the run completes** — so mid-stream the fetch returns a snapshot with no assistant message, and writing it clobbers the in-progress bubble. No local stop, no server rejoin.

## The fix

1. **`enabled` → callback form** — evaluated at fire time, gating on user-editing only, never on streaming.
2. **`onResume` → stop, then `tryRecover()`** — and critically, **no blind DB read**.

```ts
const action = resolveResumeAction({ native: isCapacitorApp(), isStreaming: effectiveIsStreaming });
if (action === 'noop') return;
if (action === 'refresh') { await handlePullUpRefresh(); return; }  // web, idle: safe

// A stream of OUR OWN, for the conversation on screen, was running when iOS froze us.
const hadTurnInFlight = selectedAgent
  ? isOwnAgentStreamForCurrentConversation
  : isOwnGlobalStreamForCurrentConversation;
const conversationAtResume = currentConversationId;

rawStop();                              // local-only; releases the channel's `consuming` mark
let attempt = await tryRecover();       // /active-streams first; no DB read while a run is live
if (attempt.recovered) return;

// Silence is not an answer. Re-ask until BOTH questions come back, bounded.
for (let i = 1; !(attempt.probeAnswered && attempt.dbAnswered) && i <= 2; i++) {
  await delay(i * 1000);
  attempt = await tryRecover();
  if (attempt.recovered) return;
}

if (hadTurnInFlight
    && currentConversationIdRef.current === conversationAtResume
    && canConcludeTurnIsLost(attempt)) {
  await handleRetry();
}
```

### Why `tryRecover`, and not a refresh

Both components **already have** `tryRecover` — the rejoin-first probe `useStreamRecovery` runs on a network error. A background/foreground cycle *is* a network error on iOS; it's just one we get told about. It asks `/active-streams` first — the server's authoritative answer — and only touches the DB when nothing is live:

| `/active-streams` says | action |
|---|---|
| stream still live | rejoin it — **no DB read at all** |
| nothing live, reply persisted | refetch the completed reply (it finished while backgrounded) |
| neither | fall through to the plain refresh |

Earlier iterations of this PR tried to make a mid-stream DB refresh *safe* (stale-guards, `mergeServerAndPending`, careful ordering). That was the wrong tree to bark up: an **own** stream is deliberately never in the pending-streams store while its POST body is being consumed (`markChannelConsuming` → `shouldAttachStream` returns false → `chat:stream_start` is skipped). So on the resume path the store is empty for the very stream being recovered, the merge had nothing to merge, and the "guarded" refresh still wrote a pre-reply snapshot over the half-streamed bubble. The right answer is to not read the DB while a run is generating.

### Why the rejoin must evict the local partial

The server mints **one** id and uses it for both the assistant UI message (`generateId: () => serverAssistantMessageId`) and the stream registry row. So the id useChat holds for the half-streamed bubble *is* the live stream's `messageId`. `Chat.stop()` is explicit that it *"keeps the generated tokens"*, so that bubble survives the stop — and the rejoin then re-adds the same stream to the pending store under the same id. Both surfaces drop a pending stream whose `messageId` already appears in `messages` (`dedupRemoteStreams`, `ChatMessagesArea.visibleRemoteStreams`), so the rejoined stream would be filtered **straight back out** and not one token of it would render.

`tryRecover`'s rejoin branch therefore reads the live `messageId` off `/active-streams` and evicts the matching local message before rejoining. (This also fixes the same latent bug on the network-error rejoin path.)

**But only when the server has something to put in its place.** `/active-streams` also returns `parts` — the registry's *debounced* checkpoint, persisted every 20 parts, so it is **empty for a stream only a few parts old**. (Counted with `isValidPartFrame`, the same predicate the bootstrap seeds with, since it is that post-filter count which becomes `skipReplayCount`.) Evicting against an empty checkpoint and then failing the SSE join (the documented multi-instance case — the multicast registry is per-process) makes the bootstrap remove the stream, leaving the user with *nothing*: strictly worse than the frozen partial. So eviction is gated on `parts.length > 0`; otherwise we keep the partial and still attempt the rejoin.

### Why `handlePullUpRefresh` must NOT reconcile with the pending store

On these two surfaces **the pending store *is* the bubble** — an in-flight stream renders from `remoteStreams`, not from `messages`. `mergeServerAndPending` synthesizes a message under the pending stream's `messageId`, i.e. exactly the id the renderers dedup on. Merging here would freeze the live bubble at a static snapshot and stop it updating until completion. So this loader deliberately writes the DB snapshot as-is; the id stays absent from `messages` and the stream keeps rendering live.

### Why silence is not an answer

"We recovered nothing" is **not** the same claim as "there was nothing to recover". `tryRecover` asks two questions, and *either* can come back unanswered — the first request after a foreground is the one most likely to fail, radio still coming up:

| unanswered | what might still exist | what regenerating would do |
|---|---|---|
| `/active-streams` silent | a run may still be **live** | every generation start calls `takeOverConversationStreams`, so the regenerate does not race it — **it aborts it**: re-running write tools it already executed (a turn that created a page creates it twice), billing the discarded tokens, stranding its partial |
| messages GET silent | the reply may already be **saved** | `handleRetry` deletes the trailing assistant **by id** — the same id the server persisted the reply under — so it **deletes the finished reply** and pays for it again |

So `RecoveryAttempt` carries `probeAnswered` and `dbAnswered` alongside `recovered`, each set only after a body we actually parsed, and `canConcludeTurnIsLost` requires **both**. The resume loop re-asks (bounded) until both come back. On persistent silence it does nothing — which is safe: the `stop()` released the `consuming` mark, so a live run is picked up by the socket-reconnect bootstrap once the network returns, a persisted reply is picked up by the next load, and a genuinely dead turn leaves the user their prompt and its retry action.

### Was the user's turn persisted? Asked by identity, not by counting

The old guard compared user-message **counts** (`dbUserCount >= localUserCount`). That silently breaks past one page: this GET is unpaginated, so the route applies its default `limit: 50` and returns only the newest 50 rows, while local `messages` is the initial 50 **plus every turn since**. Beyond that boundary the guard is **permanently false** — step 2 could never recover on a long conversation, and every interrupted turn there fell through to a regenerate that deleted the reply it should have refetched.

It now checks whether the DB contains the **id of the last local user message**. That message is by definition the newest, so it is always inside the returned window; and both routes persist the user turn under the client's id (`userMessage.id || createId()`), so the identity round-trips. Correct and pagination-proof.

### Why the fallback is a regenerate, not a DB refresh

`tryRecover` returning false means one of exactly two things, and a DB **write** is unsafe in both:

- **the probe failed** — the first request after a foreground is the likeliest to, radio still coming up. A stream may well be live, and a DB snapshot cannot contain an unpersisted reply, so a refresh would erase the in-progress bubble.
- **the DB is behind local state** — step 2's `dbUserCount >= localUserCount` guard rejected it, e.g. a send whose POST never reached the server. A refresh would erase the user's own prompt.

But doing *nothing* is wrong too, and this is subtle: `Chat.stop()` aborts the fetch, so useChat settles at `ready` with **no `error`** — and `useStreamRecovery` only fires on `status === 'error'`. The stop we added therefore destroys the very signal that used to drive recovery. A turn whose POST died on the background transition would find no stream, no reply, and no error, and the user's prompt would sit unanswered forever. (Master recovered it: the dead fetch raised an error, `useStreamRecovery` probed, came up empty, regenerated.)

So we regenerate — the same fallback `useStreamRecovery` applies — but gated four ways:

1. a turn of **our own**, for the conversation **on screen**, really was in flight (the broad `effectiveIsStreaming` stays true for a stream still running against a conversation the user has since left);
2. **both** of `tryRecover`'s questions came back (above);
3. we are **still on that conversation** — the recovery spans seconds of network, and `handleRetry` always acts on the live conversation, so a switch mid-recovery would otherwise fire a generation for the turn the user moved *to*;
4. **nothing has already restarted the turn.** `useStreamRecovery` watches the same failure from the other side and regenerates too — and it calls `clearError()` *before* its own probes, so throughout its decision window the status reads `ready` and looks idle. A single `regenerationInFlightRef` mutex wraps `handleRetry` (`regenerateTurnOnce`), and **both** paths go through it, so the same turn can never be regenerated twice; a `!isStreamingRef.current` belt then stops us regenerating *on top of* a turn that has already restarted and moved on (the mutex releases when `handleRetry`'s DELETEs finish, but the generation it kicked off is still running).

### Why the stop must come first

`rawStop()` / `stop()` is the **local-only** useChat stop. It does not signal the server (that's `abortActiveStreamByMessageId`), so the run keeps generating and stays rejoinable. But it also ends the dead response body, which releases the channel's `consuming` mark — and without that, the rejoin's bootstrap classifies the stream as one this tab is already reading off its POST body and **skips attaching it**. The rejoin would silently do nothing.

Ordering is safe because both `tryRecover` and the bootstrap `await` their `/active-streams` fetch before consulting `isChannelConsuming`, so the abort-triggered unmark (a microtask) always lands first.

## Changes

| File | Change |
|------|--------|
| `GlobalAssistantView.tsx` | `enabled` → callback; `onResume` → stop + `tryRecover` (no DB fallback); `tryRecover` evicts the stale partial on rejoin (gated on the server checkpoint being non-empty, and written through the store-syncing setter); `handlePullUpRefresh` gains a live-conversation stale-guard |
| `SidebarChatTab.tsx` | Same resume wiring (hook relocated below `tryRecover`, which it now closes over); same eviction; `handleAppResume` funnels through `loadGlobalMessages` (the documented single writer) instead of its own raw fetch |
| `lib/ai/streams/canResumeRecovery.ts` | **new** — the resume gate, extracted. Takes no streaming argument *by construction* |
| `lib/ai/streams/evictStalePartial.ts` | **new** — the eviction rule, extracted (including the checkpoint guard, counted with the bootstrap's own `isValidPartFrame`) |
| `lib/ai/streams/recoveryAttempt.ts` | **new** — `RecoveryAttempt` + `canConcludeTurnIsLost` |
| all `__tests__` | +50 tests. The gate, the eviction and the regenerate predicate are asserted against the **real** implementations, not mirrors |

## Tests

The resume wiring previously had **zero** coverage on either surface — which is how the render-time `enabled` boolean survived. Following each file's established pattern (pure mirrors of the hook-heavy component's logic), the *decision* is not mirrored: `planResume` calls the real `resolveResumeAction`, so the tests pin the wiring against the real policy.

- the gate takes **no streaming argument** — the original regression is not expressible in it
- native + live stream → `stop` → `tryRecover`, and **the DB is never read**
- native → **never** falls back to a DB refresh (the two cases where `tryRecover` returns false are exactly the two where a DB write is unsafe)
- `stop` always precedes the probe (it's what releases the `consuming` mark)
- native + idle → still probes (deterministic, not flag-gated)
- web + live fetch → noop (a live fetch survives a tab switch)
- web + idle → refresh only
- the rejoin evicts the local partial carrying the live `messageId` — and only that one message, never the user's turn
- eviction is skipped entirely when the server's checkpoint is empty (keep what the user has rather than risk an empty screen)
- regenerate fires **only** when both questions were answered, for a turn of ours, on the conversation still on screen — never on silence, never on a foreign conversation's stream, never after a mid-recovery switch

## Validation

- `bun run typecheck` — clean
- `bun run build` (apps/web) — exits 0
- `bunx eslint` on all touched files — clean
- `vitest` — 815 passing across `components/layout` + `lib/ai/streams`

## Behaviour change worth calling out

Replacing the native DB refresh with a regenerate means two narrow cases no longer refresh on resume: a conversation whose last DB message is a **user** message where no turn was in flight, and another device having deleted the trailing assistant message. Both are healed by the socket-reconnect `refreshSignal` that fires on resume anyway.

## On the tests

The resume wiring previously had **zero** coverage on either surface — which is how the render-time `enabled` boolean survived in the first place.

The three load-bearing rules are now shared pure modules, so the tests assert against the **shipped** implementation rather than a copy of it: `canResumeRecovery`, `evictStalePartial`, and `canConcludeTurnIsLost`. `planResume` remains a mirror of the *sequencing* only (the `onResume` body is genuinely imperative — stop → probe → bounded re-probe → regenerate), but its two decisions call the real `resolveResumeAction` and the real `canConcludeTurnIsLost`.

## Known follow-ups (deliberately not in this PR)

- **`resolveResumeAction` treats all Capacitor platforms as "the fetch is always dead"** — `isCapacitorApp()` is true on Android too, so a healthy Android stream gets stopped and rejoined on every foreground ≥5s. It renders correctly now that the eviction is in place, but it is needless churn. Pre-existing shared policy (`AiChatView` already does this); worth gating on `platform === 'ios'` separately.
- **`AiChatView`** still does `stop → rejoin → refresh`, and carries the same dedup collision on its rejoin path. The same fix applies. Left alone rather than widening this PR's blast radius.

Refs: #2061, #2018

