### PR TITLE
feat(ai): store-first rendering foundations (conversation cache, selector, own-stream mirror)

### DIFF
--- a/apps/web/src/hooks/useOwnStreamMirror.ts
+++ b/apps/web/src/hooks/useOwnStreamMirror.ts
@@ -22,9 +22,9 @@ export interface UseOwnStreamMirrorInput {
  * Applies `planOwnStreamMirror`'s ops to `usePendingStreamsStore` on every
  * relevant change. All the decision logic lives in the pure, exhaustively
  * tested `planOwnStreamMirror` — this hook only tracks the per-tab mutable
- * bookkeeping (`seq`, the currently-mirrored id, when the stream started)
- * that a pure function cannot own itself, and applies the resulting ops via
- * the store's own idempotent actions.
+ * bookkeeping (the currently-mirrored id, when the stream started) that a
+ * pure function cannot own itself, and applies the resulting ops via the
+ * store's own idempotent actions.
  */
 export const useOwnStreamMirror = ({
   status,
@@ -33,7 +33,6 @@ export const useOwnStreamMirror = ({
   conversationId,
   triggeredBy,
 }: UseOwnStreamMirrorInput): void => {
-  const seqRef = useRef(0);
   const mirroredIdRef = useRef<string | undefined>(undefined);
   const startedAtRef = useRef<string | undefined>(undefined);
 
@@ -41,7 +40,6 @@ export const useOwnStreamMirror = ({
     if (ownAssistantMessage && mirroredIdRef.current !== ownAssistantMessage.id) {
       startedAtRef.current = new Date().toISOString();
     }
-    seqRef.current += 1;
 
     const ops = planOwnStreamMirror({
       status,
@@ -51,7 +49,16 @@ export const useOwnStreamMirror = ({
       conversationId,
       triggeredBy,
       startedAt: startedAtRef.current ?? new Date().toISOString(),
-      seq: seqRef.current,
+      // Date.now() rather than a local incrementing ref: the store's
+      // `lastSeq` gate (applySetStreamParts) is keyed globally per messageId
+      // and survives across this hook remounting mid-stream (e.g. a parent
+      // re-key or Suspense reset while the same message is still streaming).
+      // A per-mount ref would restart at 0/1 on remount and have every write
+      // rejected as stale (seq <= the previous mount's already-higher
+      // lastSeq), freezing the mirrored stream until it ends. Wall-clock
+      // millis are monotonic across the whole process, independent of any
+      // single component instance's lifecycle.
+      seq: Date.now(),
     });
 
     const store = usePendingStreamsStore.getState();
@@ -62,5 +69,14 @@ export const useOwnStreamMirror = ({
     }
 
     mirroredIdRef.current = ownAssistantMessage?.id;
-  }, [status, ownAssistantMessage, pageId, conversationId, triggeredBy]);
+    // Deliberately depend on ownAssistantMessage's id/parts and triggeredBy's
+    // fields rather than the objects themselves: a caller building these from
+    // useChat's live message will construct a fresh `{id, parts}` wrapper on
+    // every render even when content hasn't changed, and useChat only
+    // replaces `parts` with a new array reference on a genuine content update
+    // (ai/dist/index.mjs's ReactChatState.replaceMessage clones on write) —
+    // depending on the object itself would re-run this effect (and bump seq,
+    // triggering a store write) on every unrelated parent re-render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, ownAssistantMessage?.id, ownAssistantMessage?.parts, pageId, conversationId, triggeredBy.userId, triggeredBy.displayName]);
 };

--- a/apps/web/src/hooks/useOwnStreamMirror.ts
+++ b/apps/web/src/hooks/useOwnStreamMirror.ts
@@ -1,7 +1,11 @@
 import { useEffect, useRef } from 'react';
 import type { UIMessage } from 'ai';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
-import { planOwnStreamMirror, type OwnStreamMirrorStatus } from '@/lib/ai/streams/planOwnStreamMirror';
+import {
+  planOwnStreamMirror,
+  isOwnStreamMirrorActive,
+  type OwnStreamMirrorStatus,
+} from '@/lib/ai/streams/planOwnStreamMirror';
 
 // TRANSITIONAL — see the Deletion covenant (pagespace kw69qhfck96jpssdk6w2xtbp):
 // this hook exists only because useChat remains the transport until
@@ -73,7 +77,20 @@ export const useOwnStreamMirror = ({
       else store.removeStream(op.messageId);
     }
 
-    mirroredIdRef.current = ownAssistantMessage?.id;
+    // NOT `ownAssistantMessage?.id` unconditionally: useChat typically
+    // retains the completed assistant message in local history after a
+    // stream finishes, so that id would still be defined here even though
+    // nothing is mirrored anymore (planOwnStreamMirror just emitted
+    // removeStream for it, or emitted nothing because it was already
+    // cleared). Using the same isOwnStreamMirrorActive definition
+    // planOwnStreamMirror itself uses is what makes this the source of
+    // truth for "did we actually mirror this id" rather than "does a
+    // message with this id still exist somewhere in caller state" — a
+    // continuation/regenerate reusing that same completed id (a real SDK
+    // behavior pinned in sdkServerIdAdoption.test.ts) would otherwise look
+    // like "already mirrored" against a store entry that had already been
+    // removed, and silently never get re-mirrored.
+    mirroredIdRef.current = isOwnStreamMirrorActive(status, ownAssistantMessage) ? ownAssistantMessage?.id : undefined;
     // Deliberately depend on ownAssistantMessage's id/parts and triggeredBy's
     // fields rather than the objects themselves: a caller building these from
     // useChat's live message will construct a fresh `{id, parts}` wrapper on

--- a/apps/web/src/hooks/useOwnStreamMirror.ts
+++ b/apps/web/src/hooks/useOwnStreamMirror.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+import type { UIMessage } from 'ai';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { planOwnStreamMirror, type OwnStreamMirrorStatus } from '@/lib/ai/streams/planOwnStreamMirror';
+
+// TRANSITIONAL — see the Deletion covenant (pagespace kw69qhfck96jpssdk6w2xtbp):
+// this hook exists only because useChat remains the transport until
+// WorkflowChatTransport lands, at which point the transport adapter feeds
+// usePendingStreamsStore directly and this hook is deleted (not ported).
+// Deletion gate: `grep -rn "TRANSITIONAL" apps/web/src` must return zero.
+
+export interface UseOwnStreamMirrorInput {
+  status: OwnStreamMirrorStatus;
+  /** The own tab's live assistant message (useChat's local state), or undefined when not actively streaming. */
+  ownAssistantMessage: { id: string; parts: UIMessage['parts'] } | undefined;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string };
+}
+
+/**
+ * Applies `planOwnStreamMirror`'s ops to `usePendingStreamsStore` on every
+ * relevant change. All the decision logic lives in the pure, exhaustively
+ * tested `planOwnStreamMirror` — this hook only tracks the per-tab mutable
+ * bookkeeping (`seq`, the currently-mirrored id, when the stream started)
+ * that a pure function cannot own itself, and applies the resulting ops via
+ * the store's own idempotent actions.
+ */
+export const useOwnStreamMirror = ({
+  status,
+  ownAssistantMessage,
+  pageId,
+  conversationId,
+  triggeredBy,
+}: UseOwnStreamMirrorInput): void => {
+  const seqRef = useRef(0);
+  const mirroredIdRef = useRef<string | undefined>(undefined);
+  const startedAtRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (ownAssistantMessage && mirroredIdRef.current !== ownAssistantMessage.id) {
+      startedAtRef.current = new Date().toISOString();
+    }
+    seqRef.current += 1;
+
+    const ops = planOwnStreamMirror({
+      status,
+      ownAssistantMessage,
+      mirroredMessageId: mirroredIdRef.current,
+      pageId,
+      conversationId,
+      triggeredBy,
+      startedAt: startedAtRef.current ?? new Date().toISOString(),
+      seq: seqRef.current,
+    });
+
+    const store = usePendingStreamsStore.getState();
+    for (const op of ops) {
+      if (op.type === 'addStream') store.addStream(op.stream);
+      else if (op.type === 'setStreamParts') store.setStreamParts(op.messageId, op.parts, op.seq);
+      else store.removeStream(op.messageId);
+    }
+
+    mirroredIdRef.current = ownAssistantMessage?.id;
+  }, [status, ownAssistantMessage, pageId, conversationId, triggeredBy]);
+};

--- a/apps/web/src/hooks/useOwnStreamMirror.ts
+++ b/apps/web/src/hooks/useOwnStreamMirror.ts
@@ -41,6 +41,21 @@ export const useOwnStreamMirror = ({
       startedAtRef.current = new Date().toISOString();
     }
 
+    const store = usePendingStreamsStore.getState();
+    // seq = max(wall-clock millis, storedLastSeq + 1): wall-clock alone can
+    // repeat within the same millisecond (two mirror ticks for fast local
+    // streams, or a tick right at a remount), and applySetStreamParts drops
+    // any write with seq <= lastSeq — a repeat would silently lose that
+    // chunk. Reading the store's current lastSeq as a floor and requiring
+    // strictly-greater guarantees monotonic progress regardless of clock
+    // resolution, while still being immune to this hook remounting mid-
+    // stream (unlike a local incrementing ref, which would restart at 0/1
+    // and have every write from the new instance rejected as stale against
+    // the previous instance's already-higher lastSeq).
+    const relevantId = ownAssistantMessage?.id ?? mirroredIdRef.current;
+    const storedLastSeq = (relevantId && store.streams.get(relevantId)?.lastSeq) || 0;
+    const seq = Math.max(Date.now(), storedLastSeq + 1);
+
     const ops = planOwnStreamMirror({
       status,
       ownAssistantMessage,
@@ -49,19 +64,9 @@ export const useOwnStreamMirror = ({
       conversationId,
       triggeredBy,
       startedAt: startedAtRef.current ?? new Date().toISOString(),
-      // Date.now() rather than a local incrementing ref: the store's
-      // `lastSeq` gate (applySetStreamParts) is keyed globally per messageId
-      // and survives across this hook remounting mid-stream (e.g. a parent
-      // re-key or Suspense reset while the same message is still streaming).
-      // A per-mount ref would restart at 0/1 on remount and have every write
-      // rejected as stale (seq <= the previous mount's already-higher
-      // lastSeq), freezing the mirrored stream until it ends. Wall-clock
-      // millis are monotonic across the whole process, independent of any
-      // single component instance's lifecycle.
-      seq: Date.now(),
+      seq,
     });
 
-    const store = usePendingStreamsStore.getState();
     for (const op of ops) {
       if (op.type === 'addStream') store.addStream(op.stream);
       else if (op.type === 'setStreamParts') store.setStreamParts(op.messageId, op.parts, op.seq);

--- a/apps/web/src/lib/ai/streams/__tests__/buildUserMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/buildUserMessage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { FileUIPart } from 'ai';
+import { buildUserMessage } from '../buildUserMessage';
+
+describe('buildUserMessage', () => {
+  it('given only an id, should produce a user message with empty parts', () => {
+    const msg = buildUserMessage({ id: 'u1' });
+    expect(msg).toEqual({ id: 'u1', role: 'user', parts: [] });
+  });
+
+  it('given text, should produce a single text part', () => {
+    const msg = buildUserMessage({ id: 'u1', text: 'hello' });
+    expect(msg.parts).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+
+  it('given an empty string text, should still produce a text part (only null/undefined text is omitted)', () => {
+    const msg = buildUserMessage({ id: 'u1', text: '' });
+    expect(msg.parts).toEqual([{ type: 'text', text: '' }]);
+  });
+
+  it('given files, should pass them through as-is ahead of the text part', () => {
+    const files: FileUIPart[] = [{ type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,abc' }];
+    const msg = buildUserMessage({ id: 'u1', text: 'caption', files });
+    expect(msg.parts).toEqual([files[0], { type: 'text', text: 'caption' }]);
+  });
+
+  it('given files and no text, should produce only the file parts', () => {
+    const files: FileUIPart[] = [{ type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,abc' }];
+    const msg = buildUserMessage({ id: 'u1', files });
+    expect(msg.parts).toEqual(files);
+  });
+
+  it('given metadata, should attach it', () => {
+    const msg = buildUserMessage({ id: 'u1', text: 'hi', metadata: { source: 'sidebar' } });
+    expect(msg.metadata).toEqual({ source: 'sidebar' });
+  });
+
+  it('given no metadata, should omit the metadata key entirely', () => {
+    const msg = buildUserMessage({ id: 'u1', text: 'hi' });
+    expect('metadata' in msg).toBe(false);
+  });
+
+  it('given a caller id, should carry it through unchanged', () => {
+    const msg = buildUserMessage({ id: 'client-minted-id', text: 'hi' });
+    expect(msg.id).toBe('client-minted-id');
+    expect(msg.role).toBe('user');
+  });
+
+  it('given a files array, should not mutate it', () => {
+    const files: FileUIPart[] = [{ type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,abc' }];
+    const originalLength = files.length;
+    buildUserMessage({ id: 'u1', text: 'hi', files });
+    expect(files).toHaveLength(originalLength);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -152,6 +152,19 @@ describe('chunkToPart', () => {
     ).toBeNull();
   });
 
+  it('given a tool-error chunk whose error is not JSON-serializable (circular reference), should fall back to the generic errorText', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const part = chunkToPart({
+      type: 'tool-error',
+      toolCallId: 'tc4',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+      error: circular,
+    } as never);
+    expect(part).toMatchObject({ errorText: 'Tool execution failed' });
+  });
+
   it('given a tool-error chunk missing toolCallId, should return null (idempotency key required so the error replaces the in-flight tool part)', () => {
     expect(
       chunkToPart({

--- a/apps/web/src/lib/ai/streams/__tests__/planOwnStreamMirror.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/planOwnStreamMirror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planOwnStreamMirror } from '../planOwnStreamMirror';
+import { planOwnStreamMirror, isOwnStreamMirrorActive } from '../planOwnStreamMirror';
 
 const BASE = {
   pageId: 'page-1',
@@ -115,5 +115,27 @@ describe('planOwnStreamMirror', () => {
       mirroredMessageId: 'a1',
     };
     expect(planOwnStreamMirror(input)).toEqual(planOwnStreamMirror(input));
+  });
+});
+
+describe('isOwnStreamMirrorActive', () => {
+  it('given status streaming with an assistant message, should be active', () => {
+    expect(isOwnStreamMirrorActive('streaming', { id: 'a1', parts: [] })).toBe(true);
+  });
+
+  it('given status submitted with an assistant message, should be active', () => {
+    expect(isOwnStreamMirrorActive('submitted', { id: 'a1', parts: [] })).toBe(true);
+  });
+
+  it('given status streaming with no assistant message yet, should NOT be active', () => {
+    expect(isOwnStreamMirrorActive('streaming', undefined)).toBe(false);
+  });
+
+  it('given status ready even with an assistant message still present (useChat retains completed history), should NOT be active — this is the exact case that caused the mirroredId staleness bug', () => {
+    expect(isOwnStreamMirrorActive('ready', { id: 'a1', parts: [text('done')] })).toBe(false);
+  });
+
+  it('given status error with an assistant message present, should NOT be active', () => {
+    expect(isOwnStreamMirrorActive('error', { id: 'a1', parts: [] })).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/planOwnStreamMirror.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/planOwnStreamMirror.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { planOwnStreamMirror } from '../planOwnStreamMirror';
+
+const BASE = {
+  pageId: 'page-1',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'u1', displayName: 'Me' },
+  startedAt: '2024-01-01T00:00:00.000Z',
+  seq: 1,
+};
+
+const text = (t: string) => ({ type: 'text' as const, text: t });
+
+describe('planOwnStreamMirror', () => {
+  it('given no active stream and nothing mirrored, should plan no ops', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'ready',
+      ownAssistantMessage: undefined,
+      mirroredMessageId: undefined,
+    });
+    expect(ops).toEqual([]);
+  });
+
+  it('given the stream has ended but a stale mirror entry remains, should plan removeStream', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'ready',
+      ownAssistantMessage: undefined,
+      mirroredMessageId: 'a1',
+    });
+    expect(ops).toEqual([{ type: 'removeStream', messageId: 'a1' }]);
+  });
+
+  it('given an error status with a stale mirror entry, should also plan removeStream', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'error',
+      ownAssistantMessage: undefined,
+      mirroredMessageId: 'a1',
+    });
+    expect(ops).toEqual([{ type: 'removeStream', messageId: 'a1' }]);
+  });
+
+  it('given a fresh stream start (streaming, nothing mirrored yet), should plan addStream then setStreamParts', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'streaming',
+      ownAssistantMessage: { id: 'a1', parts: [text('hi')] },
+      mirroredMessageId: undefined,
+    });
+    expect(ops).toEqual([
+      {
+        type: 'addStream',
+        stream: {
+          messageId: 'a1',
+          pageId: 'page-1',
+          conversationId: 'conv-1',
+          triggeredBy: { userId: 'u1', displayName: 'Me' },
+          isOwn: true,
+          startedAt: '2024-01-01T00:00:00.000Z',
+        },
+      },
+      { type: 'setStreamParts', messageId: 'a1', parts: [text('hi')], seq: 1 },
+    ]);
+  });
+
+  it('given a submitted status (before the first chunk lands) with the assistant message already present, should treat it as active', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'submitted',
+      ownAssistantMessage: { id: 'a1', parts: [] },
+      mirroredMessageId: undefined,
+    });
+    expect(ops[0]).toMatchObject({ type: 'addStream' });
+  });
+
+  it('given the same message already mirrored, should plan only setStreamParts', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'streaming',
+      ownAssistantMessage: { id: 'a1', parts: [text('hi there')] },
+      mirroredMessageId: 'a1',
+    });
+    expect(ops).toEqual([{ type: 'setStreamParts', messageId: 'a1', parts: [text('hi there')], seq: 1 }]);
+  });
+
+  it('given the mirrored id differs from the current assistant message id, should remove the stale entry before adding the new one', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'streaming',
+      ownAssistantMessage: { id: 'a2', parts: [text('new')] },
+      mirroredMessageId: 'a1',
+    });
+    expect(ops[0]).toEqual({ type: 'removeStream', messageId: 'a1' });
+    expect(ops[1]).toMatchObject({ type: 'addStream', stream: { messageId: 'a2' } });
+    expect(ops[2]).toEqual({ type: 'setStreamParts', messageId: 'a2', parts: [text('new')], seq: 1 });
+  });
+
+  it('given submitted status with no assistant message pushed yet and nothing mirrored, should plan no ops', () => {
+    const ops = planOwnStreamMirror({
+      ...BASE,
+      status: 'submitted',
+      ownAssistantMessage: undefined,
+      mirroredMessageId: undefined,
+    });
+    expect(ops).toEqual([]);
+  });
+
+  it('given identical input called twice, should produce deep-equal ops both times (idempotent)', () => {
+    const input = {
+      ...BASE,
+      status: 'streaming' as const,
+      ownAssistantMessage: { id: 'a1', parts: [text('hi')] },
+      mirroredMessageId: 'a1',
+    };
+    expect(planOwnStreamMirror(input)).toEqual(planOwnStreamMirror(input));
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/sdkClientMintedUserId.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/sdkClientMintedUserId.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage, UIMessageChunk, ChatTransport } from 'ai';
+import { Chat } from '@ai-sdk/react';
+
+/**
+ * Pins "Assumption B" from the PR 3 board: a client-minted user-message id
+ * only survives through the parts-form `sendMessage({ id, role: 'user',
+ * parts })` call. The `{ text, files }` shorthand rebuilds the message from
+ * scratch and always mints via `generateId()` — pinning the failure here
+ * means an SDK fix that starts honoring an id on the shorthand flips this
+ * test visibly instead of silently changing dedup behavior.
+ */
+
+const makeCapturingTransport = () => {
+  const calls: UIMessage[][] = [];
+  const transport: ChatTransport<UIMessage> = {
+    sendMessages: async ({ messages }) => {
+      calls.push(messages);
+      return new ReadableStream<UIMessageChunk>({
+        start(controller) {
+          controller.enqueue({ type: 'start', messageId: 'server-assistant-id' });
+          controller.enqueue({ type: 'finish' });
+          controller.close();
+        },
+      });
+    },
+    reconnectToStream: async () => null,
+  };
+  return { transport, calls };
+};
+
+describe('client-minted user-message id', () => {
+  it('given the parts-form send with a caller id, should carry that id into the transport request body', async () => {
+    const { transport, calls } = makeCapturingTransport();
+    const chat = new Chat({ messages: [], transport });
+
+    await chat.sendMessage({ id: 'client-minted-id', role: 'user', parts: [{ type: 'text', text: 'hi' }] });
+
+    expect(calls).toHaveLength(1);
+    const lastMessageSent = calls[0][calls[0].length - 1];
+    expect(lastMessageSent.id).toBe('client-minted-id');
+    expect(lastMessageSent.role).toBe('user');
+  });
+
+  it('given the parts-form send, should also push the message into local state under the caller id', async () => {
+    const { transport } = makeCapturingTransport();
+    const chat = new Chat({ messages: [], transport });
+
+    await chat.sendMessage({ id: 'client-minted-id', role: 'user', parts: [{ type: 'text', text: 'hi' }] });
+
+    expect(chat.messages[0].id).toBe('client-minted-id');
+  });
+
+  it('given the {text} shorthand, should drop any id property and mint a fresh one via generateId', async () => {
+    const { transport } = makeCapturingTransport();
+    let counter = 0;
+    const chat = new Chat({ messages: [], transport, generateId: () => `generated-${++counter}` });
+
+    // The shorthand's type has no `id` member (ai/dist/index.d.ts:3926-3941) —
+    // this cast simulates a caller mistakenly attaching one at the JS level,
+    // which is exactly the failure mode this test pins.
+    const shorthandWithId = { text: 'hi', id: 'should-be-dropped' } as unknown as { text: string };
+    await chat.sendMessage(shorthandWithId);
+
+    expect(chat.messages[0].id).toMatch(/^generated-\d+$/);
+    expect(chat.messages[0].id).not.toBe('should-be-dropped');
+  });
+
+  it('given the {files} shorthand, should also drop any id property and mint a fresh one', async () => {
+    const { transport } = makeCapturingTransport();
+    let counter = 0;
+    const chat = new Chat({ messages: [], transport, generateId: () => `generated-${++counter}` });
+
+    const shorthandWithId = { files: [], id: 'should-be-dropped' } as unknown as {
+      files: [];
+    };
+    await chat.sendMessage(shorthandWithId);
+
+    expect(chat.messages[0].id).toMatch(/^generated-\d+$/);
+    expect(chat.messages[0].id).not.toBe('should-be-dropped');
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/sdkServerIdAdoption.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/sdkServerIdAdoption.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { createUIMessageStream } from 'ai';
+import type { UIMessage, UIMessageChunk, ChatTransport } from 'ai';
+import { Chat } from '@ai-sdk/react';
+
+/**
+ * Pins two SDK behaviors the store-first design depends on (PR 3 board,
+ * "Assumption A"): the server-issued assistant id always wins over the
+ * client-generated id, including the pre-`start` data-part edge case where
+ * that only holds by reference-identity luck in `ReactChatState.pushMessage`.
+ * If either behavior regresses on an SDK bump, these tests turn it into a
+ * red CI run instead of a screen flash.
+ */
+
+const readAll = async (stream: ReadableStream<UIMessageChunk>): Promise<UIMessageChunk[]> => {
+  const reader = stream.getReader();
+  const chunks: UIMessageChunk[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+};
+
+describe('createUIMessageStream server-id injection', () => {
+  it('given history ending with a user message, should stamp the start chunk with the generated id', async () => {
+    const stream = createUIMessageStream({
+      generateId: () => 'server-assistant-id',
+      originalMessages: [{ id: 'u1', role: 'user', parts: [] }] as UIMessage[],
+      execute: ({ writer }) => {
+        writer.write({ type: 'start' });
+        writer.write({ type: 'finish' });
+      },
+    });
+
+    const chunks = await readAll(stream);
+    const start = chunks.find((c) => c.type === 'start');
+    expect(start).toMatchObject({ type: 'start', messageId: 'server-assistant-id' });
+  });
+
+  it('given history ending with an assistant message, should override the generated id with that message id (continuation)', async () => {
+    const stream = createUIMessageStream({
+      generateId: () => 'server-assistant-id',
+      originalMessages: [
+        { id: 'u1', role: 'user', parts: [] },
+        { id: 'a-existing', role: 'assistant', parts: [] },
+      ] as UIMessage[],
+      execute: ({ writer }) => {
+        writer.write({ type: 'start' });
+        writer.write({ type: 'finish' });
+      },
+    });
+
+    const chunks = await readAll(stream);
+    const start = chunks.find((c) => c.type === 'start');
+    expect(start).toMatchObject({ type: 'start', messageId: 'a-existing' });
+  });
+
+  it('given a start chunk that already carries a messageId, should not override it', async () => {
+    const stream = createUIMessageStream({
+      generateId: () => 'server-assistant-id',
+      originalMessages: [{ id: 'u1', role: 'user', parts: [] }] as UIMessage[],
+      execute: ({ writer }) => {
+        writer.write({ type: 'start', messageId: 'explicit-id' });
+        writer.write({ type: 'finish' });
+      },
+    });
+
+    const chunks = await readAll(stream);
+    const start = chunks.find((c) => c.type === 'start');
+    expect(start).toMatchObject({ type: 'start', messageId: 'explicit-id' });
+  });
+});
+
+describe('AbstractChat adopts the server-issued assistant id', () => {
+  const makeChat = (chunks: UIMessageChunk[]) => {
+    const transport: ChatTransport<UIMessage> = {
+      sendMessages: async () =>
+        new ReadableStream<UIMessageChunk>({
+          start(controller) {
+            for (const chunk of chunks) controller.enqueue(chunk);
+            controller.close();
+          },
+        }),
+      reconnectToStream: async () => null,
+    };
+    return new Chat({ messages: [], transport });
+  };
+
+  it('given a normal stream (start arrives first), should push the assistant message under the server id', async () => {
+    const chat = makeChat([
+      { type: 'start', messageId: 'server-assistant-id' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'hello' },
+      { type: 'text-end', id: 't1' },
+      { type: 'finish' },
+    ]);
+
+    await chat.sendMessage({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] });
+
+    expect(chat.messages).toHaveLength(2);
+    const assistant = chat.messages[1];
+    expect(assistant.role).toBe('assistant');
+    expect(assistant.id).toBe('server-assistant-id');
+  });
+
+  it('given a data part before the start chunk, should still converge to exactly one assistant message under the server id', async () => {
+    const chat = makeChat([
+      { type: 'data-commandExecution', id: 'cmd-1', data: { status: 'running' } },
+      { type: 'start', messageId: 'server-assistant-id' },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'hello' },
+      { type: 'text-end', id: 't1' },
+      { type: 'finish' },
+    ]);
+
+    await chat.sendMessage({ id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] });
+
+    const assistantMessages = chat.messages.filter((m) => m.role === 'assistant');
+    expect(assistantMessages).toHaveLength(1);
+    expect(assistantMessages[0].id).toBe('server-assistant-id');
+    expect(assistantMessages[0].parts.some((p) => p.type === 'data-commandExecution')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
@@ -15,7 +15,7 @@ const stream = (overrides: Partial<PendingStream> & { messageId: string }): Pend
   ...overrides,
 });
 
-const emptyEntry: ConversationCacheEntry = { messages: [], optimisticSends: [], loadGeneration: 0 };
+const emptyEntry: ConversationCacheEntry = { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] };
 
 describe('selectRenderedMessages', () => {
   it('given an empty cache and no streams, should return an empty array', () => {

--- a/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/selectRenderedMessages.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { selectRenderedMessages } from '../selectRenderedMessages';
+import type { ConversationCacheEntry } from '@/stores/conversationMessages/seedEmpty';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+const stream = (overrides: Partial<PendingStream> & { messageId: string }): PendingStream => ({
+  pageId: 'page-1',
+  conversationId: 'c1',
+  triggeredBy: { userId: 'u1', displayName: 'User' },
+  parts: [{ type: 'text', text: 'streaming...' }],
+  isOwn: true,
+  ...overrides,
+});
+
+const emptyEntry: ConversationCacheEntry = { messages: [], optimisticSends: [], loadGeneration: 0 };
+
+describe('selectRenderedMessages', () => {
+  it('given an empty cache and no streams, should return an empty array', () => {
+    expect(selectRenderedMessages(emptyEntry, [])).toEqual([]);
+  });
+
+  it('given only confirmed messages, should render them all in mode "confirmed"', () => {
+    const entry: ConversationCacheEntry = { ...emptyEntry, messages: [msg('m1'), msg('m2')] };
+    const result = selectRenderedMessages(entry, []);
+    expect(result).toEqual([
+      { message: msg('m1'), mode: 'confirmed' },
+      { message: msg('m2'), mode: 'confirmed' },
+    ]);
+  });
+
+  it('given optimistic sends, should render them in mode "optimistic" after confirmed messages', () => {
+    const entry: ConversationCacheEntry = {
+      ...emptyEntry,
+      messages: [msg('m1')],
+      optimisticSends: [msg('opt1')],
+    };
+    const result = selectRenderedMessages(entry, []);
+    expect(result.map((r) => r.mode)).toEqual(['confirmed', 'optimistic']);
+    expect(result[1].message.id).toBe('opt1');
+  });
+
+  it('given an active stream whose id is not in the cache, should render it in mode "streaming"', () => {
+    const result = selectRenderedMessages(emptyEntry, [stream({ messageId: 's1' })]);
+    expect(result).toHaveLength(1);
+    expect(result[0].mode).toBe('streaming');
+    expect(result[0].message.id).toBe('s1');
+    expect(result[0].message.role).toBe('assistant');
+  });
+
+  it('given a stream whose messageId already appears in confirmed messages, should drop the stream (cache wins)', () => {
+    const entry: ConversationCacheEntry = { ...emptyEntry, messages: [msg('s1')] };
+    const result = selectRenderedMessages(entry, [stream({ messageId: 's1' })]);
+    expect(result).toEqual([{ message: msg('s1'), mode: 'confirmed' }]);
+  });
+
+  it('given a stream whose messageId already appears in optimisticSends, should drop the stream (cache wins)', () => {
+    const entry: ConversationCacheEntry = { ...emptyEntry, optimisticSends: [msg('s1')] };
+    const result = selectRenderedMessages(entry, [stream({ messageId: 's1' })]);
+    expect(result).toEqual([{ message: msg('s1'), mode: 'optimistic' }]);
+  });
+
+  it('given multiple concurrent streams, should order them by startedAt ascending', () => {
+    const result = selectRenderedMessages(emptyEntry, [
+      stream({ messageId: 'later', startedAt: '2024-01-01T00:00:02.000Z' }),
+      stream({ messageId: 'earlier', startedAt: '2024-01-01T00:00:01.000Z' }),
+    ]);
+    expect(result.map((r) => r.message.id)).toEqual(['earlier', 'later']);
+  });
+
+  it('given a stream with no startedAt among others that have one, should not throw and should include it', () => {
+    const result = selectRenderedMessages(emptyEntry, [
+      stream({ messageId: 'has-time', startedAt: '2024-01-01T00:00:01.000Z' }),
+      stream({ messageId: 'no-time' }),
+    ]);
+    expect(result.map((r) => r.message.id).sort()).toEqual(['has-time', 'no-time']);
+  });
+
+  it('given the no-startedAt stream first and the timestamped one second, should still not throw', () => {
+    const result = selectRenderedMessages(emptyEntry, [
+      stream({ messageId: 'no-time' }),
+      stream({ messageId: 'has-time', startedAt: '2024-01-01T00:00:01.000Z' }),
+    ]);
+    expect(result.map((r) => r.message.id).sort()).toEqual(['has-time', 'no-time']);
+  });
+
+  it('given multiple streams with no startedAt at all, should not throw', () => {
+    const result = selectRenderedMessages(emptyEntry, [stream({ messageId: 'a' }), stream({ messageId: 'b' })]);
+    expect(result.map((r) => r.message.id).sort()).toEqual(['a', 'b']);
+  });
+
+  it('given a stream, should synthesize its assistant message from parts and startedAt', () => {
+    const result = selectRenderedMessages(emptyEntry, [
+      stream({ messageId: 's1', parts: [{ type: 'text', text: 'hi' }], startedAt: '2024-01-01T00:00:00.000Z' }),
+    ]);
+    expect(result[0].message.parts).toEqual([{ type: 'text', text: 'hi' }]);
+    expect((result[0].message as UIMessage & { createdAt?: Date }).createdAt).toEqual(
+      new Date('2024-01-01T00:00:00.000Z'),
+    );
+  });
+
+  it('given confirmed, optimistic, and streaming entries together, should order them confirmed, optimistic, then streaming', () => {
+    const entry: ConversationCacheEntry = {
+      ...emptyEntry,
+      messages: [msg('m1')],
+      optimisticSends: [msg('opt1')],
+    };
+    const result = selectRenderedMessages(entry, [stream({ messageId: 's1' })]);
+    expect(result.map((r) => r.mode)).toEqual(['confirmed', 'optimistic', 'streaming']);
+  });
+
+  it('switch-away/back: selecting a different conversation entry does not leak the first conversation streams', () => {
+    const convA: ConversationCacheEntry = { ...emptyEntry, messages: [msg('a1')] };
+    const convB: ConversationCacheEntry = { ...emptyEntry, messages: [msg('b1')] };
+    const streamsForA = [stream({ messageId: 'a-stream', conversationId: 'a' })];
+
+    const resultB = selectRenderedMessages(convB, []);
+    expect(resultB).toEqual([{ message: msg('b1'), mode: 'confirmed' }]);
+
+    // caller is responsible for pre-filtering streams by conversationId (selectChannelRemoteStreams);
+    // re-selecting A with its own streams still works after B was rendered in between.
+    const resultA = selectRenderedMessages(convA, streamsForA);
+    expect(resultA.map((r) => r.message.id)).toEqual(['a1', 'a-stream']);
+  });
+
+  it('switch-away/back: once a stream completes and its message lands in the cache, re-selecting the same conversation drops the now-redundant stream entry', () => {
+    const streamingEntry: ConversationCacheEntry = emptyEntry;
+    const liveStreams = [stream({ messageId: 's1' })];
+    const first = selectRenderedMessages(streamingEntry, liveStreams);
+    expect(first.map((r) => r.mode)).toEqual(['streaming']);
+
+    const settledEntry: ConversationCacheEntry = { ...emptyEntry, messages: [msg('s1')] };
+    const second = selectRenderedMessages(settledEntry, liveStreams);
+    expect(second).toEqual([{ message: msg('s1'), mode: 'confirmed' }]);
+  });
+});

--- a/apps/web/src/lib/ai/streams/buildUserMessage.ts
+++ b/apps/web/src/lib/ai/streams/buildUserMessage.ts
@@ -1,0 +1,35 @@
+import type { CreateUIMessage, FileUIPart, UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+export interface BuildUserMessageInput {
+  /** Client-minted id. Only the parts-form send honors this (see PR 3 board, Assumption B) — never send via the `{text, files}` shorthand. */
+  id: string;
+  text?: string;
+  /** Pre-converted file parts — callers running `convertFileListToFileUIParts` keep this function pure and synchronous. */
+  files?: FileUIPart[];
+  metadata?: UIMessage['metadata'];
+}
+
+/**
+ * Builds a parts-form `CreateUIMessage` payload for `Chat.sendMessage`, the
+ * only send shape that preserves a caller-supplied id end to end. Pure —
+ * never mutates `files`.
+ */
+export const buildUserMessage = ({
+  id,
+  text,
+  files,
+  metadata,
+}: BuildUserMessageInput): CreateUIMessage<UIMessage> => {
+  const parts: UIMessagePart[] = [
+    ...(files ?? []),
+    ...(text != null ? [{ type: 'text' as const, text }] : []),
+  ];
+  return {
+    id,
+    role: 'user',
+    parts,
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+};

--- a/apps/web/src/lib/ai/streams/planOwnStreamMirror.ts
+++ b/apps/web/src/lib/ai/streams/planOwnStreamMirror.ts
@@ -1,0 +1,84 @@
+import type { UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+// TRANSITIONAL — see the Deletion covenant (pagespace kw69qhfck96jpssdk6w2xtbp):
+// this module exists only because useChat remains the transport until
+// WorkflowChatTransport lands. It is deleted (not ported) at that swap, along
+// with useOwnStreamMirror and every other "TRANSITIONAL" marker in this repo
+// (`grep -rn "TRANSITIONAL" apps/web/src` is the deletion gate).
+
+export type OwnStreamMirrorStatus = 'submitted' | 'streaming' | 'ready' | 'error';
+
+export interface PlanOwnStreamMirrorInput {
+  status: OwnStreamMirrorStatus;
+  /** The own tab's live assistant message (useChat's local state), or undefined when not actively streaming. */
+  ownAssistantMessage: { id: string; parts: UIMessagePart[] } | undefined;
+  /** The messageId `usePendingStreamsStore` currently mirrors for this tab, or undefined. */
+  mirroredMessageId: string | undefined;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string };
+  startedAt: string;
+  /** Caller-tracked monotonic counter, bumped once per mirror tick — threaded into `setStreamParts`'s `seq` gate. */
+  seq: number;
+}
+
+export type OwnStreamMirrorOp =
+  | {
+      type: 'addStream';
+      stream: {
+        messageId: string;
+        pageId: string;
+        conversationId: string;
+        triggeredBy: { userId: string; displayName: string };
+        isOwn: true;
+        startedAt: string;
+      };
+    }
+  | { type: 'setStreamParts'; messageId: string; parts: UIMessagePart[]; seq: number }
+  | { type: 'removeStream'; messageId: string };
+
+/**
+ * Computes the idempotent `usePendingStreamsStore` ops needed to mirror the
+ * own tab's actively-streaming assistant message. Pure — the caller (
+ * `useOwnStreamMirror`) applies the returned ops via the store's own
+ * (already-idempotent) actions, so calling this repeatedly with the same or
+ * stale input is always safe: `addStream` no-ops on an existing id,
+ * `setStreamParts` no-ops on a non-advancing `seq`, `removeStream` no-ops on
+ * an absent id.
+ */
+export const planOwnStreamMirror = (input: PlanOwnStreamMirrorInput): OwnStreamMirrorOp[] => {
+  const isActive =
+    (input.status === 'submitted' || input.status === 'streaming') && input.ownAssistantMessage !== undefined;
+
+  if (!isActive) {
+    return input.mirroredMessageId !== undefined
+      ? [{ type: 'removeStream', messageId: input.mirroredMessageId }]
+      : [];
+  }
+
+  const { id, parts } = input.ownAssistantMessage as { id: string; parts: UIMessagePart[] };
+  const ops: OwnStreamMirrorOp[] = [];
+
+  if (input.mirroredMessageId !== id) {
+    if (input.mirroredMessageId !== undefined) {
+      ops.push({ type: 'removeStream', messageId: input.mirroredMessageId });
+    }
+    ops.push({
+      type: 'addStream',
+      stream: {
+        messageId: id,
+        pageId: input.pageId,
+        conversationId: input.conversationId,
+        triggeredBy: input.triggeredBy,
+        isOwn: true,
+        startedAt: input.startedAt,
+      },
+    });
+  }
+
+  ops.push({ type: 'setStreamParts', messageId: id, parts, seq: input.seq });
+
+  return ops;
+};

--- a/apps/web/src/lib/ai/streams/planOwnStreamMirror.ts
+++ b/apps/web/src/lib/ai/streams/planOwnStreamMirror.ts
@@ -40,6 +40,25 @@ export type OwnStreamMirrorOp =
   | { type: 'removeStream'; messageId: string };
 
 /**
+ * Whether the own tab currently has a live stream to mirror. `useChat`
+ * typically retains the completed assistant message in local history after
+ * a stream finishes, so `ownAssistantMessage !== undefined` alone is NOT a
+ * reliable activity signal — `status` must also be submitted/streaming.
+ * Exported (not just an internal check) so `useOwnStreamMirror` can use the
+ * exact same definition when deciding whether to clear its `mirroredIdRef`
+ * — computing that from `ownAssistantMessage?.id` alone previously left the
+ * ref pointing at a completed stream's id, which then made a continuation
+ * request reusing that same server-issued id (a real SDK behavior this PR
+ * pins in `sdkServerIdAdoption.test.ts`) silently fail to re-mirror, since
+ * `planOwnStreamMirror` saw a matching `mirroredMessageId` and skipped
+ * `addStream` against a store entry that had already been removed.
+ */
+export const isOwnStreamMirrorActive = (
+  status: OwnStreamMirrorStatus,
+  ownAssistantMessage: { id: string; parts: UIMessagePart[] } | undefined,
+): boolean => (status === 'submitted' || status === 'streaming') && ownAssistantMessage !== undefined;
+
+/**
  * Computes the idempotent `usePendingStreamsStore` ops needed to mirror the
  * own tab's actively-streaming assistant message. Pure — the caller (
  * `useOwnStreamMirror`) applies the returned ops via the store's own
@@ -49,8 +68,7 @@ export type OwnStreamMirrorOp =
  * an absent id.
  */
 export const planOwnStreamMirror = (input: PlanOwnStreamMirrorInput): OwnStreamMirrorOp[] => {
-  const isActive =
-    (input.status === 'submitted' || input.status === 'streaming') && input.ownAssistantMessage !== undefined;
+  const isActive = isOwnStreamMirrorActive(input.status, input.ownAssistantMessage);
 
   if (!isActive) {
     return input.mirroredMessageId !== undefined

--- a/apps/web/src/lib/ai/streams/selectRenderedMessages.ts
+++ b/apps/web/src/lib/ai/streams/selectRenderedMessages.ts
@@ -1,0 +1,59 @@
+import type { UIMessage } from 'ai';
+import type { ConversationCacheEntry } from '@/stores/conversationMessages/seedEmpty';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+import { synthesizeAssistantMessage } from './synthesizeAssistantMessage';
+
+export type RenderedMessageMode = 'confirmed' | 'optimistic' | 'streaming';
+
+export interface RenderedMessage {
+  message: UIMessage;
+  mode: RenderedMessageMode;
+}
+
+/**
+ * The store-first render selector (epic architecture decision:
+ * `selectRenderedMessages(conversationCache, activeStreams)`). Merges one
+ * conversation's cache entry with its live stream mirror into the list a
+ * surface renders — merge-at-render, so no effect ordering can blank a live
+ * stream.
+ *
+ * Cache wins on id collision: a stream whose `messageId` already appears in
+ * `messages` or `optimisticSends` is dropped, so a stream that has landed
+ * (or reconciled into an optimistic send) never double-renders. `messages`
+ * are assumed pre-ordered (DB order); `optimisticSends` render in send
+ * order after them; remaining streams are ordered by `startedAt` among
+ * themselves and rendered last.
+ *
+ * `activeStreams` must already be filtered to this conversation by the
+ * caller (`selectChannelRemoteStreams` + conversationId filter) — this
+ * function does no channel/conversation filtering of its own.
+ */
+export const selectRenderedMessages = (
+  cacheEntry: ConversationCacheEntry,
+  activeStreams: readonly PendingStream[],
+): RenderedMessage[] => {
+  const cacheIds = new Set([
+    ...cacheEntry.messages.map((m) => m.id),
+    ...cacheEntry.optimisticSends.map((m) => m.id),
+  ]);
+
+  const confirmed: RenderedMessage[] = cacheEntry.messages.map((message) => ({
+    message,
+    mode: 'confirmed' as const,
+  }));
+  const optimistic: RenderedMessage[] = cacheEntry.optimisticSends.map((message) => ({
+    message,
+    mode: 'optimistic' as const,
+  }));
+
+  const streaming: RenderedMessage[] = activeStreams
+    .filter((s) => !cacheIds.has(s.messageId))
+    .slice()
+    .sort((a, b) => (a.startedAt ?? '').localeCompare(b.startedAt ?? ''))
+    .map((s) => ({
+      message: synthesizeAssistantMessage(s.messageId, s.parts, s.startedAt),
+      mode: 'streaming' as const,
+    }));
+
+  return [...confirmed, ...optimistic, ...streaming];
+};

--- a/apps/web/src/lib/ai/streams/selectRenderedMessages.ts
+++ b/apps/web/src/lib/ai/streams/selectRenderedMessages.ts
@@ -2,6 +2,7 @@ import type { UIMessage } from 'ai';
 import type { ConversationCacheEntry } from '@/stores/conversationMessages/seedEmpty';
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 import { synthesizeAssistantMessage } from './synthesizeAssistantMessage';
+import { dedupRemoteStreams } from './dedupRemoteStreams';
 
 export type RenderedMessageMode = 'confirmed' | 'optimistic' | 'streaming';
 
@@ -18,11 +19,18 @@ export interface RenderedMessage {
  * stream.
  *
  * Cache wins on id collision: a stream whose `messageId` already appears in
- * `messages` or `optimisticSends` is dropped, so a stream that has landed
- * (or reconciled into an optimistic send) never double-renders. `messages`
- * are assumed pre-ordered (DB order); `optimisticSends` render in send
- * order after them; remaining streams are ordered by `startedAt` among
- * themselves and rendered last.
+ * `messages` or `optimisticSends` is dropped (reuses `dedupRemoteStreams`),
+ * so a stream that has landed (or reconciled into an optimistic send) never
+ * double-renders. `messages` are assumed pre-ordered (DB order);
+ * `optimisticSends` render in send order after them; remaining streams are
+ * ordered by `startedAt` among themselves and rendered last.
+ *
+ * Doesn't reuse `mergeServerAndPending` for the streaming tail: that helper
+ * is single-stream (one `pendingMessageId`), but this selector must support
+ * N concurrent streams per conversation (own + remote + bootstrapped, per
+ * the epic's `usePendingStreamsStore` reshape) — it bottoms out at the same
+ * `synthesizeAssistantMessage` primitive `mergeServerAndPending` itself
+ * delegates to, recomposed with a sort for the multi-stream case.
  *
  * `activeStreams` must already be filtered to this conversation by the
  * caller (`selectChannelRemoteStreams` + conversationId filter) — this
@@ -32,11 +40,6 @@ export const selectRenderedMessages = (
   cacheEntry: ConversationCacheEntry,
   activeStreams: readonly PendingStream[],
 ): RenderedMessage[] => {
-  const cacheIds = new Set([
-    ...cacheEntry.messages.map((m) => m.id),
-    ...cacheEntry.optimisticSends.map((m) => m.id),
-  ]);
-
   const confirmed: RenderedMessage[] = cacheEntry.messages.map((message) => ({
     message,
     mode: 'confirmed' as const,
@@ -46,8 +49,10 @@ export const selectRenderedMessages = (
     mode: 'optimistic' as const,
   }));
 
-  const streaming: RenderedMessage[] = activeStreams
-    .filter((s) => !cacheIds.has(s.messageId))
+  const streaming: RenderedMessage[] = dedupRemoteStreams(activeStreams, [
+    ...cacheEntry.messages,
+    ...cacheEntry.optimisticSends,
+  ])
     .slice()
     .sort((a, b) => (a.startedAt ?? '').localeCompare(b.startedAt ?? ''))
     .map((s) => ({

--- a/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
+++ b/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
@@ -18,7 +18,7 @@ describe('useConversationMessagesStore', () => {
 
   it('given a conversation never seen before, getEntry should return a seeded empty entry without mutating the store', () => {
     const entry = useConversationMessagesStore.getState().getEntry('c1');
-    expect(entry).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+    expect(entry).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] });
     expect(useConversationMessagesStore.getState().byConversationId.c1).toBeUndefined();
   });
 
@@ -73,6 +73,6 @@ describe('useConversationMessagesStore', () => {
   it('given actions against one conversation, should not affect another conversation entry', () => {
     const { addOptimisticSend, getEntry } = useConversationMessagesStore.getState();
     addOptimisticSend('c1', msg('opt1'));
-    expect(getEntry('c2')).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+    expect(getEntry('c2')).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] });
   });
 });

--- a/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
+++ b/apps/web/src/stores/__tests__/useConversationMessagesStore.test.ts
@@ -1,0 +1,78 @@
+/**
+ * useConversationMessagesStore Tests
+ *
+ * Wiring-only smoke tests: each action is a one-line shell over a pure
+ * `applyX` transition (see `stores/conversationMessages/__tests__/` for the
+ * exhaustive, mock-free behavioral coverage of those functions).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useConversationMessagesStore } from '../useConversationMessagesStore';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('useConversationMessagesStore', () => {
+  beforeEach(() => {
+    useConversationMessagesStore.setState({ byConversationId: {} });
+  });
+
+  it('given a conversation never seen before, getEntry should return a seeded empty entry without mutating the store', () => {
+    const entry = useConversationMessagesStore.getState().getEntry('c1');
+    expect(entry).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+    expect(useConversationMessagesStore.getState().byConversationId.c1).toBeUndefined();
+  });
+
+  it('given startLoad then applyLoad with the returned generation, should commit the loaded messages', () => {
+    const { startLoad, applyLoad, getEntry } = useConversationMessagesStore.getState();
+    const generation = startLoad('c1');
+    applyLoad('c1', generation, [msg('m1')]);
+    expect(getEntry('c1').messages).toEqual([msg('m1')]);
+  });
+
+  it('given failLoad after startLoad, should leave the prior entry unchanged', () => {
+    const { startLoad, applyLoad, failLoad, getEntry } = useConversationMessagesStore.getState();
+    const gen1 = startLoad('c1');
+    applyLoad('c1', gen1, [msg('m1')]);
+    const gen2 = startLoad('c1');
+    failLoad('c1', gen2);
+    expect(getEntry('c1').messages).toEqual([msg('m1')]);
+  });
+
+  it('given addOptimisticSend, should track the message in optimisticSends', () => {
+    const { addOptimisticSend, getEntry } = useConversationMessagesStore.getState();
+    addOptimisticSend('c1', msg('opt1'));
+    expect(getEntry('c1').optimisticSends).toEqual([msg('opt1')]);
+  });
+
+  it('given applyRemoteUserMessage for an id matching an optimistic send, should reconcile it into messages', () => {
+    const { addOptimisticSend, applyRemoteUserMessage, getEntry } = useConversationMessagesStore.getState();
+    addOptimisticSend('c1', msg('opt1'));
+    applyRemoteUserMessage('c1', msg('opt1'));
+    const entry = getEntry('c1');
+    expect(entry.messages).toEqual([msg('opt1')]);
+    expect(entry.optimisticSends).toEqual([]);
+  });
+
+  it('given applyEdit for a confirmed message, should update its parts', () => {
+    const { startLoad, applyLoad, applyEdit, getEntry } = useConversationMessagesStore.getState();
+    const gen = startLoad('c1');
+    applyLoad('c1', gen, [msg('m1')]);
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
+    applyEdit('c1', { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt });
+    expect(getEntry('c1').messages[0]).toMatchObject({ parts: [{ type: 'text', text: 'edited' }], editedAt });
+  });
+
+  it('given applyDelete for a confirmed message, should remove it', () => {
+    const { startLoad, applyLoad, applyDelete, getEntry } = useConversationMessagesStore.getState();
+    const gen = startLoad('c1');
+    applyLoad('c1', gen, [msg('m1'), msg('m2')]);
+    applyDelete('c1', 'm1');
+    expect(getEntry('c1').messages).toEqual([msg('m2')]);
+  });
+
+  it('given actions against one conversation, should not affect another conversation entry', () => {
+    const { addOptimisticSend, getEntry } = useConversationMessagesStore.getState();
+    addOptimisticSend('c1', msg('opt1'));
+    expect(getEntry('c2')).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+  });
+});

--- a/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
+++ b/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
@@ -221,4 +221,30 @@ describe('usePendingStreamsStore', () => {
       expect(getOwnStreams('page-empty')).toEqual([]);
     });
   });
+
+  describe('setStreamParts', () => {
+    it('given an existing stream, should replace parts wholesale rather than merge', () => {
+      const { addStream, setStreamParts, getRemotePageStreams } = usePendingStreamsStore.getState();
+      addStream({ ...BASE_STREAM, parts: [text('a')] });
+      setStreamParts('msg-1', [text('a'), text('b')], 1);
+
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.parts).toEqual([text('a'), text('b')]);
+    });
+
+    it('given a stale seq (not greater than the last write), should drop the write', () => {
+      const { addStream, setStreamParts, getRemotePageStreams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      setStreamParts('msg-1', [text('newer')], 5);
+      setStreamParts('msg-1', [text('stale')], 4);
+
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.parts).toEqual([text('newer')]);
+    });
+
+    it('given an unknown messageId, should not throw', () => {
+      const { setStreamParts } = usePendingStreamsStore.getState();
+      expect(() => setStreamParts('unknown', [text('x')], 1)).not.toThrow();
+    });
+  });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
@@ -34,4 +34,20 @@ describe('applyConversationDelete', () => {
     const result = applyConversationDelete({}, { conversationId: 'c1', messageId: 'm1' });
     expect(result).toEqual({});
   });
+
+  it('given an actual delete, should bump loadGeneration so an in-flight load snapshotted before this delete cannot later resurrect the row', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
+    expect(result.c1.loadGeneration).toBe(2);
+  });
+
+  it('given a no-op delete (id present in neither array), should not bump loadGeneration', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
+    expect(result.c1.loadGeneration).toBe(1);
+  });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyConversationDelete', () => {
   it('given a matching id in confirmed messages, should remove it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
     expect(result.c1.messages).toEqual([msg('m2')]);
@@ -16,7 +16,7 @@ describe('applyConversationDelete', () => {
 
   it('given a matching id in optimisticSends, should remove it from there too', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
     expect(result.c1.optimisticSends).toEqual([]);
@@ -24,7 +24,7 @@ describe('applyConversationDelete', () => {
 
   it('given an id present in neither, should no-op and return the same reference', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
     expect(result).toBe(initial);
@@ -35,19 +35,35 @@ describe('applyConversationDelete', () => {
     expect(result).toEqual({});
   });
 
-  it('given an actual delete, should bump loadGeneration so an in-flight load snapshotted before this delete cannot later resurrect the row', () => {
+  it('given an actual delete of a confirmed message, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
-    expect(result.c1.loadGeneration).toBe(2);
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'm1' }]);
   });
 
-  it('given a no-op delete (id present in neither array), should not bump loadGeneration', () => {
+  it('given a delete that only removed an optimistic (unconfirmed) send, should NOT record a pending mutation (it can never appear in a DB snapshot)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+  });
+
+  it('given a no-op delete (id present in neither array), should not record a pending mutation', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+  });
+
+  it('given an actual delete, should NOT bump loadGeneration (a fresh load already reflecting this delete must not be invalidated)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
     expect(result.c1.loadGeneration).toBe(1);
   });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
@@ -22,12 +22,13 @@ describe('applyConversationDelete', () => {
     expect(result.c1.optimisticSends).toEqual([]);
   });
 
-  it('given an id present in neither, should no-op and return the same reference', () => {
+  it('given an id present in neither array, should leave messages and optimisticSends unchanged (applyMessageDelete no-ops)', () => {
     const initial: ConversationMessagesById = {
       c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
-    expect(result).toBe(initial);
+    expect(result.c1.messages).toBe(initial.c1.messages);
+    expect(result.c1.optimisticSends).toBe(initial.c1.optimisticSends);
   });
 
   it('given a conversation not tracked at all, should no-op', () => {
@@ -43,20 +44,20 @@ describe('applyConversationDelete', () => {
     expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'm1' }]);
   });
 
-  it('given a delete that only removed an optimistic (unconfirmed) send, should NOT record a pending mutation (it can never appear in a DB snapshot)', () => {
+  it('given a delete that only removed an optimistic (unconfirmed) send, should STILL record the pending mutation (Codex finding: the send may already be persisted server-side despite not yet being reconciled into messages locally, so a stale load could resurrect it)', () => {
     const initial: ConversationMessagesById = {
       c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
-    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'opt1' }]);
   });
 
-  it('given a no-op delete (id present in neither array), should not record a pending mutation', () => {
+  it('given a delete for an id not locally known at all (neither array), should STILL record the pending mutation (a fully unknown message can still exist in a stale in-flight load snapshot)', () => {
     const initial: ConversationMessagesById = {
       c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
-    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
-    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'never-seen' });
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'delete', messageId: 'never-seen' }]);
   });
 
   it('given an actual delete, should NOT bump loadGeneration (a fresh load already reflecting this delete must not be invalidated)', () => {

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationDelete.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { applyConversationDelete } from '../applyConversationDelete';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('applyConversationDelete', () => {
+  it('given a matching id in confirmed messages, should remove it', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'm1' });
+    expect(result.c1.messages).toEqual([msg('m2')]);
+  });
+
+  it('given a matching id in optimisticSends, should remove it from there too', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'opt1' });
+    expect(result.c1.optimisticSends).toEqual([]);
+  });
+
+  it('given an id present in neither, should no-op and return the same reference', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationDelete(initial, { conversationId: 'c1', messageId: 'missing' });
+    expect(result).toBe(initial);
+  });
+
+  it('given a conversation not tracked at all, should no-op', () => {
+    const result = applyConversationDelete({}, { conversationId: 'c1', messageId: 'm1' });
+    expect(result).toEqual({});
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { applyConversationEdit } from '../applyConversationEdit';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string, text: string): UIMessage => ({ id, role: 'user', parts: [{ type: 'text', text }] });
+
+describe('applyConversationEdit', () => {
+  it('given a matching messageId in a tracked conversation, should replace its parts and stamp editedAt', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt },
+    });
+    expect(result.c1.messages[0]).toMatchObject({ id: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt });
+  });
+
+  it('given a messageId not present, should no-op and return the same reference', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'missing', parts: [], editedAt: new Date() },
+    });
+    expect(result).toBe(initial);
+  });
+
+  it('given a conversation not tracked at all, should no-op', () => {
+    const result = applyConversationEdit(
+      {},
+      { conversationId: 'c1', payload: { messageId: 'm1', parts: [], editedAt: new Date() } },
+    );
+    expect(result).toEqual({});
+  });
+
+  it('given other conversations tracked, should not touch them', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+      other: { messages: [msg('x', 'y')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt: new Date() },
+    });
+    expect(result.other).toBe(initial.other);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string, text: string): UIMessage => ({ id, role: 'user', parts:
 describe('applyConversationEdit', () => {
   it('given a matching messageId in a tracked conversation, should replace its parts and stamp editedAt', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
@@ -20,7 +20,7 @@ describe('applyConversationEdit', () => {
 
   it('given a messageId not present, should no-op and return the same reference', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
@@ -39,8 +39,8 @@ describe('applyConversationEdit', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
-      other: { messages: [msg('x', 'y')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+      other: { messages: [msg('x', 'y')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
@@ -49,24 +49,38 @@ describe('applyConversationEdit', () => {
     expect(result.other).toBe(initial.other);
   });
 
-  it('given an actual edit, should bump loadGeneration so an in-flight load snapshotted before this edit cannot later clobber it', () => {
+  it('given an actual edit, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
-      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt: new Date() },
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt },
     });
-    expect(result.c1.loadGeneration).toBe(2);
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([
+      { type: 'edit', payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt } },
+    ]);
   });
 
-  it('given a no-op edit (messageId not present), should not bump loadGeneration', () => {
+  it('given a no-op edit (messageId not present), should not record a pending mutation', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
       payload: { messageId: 'missing', parts: [], editedAt: new Date() },
+    });
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+  });
+
+  it('given an actual edit, should NOT bump loadGeneration (a fresh load already covering this edit must not be invalidated)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+    };
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt: new Date() },
     });
     expect(result.c1.loadGeneration).toBe(1);
   });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
@@ -48,4 +48,26 @@ describe('applyConversationEdit', () => {
     });
     expect(result.other).toBe(initial.other);
   });
+
+  it('given an actual edit, should bump loadGeneration so an in-flight load snapshotted before this edit cannot later clobber it', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt: new Date() },
+    });
+    expect(result.c1.loadGeneration).toBe(2);
+  });
+
+  it('given a no-op edit (messageId not present), should not bump loadGeneration', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyConversationEdit(initial, {
+      conversationId: 'c1',
+      payload: { messageId: 'missing', parts: [], editedAt: new Date() },
+    });
+    expect(result.c1.loadGeneration).toBe(1);
+  });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyConversationEdit.test.ts
@@ -18,7 +18,7 @@ describe('applyConversationEdit', () => {
     expect(result.c1.messages[0]).toMatchObject({ id: 'm1', parts: [{ type: 'text', text: 'new' }], editedAt });
   });
 
-  it('given a messageId not present, should no-op and return the same reference', () => {
+  it('given a messageId not present, should leave messages unchanged (applyMessageEdit no-ops)', () => {
     const initial: ConversationMessagesById = {
       c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
@@ -26,7 +26,7 @@ describe('applyConversationEdit', () => {
       conversationId: 'c1',
       payload: { messageId: 'missing', parts: [], editedAt: new Date() },
     });
-    expect(result).toBe(initial);
+    expect(result.c1.messages).toBe(initial.c1.messages);
   });
 
   it('given a conversation not tracked at all, should no-op', () => {
@@ -63,15 +63,18 @@ describe('applyConversationEdit', () => {
     ]);
   });
 
-  it('given a no-op edit (messageId not present), should not record a pending mutation', () => {
+  it('given an edit for a messageId not present yet (e.g. conversation still loading), should STILL record the pending mutation for later replay (Codex finding: dropping it here would let a stale load undo the edit once the row appears)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
     const result = applyConversationEdit(initial, {
       conversationId: 'c1',
-      payload: { messageId: 'missing', parts: [], editedAt: new Date() },
+      payload: { messageId: 'not-yet-loaded', parts: [{ type: 'text', text: 'new' }], editedAt },
     });
-    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([
+      { type: 'edit', payload: { messageId: 'not-yet-loaded', parts: [{ type: 'text', text: 'new' }], editedAt } },
+    ]);
   });
 
   it('given an actual edit, should NOT bump loadGeneration (a fresh load already covering this edit must not be invalidated)', () => {

--- a/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyFailLoad', () => {
   it('given an entry with existing messages, should keep them unchanged (never clear to empty on a failed reload)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [msg('opt1')], loadGeneration: 2 },
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [msg('opt1')], loadGeneration: 2, pendingMutationsSinceLoad: [] },
     };
     const result = applyFailLoad(initial, { conversationId: 'c1', generation: 2 });
     expect(result).toBe(initial);
@@ -18,7 +18,7 @@ describe('applyFailLoad', () => {
 
   it('given a stale generation, should also keep prior state unchanged', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 3 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [] },
     };
     const result = applyFailLoad(initial, { conversationId: 'c1', generation: 1 });
     expect(result).toBe(initial);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyFailLoad.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { applyFailLoad } from '../applyFailLoad';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('applyFailLoad', () => {
+  it('given an entry with existing messages, should keep them unchanged (never clear to empty on a failed reload)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [msg('opt1')], loadGeneration: 2 },
+    };
+    const result = applyFailLoad(initial, { conversationId: 'c1', generation: 2 });
+    expect(result).toBe(initial);
+    expect(result.c1.messages).toEqual([msg('m1'), msg('m2')]);
+    expect(result.c1.optimisticSends).toEqual([msg('opt1')]);
+  });
+
+  it('given a stale generation, should also keep prior state unchanged', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 3 },
+    };
+    const result = applyFailLoad(initial, { conversationId: 'c1', generation: 1 });
+    expect(result).toBe(initial);
+  });
+
+  it('given a conversation not tracked at all, should no-op safely', () => {
+    const result = applyFailLoad({}, { conversationId: 'unknown', generation: 1 });
+    expect(result).toEqual({});
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
@@ -8,7 +8,7 @@ const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
 describe('applyLoad', () => {
   it('given the current generation, should replace messages with the loaded set', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1'), msg('m2')] });
     expect(result.c1.messages).toEqual([msg('m1'), msg('m2')]);
@@ -16,7 +16,7 @@ describe('applyLoad', () => {
 
   it('given a stale generation (a newer load has since started), should no-op and return the same reference', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 2 },
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 2, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result).toBe(initial);
@@ -29,7 +29,7 @@ describe('applyLoad', () => {
 
   it('given an optimistic send whose id now appears in the loaded set, should reconcile it out of optimisticSends', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, {
       conversationId: 'c1',
@@ -41,7 +41,7 @@ describe('applyLoad', () => {
 
   it('given no optimistic sends match the loaded set, should leave optimisticSends untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
     expect(result.c1.optimisticSends).toEqual([msg('opt1')]);
@@ -49,7 +49,7 @@ describe('applyLoad', () => {
 
   it('given a fresh load, should preserve the loadGeneration value', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 5 },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 5, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 5, messages: [msg('m1')] });
     expect(result.c1.loadGeneration).toBe(5);
@@ -57,8 +57,8 @@ describe('applyLoad', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1 },
-      other: { messages: [msg('x')], optimisticSends: [], loadGeneration: 9 },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+      other: { messages: [msg('x')], optimisticSends: [], loadGeneration: 9, pendingMutationsSinceLoad: [] },
     };
     const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [] });
     expect(result.other).toBe(initial.other);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyLoad.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { applyLoad } from '../applyLoad';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('applyLoad', () => {
+  it('given the current generation, should replace messages with the loaded set', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1'), msg('m2')] });
+    expect(result.c1.messages).toEqual([msg('m1'), msg('m2')]);
+  });
+
+  it('given a stale generation (a newer load has since started), should no-op and return the same reference', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('old')], optimisticSends: [], loadGeneration: 2 },
+    };
+    const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
+    expect(result).toBe(initial);
+  });
+
+  it('given a conversation never started via startLoad, should no-op', () => {
+    const result = applyLoad({}, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
+    expect(result).toEqual({});
+  });
+
+  it('given an optimistic send whose id now appears in the loaded set, should reconcile it out of optimisticSends', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1 },
+    };
+    const result = applyLoad(initial, {
+      conversationId: 'c1',
+      generation: 1,
+      messages: [msg('opt1')],
+    });
+    expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
+  });
+
+  it('given no optimistic sends match the loaded set, should leave optimisticSends untouched', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1 },
+    };
+    const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [msg('m1')] });
+    expect(result.c1.optimisticSends).toEqual([msg('opt1')]);
+  });
+
+  it('given a fresh load, should preserve the loadGeneration value', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [], loadGeneration: 5 },
+    };
+    const result = applyLoad(initial, { conversationId: 'c1', generation: 5, messages: [msg('m1')] });
+    expect(result.c1.loadGeneration).toBe(5);
+  });
+
+  it('given other conversations tracked, should not touch them', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1 },
+      other: { messages: [msg('x')], optimisticSends: [], loadGeneration: 9 },
+    };
+    const result = applyLoad(initial, { conversationId: 'c1', generation: 1, messages: [] });
+    expect(result.other).toBe(initial.other);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
@@ -14,7 +14,7 @@ describe('applyOptimisticSend', () => {
 
   it('given existing optimistic sends, should append after them (send order)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt2') });
     expect(result.c1.optimisticSends).toEqual([msg('opt1'), msg('opt2')]);
@@ -22,7 +22,7 @@ describe('applyOptimisticSend', () => {
 
   it('given a message id already present in optimisticSends, should no-op (idempotent)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result).toBe(initial);
@@ -30,7 +30,7 @@ describe('applyOptimisticSend', () => {
 
   it('given a message id already present in confirmed messages, should no-op', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result).toBe(initial);
@@ -38,7 +38,7 @@ describe('applyOptimisticSend', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      other: { messages: [], optimisticSends: [], loadGeneration: 0 },
+      other: { messages: [], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.other).toBe(initial.other);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyOptimisticSend.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { applyOptimisticSend } from '../applyOptimisticSend';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('applyOptimisticSend', () => {
+  it('given a conversation never seen before, should seed it and append the message', () => {
+    const result = applyOptimisticSend({}, { conversationId: 'c1', message: msg('opt1') });
+    expect(result.c1.optimisticSends).toEqual([msg('opt1')]);
+    expect(result.c1.messages).toEqual([]);
+  });
+
+  it('given existing optimistic sends, should append after them (send order)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+    };
+    const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt2') });
+    expect(result.c1.optimisticSends).toEqual([msg('opt1'), msg('opt2')]);
+  });
+
+  it('given a message id already present in optimisticSends, should no-op (idempotent)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0 },
+    };
+    const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
+    expect(result).toBe(initial);
+  });
+
+  it('given a message id already present in confirmed messages, should no-op', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('m1') });
+    expect(result).toBe(initial);
+  });
+
+  it('given other conversations tracked, should not touch them', () => {
+    const initial: ConversationMessagesById = {
+      other: { messages: [], optimisticSends: [], loadGeneration: 0 },
+    };
+    const result = applyOptimisticSend(initial, { conversationId: 'c1', message: msg('opt1') });
+    expect(result.other).toBe(initial.other);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { applyRemoteUserMessage } from '../applyRemoteUserMessage';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string): UIMessage => ({ id, role: 'user', parts: [] });
+
+describe('applyRemoteUserMessage', () => {
+  it('given a conversation never seen before, should seed it and append the message', () => {
+    const result = applyRemoteUserMessage({}, { conversationId: 'c1', message: msg('m1') });
+    expect(result.c1.messages).toEqual([msg('m1')]);
+  });
+
+  it('given the id already confirmed, should no-op (duplicate broadcast)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
+    expect(result).toBe(initial);
+  });
+
+  it('given the id matches an optimistic send (own echo), should append to messages and reconcile it out of optimisticSends', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1 },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
+    expect(result.c1.messages).toEqual([msg('opt1')]);
+    expect(result.c1.optimisticSends).toEqual([]);
+  });
+
+  it('given other optimistic sends unrelated to the broadcast id, should leave them untouched', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1 },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
+    expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
@@ -35,4 +35,20 @@ describe('applyRemoteUserMessage', () => {
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
   });
+
+  it('given an actual append, should bump loadGeneration so an in-flight load snapshotted before this broadcast cannot later clobber it', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
+    expect(result.c1.loadGeneration).toBe(2);
+  });
+
+  it('given a duplicate broadcast (no-op), should not bump loadGeneration', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
+    expect(result.c1.loadGeneration).toBe(1);
+  });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyRemoteUserMessage.test.ts
@@ -13,7 +13,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given the id already confirmed, should no-op (duplicate broadcast)', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result).toBe(initial);
@@ -21,7 +21,7 @@ describe('applyRemoteUserMessage', () => {
 
   it('given the id matches an optimistic send (own echo), should append to messages and reconcile it out of optimisticSends', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.messages).toEqual([msg('opt1')]);
@@ -30,23 +30,31 @@ describe('applyRemoteUserMessage', () => {
 
   it('given other optimistic sends unrelated to the broadcast id, should leave them untouched', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [msg('opt1'), msg('opt2')], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('opt1') });
     expect(result.c1.optimisticSends).toEqual([msg('opt2')]);
   });
 
-  it('given an actual append, should bump loadGeneration so an in-flight load snapshotted before this broadcast cannot later clobber it', () => {
+  it('given an actual append, should record it in pendingMutationsSinceLoad so an in-flight load can replay it', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
-    expect(result.c1.loadGeneration).toBe(2);
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([{ type: 'remoteMessage', message: msg('m1') }]);
   });
 
-  it('given a duplicate broadcast (no-op), should not bump loadGeneration', () => {
+  it('given a duplicate broadcast (no-op), should not record a pending mutation', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1 },
+      c1: { messages: [msg('m1')], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
+    };
+    const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
+    expect(result.c1.pendingMutationsSinceLoad).toEqual([]);
+  });
+
+  it('given an actual append, should NOT bump loadGeneration (a fresh load already covering this message must not be invalidated)', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [], loadGeneration: 1, pendingMutationsSinceLoad: [] },
     };
     const result = applyRemoteUserMessage(initial, { conversationId: 'c1', message: msg('m1') });
     expect(result.c1.loadGeneration).toBe(1);

--- a/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
@@ -6,12 +6,22 @@ describe('applyStartLoad', () => {
   it('given a conversation never seen before, should seed it and return generation 1', () => {
     const { byConversationId, generation } = applyStartLoad({}, 'c1');
     expect(generation).toBe(1);
-    expect(byConversationId.c1).toEqual({ messages: [], optimisticSends: [], loadGeneration: 1 });
+    expect(byConversationId.c1).toEqual({
+      messages: [],
+      optimisticSends: [],
+      loadGeneration: 1,
+      pendingMutationsSinceLoad: [],
+    });
   });
 
   it('given a conversation already at generation 1, should bump to generation 2', () => {
     const initial: ConversationMessagesById = {
-      c1: { messages: [{ id: 'm1', role: 'user', parts: [] }], optimisticSends: [], loadGeneration: 1 },
+      c1: {
+        messages: [{ id: 'm1', role: 'user', parts: [] }],
+        optimisticSends: [],
+        loadGeneration: 1,
+        pendingMutationsSinceLoad: [],
+      },
     };
     const { byConversationId, generation } = applyStartLoad(initial, 'c1');
     expect(generation).toBe(2);
@@ -24,6 +34,7 @@ describe('applyStartLoad', () => {
         messages: [{ id: 'm1', role: 'user', parts: [] }],
         optimisticSends: [{ id: 'opt1', role: 'user', parts: [] }],
         loadGeneration: 1,
+        pendingMutationsSinceLoad: [],
       },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');
@@ -33,9 +44,22 @@ describe('applyStartLoad', () => {
 
   it('given other conversations tracked, should not touch them', () => {
     const initial: ConversationMessagesById = {
-      other: { messages: [], optimisticSends: [], loadGeneration: 3 },
+      other: { messages: [], optimisticSends: [], loadGeneration: 3, pendingMutationsSinceLoad: [] },
     };
     const { byConversationId } = applyStartLoad(initial, 'c1');
     expect(byConversationId.other).toBe(initial.other);
+  });
+
+  it('given pending mutations recorded under the previous generation, should reset them on a new startLoad', () => {
+    const initial: ConversationMessagesById = {
+      c1: {
+        messages: [],
+        optimisticSends: [],
+        loadGeneration: 1,
+        pendingMutationsSinceLoad: [{ type: 'remoteMessage', message: { id: 'm1', role: 'user', parts: [] } }],
+      },
+    };
+    const { byConversationId } = applyStartLoad(initial, 'c1');
+    expect(byConversationId.c1.pendingMutationsSinceLoad).toEqual([]);
   });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/applyStartLoad.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { applyStartLoad } from '../applyStartLoad';
+import type { ConversationMessagesById } from '../seedEmpty';
+
+describe('applyStartLoad', () => {
+  it('given a conversation never seen before, should seed it and return generation 1', () => {
+    const { byConversationId, generation } = applyStartLoad({}, 'c1');
+    expect(generation).toBe(1);
+    expect(byConversationId.c1).toEqual({ messages: [], optimisticSends: [], loadGeneration: 1 });
+  });
+
+  it('given a conversation already at generation 1, should bump to generation 2', () => {
+    const initial: ConversationMessagesById = {
+      c1: { messages: [{ id: 'm1', role: 'user', parts: [] }], optimisticSends: [], loadGeneration: 1 },
+    };
+    const { byConversationId, generation } = applyStartLoad(initial, 'c1');
+    expect(generation).toBe(2);
+    expect(byConversationId.c1.loadGeneration).toBe(2);
+  });
+
+  it('given a bump, should preserve existing messages and optimisticSends untouched', () => {
+    const initial: ConversationMessagesById = {
+      c1: {
+        messages: [{ id: 'm1', role: 'user', parts: [] }],
+        optimisticSends: [{ id: 'opt1', role: 'user', parts: [] }],
+        loadGeneration: 1,
+      },
+    };
+    const { byConversationId } = applyStartLoad(initial, 'c1');
+    expect(byConversationId.c1.messages).toBe(initial.c1.messages);
+    expect(byConversationId.c1.optimisticSends).toBe(initial.c1.optimisticSends);
+  });
+
+  it('given other conversations tracked, should not touch them', () => {
+    const initial: ConversationMessagesById = {
+      other: { messages: [], optimisticSends: [], loadGeneration: 3 },
+    };
+    const { byConversationId } = applyStartLoad(initial, 'c1');
+    expect(byConversationId.other).toBe(initial.other);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
@@ -143,4 +143,55 @@ describe('applyLoad reconciliation with concurrent live mutations', () => {
     expect(store.c1.messages.map((m) => m.id)).toEqual(['m1', 'm3']);
     expect(store.c1.messages[0].parts).toEqual([{ type: 'text', text: 'v2' }]);
   });
+
+  it('given an edit broadcast arrives for a message not yet present locally (conversation still loading), should still apply once the load introduces it (Codex finding #4)', () => {
+    let store: ConversationMessagesById = {};
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    // Edit arrives before this client has ever seen m1 — messages is still empty.
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
+    store = applyConversationEdit(store, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt },
+    });
+    expect(store.c1.messages).toEqual([]);
+
+    // The in-flight load's stale snapshot predates the edit.
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1', 'original')] });
+
+    expect(store.c1.messages[0].parts).toEqual([{ type: 'text', text: 'edited' }]);
+  });
+
+  it('given a delete broadcast arrives for an id that only exists in optimisticSends locally, should still exclude it once the load resolves (Codex finding #5)', () => {
+    let store: ConversationMessagesById = {
+      c1: { messages: [], optimisticSends: [msg('opt1')], loadGeneration: 0, pendingMutationsSinceLoad: [] },
+    };
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    // opt1 was actually already persisted server-side by the time it's deleted,
+    // but this client hasn't reconciled it into `messages` yet — the delete
+    // only visibly changes optimisticSends.
+    store = applyConversationDelete(store, { conversationId: 'c1', messageId: 'opt1' });
+    expect(store.c1.messages).toEqual([]);
+    expect(store.c1.optimisticSends).toEqual([]);
+
+    // The in-flight load's snapshot independently includes opt1 (it really was persisted).
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('opt1')] });
+
+    expect(store.c1.messages.some((m) => m.id === 'opt1')).toBe(false);
+  });
+
+  it('given a delete broadcast arrives for an id this client has never seen at all, should still exclude it once a stale load resolves', () => {
+    let store: ConversationMessagesById = {};
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    store = applyConversationDelete(store, { conversationId: 'c1', messageId: 'never-seen' });
+
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('never-seen'), msg('m2')] });
+
+    expect(store.c1.messages.map((m) => m.id)).toEqual(['m2']);
+  });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
@@ -11,35 +11,56 @@ const msg = (id: string, text = ''): UIMessage => ({ id, role: 'user', parts: [{
 
 /**
  * Regression coverage for a race identified in PR #2075 review
- * (chatgpt-codex-connector, apps/web/src/stores/conversationMessages/applyLoad.ts:34):
- * a conversation load reads a DB snapshot BEFORE a live socket mutation lands,
- * but resolves (calls applyLoad) AFTER it. Because the load's `generation`
- * still matched, applyLoad used to unconditionally overwrite `messages` with
- * its (now-stale) snapshot, silently dropping the live mutation until the
- * next reload. Fixed by having every live-mutation transition
- * (applyRemoteUserMessage/applyConversationEdit/applyConversationDelete)
- * bump `loadGeneration` on an actual change, so the in-flight load's
- * generation goes stale and applyLoad correctly rejects it instead.
+ * (chatgpt-codex-connector). There is no ordering guarantee between a
+ * conversation load's DB snapshot and a live socket mutation for the same
+ * conversation — either can "win the race" against the other:
+ *
+ * - A first fix bumped `loadGeneration` on every live mutation so any
+ *   in-flight load became stale and got rejected. That closed the original
+ *   finding (a stale load clobbering a live append/edit/delete) but
+ *   over-corrected: a live mutation now also invalidated a load whose
+ *   response already reflected that same mutation (or was otherwise a
+ *   fully valid, later snapshot), discarding the ENTIRE load response —
+ *   including unrelated history the mutation knew nothing about.
+ * - The actual fix (`replayPendingMutations`): `loadGeneration` only guards
+ *   against a load superseded by a *newer `startLoad`* (unchanged, original
+ *   purpose). Live mutations no longer touch `loadGeneration` at all —
+ *   instead they're recorded in `pendingMutationsSinceLoad` and replayed
+ *   onto the load's snapshot when it resolves, so the result always
+ *   reflects both sources regardless of which arrived first.
  */
-describe('applyLoad race with concurrent live mutations', () => {
-  it('given a remote user message arrives while a load is in flight, should NOT be clobbered when the stale load resolves', () => {
+describe('applyLoad reconciliation with concurrent live mutations', () => {
+  it('given a remote user message arrives while a load is in flight and the stale snapshot predates it, should NOT be clobbered', () => {
     let store: ConversationMessagesById = {};
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
 
-    // Socket broadcast lands before the fetch resolves.
     store = applyRemoteUserMessage(store, { conversationId: 'c1', message: msg('live-1', 'hello') });
 
-    // The in-flight fetch resolves with the pre-broadcast DB snapshot.
     const staleSnapshot: UIMessage[] = [msg('m0', 'existing')];
     store = applyLoad(store, { conversationId: 'c1', generation, messages: staleSnapshot });
 
-    expect(store.c1.messages.some((m) => m.id === 'live-1')).toBe(true);
+    expect(store.c1.messages.map((m) => m.id)).toEqual(['m0', 'live-1']);
+  });
+
+  it('given a remote user message arrives and the load response ALSO already includes it (Codex finding: over-aggressive invalidation), should keep the full load response with no duplicate', () => {
+    let store: ConversationMessagesById = {};
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    store = applyRemoteUserMessage(store, { conversationId: 'c1', message: msg('shared-1', 'hi') });
+
+    // The fetch response is a fully fresh snapshot that independently already
+    // contains shared-1, plus unrelated history the live mutation never saw.
+    const freshSnapshot: UIMessage[] = [msg('historical-1'), msg('historical-2'), msg('shared-1', 'hi')];
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: freshSnapshot });
+
+    expect(store.c1.messages.map((m) => m.id)).toEqual(['historical-1', 'historical-2', 'shared-1']);
   });
 
   it('given an edit lands while a load is in flight, should NOT be undone when the stale load resolves', () => {
     let store: ConversationMessagesById = {
-      c1: { messages: [msg('m1', 'original')], optimisticSends: [], loadGeneration: 0 },
+      c1: { messages: [msg('m1', 'original')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
@@ -50,7 +71,6 @@ describe('applyLoad race with concurrent live mutations', () => {
       payload: { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt },
     });
 
-    // Stale load resolves with the pre-edit snapshot.
     store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1', 'original')] });
 
     expect(store.c1.messages[0].parts).toEqual([{ type: 'text', text: 'edited' }]);
@@ -58,20 +78,24 @@ describe('applyLoad race with concurrent live mutations', () => {
 
   it('given a delete lands while a load is in flight, should NOT be resurrected when the stale load resolves', () => {
     let store: ConversationMessagesById = {
-      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 0 },
+      c1: {
+        messages: [msg('m1'), msg('m2')],
+        optimisticSends: [],
+        loadGeneration: 0,
+        pendingMutationsSinceLoad: [],
+      },
     };
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
 
     store = applyConversationDelete(store, { conversationId: 'c1', messageId: 'm1' });
 
-    // Stale load resolves with the pre-delete snapshot (m1 still present).
     store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1'), msg('m2')] });
 
     expect(store.c1.messages.some((m) => m.id === 'm1')).toBe(false);
   });
 
-  it('given NO live mutation lands during the load, the load should still commit normally (generation still matches)', () => {
+  it('given NO live mutation lands during the load, the load should still commit the snapshot as-is', () => {
     let store: ConversationMessagesById = {};
     const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
     store = afterStart;
@@ -81,7 +105,7 @@ describe('applyLoad race with concurrent live mutations', () => {
     expect(store.c1.messages).toEqual([msg('m1', 'from-db')]);
   });
 
-  it('given a second startLoad supersedes the first (rapid conversation switch), the first stale load should still be rejected as before', () => {
+  it('given a second startLoad supersedes the first (rapid conversation switch), the first stale load should still be rejected', () => {
     let store: ConversationMessagesById = {};
     const first = applyStartLoad(store, 'c1');
     store = first.byConversationId;
@@ -93,5 +117,30 @@ describe('applyLoad race with concurrent live mutations', () => {
 
     store = applyLoad(store, { conversationId: 'c1', generation: second.generation, messages: [msg('fresh-load')] });
     expect(store.c1.messages).toEqual([msg('fresh-load')]);
+  });
+
+  it('given multiple live mutations of different kinds land during one load, all should be reflected after the load resolves', () => {
+    let store: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'v1'), msg('m2')], optimisticSends: [], loadGeneration: 0, pendingMutationsSinceLoad: [] },
+    };
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    store = applyRemoteUserMessage(store, { conversationId: 'c1', message: msg('m3', 'new') });
+    store = applyConversationEdit(store, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'v2' }], editedAt: new Date() },
+    });
+    store = applyConversationDelete(store, { conversationId: 'c1', messageId: 'm2' });
+
+    // Stale snapshot: pre-edit m1, still has m2, doesn't know about m3 yet.
+    store = applyLoad(store, {
+      conversationId: 'c1',
+      generation,
+      messages: [msg('m1', 'v1'), msg('m2')],
+    });
+
+    expect(store.c1.messages.map((m) => m.id)).toEqual(['m1', 'm3']);
+    expect(store.c1.messages[0].parts).toEqual([{ type: 'text', text: 'v2' }]);
   });
 });

--- a/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/loadRaceWithLiveMutations.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { applyStartLoad } from '../applyStartLoad';
+import { applyLoad } from '../applyLoad';
+import { applyRemoteUserMessage } from '../applyRemoteUserMessage';
+import { applyConversationEdit } from '../applyConversationEdit';
+import { applyConversationDelete } from '../applyConversationDelete';
+import type { ConversationMessagesById } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string, text = ''): UIMessage => ({ id, role: 'user', parts: [{ type: 'text', text }] });
+
+/**
+ * Regression coverage for a race identified in PR #2075 review
+ * (chatgpt-codex-connector, apps/web/src/stores/conversationMessages/applyLoad.ts:34):
+ * a conversation load reads a DB snapshot BEFORE a live socket mutation lands,
+ * but resolves (calls applyLoad) AFTER it. Because the load's `generation`
+ * still matched, applyLoad used to unconditionally overwrite `messages` with
+ * its (now-stale) snapshot, silently dropping the live mutation until the
+ * next reload. Fixed by having every live-mutation transition
+ * (applyRemoteUserMessage/applyConversationEdit/applyConversationDelete)
+ * bump `loadGeneration` on an actual change, so the in-flight load's
+ * generation goes stale and applyLoad correctly rejects it instead.
+ */
+describe('applyLoad race with concurrent live mutations', () => {
+  it('given a remote user message arrives while a load is in flight, should NOT be clobbered when the stale load resolves', () => {
+    let store: ConversationMessagesById = {};
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    // Socket broadcast lands before the fetch resolves.
+    store = applyRemoteUserMessage(store, { conversationId: 'c1', message: msg('live-1', 'hello') });
+
+    // The in-flight fetch resolves with the pre-broadcast DB snapshot.
+    const staleSnapshot: UIMessage[] = [msg('m0', 'existing')];
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: staleSnapshot });
+
+    expect(store.c1.messages.some((m) => m.id === 'live-1')).toBe(true);
+  });
+
+  it('given an edit lands while a load is in flight, should NOT be undone when the stale load resolves', () => {
+    let store: ConversationMessagesById = {
+      c1: { messages: [msg('m1', 'original')], optimisticSends: [], loadGeneration: 0 },
+    };
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
+    store = applyConversationEdit(store, {
+      conversationId: 'c1',
+      payload: { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt },
+    });
+
+    // Stale load resolves with the pre-edit snapshot.
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1', 'original')] });
+
+    expect(store.c1.messages[0].parts).toEqual([{ type: 'text', text: 'edited' }]);
+  });
+
+  it('given a delete lands while a load is in flight, should NOT be resurrected when the stale load resolves', () => {
+    let store: ConversationMessagesById = {
+      c1: { messages: [msg('m1'), msg('m2')], optimisticSends: [], loadGeneration: 0 },
+    };
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    store = applyConversationDelete(store, { conversationId: 'c1', messageId: 'm1' });
+
+    // Stale load resolves with the pre-delete snapshot (m1 still present).
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1'), msg('m2')] });
+
+    expect(store.c1.messages.some((m) => m.id === 'm1')).toBe(false);
+  });
+
+  it('given NO live mutation lands during the load, the load should still commit normally (generation still matches)', () => {
+    let store: ConversationMessagesById = {};
+    const { byConversationId: afterStart, generation } = applyStartLoad(store, 'c1');
+    store = afterStart;
+
+    store = applyLoad(store, { conversationId: 'c1', generation, messages: [msg('m1', 'from-db')] });
+
+    expect(store.c1.messages).toEqual([msg('m1', 'from-db')]);
+  });
+
+  it('given a second startLoad supersedes the first (rapid conversation switch), the first stale load should still be rejected as before', () => {
+    let store: ConversationMessagesById = {};
+    const first = applyStartLoad(store, 'c1');
+    store = first.byConversationId;
+    const second = applyStartLoad(store, 'c1');
+    store = second.byConversationId;
+
+    store = applyLoad(store, { conversationId: 'c1', generation: first.generation, messages: [msg('stale-load')] });
+    expect(store.c1.messages).toEqual([]);
+
+    store = applyLoad(store, { conversationId: 'c1', generation: second.generation, messages: [msg('fresh-load')] });
+    expect(store.c1.messages).toEqual([msg('fresh-load')]);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/replayPendingMutations.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/replayPendingMutations.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { replayPendingMutations } from '../replayPendingMutations';
+import type { PendingMutation } from '../seedEmpty';
+import type { UIMessage } from 'ai';
+
+const msg = (id: string, text = ''): UIMessage => ({ id, role: 'user', parts: [{ type: 'text', text }] });
+
+describe('replayPendingMutations', () => {
+  it('given no pending mutations, should return the messages unchanged (same reference)', () => {
+    const messages = [msg('m1')];
+    const result = replayPendingMutations(messages, []);
+    expect(result).toBe(messages);
+  });
+
+  it('given a remoteMessage mutation for an id not in the base, should append it', () => {
+    const result = replayPendingMutations([msg('m0')], [{ type: 'remoteMessage', message: msg('live-1') }]);
+    expect(result).toEqual([msg('m0'), msg('live-1')]);
+  });
+
+  it('given a remoteMessage mutation for an id already present in the base, should not duplicate it', () => {
+    const result = replayPendingMutations(
+      [msg('m0'), msg('shared-1')],
+      [{ type: 'remoteMessage', message: msg('shared-1') }],
+    );
+    expect(result).toEqual([msg('m0'), msg('shared-1')]);
+  });
+
+  it('given an edit mutation for an id present in the base, should apply the edit', () => {
+    const editedAt = new Date('2024-01-01T00:00:00.000Z');
+    const result = replayPendingMutations(
+      [msg('m1', 'original')],
+      [{ type: 'edit', payload: { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt } }],
+    );
+    expect(result[0]).toMatchObject({ id: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt });
+  });
+
+  it('given an edit mutation for an id not present in the base, should no-op for that mutation', () => {
+    const result = replayPendingMutations(
+      [msg('m1', 'original')],
+      [{ type: 'edit', payload: { messageId: 'missing', parts: [], editedAt: new Date() } }],
+    );
+    expect(result).toEqual([msg('m1', 'original')]);
+  });
+
+  it('given a delete mutation for an id present in the base, should remove it', () => {
+    const result = replayPendingMutations(
+      [msg('m1'), msg('m2')],
+      [{ type: 'delete', messageId: 'm1' }],
+    );
+    expect(result).toEqual([msg('m2')]);
+  });
+
+  it('given a delete mutation for an id not present in the base, should no-op for that mutation', () => {
+    const result = replayPendingMutations([msg('m1')], [{ type: 'delete', messageId: 'missing' }]);
+    expect(result).toEqual([msg('m1')]);
+  });
+
+  it('given multiple mutations, should apply them in order', () => {
+    const result = replayPendingMutations(
+      [msg('m1', 'original')],
+      [
+        { type: 'remoteMessage', message: msg('m2', 'new') },
+        { type: 'edit', payload: { messageId: 'm1', parts: [{ type: 'text', text: 'edited' }], editedAt: new Date() } },
+        { type: 'delete', messageId: 'm2' },
+      ] as PendingMutation[],
+    );
+    expect(result.map((m) => m.id)).toEqual(['m1']);
+    expect(result[0].parts).toEqual([{ type: 'text', text: 'edited' }]);
+  });
+
+  it('given the replay, should not mutate the input messages array', () => {
+    const messages = [msg('m1')];
+    replayPendingMutations(messages, [{ type: 'remoteMessage', message: msg('m2') }]);
+    expect(messages).toEqual([msg('m1')]);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
@@ -3,7 +3,12 @@ import { seedEmpty } from '../seedEmpty';
 
 describe('seedEmpty', () => {
   it('given no arguments, should produce an empty cache entry at generation 0', () => {
-    expect(seedEmpty()).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+    expect(seedEmpty()).toEqual({
+      messages: [],
+      optimisticSends: [],
+      loadGeneration: 0,
+      pendingMutationsSinceLoad: [],
+    });
   });
 
   it('given two calls, should produce referentially independent entries', () => {

--- a/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
+++ b/apps/web/src/stores/conversationMessages/__tests__/seedEmpty.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { seedEmpty } from '../seedEmpty';
+
+describe('seedEmpty', () => {
+  it('given no arguments, should produce an empty cache entry at generation 0', () => {
+    expect(seedEmpty()).toEqual({ messages: [], optimisticSends: [], loadGeneration: 0 });
+  });
+
+  it('given two calls, should produce referentially independent entries', () => {
+    const a = seedEmpty();
+    const b = seedEmpty();
+    expect(a).not.toBe(b);
+    expect(a.messages).not.toBe(b.messages);
+  });
+});

--- a/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
@@ -1,0 +1,25 @@
+import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyConversationDeleteEvent {
+  conversationId: string;
+  messageId: string;
+}
+
+/** Applies a remote delete broadcast to a conversation's messages and optimisticSends, reusing `applyMessageDelete`. */
+export const applyConversationDelete = (
+  byConversationId: ConversationMessagesById,
+  event: ApplyConversationDeleteEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId];
+  if (!existing) return byConversationId;
+
+  const messages = applyMessageDelete(existing.messages, event.messageId);
+  const optimisticSends = applyMessageDelete(existing.optimisticSends, event.messageId);
+  if (messages === existing.messages && optimisticSends === existing.optimisticSends) return byConversationId;
+
+  return {
+    ...byConversationId,
+    [event.conversationId]: { ...existing, messages, optimisticSends },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
@@ -6,7 +6,16 @@ export interface ApplyConversationDeleteEvent {
   messageId: string;
 }
 
-/** Applies a remote delete broadcast to a conversation's messages and optimisticSends, reusing `applyMessageDelete`. */
+/**
+ * Applies a remote delete broadcast to a conversation's messages and
+ * optimisticSends, reusing `applyMessageDelete`.
+ *
+ * Bumps `loadGeneration` on an actual change: a load already in flight was
+ * snapshotted before this delete necessarily landed, so it must not be
+ * allowed to later overwrite `messages` and silently resurrect the deleted
+ * row — bumping the generation makes that in-flight `applyLoad` stale so it
+ * gets rejected.
+ */
 export const applyConversationDelete = (
   byConversationId: ConversationMessagesById,
   event: ApplyConversationDeleteEvent,
@@ -20,6 +29,6 @@ export const applyConversationDelete = (
 
   return {
     ...byConversationId,
-    [event.conversationId]: { ...existing, messages, optimisticSends },
+    [event.conversationId]: { ...existing, messages, optimisticSends, loadGeneration: existing.loadGeneration + 1 },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
@@ -10,13 +10,20 @@ export interface ApplyConversationDeleteEvent {
  * Applies a remote delete broadcast to a conversation's messages and
  * optimisticSends, reusing `applyMessageDelete`.
  *
- * Records the delete in `pendingMutationsSinceLoad` only when it actually
- * removed a *confirmed* message: there is no ordering guarantee between this
- * broadcast and any load's DB snapshot, so `applyLoad` replays pending
- * mutations onto its snapshot rather than this function invalidating the
- * load outright. A delete that only removed an optimistic (unconfirmed) send
- * needs no replay — an unconfirmed message can never appear in a DB
- * snapshot in the first place.
+ * Always records the delete in `pendingMutationsSinceLoad`, regardless of
+ * which array (if either) actually lost the id locally. There's no
+ * ordering guarantee between this broadcast and any load's DB snapshot, so
+ * a delete that's currently a local no-op still needs to be replayed onto
+ * a load response that might independently include the row:
+ * - The id was only in `optimisticSends` (an unconfirmed send that had
+ *   *already been persisted* server-side by the time it was deleted, just
+ *   not yet reconciled into `messages` locally) — an in-flight load's
+ *   snapshot can legitimately include it.
+ * - The id wasn't locally known at all yet (e.g. sent and deleted before
+ *   this client observed either event) — an in-flight load's stale
+ *   snapshot can still include it.
+ * Replaying a delete for an id a load's snapshot doesn't contain is a safe
+ * no-op (`applyMessageDelete` itself no-ops on a missing id).
  */
 export const applyConversationDelete = (
   byConversationId: ConversationMessagesById,
@@ -25,17 +32,16 @@ export const applyConversationDelete = (
   const existing = byConversationId[event.conversationId];
   if (!existing) return byConversationId;
 
-  const messages = applyMessageDelete(existing.messages, event.messageId);
-  const optimisticSends = applyMessageDelete(existing.optimisticSends, event.messageId);
-  if (messages === existing.messages && optimisticSends === existing.optimisticSends) return byConversationId;
-
-  const pendingMutationsSinceLoad =
-    messages === existing.messages
-      ? existing.pendingMutationsSinceLoad
-      : [...existing.pendingMutationsSinceLoad, { type: 'delete' as const, messageId: event.messageId }];
-
   return {
     ...byConversationId,
-    [event.conversationId]: { ...existing, messages, optimisticSends, pendingMutationsSinceLoad },
+    [event.conversationId]: {
+      ...existing,
+      messages: applyMessageDelete(existing.messages, event.messageId),
+      optimisticSends: applyMessageDelete(existing.optimisticSends, event.messageId),
+      pendingMutationsSinceLoad: [
+        ...existing.pendingMutationsSinceLoad,
+        { type: 'delete', messageId: event.messageId },
+      ],
+    },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationDelete.ts
@@ -10,11 +10,13 @@ export interface ApplyConversationDeleteEvent {
  * Applies a remote delete broadcast to a conversation's messages and
  * optimisticSends, reusing `applyMessageDelete`.
  *
- * Bumps `loadGeneration` on an actual change: a load already in flight was
- * snapshotted before this delete necessarily landed, so it must not be
- * allowed to later overwrite `messages` and silently resurrect the deleted
- * row — bumping the generation makes that in-flight `applyLoad` stale so it
- * gets rejected.
+ * Records the delete in `pendingMutationsSinceLoad` only when it actually
+ * removed a *confirmed* message: there is no ordering guarantee between this
+ * broadcast and any load's DB snapshot, so `applyLoad` replays pending
+ * mutations onto its snapshot rather than this function invalidating the
+ * load outright. A delete that only removed an optimistic (unconfirmed) send
+ * needs no replay — an unconfirmed message can never appear in a DB
+ * snapshot in the first place.
  */
 export const applyConversationDelete = (
   byConversationId: ConversationMessagesById,
@@ -27,8 +29,13 @@ export const applyConversationDelete = (
   const optimisticSends = applyMessageDelete(existing.optimisticSends, event.messageId);
   if (messages === existing.messages && optimisticSends === existing.optimisticSends) return byConversationId;
 
+  const pendingMutationsSinceLoad =
+    messages === existing.messages
+      ? existing.pendingMutationsSinceLoad
+      : [...existing.pendingMutationsSinceLoad, { type: 'delete' as const, messageId: event.messageId }];
+
   return {
     ...byConversationId,
-    [event.conversationId]: { ...existing, messages, optimisticSends, loadGeneration: existing.loadGeneration + 1 },
+    [event.conversationId]: { ...existing, messages, optimisticSends, pendingMutationsSinceLoad },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
@@ -10,10 +10,14 @@ export interface ApplyConversationEditEvent {
  * Applies a remote edit broadcast to a conversation's confirmed messages,
  * reusing `applyMessageEdit`.
  *
- * Also records the edit in `pendingMutationsSinceLoad` on an actual change:
- * there is no ordering guarantee between this broadcast and any load's DB
- * snapshot, so `applyLoad` replays pending mutations onto its snapshot
- * rather than this function invalidating the load outright.
+ * Always records the edit in `pendingMutationsSinceLoad`, even when
+ * `applyMessageEdit` is a local no-op (the target id isn't in `messages`
+ * yet — e.g. a conversation still loading for the first time). There's no
+ * ordering guarantee between this broadcast and any load's DB snapshot: a
+ * snapshot taken before the edit but resolving after it would otherwise
+ * commit the pre-edit row with no queued mutation to fix it (PR #2075
+ * review). Replaying an edit for an id the snapshot also lacks is a safe
+ * no-op (`applyMessageEdit` itself no-ops on a missing id).
  */
 export const applyConversationEdit = (
   byConversationId: ConversationMessagesById,
@@ -22,14 +26,11 @@ export const applyConversationEdit = (
   const existing = byConversationId[event.conversationId];
   if (!existing) return byConversationId;
 
-  const messages = applyMessageEdit(existing.messages, event.payload);
-  if (messages === existing.messages) return byConversationId;
-
   return {
     ...byConversationId,
     [event.conversationId]: {
       ...existing,
-      messages,
+      messages: applyMessageEdit(existing.messages, event.payload),
       pendingMutationsSinceLoad: [...existing.pendingMutationsSinceLoad, { type: 'edit', payload: event.payload }],
     },
   };

--- a/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
@@ -1,0 +1,24 @@
+import { applyMessageEdit, type MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyConversationEditEvent {
+  conversationId: string;
+  payload: MessageEditPayload;
+}
+
+/** Applies a remote edit broadcast to a conversation's confirmed messages, reusing `applyMessageEdit`. */
+export const applyConversationEdit = (
+  byConversationId: ConversationMessagesById,
+  event: ApplyConversationEditEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId];
+  if (!existing) return byConversationId;
+
+  const messages = applyMessageEdit(existing.messages, event.payload);
+  if (messages === existing.messages) return byConversationId;
+
+  return {
+    ...byConversationId,
+    [event.conversationId]: { ...existing, messages },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
@@ -10,10 +10,10 @@ export interface ApplyConversationEditEvent {
  * Applies a remote edit broadcast to a conversation's confirmed messages,
  * reusing `applyMessageEdit`.
  *
- * Bumps `loadGeneration` on an actual change: a load already in flight was
- * snapshotted before this edit necessarily landed, so it must not be allowed
- * to later overwrite `messages` and silently undo the edit — bumping the
- * generation makes that in-flight `applyLoad` stale so it gets rejected.
+ * Also records the edit in `pendingMutationsSinceLoad` on an actual change:
+ * there is no ordering guarantee between this broadcast and any load's DB
+ * snapshot, so `applyLoad` replays pending mutations onto its snapshot
+ * rather than this function invalidating the load outright.
  */
 export const applyConversationEdit = (
   byConversationId: ConversationMessagesById,
@@ -27,6 +27,10 @@ export const applyConversationEdit = (
 
   return {
     ...byConversationId,
-    [event.conversationId]: { ...existing, messages, loadGeneration: existing.loadGeneration + 1 },
+    [event.conversationId]: {
+      ...existing,
+      messages,
+      pendingMutationsSinceLoad: [...existing.pendingMutationsSinceLoad, { type: 'edit', payload: event.payload }],
+    },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
+++ b/apps/web/src/stores/conversationMessages/applyConversationEdit.ts
@@ -6,7 +6,15 @@ export interface ApplyConversationEditEvent {
   payload: MessageEditPayload;
 }
 
-/** Applies a remote edit broadcast to a conversation's confirmed messages, reusing `applyMessageEdit`. */
+/**
+ * Applies a remote edit broadcast to a conversation's confirmed messages,
+ * reusing `applyMessageEdit`.
+ *
+ * Bumps `loadGeneration` on an actual change: a load already in flight was
+ * snapshotted before this edit necessarily landed, so it must not be allowed
+ * to later overwrite `messages` and silently undo the edit — bumping the
+ * generation makes that in-flight `applyLoad` stale so it gets rejected.
+ */
 export const applyConversationEdit = (
   byConversationId: ConversationMessagesById,
   event: ApplyConversationEditEvent,
@@ -19,6 +27,6 @@ export const applyConversationEdit = (
 
   return {
     ...byConversationId,
-    [event.conversationId]: { ...existing, messages },
+    [event.conversationId]: { ...existing, messages, loadGeneration: existing.loadGeneration + 1 },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyFailLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyFailLoad.ts
@@ -1,0 +1,20 @@
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyFailLoadEvent {
+  conversationId: string;
+  generation: number;
+}
+
+/**
+ * A failed reload must never clear cached messages — the store exists so a
+ * transient fetch failure can't blank a conversation that already rendered
+ * (the historical bug this replaces: an effect calling `setMessages([])` on
+ * error). Always a no-op over `byConversationId`, for both a current and a
+ * stale generation; kept as its own named transition (rather than inlined at
+ * the call site) so the "never clear on failure" guarantee is one pure,
+ * individually-tested unit instead of caller discipline.
+ */
+export const applyFailLoad = (
+  byConversationId: ConversationMessagesById,
+  _event: ApplyFailLoadEvent,
+): ConversationMessagesById => byConversationId;

--- a/apps/web/src/stores/conversationMessages/applyLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyLoad.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from 'ai';
 import type { ConversationMessagesById } from './seedEmpty';
+import { replayPendingMutations } from './replayPendingMutations';
 
 export interface ApplyLoadEvent {
   conversationId: string;
@@ -14,8 +15,19 @@ export interface ApplyLoadEvent {
  * switching) and is dropped — the newer load's result must win, not
  * whichever network request happens to resolve last.
  *
- * Any optimistic send whose id now appears in the loaded set is reconciled
- * out of `optimisticSends` — the DB row supersedes the local echo.
+ * There is no ordering guarantee between this load's DB snapshot and any
+ * live mutation (remote message/edit/delete) that landed while it was in
+ * flight — either can "win the race". `pendingMutationsSinceLoad` (recorded
+ * by `applyRemoteUserMessage`/`applyConversationEdit`/`applyConversationDelete`
+ * since the current `loadGeneration` started) is replayed onto the loaded
+ * snapshot before committing, so the result always reflects both: a live
+ * mutation the snapshot predates is never dropped, and a live append the
+ * snapshot already includes is never duplicated (see PR #2075 review —
+ * unconditionally invalidating the load's generation on every live mutation
+ * was too aggressive and could discard a genuinely fresh/complete response).
+ *
+ * Any optimistic send whose id now appears in the (replayed) set is
+ * reconciled out of `optimisticSends` — the DB row supersedes the local echo.
  */
 export const applyLoad = (
   byConversationId: ConversationMessagesById,
@@ -24,15 +36,17 @@ export const applyLoad = (
   const existing = byConversationId[event.conversationId];
   if (!existing || event.generation !== existing.loadGeneration) return byConversationId;
 
-  const loadedIds = new Set(event.messages.map((m) => m.id));
+  const messages = replayPendingMutations(event.messages, existing.pendingMutationsSinceLoad);
+  const loadedIds = new Set(messages.map((m) => m.id));
   const optimisticSends = existing.optimisticSends.filter((m) => !loadedIds.has(m.id));
 
   return {
     ...byConversationId,
     [event.conversationId]: {
       ...existing,
-      messages: event.messages,
+      messages,
       optimisticSends,
+      pendingMutationsSinceLoad: [],
     },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyLoad.ts
@@ -1,0 +1,38 @@
+import type { UIMessage } from 'ai';
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyLoadEvent {
+  conversationId: string;
+  generation: number;
+  messages: UIMessage[];
+}
+
+/**
+ * Commits a completed DB load as the conversation's new truth. Gated by
+ * `loadGeneration`: a load whose generation no longer matches the tracked
+ * one has been superseded by a newer `startLoad` (e.g. rapid conversation
+ * switching) and is dropped — the newer load's result must win, not
+ * whichever network request happens to resolve last.
+ *
+ * Any optimistic send whose id now appears in the loaded set is reconciled
+ * out of `optimisticSends` — the DB row supersedes the local echo.
+ */
+export const applyLoad = (
+  byConversationId: ConversationMessagesById,
+  event: ApplyLoadEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId];
+  if (!existing || event.generation !== existing.loadGeneration) return byConversationId;
+
+  const loadedIds = new Set(event.messages.map((m) => m.id));
+  const optimisticSends = existing.optimisticSends.filter((m) => !loadedIds.has(m.id));
+
+  return {
+    ...byConversationId,
+    [event.conversationId]: {
+      ...existing,
+      messages: event.messages,
+      optimisticSends,
+    },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyOptimisticSend.ts
+++ b/apps/web/src/stores/conversationMessages/applyOptimisticSend.ts
@@ -1,0 +1,33 @@
+import type { UIMessage } from 'ai';
+import { seedEmpty } from './seedEmpty';
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyOptimisticSendEvent {
+  conversationId: string;
+  message: UIMessage;
+}
+
+/**
+ * Appends a client-minted user message to `optimisticSends` in send order.
+ * No-ops when the id already appears in `messages` or `optimisticSends` —
+ * a caller retrying a send (or a duplicate dispatch) must not duplicate the
+ * bubble.
+ */
+export const applyOptimisticSend = (
+  byConversationId: ConversationMessagesById,
+  event: ApplyOptimisticSendEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId] ?? seedEmpty();
+  const alreadyPresent =
+    existing.messages.some((m) => m.id === event.message.id) ||
+    existing.optimisticSends.some((m) => m.id === event.message.id);
+  if (alreadyPresent) return byConversationId;
+
+  return {
+    ...byConversationId,
+    [event.conversationId]: {
+      ...existing,
+      optimisticSends: [...existing.optimisticSends, event.message],
+    },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
+++ b/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
@@ -1,0 +1,32 @@
+import type { UIMessage } from 'ai';
+import { seedEmpty } from './seedEmpty';
+import type { ConversationMessagesById } from './seedEmpty';
+
+export interface ApplyRemoteUserMessageEvent {
+  conversationId: string;
+  message: UIMessage;
+}
+
+/**
+ * Appends a broadcast user message (e.g. another tab/collaborator's send) to
+ * `messages`. No-ops when the id is already confirmed. When the id matches
+ * one of our own `optimisticSends` (the broadcast is the echo of our own
+ * send), reconciles it out of `optimisticSends` at the same time — the
+ * confirmed row now covers it.
+ */
+export const applyRemoteUserMessage = (
+  byConversationId: ConversationMessagesById,
+  event: ApplyRemoteUserMessageEvent,
+): ConversationMessagesById => {
+  const existing = byConversationId[event.conversationId] ?? seedEmpty();
+  if (existing.messages.some((m) => m.id === event.message.id)) return byConversationId;
+
+  return {
+    ...byConversationId,
+    [event.conversationId]: {
+      ...existing,
+      messages: [...existing.messages, event.message],
+      optimisticSends: existing.optimisticSends.filter((m) => m.id !== event.message.id),
+    },
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
+++ b/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
@@ -14,11 +14,12 @@ export interface ApplyRemoteUserMessageEvent {
  * send), reconciles it out of `optimisticSends` at the same time — the
  * confirmed row now covers it.
  *
- * Bumps `loadGeneration`: a load's DB snapshot is read before this broadcast
- * necessarily landed, so a load already in flight when this arrives must not
- * be allowed to later overwrite `messages` and silently drop it — bumping
- * the generation makes that in-flight `applyLoad` stale (its generation no
- * longer matches) so it gets rejected instead of clobbering this append.
+ * Also records the append in `pendingMutationsSinceLoad`: there is no
+ * ordering guarantee between this broadcast and any load's DB snapshot, so
+ * `applyLoad` replays pending mutations onto its snapshot rather than this
+ * function invalidating the load outright — invalidating on every live
+ * append would also discard a load whose response already includes this
+ * same message (PR #2075 review).
  */
 export const applyRemoteUserMessage = (
   byConversationId: ConversationMessagesById,
@@ -33,7 +34,10 @@ export const applyRemoteUserMessage = (
       ...existing,
       messages: [...existing.messages, event.message],
       optimisticSends: existing.optimisticSends.filter((m) => m.id !== event.message.id),
-      loadGeneration: existing.loadGeneration + 1,
+      pendingMutationsSinceLoad: [
+        ...existing.pendingMutationsSinceLoad,
+        { type: 'remoteMessage', message: event.message },
+      ],
     },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
+++ b/apps/web/src/stores/conversationMessages/applyRemoteUserMessage.ts
@@ -13,6 +13,12 @@ export interface ApplyRemoteUserMessageEvent {
  * one of our own `optimisticSends` (the broadcast is the echo of our own
  * send), reconciles it out of `optimisticSends` at the same time — the
  * confirmed row now covers it.
+ *
+ * Bumps `loadGeneration`: a load's DB snapshot is read before this broadcast
+ * necessarily landed, so a load already in flight when this arrives must not
+ * be allowed to later overwrite `messages` and silently drop it — bumping
+ * the generation makes that in-flight `applyLoad` stale (its generation no
+ * longer matches) so it gets rejected instead of clobbering this append.
  */
 export const applyRemoteUserMessage = (
   byConversationId: ConversationMessagesById,
@@ -27,6 +33,7 @@ export const applyRemoteUserMessage = (
       ...existing,
       messages: [...existing.messages, event.message],
       optimisticSends: existing.optimisticSends.filter((m) => m.id !== event.message.id),
+      loadGeneration: existing.loadGeneration + 1,
     },
   };
 };

--- a/apps/web/src/stores/conversationMessages/applyStartLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyStartLoad.ts
@@ -1,0 +1,22 @@
+import { seedEmpty } from './seedEmpty';
+import type { ConversationMessagesById } from './seedEmpty';
+
+/**
+ * Bumps a conversation's `loadGeneration` so the caller can pass the returned
+ * generation into a subsequent `applyLoad`/`applyFailLoad` — any load that
+ * lands after a newer one started carries a stale generation and is ignored.
+ */
+export const applyStartLoad = (
+  byConversationId: ConversationMessagesById,
+  conversationId: string,
+): { byConversationId: ConversationMessagesById; generation: number } => {
+  const existing = byConversationId[conversationId] ?? seedEmpty();
+  const generation = existing.loadGeneration + 1;
+  return {
+    byConversationId: {
+      ...byConversationId,
+      [conversationId]: { ...existing, loadGeneration: generation },
+    },
+    generation,
+  };
+};

--- a/apps/web/src/stores/conversationMessages/applyStartLoad.ts
+++ b/apps/web/src/stores/conversationMessages/applyStartLoad.ts
@@ -5,6 +5,13 @@ import type { ConversationMessagesById } from './seedEmpty';
  * Bumps a conversation's `loadGeneration` so the caller can pass the returned
  * generation into a subsequent `applyLoad`/`applyFailLoad` — any load that
  * lands after a newer one started carries a stale generation and is ignored.
+ *
+ * Also resets `pendingMutationsSinceLoad`: any mutation recorded under the
+ * previous generation already applied directly to `messages`/`optimisticSends`
+ * (live mutations give immediate feedback regardless of pending-tracking), and
+ * since a broadcast necessarily follows its DB write, a fresh fetch started
+ * now will include that mutation's effect on its own — nothing is lost by
+ * not replaying it a second time onto this new generation's snapshot.
  */
 export const applyStartLoad = (
   byConversationId: ConversationMessagesById,
@@ -15,7 +22,7 @@ export const applyStartLoad = (
   return {
     byConversationId: {
       ...byConversationId,
-      [conversationId]: { ...existing, loadGeneration: generation },
+      [conversationId]: { ...existing, loadGeneration: generation, pendingMutationsSinceLoad: [] },
     },
     generation,
   };

--- a/apps/web/src/stores/conversationMessages/replayPendingMutations.ts
+++ b/apps/web/src/stores/conversationMessages/replayPendingMutations.ts
@@ -1,0 +1,27 @@
+import type { UIMessage } from 'ai';
+import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
+import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
+import type { PendingMutation } from './seedEmpty';
+
+/**
+ * Replays live mutations recorded during a load's flight onto that load's
+ * snapshot, in the order they happened. Reuses `applyMessageEdit`/
+ * `applyMessageDelete`. Returns the input `messages` reference unchanged
+ * when `pending` is empty.
+ */
+export const replayPendingMutations = (
+  messages: UIMessage[],
+  pending: readonly PendingMutation[],
+): UIMessage[] => {
+  if (pending.length === 0) return messages;
+
+  return pending.reduce((acc, mutation) => {
+    if (mutation.type === 'remoteMessage') {
+      return acc.some((m) => m.id === mutation.message.id) ? acc : [...acc, mutation.message];
+    }
+    if (mutation.type === 'edit') {
+      return applyMessageEdit(acc, mutation.payload);
+    }
+    return applyMessageDelete(acc, mutation.messageId);
+  }, messages);
+};

--- a/apps/web/src/stores/conversationMessages/seedEmpty.ts
+++ b/apps/web/src/stores/conversationMessages/seedEmpty.ts
@@ -1,16 +1,38 @@
 import type { UIMessage } from 'ai';
+import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
+
+/**
+ * A live mutation (remote broadcast) recorded while a load is in flight, so
+ * `applyLoad` can replay it onto the loaded snapshot regardless of which
+ * resolves first — see `replayPendingMutations`.
+ */
+export type PendingMutation =
+  | { type: 'remoteMessage'; message: UIMessage }
+  | { type: 'edit'; payload: MessageEditPayload }
+  | { type: 'delete'; messageId: string };
 
 /**
  * Per-conversation slice of `useConversationMessagesStore`. `messages` is the
  * DB-confirmed truth (server order); `optimisticSends` holds client-minted
  * user messages sent but not yet reconciled against a load. `loadGeneration`
- * guards `applyLoad`/`applyFailLoad` against a stale async load landing after
- * a newer one started (e.g. rapid conversation switching).
+ * guards `applyLoad`/`applyFailLoad` against a load superseded by a newer
+ * `startLoad` (e.g. rapid conversation switching) — the newer load's result
+ * must win, not whichever network request resolves last.
+ *
+ * `pendingMutationsSinceLoad` records every live remote mutation
+ * (append/edit/delete) applied since the current `loadGeneration` started;
+ * `applyLoad` replays them onto its loaded snapshot before committing, so a
+ * load's DB snapshot — which may have been read before or after any given
+ * live mutation, with no ordering guarantee between the two — never wins
+ * over a live mutation, AND a live mutation never causes a genuinely fresh
+ * load response to be discarded (see PR #2075 review: generation-only
+ * invalidation was too aggressive in the reverse direction).
  */
 export interface ConversationCacheEntry {
   messages: UIMessage[];
   optimisticSends: UIMessage[];
   loadGeneration: number;
+  pendingMutationsSinceLoad: PendingMutation[];
 }
 
 export type ConversationMessagesById = Record<string, ConversationCacheEntry>;
@@ -20,4 +42,5 @@ export const seedEmpty = (): ConversationCacheEntry => ({
   messages: [],
   optimisticSends: [],
   loadGeneration: 0,
+  pendingMutationsSinceLoad: [],
 });

--- a/apps/web/src/stores/conversationMessages/seedEmpty.ts
+++ b/apps/web/src/stores/conversationMessages/seedEmpty.ts
@@ -27,6 +27,16 @@ export type PendingMutation =
  * over a live mutation, AND a live mutation never causes a genuinely fresh
  * load response to be discarded (see PR #2075 review: generation-only
  * invalidation was too aggressive in the reverse direction).
+ *
+ * Accepted tradeoff: this array is cleared only by `applyLoad`/`applyStartLoad`,
+ * not by any timer or size cap — a conversation that goes a very long time
+ * between reloads (tab focus, reconnect, switch-away/back) while receiving
+ * many live mutations will accumulate all of them. This doesn't affect
+ * correctness (replay is idempotent: a message already present is never
+ * duplicated, an edit/delete of an absent id is a no-op), only memory, and
+ * every real reload trigger the epic names (refresh, reconnect, conversation
+ * switch) clears it. Revisit with a cap or per-message-id collapse if a wired
+ * consumer (PR 4/5) shows this mattering under real traffic.
  */
 export interface ConversationCacheEntry {
   messages: UIMessage[];

--- a/apps/web/src/stores/conversationMessages/seedEmpty.ts
+++ b/apps/web/src/stores/conversationMessages/seedEmpty.ts
@@ -1,0 +1,23 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Per-conversation slice of `useConversationMessagesStore`. `messages` is the
+ * DB-confirmed truth (server order); `optimisticSends` holds client-minted
+ * user messages sent but not yet reconciled against a load. `loadGeneration`
+ * guards `applyLoad`/`applyFailLoad` against a stale async load landing after
+ * a newer one started (e.g. rapid conversation switching).
+ */
+export interface ConversationCacheEntry {
+  messages: UIMessage[];
+  optimisticSends: UIMessage[];
+  loadGeneration: number;
+}
+
+export type ConversationMessagesById = Record<string, ConversationCacheEntry>;
+
+/** A freshly-materialized, empty cache entry for a conversation never seen before. */
+export const seedEmpty = (): ConversationCacheEntry => ({
+  messages: [],
+  optimisticSends: [],
+  loadGeneration: 0,
+});

--- a/apps/web/src/stores/pendingStreams/__tests__/applyAddStream.test.ts
+++ b/apps/web/src/stores/pendingStreams/__tests__/applyAddStream.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { applyAddStream } from '../applyAddStream';
+import type { PendingStreamsMap } from '../applyAddStream';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  isOwn: false,
+};
+
+describe('applyAddStream', () => {
+  it('given a new stream, should add it with empty parts and no lastSeq set', () => {
+    const result = applyAddStream(new Map(), BASE_STREAM);
+    expect(result.get('msg-1')).toEqual({ ...BASE_STREAM, parts: [] });
+  });
+
+  it('given initial parts, should seed the stream with them', () => {
+    const result = applyAddStream(new Map(), { ...BASE_STREAM, parts: [{ type: 'text', text: 'restored' }] });
+    expect(result.get('msg-1')?.parts).toEqual([{ type: 'text', text: 'restored' }]);
+  });
+
+  it('given a messageId already present, should no-op and return the same Map reference', () => {
+    const initial: PendingStreamsMap = new Map([['msg-1', { ...BASE_STREAM, parts: [{ type: 'text', text: 'existing' }] }]]);
+    const result = applyAddStream(initial, { ...BASE_STREAM, parts: [{ type: 'text', text: 'ignored' }] });
+    expect(result).toBe(initial);
+    expect(result.get('msg-1')?.parts).toEqual([{ type: 'text', text: 'existing' }]);
+  });
+
+  it('given other streams tracked, should not touch them', () => {
+    const initial: PendingStreamsMap = new Map([['other', { ...BASE_STREAM, messageId: 'other', parts: [] }]]);
+    const result = applyAddStream(initial, BASE_STREAM);
+    expect(result.get('other')).toBe(initial.get('other'));
+  });
+});

--- a/apps/web/src/stores/pendingStreams/__tests__/applyAppendPart.test.ts
+++ b/apps/web/src/stores/pendingStreams/__tests__/applyAppendPart.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { applyAddStream } from '../applyAddStream';
+import { applyAppendPart } from '../applyAppendPart';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  isOwn: false,
+};
+
+const text = (t: string) => ({ type: 'text' as const, text: t });
+
+describe('applyAppendPart', () => {
+  it('given two consecutive text parts, should merge them positionally', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applyAppendPart(streams, { messageId: 'msg-1', part: text('hello') });
+    streams = applyAppendPart(streams, { messageId: 'msg-1', part: text(' world') });
+    expect(streams.get('msg-1')?.parts).toEqual([text('hello world')]);
+  });
+
+  it('given an unknown messageId, should no-op and return the same reference', () => {
+    const streams = applyAddStream(new Map(), BASE_STREAM);
+    const result = applyAppendPart(streams, { messageId: 'unknown', part: text('lost') });
+    expect(result).toBe(streams);
+  });
+
+  it('given the append, should not mutate lastSeq', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applyAppendPart(streams, { messageId: 'msg-1', part: text('hi') });
+    expect(streams.get('msg-1')?.lastSeq).toBeUndefined();
+  });
+});

--- a/apps/web/src/stores/pendingStreams/__tests__/applyClearPageStreams.test.ts
+++ b/apps/web/src/stores/pendingStreams/__tests__/applyClearPageStreams.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { applyAddStream } from '../applyAddStream';
+import { applyClearPageStreams } from '../applyClearPageStreams';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  isOwn: false,
+};
+
+describe('applyClearPageStreams', () => {
+  it("given streams for multiple pages, should remove only the requested page's streams", () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applyAddStream(streams, { ...BASE_STREAM, messageId: 'msg-2' });
+    streams = applyAddStream(streams, { ...BASE_STREAM, messageId: 'msg-3', pageId: 'page-b' });
+
+    const result = applyClearPageStreams(streams, 'page-a');
+    expect(result.has('msg-1')).toBe(false);
+    expect(result.has('msg-2')).toBe(false);
+    expect(result.has('msg-3')).toBe(true);
+  });
+
+  it('given no streams for the page, should no-op and return the same reference', () => {
+    const streams = applyAddStream(new Map(), BASE_STREAM);
+    const result = applyClearPageStreams(streams, 'page-missing');
+    expect(result).toBe(streams);
+  });
+
+  it('given an empty store, should no-op', () => {
+    const streams = new Map();
+    const result = applyClearPageStreams(streams, 'page-a');
+    expect(result).toBe(streams);
+  });
+});

--- a/apps/web/src/stores/pendingStreams/__tests__/applyRemoveStream.test.ts
+++ b/apps/web/src/stores/pendingStreams/__tests__/applyRemoveStream.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { applyAddStream } from '../applyAddStream';
+import { applyRemoveStream } from '../applyRemoveStream';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  isOwn: false,
+};
+
+describe('applyRemoveStream', () => {
+  it('given an existing stream, should remove it', () => {
+    const streams = applyAddStream(new Map(), BASE_STREAM);
+    const result = applyRemoveStream(streams, 'msg-1');
+    expect(result.has('msg-1')).toBe(false);
+  });
+
+  it('given an unknown messageId, should no-op and return the same reference', () => {
+    const streams = applyAddStream(new Map(), BASE_STREAM);
+    const result = applyRemoveStream(streams, 'unknown');
+    expect(result).toBe(streams);
+  });
+
+  it('given other streams tracked, should not touch them', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applyAddStream(streams, { ...BASE_STREAM, messageId: 'msg-2' });
+    const other = streams.get('msg-2');
+    const result = applyRemoveStream(streams, 'msg-1');
+    expect(result.get('msg-2')).toBe(other);
+  });
+});

--- a/apps/web/src/stores/pendingStreams/__tests__/applySetStreamParts.test.ts
+++ b/apps/web/src/stores/pendingStreams/__tests__/applySetStreamParts.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { applyAddStream } from '../applyAddStream';
+import { applySetStreamParts } from '../applySetStreamParts';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  isOwn: true,
+};
+
+const text = (t: string) => ({ type: 'text' as const, text: t });
+
+describe('applySetStreamParts', () => {
+  it('given an existing stream and a fresh seq, should replace parts wholesale (not merge)', () => {
+    let streams = applyAddStream(new Map(), { ...BASE_STREAM, parts: [text('a')] });
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('a'), text('b')], seq: 1 });
+    expect(streams.get('msg-1')?.parts).toEqual([text('a'), text('b')]);
+  });
+
+  it('given the replacement, should stamp the entry lastSeq with the incoming seq', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('x')], seq: 3 });
+    expect(streams.get('msg-1')?.lastSeq).toBe(3);
+  });
+
+  it('given a seq no greater than the current lastSeq, should drop the write as stale (no-op)', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('newer')], seq: 5 });
+    const beforeStale = streams;
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('stale')], seq: 4 });
+    expect(streams).toBe(beforeStale);
+    expect(streams.get('msg-1')?.parts).toEqual([text('newer')]);
+  });
+
+  it('given a seq equal to the current lastSeq, should also drop it as stale', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('first')], seq: 1 });
+    const beforeDupe = streams;
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('dup')], seq: 1 });
+    expect(streams).toBe(beforeDupe);
+  });
+
+  it('given an unknown messageId, should no-op and return the same reference', () => {
+    const streams = applyAddStream(new Map(), BASE_STREAM);
+    const result = applySetStreamParts(streams, { messageId: 'unknown', parts: [text('x')], seq: 1 });
+    expect(result).toBe(streams);
+  });
+
+  it('given a stream with no prior lastSeq, should accept seq 0 (treated as newer than unset)', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('first')], seq: 0 });
+    expect(streams.get('msg-1')?.parts).toEqual([text('first')]);
+    expect(streams.get('msg-1')?.lastSeq).toBe(0);
+  });
+
+  it('given a later replacement, should not affect other tracked streams (channel grouping preserved)', () => {
+    let streams = applyAddStream(new Map(), BASE_STREAM);
+    streams = applyAddStream(streams, { ...BASE_STREAM, messageId: 'msg-2', pageId: 'page-b' });
+    const other = streams.get('msg-2');
+    streams = applySetStreamParts(streams, { messageId: 'msg-1', parts: [text('x')], seq: 1 });
+    expect(streams.get('msg-2')).toBe(other);
+  });
+});

--- a/apps/web/src/stores/pendingStreams/applyAddStream.ts
+++ b/apps/web/src/stores/pendingStreams/applyAddStream.ts
@@ -1,0 +1,36 @@
+import type { UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+export interface PendingStream {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string };
+  parts: UIMessagePart[];
+  isOwn: boolean;
+  /** ISO timestamp of the stream's start, used to stamp synthesized bubbles with a `createdAt`. */
+  startedAt?: string;
+  /**
+   * Monotonic write counter, set by `setStreamParts`. Absent until the first
+   * replace-semantics write — `addStream`/`appendPart` never set it.
+   */
+  lastSeq?: number;
+}
+
+export type PendingStreamsMap = Map<string, PendingStream>;
+
+/**
+ * No-op when the messageId already exists — so initial `parts` (a restored
+ * server snapshot) seed at most once even when co-mounted surfaces
+ * bootstrap the same channel concurrently.
+ */
+export const applyAddStream = (
+  streams: PendingStreamsMap,
+  stream: Omit<PendingStream, 'parts' | 'lastSeq'> & { parts?: UIMessagePart[] },
+): PendingStreamsMap => {
+  if (streams.has(stream.messageId)) return streams;
+  const next = new Map(streams);
+  next.set(stream.messageId, { ...stream, parts: stream.parts ?? [] });
+  return next;
+};

--- a/apps/web/src/stores/pendingStreams/applyAppendPart.ts
+++ b/apps/web/src/stores/pendingStreams/applyAppendPart.ts
@@ -1,0 +1,19 @@
+import { appendPart as appendPartPure } from '@/lib/ai/streams/appendPart';
+import type { PendingStream, PendingStreamsMap } from './applyAddStream';
+
+export interface ApplyAppendPartEvent {
+  messageId: string;
+  part: PendingStream['parts'][number];
+}
+
+/** Incremental merge-append (reuses `appendPart`'s shape-aware merge). No-ops on an unknown messageId. */
+export const applyAppendPart = (
+  streams: PendingStreamsMap,
+  event: ApplyAppendPartEvent,
+): PendingStreamsMap => {
+  const existing = streams.get(event.messageId);
+  if (!existing) return streams;
+  const next = new Map(streams);
+  next.set(event.messageId, { ...existing, parts: appendPartPure(existing.parts, event.part) });
+  return next;
+};

--- a/apps/web/src/stores/pendingStreams/applyClearPageStreams.ts
+++ b/apps/web/src/stores/pendingStreams/applyClearPageStreams.ts
@@ -1,0 +1,14 @@
+import type { PendingStreamsMap } from './applyAddStream';
+
+export const applyClearPageStreams = (streams: PendingStreamsMap, pageId: string): PendingStreamsMap => {
+  let changed = false;
+  const next: PendingStreamsMap = new Map();
+  for (const [id, stream] of streams) {
+    if (stream.pageId === pageId) {
+      changed = true;
+      continue;
+    }
+    next.set(id, stream);
+  }
+  return changed ? next : streams;
+};

--- a/apps/web/src/stores/pendingStreams/applyRemoveStream.ts
+++ b/apps/web/src/stores/pendingStreams/applyRemoveStream.ts
@@ -1,0 +1,8 @@
+import type { PendingStreamsMap } from './applyAddStream';
+
+export const applyRemoveStream = (streams: PendingStreamsMap, messageId: string): PendingStreamsMap => {
+  if (!streams.has(messageId)) return streams;
+  const next = new Map(streams);
+  next.delete(messageId);
+  return next;
+};

--- a/apps/web/src/stores/pendingStreams/applySetStreamParts.ts
+++ b/apps/web/src/stores/pendingStreams/applySetStreamParts.ts
@@ -1,0 +1,30 @@
+import type { PendingStream, PendingStreamsMap } from './applyAddStream';
+
+export interface ApplySetStreamPartsEvent {
+  messageId: string;
+  parts: PendingStream['parts'];
+  seq: number;
+}
+
+/**
+ * Replaces a stream's parts wholesale — unlike `appendPart`'s incremental
+ * merge, this is for writers whose source is already the fully-merged
+ * snapshot at any tick (the own-stream mirror reads useChat's local message,
+ * which is exactly that). No-ops on an unknown messageId.
+ *
+ * Gated by `seq`: a write whose seq does not exceed the entry's current
+ * `lastSeq` is stale — superseded by a later tick (e.g. a delayed effect
+ * re-run) — and is dropped rather than clobbering newer parts.
+ */
+export const applySetStreamParts = (
+  streams: PendingStreamsMap,
+  event: ApplySetStreamPartsEvent,
+): PendingStreamsMap => {
+  const existing = streams.get(event.messageId);
+  if (!existing) return streams;
+  if (event.seq <= (existing.lastSeq ?? -1)) return streams;
+
+  const next = new Map(streams);
+  next.set(event.messageId, { ...existing, parts: event.parts, lastSeq: event.seq });
+  return next;
+};

--- a/apps/web/src/stores/useConversationMessagesStore.ts
+++ b/apps/web/src/stores/useConversationMessagesStore.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+import type { UIMessage } from 'ai';
+import { applyStartLoad } from '@/stores/conversationMessages/applyStartLoad';
+import { applyLoad } from '@/stores/conversationMessages/applyLoad';
+import { applyFailLoad } from '@/stores/conversationMessages/applyFailLoad';
+import { applyOptimisticSend } from '@/stores/conversationMessages/applyOptimisticSend';
+import { applyConversationEdit } from '@/stores/conversationMessages/applyConversationEdit';
+import { applyConversationDelete } from '@/stores/conversationMessages/applyConversationDelete';
+import { applyRemoteUserMessage } from '@/stores/conversationMessages/applyRemoteUserMessage';
+import { seedEmpty, type ConversationCacheEntry, type ConversationMessagesById } from '@/stores/conversationMessages/seedEmpty';
+import type { MessageEditPayload } from '@/lib/ai/streams/applyMessageEdit';
+
+export type { ConversationCacheEntry, ConversationMessagesById };
+
+interface ConversationMessagesState {
+  byConversationId: ConversationMessagesById;
+  getEntry: (conversationId: string) => ConversationCacheEntry;
+  startLoad: (conversationId: string) => number;
+  applyLoad: (conversationId: string, generation: number, messages: UIMessage[]) => void;
+  failLoad: (conversationId: string, generation: number) => void;
+  addOptimisticSend: (conversationId: string, message: UIMessage) => void;
+  applyEdit: (conversationId: string, payload: MessageEditPayload) => void;
+  applyDelete: (conversationId: string, messageId: string) => void;
+  applyRemoteUserMessage: (conversationId: string, message: UIMessage) => void;
+}
+
+export const useConversationMessagesStore = create<ConversationMessagesState>((set, get) => ({
+  byConversationId: {},
+
+  getEntry: (conversationId) => get().byConversationId[conversationId] ?? seedEmpty(),
+
+  startLoad: (conversationId) => {
+    const { byConversationId, generation } = applyStartLoad(get().byConversationId, conversationId);
+    set({ byConversationId });
+    return generation;
+  },
+
+  applyLoad: (conversationId, generation, messages) => {
+    set((state) => ({ byConversationId: applyLoad(state.byConversationId, { conversationId, generation, messages }) }));
+  },
+
+  failLoad: (conversationId, generation) => {
+    set((state) => ({ byConversationId: applyFailLoad(state.byConversationId, { conversationId, generation }) }));
+  },
+
+  addOptimisticSend: (conversationId, message) => {
+    set((state) => ({ byConversationId: applyOptimisticSend(state.byConversationId, { conversationId, message }) }));
+  },
+
+  applyEdit: (conversationId, payload) => {
+    set((state) => ({ byConversationId: applyConversationEdit(state.byConversationId, { conversationId, payload }) }));
+  },
+
+  applyDelete: (conversationId, messageId) => {
+    set((state) => ({ byConversationId: applyConversationDelete(state.byConversationId, { conversationId, messageId }) }));
+  },
+
+  applyRemoteUserMessage: (conversationId, message) => {
+    set((state) => ({ byConversationId: applyRemoteUserMessage(state.byConversationId, { conversationId, message }) }));
+  },
+}));

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -1,29 +1,29 @@
 import { create } from 'zustand';
-import type { UIMessage } from 'ai';
-import { appendPart as appendPartPure } from '@/lib/ai/streams/appendPart';
+import { applyAddStream } from '@/stores/pendingStreams/applyAddStream';
+import { applyAppendPart } from '@/stores/pendingStreams/applyAppendPart';
+import { applySetStreamParts } from '@/stores/pendingStreams/applySetStreamParts';
+import { applyRemoveStream } from '@/stores/pendingStreams/applyRemoveStream';
+import { applyClearPageStreams } from '@/stores/pendingStreams/applyClearPageStreams';
+import type { PendingStream, PendingStreamsMap } from '@/stores/pendingStreams/applyAddStream';
 
-type UIMessagePart = UIMessage['parts'][number];
+export type { PendingStream };
 
-export interface PendingStream {
-  messageId: string;
-  pageId: string;
-  conversationId: string;
-  triggeredBy: { userId: string; displayName: string };
-  parts: UIMessagePart[];
-  isOwn: boolean;
-  /** ISO timestamp of the stream's start, used to stamp synthesized bubbles with a `createdAt`. */
-  startedAt?: string;
-}
+type UIMessagePart = PendingStream['parts'][number];
 
 interface PendingStreamsState {
-  streams: Map<string, PendingStream>;
+  streams: PendingStreamsMap;
   /**
    * No-op when the messageId already exists — so initial `parts` (a restored
    * server snapshot) seed at most once even when co-mounted surfaces
    * bootstrap the same channel concurrently.
    */
-  addStream: (stream: Omit<PendingStream, 'parts'> & { parts?: UIMessagePart[] }) => void;
+  addStream: (stream: Omit<PendingStream, 'parts' | 'lastSeq'> & { parts?: UIMessagePart[] }) => void;
   appendPart: (messageId: string, part: UIMessagePart) => void;
+  /**
+   * Replace-semantics write for the own-stream mirror: sets `parts` wholesale
+   * rather than merging, gated by `seq` (see `applySetStreamParts`).
+   */
+  setStreamParts: (messageId: string, parts: UIMessagePart[], seq: number) => void;
   removeStream: (messageId: string) => void;
   clearPageStreams: (pageId: string) => void;
   getRemotePageStreams: (pageId: string) => PendingStream[];
@@ -34,36 +34,23 @@ export const usePendingStreamsStore = create<PendingStreamsState>((set, get) => 
   streams: new Map(),
 
   addStream: (stream) => {
-    set((state) => {
-      if (state.streams.has(stream.messageId)) return state;
-      const next = new Map(state.streams);
-      next.set(stream.messageId, { ...stream, parts: stream.parts ?? [] });
-      return { streams: next };
-    });
+    set((state) => ({ streams: applyAddStream(state.streams, stream) }));
   },
 
   appendPart: (messageId, part) => {
-    set((state) => {
-      const existing = state.streams.get(messageId);
-      if (!existing) return state;
-      const next = new Map(state.streams);
-      next.set(messageId, { ...existing, parts: appendPartPure(existing.parts, part) });
-      return { streams: next };
-    });
+    set((state) => ({ streams: applyAppendPart(state.streams, { messageId, part }) }));
+  },
+
+  setStreamParts: (messageId, parts, seq) => {
+    set((state) => ({ streams: applySetStreamParts(state.streams, { messageId, parts, seq }) }));
   },
 
   removeStream: (messageId) => {
-    set((state) => {
-      const next = new Map(state.streams);
-      next.delete(messageId);
-      return { streams: next };
-    });
+    set((state) => ({ streams: applyRemoveStream(state.streams, messageId) }));
   },
 
   clearPageStreams: (pageId) => {
-    set((state) => ({
-      streams: new Map([...state.streams].filter(([, s]) => s.pageId !== pageId)),
-    }));
+    set((state) => ({ streams: applyClearPageStreams(state.streams, pageId) }));
   },
 
   getRemotePageStreams: (pageId) => {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,6 +26,11 @@ export default defineConfig({
         '**/node_modules/**',
       ],
       thresholds: {
+        // The /* ratchet:start */.../* ratchet:end */ markers below are load-bearing:
+        // ../../scripts/coverage-ratchet.mjs matches this exact comment-delimited region
+        // to rewrite only these four scalars and never touch the per-glob keys after
+        // ratchet:end. Do not remove/move the markers, and do not add new scalar
+        // thresholds inside them — see that script's header comment for why.
         /* ratchet:start */
         lines: 44,
         branches: 85,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -26,10 +26,21 @@ export default defineConfig({
         '**/node_modules/**',
       ],
       thresholds: {
+        /* ratchet:start */
         lines: 44,
         branches: 85,
         functions: 56,
         statements: 44,
+        /* ratchet:end */
+        // Store-first rendering foundations (E1 PR3): new pure modules gated
+        // at 100% branch. Single-star globs deliberately exclude __tests__/
+        // subdirectories — test files carry their own incidental branches
+        // (e.g. it.each fixtures) that have no bearing on source coverage.
+        'src/lib/ai/streams/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/stores/useConversationMessagesStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/stores/usePendingStreamsStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/stores/conversationMessages/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/stores/pendingStreams/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
       },
     },
   },

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -46,9 +46,17 @@ for (const pkg of packages) {
     statements: Math.floor(t.statements.pct),
   };
 
-  // Match the thresholds block and replace values
-  const thresholdRegex = /thresholds:\s*\{[^}]+\}/s;
-  const match = config.match(thresholdRegex);
+  // Match the sentinel-marked ratchet region first — packages with per-glob
+  // threshold keys after the four ratcheted scalars (e.g. apps/web's 100%
+  // gates on new pure modules) would otherwise have `[^}]+` stop at the
+  // glob sub-objects' first `}`, truncating the match and corrupting the
+  // rewrite. Fall back to the plain block match for packages with no
+  // sentinel, so processor/realtime/db/lib keep working unchanged.
+  const sentinelRegex = /\/\* ratchet:start \*\/[\s\S]*?\/\* ratchet:end \*\//;
+  const plainRegex = /thresholds:\s*\{[^}]+\}/s;
+  const sentinelMatch = config.match(sentinelRegex);
+  const match = sentinelMatch ?? config.match(plainRegex);
+  const thresholdRegex = sentinelMatch ? sentinelRegex : plainRegex;
 
   if (!match) {
     console.log(`[skip] ${pkg.name}: no thresholds block found in vitest config`);
@@ -80,7 +88,12 @@ for (const pkg of packages) {
     continue;
   }
 
-  const newBlock = `thresholds: {\n        lines: ${finalThresholds.lines},\n        branches: ${finalThresholds.branches},\n        functions: ${finalThresholds.functions},\n        statements: ${finalThresholds.statements},\n      }`;
+  // The sentinel rewrite preserves everything after `ratchet:end` (the
+  // per-glob 100% keys) — only the four ratcheted scalars inside the markers
+  // are replaced.
+  const newBlock = sentinelMatch
+    ? `/* ratchet:start */\n        lines: ${finalThresholds.lines},\n        branches: ${finalThresholds.branches},\n        functions: ${finalThresholds.functions},\n        statements: ${finalThresholds.statements},\n        /* ratchet:end */`
+    : `thresholds: {\n        lines: ${finalThresholds.lines},\n        branches: ${finalThresholds.branches},\n        functions: ${finalThresholds.functions},\n        statements: ${finalThresholds.statements},\n      }`;
 
   config = config.replace(thresholdRegex, newBlock);
 


### PR DESCRIPTION
## Summary

PR 3 of the "Deterministic Chat Rendering & Send" epic — store foundations. Purely additive: no consumer/surface changes (those land in PR 4/5). All new pure modules are 100% branch-covered.

- **3.0a/3.0b (spikes)** — pin two fragile `ai@6.0.212` SDK behaviors as tests so an SDK bump turns a broken dedup contract into red CI instead of a screen flash: server-issued assistant id always wins (including the trailing-assistant-override and pre-`start` data-part reference-identity cases), and a client-minted user-message id only survives through the parts-form `sendMessage` — the `{text, files}` shorthand silently drops it.
- **3.0c** — `buildUserMessage` pure helper producing the parts-form payload consumer PRs will need to carry a caller id.
- **3.1/3.2** — `useConversationMessagesStore`: per-conversation DB-truth + optimistic-send cache, `loadGeneration`-gated against a load superseded by a newer `startLoad`; live socket mutations landing mid-flight are reconciled via replay, not invalidation (see fixes below).
- **3.3/3.4** — `selectRenderedMessages`: the store-first render selector (per the epic's architecture decision), merges the conversation cache with `usePendingStreamsStore`, cache wins on id collision (reuses `dedupRemoteStreams`), reuses `synthesizeAssistantMessage`.
- **3.5/3.6** — `usePendingStreamsStore` reshape: new `setStreamParts` (replace semantics, `seq`-gated against stale writes) alongside the existing actions, all refactored into one-line shells over pure `applyX` functions. Fully backward compatible — all 21 pre-existing store tests pass unmodified. Call-site migration is **deferred to PR 4/5** (see the board note on leaf 3.6).
- **3.7/3.8** — `planOwnStreamMirror` / `useOwnStreamMirror`: the TRANSITIONAL own-stream sync, carrying delete-me markers per the epic's Deletion covenant (dies at the SDK7 transport swap).
- **3.9** — per-glob 100% branch thresholds for the new modules via a sentinel-comment region in `vitest.config.ts`; `coverage-ratchet.mjs` now matches the sentinel region first (falling back to the plain block match for the other four packages) so per-glob sub-objects can't truncate its regex.

Every store mutation is a pure, individually-tested `applyX` function; zustand actions are one-line shells (transition-purity contract, leaf 3.0d).

## Post-review fixes (four rounds with chatgpt-codex-connector + an 8-angle self-review)

**Load/live-mutation reconciliation** — there's no ordering guarantee between a conversation load's DB snapshot and a live socket mutation (append/edit/delete) for the same conversation. Went through three iterations:
1. Generation-invalidation (first attempt) — over-corrected, could discard an entire valid load response.
2. Mutation-replay (18295025c) — `loadGeneration` back to guarding only a load superseded by a newer `startLoad`; live mutations recorded in `pendingMutationsSinceLoad`, replayed onto the load's snapshot.
3. Always-queue refinement (af49823e8) — the replay design only queued a mutation when it visibly changed local state; two edge cases (an edit for a not-yet-loaded message, a delete that only hit `optimisticSends`) were silently dropped. Both now always queue when the conversation is tracked — replay against a snapshot that also lacks the id is a safe no-op.

**Own-stream mirror** (4e8faec7b) — `mirroredIdRef` wasn't cleared when the mirror went inactive (`useChat` retains the completed message in local history), so a continuation/regenerate reusing the same server-issued id — a real SDK behavior this PR itself pins — would silently fail to re-mirror. Extracted a shared `isOwnStreamMirrorActive` helper so `planOwnStreamMirror` and the hook use one source of truth for "is this id actually mirrored right now."

Also fixed: `selectRenderedMessages` now reuses `dedupRemoteStreams` instead of reimplementing the same filter inline; `useOwnStreamMirror`'s sequence counter is `max(Date.now(), storedLastSeq + 1)` (immune to hook remounts, strictly monotonic even within the same millisecond) with effect deps on primitive fields instead of wrapper objects.

Every fix in this chain was verified by reverting it and confirming the corresponding regression test(s) actually fail without it — 21 tests across four rounds all correctly catch their respective bug on revert (the mirroredId fix is proven via its extracted pure helper's unit tests plus a manual trace, since the hook itself can't be render-tested in this worktree per the epic's documented constraint).

Two scope corrections documented on the board (leaf notes): the 3.6 call-site-migration deferral, and 3.9's glob pattern (`*.ts` not `**/*.ts`, to exclude `__tests__/`) plus a one-test fix to a pre-existing `chunkToPart.ts` coverage gap that blocked an honest 100% claim on that directory.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun vitest run src/lib/ai/streams src/stores` — 853 tests passed across 74 files
- [x] Coverage: all 5 gated globs (`lib/ai/streams/*.ts`, both new stores, `conversationMessages/*.ts`, `pendingStreams/*.ts`) at 100% lines/branches/functions/statements
- [x] `node scripts/coverage-ratchet.mjs --dry-run` — exits clean on all five packages; sentinel rewrite verified byte-correct via a disposable-copy simulation
- [x] ESLint clean on all touched files
- [x] No consumer/component files touched (verified via `git status`)
- [x] Every fix verified via revert-and-rerun to confirm its regression test(s) actually catch the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0161UQ3osV22WKknQA5PQ5xE