### PR TITLE
fix(sprites): watchdog quiets while attached-but-idle (closes reconnect churn)

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -49,8 +49,18 @@ function makeShell(): PtyShell & {
   resize: ReturnType<typeof vi.fn>;
   kill: ReturnType<typeof vi.fn>;
   setViewerAttached: ReturnType<typeof vi.fn>;
+  /** Stands in for the shell swallowing a watchdog trip (detach-quiet / attach-quiet). */
+  setQuiesced: (quiesced: boolean) => void;
 } {
-  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn(), isQuiesced: () => false };
+  let quiesced = false;
+  return {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    setViewerAttached: vi.fn(),
+    isQuiesced: () => quiesced,
+    setQuiesced: (next: boolean) => { quiesced = next; },
+  };
 }
 
 function makeSprite(sessions: Array<{ id: string; command: string; isActive: boolean; tty: boolean }> = []) {
@@ -1140,6 +1150,92 @@ describe('buildAgentTerminalHandlers', () => {
 
       expect(billing.releaseHold).toHaveBeenCalledWith('hold-1');
       expect(billing.trackUsage).not.toHaveBeenCalled();
+    });
+
+    /**
+     * Billing must track SANDBOX RESIDENCY, not tab-open time. Once the watchdog
+     * quiesces an idle shell, its task hold is released and the Sprite pauses —
+     * costing us nothing. An ATTACHED session is never reaped (`DETACHED_IDLE_MS`
+     * only arms on disconnect), so billing wall-clock through a quiesce would
+     * charge the payer, without bound, for a sandbox that is not running: leave a
+     * tab open overnight, get billed for the night.
+     */
+    it('given the shell quiesced, settles the window so far and then STOPS the clock (a paused sprite is not billable)', async () => {
+      const billing = makeBilling();
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+      await onConnect(validPayload);
+
+      // Ten minutes of real, live session — billable.
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+      expect(billing.trackUsage).toHaveBeenCalledTimes(1);
+      expect(billing.trackUsage.mock.calls[0][0]).toMatchObject({ activeSeconds: SETTLE_HEARTBEAT_MS / 1000 });
+
+      // The viewer goes idle; the watchdog quiets the shell and the sprite pauses.
+      shell.setQuiesced(true);
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+      // That beat bills the window that ended at the quiesce…
+      expect(billing.trackUsage).toHaveBeenCalledTimes(2);
+
+      // …and every beat after it bills NOTHING, however long the tab stays open.
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS * 5);
+      expect(billing.trackUsage).toHaveBeenCalledTimes(2);
+    });
+
+    it('given a quiesced shell, does not reserve the payer\'s credits for a window that is not running', async () => {
+      const billing = makeBilling();
+      const { onConnect } = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+      await onConnect(validPayload);
+      const gatesAtConnect = billing.gate.mock.calls.length;
+
+      shell.setQuiesced(true);
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS * 3);
+
+      expect(billing.gate).toHaveBeenCalledTimes(gatesAtConnect); // no re-hold while paused
+      expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ connectedAt: undefined });
+    });
+
+    it('given a keystroke resumes a quiesced shell, restarts the clock AT THE KEYSTROKE, not at the next heartbeat', async () => {
+      // The heartbeat is ten minutes wide. Restarting the clock on the next beat
+      // would hand the payer up to ten minutes of a live, running sandbox free.
+      const billing = makeBilling();
+      const handlers = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+      await handlers.onConnect(validPayload);
+
+      shell.setQuiesced(true);
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS); // clock stops
+      const settlesWhileQuiet = billing.trackUsage.mock.calls.length;
+
+      // The viewer types: the shell resumes, the sprite wakes, consumption starts.
+      shell.setQuiesced(false);
+      handlers.onInput({ data: 'ls\n' });
+
+      // Nine minutes of live sandbox BEFORE the next beat — all of it billable.
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+
+      expect(billing.trackUsage).toHaveBeenCalledTimes(settlesWhileQuiet + 1);
+      const resumed = billing.trackUsage.mock.calls[settlesWhileQuiet][0] as { activeSeconds: number };
+      expect(resumed.activeSeconds).toBe(SETTLE_HEARTBEAT_MS / 1000); // the whole window, not zero
+    });
+
+    it('given a viewer returns to a quiesced shell, restarts the clock on the reattach', async () => {
+      const billing = makeBilling();
+      const handlers = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket, persistStreamSessionId, billing });
+      await handlers.onConnect(validPayload);
+
+      shell.setQuiesced(true);
+      await vi.advanceTimersByTimeAsync(SETTLE_HEARTBEAT_MS);
+      expect(sessionMap.getByKey('branch1:agent:cli')).toMatchObject({ connectedAt: undefined });
+
+      handlers.onDisconnect();
+      shell.setQuiesced(false);
+
+      const socket2 = makeSocket('sock2');
+      const handlers2 = buildAgentTerminalHandlers({ sessionMap, openShell, checkAuth, socket: socket2, persistStreamSessionId, billing });
+      await handlers2.onConnect(validPayload); // tab-back -> attachToLiveSession
+
+      const session = sessionMap.getByKey('branch1:agent:cli') as { connectedAt?: number };
+      expect(session.connectedAt).toBeTypeOf('number'); // clock running again
     });
 
     it('given the END-of-session settle rejects, should log and still tear the session down (billing never blocks cleanup)', async () => {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-handler.test.ts
@@ -50,7 +50,7 @@ function makeShell(): PtyShell & {
   kill: ReturnType<typeof vi.fn>;
   setViewerAttached: ReturnType<typeof vi.fn>;
 } {
-  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn() };
+  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn(), isQuiesced: () => false };
 }
 
 function makeSprite(sessions: Array<{ id: string; command: string; isActive: boolean; tty: boolean }> = []) {

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
@@ -15,8 +15,22 @@ import { assert } from './riteway';
 
 const TICK_INTERVAL_MS = 60_000;
 
-function makeShell(): PtyShell & { kill: ReturnType<typeof vi.fn> } {
-  return { write: vi.fn(), resize: vi.fn(), kill: vi.fn(), setViewerAttached: vi.fn() };
+/**
+ * `setQuiesced` stands in for what the real shell does on its own: swallow a
+ * watchdog trip instead of reconnecting (`detach-quiet` / `attach-quiet`),
+ * leaving the exec socket deliberately down until a viewer returns or a
+ * keystroke arrives.
+ */
+function makeShell(): PtyShell & { kill: ReturnType<typeof vi.fn>; setQuiesced: (quiesced: boolean) => void } {
+  let quiesced = false;
+  return {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    setViewerAttached: vi.fn(),
+    isQuiesced: () => quiesced,
+    setQuiesced: (next: boolean) => { quiesced = next; },
+  };
 }
 
 function makeSocket(id = 'sock1', userId = 'user1'): SocketLike & { emit: ReturnType<typeof vi.fn> } {
@@ -235,6 +249,118 @@ describe('agent terminal task holds (wiring)', () => {
       should: 'report activity as unobservable so the controller never deletes on a frozen clock',
       actual: { attached: lastTick.attached, observable: lastTick.activityObservable },
       expected: { attached: false, observable: false },
+    });
+  });
+
+  /**
+   * The attached-but-idle leak. `planHold`'s `needHold = attached || agentRunning`
+   * means an attached viewer pins the sprite forever — so quieting the watchdog
+   * alone saves the ~45s exec round-trips but NOT the residency (the RAM bill
+   * this change exists to cut). `attached` has to mean "a LIVE exec connection
+   * exists", and a quiesced socket is not one.
+   */
+  it('ticks NOT-attached once the shell quiesces its socket, so the idle hold is released and the sprite can pause', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    // The watchdog swallowed a trip on an attached-but-idle shell (attach-quiet):
+    // the viewer is still here, but the exec connection is deliberately down.
+    shell.setQuiesced(true);
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+
+    const lastTick = hold.ticks[hold.ticks.length - 1];
+    assert({
+      given: 'a heartbeat while the viewer is attached but the socket is quiesced',
+      should: 'report attached: false — there is no live connection for the platform to keep the sprite up FOR',
+      actual: lastTick.attached,
+      expected: false,
+    });
+
+    assert({
+      given: 'a heartbeat while the viewer is attached but the socket is quiesced',
+      should: 'still trust staleness — a shell is only quieted BECAUSE its clock was already stale on a live socket',
+      actual: lastTick.activityObservable,
+      expected: true,
+    });
+  });
+
+  it('ticks attached again once a keystroke resumes the quiesced socket (the hold must come back)', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    shell.setQuiesced(true);
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+    shell.setQuiesced(false); // the real shell clears this in `resumeIfLazyReattachNeeded`
+    vi.advanceTimersByTime(TICK_INTERVAL_MS);
+
+    assert({
+      given: 'a heartbeat after the socket came back',
+      should: 'report attached: true so the hold is recreated',
+      actual: hold.ticks[hold.ticks.length - 1].attached,
+      expected: true,
+    });
+  });
+
+  /**
+   * The one session whose silence proves nothing. A RESUMED agent was verified
+   * LIVE at connect and may simply be thinking; we hold only the connect stamp,
+   * so aging that into a quiet verdict would drop the hold (the tick above) and
+   * pause the sprite under a working agent. `getLastActivityAt` returns
+   * `undefined` for it — "no trustworthy idleness signal" — which keeps the
+   * watchdog reattaching, exactly the same trust rule `disconnectConnection`
+   * already applies (`hasOutput || !resumedAtCreate`).
+   */
+  it('offers the watchdog NO idleness signal for a resumed agent that has not yet spoken', async () => {
+    const auth = makeAuthSuccess();
+    const liveSession = { id: 'sess-live', command: 'claude', isActive: true, tty: true };
+    auth.sprite.listSessions = vi.fn(async () => [liveSession]);
+    auth.resolveSandbox = vi.fn(async () => ({
+      ok: true as const,
+      agentTerminalId: 'agent-terminal-1',
+      sandboxId: 'sbx1',
+      cwd: '/workspace',
+      sprite: auth.sprite,
+      command: 'claude',
+      args: [],
+      commandOverride: null,
+      streamSessionId: 'sess-live', // still running server-side — this is a RESUME
+      releaseSlot: vi.fn(),
+    }));
+    checkAuth.mockResolvedValue(auth);
+
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    const args = (openShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as OpenPtyShellArgs;
+
+    assert({
+      given: 'a resumed agent that has not yet emitted a byte',
+      should: 'report no activity clock at all, so the watchdog keeps the socket up rather than quieting it',
+      actual: args.getLastActivityAt?.(),
+      expected: undefined,
+    });
+
+    args.onOutput('thinking… done\r\n');
+
+    assert({
+      given: 'the resumed agent finally speaks',
+      should: 'hand over the real clock again — silence is evidence of idleness once we have heard it once',
+      actual: typeof args.getLastActivityAt?.(),
+      expected: 'number',
+    });
+  });
+
+  it('offers the watchdog a real clock for a FRESH (non-resumed) session from the very first tick', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    const args = (openShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as OpenPtyShellArgs;
+
+    assert({
+      given: 'a fresh session whose launch is its own first activity',
+      should: 'report the launch stamp — a fresh boot that goes silent IS idle and may be quieted',
+      actual: typeof args.getLastActivityAt?.(),
+      expected: 'number',
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-task-hold.test.ts
@@ -14,6 +14,14 @@ import type { TaskHoldController, TaskHoldState } from '@pagespace/lib/services/
 import { assert } from './riteway';
 
 const TICK_INTERVAL_MS = 60_000;
+/**
+ * The controller's EFFECTIVE idle window. Deliberately not `2 * TICK_INTERVAL_MS`
+ * (the default formula) and not `TASK_HOLD_AGENT_IDLE_MS`: `refreshMs` is
+ * configurable via `SPRITE_TASK_HOLD_REFRESH_MS`, so anything that decides "may
+ * this sprite pause?" alongside the hold must read this window from the
+ * controller rather than assume the module constant.
+ */
+const AGENT_IDLE_MS = 37_000;
 
 /**
  * `setQuiesced` stands in for what the real shell does on its own: swallow a
@@ -78,6 +86,9 @@ function makeRecordingHold() {
   let ended = false;
   const controller: TaskHoldController = {
     tickIntervalMs: TICK_INTERVAL_MS,
+    // Deliberately NOT the TASK_HOLD_AGENT_IDLE_MS default: the watchdog must
+    // read the controller's EFFECTIVE window, not assume the module constant.
+    agentIdleMs: AGENT_IDLE_MS,
     tick: (state) => {
       ticks.push({ ...state });
     },
@@ -347,6 +358,28 @@ describe('agent terminal task holds (wiring)', () => {
       should: 'hand over the real clock again — silence is evidence of idleness once we have heard it once',
       actual: typeof args.getLastActivityAt?.(),
       expected: 'number',
+    });
+  });
+
+  /**
+   * Coherence. The watchdog's `attach-quiet` and the hold both answer "may this
+   * sprite pause?", and they must answer it on the SAME window. `refreshMs` (and
+   * therefore the derived idle window) is configurable, so the shell reads the
+   * controller's effective window instead of assuming `TASK_HOLD_AGENT_IDLE_MS`.
+   * If it assumed the default, a longer-configured hold would leave a shell that
+   * is quiet, blind, AND still pinning the sprite.
+   */
+  it('hands the watchdog the hold controller\'s EFFECTIVE idle window, not the module default', async () => {
+    const handlers = build();
+    await handlers.onConnect(validPayload);
+
+    const args = (openShell as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0] as OpenPtyShellArgs;
+
+    assert({
+      given: 'a hold controller configured with a non-default idle window',
+      should: 'report that window to the watchdog, so the two never disagree about idleness',
+      actual: args.getIdleMs?.(),
+      expected: AGENT_IDLE_MS,
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -242,6 +242,34 @@ describe('planWatchdogResponse (pure)', () => {
   });
 
   assert({
+    given: 'a hold configured with a LONGER idle window than the default, and activity stale only by the default',
+    should: 'still reattach — judging on the default would quiet a shell whose hold is still held, leaving it quiet, blind AND pinning the sprite',
+    actual: planWatchdogResponse({
+      viewersAttached: true,
+      closed: false,
+      consecutiveFailures: 0,
+      lastActivityAt: NOW - TASK_HOLD_AGENT_IDLE_MS - 1,
+      now: NOW,
+      idleMs: TASK_HOLD_AGENT_IDLE_MS * 2,
+    }),
+    expected: 'reattach' as const,
+  });
+
+  assert({
+    given: 'a hold configured with a SHORTER idle window, and activity stale by that window but not the default',
+    should: 'quiet — the hold has already let go, so holding a socket open past it is pure churn',
+    actual: planWatchdogResponse({
+      viewersAttached: true,
+      closed: false,
+      consecutiveFailures: 0,
+      lastActivityAt: NOW - 31_000,
+      now: NOW,
+      idleMs: 30_000,
+    }),
+    expected: 'attach-quiet' as const,
+  });
+
+  assert({
     given: 'a caller that keeps no activity clock (getLastActivityAt omitted)',
     should: 'reattach exactly as before this verdict existed — an unknown clock is not evidence of idleness',
     actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: undefined, now: NOW }),

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -214,6 +214,34 @@ describe('planWatchdogResponse (pure)', () => {
   });
 
   assert({
+    given: 'a RESUME (viewer returned / keystroke) on a session whose clock is long stale',
+    should: 'reattach — the human interaction IS the activity; the idle gate must not veto the very thing the quiet verdict was waiting for',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 1, lastActivityAt: STALE, now: NOW, resumeRequested: true }),
+    expected: 'reattach' as const,
+  });
+
+  assert({
+    given: 'a resume request with NO viewer attached',
+    should: 'still go quiet — a resume cannot fabricate a viewer to reconnect for',
+    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 1, lastActivityAt: STALE, now: NOW, resumeRequested: true }),
+    expected: 'detach-quiet' as const,
+  });
+
+  assert({
+    given: 'a resume request on an already-closed shell',
+    should: 'still go quiet — there is nothing left to reconnect',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: true, consecutiveFailures: 1, lastActivityAt: STALE, now: NOW, resumeRequested: true }),
+    expected: 'detach-quiet' as const,
+  });
+
+  assert({
+    given: 'a resume whose own retries have exhausted the failure budget',
+    should: 'go fatal — a resume is bounded by the same budget as any other attempt, not exempt from it',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 6, lastActivityAt: STALE, now: NOW, resumeRequested: true }),
+    expected: 'fatal' as const,
+  });
+
+  assert({
     given: 'a caller that keeps no activity clock (getLastActivityAt omitted)',
     should: 'reattach exactly as before this verdict existed — an unknown clock is not evidence of idleness',
     actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: undefined, now: NOW }),
@@ -636,6 +664,68 @@ describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
   });
 
   /**
+   * The tab-back regression: a viewer who returns after a LONG detached gap
+   * necessarily brings a stale activity clock with them. If the resume is
+   * re-litigated by the idle gate it quiets straight back down — the socket
+   * never comes up, the viewer sees only stale scrollback until they type, and
+   * (because the hold heartbeat keys off the same quiescence) the Sprite stays
+   * paused underneath them. This is the documented `setViewerAttached(true)`
+   * resume path from leaf 3-2, and it must survive `attach-quiet` untouched.
+   */
+  it('given a viewer returns after a detached trip AND a long idle gap, still reattaches — the resume is not re-vetoed by the idle gate', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const onOutput = vi.fn();
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sprite.attachSession).not.toHaveBeenCalled(); // quiet while detached
+
+    // The tab stays closed well past the idle window — the clock goes stale.
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+
+    shell.setViewerAttached(true); // …and the viewer comes back
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    expect(shell.isQuiesced()).toBe(false); // the hold can come back too
+
+    attachCmd._stdout.emit('data', 'back\r\n');
+    expect(onOutput).toHaveBeenCalledWith('back\r\n'); // live output, without typing a thing
+  });
+
+  it('given the viewer returns and then still does nothing, the NEXT watchdog trip quiets again (the resume is one attempt, not an exemption)', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('keepalive'));
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sprite.attachSession).toHaveBeenCalledTimes(1); // the resume reconnected
+
+    // The viewer just sits there. The reattached socket trips again — and this
+    // time there is no resume behind it, so it goes quiet.
+    attachCmd._emitter.emit('error', new Error('keepalive'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).toHaveBeenCalledTimes(1); // no second attach: quiet again
+    expect(shell.isQuiesced()).toBe(true);
+  });
+
+  /**
    * `isQuiesced()` is what the Sprites Tasks API hold reads to tell "a viewer is
    * attached" from "a LIVE exec connection exists" — only the second is a reason
    * to keep a Sprite resident. If this ever reported `false` through an
@@ -788,6 +878,30 @@ describe('input queued across a reconnect (no silent stdin loss)', () => {
 
     await vi.advanceTimersByTimeAsync(500); // backoff + listSessions resolve; attachSession called
     attachCmd._emitter.emit('spawn'); // the replacement confirms open
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    expect(attachCmd.stdin!.write).toHaveBeenCalledWith('ls\n');
+  });
+
+  it('given a keystroke arrives while the caller\'s activity clock is still STALE, resumes anyway (no stamp-before-write race)', async () => {
+    // The resume must not depend on the caller having raced a timestamp into its
+    // own clock before calling write(). The keystroke IS the activity; the shell
+    // does not re-ask the idle gate about it (`resumeRequested`).
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000); // attach-quiet
+
+    shell.write('ls\n'); // NOTE: no activity.touch() — the clock is still stale
+    await vi.advanceTimersByTimeAsync(500);
+    attachCmd._emitter.emit('spawn');
 
     expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
     expect(attachCmd.stdin!.write).toHaveBeenCalledWith('ls\n');

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import { openPtyShell, planReconnect, planWatchdogResponse, planTeardown, sessionIds } from '../sprites-shell';
 import { appendScrollback } from '../terminal-session-map';
 import { spawnWithSelfHealingCwd } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { TASK_HOLD_AGENT_IDLE_MS } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // riteway-style assertion (given/should/actual/expected) on top of vitest. There IS a
@@ -90,6 +91,20 @@ const liveSession: SpriteSessionInfo = { id: 'sess-1', command: 'bash', isActive
  */
 const announces = (id: string) => ({ type: 'session_info', session_id: id, command: 'bash', tty: true });
 
+/**
+ * A stand-in for the caller's activity clock — `agent-terminal-handler.ts`'s
+ * `latestActivityAt(session)`, which is `max(lastOutputAt, lastInputAt)` and is
+ * seeded at launch. `touch()` is what the handler does on both edges it owns:
+ * `session.lastInputAt = Date.now()` immediately BEFORE `command.write()`, and
+ * `session.lastOutputAt = Date.now()` in `onOutput`. Under `vi.useFakeTimers()`
+ * `Date.now()` is the fake clock, so advancing timers ages this exactly as real
+ * idleness would.
+ */
+function activityClock(): { get: () => number; touch: () => void } {
+  let at = Date.now();
+  return { get: () => at, touch: () => { at = Date.now(); } };
+}
+
 describe('planReconnect (pure)', () => {
   assert({
     given: 'a known persisted id still present in the live sessions',
@@ -127,40 +142,82 @@ describe('planReconnect (pure)', () => {
   });
 });
 
+// A fixed "now" plus the two activity ages that matter, expressed against the
+// SAME idle window the Sprites Tasks API hold uses — deliberately not a local
+// constant of our own (see `planWatchdogResponse`).
+const NOW = 1_700_000_000_000;
+const FRESH = NOW - 1_000; // typed/produced a second ago
+const STALE = NOW - TASK_HOLD_AGENT_IDLE_MS - 1; // idle past the hold's own window
+
 describe('planWatchdogResponse (pure)', () => {
   assert({
     given: 'no viewer attached',
     should: 'go quiet — no reconnect attempt',
-    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 0 }),
+    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 0, lastActivityAt: FRESH, now: NOW }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'no viewer attached, even past the reconnect failure budget',
     should: 'still go quiet rather than declare fatal — nobody is watching to receive the exit, and a later viewer must still be able to reattach',
-    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 99 }),
+    actual: planWatchdogResponse({ viewersAttached: false, closed: false, consecutiveFailures: 99, lastActivityAt: FRESH, now: NOW }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'the shell already closed',
     should: 'go quiet — there is nothing left to reconnect',
-    actual: planWatchdogResponse({ viewersAttached: true, closed: true, consecutiveFailures: 0 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: true, consecutiveFailures: 0, lastActivityAt: FRESH, now: NOW }),
     expected: 'detach-quiet' as const,
   });
 
   assert({
     given: 'an attached viewer and failures within the budget',
     should: 'reattach transparently',
-    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 1 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 1, lastActivityAt: FRESH, now: NOW }),
     expected: 'reattach' as const,
   });
 
   assert({
     given: 'an attached viewer but the failure budget is exhausted',
     should: 'go fatal',
-    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 6 }),
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 6, lastActivityAt: FRESH, now: NOW }),
     expected: 'fatal' as const,
+  });
+
+  assert({
+    given: 'an attached viewer whose session has been idle past the task-hold idle window',
+    should: 'go quiet — reattaching would keep the Sprite resident for a prompt producing nothing; the next keystroke resumes it',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: STALE, now: NOW }),
+    expected: 'attach-quiet' as const,
+  });
+
+  assert({
+    given: 'an attached viewer with FRESH activity (an agent mid-run)',
+    should: 'still reattach — unchanged; output is flowing and someone is watching it',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: FRESH, now: NOW }),
+    expected: 'reattach' as const,
+  });
+
+  assert({
+    given: 'activity exactly at the idle boundary (idleMs ago to the millisecond)',
+    should: 'go quiet — `isAgentActive` is a strict < , and this is the same edge the Tasks API hold already drops on',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: NOW - TASK_HOLD_AGENT_IDLE_MS, now: NOW }),
+    expected: 'attach-quiet' as const,
+  });
+
+  assert({
+    given: 'an attached viewer, stale activity, AND an exhausted failure budget',
+    should: 'go quiet rather than fatal — no attempt ran, so nothing proves the shell is dead, and fatal would latch `closed` on a healthy idle shell',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 99, lastActivityAt: STALE, now: NOW }),
+    expected: 'attach-quiet' as const,
+  });
+
+  assert({
+    given: 'a caller that keeps no activity clock (getLastActivityAt omitted)',
+    should: 'reattach exactly as before this verdict existed — an unknown clock is not evidence of idleness',
+    actual: planWatchdogResponse({ viewersAttached: true, closed: false, consecutiveFailures: 0, lastActivityAt: undefined, now: NOW }),
+    expected: 'reattach' as const,
   });
 });
 
@@ -467,6 +524,136 @@ describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
     expect(onExit).not.toHaveBeenCalled();
     expect(sprite.attachSession.mock.calls.length).toBeGreaterThan(6);
   });
+
+  /**
+   * The ATTACHED-but-idle case leaf 3-2 explicitly left alone: a browser tab
+   * left open on an idle prompt reconnected to the Sprite every ~45s forever,
+   * and an open TTY connection is itself what keeps a Sprite from pausing. The
+   * viewer here never leaves — the only thing that changes is that they stop
+   * typing — so `setViewerAttached(true)` never fires and the keystroke has to
+   * be the resume trigger.
+   *
+   * `vi.useFakeTimers()` mocks `Date` too, so advancing the clock past
+   * `TASK_HOLD_AGENT_IDLE_MS` genuinely ages the activity these shells report.
+   */
+  it('given an attached viewer whose session has been idle past the task-hold window, swallows the watchdog trip — no listSessions/attachSession', async () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+    const onExit = vi.fn();
+    const activity = activityClock();
+
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit, getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    // Nobody types, nothing is produced: the session ages past the same idle
+    // window that already drops its Tasks API hold. The viewer stays attached
+    // throughout.
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+
+    for (let i = 0; i < 3; i += 1) {
+      cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    expect(sprite.listSessions).not.toHaveBeenCalled();
+    expect(sprite.attachSession).not.toHaveBeenCalled();
+    expect(sprite.createSession).toHaveBeenCalledTimes(1); // only the original
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given an attached-but-idle shell that went quiet, a keystroke reattaches it transparently', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const onOutput = vi.fn();
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(sprite.attachSession).not.toHaveBeenCalled(); // quiet, though attached
+
+    // The viewer types. The handler stamps the keystroke into its activity clock
+    // before handing it to the PTY (`session.lastInputAt = Date.now()` precedes
+    // `command.write()`), which is what makes this write count as activity.
+    activity.touch();
+    shell.write('ls\n');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+
+    attachCmd._stdout.emit('data', 'back\r\n');
+    expect(onOutput).toHaveBeenCalledWith('back\r\n');
+  });
+
+  it('given an attached viewer with FRESH activity (an agent mid-run), keeps reattaching transparently — unaffected by attach-quiet', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const onExit = vi.fn();
+    const activity = activityClock();
+
+    openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit, getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    // Output is flowing right up to the drop — a real agent working.
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+    activity.touch();
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given an attached-but-idle shell that went quiet after the sprite paused, a keystroke transparently gets a fresh session', async () => {
+    const cmd = buildFakeCommand();
+    const freshCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [] }); // sess-1 is gone: the Sprite paused
+    sprite.createSession.mockReturnValueOnce(cmd).mockReturnValueOnce(freshCmd);
+    const onOutput = vi.fn();
+    const onExit = vi.fn();
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput, onExit, getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    activity.touch();
+    shell.write('echo hi\n');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.createSession).toHaveBeenCalledTimes(2); // initial + fresh fallback
+    freshCmd._stdout.emit('data', 'fresh prompt\r\n');
+    expect(onOutput).toHaveBeenCalledWith('fresh prompt\r\n');
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it('given an idle attached shell that never tripped the watchdog, a keystroke changes nothing (no reattach to pay back)', async () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('spawn');
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1); // idle, but the socket never dropped
+
+    activity.touch();
+    shell.write('ls\n');
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(sprite.attachSession).not.toHaveBeenCalled();
+    expect(sprite.listSessions).not.toHaveBeenCalled();
+    expect(cmd.stdin!.write).toHaveBeenCalledWith('ls\n'); // straight to the live socket
+  });
 });
 
 /**
@@ -524,6 +711,34 @@ describe('input queued across a reconnect (no silent stdin loss)', () => {
     await vi.advanceTimersByTimeAsync(500); // reconnect resolves; attachSession called
     attachCmd._emitter.emit('spawn');
 
+    expect(attachCmd.stdin!.write).toHaveBeenCalledWith('ls\n');
+  });
+
+  it('given an attached-but-idle shell went quiet, the very keystroke that resumes it reaches the PTY once the replacement opens', async () => {
+    // The attach-quiet companion of the tab-back case above: the viewer never
+    // detached, so the keystroke is BOTH the resume trigger and the first thing
+    // that has to survive the reconnect it triggers. It must not be handed to
+    // the dead socket, and it must not be dropped.
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1); // idle past the hold's window
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000); // trip swallowed: attach-quiet
+
+    activity.touch();
+    shell.write('ls\n'); // resumes the reconnect AND queues, in one call
+    expect(cmd.stdin!.write).not.toHaveBeenCalledWith('ls\n'); // never handed to the dead socket
+
+    await vi.advanceTimersByTimeAsync(500); // backoff + listSessions resolve; attachSession called
+    attachCmd._emitter.emit('spawn'); // the replacement confirms open
+
+    expect(sprite.attachSession).toHaveBeenCalledWith('sess-1', { cols: 80, rows: 24 });
     expect(attachCmd.stdin!.write).toHaveBeenCalledWith('ls\n');
   });
 

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -686,9 +686,16 @@ describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
     await vi.advanceTimersByTimeAsync(2000);
 
     expect(sprite.createSession).toHaveBeenCalledTimes(2); // initial + fresh fallback
+    freshCmd._emitter.emit('spawn');
     freshCmd._stdout.emit('data', 'fresh prompt\r\n');
     expect(onOutput).toHaveBeenCalledWith('fresh prompt\r\n');
     expect(onExit).not.toHaveBeenCalled();
+    // The accepted consequence of letting an idle sprite actually pause: the old
+    // exec session did not survive it, so the keystroke that woke the shell lands
+    // in the REPLACEMENT one. Asserted rather than assumed — it is the behavior a
+    // user sees (their `cd` is gone and their command runs in a fresh bash), and
+    // it is exactly what the detached tab-back path has always done (leaf 3-2).
+    expect(freshCmd.stdin!.write).toHaveBeenCalledWith('echo hi\n');
   });
 
   /**

--- a/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
+++ b/apps/realtime/src/terminal/__tests__/sprites-shell.test.ts
@@ -635,6 +635,57 @@ describe('viewer attach/detach gates the watchdog reconnect (leaf 3-2)', () => {
     expect(onExit).not.toHaveBeenCalled();
   });
 
+  /**
+   * `isQuiesced()` is what the Sprites Tasks API hold reads to tell "a viewer is
+   * attached" from "a LIVE exec connection exists" — only the second is a reason
+   * to keep a Sprite resident. If this ever reported `false` through an
+   * attach-quiet window, the hold would pin the sandbox behind an open tab and
+   * the whole idle-cost fix would be inert.
+   */
+  it('reports isQuiesced across the whole quiet window: false while live, true once a trip is swallowed, false again once paid back', async () => {
+    const cmd = buildFakeCommand();
+    const attachCmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession], attachCmd });
+    const activity = activityClock();
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn(), getLastActivityAt: activity.get });
+    cmd._emitter.emit('message', announces('sess-1'));
+    cmd._emitter.emit('spawn');
+
+    expect(shell.isQuiesced()).toBe(false); // live socket
+
+    await vi.advanceTimersByTimeAsync(TASK_HOLD_AGENT_IDLE_MS + 1);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(shell.isQuiesced()).toBe(true); // attach-quiet: deliberately down
+
+    activity.touch();
+    shell.write('ls\n');
+    await vi.advanceTimersByTimeAsync(2000);
+    attachCmd._emitter.emit('spawn');
+
+    expect(shell.isQuiesced()).toBe(false); // paid back
+  });
+
+  it('reports isQuiesced true for a DETACHED swallowed trip too — the hold reads one flag, not two', async () => {
+    const cmd = buildFakeCommand();
+    const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });
+
+    const shell = openPtyShell({ sprite, cols: 80, rows: 24, onOutput: vi.fn(), onExit: vi.fn() });
+    cmd._emitter.emit('message', announces('sess-1'));
+    shell.setViewerAttached(false);
+    cmd._emitter.emit('error', new Error('WebSocket keepalive timeout'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(shell.isQuiesced()).toBe(true);
+
+    shell.setViewerAttached(true);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(shell.isQuiesced()).toBe(false);
+  });
+
   it('given an idle attached shell that never tripped the watchdog, a keystroke changes nothing (no reattach to pay back)', async () => {
     const cmd = buildFakeCommand();
     const sprite = buildFakeSprite(cmd, { sessions: [liveSession] });

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -999,6 +999,13 @@ export function buildAgentTerminalHandlers({
           // moment it does, `hasOutput` flips and the normal idle window governs.
           getLastActivityAt: () =>
             (session.hasOutput || !session.resumedAtCreate ? latestActivityAt(session) : undefined),
+          // The window the hold is ACTUALLY judging idleness on — configurable
+          // (`SPRITE_TASK_HOLD_REFRESH_MS`), so it is read from the controller
+          // rather than assumed to be the default. Both signals must answer "may
+          // this sprite pause?" on the same window or they contradict each other.
+          // A getter because the controller is built after this shell is opened;
+          // `undefined` (no hold wired) falls back to `TASK_HOLD_AGENT_IDLE_MS`.
+          getIdleMs: () => session.taskHold?.agentIdleMs,
           onOutput: (data) => {
             // The hold's "agent output is flowing" signal — kept fresh here so
             // a DETACHED session with an agent mid-run keeps its sprite up.

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -388,10 +388,15 @@ async function settleAccruedWindow(
   // window instead of retrying it.
   //
   // No fresh hold is placed either: a hold RESERVES the payer's credits for the
-  // next window, and there is no next window until they come back. Skipping the
-  // gate also means an insolvent payer's quiesced terminal is not torn down
-  // while it sits there costing nothing — they are gated on resume, which is the
-  // moment they would start consuming again.
+  // next window, and there is no next window until they come back.
+  //
+  // Skipping the gate does mean an insolvent payer's quiesced terminal is not
+  // torn down while it sits there — correct, since it is consuming nothing — and
+  // that they are re-gated at the first heartbeat AFTER they resume rather than
+  // at the instant of resume. That is the same bounded exposure any mid-window
+  // insolvency already carries (a payer who runs out with nine minutes left in a
+  // ten-minute window keeps those nine minutes), not a new one: the settle
+  // cadence, not this branch, is what bounds it.
   if (stopClock) {
     session.connectedAt = undefined;
     return true;

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -341,6 +341,7 @@ async function settleAccruedWindow(
   sessionMap: TerminalSessionMap,
   session: TerminalSession,
   sessionKey: string,
+  { stopClock = false }: { stopClock?: boolean } = {},
 ): Promise<boolean> {
   if (!session.payerId || session.connectedAt === undefined) return true;
   const payerId = session.payerId;
@@ -373,6 +374,28 @@ async function settleAccruedWindow(
     return true;
   }
   if (sessionMap.getByKey(sessionKey) !== session) return true;
+  // The shell quiesced: its exec socket is deliberately down and its Sprite is
+  // free to pause (the task hold was released with it — see
+  // `startTaskHoldHeartbeat`). A paused sandbox costs us nothing, so billing the
+  // payer wall-clock for it would charge them for a tab, not for a sandbox — and
+  // an ATTACHED session is never reaped, so that overbilling would be unbounded.
+  // Stop the clock instead: the window just settled is the last billable one
+  // until the socket comes back (`resumeBillingClock`).
+  //
+  // Set only AFTER a successful settle and only while this session is still the
+  // live one — a failed settle has already rolled `connectedAt` back to the
+  // window start, and clearing it here would silently discard that unbilled
+  // window instead of retrying it.
+  //
+  // No fresh hold is placed either: a hold RESERVES the payer's credits for the
+  // next window, and there is no next window until they come back. Skipping the
+  // gate also means an insolvent payer's quiesced terminal is not torn down
+  // while it sits there costing nothing — they are gated on resume, which is the
+  // moment they would start consuming again.
+  if (stopClock) {
+    session.connectedAt = undefined;
+    return true;
+  }
   try {
     const gate = await billing.gate({ payerId });
     if (!gate.allowed) return false;
@@ -392,10 +415,31 @@ async function settleAccruedWindow(
 }
 
 /**
+ * Restart the billing clock a quiesced window stopped (`settleAccruedWindow`'s
+ * `stopClock`). Called at the very instant the shell resumes — a keystroke, or a
+ * viewer returning — NOT left to the next heartbeat: that is `SETTLE_HEARTBEAT_MS`
+ * (ten minutes) away, and a session that resumed nine minutes before its next
+ * tick would have those nine minutes billed as free.
+ *
+ * Idempotent, and inert for an unmetered session (no `payerId`) or one whose
+ * clock is already running — `connectedAt` is only ever `undefined` here because
+ * a quiesce stopped it.
+ */
+function resumeBillingClock(session: TerminalSession): void {
+  if (!session.payerId) return;
+  if (session.connectedAt !== undefined) return;
+  session.connectedAt = Date.now();
+}
+
+/**
  * Arms the heartbeat for a metered session (see SETTLE_HEARTBEAT_MS). A
  * module-level factory rather than a closure inside onConnect so the
  * long-lived interval callback captures only what it needs — not the whole
  * connect scope (auth result, Sprite handle, session-list snapshots).
+ *
+ * Each tick re-reads whether the shell is QUIESCED, so the same beat that bills
+ * a live session's window stops an idle one's clock — and starts it again when
+ * the socket comes back. Billing tracks sandbox residency, not tab-open time.
  */
 function startSettleHeartbeat(
   billing: SandboxBillingDeps,
@@ -409,7 +453,13 @@ function startSettleHeartbeat(
     if (settling) return;
     settling = true;
     try {
-      const solvent = await settleAccruedWindow(billing, sessionMap, session, sessionKey);
+      const quiesced = session.command.isQuiesced();
+      // A backstop for the precise `resumeBillingClock` calls at the resume
+      // sites: if a socket came back through some path that did not restart the
+      // clock, this beat notices and restarts it rather than letting the session
+      // run on free forever.
+      if (!quiesced) resumeBillingClock(session);
+      const solvent = await settleAccruedWindow(billing, sessionMap, session, sessionKey, { stopClock: quiesced });
       if (!solvent && sessionMap.getByKey(sessionKey) === session) {
         loggers.realtime.info('Agent terminal session ended (payer out of credits at heartbeat)', {
           sessionKey,
@@ -720,6 +770,12 @@ export function buildAgentTerminalHandlers({
     // connection never actually dropped, since output is already flowing.
     session.command.setViewerAttached(true);
     session.viewerAttached = true;
+    // The line above resumes a shell that quiesced while they were gone, which
+    // wakes the Sprite — so the payer is consuming a sandbox again and the
+    // billing clock (stopped at the quiesce — see `settleAccruedWindow`'s
+    // `stopClock`) restarts HERE, not at the next ten-minute heartbeat. A no-op
+    // for a session that never quiesced: its clock never stopped.
+    resumeBillingClock(session);
     // A viewer is back AND the `setViewerAttached(true)` above has just resumed
     // the shell's socket, so the hold (deleted while idle) is re-created
     // immediately rather than waiting out a heartbeat interval. Derived, not
@@ -1205,6 +1261,14 @@ export function buildAgentTerminalHandlers({
         // Input is activity for the task hold: a typed prompt is work in
         // progress even before the agent's first byte of output.
         session.lastInputAt = Date.now();
+        // A keystroke also RESUMES a quiesced shell (sprites-shell.ts's `write`
+        // pays back the swallowed watchdog trip), which wakes the Sprite and
+        // re-takes the platform hold — so the payer starts consuming a sandbox
+        // again, and the billing clock has to start with it. Done here, at the
+        // instant of the keystroke, rather than at the next heartbeat: that is
+        // ten minutes away (`SETTLE_HEARTBEAT_MS`), and every one of those
+        // minutes would otherwise be billed as free.
+        resumeBillingClock(session);
         session.command.write(p.data);
       }
     },

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -458,14 +458,44 @@ function startTaskHoldHeartbeat(
 ): ReturnType<typeof setInterval> {
   const tick = () =>
     taskHold.tick({
-      attached: session.viewerAttached,
+      // `attached` means "a LIVE EXEC CONNECTION exists on the Sprite for a
+      // viewer", not merely "a browser tab is open". Those were the same thing
+      // until the watchdog learned to quiet an attached-but-idle shell: a
+      // quiesced socket (`isQuiesced`) is deliberately DOWN, so it gives the
+      // platform nothing to keep the sandbox resident FOR, and holding the
+      // sprite up for it is exactly the idle-cost bug this change exists to
+      // close. Without this, `planHold`'s `needHold = attached || agentRunning`
+      // would refresh the hold forever behind any open tab — the watchdog would
+      // have gone quiet while the hold went on pinning the Sprite, and the RAM
+      // bill would not move.
+      //
+      // A viewer whose shell was paused out from under them gets it back
+      // transparently: their next keystroke resumes the socket, and the shell's
+      // own reconnect either reattaches the surviving session or falls back to a
+      // fresh one (`planReconnect`) — the same recovery a returning DETACHED
+      // viewer has always had.
+      attached: session.viewerAttached && !session.command.isQuiesced(),
       lastActivityAt: latestActivityAt(session),
-      // While DETACHED the exec socket may be dead (the shell deliberately
-      // never reconnects it — leaf 3-2), so a frozen activity clock is not
-      // evidence of idleness; the controller then keeps an existing hold
-      // rather than deleting it under an agent it can no longer see. And a
-      // detached agent that FINISHES while the socket survived still releases
-      // promptly: its PTY exit reaches onExit, whose teardown ends the hold.
+      // Whether a STALE clock is trustworthy evidence of idleness.
+      //
+      // While DETACHED the exec socket may have died mid-run — the shell
+      // deliberately never reconnects it (leaf 3-2) — so the clock can freeze
+      // under an agent that is still working. That is blind, and the controller
+      // then keeps an existing hold rather than deleting it under an agent it
+      // can no longer see. And a detached agent that FINISHES while the socket
+      // survived still releases promptly: its PTY exit reaches onExit, whose
+      // teardown ends the hold.
+      //
+      // An ATTACHED shell stays observable even once the watchdog quiets it,
+      // which is why this is still just `viewerAttached`. A shell is only ever
+      // quiesced-while-attached BECAUSE its clock was already stale past the
+      // idle window while the socket was live and watching (`attach-quiet` is
+      // unreachable with fresh activity — see `planWatchdogResponse`). The
+      // freeze is a CONSEQUENCE of idleness we observed, not a blindfold that
+      // hides work. Passing `false` here instead would invert the policy and
+      // pin the hold forever: `agentRunning` is
+      // `isAgentActive(...) || (!activityObservable && holdExists)`, so an
+      // unobservable session with a live hold counts as running by definition.
       activityObservable: session.viewerAttached,
     });
   tick();
@@ -946,7 +976,20 @@ export function buildAgentTerminalHandlers({
           // the Sprite every ~45s for a viewer who is only watching an idle
           // prompt. The next keystroke reattaches transparently. See
           // `planWatchdogResponse`'s `attach-quiet`.
-          getLastActivityAt: () => latestActivityAt(session),
+          //
+          // `undefined` — "no trustworthy idleness signal, keep the socket up" —
+          // for the ONE session whose silence proves nothing: a RESUMED agent
+          // that has not yet emitted a byte to us. It was verified live at
+          // connect, so it may be mid-run and merely thinking; our clock holds
+          // nothing but the connect stamp, and letting that age into a quiet
+          // verdict would drop the hold (see the tick below) and pause the
+          // sprite under a working agent. This is the SAME trust rule
+          // `disconnectConnection` already applies to its own hold tick
+          // (`hasOutput || !resumedAtCreate`) — silence is only evidence of
+          // idleness once we have heard this session speak at least once. The
+          // moment it does, `hasOutput` flips and the normal idle window governs.
+          getLastActivityAt: () =>
+            (session.hasOutput || !session.resumedAtCreate ? latestActivityAt(session) : undefined),
           onOutput: (data) => {
             // The hold's "agent output is flowing" signal — kept fresh here so
             // a DETACHED session with an agent mid-run keeps its sprite up.

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -939,6 +939,14 @@ export function buildAgentTerminalHandlers({
           command: launch.command,
           args: launch.args,
           cwd: sandbox.cwd,
+          // The watchdog's idle signal, read off the SAME clock the Tasks API
+          // hold ticks on (`startTaskHoldHeartbeat` below): once this session
+          // has been idle long enough for the platform hold to be dropped, the
+          // watchdog stops reattaching for it too, instead of reconnecting to
+          // the Sprite every ~45s for a viewer who is only watching an idle
+          // prompt. The next keystroke reattaches transparently. See
+          // `planWatchdogResponse`'s `attach-quiet`.
+          getLastActivityAt: () => latestActivityAt(session),
           onOutput: (data) => {
             // The hold's "agent output is flowing" signal — kept fresh here so
             // a DETACHED session with an agent mid-run keeps its sprite up.

--- a/apps/realtime/src/terminal/agent-terminal-handler.ts
+++ b/apps/realtime/src/terminal/agent-terminal-handler.ts
@@ -720,10 +720,19 @@ export function buildAgentTerminalHandlers({
     // connection never actually dropped, since output is already flowing.
     session.command.setViewerAttached(true);
     session.viewerAttached = true;
-    // A viewer is attached again — that alone is "work in progress", so the
-    // hold (deleted while detached-and-idle) is re-created immediately rather
-    // than waiting out a heartbeat interval.
-    session.taskHold?.tick({ attached: true, lastActivityAt: latestActivityAt(session), activityObservable: true });
+    // A viewer is back AND the `setViewerAttached(true)` above has just resumed
+    // the shell's socket, so the hold (deleted while idle) is re-created
+    // immediately rather than waiting out a heartbeat interval. Derived, not
+    // hardcoded `true`: `attached` means "a LIVE exec connection exists" (see
+    // `startTaskHoldHeartbeat`), and a viewer alone no longer earns a hold.
+    // Both terms are necessarily true right here — the resume clears quiescence
+    // synchronously — so this is the same value either way; deriving it is what
+    // keeps the two tick sites from drifting apart.
+    session.taskHold?.tick({
+      attached: session.viewerAttached && !session.command.isQuiesced(),
+      lastActivityAt: latestActivityAt(session),
+      activityObservable: true,
+    });
     sessionMap.reattach(sessionKey, socketKey(connectionId));
     activeConnectionIds.add(connectionId);
     // `resumed` says the agent was ALREADY DOING THINGS before this connect, so a

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -4,6 +4,7 @@ import type {
   SpriteSessionInfo,
 } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import { readSessionInfoId, spawnWithSelfHealingCwd } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
+import { isAgentActive } from '@pagespace/lib/services/sandbox/sandbox-client/sprite-tasks';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
@@ -170,6 +171,31 @@ export type OpenPtyShellArgs = {
    * the caller already supplied — there is nothing new to persist.
    */
   onSessionId?(sessionId: string): void;
+  /**
+   * A cheap, synchronous read of the caller's ALREADY-MAINTAINED activity clock
+   * — the epoch-ms of this session's last output, keystroke, or launch
+   * (`agent-terminal-handler.ts`'s `latestActivityAt`). Consulted on every
+   * watchdog trip, and only there, so it must not do work: no I/O, no
+   * allocation of note.
+   *
+   * This is the SAME clock the Sprites Tasks API hold ticks on (leaf 5-1), read
+   * through the SAME `isAgentActive` predicate and idle window — deliberately,
+   * so the two answers to "is this sprite allowed to pause?" can never disagree.
+   * A shell whose hold has been dropped for idleness must not still be poking
+   * the Sprite every ~45s to keep a socket alive for it.
+   *
+   * OMITTED means the watchdog behaves exactly as it did before `attach-quiet`
+   * existed: an attached shell is always reattached, never quieted. A caller with
+   * no activity clock has no basis to claim the session is idle, and guessing
+   * "idle" from the absence of information would silence output for a viewer who
+   * is sitting right there.
+   *
+   * CONTRACT for callers that DO supply it: a keystroke must be recorded in this
+   * clock BEFORE it is handed to `write()`, because `write()`'s lazy reattach
+   * re-consults `planWatchdogResponse`, which reads this. (The handler does:
+   * `session.lastInputAt = Date.now()` immediately precedes `command.write()`.)
+   */
+  getLastActivityAt?(): number | undefined;
 };
 
 // The @fly/sprites WSCommand keepalive is output-driven: it declares the socket
@@ -184,7 +210,7 @@ export type OpenPtyShellArgs = {
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 200;
 
-export type WatchdogAction = 'reattach' | 'detach-quiet' | 'fatal';
+export type WatchdogAction = 'reattach' | 'attach-quiet' | 'detach-quiet' | 'fatal';
 
 /**
  * What the watchdog should do about a dropped socket, given whether anyone is
@@ -224,6 +250,47 @@ export type WatchdogAction = 'reattach' | 'detach-quiet' | 'fatal';
  * feature would need that map reworked long before this signature could mean
  * anything other than boolean.
  *
+ * `attach-quiet` is the same trade, one step further in: an ATTACHED viewer
+ * whose session has been idle past `TASK_HOLD_AGENT_IDLE_MS` (no output, no
+ * keystroke — `isAgentActive`, the very predicate the Sprites Tasks API hold
+ * ticks on) is watching a prompt that is producing nothing. Reattaching for
+ * them places a real exec connection on the Sprite every ~45s, indefinitely,
+ * for as long as a browser tab sits open — and per
+ * docs.sprites.dev/keeping-sprites-running an open TTY connection is itself
+ * activity that stops the Sprite from ever pausing, so the churn doesn't merely
+ * cost the round-trip: it holds the whole sandbox resident (the RAM-to-CPU cost
+ * skew this leaf exists to close). We let the drop stand and reattach lazily on
+ * the next keystroke instead — `write()` resumes it exactly as
+ * `setViewerAttached(true)` resumes a `detach-quiet` (both go through
+ * `resumeIfLazyReattachNeeded`), and the keystroke itself is queued in
+ * `pendingInput` and flushed the moment the replacement command opens, so the
+ * reattach is invisible.
+ *
+ * The trade-off, stated plainly (mirroring `detach-quiet`'s): while
+ * `attach-quiet` is in effect, output from a BACKGROUND process — one nobody
+ * triggered with a keystroke — will not reach the client until the next
+ * keystroke. That is bounded by exactly the same idle window the Tasks API hold
+ * already uses, which is the point of reusing `isAgentActive` rather than
+ * inventing a second threshold: a session that has produced no byte and taken
+ * no input for `TASK_HOLD_AGENT_IDLE_MS` has ALREADY had its platform hold
+ * deleted and is already free to be paused by the Sprite. Nothing here newly
+ * exposes a legitimately-running background job to an earlier pause than it was
+ * exposed to before — a job that is actually running keeps `lastActivityAt`
+ * fresh with its own output, which keeps both the hold and this reattach alive.
+ *
+ * `lastActivityAt` of `undefined` means the caller keeps no activity clock (the
+ * `getLastActivityAt` arg was omitted), NOT "never active": with no information
+ * we cannot claim idleness, so an attached shell reattaches, exactly as it did
+ * before this verdict existed. This is why the check is not a bare
+ * `!isAgentActive(...)`, which treats an unknown clock as idle.
+ *
+ * Both quiet verdicts are decided BEFORE the failure budget, for the reason
+ * spelled out above: a quiet verdict means no attempt runs, and an attempt that
+ * never ran is not evidence the shell is dead. Going `fatal` here would latch
+ * `closed` on a perfectly healthy idle shell. `fatal` stays reachable — a
+ * keystroke resets the budget and re-arms real attempts (`write()` →
+ * `resumeIfLazyReattachNeeded`), and those failing repeatedly still exhausts it.
+ *
  * `consecutiveFailures` must be the count AFTER `reconnect()`'s own increment
  * — this is the single place that decision is made (the error handler, the
  * internal retry recursion, and the lazy `setViewerAttached(true)` reattach
@@ -236,13 +303,21 @@ export function planWatchdogResponse({
   viewersAttached,
   closed,
   consecutiveFailures,
+  lastActivityAt,
+  now,
 }: {
   viewersAttached: boolean;
   closed: boolean;
   consecutiveFailures: number;
+  /** Epoch-ms of the session's last output/keystroke/launch; `undefined` = the caller keeps no clock. */
+  lastActivityAt: number | undefined;
+  now: number;
 }): WatchdogAction {
   if (closed) return 'detach-quiet';
   if (!viewersAttached) return 'detach-quiet';
+  // Default `idleMs` on purpose: this MUST be the same window the Tasks API
+  // hold uses (TASK_HOLD_AGENT_IDLE_MS), not a knob of its own.
+  if (lastActivityAt !== undefined && !isAgentActive({ lastActivityAt, now })) return 'attach-quiet';
   return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
 }
 
@@ -401,6 +476,7 @@ export function openPtyShell({
   onOutput,
   onExit,
   onSessionId,
+  getLastActivityAt,
 }: OpenPtyShellArgs): PtyShell {
   const toBuf = (chunk: unknown): Buffer => (typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
 
@@ -958,14 +1034,27 @@ export function openPtyShell({
     // keyed on (the inline check this replaces compared the same
     // post-increment value), so a 'fatal' verdict here is the real one, not
     // a preview of one `reconnect()` would recompute differently.
-    const action = planWatchdogResponse({ viewersAttached: viewerAttached, closed, consecutiveFailures });
-    if (action === 'detach-quiet') {
-      // No viewer: proceeding would only place a fresh exec connection on the
-      // Sprite to relay output nobody is watching — exactly the churn this
-      // gate exists to remove. Undo the speculative increment above: no
-      // attempt actually ran, so it must not count against the budget.
-      // Remember one is owed; `setViewerAttached(true)` resumes it (with a
-      // fresh budget of its own — see there).
+    const action = planWatchdogResponse({
+      viewersAttached: viewerAttached,
+      closed,
+      consecutiveFailures,
+      lastActivityAt: getLastActivityAt?.(),
+      now: Date.now(),
+    });
+    if (action === 'detach-quiet' || action === 'attach-quiet') {
+      // Nothing worth reconnecting FOR. Either no viewer at all
+      // ('detach-quiet'), or a viewer watching a session that has produced and
+      // received nothing for the whole Tasks-API idle window ('attach-quiet').
+      // Either way, proceeding would only place a fresh exec connection on the
+      // Sprite — relaying output nobody is watching, or output nothing is
+      // producing — and that connection is itself what keeps the Sprite from
+      // pausing. Exactly the churn these gates exist to remove; the two
+      // verdicts are handled identically because the remedy is identical.
+      //
+      // Undo the speculative increment above: no attempt actually ran, so it
+      // must not count against the budget. Remember one is owed;
+      // `resumeIfLazyReattachNeeded` pays it (with a fresh budget of its own —
+      // see there) on the next viewer attach or the next keystroke.
       consecutiveFailures -= 1;
       needsLazyReattach = true;
       reconnecting = false;
@@ -1094,6 +1183,33 @@ export function openPtyShell({
     }
   }
 
+  /**
+   * Pay back a watchdog trip that was swallowed by a quiet verdict. Shared by
+   * the two things that can make a quiet shell interesting again: a viewer
+   * coming back (`setViewerAttached(true)` — resumes a `detach-quiet`) and a
+   * keystroke arriving (`write()` — resumes an `attach-quiet`, whose viewer
+   * never left). Both mean the same thing to the socket: someone is going to
+   * want bytes now, so re-establish it.
+   *
+   * A no-op unless a trip was ACTUALLY swallowed: a viewer toggling
+   * attach/detach faster than the ~45s keepalive, or typing into a healthy
+   * shell, never tripped anything, and output is already flowing.
+   */
+  function resumeIfLazyReattachNeeded(): void {
+    if (!needsLazyReattach || closed) return;
+    needsLazyReattach = false;
+    // A deliberate resume after a (possibly long) quiet gap is a FRESH attempt,
+    // not a continuation of whatever consecutive failures triggered the
+    // original quiet-down. Reset both budgets so a shell that happened to be
+    // at/near its cap when it went quiet gets a real attempt instead of an
+    // instant fatal(-1) with zero retries — "consecutive" is meant to bound
+    // rapid retries close together in time, not something spanning a
+    // human-timescale idle window.
+    consecutiveFailures = 0;
+    abandonedUnnamedSessions = 0;
+    void reconnect();
+  }
+
   if (currentSessionId !== undefined) {
     current = sprite.attachSession(currentSessionId, { cols, rows });
   } else {
@@ -1108,9 +1224,17 @@ export function openPtyShell({
   return {
     write: (data) => {
       if (closed) return;
-      // The wired command is known-stale (a reconnect — attached or lazy — is
-      // in flight) and its replacement hasn't opened yet: queue rather than
-      // hand bytes to a socket that would silently swallow them.
+      // A keystroke is precisely the event `attach-quiet` was waiting for: the
+      // viewer never left, they simply had nothing to say for a while, and now
+      // they do. Re-establish the socket before touching stdin. (Nothing to pay
+      // back = nothing happens; a healthy shell's writes are unaffected.)
+      resumeIfLazyReattachNeeded();
+      // The wired command is known-stale (a reconnect — attached, quiet, or
+      // lazy — is in flight) and its replacement hasn't opened yet: queue
+      // rather than hand bytes to a socket that would silently swallow them.
+      // This is what makes the resume above invisible: `flushPendingInput`
+      // delivers these bytes the moment the replacement command opens, so no
+      // new UI state (and no lost keystroke) is involved.
       if (!inputReady) { pendingInput.push(data); return; }
       current.stdin?.write(data);
     },
@@ -1146,22 +1270,12 @@ export function openPtyShell({
     },
     setViewerAttached: (attached) => {
       viewerAttached = attached;
-      // A lazy reattach only fires if a watchdog trip actually got swallowed while
-      // detached — a viewer toggling attach/detach faster than the ~45s keepalive
-      // (nothing ever tripped) is a no-op here, correctly: output is already flowing.
-      if (attached && needsLazyReattach && !closed) {
-        needsLazyReattach = false;
-        // A deliberate, viewer-initiated reattach after a (possibly long) detached
-        // gap is a FRESH attempt, not a continuation of whatever consecutive
-        // failures triggered the original quiet-down. Reset both budgets so a
-        // shell that happened to be at/near its cap when it went quiet gets a
-        // real attempt instead of an instant fatal(-1) with zero retries —
-        // "consecutive" is meant to bound rapid retries close together in time,
-        // not something spanning a human-timescale detached window.
-        consecutiveFailures = 0;
-        abandonedUnnamedSessions = 0;
-        void reconnect();
-      }
+      // A returning viewer pays back a swallowed trip — see
+      // `resumeIfLazyReattachNeeded`, which `write()` also calls (an
+      // `attach-quiet` shell's viewer never left, so a keystroke is its only
+      // resume trigger). `viewerAttached` is set FIRST so the reconnect this
+      // may kick off sees the viewer that is now here.
+      if (attached) resumeIfLazyReattachNeeded();
     },
   };
 }

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1103,12 +1103,22 @@ export function openPtyShell({
 
     // The SOLE consult of `planWatchdogResponse` — every entry point funnels
     // through here: the error handler's direct call, this function's own
-    // recursive retry (the `catch` block below), and the lazy reattach
-    // `setViewerAttached(true)` triggers. Passing the count AFTER the
-    // increment above matches exactly what this decision has always been
-    // keyed on (the inline check this replaces compared the same
-    // post-increment value), so a 'fatal' verdict here is the real one, not
-    // a preview of one `reconnect()` would recompute differently.
+    // recursive retry (the `catch` block below), and the lazy reattach that
+    // `resumeIfLazyReattachNeeded` pays back (a viewer returning, or a
+    // keystroke). Passing the count AFTER the increment above matches exactly
+    // what this decision has always been keyed on (the inline check this
+    // replaces compared the same post-increment value), so a 'fatal' verdict
+    // here is the real one, not a preview of one `reconnect()` would recompute
+    // differently.
+    //
+    // INVARIANT, load-bearing for the resume path: whenever `needsLazyReattach`
+    // is true, `reconnecting` is false. Every quiet verdict below clears
+    // `reconnecting` in the same breath that it sets the debt, so the
+    // `reconnecting` early-return above can never swallow a resume that has
+    // already cleared the flag. Keep it that way — a quiet branch that returned
+    // while still `reconnecting` would drop the debt on the floor silently, and
+    // the viewer would sit at a dead terminal with nothing left to trigger a
+    // reattach.
     const action = planWatchdogResponse({
       viewersAttached: viewerAttached,
       closed,

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -1296,6 +1296,14 @@ export function openPtyShell({
       if (!inputReady) { pendingInput.push(data); return; }
       current.stdin?.write(data);
     },
+    // Deliberately NOT a resume trigger, unlike `write()`. A resize says "render
+    // differently", not "I want output now" — and it is not lost by waiting:
+    // `lastCols`/`lastRows` are recorded here and every reconnect path attaches
+    // with them, so a quiet shell comes back at the size the viewer last chose.
+    // Resuming on it would put a live socket back on the Sprite for someone who
+    // merely dragged a pane divider while idle, which is the churn this all
+    // exists to remove. (The resize sent to an already-dead command below is
+    // swallowed the same way a stale write is — see `inputReady`.)
     resize: (c, r) => { lastCols = c; lastRows = r; if (!closed) current.resize?.(c, r); },
     // Anything still held (an unresolved replay, queued stderr) is dropped with it: the
     // viewer is gone, and `closed` stops every listener from speaking after this point.

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -211,10 +211,11 @@ export type OpenPtyShellArgs = {
    * output for a viewer sitting right there — and, since the hold heartbeat
    * keys off the same quiescence, would pause the Sprite under a live agent.
    *
-   * CONTRACT for callers that DO supply it: a keystroke must be recorded in this
-   * clock BEFORE it is handed to `write()`, because `write()`'s lazy reattach
-   * re-consults `planWatchdogResponse`, which reads this. (The handler does:
-   * `session.lastInputAt = Date.now()` immediately precedes `command.write()`.)
+   * Read ONLY on a watchdog trip, never on a resume: a viewer returning or a
+   * keystroke arriving is itself the activity the quiet verdict was waiting for,
+   * so `resumeIfLazyReattachNeeded` reconnects regardless of what this says (see
+   * `planWatchdogResponse`'s `resumeRequested`). Callers therefore do NOT have
+   * to race a stamp into this clock ahead of `write()` for their input to land.
    */
   getLastActivityAt?(): number | undefined;
 };
@@ -305,6 +306,17 @@ export type WatchdogAction = 'reattach' | 'attach-quiet' | 'detach-quiet' | 'fat
  * before this verdict existed. This is why the check is not a bare
  * `!isAgentActive(...)`, which treats an unknown clock as idle.
  *
+ * A RESUME is not a watchdog trip and must never be re-vetoed by the idle gate
+ * (`resumeRequested`). The trigger for a resume is a human — a viewer tabbing
+ * back, or a keystroke — and a viewer who returns to a shell that went quiet
+ * two hours ago necessarily brings a stale activity clock with them. Asking
+ * "has this session been idle?" at that moment answers "yes" and quiets the
+ * shell straight back down, so the socket never comes up, the viewer stares at
+ * stale scrollback, and (since the hold heartbeat keys off the same quiescence)
+ * the Sprite stays paused underneath them. The clock describes the SESSION's
+ * activity; the resume is the VIEWER's. Only the first is what `attach-quiet`
+ * is about.
+ *
  * Both quiet verdicts are decided BEFORE the failure budget, for the reason
  * spelled out above: a quiet verdict means no attempt runs, and an attempt that
  * never ran is not evidence the shell is dead. Going `fatal` here would latch
@@ -326,19 +338,28 @@ export function planWatchdogResponse({
   consecutiveFailures,
   lastActivityAt,
   now,
+  resumeRequested = false,
 }: {
   viewersAttached: boolean;
   closed: boolean;
   consecutiveFailures: number;
-  /** Epoch-ms of the session's last output/keystroke/launch; `undefined` = the caller keeps no clock. */
+  /** Epoch-ms of the session's last output/keystroke/launch; `undefined` = the caller offers no trustworthy idleness signal. */
   lastActivityAt: number | undefined;
   now: number;
+  /**
+   * This call is paying back a swallowed trip on a HUMAN's request — a viewer
+   * returned, or a keystroke arrived (`resumeIfLazyReattachNeeded`) — rather
+   * than reacting to a fresh watchdog trip. The activity clock is then beside
+   * the point: the human interaction IS the activity, and it is the very thing
+   * the quiet verdict was waiting for. Defaults to false — an ordinary trip.
+   */
+  resumeRequested?: boolean;
 }): WatchdogAction {
   if (closed) return 'detach-quiet';
   if (!viewersAttached) return 'detach-quiet';
   // Default `idleMs` on purpose: this MUST be the same window the Tasks API
   // hold uses (TASK_HOLD_AGENT_IDLE_MS), not a knob of its own.
-  if (lastActivityAt !== undefined && !isAgentActive({ lastActivityAt, now })) return 'attach-quiet';
+  if (!resumeRequested && lastActivityAt !== undefined && !isAgentActive({ lastActivityAt, now })) return 'attach-quiet';
   return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
 }
 
@@ -1042,7 +1063,16 @@ export function openPtyShell({
     });
   }
 
-  async function reconnect(): Promise<void> {
+  /**
+   * `resume` marks a reconnect a HUMAN asked for — a viewer returning, or a
+   * keystroke (`resumeIfLazyReattachNeeded`) — rather than the watchdog reacting
+   * to a drop. It survives this attempt's internal retries (the `catch` below
+   * re-enters with it), because a resume that fails once is still a resume: the
+   * viewer is still there, waiting, and abandoning it to a quiet verdict would
+   * leave them staring at a dead terminal. It is bounded by the same
+   * `MAX_RECONNECT_ATTEMPTS` budget as any other attempt.
+   */
+  async function reconnect({ resume = false }: { resume?: boolean } = {}): Promise<void> {
     if (closed || reconnecting) return;
     reconnecting = true;
     consecutiveFailures += 1;
@@ -1061,6 +1091,7 @@ export function openPtyShell({
       consecutiveFailures,
       lastActivityAt: getLastActivityAt?.(),
       now: Date.now(),
+      resumeRequested: resume,
     });
     if (action === 'detach-quiet' || action === 'attach-quiet') {
       // Nothing worth reconnecting FOR. Either no viewer at all
@@ -1200,7 +1231,8 @@ export function openPtyShell({
       // `abandonedUnnamedSessions` for a session that never existed.
       lastErrorWasPreOpenDrop = true;
       // Reattach itself failed; retry until the bounded budget is exhausted.
-      void reconnect();
+      // A resume stays a resume across its own retries — see `reconnect`'s doc.
+      void reconnect({ resume });
     }
   }
 
@@ -1228,7 +1260,12 @@ export function openPtyShell({
     // human-timescale idle window.
     consecutiveFailures = 0;
     abandonedUnnamedSessions = 0;
-    void reconnect();
+    // `resume: true` — this reconnect is a HUMAN's, not the watchdog's, so the
+    // idle gate must not veto it. A viewer returning to a shell that went quiet
+    // an hour ago necessarily arrives with a stale clock; re-asking "is this
+    // session idle?" here would quiet it straight back down and hand them a dead
+    // terminal. See `planWatchdogResponse`'s `resumeRequested`.
+    void reconnect({ resume: true });
   }
 
   if (currentSessionId !== undefined) {

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -135,6 +135,23 @@ export type PtyShell = {
    * before this leaf.
    */
   setViewerAttached(attached: boolean): void;
+  /**
+   * Is this shell's exec connection currently DOWN ON PURPOSE — a watchdog trip
+   * the shell swallowed (`detach-quiet` or `attach-quiet`) rather than
+   * reconnected, and has not yet paid back?
+   *
+   * The Sprites Tasks API hold reads this (`startTaskHoldHeartbeat`), and it is
+   * the difference between the hold's two very different meanings of "attached":
+   * a viewer bound to this session, versus a LIVE EXEC CONNECTION on the Sprite.
+   * Only the second is a reason to keep a Sprite resident — a quiesced socket
+   * gives the platform nothing to hold the sandbox up FOR.
+   *
+   * NOT true during an ordinary reconnect's sub-second backoff: that socket is
+   * coming straight back, and the hold heartbeat only ticks once a minute
+   * anyway. This is specifically "we have decided not to reconnect until
+   * something happens" (a viewer returns, or a keystroke arrives).
+   */
+  isQuiesced(): boolean;
 };
 
 export type OpenPtyShellArgs = {
@@ -184,11 +201,15 @@ export type OpenPtyShellArgs = {
    * A shell whose hold has been dropped for idleness must not still be poking
    * the Sprite every ~45s to keep a socket alive for it.
    *
-   * OMITTED means the watchdog behaves exactly as it did before `attach-quiet`
-   * existed: an attached shell is always reattached, never quieted. A caller with
-   * no activity clock has no basis to claim the session is idle, and guessing
-   * "idle" from the absence of information would silence output for a viewer who
-   * is sitting right there.
+   * OMITTED — or returning `undefined` — means the watchdog behaves exactly as
+   * it did before `attach-quiet` existed: an attached shell is always
+   * reattached, never quieted. `undefined` is the caller's way of saying "I have
+   * no TRUSTWORTHY idleness signal for this session", which covers both a caller
+   * with no clock at all and a caller whose clock it would be unsafe to age out
+   * (the handler returns `undefined` for a resumed agent that has not yet
+   * spoken). Guessing "idle" from the absence of information would silence
+   * output for a viewer sitting right there — and, since the hold heartbeat
+   * keys off the same quiescence, would pause the Sprite under a live agent.
    *
    * CONTRACT for callers that DO supply it: a keystroke must be recorded in this
    * clock BEFORE it is handed to `write()`, because `write()`'s lazy reattach
@@ -1277,5 +1298,10 @@ export function openPtyShell({
       // may kick off sees the viewer that is now here.
       if (attached) resumeIfLazyReattachNeeded();
     },
+    // `needsLazyReattach` IS the quiesced state: it is set exactly when a
+    // watchdog trip was swallowed by a quiet verdict, and cleared exactly when
+    // that trip is paid back (`resumeIfLazyReattachNeeded`). Nothing else can
+    // leave this shell's socket deliberately down.
+    isQuiesced: () => needsLazyReattach,
   };
 }

--- a/apps/realtime/src/terminal/sprites-shell.ts
+++ b/apps/realtime/src/terminal/sprites-shell.ts
@@ -218,6 +218,17 @@ export type OpenPtyShellArgs = {
    * to race a stamp into this clock ahead of `write()` for their input to land.
    */
   getLastActivityAt?(): number | undefined;
+  /**
+   * The idle window the caller's Sprites Tasks API hold is ACTUALLY using
+   * (`TaskHoldController.agentIdleMs`) — a getter, not a value, because the hold
+   * controller is constructed after the shell is opened. `undefined` (or
+   * omitted) falls back to `TASK_HOLD_AGENT_IDLE_MS`.
+   *
+   * Exists so the watchdog cannot drift from the hold: both must answer "may
+   * this sprite pause?" on the same window, and that window is configurable.
+   * See `planWatchdogResponse`'s `idleMs`.
+   */
+  getIdleMs?(): number | undefined;
 };
 
 // The @fly/sprites WSCommand keepalive is output-driven: it declares the socket
@@ -339,6 +350,7 @@ export function planWatchdogResponse({
   lastActivityAt,
   now,
   resumeRequested = false,
+  idleMs,
 }: {
   viewersAttached: boolean;
   closed: boolean;
@@ -354,12 +366,23 @@ export function planWatchdogResponse({
    * the quiet verdict was waiting for. Defaults to false — an ordinary trip.
    */
   resumeRequested?: boolean;
+  /**
+   * The idle window to judge `lastActivityAt` against. This is NOT a knob of the
+   * watchdog's own: it must be the EFFECTIVE window the Sprites Tasks API hold
+   * is using (`TaskHoldController.agentIdleMs`), which is configurable and so is
+   * not always the `TASK_HOLD_AGENT_IDLE_MS` default. `undefined` falls back to
+   * that default — correct when no hold controller is wired at all.
+   *
+   * Passing the default blindly would be a separate threshold in disguise, and
+   * the two would disagree the moment `SPRITE_TASK_HOLD_REFRESH_MS` is set: a
+   * shell quieting on 2 minutes while its hold is still held on 4 would be
+   * quiet, blind, AND still pinning the sprite — the worst of every world.
+   */
+  idleMs?: number;
 }): WatchdogAction {
   if (closed) return 'detach-quiet';
   if (!viewersAttached) return 'detach-quiet';
-  // Default `idleMs` on purpose: this MUST be the same window the Tasks API
-  // hold uses (TASK_HOLD_AGENT_IDLE_MS), not a knob of its own.
-  if (!resumeRequested && lastActivityAt !== undefined && !isAgentActive({ lastActivityAt, now })) return 'attach-quiet';
+  if (!resumeRequested && lastActivityAt !== undefined && !isAgentActive({ lastActivityAt, now, idleMs })) return 'attach-quiet';
   return consecutiveFailures > MAX_RECONNECT_ATTEMPTS ? 'fatal' : 'reattach';
 }
 
@@ -519,6 +542,7 @@ export function openPtyShell({
   onExit,
   onSessionId,
   getLastActivityAt,
+  getIdleMs,
 }: OpenPtyShellArgs): PtyShell {
   const toBuf = (chunk: unknown): Buffer => (typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer));
 
@@ -1092,6 +1116,7 @@ export function openPtyShell({
       lastActivityAt: getLastActivityAt?.(),
       now: Date.now(),
       resumeRequested: resume,
+      idleMs: getIdleMs?.(),
     });
     if (action === 'detach-quiet' || action === 'attach-quiet') {
       // Nothing worth reconnecting FOR. Either no viewer at all

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprite-tasks.test.ts
@@ -632,6 +632,38 @@ describe('createTaskHoldController', () => {
   /** Let the controller's internal op queue drain. */
   const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
+  /**
+   * Exposed for the same reason as `tickIntervalMs`: the terminal watchdog's
+   * `attach-quiet` decides "may this sprite pause?" alongside this controller
+   * and must decide it on the SAME window. `refreshMs` is configurable, so the
+   * effective window is not always the `TASK_HOLD_AGENT_IDLE_MS` default — a
+   * consumer that assumed the constant would diverge the moment it was tuned.
+   */
+  it('reports the EFFECTIVE idle window it judges activity on', () => {
+    const { client } = fakeClient();
+
+    assert({
+      given: 'a controller left on the default refresh cadence',
+      should: 'report the default idle window (two refresh intervals)',
+      actual: createTaskHoldController({ client, taskName: 'ps-hold-x' }).agentIdleMs,
+      expected: TASK_HOLD_AGENT_IDLE_MS,
+    });
+
+    assert({
+      given: 'a controller whose refresh cadence was tuned down',
+      should: 'report two of ITS OWN refresh intervals, not the module default',
+      actual: createTaskHoldController({ client, taskName: 'ps-hold-x', refreshMs: 15_000 }).agentIdleMs,
+      expected: 30_000,
+    });
+
+    assert({
+      given: 'a controller given an explicit agentIdleMs',
+      should: 'report exactly that',
+      actual: createTaskHoldController({ client, taskName: 'ps-hold-x', agentIdleMs: 7_000 }).agentIdleMs,
+      expected: 7_000,
+    });
+  });
+
   it('creates on the first attached tick and refreshes on the cadence', async () => {
     let now = T0;
     const { client, calls } = fakeClient();

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
@@ -401,6 +401,20 @@ export interface TaskHoldController {
   end(): void;
   /** The heartbeat cadence the owner should tick at (== refreshMs). */
   readonly tickIntervalMs: number;
+  /**
+   * The EFFECTIVE idle window this controller judges `lastActivityAt` against
+   * (`agentIdleMs ?? 2 * refreshMs`) — NOT necessarily the
+   * {@link TASK_HOLD_AGENT_IDLE_MS} default, since `refreshMs` is configurable
+   * (`SPRITE_TASK_HOLD_REFRESH_MS`, or derived from a custom expiry).
+   *
+   * Exposed for the same reason as `tickIntervalMs`: anything that decides
+   * "may this sprite pause?" alongside this controller has to decide it on the
+   * SAME window, or the two answers diverge. The terminal watchdog's
+   * `attach-quiet` (sprites-shell.ts) reads it for exactly that — a shell that
+   * quiets on a 2-minute window while its hold is still held on a 4-minute one
+   * would be quiet, blind, AND still pinning the sprite.
+   */
+  readonly agentIdleMs: number;
 }
 
 /**
@@ -490,6 +504,7 @@ export function createTaskHoldController({
 
   return {
     tickIntervalMs: refreshMs,
+    agentIdleMs: idleMs,
 
     tick({ attached, lastActivityAt, activityObservable = true }) {
       if (ended) return;

--- a/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprite-tasks.ts
@@ -369,16 +369,27 @@ export interface TaskHoldState {
   /** When the PTY was last ACTIVE — launch, typed input, or produced output — if ever (see {@link isAgentActive}). */
   lastActivityAt: number | undefined;
   /**
-   * Can the caller still OBSERVE activity? While a viewer is attached the
-   * exec WebSocket is kept alive (the shell's watchdog reconnects), so "no
-   * output for N minutes" is real data. While DETACHED the shell deliberately
-   * never reconnects a dropped socket (leaf 3-2), so the activity clock can
-   * freeze under an agent that is still working. FRESH activity is always
+   * Can the caller still OBSERVE activity? FRESH activity is always
    * trustworthy evidence of work (we saw the bytes); STALE activity is only
    * trustworthy evidence of idleness when this is true. When false, an
    * existing hold is kept refreshed (until the session ends or is reaped —
    * a bounded ~30min) rather than deleted on a clock that may be blind.
    * Defaults to true.
+   *
+   * The distinction is WHY the clock froze, not whether the socket is up.
+   * While DETACHED the shell deliberately never reconnects a dropped socket
+   * (leaf 3-2), and that socket may have died mid-run — the clock can freeze
+   * under an agent that is still working, so staleness proves nothing. An
+   * ATTACHED shell whose watchdog has gone quiet is the opposite case: it is
+   * only ever quieted BECAUSE its clock was already stale past the idle window
+   * while the socket was live and watching, so the freeze is a consequence of
+   * idleness the caller observed, not a blindfold. Attached callers therefore
+   * pass true even while their socket is quiesced.
+   *
+   * CAUTION for callers: passing false does not merely "not release" the hold
+   * — combined with an existing hold it makes `agentRunning` true by
+   * definition, which forces `needHold` regardless of `attached`. Passing
+   * false to try to release a hold pins it instead.
    */
   activityObservable?: boolean;
 }


### PR DESCRIPTION
Task 1 of 2 in the **Sprites Idle-Cost Remediation** epic (`tasks/sprites-idle-cost-remediation.md` — note: that spec file is not on `master`; I worked from the task brief. The parallel task covers `packages/lib/src/services/machines/` + the cron/reconciler, untouched here).

## Root cause

This month's Sprites bill was $50.85 RAM against $0.99 CPU (~51:1) — sandboxes resident and billing while doing essentially nothing. An idle terminal with a browser tab left open had **two** independent things pinning its Sprite. This PR removes both.

**1. Watchdog reconnect churn.** The `@fly/sprites` exec WebSocket watchdog kills the connection after 45s with no inbound frame even though the shell is alive server-side, so an idle prompt trips it on a fixed cadence. `planWatchdogResponse` answered every trip with `'reattach'` **whenever a viewer was attached** — regardless of whether anyone was typing. So an idle tab made a real `listSessions` + `attachSession` round-trip every ~45s, forever. Per [docs.sprites.dev/keeping-sprites-running](https://docs.sprites.dev/keeping-sprites-running), an open TTY connection is itself activity that prevents a Sprite from pausing.

**2. The Tasks API hold (found while reviewing this PR — the bigger half).** `planHold`'s `needHold = attached || agentRunning`, and `startTaskHoldHeartbeat` passed `attached: session.viewerAttached`. So an attached viewer kept a platform hold *created and refreshed forever*, explicitly telling the Sprite "work in progress". The 30-min reap (`DETACHED_IDLE_MS`) only arms on **disconnect**, so an attached idle terminal never released it. **Quieting the watchdog alone would not have moved the RAM bill at all** — the hold would have gone on pinning the sandbox behind every open tab.

PR #2029 (leaf 3-2) fixed the *detached* case and explicitly left the attached case alone. This closes that gap on both fronts.

## What changed

### `sprites-shell.ts`
- **`WatchdogAction` gains `'attach-quiet'`.** `planWatchdogResponse` returns it when a viewer is attached but the session has been idle past the hold's idle window, and the `reconnect()` call site handles it identically to `'detach-quiet'`: undo the speculative `consecutiveFailures` increment, set `needsLazyReattach`, touch no Sprite.
- **The idle window is not a knob of its own.** It reuses `isAgentActive` from `sprite-tasks.ts` — the predicate the Tasks API hold ticks on — judged against the hold controller's **effective** `agentIdleMs`, not the `TASK_HOLD_AGENT_IDLE_MS` constant (see the third fix below).
- **Lazy resume is shared and is never re-vetoed.** `resumeIfLazyReattachNeeded()` is called from **both** `setViewerAttached(true)` (resumes a `detach-quiet`) and `write()` (resumes an `attach-quiet`, whose viewer never left, so a keystroke is its only possible signal). It reconnects with `{ resume: true }`, and `planWatchdogResponse` skips **only** the idle gate for a resume — never the closed/detached/budget gates.
- **`PtyShell.isQuiesced()`** — reports a socket the watchdog deliberately left down. This is what lets the hold tell "a tab is open" from "a live exec connection exists".
- `resize()` is deliberately **not** a resume trigger, and says why in-code: it means "render differently", not "I want output", and nothing is lost by waiting — every reconnect path attaches with the recorded `lastCols`/`lastRows`.

### `agent-terminal-handler.ts`
- **The hold's `attached` now means "a LIVE exec connection exists"**: `session.viewerAttached && !session.command.isQuiesced()`. Once the watchdog quiesces an idle shell, `needHold` falls to `agentRunning` alone, the hold is deleted, and the Sprite can finally pause. Both hold-tick sites derive it the same way rather than hardcoding `true`.
- **`getLastActivityAt` honors the codebase's existing trust rule for silence.** It returns `undefined` — "no trustworthy idleness signal, keep the socket up" — for a **resumed** agent that has not yet emitted a byte. It was verified live at connect and may be merely thinking; aging its connect stamp into a quiet verdict would drop the hold and pause the Sprite under a working agent. This is exactly the rule `disconnectConnection` already applies to its own tick (`hasOutput || !resumedAtCreate`). The moment the agent speaks once, `hasOutput` flips and the normal idle window governs.

### `sprite-tasks.ts`
- **`TaskHoldController` now exposes its effective `agentIdleMs`** (same rationale as the existing `tickIntervalMs`). The controller computes `agentIdleMs ?? 2 * refreshMs`, and `refreshMs` is env-configurable — so the watchdog reading the module default would have been *a separate threshold in disguise*, diverging the moment `SPRITE_TASK_HOLD_REFRESH_MS` is set. With a longer-configured hold that divergence leaves a session quiet, **blind** (socket down, so no output can refresh the clock), **and still pinning the Sprite** — precisely the state this epic exists to eliminate.
- `TaskHoldState.activityObservable`'s doc rested on a premise this PR falsifies ("while a viewer is attached the exec WebSocket is kept alive"). Rewritten to state the real invariant — *the distinction is why the clock froze, not whether the socket is up* — plus a caution that passing `false` to try to **release** a hold **pins** it instead (`agentRunning = isAgentActive(...) || (!activityObservable && holdExists)`).

### `agent-terminal-handler.ts` — billing (the mirror image of the same bug)
`settleAccruedWindow` bills `activeSeconds` as wall-clock for as long as the session object lives, regardless of whether the sandbox is running. That was defensible while an attached idle terminal pinned its Sprite. Now the Sprite pauses — and an attached session is **never reaped** (`DETACHED_IDLE_MS` only arms on disconnect) — so the payer would have kept being charged, **without bound**, for a sandbox costing us nothing. (The detached path already had a bounded ~30-min version of this; the same change fixes it.)

Billing now tracks **sandbox residency, not tab-open time**: the heartbeat re-reads `isQuiesced()`, settles the window that just ended, and stops the clock — but **only after a successful settle and only while the session is still live**, so a failed settle still rolls back and retries its window instead of discarding it. No fresh hold is placed while quiesced (a hold reserves credits for a *next* window, and there is none until they return; they are gated on resume). The clock restarts **at the resume instant** — a keystroke or a viewer reattaching — not at the next beat, because `SETTLE_HEARTBEAT_MS` is ten minutes and those minutes would otherwise be billed as free.

## Trade-offs, stated plainly (and documented in-code, mirroring how `detach-quiet` documents its own)

1. **Background output is invisible until the next keystroke** while `attach-quiet` is in effect. Bounded by the same idle window the hold already uses.
2. **An idle Sprite now genuinely pauses under a watching user.** Exec sessions do not survive a pause, so a user who idles past the window and comes back to type may get a **fresh shell** (cwd/env/history gone), and the keystroke that woke it lands in that fresh shell. This is the same trade #2029 already accepted for detached viewers — and it is the only way the residency cost drops. Confirmed as intended before implementing.
3. A **silent** background job (a quiet compile longer than the idle window) can be killed by that pause. The resumed-agent carve-out above covers the case where we have no right to call silence idleness at all; beyond that, a job that is actually running keeps `lastActivityAt` fresh with its own output, which keeps both the hold and the socket alive.

## Judgment calls (flagging rather than stubbing)

1. **`lastActivityAt === undefined` returns `'reattach'`, not `'attach-quiet'`.** A bare `!isAgentActive(...)` would read an *absent* clock as "idle" and silence output for a viewer sitting right there. An unknown clock is not evidence of idleness — and it is the seam the resumed-agent carve-out rides on.
2. **Both quiet verdicts are decided *before* the failure budget.** A quiet verdict means no attempt ran, and an attempt that never ran is not evidence the shell is dead — `fatal` would latch `closed` on a healthy idle shell. `fatal` stays reachable: a keystroke resets the budget and re-arms real attempts.
3. **A resume skips the idle gate but nothing else.** It cannot fabricate a viewer, cannot revive a closed shell, and is bounded by the same `MAX_RECONNECT_ATTEMPTS` budget. It does survive its own internal retries — a resume that fails once is still a resume, and the viewer is still sitting there.

## Verification

- `bunx vitest run src/terminal` (apps/realtime) — **477 passed / 12 files** (was 457 before this PR). No existing test skipped, weakened, or changed in intent.
- `bunx vitest run src/services/sandbox` (packages/lib) — **751 passed / 39 files**.
- Two regression tests were confirmed to **fail on the pre-fix code** and pass now, so they are not vacuous: the tab-back resume, and the billing clock restarting at the keystroke (it reported `0` billable seconds instead of the full window).
- Billing coverage: a quiesce settles once then bills nothing across five further beats; a quiesced shell reserves no credits (`connectedAt: undefined`); a keystroke restarts the clock at the keystroke; a returning viewer restarts it on the reattach.
- New coverage: pure rows for attached+stale → `attach-quiet`, attached+fresh → `reattach`, the exact idle boundary, stale+exhausted-budget → quiet not fatal, absent clock → reattach, resume+stale → reattach, resume+detached → still quiet, resume+closed → still quiet, resume+exhausted → fatal, and a longer/shorter configured idle window. Integration: attached+idle swallowing three trips with zero SDK calls; the tab-back-after-a-long-gap resume; a keystroke resuming with a still-stale clock (no stamp-before-write race); the resuming keystroke reaching the PTY once the replacement opens; a viewer who returns and then idles again quieting on the *next* trip; `isQuiesced()` across the full lifecycle, attached and detached. Hold wiring: a quiesced socket ticks `attached: false` (hold released) and `attached: true` again once resumed; a resumed-but-silent agent offers the watchdog no clock, and hands over a real one the moment it speaks; the controller's effective idle window reaches the watchdog.
- `bun run lint` (apps/realtime, packages/lib) — clean.
- `bun run typecheck` — output **byte-identical before and after** this change (481 pre-existing errors, all from `@fly/sprites` not being installable locally and unbuilt `@pagespace/lib` types; none in the files touched here). CI has the real typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeF4hUGZmaaGkqvvYoh7HF
