### PR TITLE
docs: rewrite README around the everything-workspace positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ AI works *directly in* your workspace, and so does everything else you use to ge
 ## See It In Action
 
 ### One prompt creates entire projects
-```
+```text
 You: "Create a complete documentation site for our API"
 AI: *Creates 24 nested documents with actual content in your workspace*
 ```
 
 ### Your team collaborates with AI
-```
+```text
 Team Member A: "Can you analyze our Q3 metrics?"
 AI: *Reads relevant documents, creates analysis page*
 Team Member B: *Sees the conversation and analysis in real-time*
@@ -61,7 +61,7 @@ $ pagespace agents ask <agentId> "Summarize what changed on the roadmap this wee
 ```
 
 ### An agent that can actually ship code
-```
+```text
 You: "Spin up a machine on feature/pricing-v2 and fix the failing test"
 AI: *Opens a real terminal, reproduces the failure, edits the code, commits, opens a PR*
 ```
@@ -71,7 +71,8 @@ AI: *Opens a real terminal, reproduces the failure, edits the code, commits, ope
 # Zero-install MCP — add to Claude Desktop, Claude Code, or Cursor's config
 npx -y -p @pagespace/cli pagespace-mcp
 ```
-```
+
+```text
 Claude: "Update all meeting notes in my PageSpace"
 *Claude directly edits documents at www.pagespace.ai*
 ```
@@ -128,6 +129,7 @@ Script your workspace from a terminal.
 npm install -g @pagespace/cli
 pagespace login              # browser OAuth login
 pagespace keys                # mint a drive-scoped access key
+pagespace keys use <name>     # activate it for this machine
 pagespace drives list
 pagespace search text "roadmap" --all-drives
 ```
@@ -267,7 +269,9 @@ Each item in a drive is a typed page with a specific role:
 PageSpace is built around a zero-trust model for cloud deployment. One explicit exception is desktop-local MCP server hosting, which runs inside the user's local trust boundary (same model as Claude Desktop).
 
 - **OAuth 2.1 authorization server**: `pagespace login` and every scoped access key are minted
-  through a real browser consent flow, not a static bearer token
+  through a real browser consent flow, not handed out as a fixed, unrotatable static token. The
+  resulting key is still a bearer secret once issued, so it gets the same handling and revocation
+  expectations as any other credential — see Connected Apps below
 - **Connected Apps**: See every OAuth grant on your account, including the CLI and any MCP
   client, from Settings, and revoke one instantly. Minting and revoking both require a fresh
   step-up confirmation (passkey, or a confirmation email if you have no passkey)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,37 @@
-# PageSpace: Where AI Can Actually Work
+# PageSpace: The AI-Native Workspace for Everything You Do
 
-**[www.pagespace.ai](https://www.pagespace.ai)** • Desktop Apps • [AI Agent Hub](https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t)
+**[www.pagespace.ai](https://www.pagespace.ai)** • Desktop Apps • [CLI](https://www.npmjs.com/package/@pagespace/cli) & [SDK](https://www.npmjs.com/package/@pagespace/sdk) • [AI Agent Hub](https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t)
 
-> PageSpace turns your projects into intelligent workspaces where AI agents collaborate alongside your team with real tools to create, edit, and organize content.
+> PageSpace is one workspace for everything you'd otherwise scatter across a docs tool, a task
+> tracker, a calendar, a team chat app, a dev environment, and a website builder. AI agents work
+> directly inside all of it: documents, sheets, code, tasks, calendar, team channels, cloud dev
+> machines, and published sites all live as pages in the same hierarchy, editable by people and AI
+> together in real time, and scriptable from a CLI, an SDK, or any MCP client.
 
 ---
 
 ## What Makes PageSpace Different?
 
-In most tools, you chat with AI *about* your work. In PageSpace, AI works *directly in* your workspace:
+In most tools, you chat with AI *about* your work, in a window bolted onto the side. In PageSpace,
+AI works *directly in* your workspace, and so does everything else you use to get things done:
 
-- **AI with real tools**: Your AI can create documents, organize projects, edit content - not just answer questions
-- **External AI integration**: Connect Claude Desktop or Cursor to directly manipulate your workspace via MCP
-- **Team + AI collaboration**: Multiple people and AIs working on the same pages simultaneously
-- **100+ AI models**: From free (Qwen, DeepSeek) to premium (Claude Opus 4.5, GPT-5, Gemini 3) - you choose
-- **Zero-trust direction (cloud)**: Opaque tokens, per-event authorization, and tamper-evident audit trails
-- **Your workspace understands context**: AI intelligence flows through your project hierarchy
+- **AI with real tools**: Your AI can create documents, run spreadsheet formulas, manage tasks,
+  schedule calendar events, and work inside an actual dev environment, not just answer questions
+- **One hierarchy, not five apps**: Docs, sheets, code, tasks, calendar, team channels, cloud dev
+  machines, and published sites are all pages in the same drive, not separate tools you swivel-chair between
+- **Build on it, not just in it**: A CLI, a typed SDK, and an MCP server are generated from one
+  shared operation registry, so external AI (Claude Desktop, Cursor, Claude Code) and your own
+  scripts get the exact same capabilities the web app has, and can never drift out of sync
+- **Publish anything**: Turn any Document, Code, Sheet, or Canvas page into a live public site on
+  a free subdomain or your own custom domain
+- **Cloud dev machines**: Spin up a sandboxed terminal on a git branch and hand it to a coding
+  agent that can read, edit, run, commit, and open a PR without leaving PageSpace
+- **100+ AI models**: From free (Qwen, DeepSeek) to premium (Claude Opus 4.5, GPT-5, Gemini 3),
+  you choose, or bring your own API key
+- **Pay for what you actually use**: AI and cloud-machine usage are metered against real provider
+  cost, not a flat per-seat guess
+- **Zero-trust direction (cloud)**: OAuth-based auth, opaque tokens, per-event authorization, and
+  tamper-evident audit trails
 
 ## Preview
 
@@ -38,12 +54,24 @@ AI: *Reads relevant documents, creates analysis page*
 Team Member B: *Sees the conversation and analysis in real-time*
 ```
 
+### Script or terminal, same workspace
+```bash
+$ pagespace tasks create <listId> --title "Ship the Q3 report" --priority high
+$ pagespace agents ask <agentId> "Summarize what changed on the roadmap this week"
+```
+
+### An agent that can actually ship code
+```
+You: "Spin up a machine on feature/pricing-v2 and fix the failing test"
+AI: *Opens a real terminal, reproduces the failure, edits the code, commits, opens a PR*
+```
+
 ### External AI edits your workspace
 ```bash
-# Install MCP server
-npm install -g pagespace-mcp@latest
-
-# In Claude Desktop
+# Zero-install MCP — add to Claude Desktop, Claude Code, or Cursor's config
+npx -y -p @pagespace/cli pagespace-mcp
+```
+```
 Claude: "Update all meeting notes in my PageSpace"
 *Claude directly edits documents at www.pagespace.ai*
 ```
@@ -89,49 +117,70 @@ Native desktop apps that connect to your PageSpace cloud workspace.
 
 ---
 
-## Connect External AI (Claude, Cursor)
+## Build on PageSpace
 
-PageSpace includes an MCP server that lets Claude Desktop and other AI tools directly manipulate your workspace:
+A CLI, a typed SDK, and an MCP server, all generated from **one shared operation registry**, so
+a CLI verb, an SDK method, and an MCP tool can never drift apart from each other.
 
-### Quick Setup
-1. **Install the MCP server**
-   ```bash
-   npm install -g pagespace-mcp@latest
-   ```
+### CLI
+Script your workspace from a terminal.
+```bash
+npm install -g @pagespace/cli
+pagespace login              # browser OAuth login
+pagespace keys                # mint a drive-scoped access key
+pagespace drives list
+pagespace search text "roadmap" --all-drives
+```
 
-2. **Get your token** from [pagespace.ai/dashboard/settings/mcp](https://pagespace.ai/dashboard/settings/mcp)
+### SDK
+Build your own integrations.
+```bash
+npm install @pagespace/sdk
+```
+```ts
+import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
 
-3. **Configure Claude Desktop** (add to MCP settings):
-   ```json
-   {
-     "mcpServers": {
-       "pagespace": {
-         "command": "npx",
-         "args": ["-y", "pagespace-mcp@latest"],
-         "env": {
-           "PAGESPACE_API_URL": "https://pagespace.ai",
-           "PAGESPACE_AUTH_TOKEN": "your-mcp-token"
-         }
-       }
-     }
-   }
-   ```
+const client = new PageSpaceClient({
+  baseUrl: 'https://pagespace.ai',
+  auth: new StaticTokenProvider(process.env.PAGESPACE_TOKEN!),
+});
 
-4. **Claude can now work in your PageSpace!**
-   - "Show me my drives and pages"
-   - "Create a new project structure"
-   - "Edit line 42 in the requirements document"
+const drives = await client.drives.list({});
+```
 
-[Full MCP documentation →](https://www.npmjs.com/package/pagespace-mcp)
+### MCP
+Connect Claude Desktop, Claude Code, or Cursor.
+```json
+{
+  "mcpServers": {
+    "pagespace": {
+      "command": "npx",
+      "args": ["-y", "-p", "@pagespace/cli", "pagespace-mcp"],
+      "env": { "PAGESPACE_KEY": "agent" }
+    }
+  }
+}
+```
+
+Auth is OAuth-based. `pagespace login` identifies *you* but grants no content access on its own;
+actual read/write access comes from a separately minted, drive-scoped key, and every grant (the
+CLI or an MCP client) is visible and revocable from Settings → Connected Apps. See
+[`packages/cli/README.md`](./packages/cli/README.md) and
+[`packages/sdk/README.md`](./packages/sdk/README.md) for the full command reference, auth model,
+and error handling, or the [PageSpace MCP docs](https://pagespace.ai/docs/integrations/mcp) for
+client-by-client setup. (Coming from the standalone `pagespace-mcp` npm package? It's deprecated
+in favor of `pagespace mcp`, part of `@pagespace/cli`; see the
+[migration guide](./packages/cli/docs/migrating-from-pagespace-mcp.md).)
 
 ---
 
 ## Core Features
 
 ### AI Agent Infrastructure
-- **76 workspace tools** for AI to manipulate content directly
+- **76 workspace tools** for AI to manipulate content directly. The same operation registry
+  generates every `pagespace` CLI verb, SDK method, and MCP tool, so none of the three can drift
 - **Tool permissions**: Control what each AI can do in your workspace
-- **MCP protocol support**: Connect external AI tools like Claude Desktop and Cursor
+- **MCP protocol support**: Connect external AI tools like Claude Desktop, Cursor, and Claude Code
 
 ### Everything Is a Drive Page
 Each item in a drive is a typed page with a specific role:
@@ -145,9 +194,31 @@ Each item in a drive is a typed page with a specific role:
 - **AI Chat**: Tool-enabled AI conversation page with persistent context
 - **File**: Uploaded file page for preview, download, and file-to-page linking
 - **Folder**: Hierarchical container page for organizing everything else
+- **Machine**: Cloud dev sandbox with a terminal, git, and agent execution
 
 - Hierarchical context flows through your workspace
 - Real-time collaboration is built into collaborative page types
+
+### Cloud Dev Machines
+- **Sandboxed terminals**: Isolated dev environments (Fly Sprites microVMs), one per branch, with
+  a working directory, file tree, diff view, and an actual shell
+- **Agent-run terminals**: Spawn a named, pluggable coding agent (Claude Code and others) into a
+  machine to work it autonomously: read, edit, run, commit, and push
+- **Scoped AI access**: Grant a specific AI page-agent access to a specific machine, no more
+- **Deep GitHub tooling**: Agents can open/merge PRs, manage issues, search code, inspect commits,
+  rerun CI, and recover from conflicted merges/rebases, with or without a full code-execution
+  sandbox
+- **Metered like everything else**: Machine/terminal time bills through the same credit system as
+  AI usage, settled in short heartbeats so a mid-session deploy can't drop your usage
+
+### Publish Anything
+- **Publish any page**: Document, Code, Sheet, and Canvas pages can all be published as live public
+  sites, not just Canvas
+- **Your domain or ours**: Serve from a free `*.pagespace.site` subdomain or connect a custom
+  domain with managed TLS
+- **SEO controls**: Per-page title, description, OG image, and robots/noindex overrides
+- **Site details**: Custom 404 page, drive-wide favicon, and pick an uploaded file as your OG
+  image instead of hosting one elsewhere
 
 ### Multi-Provider AI Support
 - **Built-in models** via PageSpace (no API key needed)
@@ -157,7 +228,8 @@ Each item in a drive is a typed page with a specific role:
 
 ### Unified Messaging & Inbox
 - **Unified inbox**: DMs and channels in one view across dashboard and drives
-- **Channel collaboration**: Agent mentions, read status tracking, unread indicators, and attachments
+- **Channel collaboration**: Agent mentions (with image-attachment context for vision-capable
+  models), read status tracking, unread indicators, and attachments
 - **Conversation controls**: Message edit/delete support with richer tool-call rendering
 
 ### Tasks & Calendar Workspace
@@ -165,6 +237,20 @@ Each item in a drive is a typed page with a specific role:
 - **Native calendar views**: Month, week, day, and agenda layouts for personal or drive contexts
 - **Google Calendar sync**: OAuth connection, two-way sync, push updates, and attendee mapping
 - **Calendar AI tools**: Create, update, RSVP, and manage events from natural-language prompts
+
+### Integrations
+- **Built-in providers**: GitHub, Slack, Notion, and generic webhooks, plus a native Google
+  Calendar sync (see Tasks & Calendar above)
+- **Two doors, one workspace**: MCP is how external AI (Claude Desktop, Cursor, Claude Code) comes
+  *into* PageSpace; the CLI, SDK, and these integrations are how PageSpace reaches *out*
+- **Custom integrations**: Register your own webhook-backed tool providers alongside the built-ins
+
+### Metered AI Billing
+- **Pay for what you use**: Every plan includes a monthly credit allowance metered against real AI
+  usage, not a flat per-seat price
+- **Metered on model cost**: Credits are consumed on actual provider cost, with a live usage
+  breakdown by model, feature, and cloud machine
+- **Buy more anytime**: Stripe-backed subscriptions, with credit top-ups available on any plan
 
 ### Editing Experience
 - **Documents**: Built as rich text pages that also support markdown-based authoring
@@ -180,12 +266,17 @@ Each item in a drive is a typed page with a specific role:
 ### Security Architecture
 PageSpace is built around a zero-trust model for cloud deployment. One explicit exception is desktop-local MCP server hosting, which runs inside the user's local trust boundary (same model as Claude Desktop).
 
+- **OAuth 2.1 authorization server**: `pagespace login` and every scoped access key are minted
+  through a real browser consent flow, not a static bearer token
+- **Connected Apps**: See every OAuth grant on your account, including the CLI and any MCP
+  client, from Settings, and revoke one instantly. Minting and revoking both require a fresh
+  step-up confirmation (passkey, or a confirmation email if you have no passkey)
 - **Opaque session tokens**: Server-validated tokens with SHA3-256 hash-only storage — raw tokens never persisted
 - **Per-event authorization**: Every sensitive operation re-validates permissions against the database
 - **Instant token revocation**: Token versioning enables immediate session invalidation across all devices
 - **Device fingerprinting**: Trust scoring detects token theft via IP/User-Agent anomalies
 - **Tamper-evident audit trails**: Hash-chained security logs for compliance and forensics
-- **Scoped external access**: MCP tokens enforce drive/page scope with strict auth validation
+- **Scoped external access**: Access keys enforce drive/page scope with strict auth validation
 - **Defense-in-depth**: SameSite cookies + CSRF tokens + origin validation + rate limiting
 - **Comprehensive security headers**: CSP with nonces, HSTS, X-Frame-Options, and more
 
@@ -237,6 +328,9 @@ PageSpace provides comprehensive data protection so you never lose work:
 - **Unified Team Comms**: DMs + channels + AI in one inbox workflow
 - **Planning & Scheduling**: Tasks and calendars with AI-assisted event operations
 - **Project Management**: AI handles routine updates while your team focuses on decisions
+- **Agentic Development**: Hand a cloud dev machine to a coding agent and get a PR back
+- **Publish From Your Workspace**: Turn internal docs or a Canvas page into a live public site
+- **Build Your Own Tools**: Script your workspace with the CLI/SDK, or wire up your own MCP client
 - **Creative Workflows**: Brainstorm with AI that can actually implement ideas
 
 ---
@@ -258,6 +352,6 @@ Third-party open-source components retained in the dependency tree remain under 
 
 ---
 
-**Built by people who believe AI should work with you, not just talk to you.**
+**Built by people who believe AI should work with you: in your documents, your tasks, your calendar, your codebase, and your published sites, not just in a chat window beside them.**
 
 [Get started at www.pagespace.ai →](https://www.pagespace.ai)


### PR DESCRIPTION
## Summary

The README was stuck describing an early version of PageSpace — basic page types, the old MCP server, version history, security — with no mention of the CLI, SDK, cloud dev Machines, page publishing, or live metered billing that ~200 PRs have since shipped. It also undersold the product as an AI-document tool rather than the everything-workspace it's become.

- Repositions the pitch: one AI-native workspace for docs, tasks, calendar, team chat, cloud dev machines, and published sites, all one page hierarchy, all AI-addressable.
- Adds a **Build on PageSpace** section covering `@pagespace/cli`, `@pagespace/sdk`, and `pagespace mcp` — all generated from one shared operation registry (light-touch, links out to `packages/cli/README.md` / `packages/sdk/README.md` for the full command reference and auth model).
- Adds **Cloud Dev Machines**, **Publish Anything**, **Metered AI Billing**, and **Integrations** sections; extends **Security Architecture** with the OAuth 2.1 authorization server and Connected Apps.
- Adds the **Machine** page type (now 10 page types, per the `PageType` enum) to the page-type list.
- License section is byte-for-byte unchanged.

## Verification

Every factual claim was checked against current code and adversarially re-verified across 3 consecutive clean passes (workspace-tool count via an AST-based script matching the CI-guarded `**76 workspace tools**` phrase, OAuth client registry scope, billing/publishing wiring, usage-breakdown granularity, page-type enum). Full findings log recorded on PageSpace page [`b919b5r5dg3holwuw5jf6mwu`](https://pagespace.ai/dashboard/lng6q95adrfndmdnnf9z8g6p/b919b5r5dg3holwuw5jf6mwu).

### Test plan
- [x] `WORKSPACE_TOOL_COUNT` re-verified against `apps/web/src/lib/ai/core/ai-tools.ts` (76, unchanged) — matches the CI-guarded `**76 workspace tools**` phrase in `apps/web/src/lib/ai/core/__tests__/tool-registry-docs.test.ts`
- [x] License section diffed byte-for-byte against the prior version — identical
- [x] Page-type list confirmed at 10 entries including Machine
- [x] Docs-only change — no code touched, no app tests affected

## Review feedback addressed (46feff641)

CodeRabbit + Codex flagged 4 issues, all verified against source before acting:

- **Fixed** — unbalanced/adjacent Markdown fences in the "External AI edits your workspace" example (introduced when splitting an original single-block example in two); also labeled two other pre-existing unlabeled example fences for markdownlint (MD040) compliance.
- **Fixed** — CLI quickstart was missing the `pagespace keys use <name>` activation step; without it `pagespace drives list` hits "No explicit credential found" per `run.ts`'s auth gate. Now matches `packages/cli/README.md`'s own quickstart exactly.
- **Fixed** — clarified that a scoped access key is itself a bearer secret once issued, with a pointer to the Connected Apps revocation flow.
- **Not changed** — CodeRabbit suggested swapping the zero-install MCP example's `PAGESPACE_KEY` for `PAGESPACE_TOKEN` + `PAGESPACE_API_URL`. Checked against `packages/cli/README.md`'s own canonical example and the CLI's tests (`auth/__tests__/resolve.test.ts:276`, `commands/__tests__/mcp.test.ts:142`) — both use `PAGESPACE_KEY`, confirming the original wording was already correct. Replied with evidence; thread resolved as a non-issue.

All CI checks green (Unit Tests, Lint & TypeScript Check, CodeRabbit). Branch is clean against master with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JitCswAtUfmNZ1BK2FW87W