### PR TITLE
fix(ai): best-effort per-conversation send serialization (advisory lock)

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -93,6 +93,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
@@ -112,6 +113,15 @@ vi.mock('@pagespace/db/db', () => ({
       })),
     })),
   },
+  // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
+  // exactly as before. Its own retry/degrade behavior is covered by
+  // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
+  getAdvisoryLockPool: vi.fn(() => ({
+    connect: vi.fn(async () => ({
+      query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+      release: vi.fn(),
+    })),
+  })),
 }));
 
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn() }));

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -33,6 +33,7 @@ import type { SubscriptionTier } from '@pagespace/lib/services/subscription-util
 import { broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { takeOverConversationStreams } from '@/lib/ai/core/stream-takeover';
+import { startGenerationExclusive } from '@/lib/ai/core/start-generation-exclusive';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope, getAllowedDriveIds, isScopedMCPAuth, canPrincipalViewPage, canPrincipalEditPage } from '@/lib/auth';
@@ -1195,35 +1196,35 @@ export async function POST(request: Request) {
     // terminal write never landed (crashed process; the write is fire-and-forget) would
     // otherwise lock the user out of their own chat. See stream-liveness.ts.
     //
-    // KNOWN RACE — this does NOT guarantee "at most one generation per conversation", and this
-    // comment used to claim that it did. It is a check-then-act with no serialization: the SELECT
-    // inside takeOverConversationStreams and the INSERT inside createStreamLifecycle (a few
-    // statements below) are not atomic together. Two near-simultaneous sends can BOTH see zero
-    // in-flight rows and BOTH proceed — two generations, two sets of tool calls, two bills.
-    //
-    // Deliberately not closed here: it needs DB-level serialization (an advisory lock spanning
-    // takeover+insert, or a partial unique index on (conversation_id) WHERE status='streaming' —
-    // whose migration would fail outright on any pre-existing duplicate rows, so it needs a
-    // reconciliation step first). That is its own change with its own migration risk, and `master`
-    // has no takeover at all — concurrent sends there ALWAYS double-generate — so this is a strict
-    // improvement, not a regression.
-    //
-    // Do not read what follows as if the race were closed. It is narrow, not absent.
-    await takeOverConversationStreams({
+    // BEST-EFFORT, not an invariant — named honestly. `startGenerationExclusive` closes the
+    // check-then-act race documented here previously (the SELECT inside
+    // takeOverConversationStreams and the INSERT inside createStreamLifecycle are not atomic on
+    // their own) by holding a per-conversation Postgres advisory lock across both. On lock_busy
+    // it retries briefly, then proceeds UNLOCKED rather than blocking the send — availability
+    // wins over serialization, so a rare contention/pool-exhaustion case can still double-generate.
+    // See start-generation-exclusive.ts and the PR 4 board page.
+    const generation = await startGenerationExclusive({
       conversationId: conversationId!,
-      channelId: chatId,
+      run: async () => {
+        await takeOverConversationStreams({
+          conversationId: conversationId!,
+          channelId: chatId!,
+        });
+
+        return createStreamLifecycle({
+          messageId: serverAssistantMessageId!,
+          channelId: chatId!,
+          conversationId: conversationId!,
+          userId: userId!,
+          displayName,
+          browserSessionId,
+          streamId,
+          isShared: isConversationShared,
+        });
+      },
     });
 
-    lifecycle = await createStreamLifecycle({
-      messageId: serverAssistantMessageId,
-      channelId: chatId,
-      conversationId: conversationId!,
-      userId: userId!,
-      displayName,
-      browserSessionId,
-      streamId,
-      isShared: isConversationShared,
-    });
+    lifecycle = generation.result;
 
     // Bind the terminal write to the abort itself. onAbort (below) already calls finish(true),
     // but it only fires while a streamText is live — and a cross-instance abort now WAITS for

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/conversation-id-resolution.test.ts
@@ -68,6 +68,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
@@ -102,7 +103,16 @@ vi.mock('@pagespace/db/db', () => {
   }));
   const insert = vi.fn(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) })) }));
   const update = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
-  return { db: { select, insert, update } };
+  // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
+  // exactly as before. Its own retry/degrade behavior is covered by
+  // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
+  const getAdvisoryLockPool = vi.fn(() => ({
+    connect: vi.fn(async () => ({
+      query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+      release: vi.fn(),
+    })),
+  }));
+  return { db: { select, insert, update }, getAdvisoryLockPool };
 });
 
 vi.mock('@pagespace/db/operators', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -77,6 +77,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
@@ -111,7 +112,16 @@ vi.mock('@pagespace/db/db', () => {
   }));
   const insert = vi.fn(() => ({ values: vi.fn(() => ({ onConflictDoUpdate: vi.fn().mockResolvedValue(undefined) })) }));
   const update = vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })) }));
-  return { db: { select, insert, update } };
+  // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
+  // exactly as before. Its own retry/degrade behavior is covered by
+  // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
+  const getAdvisoryLockPool = vi.fn(() => ({
+    connect: vi.fn(async () => ({
+      query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+      release: vi.fn(),
+    })),
+  }));
+  return { db: { select, insert, update }, getAdvisoryLockPool };
 });
 
 vi.mock('@pagespace/db/operators', () => ({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -77,6 +77,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
@@ -123,8 +124,19 @@ vi.mock('@pagespace/db/db', () => {
     })),
   }));
 
+  // startGenerationExclusive's advisory lock: always free, so takeover+lifecycle-create run
+  // exactly as before. Its own retry/degrade behavior is covered by
+  // start-generation-exclusive.test.ts — this file only verifies this route wires it in.
+  const getAdvisoryLockPool = vi.fn(() => ({
+    connect: vi.fn(async () => ({
+      query: vi.fn().mockResolvedValue({ rows: [{ acquired: true }] }),
+      release: vi.fn(),
+    })),
+  }));
+
   return {
     db: { select, insert, update },
+    getAdvisoryLockPool,
   };
 });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -25,6 +25,7 @@ import { broadcastChatUserMessage } from '@/lib/websocket';
 import { broadcastGlobalConversationAdded } from '@/lib/websocket/socket-utils';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { takeOverConversationStreams } from '@/lib/ai/core/stream-takeover';
+import { startGenerationExclusive } from '@/lib/ai/core/start-generation-exclusive';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
@@ -1075,26 +1076,35 @@ MENTION PROCESSING:
     // assistant rows, two bills. Takeover, not 409; see stream-liveness.ts for why rejecting
     // would self-lock the conversation.
     //
-    // KNOWN RACE — this does NOT guarantee "at most one generation per conversation", and this
-    // comment used to claim that it did. See the docblock on takeOverConversationStreams: the
-    // SELECT there and the INSERT in createStreamLifecycle are not atomic together, so two
-    // near-simultaneous sends can both find nothing in flight and both proceed. It narrows the
-    // window; it does not close it.
-    await takeOverConversationStreams({
+    // BEST-EFFORT, not an invariant — named honestly. `startGenerationExclusive` closes the
+    // check-then-act race documented here previously (the SELECT inside
+    // takeOverConversationStreams and the INSERT inside createStreamLifecycle are not atomic on
+    // their own) by holding a per-conversation Postgres advisory lock across both. On lock_busy
+    // it retries briefly, then proceeds UNLOCKED rather than blocking the send — availability
+    // wins over serialization, so a rare contention/pool-exhaustion case can still double-generate.
+    // See start-generation-exclusive.ts and the PR 4 board page.
+    const generation = await startGenerationExclusive({
       conversationId,
-      channelId,
+      run: async () => {
+        await takeOverConversationStreams({
+          conversationId,
+          channelId,
+        });
+
+        return createStreamLifecycle({
+          messageId: serverAssistantMessageId,
+          channelId,
+          conversationId,
+          userId,
+          displayName,
+          browserSessionId,
+          streamId,
+          isShared: conversation.isShared === true,
+        });
+      },
     });
 
-    lifecycle = await createStreamLifecycle({
-      messageId: serverAssistantMessageId,
-      channelId,
-      conversationId,
-      userId,
-      displayName,
-      browserSessionId,
-      streamId,
-      isShared: conversation.isShared === true,
-    });
+    lifecycle = generation.result;
 
     // Bind the terminal write to the abort itself. onAbort (below) already calls finish(true),
     // but it only fires while a streamText is live — and a cross-instance abort now WAITS for

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLoggerWarn, mockLogPerformance, mockGetAdvisoryLockPool } = vi.hoisted(() => ({
+  mockLoggerWarn: vi.fn(),
+  mockLogPerformance: vi.fn(),
+  mockGetAdvisoryLockPool: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), warn: mockLoggerWarn, error: vi.fn(), debug: vi.fn() } },
+  logPerformance: mockLogPerformance,
+}));
+
+vi.mock('@pagespace/db/db', () => ({ getAdvisoryLockPool: mockGetAdvisoryLockPool }));
+
+import {
+  decideOnLockBusy,
+  startGenerationExclusive,
+  MAX_LOCK_BUSY_RETRIES,
+  LOCK_BUSY_RETRY_DELAY_MS,
+} from '../start-generation-exclusive';
+import type { AdvisoryLockClient, AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+
+function makeClient(acquiredSequence: boolean[]) {
+  const query = vi.fn();
+  for (const acquired of acquiredSequence) {
+    query.mockResolvedValueOnce({ rows: [{ acquired }] }); // try-lock
+    if (acquired) query.mockResolvedValueOnce({ rows: [] }); // unlock
+  }
+  return { query, release: vi.fn() } satisfies AdvisoryLockClient;
+}
+
+function makePool(client: AdvisoryLockClient): AdvisoryLockPool {
+  return { connect: vi.fn(async () => client) };
+}
+
+beforeEach(() => {
+  mockLoggerWarn.mockReset();
+  mockLogPerformance.mockReset();
+  mockGetAdvisoryLockPool.mockReset();
+});
+
+describe('decideOnLockBusy (pure)', () => {
+  it('given fewer busy attempts than the retry budget, should retry after the fixed delay', () => {
+    for (let attemptsMade = 1; attemptsMade <= MAX_LOCK_BUSY_RETRIES; attemptsMade++) {
+      expect(decideOnLockBusy({ attemptsMade })).toEqual({ action: 'retry', delayMs: LOCK_BUSY_RETRY_DELAY_MS });
+    }
+  });
+
+  it('given the retry budget is exhausted, should proceed unlocked', () => {
+    expect(decideOnLockBusy({ attemptsMade: MAX_LOCK_BUSY_RETRIES + 1 })).toEqual({ action: 'proceed_unlocked' });
+  });
+});
+
+describe('startGenerationExclusive', () => {
+  it('given the lock is free on the first try, should acquire it, run inside the lock, and report outcome "locked"', async () => {
+    const client = makeClient([true]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+    const sleep = vi.fn(async () => {});
+
+    const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+    expect(result).toEqual({ outcome: 'locked', result: 'lifecycle-handle' });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLogPerformance).not.toHaveBeenCalled();
+  });
+
+  it('given the lock is busy then frees up within the retry budget, should retry with the fixed backoff and still run inside the lock', async () => {
+    const client = makeClient([false, false, true]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+    const sleep = vi.fn(async () => {});
+
+    const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+    expect(result).toEqual({ outcome: 'locked', result: 'lifecycle-handle' });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, LOCK_BUSY_RETRY_DELAY_MS);
+    expect(sleep).toHaveBeenNthCalledWith(2, LOCK_BUSY_RETRY_DELAY_MS);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLogPerformance).not.toHaveBeenCalled();
+  });
+
+  it('given the lock stays busy through the full retry budget, should retry exactly 3 times at 300ms then proceed unlocked, running fn exactly once outside the lock', async () => {
+    const client = makeClient([false, false, false, false]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+    const sleep = vi.fn(async () => {});
+
+    const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+    expect(result).toEqual({ outcome: 'degraded', result: 'lifecycle-handle' });
+    // fn is never passed to (and never invoked by) withAdvisoryLock on a lock_busy outcome —
+    // it only runs once, directly, for the unlocked fallback.
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledTimes(MAX_LOCK_BUSY_RETRIES);
+    expect(sleep).toHaveBeenCalledWith(LOCK_BUSY_RETRY_DELAY_MS);
+  });
+
+  it('given it degrades to unlocked, should name the guarantee "best-effort"/"degraded" in a structured warn AND emit a named metric — never silently', async () => {
+    const client = makeClient([false, false, false, false]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+    const sleep = vi.fn(async () => {});
+
+    await startGenerationExclusive({ conversationId: 'conv-42', run, pool, sleep });
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    const [warnMessage, warnMeta] = mockLoggerWarn.mock.calls[0];
+    expect(String(warnMessage).toLowerCase()).toMatch(/degrad|unlocked|best-effort/);
+    expect(warnMeta).toMatchObject({ conversationId: 'conv-42' });
+
+    expect(mockLogPerformance).toHaveBeenCalledTimes(1);
+    const [metricName, metricValue, metricUnit, metricMeta] = mockLogPerformance.mock.calls[0];
+    expect(metricName).toEqual(expect.stringContaining('advisory_lock'));
+    expect(metricValue).toBe(1);
+    expect(metricUnit).toBe('count');
+    expect(metricMeta).toMatchObject({ conversationId: 'conv-42' });
+  });
+
+  it('given the lock is acquired, should never emit degraded telemetry', async () => {
+    const client = makeClient([true]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+
+    await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep: vi.fn(async () => {}) });
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+    expect(mockLogPerformance).not.toHaveBeenCalled();
+  });
+
+  it('should scope the advisory lock key to the conversation, distinguishing it from other lock consumers', async () => {
+    const client = makeClient([true]);
+    const pool = makePool(client);
+    const run = vi.fn(async () => 'lifecycle-handle');
+
+    await startGenerationExclusive({ conversationId: 'conv-distinctive-123', run, pool, sleep: vi.fn(async () => {}) });
+
+    const tryLockCall = client.query.mock.calls[0];
+    expect(tryLockCall[1]).toEqual(['ai-send:conv-distinctive-123']);
+  });
+
+  it('given no pool override, should default to the dedicated advisory-lock pool (getAdvisoryLockPool)', async () => {
+    const client = makeClient([true]);
+    const pool = makePool(client);
+    mockGetAdvisoryLockPool.mockReturnValue(pool);
+    const run = vi.fn(async () => 'lifecycle-handle');
+
+    const result = await startGenerationExclusive({ conversationId: 'conv-1', run, sleep: vi.fn(async () => {}) });
+
+    expect(mockGetAdvisoryLockPool).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ outcome: 'locked', result: 'lifecycle-handle' });
+  });
+
+  it('given no sleep override, should back off with a real timer-based delay between retries', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeClient([false, true]);
+      const pool = makePool(client);
+      const run = vi.fn(async () => 'lifecycle-handle');
+
+      const pending = startGenerationExclusive({ conversationId: 'conv-1', run, pool });
+      await vi.advanceTimersByTimeAsync(LOCK_BUSY_RETRY_DELAY_MS);
+      const result = await pending;
+
+      expect(result).toEqual({ outcome: 'locked', result: 'lifecycle-handle' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -217,14 +217,25 @@ describe('startGenerationExclusive', () => {
       expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
       const [warnMessage, warnMeta] = mockLoggerWarn.mock.calls[0];
       expect(String(warnMessage).toLowerCase()).toMatch(/degrad|unlocked|best-effort/);
-      expect(warnMeta).toMatchObject({ conversationId: 'conv-77', reason: 'lock_error' });
+      expect(warnMeta).toMatchObject({ conversationId: 'conv-77', reason: 'lock_error', error: 'pool exhausted' });
 
       expect(mockLogPerformance).toHaveBeenCalledTimes(1);
       const [metricName, metricValue, metricUnit, metricMeta] = mockLogPerformance.mock.calls[0];
       expect(metricName).toEqual(expect.stringContaining('advisory_lock'));
       expect(metricValue).toBe(1);
       expect(metricUnit).toBe('count');
-      expect(metricMeta).toMatchObject({ conversationId: 'conv-77', reason: 'lock_error' });
+      expect(metricMeta).toEqual({ conversationId: 'conv-77', attemptsMade: 0, reason: 'lock_error' });
+    });
+
+    it('given the lock machinery throws a non-Error value, should still stringify it in the warn metadata', async () => {
+      const pool: AdvisoryLockPool = { connect: vi.fn(async () => { throw 'connection reset'; }) };
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+      const [, warnMeta] = mockLoggerWarn.mock.calls[0];
+      expect(warnMeta).toMatchObject({ error: 'connection reset' });
     });
 
     it('given the lock-busy degrade path, telemetry should carry reason "lock_busy" (distinguishable from lock_error)', async () => {

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -172,4 +172,73 @@ describe('startGenerationExclusive', () => {
       vi.useRealTimers();
     }
   });
+
+  describe('lock machinery failure (pool.connect()/try-lock query throws — NOT a resolved lock_busy)', () => {
+    it('given pool.connect() rejects, should proceed unlocked (never propagate) and run fn exactly once', async () => {
+      const pool: AdvisoryLockPool = { connect: vi.fn(async () => { throw new Error('connection refused'); }) };
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+      expect(result).toEqual({ outcome: 'degraded', result: 'lifecycle-handle' });
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the try-lock query itself throws (poisoned connection), should proceed unlocked (never propagate) and run fn exactly once', async () => {
+      const client = { query: vi.fn().mockRejectedValueOnce(new Error('connection reset')), release: vi.fn() } satisfies AdvisoryLockClient;
+      const pool = makePool(client);
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+      expect(result).toEqual({ outcome: 'degraded', result: 'lifecycle-handle' });
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
+    it('given the lock machinery fails, should NOT retry/sleep (unlike lock_busy) — it degrades immediately', async () => {
+      const pool: AdvisoryLockPool = { connect: vi.fn(async () => { throw new Error('pool exhausted'); }) };
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+      expect(sleep).not.toHaveBeenCalled();
+    });
+
+    it('given the lock machinery fails, should emit telemetry naming it distinctly from a lock_busy degrade — never silently', async () => {
+      const pool: AdvisoryLockPool = { connect: vi.fn(async () => { throw new Error('pool exhausted'); }) };
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      await startGenerationExclusive({ conversationId: 'conv-77', run, pool, sleep });
+
+      expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+      const [warnMessage, warnMeta] = mockLoggerWarn.mock.calls[0];
+      expect(String(warnMessage).toLowerCase()).toMatch(/degrad|unlocked|best-effort/);
+      expect(warnMeta).toMatchObject({ conversationId: 'conv-77', reason: 'lock_error' });
+
+      expect(mockLogPerformance).toHaveBeenCalledTimes(1);
+      const [metricName, metricValue, metricUnit, metricMeta] = mockLogPerformance.mock.calls[0];
+      expect(metricName).toEqual(expect.stringContaining('advisory_lock'));
+      expect(metricValue).toBe(1);
+      expect(metricUnit).toBe('count');
+      expect(metricMeta).toMatchObject({ conversationId: 'conv-77', reason: 'lock_error' });
+    });
+
+    it('given the lock-busy degrade path, telemetry should carry reason "lock_busy" (distinguishable from lock_error)', async () => {
+      const client = makeClient([false, false, false, false]);
+      const pool = makePool(client);
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
+
+      const [, warnMeta] = mockLoggerWarn.mock.calls[0];
+      expect(warnMeta).toMatchObject({ reason: 'lock_busy' });
+      const [, , , metricMeta] = mockLogPerformance.mock.calls[0];
+      expect(metricMeta).toMatchObject({ reason: 'lock_busy' });
+    });
+  });
 });

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -80,13 +80,20 @@ type DegradeReason =
    */
   | 'lock_error';
 
-function degradeToUnlocked(info: { conversationId: string; attemptsMade: number; reason: DegradeReason }): void {
+function degradeToUnlocked(info: {
+  conversationId: string;
+  attemptsMade: number;
+  reason: DegradeReason;
+  /** Set only for `reason: 'lock_error'` — the error the lock connection itself threw. */
+  error?: unknown;
+}): void {
+  const { error, ...metricInfo } = info;
   // Rail 8: never silent. Named metric + structured warn, always — best-effort serialization
   // gives up here; availability wins over serialization, a send must never block on this lock.
-  logPerformance('ai_send.advisory_lock_degraded', 1, 'count', info);
+  logPerformance('ai_send.advisory_lock_degraded', 1, 'count', metricInfo);
   loggers.ai.warn(
     'start-generation-exclusive: advisory lock unavailable, proceeding unlocked (degraded, best-effort serialization)',
-    info,
+    { ...metricInfo, ...(error !== undefined ? { error: error instanceof Error ? error.message : String(error) } : {}) },
   );
 }
 
@@ -112,7 +119,7 @@ export async function startGenerationExclusive<T>(
       // way lock contention might, so retrying here would only add latency to a send that
       // must never block. See the PR board page's verification: "Lock-pool exhaustion
       // simulation: proceeds unlocked, metric emitted, warn logged, both requests complete."
-      degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error' });
+      degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error', error });
       const result = await run();
       return { outcome: 'degraded', result };
     }

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -1,0 +1,97 @@
+import { getAdvisoryLockPool } from '@pagespace/db/db';
+import { withAdvisoryLock, type AdvisoryLockPool } from '@pagespace/db/advisory-lock';
+import { loggers, logPerformance } from '@pagespace/lib/logging/logger-config';
+
+/**
+ * Per-conversation in-flight guard, closed (best-effort) via a Postgres session-level
+ * advisory lock. See route.ts:1193-1211 (POST /api/ai/chat) for the check-then-act race this
+ * replaces: `takeOverConversationStreams`'s SELECT and `createStreamLifecycle`'s INSERT were not
+ * atomic together, so two near-simultaneous sends could both see zero in-flight rows and both
+ * proceed — two generations, two bills.
+ *
+ * NOT an invariant. On `lock_busy` — the lock already held by a concurrent send on the SAME
+ * conversation — this retries `MAX_LOCK_BUSY_RETRIES` times at `LOCK_BUSY_RETRY_DELAY_MS`
+ * apart, then gives up and runs `fn` UNLOCKED: availability wins over serialization, a send must
+ * never block on this. That degraded path is today's (pre-this-PR) behavior exactly — a
+ * concurrent double-generate stays possible, just narrowed to the rare pool-exhaustion/contention
+ * case instead of every concurrent send. See the PR 4 board page for the full guarantee, named
+ * honestly as best-effort (epic rail 12).
+ *
+ * `fn` (takeover + lifecycle-create today; the assistant message-row insert once PR 2 lands —
+ * see the seam note on the PR 2 page) runs exactly once per call, either inside the lock or,
+ * on degrade, once unlocked. It never runs twice for one `startGenerationExclusive` call.
+ */
+
+export const MAX_LOCK_BUSY_RETRIES = 3;
+export const LOCK_BUSY_RETRY_DELAY_MS = 300;
+
+function advisoryLockKeyFor(conversationId: string): string {
+  return `ai-send:${conversationId}`;
+}
+
+export type LockBusyDecision = { action: 'retry'; delayMs: number } | { action: 'proceed_unlocked' };
+
+/**
+ * Pure decision: given how many `lock_busy` outcomes have been seen so far for this call,
+ * should it retry (and how long to wait), or give up and proceed unlocked? No I/O, no clock —
+ * every branch is exhaustively testable by attemptsMade alone.
+ */
+export function decideOnLockBusy({ attemptsMade }: { attemptsMade: number }): LockBusyDecision {
+  return attemptsMade <= MAX_LOCK_BUSY_RETRIES
+    ? { action: 'retry', delayMs: LOCK_BUSY_RETRY_DELAY_MS }
+    : { action: 'proceed_unlocked' };
+}
+
+export type StartGenerationExclusiveOutcome<T> =
+  | { outcome: 'locked'; result: T }
+  | { outcome: 'degraded'; result: T };
+
+export interface StartGenerationExclusiveParams<T> {
+  conversationId: string;
+  /**
+   * The critical section: takeover + lifecycle-create today. Runs exactly once, either inside
+   * the advisory lock or (degraded) unlocked — never both, never twice.
+   */
+  run: () => Promise<T>;
+  /** Defaults to the dedicated advisory-lock pool (db.ts:36-55). Overridable for tests. */
+  pool?: AdvisoryLockPool;
+  /** Overridable for tests; defaults to a real timer-backed sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function startGenerationExclusive<T>(
+  params: StartGenerationExclusiveParams<T>,
+): Promise<StartGenerationExclusiveOutcome<T>> {
+  const { conversationId, run } = params;
+  const pool = params.pool ?? getAdvisoryLockPool();
+  const sleep = params.sleep ?? defaultSleep;
+  const lockKey = advisoryLockKeyFor(conversationId);
+
+  let attemptsMade = 0;
+  for (;;) {
+    const attempt = await withAdvisoryLock(pool, lockKey, run);
+    if (attempt.outcome === 'acquired') {
+      return { outcome: 'locked', result: attempt.result };
+    }
+
+    attemptsMade += 1;
+    const decision = decideOnLockBusy({ attemptsMade });
+    if (decision.action === 'retry') {
+      await sleep(decision.delayMs);
+      continue;
+    }
+
+    // Degraded path (rail 8: never silent). Best-effort serialization gives up here —
+    // availability wins over serialization, a send must never block on this lock.
+    logPerformance('ai_send.advisory_lock_degraded', 1, 'count', { conversationId, attemptsMade });
+    loggers.ai.warn(
+      'start-generation-exclusive: advisory lock busy after retries, proceeding unlocked (degraded, best-effort serialization)',
+      { conversationId, attemptsMade },
+    );
+
+    const result = await run();
+    return { outcome: 'degraded', result };
+  }
+}

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -17,6 +17,14 @@ import { loggers, logPerformance } from '@pagespace/lib/logging/logger-config';
  * case instead of every concurrent send. See the PR 4 board page for the full guarantee, named
  * honestly as best-effort (epic rail 12).
  *
+ * A SECOND, distinct degrade path: if the lock connection itself is broken — `pool.connect()`
+ * or the try-lock query throws, e.g. the dedicated advisory-lock pool (`getAdvisoryLockPool`,
+ * `max: 10`) is exhausted or a connection resets — that is degraded to unlocked immediately, with
+ * no retry. It is not `lock_busy` (nothing resolved false; nothing is contending for the lock)
+ * and retrying a broken connection on a 300ms cadence would only add latency to a send that must
+ * never block. Both degrade paths emit the same telemetry, tagged with a `reason` so they stay
+ * distinguishable (`lock_busy` vs `lock_error`) in logs/metrics.
+ *
  * `fn` (takeover + lifecycle-create today; the assistant message-row insert once PR 2 lands —
  * see the seam note on the PR 2 page) runs exactly once per call, either inside the lock or,
  * on degrade, once unlocked. It never runs twice for one `startGenerationExclusive` call.
@@ -61,6 +69,27 @@ export interface StartGenerationExclusiveParams<T> {
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** Why this call degraded to running `run` unlocked, for the shared telemetry below. */
+type DegradeReason =
+  /** The retry budget was exhausted on a resolved `lock_busy` (another send holds the lock). */
+  | 'lock_busy'
+  /**
+   * The lock machinery itself failed — `pool.connect()` or the try-lock query threw (pool
+   * exhaustion, connection reset), never resolving to `acquired`/`lock_busy` at all. Distinct
+   * from `lock_busy`: nothing is contending for the lock, the lock connection is just broken.
+   */
+  | 'lock_error';
+
+function degradeToUnlocked(info: { conversationId: string; attemptsMade: number; reason: DegradeReason }): void {
+  // Rail 8: never silent. Named metric + structured warn, always — best-effort serialization
+  // gives up here; availability wins over serialization, a send must never block on this lock.
+  logPerformance('ai_send.advisory_lock_degraded', 1, 'count', info);
+  loggers.ai.warn(
+    'start-generation-exclusive: advisory lock unavailable, proceeding unlocked (degraded, best-effort serialization)',
+    info,
+  );
+}
+
 export async function startGenerationExclusive<T>(
   params: StartGenerationExclusiveParams<T>,
 ): Promise<StartGenerationExclusiveOutcome<T>> {
@@ -71,7 +100,23 @@ export async function startGenerationExclusive<T>(
 
   let attemptsMade = 0;
   for (;;) {
-    const attempt = await withAdvisoryLock(pool, lockKey, run);
+    let attempt;
+    try {
+      attempt = await withAdvisoryLock(pool, lockKey, run);
+    } catch (error) {
+      // The lock connection itself failed (pool.connect() or the try-lock query threw) —
+      // NOT `run` throwing. `run` (takeover + lifecycle-create) is documented to catch and
+      // log its own errors and never throw, so this catch can only be reached by the lock
+      // machinery; `run` has not been invoked yet on this path. Degrade immediately rather
+      // than retry: a broken connection is not "busy" and won't resolve itself in 300ms the
+      // way lock contention might, so retrying here would only add latency to a send that
+      // must never block. See the PR board page's verification: "Lock-pool exhaustion
+      // simulation: proceeds unlocked, metric emitted, warn logged, both requests complete."
+      degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error' });
+      const result = await run();
+      return { outcome: 'degraded', result };
+    }
+
     if (attempt.outcome === 'acquired') {
       return { outcome: 'locked', result: attempt.result };
     }
@@ -83,14 +128,7 @@ export async function startGenerationExclusive<T>(
       continue;
     }
 
-    // Degraded path (rail 8: never silent). Best-effort serialization gives up here —
-    // availability wins over serialization, a send must never block on this lock.
-    logPerformance('ai_send.advisory_lock_degraded', 1, 'count', { conversationId, attemptsMade });
-    loggers.ai.warn(
-      'start-generation-exclusive: advisory lock busy after retries, proceeding unlocked (degraded, best-effort serialization)',
-      { conversationId, attemptsMade },
-    );
-
+    degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_busy' });
     const result = await run();
     return { outcome: 'degraded', result };
   }

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -80,21 +80,28 @@ type DegradeReason =
    */
   | 'lock_error';
 
-function degradeToUnlocked(info: {
-  conversationId: string;
-  attemptsMade: number;
-  reason: DegradeReason;
-  /** Set only for `reason: 'lock_error'` — the error the lock connection itself threw. */
-  error?: unknown;
-}): void {
+function degradeToUnlocked<T>(
+  info: {
+    conversationId: string;
+    attemptsMade: number;
+    reason: DegradeReason;
+    /** Set only for `reason: 'lock_error'` — the error the lock connection itself threw. */
+    error?: unknown;
+  },
+  run: () => Promise<T>,
+): Promise<StartGenerationExclusiveOutcome<T>> {
   const { error, ...metricInfo } = info;
+  const errorMessage = error === undefined ? undefined : error instanceof Error ? error.message : String(error);
+
   // Rail 8: never silent. Named metric + structured warn, always — best-effort serialization
   // gives up here; availability wins over serialization, a send must never block on this lock.
   logPerformance('ai_send.advisory_lock_degraded', 1, 'count', metricInfo);
   loggers.ai.warn(
     'start-generation-exclusive: advisory lock unavailable, proceeding unlocked (degraded, best-effort serialization)',
-    { ...metricInfo, ...(error !== undefined ? { error: error instanceof Error ? error.message : String(error) } : {}) },
+    { ...metricInfo, error: errorMessage },
   );
+
+  return run().then((result) => ({ outcome: 'degraded', result }));
 }
 
 export async function startGenerationExclusive<T>(
@@ -119,9 +126,7 @@ export async function startGenerationExclusive<T>(
       // way lock contention might, so retrying here would only add latency to a send that
       // must never block. See the PR board page's verification: "Lock-pool exhaustion
       // simulation: proceeds unlocked, metric emitted, warn logged, both requests complete."
-      degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error', error });
-      const result = await run();
-      return { outcome: 'degraded', result };
+      return degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error', error }, run);
     }
 
     if (attempt.outcome === 'acquired') {
@@ -135,8 +140,6 @@ export async function startGenerationExclusive<T>(
       continue;
     }
 
-    degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_busy' });
-    const result = await run();
-    return { outcome: 'degraded', result };
+    return degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_busy' }, run);
   }
 }


### PR DESCRIPTION
## Summary

PR 4 of the "Server Stream Durability & Rejoin" epic — closes the check-then-act race
between `takeOverConversationStreams`'s SELECT and `createStreamLifecycle`'s INSERT
(documented at `apps/web/src/app/api/ai/chat/route.ts:1193-1211`), which allowed two
near-simultaneous sends on the same conversation to both see zero in-flight rows and
both proceed — two generations, two sets of tool calls, two bills.

- Adds `startGenerationExclusive` (`apps/web/src/lib/ai/core/start-generation-exclusive.ts`),
  wrapping takeover + stream-lifecycle-create in a per-conversation Postgres advisory
  try-lock (`ai-send:<conversationId>`, via `withAdvisoryLock`/`getAdvisoryLockPool` —
  `packages/db/src/advisory-lock.ts`).
- **Best-effort, not an invariant** (named honestly per the board): on `lock_busy`, retries
  3×300ms then proceeds **unlocked** — availability wins over serialization, a send must
  never block on this lock.
- **Two distinct degrade paths, both telemetered, both tested:**
  - `lock_busy` — the lock is held by a concurrent send on the SAME conversation; retries
    exhausted, proceeds unlocked.
  - `lock_error` — the lock connection itself failed (`pool.connect()` or the try-lock query
    threw: pool exhaustion, connection reset); proceeds unlocked immediately, no retry (a
    broken connection isn't "busy" and won't resolve on a 300ms cadence). Added after
    self-review and an independent Codex review both caught that the initial implementation
    only handled the resolved `lock_busy` outcome — a connection failure propagated
    uncaught and turned "never block a send" into a hard 500.
  - Both paths emit a named metric (`logPerformance`) + structured warn, tagged with
    `reason` so they stay distinguishable in logs/metrics — never silent.
- The lock-busy retry/degrade decision (`decideOnLockBusy`) is a pure function, 100%
  branch tested.
- Wired into both `POST /api/ai/chat` and `POST /api/ai/global/[id]/messages`.
- Existing route-level mock-DB tests updated with a lock-always-free advisory-pool mock
  so they continue exercising the same takeover+lifecycle-create path as before.
- Leaves a seam note on PR 2's board page (assistant message row at stream start): the
  placeholder insert slots in as one more `await` inside `startGenerationExclusive`'s
  `run` closure — no change to the primitive itself needed.

## Test plan

- [x] `bun run typecheck` (web) — clean
- [x] `bun run lint` (web) — clean (0 errors; pre-existing unrelated warnings only)
- [x] `bun vitest run src/lib/ai/core/__tests__/start-generation-exclusive.test.ts` — 16/16, 100% line/branch/function coverage
- [x] `bun vitest run src/lib/ai/core/__tests__` — 895+/895+ passing
- [x] `bun vitest run src/app/api/ai` — 473+/473+ passing (+3 in the gate-callsites guard)
- [x] All CI checks green (Lint & TypeScript, Unit Tests, Security Test Suite, CodeQL, Dependency Audit, Secret Scanning, Static Security Analysis)
- [x] No merge conflicts with `master` (verified via `git merge-tree` after master advanced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0197HJSWMLvTu8qe75V7Dkvs