### PR TITLE
feat(ai): materialize interrupted streams on dead-row reap

### DIFF
--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -292,6 +292,33 @@ describe('GET /api/ai/chat/active-streams', () => {
       });
     });
 
+    // A page channel carries EVERY conversation on it, including other members' PRIVATE ones.
+    // Without this gate, any user with mere page-view access could trigger a reap side effect
+    // (a DB write + broadcast) for a conversation whose content they can never see returned —
+    // the same authorization gap the response payload itself already closes via
+    // filterSubscribableStreams.
+    it("given a provably-dead row in a conversation the caller may NOT subscribe to (another member's private conversation), does not materialize it", async () => {
+      const longAgo = new Date(Date.now() - 5 * 60 * 1000);
+      mockOrderBy.mockResolvedValueOnce([
+        {
+          messageId: 'msg-not-mine',
+          conversationId: 'their-private-conv',
+          userId: 'user-other',
+          displayName: 'Alice',
+          browserSessionId: 'session-2',
+          parts: [{ type: 'text', text: 'private content' }],
+          startedAt: longAgo,
+          lastHeartbeatAt: longAgo,
+        },
+      ]);
+      // Conversation-scoped authorization drops it, exactly as it does for the response payload.
+      mockFilterSubscribableStreams.mockResolvedValueOnce([]);
+
+      await GET(makeRequest());
+
+      expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+    });
+
     it('given a live, checkpointing row, does not materialize it', async () => {
       mockOrderBy.mockResolvedValueOnce([
         {

--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
-const { mockOrderBy } = vi.hoisted(() => ({ mockOrderBy: vi.fn() }));
+const { mockOrderBy, mockMaterializeInterruptedStream } = vi.hoisted(() => ({
+  mockOrderBy: vi.fn(),
+  mockMaterializeInterruptedStream: vi.fn(),
+}));
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
@@ -68,6 +71,13 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 
 vi.mock('@pagespace/lib/ai/global-channel-id', () => ({
   parseGlobalChannelId: vi.fn(() => null),
+}));
+
+// Materialization is its own unit with its own tests (materialize-interrupted-stream.test.ts).
+// Stubbed here so these tests exercise the lazy sweep's DECISION (which rows get reaped), not
+// how a row is turned into an interrupted message.
+vi.mock('@/lib/ai/core/materialize-interrupted-stream', () => ({
+  materializeInterruptedStream: mockMaterializeInterruptedStream,
 }));
 
 import { GET } from '../route';
@@ -249,6 +259,81 @@ describe('GET /api/ai/chat/active-streams', () => {
     const body = await response.json();
 
     expect(body.streams).toEqual([]);
+  });
+
+  // The lazy sweep: this query already reads every 'streaming' row on the channel, so a row
+  // that is not live AND is provably dead (not mere staleness) is reaped here instead of
+  // waiting on a cron or the next send's takeover.
+  describe('the lazy materialization sweep', () => {
+    it('given a provably-dead row (crashed process), materializes it as interrupted', async () => {
+      const parts = [{ type: 'text', text: 'partial before crash' }];
+      const longAgo = new Date(Date.now() - 5 * 60 * 1000);
+      mockOrderBy.mockResolvedValueOnce([
+        {
+          messageId: 'msg-dead',
+          conversationId: 'conv-1',
+          userId: 'user-2',
+          displayName: 'Alice',
+          browserSessionId: 'session-2',
+          parts,
+          startedAt: longAgo,
+          lastHeartbeatAt: longAgo,
+        },
+      ]);
+
+      await GET(makeRequest());
+
+      expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith({
+        messageId: 'msg-dead',
+        channelId: mockChannelId,
+        conversationId: 'conv-1',
+        userId: 'user-2',
+        parts,
+      });
+    });
+
+    it('given a live, checkpointing row, does not materialize it', async () => {
+      mockOrderBy.mockResolvedValueOnce([
+        {
+          messageId: 'msg-live',
+          conversationId: 'conv-1',
+          userId: 'user-2',
+          displayName: 'Alice',
+          browserSessionId: 'session-2',
+          parts: [],
+          startedAt: new Date(Date.now() - 5 * 60 * 1000),
+          lastHeartbeatAt: new Date(Date.now() - 10 * 1000),
+        },
+      ]);
+
+      await GET(makeRequest());
+
+      expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+    });
+
+    // A long-running generation whose heartbeat rode all the way to the cap is ambiguous, not
+    // dead — isProvablyDead refuses to judge it (see stream-liveness.ts). Reaping it here would
+    // destroy a still-generating stream's only crash-recovery snapshot.
+    it('given a long-lived stream whose heartbeat is silent by DESIGN (rode to the cap), does not materialize it', async () => {
+      const startedAt = new Date(Date.now() - 65 * 60 * 1000);
+      mockOrderBy.mockResolvedValueOnce([
+        {
+          messageId: 'msg-long-silent',
+          conversationId: 'conv-1',
+          userId: 'user-1',
+          displayName: 'Me',
+          browserSessionId: 'session-1',
+          parts: [],
+          startedAt,
+          // Beat stopped almost exactly at the 60-minute cap — ambiguous, not proof of death.
+          lastHeartbeatAt: new Date(startedAt.getTime() + 60 * 60 * 1000 - 1_000),
+        },
+      ]);
+
+      await GET(makeRequest());
+
+      expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+    });
   });
 
   it('given no active streams, should return an empty streams array', async () => {

--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -289,6 +289,7 @@ describe('GET /api/ai/chat/active-streams', () => {
         conversationId: 'conv-1',
         userId: 'user-2',
         parts,
+        startedAt: longAgo,
       });
     });
 

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -99,19 +99,23 @@ export async function GET(request: Request) {
       .orderBy(asc(aiStreamSessions.startedAt), asc(aiStreamSessions.messageId));
 
     // Page access is not enough. A page channel carries EVERY conversation on the page,
-    // and conversations are private by default — so returning every streaming row (with
-    // its buffered `parts` snapshot!) to anyone who can view the page hands one member's
-    // private conversation to all the others. Narrow to what this user may subscribe to:
-    // their own streams, plus streams in explicitly shared conversations.
-    const live = rows.filter((r) => isStreamRowLive(r, now));
-    const streams = await filterSubscribableStreams({ userId, rows: live });
+    // and conversations are private by default — so acting on every streaming row (with its
+    // buffered `parts` snapshot, or even just the side effect of reaping it!) for anyone who
+    // can view the page hands one member's private conversation to all the others. Narrow to
+    // what this user may subscribe to — their own streams, plus streams in explicitly shared
+    // conversations — BEFORE either building the response or running the lazy sweep below, so
+    // an unauthorized-to-that-conversation poller can't even trigger a reap side effect for a
+    // conversation whose content it will never see returned.
+    const authorized = await filterSubscribableStreams({ userId, rows });
+    const streams = authorized.filter((r) => isStreamRowLive(r, now));
 
-    // Lazy reap: this query already reads every 'streaming' row on the channel, so any row that
-    // is not live and is PROVABLY dead (never mere staleness — see isProvablyDead) is reaped here
-    // rather than waiting on a cron or the next send's takeover. Fire-and-forget: a channel with
-    // no more traffic on it would otherwise never trigger a takeover again, and this response must
-    // not wait on a reap of rows the caller didn't even ask to see.
-    for (const row of rows) {
+    // Lazy reap: this query already reads every 'streaming' row on the channel, so any
+    // authorized-to-view row that is not live and is PROVABLY dead (never mere staleness — see
+    // isProvablyDead) is reaped here rather than waiting on a cron or the next send's takeover.
+    // Fire-and-forget: a channel with no more traffic on it would otherwise never trigger a
+    // takeover again, and this response must not wait on a reap of rows the caller didn't even
+    // ask to see.
+    for (const row of authorized) {
       if (isStreamRowLive(row, now)) continue;
       if (!isProvablyDead(row, now)) continue;
       void materializeInterruptedStream({

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -124,6 +124,7 @@ export async function GET(request: Request) {
         conversationId: row.conversationId,
         userId: row.userId,
         parts: row.parts,
+        startedAt: row.startedAt,
       });
     }
 

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -7,8 +7,9 @@ import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
-import { isStreamRowLive } from '@/lib/ai/core/stream-liveness';
+import { isStreamRowLive, isProvablyDead } from '@/lib/ai/core/stream-liveness';
 import { filterSubscribableStreams } from '@/lib/ai/core/stream-subscription-authz';
+import { materializeInterruptedStream } from '@/lib/ai/core/materialize-interrupted-stream';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 
@@ -104,6 +105,23 @@ export async function GET(request: Request) {
     // their own streams, plus streams in explicitly shared conversations.
     const live = rows.filter((r) => isStreamRowLive(r, now));
     const streams = await filterSubscribableStreams({ userId, rows: live });
+
+    // Lazy reap: this query already reads every 'streaming' row on the channel, so any row that
+    // is not live and is PROVABLY dead (never mere staleness — see isProvablyDead) is reaped here
+    // rather than waiting on a cron or the next send's takeover. Fire-and-forget: a channel with
+    // no more traffic on it would otherwise never trigger a takeover again, and this response must
+    // not wait on a reap of rows the caller didn't even ask to see.
+    for (const row of rows) {
+      if (isStreamRowLive(row, now)) continue;
+      if (!isProvablyDead(row, now)) continue;
+      void materializeInterruptedStream({
+        messageId: row.messageId,
+        channelId,
+        conversationId: row.conversationId,
+        userId: row.userId,
+        parts: row.parts,
+      });
+    }
 
     return NextResponse.json({
       streams: streams.map((s) => ({

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from 'react';
+import { RotateCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { CompactToolCallRenderer, CompactToolRunGroup } from './tool-calls';
 import { StreamingMarkdown } from './StreamingMarkdown';
 import { MessageActionButtons } from './MessageActionButtons';
@@ -257,6 +259,11 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
   const { getToolCallOpen, setToolCallOpen } = useToolCallOpenState();
 
   const isInterrupted = message.role === 'assistant' && message.status === 'interrupted';
+  // CompactTextBlock already renders its own retry button whenever it has non-empty content —
+  // this guards the message-level retry button below from double-rendering for that case.
+  const hasNonEmptyTextBlock = groupedParts.some(
+    (g) => isTextGroupPart(g) && g.parts.map((p) => p.text).join('').trim() !== '',
+  );
 
   const createdAt = message.createdAt;
   const editedAt = message.editedAt;
@@ -429,6 +436,21 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
             </span>
             {canRetry && (
               <span className="text-gray-500 dark:text-gray-400">Cut short — retry to continue.</span>
+            )}
+            {/* CompactTextBlock is the only other place a retry button lives, and it only
+                renders for non-empty content — this is the sole retry control for an
+                empty/tool-only interrupted message. Gated on !hasNonEmptyTextBlock so a message
+                that DID stream real text doesn't show the button twice. */}
+            {canRetry && !hasNonEmptyTextBlock && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRetry}
+                className="h-4 px-0.5"
+                title="Retry this message"
+              >
+                <RotateCw className="h-2 w-2" />
+              </Button>
             )}
           </div>
         )}

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -448,6 +448,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
                 onClick={handleRetry}
                 className="h-4 px-0.5"
                 title="Retry this message"
+                aria-label="Retry this message"
               >
                 <RotateCw className="h-2 w-2" />
               </Button>

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -256,6 +256,8 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
   const groupedParts = useGroupedParts(message.parts);
   const { getToolCallOpen, setToolCallOpen } = useToolCallOpenState();
 
+  const isInterrupted = message.role === 'assistant' && message.status === 'interrupted';
+
   const createdAt = message.createdAt;
   const editedAt = message.editedAt;
 
@@ -420,6 +422,16 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
           }
           return null;
         })}
+        {isInterrupted && (
+          <div className="mt-1 flex items-center gap-1.5 text-[10px]" data-testid="interrupted-affordance">
+            <span className="rounded bg-amber-100 dark:bg-amber-950/40 px-1 py-0.5 font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+              Interrupted
+            </span>
+            {canRetry && (
+              <span className="text-gray-500 dark:text-gray-400">Cut short — retry to continue.</span>
+            )}
+          </div>
+        )}
       </div>
 
       {onDelete && (

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { cn } from '@/lib/utils';
+import { RotateCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { ToolCallRenderer, ToolRunGroup } from './tool-calls';
 
 import { StreamingMarkdown } from './StreamingMarkdown';
@@ -263,6 +265,13 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   const hasToolCalls = message.role === 'assistant' && groupedParts.some(g => isProcessedToolPart(g) || isToolRunGroupPart(g));
 
   const isInterrupted = message.role === 'assistant' && message.status === 'interrupted';
+  // TextBlock already renders its own retry button in its footer whenever it has non-empty
+  // content — the message-level retry button below exists ONLY for the case TextBlock can't
+  // cover (empty or tool-only content, where no TextBlock ever renders). Without this check, a
+  // normal interrupted message with real text would show two retry buttons.
+  const hasNonEmptyTextBlock = groupedParts.some(
+    (g) => isTextGroupPart(g) && g.parts.map((p) => p.text).join('').trim() !== '',
+  );
 
   const createdAt = message.createdAt;
   const editedAt = message.editedAt;
@@ -429,6 +438,21 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
             </span>
             {canRetry && (
               <span className="text-gray-500 dark:text-gray-400">Generation was cut short — retry to continue.</span>
+            )}
+            {/* An interrupted message with empty or tool-only content never renders a TextBlock
+                (its footer is where the retry button normally lives) — this is the only retry
+                control such a message gets. Gated on !hasNonEmptyTextBlock so a message that DID
+                stream real text before dying doesn't show this button twice. */}
+            {canRetry && !hasNonEmptyTextBlock && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRetry}
+                className="h-5 px-1"
+                title="Retry this message"
+              >
+                <RotateCw className="h-2.5 w-2.5" />
+              </Button>
             )}
           </div>
         )}

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -33,6 +33,8 @@ interface TextBlockProps {
   onCancelEdit?: () => void;
   /** Whether this message is currently being streamed (for progressive markdown rendering) */
   isStreaming?: boolean;
+  /** The generation died mid-flight; this is a real but partial, terminal reply. */
+  isInterrupted?: boolean;
 }
 
 /**
@@ -51,11 +53,17 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
   isEditing,
   onSaveEdit,
   onCancelEdit,
-  isStreaming = false
+  isStreaming = false,
+  isInterrupted = false,
 }) => {
   const content = parts.map(part => part.text).join('');
 
-  if (!content.trim() && !isEditing) return null;
+  // An interrupted reply may have died before a single part ever arrived — content is then
+  // literally empty. That is not "nothing to show": it is the honest, terminal fact that the
+  // generation produced nothing before it was cut short, and hiding it would recreate the
+  // silent-loss problem this status exists to surface. Only a genuinely empty, non-terminal
+  // block still renders as nothing.
+  if (!content.trim() && !isEditing && !isInterrupted) return null;
 
   return (
     <div
@@ -89,6 +97,16 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
               />
             </div>
           </div>
+          {isInterrupted && (
+            <div className="mt-1 flex items-center gap-2 text-xs" data-testid="interrupted-affordance">
+              <span className="rounded bg-amber-100 dark:bg-amber-950/40 px-1.5 py-0.5 font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                Interrupted
+              </span>
+              {onRetry && (
+                <span className="text-gray-500 dark:text-gray-400">Generation was cut short — retry to continue.</span>
+              )}
+            </div>
+          )}
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
           <div className="flex items-center justify-between mt-2">
             <div className="text-xs text-gray-500">
@@ -262,6 +280,8 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   // Check if this message has tool calls (for showing undo button on assistant messages)
   const hasToolCalls = message.role === 'assistant' && groupedParts.some(g => isProcessedToolPart(g) || isToolRunGroupPart(g));
 
+  const isInterrupted = message.role === 'assistant' && message.status === 'interrupted';
+
   const createdAt = message.createdAt;
   const editedAt = message.editedAt;
 
@@ -374,6 +394,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 onSaveEdit={handleSaveEdit}
                 onCancelEdit={() => setIsEditing(false)}
                 isStreaming={isStreaming}
+                isInterrupted={isLastTextBlock && isInterrupted}
               />
             );
           } else if (isFileGroupPart(group)) {

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -33,8 +33,6 @@ interface TextBlockProps {
   onCancelEdit?: () => void;
   /** Whether this message is currently being streamed (for progressive markdown rendering) */
   isStreaming?: boolean;
-  /** The generation died mid-flight; this is a real but partial, terminal reply. */
-  isInterrupted?: boolean;
 }
 
 /**
@@ -53,17 +51,11 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
   isEditing,
   onSaveEdit,
   onCancelEdit,
-  isStreaming = false,
-  isInterrupted = false,
+  isStreaming = false
 }) => {
   const content = parts.map(part => part.text).join('');
 
-  // An interrupted reply may have died before a single part ever arrived — content is then
-  // literally empty. That is not "nothing to show": it is the honest, terminal fact that the
-  // generation produced nothing before it was cut short, and hiding it would recreate the
-  // silent-loss problem this status exists to surface. Only a genuinely empty, non-terminal
-  // block still renders as nothing.
-  if (!content.trim() && !isEditing && !isInterrupted) return null;
+  if (!content.trim() && !isEditing) return null;
 
   return (
     <div
@@ -97,16 +89,6 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
               />
             </div>
           </div>
-          {isInterrupted && (
-            <div className="mt-1 flex items-center gap-2 text-xs" data-testid="interrupted-affordance">
-              <span className="rounded bg-amber-100 dark:bg-amber-950/40 px-1.5 py-0.5 font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
-                Interrupted
-              </span>
-              {onRetry && (
-                <span className="text-gray-500 dark:text-gray-400">Generation was cut short — retry to continue.</span>
-              )}
-            </div>
-          )}
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
           <div className="flex items-center justify-between mt-2">
             <div className="text-xs text-gray-500">
@@ -394,7 +376,6 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 onSaveEdit={handleSaveEdit}
                 onCancelEdit={() => setIsEditing(false)}
                 isStreaming={isStreaming}
-                isInterrupted={isLastTextBlock && isInterrupted}
               />
             );
           } else if (isFileGroupPart(group)) {
@@ -441,6 +422,16 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
           }
           return null;
         })}
+        {isInterrupted && (
+          <div className="mr-2 sm:mr-8 mt-1 flex items-center gap-2 text-xs" data-testid="interrupted-affordance">
+            <span className="rounded bg-amber-100 dark:bg-amber-950/40 px-1.5 py-0.5 font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+              Interrupted
+            </span>
+            {canRetry && (
+              <span className="text-gray-500 dark:text-gray-400">Generation was cut short — retry to continue.</span>
+            )}
+          </div>
+        )}
       </div>
 
       {onDelete && (

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -450,6 +450,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 onClick={handleRetry}
                 className="h-5 px-1"
                 title="Retry this message"
+                aria-label="Retry this message"
               >
                 <RotateCw className="h-2.5 w-2.5" />
               </Button>

--- a/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
@@ -71,6 +71,20 @@ describe('CompactMessageRenderer — interrupted affordance', () => {
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
   });
 
+  // The regression this guards against: CompactTextBlock never renders on empty content, so
+  // its footer (the only place the retry BUTTON usually lives) never appears either.
+  it('given an interrupted message with zero content and a retry handler, still exposes an actual retry button', () => {
+    render(
+      <CompactMessageRenderer
+        message={assistantMessage({ status: 'interrupted', parts: [{ type: 'text', text: '' }] })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getByTitle('Retry this message')).toBeInTheDocument();
+  });
+
   it('given an interrupted message with ONLY a tool part (no text ever arrived), still shows the badge', () => {
     render(
       <CompactMessageRenderer
@@ -90,6 +104,41 @@ describe('CompactMessageRenderer — interrupted affordance', () => {
     );
 
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
+  });
+
+  it('given an interrupted message with ONLY a tool part and a retry handler, still exposes an actual retry button', () => {
+    render(
+      <CompactMessageRenderer
+        message={assistantMessage({
+          status: 'interrupted',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'tc-1',
+              toolName: 'search',
+              input: { q: 'hello' },
+              state: 'input-available',
+            } as unknown as UIMessage['parts'][number],
+          ],
+        })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getByTitle('Retry this message')).toBeInTheDocument();
+  });
+
+  it('given an interrupted message WITH real text content and a retry handler, shows exactly ONE retry button', () => {
+    render(
+      <CompactMessageRenderer
+        message={assistantMessage({ status: 'interrupted' })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getAllByTitle('Retry this message')).toHaveLength(1);
   });
 
   it('given a USER message with status "interrupted" (should never happen, but must never mislabel), shows no badge', () => {

--- a/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
@@ -129,10 +129,15 @@ describe('CompactMessageRenderer — interrupted affordance', () => {
     expect(screen.getByTitle('Retry this message')).toBeInTheDocument();
   });
 
+  // CompactTextBlock's footer (MessageActionButtons) only renders at all when BOTH onEdit and
+  // onDelete are supplied (not onRetry alone) — supply them so TextBlock's own retry button
+  // actually appears, or the "exactly one" assertion would trivially pass on zero.
   it('given an interrupted message WITH real text content and a retry handler, shows exactly ONE retry button', () => {
     render(
       <CompactMessageRenderer
         message={assistantMessage({ status: 'interrupted' })}
+        onEdit={async () => {}}
+        onDelete={async () => {}}
         onRetry={() => {}}
         isLastAssistantMessage
       />,

--- a/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/CompactMessageRenderer.interrupted.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { UIMessage } from 'ai';
-import { MessageRenderer } from '../MessageRenderer';
+import { CompactMessageRenderer } from '../CompactMessageRenderer';
 import type { ConversationMessage } from '../message-types';
 
 vi.mock('@/hooks/useAuth', () => ({
@@ -21,28 +21,26 @@ function assistantMessage(overrides: Partial<ConversationMessage> = {}): Convers
   } as unknown as ConversationMessage & UIMessage;
 }
 
-describe('MessageRenderer — interrupted affordance', () => {
+// Parity coverage for the sidebar/compact surface — this is the actual renderer behind
+// SidebarChatTab (global-assistant conversations, the exact channel type
+// materializeInterruptedStream's page-vs-global routing exists for). Mirrors
+// MessageRenderer.interrupted.test.tsx so the two surfaces can't silently drift.
+describe('CompactMessageRenderer — interrupted affordance', () => {
   it('given an assistant message with status "interrupted", shows the Interrupted badge', () => {
-    render(<MessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
+    render(<CompactMessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
 
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
   });
 
   it('given an assistant message with status "complete", shows no badge', () => {
-    render(<MessageRenderer message={assistantMessage({ status: 'complete' })} />);
-
-    expect(screen.queryByText('Interrupted')).not.toBeInTheDocument();
-  });
-
-  it('given no status at all (a pre-column row), shows no badge', () => {
-    render(<MessageRenderer message={assistantMessage()} />);
+    render(<CompactMessageRenderer message={assistantMessage({ status: 'complete' })} />);
 
     expect(screen.queryByText('Interrupted')).not.toBeInTheDocument();
   });
 
   it('given an interrupted message with a retry handler, shows the retry hint text', () => {
     render(
-      <MessageRenderer
+      <CompactMessageRenderer
         message={assistantMessage({ status: 'interrupted' })}
         onRetry={() => {}}
         isLastAssistantMessage
@@ -53,15 +51,19 @@ describe('MessageRenderer — interrupted affordance', () => {
   });
 
   it('given an interrupted message with no retry handler available, shows the badge without a retry hint', () => {
-    render(<MessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
+    render(<CompactMessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
 
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
     expect(screen.queryByText(/retry to continue/i)).not.toBeInTheDocument();
   });
 
+  // The bug this test guards against: CompactTextBlock's own `!content.trim()` guard hides an
+  // empty text block entirely. Without a message-level badge independent of that guard, a
+  // global-assistant stream that died before any text arrived would render as nothing at all in
+  // the sidebar — reproducing the exact silent-loss bug this feature exists to fix.
   it('given an interrupted message with zero content (died before any part arrived), still renders the badge', () => {
     render(
-      <MessageRenderer
+      <CompactMessageRenderer
         message={assistantMessage({ status: 'interrupted', parts: [{ type: 'text', text: '' }] })}
       />,
     );
@@ -69,13 +71,9 @@ describe('MessageRenderer — interrupted affordance', () => {
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
   });
 
-  // The badge must not be coupled to any one part shape: a stream can die mid-tool-call, before
-  // any trailing text ever arrives, leaving `parts` entirely tool-only (no text-group at all).
-  // Nesting the badge inside the text block's own render would make it vanish for exactly this
-  // message — the affordance must render at the message level, independent of which groups exist.
   it('given an interrupted message with ONLY a tool part (no text ever arrived), still shows the badge', () => {
     render(
-      <MessageRenderer
+      <CompactMessageRenderer
         message={assistantMessage({
           status: 'interrupted',
           parts: [
@@ -96,7 +94,7 @@ describe('MessageRenderer — interrupted affordance', () => {
 
   it('given a USER message with status "interrupted" (should never happen, but must never mislabel), shows no badge', () => {
     render(
-      <MessageRenderer
+      <CompactMessageRenderer
         message={{
           id: 'msg-user',
           role: 'user',

--- a/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
@@ -69,6 +69,21 @@ describe('MessageRenderer — interrupted affordance', () => {
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
   });
 
+  // The regression this guards against: an empty-content interrupted message never renders a
+  // TextBlock, so TextBlock's own footer (the only place the retry BUTTON usually lives) never
+  // appears either — the hint text alone is not an actionable control.
+  it('given an interrupted message with zero content and a retry handler, still exposes an actual retry button', () => {
+    render(
+      <MessageRenderer
+        message={assistantMessage({ status: 'interrupted', parts: [{ type: 'text', text: '' }] })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getByTitle('Retry this message')).toBeInTheDocument();
+  });
+
   // The badge must not be coupled to any one part shape: a stream can die mid-tool-call, before
   // any trailing text ever arrives, leaving `parts` entirely tool-only (no text-group at all).
   // Nesting the badge inside the text block's own render would make it vanish for exactly this
@@ -92,6 +107,43 @@ describe('MessageRenderer — interrupted affordance', () => {
     );
 
     expect(screen.getByText('Interrupted')).toBeInTheDocument();
+  });
+
+  it('given an interrupted message with ONLY a tool part and a retry handler, still exposes an actual retry button', () => {
+    render(
+      <MessageRenderer
+        message={assistantMessage({
+          status: 'interrupted',
+          parts: [
+            {
+              type: 'tool-search',
+              toolCallId: 'tc-1',
+              toolName: 'search',
+              input: { q: 'hello' },
+              state: 'input-available',
+            } as unknown as UIMessage['parts'][number],
+          ],
+        })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getByTitle('Retry this message')).toBeInTheDocument();
+  });
+
+  // The other half of the fix: a message that DID stream real text before dying already gets a
+  // retry button from TextBlock's own footer — the message-level button must not duplicate it.
+  it('given an interrupted message WITH real text content and a retry handler, shows exactly ONE retry button', () => {
+    render(
+      <MessageRenderer
+        message={assistantMessage({ status: 'interrupted' })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getAllByTitle('Retry this message')).toHaveLength(1);
   });
 
   it('given a USER message with status "interrupted" (should never happen, but must never mislabel), shows no badge', () => {

--- a/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import { MessageRenderer } from '../MessageRenderer';
+import type { ConversationMessage } from '../message-types';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', name: 'Test User' } }),
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => null,
+}));
+
+function assistantMessage(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    parts: [{ type: 'text', text: 'Partial reply before the process died' }],
+    ...overrides,
+  } as unknown as ConversationMessage & UIMessage;
+}
+
+describe('MessageRenderer — interrupted affordance', () => {
+  it('given an assistant message with status "interrupted", shows the Interrupted badge', () => {
+    render(<MessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
+
+    expect(screen.getByText('Interrupted')).toBeInTheDocument();
+  });
+
+  it('given an assistant message with status "complete", shows no badge', () => {
+    render(<MessageRenderer message={assistantMessage({ status: 'complete' })} />);
+
+    expect(screen.queryByText('Interrupted')).not.toBeInTheDocument();
+  });
+
+  it('given no status at all (a pre-column row), shows no badge', () => {
+    render(<MessageRenderer message={assistantMessage()} />);
+
+    expect(screen.queryByText('Interrupted')).not.toBeInTheDocument();
+  });
+
+  it('given an interrupted message with a retry handler, shows the retry hint text', () => {
+    render(
+      <MessageRenderer
+        message={assistantMessage({ status: 'interrupted' })}
+        onRetry={() => {}}
+        isLastAssistantMessage
+      />,
+    );
+
+    expect(screen.getByText(/retry to continue/i)).toBeInTheDocument();
+  });
+
+  it('given an interrupted message with no retry handler available, shows the badge without a retry hint', () => {
+    render(<MessageRenderer message={assistantMessage({ status: 'interrupted' })} />);
+
+    expect(screen.getByText('Interrupted')).toBeInTheDocument();
+    expect(screen.queryByText(/retry to continue/i)).not.toBeInTheDocument();
+  });
+
+  it('given an interrupted message with zero content (died before any part arrived), still renders the badge', () => {
+    render(
+      <MessageRenderer
+        message={assistantMessage({ status: 'interrupted', parts: [{ type: 'text', text: '' }] })}
+      />,
+    );
+
+    expect(screen.getByText('Interrupted')).toBeInTheDocument();
+  });
+
+  it('given a USER message with status "interrupted" (should never happen, but must never mislabel), shows no badge', () => {
+    render(
+      <MessageRenderer
+        message={{
+          id: 'msg-user',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hi' }],
+          status: 'interrupted',
+        } as unknown as ConversationMessage & UIMessage}
+      />,
+    );
+
+    expect(screen.queryByText('Interrupted')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/MessageRenderer.interrupted.test.tsx
@@ -134,10 +134,16 @@ describe('MessageRenderer — interrupted affordance', () => {
 
   // The other half of the fix: a message that DID stream real text before dying already gets a
   // retry button from TextBlock's own footer — the message-level button must not duplicate it.
+  // TextBlock's footer (MessageActionButtons) only renders at all when BOTH onEdit and onDelete
+  // are supplied (not onRetry alone), matching how the real chat surfaces always wire all three
+  // together — so this test must supply them too, or TextBlock's footer never appears and the
+  // "exactly one" assertion would trivially pass on zero.
   it('given an interrupted message WITH real text content and a retry handler, shows exactly ONE retry button', () => {
     render(
       <MessageRenderer
         message={assistantMessage({ status: 'interrupted' })}
+        onEdit={async () => {}}
+        onDelete={async () => {}}
         onRetry={() => {}}
         isLastAssistantMessage
       />,

--- a/apps/web/src/components/ai/shared/chat/message-types.ts
+++ b/apps/web/src/components/ai/shared/chat/message-types.ts
@@ -15,6 +15,14 @@ export interface ConversationMessage extends UIMessage {
   editedAt?: Date;
   createdAt?: Date;
   userName?: string | null;
+  /**
+   * Lifecycle state of an assistant row (see chat_messages.status / messages.status).
+   * `'interrupted'` means the generation died mid-flight and this is a real, partial
+   * reply, terminal and never resumed on its own — MessageRenderer badges it and
+   * surfaces a retry hint. Absent on rows saved before this column existed, which
+   * read as `'complete'` server-side by default.
+   */
+  status?: 'streaming' | 'complete' | 'interrupted';
 }
 
 /**

--- a/apps/web/src/lib/ai/core/__tests__/abort-stream-anywhere-pending.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/abort-stream-anywhere-pending.test.ts
@@ -44,7 +44,7 @@ describe('abortStreamAnywhere', () => {
     vi.mocked(abortConversationStreams).mockResolvedValue({ aborted: [] });
     vi.mocked(markAbortRequested).mockResolvedValue({ marked: [], failed: false });
     vi.mocked(awaitAbortSettled).mockResolvedValue({ aborted: [], reconcile: [], stillLive: [], code: 'aborted' });
-    vi.mocked(reconcileDeadStreamRows).mockResolvedValue(undefined);
+    vi.mocked(reconcileDeadStreamRows).mockResolvedValue([]);
     vi.mocked(recordPendingAbort).mockResolvedValue(undefined);
   });
 

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -31,7 +31,6 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => ({ conds: args })),
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
-  ne: vi.fn((field: unknown, value: unknown) => ({ ne: [field, value] })),
 }));
 
 vi.mock('@pagespace/db/schema/ai-streams', () => ({
@@ -78,12 +77,15 @@ const toolCallPart = (): UIMessagePart =>
     state: 'output-available',
   }) as UIMessagePart;
 
+const STREAM_STARTED_AT = new Date('2026-07-15T00:00:00.000Z');
+
 const pageRow = (over: Partial<MaterializableStreamRow> = {}): MaterializableStreamRow => ({
   messageId: 'msg-1',
   channelId: 'page-abc123',
   conversationId: 'conv-1',
   userId: 'user-a',
   parts: [textPart('partial reply')],
+  startedAt: STREAM_STARTED_AT,
   ...over,
 });
 
@@ -92,6 +94,7 @@ const globalRow = (over: Partial<MaterializableStreamRow> = {}): MaterializableS
   channelId: 'user:user-a:global',
   conversationId: 'conv-2',
   userId: 'user-a',
+  startedAt: STREAM_STARTED_AT,
   parts: [textPart('partial global reply')],
   ...over,
 });
@@ -206,31 +209,31 @@ describe('materializeInterruptedStream — content from the parts snapshot', () 
   });
 });
 
-describe('materializeInterruptedStream — the #2022 invariant (never overwrite complete)', () => {
+describe('materializeInterruptedStream — the #2022 invariant (compare-and-swap: only from streaming)', () => {
   // Stands in for Postgres evaluating `ON CONFLICT ... DO UPDATE SET ... WHERE <setWhere>`:
   // the update is applied only when the simulated current row's status satisfies the guard.
   const simulatePostgresConflict = (currentStatus: string) => {
-    mockOnConflictDoUpdate.mockImplementation(async (config: { setWhere: { ne: [string, string] } }) => {
-      const [, guardedAgainst] = config.setWhere.ne;
-      return guardedAgainst === currentStatus ? 'skipped' : 'updated';
+    mockOnConflictDoUpdate.mockImplementation(async (config: { setWhere: { field: string; value: string } }) => {
+      const { value: requiredStatus } = config.setWhere;
+      return requiredStatus === currentStatus ? 'updated' : 'skipped';
     });
   };
 
-  it('the onConflictDoUpdate guard names the row status column and "complete"', async () => {
+  it('the onConflictDoUpdate guard requires the row to still be streaming', async () => {
     await materializeInterruptedStream(pageRow());
 
     assert({
       given: 'any materialization attempt',
-      should: 'guard the conflict update with status != complete',
+      should: 'guard the conflict update with status == streaming',
       actual: mockOnConflictDoUpdate.mock.calls[0][0].setWhere,
-      expected: { ne: ['chat_messages.status', 'complete'] },
+      expected: { field: 'chat_messages.status', value: 'streaming' },
     });
   });
 
   it('given a row already complete (the old worker\'s onFinish landed first), the simulated conflict update is a no-op', async () => {
     simulatePostgresConflict('complete');
 
-    const outcome = await mockOnConflictDoUpdate({ setWhere: { ne: ['chat_messages.status', 'complete'] } });
+    const outcome = await mockOnConflictDoUpdate({ setWhere: { field: 'chat_messages.status', value: 'streaming' } });
 
     assert({
       given: 'a message row already flipped to complete between the caller\'s read and this write',
@@ -240,16 +243,49 @@ describe('materializeInterruptedStream — the #2022 invariant (never overwrite 
     });
   });
 
+  // The gap the guard was widened to close: a clean Stop whose onFinish already persisted the
+  // FULL content as 'interrupted', but whose ai_stream_sessions terminal write then failed
+  // (fire-and-forget), leaves the session row eligible for a later sweep. A `!= 'complete'`
+  // guard would let that sweep clobber the already-correct content with an older checkpoint;
+  // `== 'streaming'` cannot, because the row already left 'streaming'.
+  it('given a row already interrupted by its own onFinish (session-row settle failed separately), the simulated conflict update is a no-op', async () => {
+    simulatePostgresConflict('interrupted');
+
+    const outcome = await mockOnConflictDoUpdate({ setWhere: { field: 'chat_messages.status', value: 'streaming' } });
+
+    assert({
+      given: 'a message row already correctly interrupted by its own generation',
+      should: 'never overwrite it with a possibly-staler checkpoint',
+      actual: outcome,
+      expected: 'skipped',
+    });
+  });
+
   it('given a row still streaming, the simulated conflict update applies', async () => {
     simulatePostgresConflict('streaming');
 
-    const outcome = await mockOnConflictDoUpdate({ setWhere: { ne: ['chat_messages.status', 'complete'] } });
+    const outcome = await mockOnConflictDoUpdate({ setWhere: { field: 'chat_messages.status', value: 'streaming' } });
 
     assert({
       given: 'a message row still streaming',
       should: 'apply the interrupted write',
       actual: outcome,
       expected: 'updated',
+    });
+  });
+});
+
+describe('materializeInterruptedStream — the defensive insert-if-missing path', () => {
+  it('uses the stream\'s actual start time, not reap time, as createdAt for a newly-inserted row', async () => {
+    const startedAt = new Date('2026-07-15T01:23:45.000Z');
+    await materializeInterruptedStream(pageRow({ startedAt }));
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a materialization whose placeholder insert never happened',
+      should: 'timestamp the recovered row at the stream\'s actual start, so it still sorts correctly against a later user message',
+      actual: values.createdAt,
+      expected: startedAt,
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -144,18 +144,40 @@ describe('materializeInterruptedStream — table routing', () => {
       expected: { userId: 'user-a', status: 'interrupted' },
     });
   });
+
+  // Mirrors saveMessageToDatabase's own update-set ("Update conversationId if message is
+  // reprocessed") — a message reparented into a different conversation before this sweep ran
+  // must not be left pointing at a stale conversationId after materialization.
+  it('re-syncs conversationId on the conflict update, same as the normal terminal-write path', async () => {
+    await materializeInterruptedStream(pageRow({ conversationId: 'conv-fresh' }));
+
+    const setClause = mockOnConflictDoUpdate.mock.calls[0][0].set;
+    assert({
+      given: 'a materialization upsert',
+      should: 'include conversationId in the conflict update set clause',
+      actual: setClause.conversationId,
+      expected: 'conv-fresh',
+    });
+  });
 });
 
 describe('materializeInterruptedStream — content from the parts snapshot', () => {
-  it('builds message content via the shared execute-end/onFinish payload builder', async () => {
+  // The normal execute-end/onFinish path runs any non-empty parts array through
+  // extractStructuredContentFromParts before persisting (message-utils.ts:536,666) — the
+  // structured JSON envelope is what preserves file/data parts and chronological ordering on
+  // reload. Materialize must produce the SAME envelope, not the plain concatenated text, or a
+  // materialized reply with tool calls/file parts would silently degrade to flat text forever
+  // (it's a terminal write — no later pass ever fixes it).
+  it('builds message content via the same structured-content pipeline execute-end/onFinish use, not plain concatenated text', async () => {
     await materializeInterruptedStream(pageRow({ parts: [textPart('Hello'), textPart(' world')] }));
 
     const values = mockInsertValues.mock.calls[0][0];
+    const parsed = JSON.parse(values.content as string);
     assert({
       given: 'a parts snapshot with two text parts',
-      should: 'produce the same concatenated content buildAssistantPersistencePayload would for a finished stream',
-      actual: values.content,
-      expected: 'Hello world',
+      should: 'persist the structured-content envelope (matching saveMessageToDatabase), not flat text',
+      actual: { originalContent: parsed.originalContent, textParts: parsed.textParts },
+      expected: { originalContent: 'Hello world', textParts: ['Hello', ' world'] },
     });
   });
 
@@ -313,6 +335,26 @@ describe('materializeInterruptedStream — broadcast', () => {
     await materializeInterruptedStream(pageRow());
 
     expect(mockBroadcastAiStreamComplete).not.toHaveBeenCalled();
+  });
+
+  it('logs but does not throw when the broadcast itself fails', async () => {
+    mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('broadcast failed'),
+      expect.objectContaining({ error: 'socket down' }),
+    );
+  });
+
+  it('logs a non-Error broadcast rejection without throwing', async () => {
+    mockBroadcastAiStreamComplete.mockRejectedValue('a rejected string, not an Error instance');
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('broadcast failed'),
+      expect.objectContaining({ error: 'unknown' }),
+    );
   });
 });
 

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { assert } from './riteway';
+
+const {
+  mockInsert,
+  mockInsertValues,
+  mockOnConflictDoUpdate,
+  mockUpdateSet,
+  mockUpdateWhere,
+  mockBroadcastAiStreamComplete,
+  mockLoggerWarn,
+} = vi.hoisted(() => ({
+  mockInsert: vi.fn(),
+  mockInsertValues: vi.fn(),
+  mockOnConflictDoUpdate: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
+  mockBroadcastAiStreamComplete: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    insert: mockInsert,
+    update: vi.fn(() => ({ set: mockUpdateSet })),
+  },
+}));
+
+// Identity-shaped operators (the house pattern — see stream-abort-mark.test.ts) so a test can
+// assert on the predicate itself rather than trusting drizzle to have built it correctly.
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn((...args: unknown[]) => ({ conds: args })),
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
+  ne: vi.fn((field: unknown, value: unknown) => ({ ne: [field, value] })),
+}));
+
+vi.mock('@pagespace/db/schema/ai-streams', () => ({
+  aiStreamSessions: {
+    messageId: 'ai_stream_sessions.message_id',
+    status: 'ai_stream_sessions.status',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: {
+    id: 'chat_messages.id',
+    status: 'chat_messages.status',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/conversations', () => ({
+  messages: {
+    id: 'messages.id',
+    status: 'messages.status',
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { ai: { info: vi.fn(), warn: mockLoggerWarn, error: vi.fn(), debug: vi.fn() } },
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastAiStreamComplete: mockBroadcastAiStreamComplete,
+}));
+
+import { materializeInterruptedStream, type MaterializableStreamRow } from '../materialize-interrupted-stream';
+import type { UIMessagePart } from '../stream-multicast-registry';
+
+const textPart = (text: string): UIMessagePart => ({ type: 'text', text }) as UIMessagePart;
+
+const toolCallPart = (): UIMessagePart =>
+  ({
+    type: 'tool-search',
+    toolCallId: 'tc-1',
+    toolName: 'search',
+    input: { q: 'hello' },
+    output: { results: [] },
+    state: 'output-available',
+  }) as UIMessagePart;
+
+const pageRow = (over: Partial<MaterializableStreamRow> = {}): MaterializableStreamRow => ({
+  messageId: 'msg-1',
+  channelId: 'page-abc123',
+  conversationId: 'conv-1',
+  userId: 'user-a',
+  parts: [textPart('partial reply')],
+  ...over,
+});
+
+const globalRow = (over: Partial<MaterializableStreamRow> = {}): MaterializableStreamRow => ({
+  messageId: 'msg-2',
+  channelId: 'user:user-a:global',
+  conversationId: 'conv-2',
+  userId: 'user-a',
+  parts: [textPart('partial global reply')],
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInsert.mockReturnValue({ values: mockInsertValues });
+  mockInsertValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
+  mockOnConflictDoUpdate.mockResolvedValue(undefined);
+  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+  mockUpdateWhere.mockResolvedValue(undefined);
+  mockBroadcastAiStreamComplete.mockResolvedValue(undefined);
+});
+
+describe('materializeInterruptedStream — table routing', () => {
+  it('given a page-chat channelId, writes to chat_messages with pageId = channelId', async () => {
+    await materializeInterruptedStream(pageRow({ channelId: 'page-abc123' }));
+
+    assert({
+      given: 'a provably-dead page-chat stream row',
+      should: 'insert into chat_messages, not messages',
+      actual: mockInsert.mock.calls[0][0],
+      expected: { id: 'chat_messages.id', status: 'chat_messages.status' },
+    });
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a page-chat row',
+      should: 'set pageId from channelId, userId null, sourceAgentId null (mirrors the placeholder insert contract)',
+      actual: { pageId: values.pageId, userId: values.userId, sourceAgentId: values.sourceAgentId, status: values.status },
+      expected: { pageId: 'page-abc123', userId: null, sourceAgentId: null, status: 'interrupted' },
+    });
+  });
+
+  it('given a global-assistant channelId, writes to messages with the row owner as userId', async () => {
+    await materializeInterruptedStream(globalRow({ channelId: 'user:user-a:global', userId: 'user-a' }));
+
+    assert({
+      given: 'a provably-dead global-assistant stream row',
+      should: 'insert into messages, not chat_messages',
+      actual: mockInsert.mock.calls[0][0],
+      expected: { id: 'messages.id', status: 'messages.status' },
+    });
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a global-assistant row',
+      should: 'set userId to the stream owner (messages.userId is NOT NULL)',
+      actual: { userId: values.userId, status: values.status },
+      expected: { userId: 'user-a', status: 'interrupted' },
+    });
+  });
+});
+
+describe('materializeInterruptedStream — content from the parts snapshot', () => {
+  it('builds message content via the shared execute-end/onFinish payload builder', async () => {
+    await materializeInterruptedStream(pageRow({ parts: [textPart('Hello'), textPart(' world')] }));
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a parts snapshot with two text parts',
+      should: 'produce the same concatenated content buildAssistantPersistencePayload would for a finished stream',
+      actual: values.content,
+      expected: 'Hello world',
+    });
+  });
+
+  it('given parts that include a tool call, serializes toolCalls/toolResults as JSON rather than leaving them null', async () => {
+    await materializeInterruptedStream(pageRow({ parts: [textPart('Here'), toolCallPart()] }));
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a parts snapshot with a completed tool call',
+      should: 'persist non-null, JSON-serialized toolCalls and toolResults',
+      actual: { toolCalls: values.toolCalls !== null, toolResults: values.toolResults !== null },
+      expected: { toolCalls: true, toolResults: true },
+    });
+  });
+
+  it('given no parts at all, still writes an interrupted row with empty content', async () => {
+    await materializeInterruptedStream(pageRow({ parts: [] }));
+
+    const values = mockInsertValues.mock.calls[0][0];
+    assert({
+      given: 'a stream that died before any part was ever pushed',
+      should: 'materialize an empty-but-honest interrupted row rather than skipping it',
+      actual: { content: values.content, status: values.status },
+      expected: { content: '', status: 'interrupted' },
+    });
+  });
+});
+
+describe('materializeInterruptedStream — the #2022 invariant (never overwrite complete)', () => {
+  // Stands in for Postgres evaluating `ON CONFLICT ... DO UPDATE SET ... WHERE <setWhere>`:
+  // the update is applied only when the simulated current row's status satisfies the guard.
+  const simulatePostgresConflict = (currentStatus: string) => {
+    mockOnConflictDoUpdate.mockImplementation(async (config: { setWhere: { ne: [string, string] } }) => {
+      const [, guardedAgainst] = config.setWhere.ne;
+      return guardedAgainst === currentStatus ? 'skipped' : 'updated';
+    });
+  };
+
+  it('the onConflictDoUpdate guard names the row status column and "complete"', async () => {
+    await materializeInterruptedStream(pageRow());
+
+    assert({
+      given: 'any materialization attempt',
+      should: 'guard the conflict update with status != complete',
+      actual: mockOnConflictDoUpdate.mock.calls[0][0].setWhere,
+      expected: { ne: ['chat_messages.status', 'complete'] },
+    });
+  });
+
+  it('given a row already complete (the old worker\'s onFinish landed first), the simulated conflict update is a no-op', async () => {
+    simulatePostgresConflict('complete');
+
+    const outcome = await mockOnConflictDoUpdate({ setWhere: { ne: ['chat_messages.status', 'complete'] } });
+
+    assert({
+      given: 'a message row already flipped to complete between the caller\'s read and this write',
+      should: 'never relabel it interrupted',
+      actual: outcome,
+      expected: 'skipped',
+    });
+  });
+
+  it('given a row still streaming, the simulated conflict update applies', async () => {
+    simulatePostgresConflict('streaming');
+
+    const outcome = await mockOnConflictDoUpdate({ setWhere: { ne: ['chat_messages.status', 'complete'] } });
+
+    assert({
+      given: 'a message row still streaming',
+      should: 'apply the interrupted write',
+      actual: outcome,
+      expected: 'updated',
+    });
+  });
+});
+
+describe('materializeInterruptedStream — settling the session row', () => {
+  it('settles ai_stream_sessions terminal only after the message write succeeds', async () => {
+    await materializeInterruptedStream(pageRow({ messageId: 'msg-settle' }));
+
+    const written = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>;
+    assert({
+      given: 'a successful message materialization',
+      should: 'drive the session row terminal, clearing its parts snapshot',
+      actual: { status: written.status, parts: written.parts, rawPartsCount: written.rawPartsCount, abortRequestedAt: written.abortRequestedAt },
+      expected: { status: 'aborted', parts: [], rawPartsCount: 0, abortRequestedAt: null },
+    });
+
+    const conds = (mockUpdateWhere.mock.calls[0][0] as { conds: Array<{ field?: string; value?: unknown }> }).conds;
+    assert({
+      given: 'the session-row settle write',
+      should: 'only ever touch a row still marked streaming',
+      actual: conds.find((c) => c.field === 'ai_stream_sessions.status')?.value,
+      expected: 'streaming',
+    });
+  });
+
+  it('does not settle the session row when the message write fails', async () => {
+    mockOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
+
+    await materializeInterruptedStream(pageRow());
+
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    assert({
+      given: 'a message upsert that could not be confirmed',
+      should: 'warn rather than silently losing the row',
+      actual: mockLoggerWarn.mock.calls.length > 0,
+      expected: true,
+    });
+  });
+
+  it('logs but does not throw when the session-row settle itself fails', async () => {
+    mockUpdateWhere.mockRejectedValue(new Error('db down'));
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalled();
+  });
+
+  it('logs a non-Error message-write rejection without throwing', async () => {
+    mockOnConflictDoUpdate.mockRejectedValue('a rejected string, not an Error instance');
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ error: 'unknown' }),
+    );
+  });
+
+  it('logs a non-Error session-settle rejection without throwing', async () => {
+    mockUpdateWhere.mockRejectedValue('a rejected string, not an Error instance');
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ error: 'unknown' }),
+    );
+  });
+});
+
+describe('materializeInterruptedStream — broadcast', () => {
+  it('broadcasts stream_complete with aborted:true after a successful materialization', async () => {
+    await materializeInterruptedStream(pageRow({ messageId: 'msg-3', channelId: 'page-xyz', conversationId: 'conv-3' }));
+
+    assert({
+      given: 'a materialized interrupted stream',
+      should: 'tell every subscriber the generation is over, the same as a live abort would',
+      actual: mockBroadcastAiStreamComplete.mock.calls[0][0],
+      expected: { messageId: 'msg-3', pageId: 'page-xyz', conversationId: 'conv-3', aborted: true },
+    });
+  });
+
+  it('does not broadcast when the message write failed (nothing was actually materialized)', async () => {
+    mockOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
+
+    await materializeInterruptedStream(pageRow());
+
+    expect(mockBroadcastAiStreamComplete).not.toHaveBeenCalled();
+  });
+});
+
+describe('materializeInterruptedStream — never throws', () => {
+  it('resolves even when every DB call rejects', async () => {
+    mockOnConflictDoUpdate.mockResolvedValue(undefined);
+    mockUpdateWhere.mockRejectedValue(new Error('db down'));
+    mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -291,6 +291,10 @@ describe('materializeInterruptedStream — the defensive insert-if-missing path'
 });
 
 describe('materializeInterruptedStream — settling the session row', () => {
+  it('reports true when both the message write and the session settle succeed', async () => {
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(true);
+  });
+
   it('settles ai_stream_sessions terminal only after the message write succeeds', async () => {
     await materializeInterruptedStream(pageRow({ messageId: 'msg-settle' }));
 
@@ -314,7 +318,7 @@ describe('materializeInterruptedStream — settling the session row', () => {
   it('does not settle the session row when the message write fails', async () => {
     mockOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
 
-    await materializeInterruptedStream(pageRow());
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
 
     expect(mockUpdateSet).not.toHaveBeenCalled();
     assert({
@@ -325,27 +329,27 @@ describe('materializeInterruptedStream — settling the session row', () => {
     });
   });
 
-  it('logs but does not throw when the session-row settle itself fails', async () => {
+  it('logs but does not throw when the session-row settle itself fails, and reports false (not truly reconciled)', async () => {
     mockUpdateWhere.mockRejectedValue(new Error('db down'));
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
     expect(mockLoggerWarn).toHaveBeenCalled();
   });
 
-  it('logs a non-Error message-write rejection without throwing', async () => {
+  it('logs a non-Error message-write rejection without throwing, and reports false', async () => {
     mockOnConflictDoUpdate.mockRejectedValue('a rejected string, not an Error instance');
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ error: 'unknown' }),
     );
   });
 
-  it('logs a non-Error session-settle rejection without throwing', async () => {
+  it('logs a non-Error session-settle rejection without throwing, and reports false', async () => {
     mockUpdateWhere.mockRejectedValue('a rejected string, not an Error instance');
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ error: 'unknown' }),
@@ -373,10 +377,10 @@ describe('materializeInterruptedStream — broadcast', () => {
     expect(mockBroadcastAiStreamComplete).not.toHaveBeenCalled();
   });
 
-  it('logs but does not throw when the broadcast itself fails', async () => {
+  it('logs but does not throw when the broadcast itself fails — a broadcast failure alone does not undo an otherwise-successful materialization', async () => {
     mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(true);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.stringContaining('broadcast failed'),
       expect.objectContaining({ error: 'socket down' }),
@@ -386,7 +390,7 @@ describe('materializeInterruptedStream — broadcast', () => {
   it('logs a non-Error broadcast rejection without throwing', async () => {
     mockBroadcastAiStreamComplete.mockRejectedValue('a rejected string, not an Error instance');
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(true);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.stringContaining('broadcast failed'),
       expect.objectContaining({ error: 'unknown' }),
@@ -395,11 +399,11 @@ describe('materializeInterruptedStream — broadcast', () => {
 });
 
 describe('materializeInterruptedStream — never throws', () => {
-  it('resolves even when every DB call rejects', async () => {
+  it('resolves (with false, since the session row never settled) even when every DB call rejects', async () => {
     mockOnConflictDoUpdate.mockResolvedValue(undefined);
     mockUpdateWhere.mockRejectedValue(new Error('db down'));
     mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
 
-    await expect(materializeInterruptedStream(pageRow())).resolves.toBeUndefined();
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -105,7 +105,9 @@ beforeEach(() => {
   mockInsertValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
   mockOnConflictDoUpdate.mockResolvedValue(undefined);
   mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-  mockUpdateWhere.mockResolvedValue(undefined);
+  // Defaults to "one row actually settled" (rowCount: 1) — the common case. Tests exercising the
+  // zero-row race (a concurrent reap already settled this row) override this per-case.
+  mockUpdateWhere.mockResolvedValue({ rowCount: 1 });
   mockBroadcastAiStreamComplete.mockResolvedValue(undefined);
 });
 
@@ -313,6 +315,28 @@ describe('materializeInterruptedStream — settling the session row', () => {
       actual: conds.find((c) => c.field === 'ai_stream_sessions.status')?.value,
       expected: 'streaming',
     });
+  });
+
+  // The conditional UPDATE (`WHERE messageId = X AND status = 'streaming'`) does NOT throw when
+  // it matches zero rows — it succeeds and changes nothing. That happens when a concurrent reap
+  // (another instance's takeover, or a second sweep racing this one) already settled this exact
+  // row first. Reporting `true` here would credit THIS call with settling a row someone else
+  // already handled, and — more importantly — would mask the case where the row was never
+  // settled by anyone (see the `rowCount: 0` semantics matching compaction-repository.ts's own
+  // conditional-update pattern).
+  it('reports false when the session-row update matches zero rows (a concurrent reap already settled it)', async () => {
+    mockUpdateWhere.mockResolvedValue({ rowCount: 0 });
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
+    // The message write still succeeded and is not itself an error — only the session-settle
+    // half is "unsettled", so this is not a warn-worthy failure the way a thrown error is.
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('defensively treats a missing rowCount (driver/mock returns undefined) as zero, not as settled', async () => {
+    mockUpdateWhere.mockResolvedValue({});
+
+    await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
   });
 
   it('does not settle the session row when the message write fails', async () => {

--- a/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
@@ -91,6 +91,10 @@ beforeEach(() => {
   mockUpdateWhere.mockImplementation(whereResult);
   mockReturning.mockResolvedValue([]);
   mockSelectWhere.mockResolvedValue([]);
+  // Defaults to "succeeded" — most tests here are about WHICH rows get read/handed off, not
+  // about materialize's own success/failure reporting (that's covered explicitly below and in
+  // materialize-interrupted-stream.test.ts).
+  mockMaterializeInterruptedStream.mockResolvedValue(true);
 });
 
 const selectConditions = (): Predicate['conds'] =>
@@ -527,18 +531,37 @@ describe('reconcileDeadStreamRows — materializes each dead row as an interrupt
   });
 
   it('does nothing when there is nothing to reconcile', async () => {
-    await reconcileDeadStreamRows({ messageIds: [] });
+    await expect(reconcileDeadStreamRows({ messageIds: [] })).resolves.toEqual([]);
 
     expect(mockSelectWhere).not.toHaveBeenCalled();
     expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
   });
 
-  it('warns and does not throw when the read itself fails', async () => {
+  it('warns and does not throw when the read itself fails, reporting nothing reconciled', async () => {
     mockSelectWhere.mockRejectedValueOnce(new Error('db down'));
 
-    await expect(reconcileDeadStreamRows({ messageIds: ['msg-dead'] })).resolves.toBeUndefined();
+    await expect(reconcileDeadStreamRows({ messageIds: ['msg-dead'] })).resolves.toEqual([]);
     expect(mockLoggerWarn).toHaveBeenCalled();
     expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+  });
+
+  it('returns only the messageIds materializeInterruptedStream actually succeeded on', async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-ok', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts: [], startedAt: new Date() },
+      { messageId: 'msg-failed', channelId: 'page-1', conversationId: 'conv-2', userId: 'user-2', parts: [], startedAt: new Date() },
+    ]);
+    mockMaterializeInterruptedStream
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const reconciled = await reconcileDeadStreamRows({ messageIds: ['msg-ok', 'msg-failed'] });
+
+    assert({
+      given: 'one row that materializes successfully and one that does not',
+      should: 'report only the successful one as reconciled — never claim a retryable ghost row was handled',
+      actual: reconciled,
+      expected: ['msg-ok'],
+    });
   });
 });
 

--- a/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
@@ -498,10 +498,11 @@ describe('reconcileDeadStreamRows — materializes each dead row as an interrupt
     });
   });
 
-  it('hands each row it reads to materializeInterruptedStream with its full parts snapshot', async () => {
+  it('hands each row it reads to materializeInterruptedStream with its full parts snapshot and startedAt', async () => {
     const parts = [{ type: 'text', text: 'partial reply' }];
+    const startedAt = new Date('2026-07-15T00:00:00.000Z');
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts },
+      { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts, startedAt },
     ]);
 
     await reconcileDeadStreamRows({ messageIds: ['msg-dead'] });
@@ -510,7 +511,7 @@ describe('reconcileDeadStreamRows — materializes each dead row as an interrupt
       given: 'a dead row read fresh from the DB',
       should: 'materialize it as an interrupted message rather than just wiping the session row',
       actual: mockMaterializeInterruptedStream.mock.calls[0][0],
-      expected: { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts },
+      expected: { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts, startedAt },
     });
   });
 

--- a/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-abort-mark.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { assert } from './riteway';
 
-const { mockUpdateSet, mockUpdateWhere, mockReturning, mockSelectWhere, mockLoggerWarn } = vi.hoisted(() => ({
+const {
+  mockUpdateSet,
+  mockUpdateWhere,
+  mockReturning,
+  mockSelectWhere,
+  mockLoggerWarn,
+  mockMaterializeInterruptedStream,
+} = vi.hoisted(() => ({
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
   mockReturning: vi.fn(),
   mockSelectWhere: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockMaterializeInterruptedStream: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -45,6 +53,14 @@ vi.mock('@pagespace/db/schema/ai-streams', () => ({
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { ai: { info: vi.fn(), warn: mockLoggerWarn, error: vi.fn(), debug: vi.fn() } },
+}));
+
+// Materialization is its own unit with its own tests (materialize-interrupted-stream.test.ts —
+// where the #2022 never-overwrite-complete guard and the settle/broadcast steps are asserted).
+// Stubbed here so these tests exercise what reconcileDeadStreamRows reads and hands off, not how
+// a row is turned into an interrupted message.
+vi.mock('@/lib/ai/core/materialize-interrupted-stream', () => ({
+  materializeInterruptedStream: mockMaterializeInterruptedStream,
 }));
 
 import {
@@ -464,38 +480,64 @@ describe('readMarkedStreams — what the watcher is allowed to act on', () => {
   });
 });
 
-describe('reconcileDeadStreamRows — the destructive write', () => {
-  // This wipes `parts` — the stream's only crash-recovery snapshot — and hides the row from every
-  // subscriber. It may ONLY ever touch a row whose owner is provably gone. Drop the status
-  // predicate and a stream that terminated on its own between the read and here is retroactively
-  // relabelled 'aborted'; worse, widen it and you erase a live stream.
-  it('only ever touches rows still marked streaming', async () => {
+describe('reconcileDeadStreamRows — materializes each dead row as an interrupted message', () => {
+  // Only rows still 'streaming' may be reconciled. Drop this predicate and a stream that
+  // terminated on its own between the caller's read and here would be picked up and
+  // materialized a second time (materializeInterruptedStream's own guard makes that a no-op
+  // rather than data corruption, but this SELECT is the first line of defense).
+  it('reads only rows still marked streaming', async () => {
+    mockSelectWhere.mockResolvedValueOnce([]);
+
     await reconcileDeadStreamRows({ messageIds: ['msg-dead'] });
 
     assert({
-      given: 'a row whose owning process is gone',
-      should: 'refuse to overwrite a row that has already reached a terminal status',
-      actual: conditions().find((c) => c.field === 'ai_stream_sessions.status')?.value,
+      given: 'messageIds the caller proved dead',
+      should: 'only read rows still marked streaming — one that terminated on its own is left alone',
+      actual: selectConditions().find((c) => c.field === 'ai_stream_sessions.status')?.value,
       expected: 'streaming',
     });
   });
 
-  it('drives the row terminal and clears its now-meaningless abort mark', async () => {
+  it('hands each row it reads to materializeInterruptedStream with its full parts snapshot', async () => {
+    const parts = [{ type: 'text', text: 'partial reply' }];
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts },
+    ]);
+
     await reconcileDeadStreamRows({ messageIds: ['msg-dead'] });
 
-    const written = mockUpdateSet.mock.calls[0][0] as Record<string, unknown>;
     assert({
-      given: 'a dead row being reconciled',
-      should: 'mark it aborted, clear its parts snapshot, and drop the abort request',
-      actual: { status: written.status, parts: written.parts, abortRequestedAt: written.abortRequestedAt },
-      expected: { status: 'aborted', parts: [], abortRequestedAt: null },
+      given: 'a dead row read fresh from the DB',
+      should: 'materialize it as an interrupted message rather than just wiping the session row',
+      actual: mockMaterializeInterruptedStream.mock.calls[0][0],
+      expected: { messageId: 'msg-dead', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts },
     });
+  });
+
+  it('materializes multiple dead rows independently', async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-a', channelId: 'page-1', conversationId: 'conv-1', userId: 'user-1', parts: [] },
+      { messageId: 'msg-b', channelId: 'page-2', conversationId: 'conv-2', userId: 'user-2', parts: [] },
+    ]);
+
+    await reconcileDeadStreamRows({ messageIds: ['msg-a', 'msg-b'] });
+
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledTimes(2);
   });
 
   it('does nothing when there is nothing to reconcile', async () => {
     await reconcileDeadStreamRows({ messageIds: [] });
 
-    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(mockSelectWhere).not.toHaveBeenCalled();
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+  });
+
+  it('warns and does not throw when the read itself fails', async () => {
+    mockSelectWhere.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(reconcileDeadStreamRows({ messageIds: ['msg-dead'] })).resolves.toBeUndefined();
+    expect(mockLoggerWarn).toHaveBeenCalled();
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
@@ -196,6 +196,23 @@ describe('takeOverConversationStreams', () => {
     );
   });
 
+  // Codex review finding: a recovered reply timestamped at reap time (instead of the stream's
+  // actual start) can sort after a user's later follow-up message. Carrying startedAt through
+  // is what lets materializeInterruptedStream's defensive insert-if-missing path get this right.
+  it("passes the row's actual startedAt through to materializeInterruptedStream, not takeover time", async () => {
+    const longAgo = new Date(Date.now() - 30 * 60 * 1000);
+    mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'Stream not found or already completed' });
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-dead', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [] },
+    ]);
+
+    await takeOverConversationStreams(ARGS);
+
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith(
+      expect.objectContaining({ startedAt: longAgo }),
+    );
+  });
+
   // A liveness guess must never gate the abort. The heartbeat can lag (a slow DB write,
   // a GC pause), and skipping the abort for a row we wrongly called dead would leave a
   // REAL generation running while we start a second one beside it — precisely what this

--- a/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
@@ -108,8 +108,12 @@ describe('takeOverConversationStreams', () => {
       failed: false,
     }));
     mockAwaitAbortSettled.mockResolvedValue(settled());
-    mockReconcileDead.mockResolvedValue(undefined);
-    mockMaterializeInterruptedStream.mockResolvedValue(undefined);
+    mockReconcileDead.mockResolvedValue([]);
+    // Defaults to "succeeded" — materializeInterruptedStream now reports success/failure via its
+    // return value, and most tests here are about ELIGIBILITY (which rows get materialized), not
+    // about materialize's own failure handling (that's materialize-interrupted-stream.test.ts's
+    // job). Tests exercising the accurate-reporting behavior override this per-case.
+    mockMaterializeInterruptedStream.mockResolvedValue(true);
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdateWhere.mockResolvedValue(undefined);
   });

--- a/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const {
   mockSelectWhere,
-  mockUpdateWhere,
-  mockUpdateSet,
   mockAbortStreamByMessageId,
   mockLoggerInfo,
   mockLoggerWarn,
@@ -11,30 +9,28 @@ const {
   mockWasRecentlyFinishedHere,
   mockAwaitAbortSettled,
   mockReconcileDead,
+  mockMaterializeInterruptedStream,
 } = vi.hoisted(() => ({
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockSelectWhere: vi.fn(),
-  mockUpdateWhere: vi.fn().mockResolvedValue(undefined),
-  mockUpdateSet: vi.fn(),
   mockAbortStreamByMessageId: vi.fn(),
   mockMarkAsOwner: vi.fn(),
   mockWasRecentlyFinishedHere: vi.fn(),
   mockAwaitAbortSettled: vi.fn(),
   mockReconcileDead: vi.fn(),
+  mockMaterializeInterruptedStream: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
     select: vi.fn(() => ({ from: vi.fn(() => ({ where: mockSelectWhere })) })),
-    update: vi.fn(() => ({ set: mockUpdateSet })),
   },
 }));
 
 vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   eq: vi.fn((col: unknown, val: unknown) => ({ eq: [col, val] })),
-  inArray: vi.fn((col: unknown, vals: unknown) => ({ inArray: [col, vals] })),
 }));
 
 vi.mock('@pagespace/db/schema/ai-streams', () => ({
@@ -63,6 +59,14 @@ vi.mock('@/lib/ai/core/stream-abort-mark', () => ({
   reconcileDeadStreamRows: mockReconcileDead,
 }));
 
+// Materialization is its own unit with its own tests (materialize-interrupted-stream.test.ts —
+// where the #2022 never-overwrite-complete guard and the settle/broadcast steps are asserted).
+// Stubbed here so these tests exercise what the TAKEOVER decides to reconcile, not how a row is
+// turned into an interrupted message.
+vi.mock('@/lib/ai/core/materialize-interrupted-stream', () => ({
+  materializeInterruptedStream: mockMaterializeInterruptedStream,
+}));
+
 vi.mock('@/lib/ai/core/stream-abort-registry', async (importOriginal) => ({
   ...(await importOriginal<object>()),
   abortStreamByMessageId: mockAbortStreamByMessageId,
@@ -70,7 +74,6 @@ vi.mock('@/lib/ai/core/stream-abort-registry', async (importOriginal) => ({
 }));
 
 import { takeOverConversationStreams } from '../stream-takeover';
-import { inArray } from '@pagespace/db/operators';
 
 const ARGS = { conversationId: 'conv-1', channelId: 'page-1' };
 
@@ -92,8 +95,6 @@ const settled = (
 describe('takeOverConversationStreams', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-    mockUpdateWhere.mockResolvedValue(undefined);
     mockAbortStreamByMessageId.mockReturnValue({ aborted: true, reason: '' });
     mockWasRecentlyFinishedHere.mockReturnValue(false);
     mockMarkAsOwner.mockImplementation(async ({ messageIds }: { messageIds: string[] }) => ({
@@ -102,6 +103,7 @@ describe('takeOverConversationStreams', () => {
     }));
     mockAwaitAbortSettled.mockResolvedValue(settled());
     mockReconcileDead.mockResolvedValue(undefined);
+    mockMaterializeInterruptedStream.mockResolvedValue(undefined);
   });
 
   it('given no in-flight stream on the conversation, should do nothing (the common case must be cheap)', async () => {
@@ -111,40 +113,47 @@ describe('takeOverConversationStreams', () => {
 
     expect(result).toEqual({ aborted: [], reconciled: [] });
     expect(mockAbortStreamByMessageId).not.toHaveBeenCalled();
-    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
   });
 
   // The bug this exists for: a second send used to simply start a SECOND generation on
   // the same conversation. Two agents editing the same pages, two assistant rows, two
   // bills. The only pre-existing limiter was the credit gate's per-USER maxInFlight.
-  it('given a live stream on the conversation, should abort it and drive its row terminal before the new generation starts', async () => {
+  it('given a live stream on the conversation, should abort it and materialize its row as interrupted before the new generation starts', async () => {
+    const parts = [{ type: 'text', text: 'partial' }];
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date() },
+      { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date(), parts },
     ]);
 
     const result = await takeOverConversationStreams(ARGS);
 
     expect(mockAbortStreamByMessageId).toHaveBeenCalledWith({ messageId: 'msg-live', userId: 'user-1' });
     expect(result).toEqual({ aborted: ['msg-live'], reconciled: ['msg-live'] });
-    expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ status: 'aborted', parts: [], completedAt: expect.any(Date) }),
-    );
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith({
+      messageId: 'msg-live',
+      channelId: 'page-1',
+      conversationId: 'conv-1',
+      userId: 'user-1',
+      parts,
+    });
   });
 
   // A crashed process leaves status='streaming' forever (the terminal write is
   // fire-and-forget). A 409 here would lock the user out of their own conversation for
   // as long as that row survives — strictly worse than the bug being fixed.
-  it('given a STALE streaming row (crashed process), should NOT block the send and should reconcile the dead row', async () => {
+  it('given a STALE streaming row (crashed process), should NOT block the send and should materialize the dead row', async () => {
     const longAgo = new Date(Date.now() - 30 * 60 * 1000);
     mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'Stream not found or already completed' });
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-dead', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo },
+      { messageId: 'msg-dead', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [] },
     ]);
 
     const result = await takeOverConversationStreams(ARGS);
 
     expect(result).toEqual({ aborted: [], reconciled: ['msg-dead'] });
-    expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ status: 'aborted' }));
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'msg-dead' }),
+    );
   });
 
   // A liveness guess must never gate the abort. The heartbeat can lag (a slow DB write,
@@ -154,7 +163,7 @@ describe('takeOverConversationStreams', () => {
   it('given a row that looks stale, should STILL attempt the abort', async () => {
     const longAgo = new Date(Date.now() - 30 * 60 * 1000);
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-looks-dead', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo },
+      { messageId: 'msg-looks-dead', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [] },
     ]);
 
     await takeOverConversationStreams(ARGS);
@@ -171,10 +180,10 @@ describe('takeOverConversationStreams', () => {
   // `status='aborted', parts=[]` over a stream that is still generating would hide it from every
   // subscriber and destroy its only crash-recovery snapshot — while it kept calling tools and
   // kept billing. The mark is the ONLY write allowed here.
-  it('given a LIVE row on another instance that has not stopped yet, should mark it but never terminal-write its row', async () => {
+  it('given a LIVE row on another instance that has not stopped yet, should mark it but never materialize its row', async () => {
     mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'Stream not found or already completed' });
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date() },
+      { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date(), parts: [] },
     ]);
     mockAwaitAbortSettled.mockResolvedValue(settled({ stillLive: ['msg-elsewhere'], code: 'unconfirmed' }));
 
@@ -182,8 +191,8 @@ describe('takeOverConversationStreams', () => {
 
     expect(mockMarkAsOwner).toHaveBeenCalledWith({ messageIds: ['msg-elsewhere'] });
     expect(result).toEqual({ aborted: [], reconciled: [] });
-    // The reconcile UPDATE — the one that would write status/parts. It must not have run.
-    expect(mockUpdateSet).not.toHaveBeenCalled();
+    // The reconcile write — the one that would materialize the row. It must not have run.
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
   });
 
   // The capability this whole change exists to add. Before it, this send would have started a
@@ -192,7 +201,7 @@ describe('takeOverConversationStreams', () => {
   it('given a live row on another instance that DOES stop, should report it as taken over', async () => {
     mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'Stream not found or already completed' });
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date() },
+      { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date(), parts: [] },
     ]);
     mockAwaitAbortSettled.mockResolvedValue(settled({ aborted: ['msg-elsewhere'], code: 'aborted' }));
 
@@ -209,7 +218,7 @@ describe('takeOverConversationStreams', () => {
   // caller's right to write to the conversation was established upstream.
   it("given a live stream owned by ANOTHER user, should abort it as its OWNER so the takeover actually stops it", async () => {
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-other-user', userId: 'user-A', lastHeartbeatAt: new Date(), startedAt: new Date() },
+      { messageId: 'msg-other-user', userId: 'user-A', lastHeartbeatAt: new Date(), startedAt: new Date(), parts: [] },
     ]);
 
     const result = await takeOverConversationStreams(ARGS);
@@ -219,16 +228,25 @@ describe('takeOverConversationStreams', () => {
     expect(result.reconciled).toEqual(['msg-other-user']);
   });
 
-  it('given the reconcile UPDATE, should be conditional on status=streaming so a stream that ended on its own is not relabelled', async () => {
+  // Multiple in-flight rows reconciled in the same takeover must each get their OWN
+  // materialization call, carrying their OWN parts snapshot — a shared/blended write here
+  // would cross-contaminate two different replies.
+  it('given two dead rows in the same takeover, should materialize each independently with its own parts', async () => {
+    const longAgo = new Date(Date.now() - 30 * 60 * 1000);
+    mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'Stream not found or already completed' });
     mockSelectWhere.mockResolvedValueOnce([
-      { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date() },
+      { messageId: 'msg-a', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [{ type: 'text', text: 'A' }] },
+      { messageId: 'msg-b', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [{ type: 'text', text: 'B' }] },
     ]);
 
     await takeOverConversationStreams(ARGS);
 
-    const where = mockUpdateWhere.mock.calls[0][0] as { and: unknown[] };
-    expect(where.and).toContainEqual({ eq: ['status', 'streaming'] });
-    expect(vi.mocked(inArray)).toHaveBeenCalledWith('messageId', ['msg-live']);
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'msg-a', parts: [{ type: 'text', text: 'A' }] }),
+    );
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'msg-b', parts: [{ type: 'text', text: 'B' }] }),
+    );
   });
 
   // A failed takeover must degrade to the OLD behaviour (a concurrent generation), not
@@ -241,54 +259,17 @@ describe('takeOverConversationStreams', () => {
     expect(result).toEqual({ aborted: [], reconciled: [] });
   });
 
-  // Partial failure. The aborts land FIRST — real in-process generations are stopped — and only
-  // then does the reconcile UPDATE run. A single try/catch around the whole function reported
-  // `{aborted: [], reconciled: []}` when that UPDATE threw: "nothing happened", while streams had
-  // in fact been stopped. The caller and the logs were told the exact opposite of the truth.
-  describe('partial failure: aborts landed but the reconcile UPDATE throws', () => {
-    it('reports what it ACTUALLY aborted, rather than claiming nothing happened', async () => {
-      mockSelectWhere.mockResolvedValue([
-        { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date() },
-      ]);
-      mockAbortStreamByMessageId.mockReturnValue({ aborted: true, reason: '' });
-      mockUpdateWhere.mockRejectedValueOnce(new Error('db down'));
+  // The SELECT failing is different: nothing was stopped, so reporting nothing is correct.
+  it('given the SELECT itself fails, reports nothing aborted — because nothing was', async () => {
+    mockSelectWhere.mockRejectedValueOnce(new Error('db down'));
 
-      const result = await takeOverConversationStreams({
-        conversationId: 'conv-1',
-        channelId: 'page-1',
-      });
-
-      // The stream IS stopped. Saying otherwise is the bug.
-      expect(result.aborted).toEqual(['msg-live']);
-      // ...but its row was NOT driven terminal, and we must not pretend it was.
-      expect(result.reconciled).toEqual([]);
+    const result = await takeOverConversationStreams({
+      conversationId: 'conv-1',
+      channelId: 'page-1',
     });
 
-    it('still does not block the send — a failed takeover must never lock the conversation', async () => {
-      mockSelectWhere.mockResolvedValue([
-        { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date() },
-      ]);
-      mockAbortStreamByMessageId.mockReturnValue({ aborted: true, reason: '' });
-      mockUpdateWhere.mockRejectedValueOnce(new Error('db down'));
-
-      await expect(
-        takeOverConversationStreams({ conversationId: 'conv-1', channelId: 'page-1' }),
-      ).resolves.toBeDefined();
-    });
-
-    // The SELECT failing is different: nothing was stopped, so reporting nothing is correct.
-    it('given the SELECT itself fails, reports nothing aborted — because nothing was', async () => {
-      mockSelectWhere.mockRejectedValueOnce(new Error('db down'));
-
-      const result = await takeOverConversationStreams({
-        conversationId: 'conv-1',
-        channelId: 'page-1',
-      });
-
-      expect(result).toEqual({ aborted: [], reconciled: [] });
-    });
+    expect(result).toEqual({ aborted: [], reconciled: [] });
   });
-
 
   // A log that misreports is a signal that attests to nothing — the same defect as a test that
   // cannot fail. This one used to lie at exactly the moment an operator most needed the truth.
@@ -298,7 +279,7 @@ describe('takeOverConversationStreams', () => {
       // has not confirmed, so it is still generating, and this send is about to start a second
       // generation beside it. That is the moment an operator most needs the truth.
       mockSelectWhere.mockResolvedValue([
-        { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date() },
+        { messageId: 'msg-elsewhere', userId: 'user-1', lastHeartbeatAt: new Date(), parts: [] },
       ]);
       mockAbortStreamByMessageId.mockReturnValue({ aborted: false, reason: 'not found' });
       mockAwaitAbortSettled.mockResolvedValue(settled({ stillLive: ['msg-elsewhere'], code: 'unconfirmed' }));
@@ -324,7 +305,7 @@ describe('takeOverConversationStreams', () => {
 
     it('given a stream it DID stop, says so', async () => {
       mockSelectWhere.mockResolvedValue([
-        { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date() },
+        { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), parts: [] },
       ]);
       mockAbortStreamByMessageId.mockReturnValue({ aborted: true, reason: '' });
 

--- a/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-takeover.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const {
   mockSelectWhere,
+  mockUpdateSet,
+  mockUpdateWhere,
   mockAbortStreamByMessageId,
   mockLoggerInfo,
   mockLoggerWarn,
@@ -14,6 +16,8 @@ const {
   mockLoggerInfo: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockSelectWhere: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdateWhere: vi.fn(),
   mockAbortStreamByMessageId: vi.fn(),
   mockMarkAsOwner: vi.fn(),
   mockWasRecentlyFinishedHere: vi.fn(),
@@ -25,12 +29,14 @@ const {
 vi.mock('@pagespace/db/db', () => ({
   db: {
     select: vi.fn(() => ({ from: vi.fn(() => ({ where: mockSelectWhere })) })),
+    update: vi.fn(() => ({ set: mockUpdateSet })),
   },
 }));
 
 vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   eq: vi.fn((col: unknown, val: unknown) => ({ eq: [col, val] })),
+  inArray: vi.fn((col: unknown, vals: unknown) => ({ inArray: [col, vals] })),
 }));
 
 vi.mock('@pagespace/db/schema/ai-streams', () => ({
@@ -104,6 +110,8 @@ describe('takeOverConversationStreams', () => {
     mockAwaitAbortSettled.mockResolvedValue(settled());
     mockReconcileDead.mockResolvedValue(undefined);
     mockMaterializeInterruptedStream.mockResolvedValue(undefined);
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockResolvedValue(undefined);
   });
 
   it('given no in-flight stream on the conversation, should do nothing (the common case must be cheap)', async () => {
@@ -119,7 +127,7 @@ describe('takeOverConversationStreams', () => {
   // The bug this exists for: a second send used to simply start a SECOND generation on
   // the same conversation. Two agents editing the same pages, two assistant rows, two
   // bills. The only pre-existing limiter was the credit gate's per-USER maxInFlight.
-  it('given a live stream on the conversation, should abort it and materialize its row as interrupted before the new generation starts', async () => {
+  it('given a live stream on the conversation, should abort it and drive its session row terminal before the new generation starts', async () => {
     const parts = [{ type: 'text', text: 'partial' }];
     mockSelectWhere.mockResolvedValueOnce([
       { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date(), parts },
@@ -129,13 +137,45 @@ describe('takeOverConversationStreams', () => {
 
     expect(mockAbortStreamByMessageId).toHaveBeenCalledWith({ messageId: 'msg-live', userId: 'user-1' });
     expect(result).toEqual({ aborted: ['msg-live'], reconciled: ['msg-live'] });
-    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith({
-      messageId: 'msg-live',
-      channelId: 'page-1',
-      conversationId: 'conv-1',
-      userId: 'user-1',
-      parts,
-    });
+    expect(mockUpdateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'aborted', parts: [] }),
+    );
+  });
+
+  // THE regression this fix guards against: a row we JUST aborted ourselves, in THIS process, is
+  // NOT provably dead — its own generation is moments from running its own onFinish, which
+  // persists the full, correct content as status='interrupted' via the normal execute-end path.
+  // Materializing here too would race that natural write with an OLDER debounced checkpoint and
+  // could silently overwrite fresher content with staler content — the exact silent-loss bug this
+  // whole feature exists to prevent, reintroduced by conflating "we stopped it" with "it is dead".
+  it('given a row we just aborted ourselves (fresh heartbeat — its own onFinish is about to persist the real content), must NOT materialize it', async () => {
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-live', userId: 'user-1', lastHeartbeatAt: new Date(), startedAt: new Date(), parts: [{ type: 'text', text: 'stale-checkpoint' }] },
+    ]);
+
+    await takeOverConversationStreams(ARGS);
+
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
+  });
+
+  // The other half of the same fix: a row whose heartbeat is ALREADY stale (the process died
+  // before we ever tried to abort it) has no generation left to persist anything — this is the
+  // only chance its content gets saved, so it materializes even though `abortStreamByMessageId`
+  // also reports it (the abort is a free no-op against an unknown/dead registry entry).
+  it('given a row whose heartbeat was ALREADY stale before this takeover touched it, materializes it (no generation is left to do it)', async () => {
+    const longAgo = new Date(Date.now() - 30 * 60 * 1000);
+    mockSelectWhere.mockResolvedValueOnce([
+      { messageId: 'msg-abandoned', userId: 'user-1', lastHeartbeatAt: longAgo, startedAt: longAgo, parts: [{ type: 'text', text: 'last known content' }] },
+    ]);
+
+    await takeOverConversationStreams(ARGS);
+
+    expect(mockMaterializeInterruptedStream).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'msg-abandoned' }),
+    );
+    // And the cheap session-row wipe must NOT ALSO run for this row — materialize already
+    // settles the session row itself; a second bulk wipe here would be redundant.
+    expect(mockUpdateSet).not.toHaveBeenCalled();
   });
 
   // A crashed process leaves status='streaming' forever (the terminal write is
@@ -226,6 +266,8 @@ describe('takeOverConversationStreams', () => {
     expect(mockAbortStreamByMessageId).toHaveBeenCalledWith({ messageId: 'msg-other-user', userId: 'user-A' });
     expect(result.aborted).toEqual(['msg-other-user']);
     expect(result.reconciled).toEqual(['msg-other-user']);
+    // Fresh heartbeat, just aborted by us — its own onFinish will persist the real content.
+    expect(mockMaterializeInterruptedStream).not.toHaveBeenCalled();
   });
 
   // Multiple in-flight rows reconciled in the same takeover must each get their OWN

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -171,9 +171,9 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
     return false;
   }
 
-  let settled = true;
+  let settled: boolean;
   try {
-    await db
+    const result = await db
       .update(aiStreamSessions)
       .set({ status: 'aborted', completedAt: now, parts: [], rawPartsCount: 0, abortRequestedAt: null })
       .where(and(
@@ -182,6 +182,12 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
         // caller's read and here is not retroactively relabelled.
         eq(aiStreamSessions.status, 'streaming'),
       ));
+    // A conditional UPDATE that matches zero rows does not throw — it succeeds and changes
+    // nothing. That happens when a concurrent reap (another instance's takeover, or a second
+    // sweep racing this one) already settled this exact row first. `rowCount` is the only way
+    // to tell "I settled it" from "someone else already had" — matching the established
+    // pattern for the same class of conditional update (compaction-repository.ts).
+    settled = (result.rowCount ?? 0) > 0;
   } catch (error) {
     settled = false;
     loggers.ai.warn('materializeInterruptedStream: could not settle session row', {

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db';
-import { and, eq, ne } from '@pagespace/db/operators';
+import { and, eq } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { chatMessages } from '@pagespace/db/schema/core';
 import { messages } from '@pagespace/db/schema/conversations';
@@ -30,6 +30,12 @@ export interface MaterializableStreamRow {
    *  never by more (see PR 1's time-based cadence). This is the only content a dead process
    *  leaves behind; there is no live buffer to fall back to. */
   parts: unknown[];
+  /** The stream's actual start time. Used ONLY as the `createdAt` for the defensive
+   *  insert-if-missing branch below (the placeholder row should already exist per PR 2, but a
+   *  failed placeholder insert is the one case this function must still degrade gracefully
+   *  for) — never reap/takeover time, or a recovered reply can sort after a user's later
+   *  follow-up message that was saved in the interim. */
+  startedAt: Date;
 }
 
 /**
@@ -44,11 +50,16 @@ export interface MaterializableStreamRow {
  *      onFinish already use in `saveMessageToDatabase`/`saveGlobalAssistantMessageToDatabase`,
  *      so a materialized reply preserves file/data parts and ordering exactly like one the
  *      model actually finished, instead of degrading to flat extracted text).
- *   2. Upsert the assistant message row as `status: 'interrupted'` — but ONLY if it is not
- *      already `'complete'`. That guard is the #2022 invariant: the old worker's own
- *      terminal write is fire-and-forget and can land in the gap between the caller's
- *      liveness read and this write. A `setWhere` on the conflict clause makes the guard
- *      atomic — there is no separate read to race.
+ *   2. Upsert the assistant message row as `status: 'interrupted'` — but ONLY if it is still
+ *      `'streaming'` (the placeholder state). That guard is the #2022 invariant, and it is
+ *      deliberately compare-and-swap rather than a blanket "not complete": the old worker's own
+ *      terminal write is fire-and-forget and can land in the gap between the caller's liveness
+ *      read and this write — and it can ALSO leave a row `'interrupted'` (a clean Stop whose
+ *      onFinish wrote full content but whose session-row settle then failed). Guarding on
+ *      `!= 'complete'` would still let a later sweep clobber that already-correct interrupted
+ *      row with an older debounced checkpoint; guarding on `== 'streaming'` cannot, because a
+ *      row leaves `'streaming'` exactly once. A `setWhere` on the conflict clause makes the
+ *      guard atomic — there is no separate read to race.
  *   3. Only once the message write is confirmed: settle the `ai_stream_sessions` row
  *      terminal (`status: 'aborted'`, parts cleared) and broadcast `stream_complete`.
  *      Settling first would let a crashed sweep lose the row's only content — the session
@@ -85,7 +96,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           content: structuredContent,
           toolCalls: toolCallsJson,
           toolResults: toolResultsJson,
-          createdAt: now,
+          // Only reached if the placeholder insert (PR 2's seam) never happened — the stream's
+          // actual start, not reap time, so a recovered reply still sorts correctly against a
+          // user's later follow-up message.
+          createdAt: row.startedAt,
           isActive: true,
           status: 'interrupted',
         })
@@ -101,9 +115,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
             conversationId: row.conversationId,
             status: 'interrupted',
           },
-          // The #2022 invariant, enforced atomically: never relabel a row the normal
-          // terminal path already finished.
-          setWhere: ne(messages.status, 'complete'),
+          // The #2022 invariant, enforced atomically as a compare-and-swap: only a row still
+          // `'streaming'` may be relabelled. Never re-touch a row already `'interrupted'` or
+          // `'complete'` — see the docblock above for why `!= 'complete'` alone isn't enough.
+          setWhere: eq(messages.status, 'streaming'),
         });
     } else {
       await db
@@ -116,7 +131,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           content: structuredContent,
           toolCalls: toolCallsJson,
           toolResults: toolResultsJson,
-          createdAt: now,
+          // Only reached if the placeholder insert (PR 2's seam) never happened — the stream's
+          // actual start, not reap time, so a recovered reply still sorts correctly against a
+          // user's later follow-up message.
+          createdAt: row.startedAt,
           isActive: true,
           userId: null,
           sourceAgentId: null,
@@ -131,7 +149,7 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
             conversationId: row.conversationId,
             status: 'interrupted',
           },
-          setWhere: ne(chatMessages.status, 'complete'),
+          setWhere: eq(chatMessages.status, 'streaming'),
         });
     }
   } catch (error) {

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -71,8 +71,16 @@ export interface MaterializableStreamRow {
  * — building the payload from `row.parts` — lives INSIDE the same try/catch as the DB write:
  * a malformed parts snapshot must degrade exactly like a failed write, not escape uncaught to
  * a caller that assumes this function never throws.
+ *
+ * Returns whether the row was actually driven fully terminal (message written AND the session
+ * row settled) — `false` on any failure. Callers that aggregate this into a "reconciled" count
+ * or log line MUST use the return value rather than assuming every call they made succeeded:
+ * a `Promise.all` over several rows tells you nothing about which ones actually landed, and a
+ * batch reported as "reconciled" when some rows silently stayed `'streaming'` is exactly the
+ * misreporting bug (a log that attests to nothing) this module's sibling functions already
+ * guard against.
  */
-export const materializeInterruptedStream = async (row: MaterializableStreamRow): Promise<void> => {
+export const materializeInterruptedStream = async (row: MaterializableStreamRow): Promise<boolean> => {
   const now = new Date();
 
   try {
@@ -160,9 +168,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
     // Leave the session row at 'streaming' — the next sweep (takeover, reconciler, or the
     // active-streams lazy pass) will find this row again and retry the whole thing. Settling
     // it here would report the stream over while its reply was never actually saved.
-    return;
+    return false;
   }
 
+  let settled = true;
   try {
     await db
       .update(aiStreamSessions)
@@ -174,6 +183,7 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
         eq(aiStreamSessions.status, 'streaming'),
       ));
   } catch (error) {
+    settled = false;
     loggers.ai.warn('materializeInterruptedStream: could not settle session row', {
       messageId: row.messageId,
       error: error instanceof Error ? error.message : 'unknown',
@@ -191,4 +201,6 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
       error: error instanceof Error ? error.message : 'unknown',
     });
   });
+
+  return settled;
 };

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -1,0 +1,156 @@
+import { db } from '@pagespace/db/db';
+import { and, eq, ne } from '@pagespace/db/operators';
+import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
+import { chatMessages } from '@pagespace/db/schema/core';
+import { messages } from '@pagespace/db/schema/conversations';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
+import { broadcastAiStreamComplete } from '@/lib/websocket';
+import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistantParts';
+import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
+
+/**
+ * An `ai_stream_sessions` row the CALLER has already proven dead (`isProvablyDead` —
+ * stream-liveness.ts). This module does not re-derive eligibility; it only re-guards the
+ * one invariant that survives even a correct eligibility call: the #2022 race where the old
+ * worker's own terminal write lands between the caller's read and this write.
+ */
+export interface MaterializableStreamRow {
+  messageId: string;
+  /** The stream's channel — a real pageId for page-chat, or a synthetic `user:<id>:global`
+   *  id for the global assistant (see `parseGlobalChannelId`). Decides which message table
+   *  this row belongs to. */
+  channelId: string;
+  conversationId: string;
+  /** The stream's owner. For a global-assistant row this doubles as `messages.userId`
+   *  (NOT NULL there) — the same field the normal save path already uses. */
+  userId: string;
+  /** The last debounced parts snapshot — possibly stale by up to one checkpoint interval,
+   *  never by more (see PR 1's time-based cadence). This is the only content a dead process
+   *  leaves behind; there is no live buffer to fall back to. */
+  parts: unknown[];
+}
+
+/**
+ * Turn a provably-dead stream into an honest, terminal assistant message instead of a
+ * silent loss.
+ *
+ * Three things happen, in an order chosen so a failure at any step leaves the row eligible
+ * for the NEXT sweep to retry rather than half-materialized:
+ *
+ *   1. Build the message payload from the parts snapshot (`buildAssistantPersistencePayload`
+ *      — the same primitive execute-end and onFinish already use, so a materialized reply
+ *      renders identically to one the model actually finished).
+ *   2. Upsert the assistant message row as `status: 'interrupted'` — but ONLY if it is not
+ *      already `'complete'`. That guard is the #2022 invariant: the old worker's own
+ *      terminal write is fire-and-forget and can land in the gap between the caller's
+ *      liveness read and this write. A `setWhere` on the conflict clause makes the guard
+ *      atomic — there is no separate read to race.
+ *   3. Only once the message write is confirmed: settle the `ai_stream_sessions` row
+ *      terminal (`status: 'aborted'`, parts cleared) and broadcast `stream_complete`.
+ *      Settling first would let a crashed sweep lose the row's only content — the session
+ *      row would read terminal while no terminal message ever got written.
+ *
+ * Never throws. Every step logs and degrades — a reap that fails partway must not take
+ * down the caller's loop over the rest of its batch (takeover, the abort-mark reconciler,
+ * and the active-streams lazy sweep all call this per-row, in a loop).
+ */
+export const materializeInterruptedStream = async (row: MaterializableStreamRow): Promise<void> => {
+  const payload = buildAssistantPersistencePayload(row.messageId, row.parts as UIMessagePart[]);
+  const toolCallsJson = payload.toolCalls ? JSON.stringify(payload.toolCalls) : null;
+  const toolResultsJson = payload.toolResults ? JSON.stringify(payload.toolResults) : null;
+  const now = new Date();
+
+  try {
+    const globalOwnerId = parseGlobalChannelId(row.channelId);
+
+    if (globalOwnerId !== null) {
+      await db
+        .insert(messages)
+        .values({
+          id: row.messageId,
+          conversationId: row.conversationId,
+          userId: row.userId,
+          role: 'assistant',
+          content: payload.content,
+          toolCalls: toolCallsJson,
+          toolResults: toolResultsJson,
+          createdAt: now,
+          isActive: true,
+          status: 'interrupted',
+        })
+        .onConflictDoUpdate({
+          target: messages.id,
+          set: {
+            content: payload.content,
+            toolCalls: toolCallsJson,
+            toolResults: toolResultsJson,
+            status: 'interrupted',
+          },
+          // The #2022 invariant, enforced atomically: never relabel a row the normal
+          // terminal path already finished.
+          setWhere: ne(messages.status, 'complete'),
+        });
+    } else {
+      await db
+        .insert(chatMessages)
+        .values({
+          id: row.messageId,
+          pageId: row.channelId,
+          conversationId: row.conversationId,
+          role: 'assistant',
+          content: payload.content,
+          toolCalls: toolCallsJson,
+          toolResults: toolResultsJson,
+          createdAt: now,
+          isActive: true,
+          userId: null,
+          sourceAgentId: null,
+          status: 'interrupted',
+        })
+        .onConflictDoUpdate({
+          target: chatMessages.id,
+          set: {
+            content: payload.content,
+            toolCalls: toolCallsJson,
+            toolResults: toolResultsJson,
+            status: 'interrupted',
+          },
+          setWhere: ne(chatMessages.status, 'complete'),
+        });
+    }
+  } catch (error) {
+    loggers.ai.warn('materializeInterruptedStream: message upsert failed', {
+      messageId: row.messageId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    // Leave the session row at 'streaming' — the next sweep (takeover, reconciler, or the
+    // active-streams lazy pass) will find this row again and retry the whole thing. Settling
+    // it here would report the stream over while its reply was never actually saved.
+    return;
+  }
+
+  try {
+    await db
+      .update(aiStreamSessions)
+      .set({ status: 'aborted', completedAt: now, parts: [], rawPartsCount: 0, abortRequestedAt: null })
+      .where(and(
+        eq(aiStreamSessions.messageId, row.messageId),
+        // Conditional so a row that reached a terminal status by some other path between the
+        // caller's read and here is not retroactively relabelled.
+        eq(aiStreamSessions.status, 'streaming'),
+      ));
+  } catch (error) {
+    loggers.ai.warn('materializeInterruptedStream: could not settle session row', {
+      messageId: row.messageId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+
+  broadcastAiStreamComplete({
+    messageId: row.messageId,
+    pageId: row.channelId,
+    conversationId: row.conversationId,
+    aborted: true,
+  }).catch(() => {});
+};

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -7,6 +7,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { broadcastAiStreamComplete } from '@/lib/websocket';
 import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistantParts';
+import { extractStructuredContentFromParts } from '@/lib/ai/core/message-utils';
 import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
 
 /**
@@ -38,9 +39,11 @@ export interface MaterializableStreamRow {
  * Three things happen, in an order chosen so a failure at any step leaves the row eligible
  * for the NEXT sweep to retry rather than half-materialized:
  *
- *   1. Build the message payload from the parts snapshot (`buildAssistantPersistencePayload`
- *      — the same primitive execute-end and onFinish already use, so a materialized reply
- *      renders identically to one the model actually finished).
+ *   1. Build the message payload from the parts snapshot (`buildAssistantPersistencePayload`,
+ *      then `extractStructuredContentFromParts` — the SAME two-step pipeline execute-end and
+ *      onFinish already use in `saveMessageToDatabase`/`saveGlobalAssistantMessageToDatabase`,
+ *      so a materialized reply preserves file/data parts and ordering exactly like one the
+ *      model actually finished, instead of degrading to flat extracted text).
  *   2. Upsert the assistant message row as `status: 'interrupted'` — but ONLY if it is not
  *      already `'complete'`. That guard is the #2022 invariant: the old worker's own
  *      terminal write is fire-and-forget and can land in the gap between the caller's
@@ -53,15 +56,22 @@ export interface MaterializableStreamRow {
  *
  * Never throws. Every step logs and degrades — a reap that fails partway must not take
  * down the caller's loop over the rest of its batch (takeover, the abort-mark reconciler,
- * and the active-streams lazy sweep all call this per-row, in a loop).
+ * and the active-streams lazy sweep all call this per-row, in a loop). This is why step 1
+ * — building the payload from `row.parts` — lives INSIDE the same try/catch as the DB write:
+ * a malformed parts snapshot must degrade exactly like a failed write, not escape uncaught to
+ * a caller that assumes this function never throws.
  */
 export const materializeInterruptedStream = async (row: MaterializableStreamRow): Promise<void> => {
-  const payload = buildAssistantPersistencePayload(row.messageId, row.parts as UIMessagePart[]);
-  const toolCallsJson = payload.toolCalls ? JSON.stringify(payload.toolCalls) : null;
-  const toolResultsJson = payload.toolResults ? JSON.stringify(payload.toolResults) : null;
   const now = new Date();
 
   try {
+    const payload = buildAssistantPersistencePayload(row.messageId, row.parts as UIMessagePart[]);
+    const structuredContent = payload.uiMessage.parts.length > 0
+      ? await extractStructuredContentFromParts(payload.uiMessage.parts, payload.content)
+      : payload.content;
+    const toolCallsJson = payload.toolCalls ? JSON.stringify(payload.toolCalls) : null;
+    const toolResultsJson = payload.toolResults ? JSON.stringify(payload.toolResults) : null;
+
     const globalOwnerId = parseGlobalChannelId(row.channelId);
 
     if (globalOwnerId !== null) {
@@ -72,7 +82,7 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           conversationId: row.conversationId,
           userId: row.userId,
           role: 'assistant',
-          content: payload.content,
+          content: structuredContent,
           toolCalls: toolCallsJson,
           toolResults: toolResultsJson,
           createdAt: now,
@@ -82,9 +92,13 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
         .onConflictDoUpdate({
           target: messages.id,
           set: {
-            content: payload.content,
+            content: structuredContent,
             toolCalls: toolCallsJson,
             toolResults: toolResultsJson,
+            // Re-synced on conflict, mirroring saveMessageToDatabase's own update-set — a
+            // message reprocessed/reparented into a different conversation before this sweep
+            // ran should not have its conversationId left stale.
+            conversationId: row.conversationId,
             status: 'interrupted',
           },
           // The #2022 invariant, enforced atomically: never relabel a row the normal
@@ -99,7 +113,7 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           pageId: row.channelId,
           conversationId: row.conversationId,
           role: 'assistant',
-          content: payload.content,
+          content: structuredContent,
           toolCalls: toolCallsJson,
           toolResults: toolResultsJson,
           createdAt: now,
@@ -111,9 +125,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
         .onConflictDoUpdate({
           target: chatMessages.id,
           set: {
-            content: payload.content,
+            content: structuredContent,
             toolCalls: toolCallsJson,
             toolResults: toolResultsJson,
+            conversationId: row.conversationId,
             status: 'interrupted',
           },
           setWhere: ne(chatMessages.status, 'complete'),
@@ -152,5 +167,10 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
     pageId: row.channelId,
     conversationId: row.conversationId,
     aborted: true,
-  }).catch(() => {});
+  }).catch((error) => {
+    loggers.ai.warn('materializeInterruptedStream: broadcast failed', {
+      messageId: row.messageId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  });
 };

--- a/apps/web/src/lib/ai/core/stream-abort-mark.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-mark.ts
@@ -279,13 +279,19 @@ export const awaitAbortSettled = async ({
  * them through `decideAbortOutcome`'s messageId-only contract — that keeps this the only place
  * that needs the wider column set, and re-applies the same `status='streaming'` guard against
  * whatever landed between the caller's read and here.
+ *
+ * Returns the messageIds actually driven terminal — a subset of `messageIds`, never assumed to
+ * be all of them. `materializeInterruptedStream` never throws but can still fail partway (and
+ * report so via its own return value); a caller that reports every requested id as "reconciled"
+ * regardless of whether the row read even found it, or the write actually landed, would silently
+ * misreport a retryable ghost row as handled.
  */
 export const reconcileDeadStreamRows = async ({
   messageIds,
 }: {
   messageIds: readonly string[];
-}): Promise<void> => {
-  if (messageIds.length === 0) return;
+}): Promise<string[]> => {
+  if (messageIds.length === 0) return [];
 
   let rows: { messageId: string; channelId: string; conversationId: string; userId: string; parts: unknown[]; startedAt: Date }[];
   try {
@@ -310,14 +316,19 @@ export const reconcileDeadStreamRows = async ({
       messageIds,
       error: error instanceof Error ? error.message : 'unknown',
     });
-    return;
+    return [];
   }
 
   // Concurrent, not sequential — `materializeInterruptedStream` never throws (it catches and
   // logs its own DB failures per step) and each row is independent, so there is no correctness
   // reason to serialize a mass-crash-recovery batch (potentially dozens of rows after an
   // instance dies) into N sequential round trips.
-  await Promise.all(rows.map((row) => materializeInterruptedStream(row)));
+  const results = await Promise.all(rows.map(async (row) => {
+    const ok = await materializeInterruptedStream(row);
+    return ok ? row.messageId : null;
+  }));
+
+  return results.filter((id): id is string => id !== null);
 };
 
 /**

--- a/apps/web/src/lib/ai/core/stream-abort-mark.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-mark.ts
@@ -11,6 +11,7 @@ import {
   ABORT_SETTLE_POLL_MS,
   ABORT_SETTLE_TIMEOUT_MS,
 } from '@/lib/ai/core/stream-horizons';
+import { materializeInterruptedStream } from '@/lib/ai/core/materialize-interrupted-stream';
 
 /**
  * The cross-instance half of Stop.
@@ -263,7 +264,9 @@ export const awaitAbortSettled = async ({
 };
 
 /**
- * Drive terminal the rows whose owner is provably gone.
+ * Drive terminal the rows whose owner is provably gone — and, since Server Stream Durability
+ * PR 3, materialize each one's parts snapshot into an honest `status: 'interrupted'` assistant
+ * message rather than just wiping the session row.
  *
  * Only ever called with `decideAbortOutcome().reconcile` — rows that are still 'streaming' but
  * whose heartbeat is stale, i.e. whose process died without writing its terminal status. This is
@@ -271,6 +274,11 @@ export const awaitAbortSettled = async ({
  * hard rule: a row that we did not stop and that STILL LOOKS ALIVE must never be written here.
  * Marking a running stream 'aborted' and wiping its parts would hide it from every subscriber and
  * destroy its only crash-recovery snapshot, while it kept on generating.
+ *
+ * Re-selects the full row (channelId, conversationId, userId, parts) fresh rather than threading
+ * them through `decideAbortOutcome`'s messageId-only contract — that keeps this the only place
+ * that needs the wider column set, and re-applies the same `status='streaming'` guard against
+ * whatever landed between the caller's read and here.
  */
 export const reconcileDeadStreamRows = async ({
   messageIds,
@@ -279,10 +287,17 @@ export const reconcileDeadStreamRows = async ({
 }): Promise<void> => {
   if (messageIds.length === 0) return;
 
+  let rows: { messageId: string; channelId: string; conversationId: string; userId: string; parts: unknown[] }[];
   try {
-    await db
-      .update(aiStreamSessions)
-      .set({ status: 'aborted', completedAt: new Date(), parts: [], abortRequestedAt: null })
+    rows = await db
+      .select({
+        messageId: aiStreamSessions.messageId,
+        channelId: aiStreamSessions.channelId,
+        conversationId: aiStreamSessions.conversationId,
+        userId: aiStreamSessions.userId,
+        parts: aiStreamSessions.parts,
+      })
+      .from(aiStreamSessions)
       .where(and(
         inArray(aiStreamSessions.messageId, [...messageIds]),
         // Conditional on status, so a stream that terminated on its own between the read and here
@@ -290,10 +305,15 @@ export const reconcileDeadStreamRows = async ({
         eq(aiStreamSessions.status, 'streaming'),
       ));
   } catch (error) {
-    loggers.ai.warn('cross-instance abort: could not reconcile dead stream row(s)', {
+    loggers.ai.warn('cross-instance abort: could not read dead stream row(s) for materialization', {
       messageIds,
       error: error instanceof Error ? error.message : 'unknown',
     });
+    return;
+  }
+
+  for (const row of rows) {
+    await materializeInterruptedStream(row);
   }
 };
 

--- a/apps/web/src/lib/ai/core/stream-abort-mark.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-mark.ts
@@ -287,7 +287,7 @@ export const reconcileDeadStreamRows = async ({
 }): Promise<void> => {
   if (messageIds.length === 0) return;
 
-  let rows: { messageId: string; channelId: string; conversationId: string; userId: string; parts: unknown[] }[];
+  let rows: { messageId: string; channelId: string; conversationId: string; userId: string; parts: unknown[]; startedAt: Date }[];
   try {
     rows = await db
       .select({
@@ -296,6 +296,7 @@ export const reconcileDeadStreamRows = async ({
         conversationId: aiStreamSessions.conversationId,
         userId: aiStreamSessions.userId,
         parts: aiStreamSessions.parts,
+        startedAt: aiStreamSessions.startedAt,
       })
       .from(aiStreamSessions)
       .where(and(

--- a/apps/web/src/lib/ai/core/stream-abort-mark.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-mark.ts
@@ -312,9 +312,11 @@ export const reconcileDeadStreamRows = async ({
     return;
   }
 
-  for (const row of rows) {
-    await materializeInterruptedStream(row);
-  }
+  // Concurrent, not sequential — `materializeInterruptedStream` never throws (it catches and
+  // logs its own DB failures per step) and each row is independent, so there is no correctness
+  // reason to serialize a mass-crash-recovery batch (potentially dozens of rows after an
+  // instance dies) into N sequential round trips.
+  await Promise.all(rows.map((row) => materializeInterruptedStream(row)));
 };
 
 /**

--- a/apps/web/src/lib/ai/core/stream-liveness.ts
+++ b/apps/web/src/lib/ai/core/stream-liveness.ts
@@ -104,9 +104,10 @@ export const isBeyondReconcileBackstop = (row: StreamLivenessRow, now: number): 
 /**
  * May this row be driven TERMINAL on the strength of its heartbeat alone?
  *
- * The one predicate both terminal writers share (`decideStreamTakeover` and `decideAbortOutcome`),
- * so they cannot drift apart on the one write that is unforgiving in both directions: reap a live
- * stream and you erase it mid-flight; fail to reap a dead one and it haunts its conversation.
+ * The one predicate every terminal writer shares (`decideStreamTakeover`, `decideAbortOutcome`,
+ * and the active-streams lazy sweep's own materialization pass), so they cannot drift apart on
+ * the one write that is unforgiving in both directions: reap a live stream and you erase it
+ * mid-flight; fail to reap a dead one and it haunts its conversation.
  */
 export const isProvablyDead = (
   row: StreamLivenessRow,

--- a/apps/web/src/lib/ai/core/stream-takeover.ts
+++ b/apps/web/src/lib/ai/core/stream-takeover.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db';
-import { and, eq, inArray } from '@pagespace/db/operators';
+import { and, eq } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { abortStreamByMessageId, wasRecentlyFinishedHere } from '@/lib/ai/core/stream-abort-registry';
@@ -10,6 +10,7 @@ import {
   reconcileDeadStreamRows,
 } from '@/lib/ai/core/stream-abort-mark';
 import { TAKEOVER_SETTLE_TIMEOUT_MS } from '@/lib/ai/core/stream-horizons';
+import { materializeInterruptedStream } from '@/lib/ai/core/materialize-interrupted-stream';
 
 /**
  * Per-conversation in-flight guard. Used by both chat routes (POST /api/ai/chat and
@@ -75,6 +76,11 @@ export const takeOverConversationStreams = async ({
         userId: aiStreamSessions.userId,
         lastHeartbeatAt: aiStreamSessions.lastHeartbeatAt,
         startedAt: aiStreamSessions.startedAt,
+        // The debounced parts snapshot — needed only if this row ends up in `reconcile` and gets
+        // materialized into an interrupted message. Selected unconditionally since it rides the
+        // same query as everything else here and there are at most a handful of in-flight rows
+        // per conversation.
+        parts: aiStreamSessions.parts,
       })
       .from(aiStreamSessions)
       .where(and(
@@ -117,42 +123,28 @@ export const takeOverConversationStreams = async ({
     const { reconcile } = decideStreamTakeover({ rows, abortedMessageIds: aborted, now });
 
     if (reconcile.length > 0) {
-      // Its OWN catch, deliberately.
+      // Per-row, deliberately — since Server Stream Durability PR 3, reconciling a row means
+      // materializing its parts snapshot into an honest `status: 'interrupted'` message, not just
+      // wiping the session row. `materializeInterruptedStream` never throws (it catches and logs
+      // its own DB failures per step), so unlike the old bulk UPDATE, one row's write failing can
+      // no longer take out the whole batch or misreport what happened to the others.
       //
-      // By this point the aborts above have already landed: real in-process generations have
-      // been STOPPED. If this UPDATE then throws and the outer catch swallows it, we return
-      // `{aborted: [], reconciled: []}` — "nothing happened" — which is a lie. Streams were
-      // stopped, and their rows are still `status='streaming'`, so every reader treats them as
-      // live: /active-streams advertises them, clients render a Stop button for a generation that
-      // is already dead. The one thing the caller must be told accurately is what was actually
-      // aborted, and the old shape guaranteed it would be told the opposite.
-      //
-      // The rows self-heal: a stopped generation stops beating, so within
-      // STREAM_HEARTBEAT_STALE_MS the liveness predicate calls them dead, /active-streams stops
-      // serving them, and the next takeover reconciles them. That is exactly the failure mode the
-      // heartbeat exists to absorb — so the right move is to report the truth and let it, not to
-      // fail the send.
-      try {
-        // Conditional on status so a stream that terminated on its own between the
-        // SELECT and here isn't retroactively relabelled 'aborted'.
-        await db
-          .update(aiStreamSessions)
-          .set({ status: 'aborted', completedAt: new Date(), parts: [], abortRequestedAt: null })
-          .where(and(
-            inArray(aiStreamSessions.messageId, reconcile),
-            eq(aiStreamSessions.status, 'streaming'),
-          ));
-      } catch (error) {
-        loggers.ai.warn('AI Chat API: takeover aborted streams but could not reconcile their rows', {
-          conversationId,
+      // A row whose materialization fails simply stays `status='streaming'` and is picked up again
+      // by the next takeover, the abort-mark reconciler, or the active-streams lazy sweep — the
+      // same self-heal this module already relies on for heartbeat-driven reconciliation: a
+      // stopped generation stops beating, so within STREAM_HEARTBEAT_STALE_MS the liveness
+      // predicate calls it dead and the next pass reconciles it.
+      const rowById = new Map(rows.map((r) => [r.messageId, r]));
+      for (const messageId of reconcile) {
+        const row = rowById.get(messageId);
+        if (!row) continue;
+        await materializeInterruptedStream({
+          messageId,
           channelId,
-          // The streams ARE stopped. These rows will read 'streaming' until their heartbeat
-          // goes stale (~2 min), then be reconciled by the next takeover.
-          aborted,
-          unreconciled: reconcile,
-          error: error instanceof Error ? error.message : 'unknown',
+          conversationId,
+          userId: row.userId,
+          parts: row.parts,
         });
-        return { aborted, reconciled: [] };
       }
     }
 

--- a/apps/web/src/lib/ai/core/stream-takeover.ts
+++ b/apps/web/src/lib/ai/core/stream-takeover.ts
@@ -157,6 +157,7 @@ export const takeOverConversationStreams = async ({
           conversationId,
           userId: row.userId,
           parts: row.parts,
+          startedAt: row.startedAt,
         });
       }));
 

--- a/apps/web/src/lib/ai/core/stream-takeover.ts
+++ b/apps/web/src/lib/ai/core/stream-takeover.ts
@@ -1,9 +1,9 @@
 import { db } from '@pagespace/db/db';
-import { and, eq } from '@pagespace/db/operators';
+import { and, eq, inArray } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { abortStreamByMessageId, wasRecentlyFinishedHere } from '@/lib/ai/core/stream-abort-registry';
-import { decideStreamTakeover } from '@/lib/ai/core/stream-liveness';
+import { decideStreamTakeover, isProvablyDead } from '@/lib/ai/core/stream-liveness';
 import {
   awaitAbortSettled,
   markAbortRequestedAsOwner,
@@ -123,28 +123,64 @@ export const takeOverConversationStreams = async ({
     const { reconcile } = decideStreamTakeover({ rows, abortedMessageIds: aborted, now });
 
     if (reconcile.length > 0) {
-      // Per-row, deliberately — since Server Stream Durability PR 3, reconciling a row means
-      // materializing its parts snapshot into an honest `status: 'interrupted'` message, not just
-      // wiping the session row. `materializeInterruptedStream` never throws (it catches and logs
-      // its own DB failures per step), so unlike the old bulk UPDATE, one row's write failing can
-      // no longer take out the whole batch or misreport what happened to the others.
+      // `reconcile` mixes two DIFFERENT kinds of row, and they must be handled differently —
+      // conflating them is exactly the race that used to silently clobber fresher content with a
+      // staler one:
       //
-      // A row whose materialization fails simply stays `status='streaming'` and is picked up again
-      // by the next takeover, the abort-mark reconciler, or the active-streams lazy sweep — the
-      // same self-heal this module already relies on for heartbeat-driven reconciliation: a
-      // stopped generation stops beating, so within STREAM_HEARTBEAT_STALE_MS the liveness
-      // predicate calls it dead and the next pass reconciles it.
+      //   - PROVABLY DEAD (heartbeat stale): the owning process is gone. Nothing else will EVER
+      //     write this row's terminal message, so it is materialized here — this is the only
+      //     chance the content has.
+      //   - JUST ABORTED BY US, THIS REQUEST (`aborted.has(id)`, heartbeat still fresh): the
+      //     owning generation is THIS SAME PROCESS, moments from running its own onFinish, which
+      //     persists the full, correct content as `status: 'interrupted'` via the normal
+      //     execute-end/onFinish path (message-utils.ts). Materializing here too would race that
+      //     natural write with an OLDER checkpoint snapshot and could overwrite it — the exact
+      //     silent-content-loss bug this module exists to prevent, just introduced by this PR
+      //     instead of fixed by it. So these rows get ONLY the cheap, ephemeral session-row wipe
+      //     (today's pre-existing behavior); the durable message is left to its own generation.
       const rowById = new Map(rows.map((r) => [r.messageId, r]));
-      for (const messageId of reconcile) {
+      const provablyDead = reconcile.filter((id) => {
+        const row = rowById.get(id);
+        return row !== undefined && isProvablyDead(row, now);
+      });
+      const justAbortedStillAlive = reconcile.filter((id) => !provablyDead.includes(id));
+
+      // `materializeInterruptedStream` never throws (it catches and logs its own DB failures per
+      // step), so a batch of independent rows can run concurrently without one row's failure
+      // taking out the others or needing its own try/catch here.
+      await Promise.all(provablyDead.map((messageId) => {
         const row = rowById.get(messageId);
-        if (!row) continue;
-        await materializeInterruptedStream({
+        if (!row) return Promise.resolve();
+        return materializeInterruptedStream({
           messageId,
           channelId,
           conversationId,
           userId: row.userId,
           parts: row.parts,
         });
+      }));
+
+      if (justAbortedStillAlive.length > 0) {
+        try {
+          // Conditional on status so a stream that terminated on its own between the SELECT and
+          // here isn't retroactively relabelled 'aborted'.
+          await db
+            .update(aiStreamSessions)
+            .set({ status: 'aborted', completedAt: new Date(), parts: [], abortRequestedAt: null })
+            .where(and(
+              inArray(aiStreamSessions.messageId, justAbortedStillAlive),
+              eq(aiStreamSessions.status, 'streaming'),
+            ));
+        } catch (error) {
+          loggers.ai.warn('AI Chat API: takeover aborted streams but could not clear their session rows', {
+            conversationId,
+            channelId,
+            // The streams ARE stopped, and their own onFinish will still persist the durable
+            // message correctly. Only the ephemeral session-row cleanup failed here.
+            unreconciled: justAbortedStillAlive,
+            error: error instanceof Error ? error.message : 'unknown',
+          });
+        }
       }
     }
 

--- a/apps/web/src/lib/ai/core/stream-takeover.ts
+++ b/apps/web/src/lib/ai/core/stream-takeover.ts
@@ -122,6 +122,10 @@ export const takeOverConversationStreams = async ({
     // subscriber and destroy its only crash-recovery snapshot.
     const { reconcile } = decideStreamTakeover({ rows, abortedMessageIds: aborted, now });
 
+    // Populated below with only the ids ACTUALLY driven terminal — never assumed from
+    // `reconcile` itself, which is only what we attempted.
+    let locallyReconciled: string[] = [];
+
     if (reconcile.length > 0) {
       // `reconcile` mixes two DIFFERENT kinds of row, and they must be handled differently —
       // conflating them is exactly the race that used to silently clobber fresher content with a
@@ -146,12 +150,15 @@ export const takeOverConversationStreams = async ({
       const justAbortedStillAlive = reconcile.filter((id) => !provablyDead.includes(id));
 
       // `materializeInterruptedStream` never throws (it catches and logs its own DB failures per
-      // step), so a batch of independent rows can run concurrently without one row's failure
-      // taking out the others or needing its own try/catch here.
-      await Promise.all(provablyDead.map((messageId) => {
+      // step) and returns whether it actually succeeded — a batch of independent rows can run
+      // concurrently without one row's failure taking out the others, but the RESULT must still
+      // be checked per-row: `Promise.all` resolving tells you nothing about which calls actually
+      // landed, and reporting every id as reconciled regardless would be exactly the misreporting
+      // bug this module's own docblock warns against.
+      const materializedIds = (await Promise.all(provablyDead.map(async (messageId) => {
         const row = rowById.get(messageId);
-        if (!row) return Promise.resolve();
-        return materializeInterruptedStream({
+        if (!row) return null;
+        const ok = await materializeInterruptedStream({
           messageId,
           channelId,
           conversationId,
@@ -159,8 +166,10 @@ export const takeOverConversationStreams = async ({
           parts: row.parts,
           startedAt: row.startedAt,
         });
-      }));
+        return ok ? messageId : null;
+      }))).filter((id): id is string => id !== null);
 
+      let wipedIds: string[] = [];
       if (justAbortedStillAlive.length > 0) {
         try {
           // Conditional on status so a stream that terminated on its own between the SELECT and
@@ -172,6 +181,7 @@ export const takeOverConversationStreams = async ({
               inArray(aiStreamSessions.messageId, justAbortedStillAlive),
               eq(aiStreamSessions.status, 'streaming'),
             ));
+          wipedIds = justAbortedStillAlive;
         } catch (error) {
           loggers.ai.warn('AI Chat API: takeover aborted streams but could not clear their session rows', {
             conversationId,
@@ -183,6 +193,8 @@ export const takeOverConversationStreams = async ({
           });
         }
       }
+
+      locallyReconciled = [...materializedIds, ...wipedIds];
     }
 
     // A live row this instance does not own. This USED to be the end of the road — it was logged
@@ -234,12 +246,13 @@ export const takeOverConversationStreams = async ({
       });
 
       remotelyAborted = outcome.aborted;
-      remotelyReconciled = outcome.reconcile;
       stillLive = outcome.stillLive;
 
       // Rows whose owner is provably gone (stale heartbeat) — nothing is running, but nothing
       // wrote their terminal status either. Same licence decideStreamTakeover already grants.
-      await reconcileDeadStreamRows({ messageIds: outcome.reconcile });
+      // `outcome.reconcile` is only what's ELIGIBLE to be driven terminal — reconcileDeadStreamRows
+      // returns what it ACTUALLY materialized, which is what belongs in the caller's own report.
+      remotelyReconciled = await reconcileDeadStreamRows({ messageIds: outcome.reconcile });
 
       if (stillLive.length > 0) {
         // The honest, narrower successor to the old warn. It no longer means "we cannot stop
@@ -259,8 +272,9 @@ export const takeOverConversationStreams = async ({
     // Rows driven terminal by the cross-instance path are reconciled just as surely as the ones
     // this instance reconciled directly. Leaving them out under-reports what the takeover actually
     // did — and this module's own docblock is emphatic that a log which misreports attests to
-    // nothing, which is the same defect as a test that cannot fail.
-    const allReconciled = [...reconcile, ...remotelyReconciled];
+    // nothing, which is the same defect as a test that cannot fail. `locallyReconciled` (not
+    // `reconcile`) is what was actually driven terminal, not merely attempted.
+    const allReconciled = [...locallyReconciled, ...remotelyReconciled];
 
     // Only claim a takeover when one actually happened.
     //

--- a/apps/web/src/services/api/__tests__/ai-undo-service.test.ts
+++ b/apps/web/src/services/api/__tests__/ai-undo-service.test.ts
@@ -44,13 +44,13 @@ vi.mock('@pagespace/db/operators', () => ({
   desc: vi.fn((a) => ({ field: a, direction: 'desc' })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  chatMessages: { id: 'id', conversationId: 'conversationId', createdAt: 'createdAt', isActive: 'isActive' },
+  chatMessages: { id: 'id', conversationId: 'conversationId', createdAt: 'createdAt', isActive: 'isActive', status: 'status' },
 }));
 vi.mock('@pagespace/db/schema/monitoring', () => ({
   activityLogs: { id: 'id', aiConversationId: 'aiConversationId', isAiGenerated: 'isAiGenerated', timestamp: 'timestamp' },
 }));
 vi.mock('@pagespace/db/schema/conversations', () => ({
-  messages: { id: 'id', conversationId: 'conversationId', createdAt: 'createdAt', isActive: 'isActive' },
+  messages: { id: 'id', conversationId: 'conversationId', createdAt: 'createdAt', isActive: 'isActive', status: 'status' },
 }));
 
 // Mock the rollback service
@@ -877,6 +877,98 @@ describe('ai-undo-service', () => {
 
       expect(result).not.toBeNull();
       expect(result!.driveId).toBeNull();
+    });
+  });
+
+  // ============================================
+  // Undo excludes in-flight streaming rows (#2022 safe default — D.2)
+  //
+  // The implementation is real (previewAiUndo's count query and both of executeAiUndo's
+  // soft-delete updates already add ne(table.status, 'streaming') — see the SAFE DEFAULT
+  // comments in ai-undo-service.ts). It was previously claimed "tested" with zero assertions
+  // on the actual where-clause: the only prior diff to this file was a one-line `ne` mock
+  // addition so the changed source didn't throw on an unmocked import. These tests close that
+  // gap by asserting the mocked `where(...)` call actually carries the ne(status,'streaming')
+  // condition, mirroring the rigor already applied to the sibling 409-mutation-guard tests.
+  // ============================================
+
+  describe('undo excludes in-flight streaming rows (#2022 safe default — D.2)', () => {
+    it("previewAiUndo's affected-message count query excludes status='streaming' rows", async () => {
+      const mockMessage = createMockMessage();
+      mockDb.query.chatMessages.findFirst.mockResolvedValue(mockMessage);
+      mockDb.query.pages.findFirst.mockResolvedValue({ driveId: mockDriveId });
+
+      const whereMock = vi.fn().mockImplementation(() =>
+        whereMock.mock.calls.length === 1 ? [] : { orderBy: vi.fn().mockResolvedValue([]) }
+      );
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({ where: whereMock }),
+      }));
+
+      await previewAiUndo(mockMessageId, mockUserId);
+
+      const affectedMessagesConds = whereMock.mock.calls[0][0] as unknown[];
+      expect(affectedMessagesConds).toContainEqual({ field: 'status', op: 'ne', value: 'streaming' });
+    });
+
+    it("executeAiUndo's primary-table soft-delete update excludes status='streaming' rows", async () => {
+      const mockMessage = createMockMessage();
+      mockDb.query.chatMessages.findFirst.mockResolvedValue(mockMessage);
+      mockDb.query.pages.findFirst.mockResolvedValue({ driveId: mockDriveId });
+
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) return [{ id: 'msg_1' }];
+            return { orderBy: vi.fn().mockResolvedValue([]) };
+          }),
+        }),
+      }));
+
+      const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+      const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+      const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+      mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
+        await callback({ update: updateMock });
+      });
+
+      await executeAiUndo(mockMessageId, mockUserId, 'messages_only');
+
+      // First update() call is the primary table (source-based); second is the secondary table.
+      const primaryConds = updateWhereMock.mock.calls[0][0] as unknown[];
+      expect(primaryConds).toContainEqual({ field: 'status', op: 'ne', value: 'streaming' });
+    });
+
+    it("executeAiUndo's secondary-table soft-delete update excludes status='streaming' rows", async () => {
+      const mockMessage = createMockMessage();
+      mockDb.query.chatMessages.findFirst.mockResolvedValue(mockMessage);
+      mockDb.query.pages.findFirst.mockResolvedValue({ driveId: mockDriveId });
+
+      let selectCallCount = 0;
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCallCount++;
+            if (selectCallCount === 1) return [{ id: 'msg_1' }];
+            return { orderBy: vi.fn().mockResolvedValue([]) };
+          }),
+        }),
+      }));
+
+      const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+      const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+      const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+      mockDb.transaction.mockImplementation(async (callback: (tx: Record<string, unknown>) => Promise<void>) => {
+        await callback({ update: updateMock });
+      });
+
+      await executeAiUndo(mockMessageId, mockUserId, 'messages_only');
+
+      expect(updateWhereMock).toHaveBeenCalledTimes(2);
+      const secondaryConds = updateWhereMock.mock.calls[1][0] as unknown[];
+      expect(secondaryConds).toContainEqual({ field: 'status', op: 'ne', value: 'streaming' });
     });
   });
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -42,6 +42,10 @@ export default defineConfig({
         // subdirectories — test files carry their own incidental branches
         // (e.g. it.each fixtures) that have no bearing on source coverage.
         'src/lib/ai/streams/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        // Server Stream Durability PR 3: dead-row materialization eligibility and the
+        // #2022 never-overwrite-complete guard — gated at 100% branch per the epic's own
+        // constraints.
+        'src/lib/ai/core/materialize-interrupted-stream.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/useConversationMessagesStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/usePendingStreamsStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/conversationMessages/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },


### PR DESCRIPTION
## Summary
PR 3 of the "Server Stream Durability & Rejoin" epic — dependency (status column, PR #2076) merged, branch rebased onto current master.

- `materializeInterruptedStream(row)` (`apps/web/src/lib/ai/core/materialize-interrupted-stream.ts`): from a provably-dead `ai_stream_sessions` row, builds the message payload from its parts snapshot (reusing `buildAssistantPersistencePayload` + `extractStructuredContentFromParts`, the same pipeline execute-end/onFinish use — preserves file/data parts and ordering, not just flat text), upserts `chat_messages`/`messages` to `status: 'interrupted'` guarded by a **compare-and-swap** `setWhere: eq(status, 'streaming')` on the conflict clause (a row leaves `'streaming'` exactly once, so this can never re-touch an already-terminal row whether it landed at `'complete'` or `'interrupted'` by the normal path), re-syncs `conversationId` on conflict, uses the stream's real `startedAt` (not reap time) for the defensive insert-if-missing branch, then settles the session row terminal (checking actual `rowCount`, not just no-throw — a conditional UPDATE that matches zero rows because a concurrent reap already settled it does not throw) and broadcasts `stream_complete({aborted: true})`. Returns whether the row was genuinely driven terminal, never throws.
- Wired into all three reap paths named on the board: `stream-takeover.ts`'s reconcile set, `stream-abort-mark.ts`'s `reconcileDeadStreamRows`, and a new lazy sweep in `GET /api/ai/chat/active-streams`. **Critical fix during review:** the takeover's local reconcile set used to conflate "provably dead" (heartbeat stale — no generation will ever write this row again) with "we just aborted it ourselves this request" (still alive moments ago, about to run its own `onFinish`, which persists the full, correct content). Materializing the latter raced that natural write with an older debounced checkpoint and could silently overwrite fresher content with staler content. Now only provably-dead rows are materialized; just-aborted-but-alive rows get the original cheap session-row wipe and their own generation's `onFinish` persists the real content. Every reconcile/materialize call site now reports actual success (not attempted eligibility) up through `reconciled`/`remotelyReconciled`, and per-row reconciliation runs concurrently (`Promise.all`). The active-streams lazy sweep runs over the subscription-authorized row set, so a user with mere page-view access can't trigger a reap side effect for another member's private conversation.
- Client: `ConversationMessage.status` threads to `MessageRenderer` **and** `CompactMessageRenderer` (the actual sidebar/global-assistant surface), which render an "Interrupted" badge + a real retry **button** at the message level, independent of which part groups exist — including for a message with zero content, or one interrupted mid-tool-call with no trailing text — de-duplicated against `TextBlock`'s own retry button for messages with real text content.
- 100% branch coverage on the new module, gated via a per-glob vitest threshold per the epic's own constraints ("materialize eligibility").
- **Scope addition (reviewer-filed, discovery-protocol class 2):** added the 3 tests D.2 (epic board) flagged as claimed-tested-but-uncovered — `previewAiUndo`'s affected-message count query and both of `executeAiUndo`'s soft-delete updates now assert the `ne(status,'streaming')` guard is actually present, not just claimed.

Filed two epic-level `D —` tasks for real-but-unscheduled gaps found during review (not blocking): mention-notifications not firing for a materialized interrupted reply, and a live-tab socket-immediacy gap for the badge.

This PR went through an unusually thorough convergence pass: an internal 8-angle review followed by four rounds of external bot review (CodeRabbit + Codex) that independently confirmed and added to the findings — content-fidelity loss, badge/retry-button coupling to text-block rendering, an authorization gap in the lazy sweep, the compare-and-swap guard, the insert-timestamp ordering, per-row reconciliation-accuracy reporting, and a rowCount check for the session-settle write. All fixed, tested, and CI-green.

Staging kill-mid-stream drill procedure documented on the PR board page (`epuyvd3qh3u9rj04nzc2rs4m`) per leaf 3.5 — not run from this environment.

## Test plan
- [x] `bun run typecheck` (Turbo build) — green
- [x] `bun vitest run` across `ai/core`, `ai/streams`, chat components, chat routes, and `ai-undo-service` — 108 files / 1338 tests passing (local, non-render)
- [x] `materialize-interrupted-stream.test.ts` (24 tests) at 100% branch/line/stmt/func coverage
- [x] `stream-takeover.test.ts` / `stream-abort-mark.test.ts` updated for the corrected eligibility split, concurrent per-row processing, startedAt threading, and accurate reconciliation reporting
- [x] `active-streams` lazy-sweep tests (dead row reaped, live row untouched, ambiguous-cap row untouched, unauthorized-conversation row NOT reaped)
- [x] `MessageRenderer.interrupted.test.tsx` + `CompactMessageRenderer.interrupted.test.tsx` (badge + retry button render independent of part-group shape, no duplicate button for text-bearing messages)
- [x] `ai-undo-service.test.ts` — 3 new D.2 tests, 23/23 passing
- [x] CI green: Unit Tests, Lint & TypeScript Check, CodeQL, Security Test Suite, Static Security Analysis, Secret Scanning, Dependency Audit, CodeRabbit (verified across 5 consecutive pushes)
- [ ] Staging kill-mid-stream drill (documented, not executed from this environment — see PR board page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013c3xvumpqg33Ss6AKAP7XB