### PR TITLE
fix(ai): guard placeholder INSERT + harden run-failure classification

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -1021,14 +1021,17 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     // callback, before the placeholder INSERT ever ran) — otherwise it fabricates a phantom
     // 'interrupted' row for a request that never started generating.
     it('given the pre-generation setup throws before lifecycle is created, should NOT persist a phantom row', async () => {
-      // Persistent (not -Once): startGenerationExclusive degrades-and-retries run() unlocked
-      // once on failure (see start-generation-exclusive.ts) — a single rejection would be
-      // silently swallowed by that retry. Rejecting every call forces the error to actually
-      // propagate to the route's outer catch with `lifecycle` never assigned.
+      // Persistent (not -Once) so this stays a valid regression test regardless: a `run`
+      // failure now propagates once and is never retried unlocked (see
+      // start-generation-exclusive.ts's guardedRun/runThrew — the double-generation/
+      // double-billing fix), so takeOverConversationStreams below is asserted to run exactly
+      // once. If that guard ever regresses, a persistent rejection means the retried call
+      // would ALSO fail loudly here rather than silently succeeding and masking the bug.
       mockTakeOverConversationStreams.mockRejectedValue(new Error('takeover boom'));
 
       await POST(makeRequest());
 
+      expect(mockTakeOverConversationStreams).toHaveBeenCalledTimes(1);
       expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
       const assistantSave = mockSaveMessageToDatabase.mock.calls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
       expect(assistantSave).toBeUndefined();

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1274,20 +1274,35 @@ export async function POST(request: Request) {
         // stream row without its placeholder, or vice versa. Skipped when pre-aborted — the
         // user pressed Stop before streamText ever ran, so there is no generation to show and
         // no execute-end/onFinish write will ever arrive to flip this row out of 'streaming'.
+        //
+        // Own try/catch, matching every other operation in this closure (takeOverConversationStreams,
+        // createStreamLifecycle): `run` must never throw while the advisory lock is held, or
+        // start-generation-exclusive.ts's caller misclassifies it as lock-machinery failure and
+        // invokes `run` a SECOND time, unlocked — double generation, double billing. Best-effort:
+        // a failed placeholder just means history can't show this entry mid-stream; the generation
+        // itself still proceeds.
         if (!streamLifecycle.preAborted) {
-          await db.insert(chatMessages).values({
-            id: serverAssistantMessageId!,
-            pageId: chatId!,
-            conversationId: conversationId!,
-            role: 'assistant',
-            content: '',
-            toolCalls: null,
-            toolResults: null,
-            isActive: true,
-            userId: null,
-            sourceAgentId: null,
-            status: 'streaming',
-          });
+          try {
+            await db.insert(chatMessages).values({
+              id: serverAssistantMessageId!,
+              pageId: chatId!,
+              conversationId: conversationId!,
+              role: 'assistant',
+              content: '',
+              toolCalls: null,
+              toolResults: null,
+              isActive: true,
+              userId: null,
+              sourceAgentId: null,
+              status: 'streaming',
+            });
+          } catch (error) {
+            loggers.ai.warn('AI Chat API: placeholder assistant row INSERT failed', {
+              messageId: serverAssistantMessageId,
+              conversationId,
+              error: error instanceof Error ? error.message : 'unknown',
+            });
+          }
         }
 
         return streamLifecycle;

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -1270,10 +1270,12 @@ export async function POST(request: Request) {
         // Assistant message row at stream start (Server Stream Durability epic, PR 2): a
         // 'streaming' placeholder so history can show in-flight entries and pre-checkpoint
         // process death doesn't silently lose the reply. Same critical section as
-        // takeover+lifecycle-create (PR 4 seam note) so a second send can never observe a
-        // stream row without its placeholder, or vice versa. Skipped when pre-aborted — the
-        // user pressed Stop before streamText ever ran, so there is no generation to show and
-        // no execute-end/onFinish write will ever arrive to flip this row out of 'streaming'.
+        // takeover+lifecycle-create (PR 4 seam note) so a second send observes the stream row
+        // and its placeholder together — except on the best-effort insert failure below, where
+        // the placeholder is skipped and only the stream row exists (named honestly, not an
+        // invariant). Skipped when pre-aborted — the user pressed Stop before streamText ever
+        // ran, so there is no generation to show and no execute-end/onFinish write will ever
+        // arrive to flip this row out of 'streaming'.
         //
         // Own try/catch, matching every other operation in this closure (takeOverConversationStreams,
         // createStreamLifecycle): `run` must never throw while the advisory lock is held, or
@@ -1776,9 +1778,10 @@ export async function POST(request: Request) {
     //
     // Requires `lifecycle` itself (not just `!lifecycle?.preAborted`) so this never fires for a
     // throw that happened INSIDE startGenerationExclusive's callback, before `lifecycle` is ever
-    // assigned (line ~1297) — e.g. takeOverConversationStreams or the placeholder INSERT itself
-    // failing. In that window no placeholder row exists at all, so this upsert would INSERT a
-    // stray phantom 'interrupted' row for a request that never started generating.
+    // assigned (line ~1297) — e.g. takeOverConversationStreams or createStreamLifecycle failing
+    // (the placeholder INSERT itself has its own try/catch and can no longer throw here). In
+    // that window no placeholder row exists at all, so this upsert would INSERT a stray phantom
+    // 'interrupted' row for a request that never started generating.
     if (!assistantMessagePersisted && serverAssistantMessageId && chatId && conversationId && lifecycle && !lifecycle.preAborted) {
       try {
         await saveMessageToDatabase({

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -880,12 +880,17 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
     // callback, before the placeholder INSERT ever ran) — otherwise it fabricates a phantom
     // 'interrupted' row for a request that never started generating.
     it('given the pre-generation setup throws before lifecycle is created, should NOT persist a phantom row', async () => {
-      // Persistent (not -Once): startGenerationExclusive degrades-and-retries run() unlocked
-      // once on failure — a single rejection would be silently swallowed by that retry.
+      // Persistent (not -Once) so this stays a valid regression test regardless: a `run`
+      // failure now propagates once and is never retried unlocked (see
+      // start-generation-exclusive.ts's guardedRun/runThrew — the double-generation/
+      // double-billing fix), so takeOverConversationStreams below is asserted to run exactly
+      // once. If that guard ever regresses, a persistent rejection means the retried call
+      // would ALSO fail loudly here rather than silently succeeding and masking the bug.
       mockTakeOverConversationStreams.mockRejectedValue(new Error('takeover boom'));
 
       await POST(makeRequest(), makeContext());
 
+      expect(mockTakeOverConversationStreams).toHaveBeenCalledTimes(1);
       expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
       const assistantSave = mockSaveGlobalAssistantMessageToDatabase.mock.calls.find((c: { role?: string }[]) => c[0]?.role === 'assistant');
       expect(assistantSave).toBeUndefined();

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1156,18 +1156,33 @@ MENTION PROCESSING:
         // stream row without its placeholder, or vice versa. Skipped when pre-aborted — the
         // user pressed Stop before streamText ever ran, so there is no generation to show and
         // no execute-end/onFinish write will ever arrive to flip this row out of 'streaming'.
+        //
+        // Own try/catch, matching every other operation in this closure (takeOverConversationStreams,
+        // createStreamLifecycle): `run` must never throw while the advisory lock is held, or
+        // start-generation-exclusive.ts's caller misclassifies it as lock-machinery failure and
+        // invokes `run` a SECOND time, unlocked — double generation, double billing. Best-effort:
+        // a failed placeholder just means history can't show this entry mid-stream; the generation
+        // itself still proceeds.
         if (!streamLifecycle.preAborted) {
-          await db.insert(messages).values({
-            id: serverAssistantMessageId,
-            conversationId,
-            userId,
-            role: 'assistant',
-            content: '',
-            toolCalls: null,
-            toolResults: null,
-            isActive: true,
-            status: 'streaming',
-          });
+          try {
+            await db.insert(messages).values({
+              id: serverAssistantMessageId,
+              conversationId,
+              userId,
+              role: 'assistant',
+              content: '',
+              toolCalls: null,
+              toolResults: null,
+              isActive: true,
+              status: 'streaming',
+            });
+          } catch (error) {
+            loggers.ai.warn('Global AI messages API: placeholder assistant row INSERT failed', {
+              messageId: serverAssistantMessageId,
+              conversationId,
+              error: error instanceof Error ? error.message : 'unknown',
+            });
+          }
         }
 
         return streamLifecycle;

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -1152,10 +1152,12 @@ MENTION PROCESSING:
         // Assistant message row at stream start (Server Stream Durability epic, PR 2): a
         // 'streaming' placeholder so history can show in-flight entries and pre-checkpoint
         // process death doesn't silently lose the reply. Same critical section as
-        // takeover+lifecycle-create (PR 4 seam note) so a second send can never observe a
-        // stream row without its placeholder, or vice versa. Skipped when pre-aborted — the
-        // user pressed Stop before streamText ever ran, so there is no generation to show and
-        // no execute-end/onFinish write will ever arrive to flip this row out of 'streaming'.
+        // takeover+lifecycle-create (PR 4 seam note) so a second send observes the stream row
+        // and its placeholder together — except on the best-effort insert failure below, where
+        // the placeholder is skipped and only the stream row exists (named honestly, not an
+        // invariant). Skipped when pre-aborted — the user pressed Stop before streamText ever
+        // ran, so there is no generation to show and no execute-end/onFinish write will ever
+        // arrive to flip this row out of 'streaming'.
         //
         // Own try/catch, matching every other operation in this closure (takeOverConversationStreams,
         // createStreamLifecycle): `run` must never throw while the advisory lock is held, or
@@ -1529,8 +1531,9 @@ MENTION PROCESSING:
     //
     // Requires `lifecycle` itself (not just `!lifecycle?.preAborted`) so this never fires for a
     // throw that happened INSIDE startGenerationExclusive's callback, before `lifecycle` is ever
-    // assigned — e.g. takeOverConversationStreams or the placeholder INSERT itself failing. In
-    // that window no placeholder row exists at all, so this upsert would INSERT a stray phantom
+    // assigned — e.g. takeOverConversationStreams or createStreamLifecycle failing (the
+    // placeholder INSERT itself has its own try/catch and can no longer throw here). In that
+    // window no placeholder row exists at all, so this upsert would INSERT a stray phantom
     // 'interrupted' row for a request that never started generating.
     if (!assistantMessagePersisted && cleanupContext && lifecycle && !lifecycle.preAborted) {
       try {

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -252,4 +252,65 @@ describe('startGenerationExclusive', () => {
       expect(metricMeta).toMatchObject({ reason: 'lock_busy' });
     });
   });
+
+  describe('run() throws while the lock is genuinely acquired (NOT a lock-machinery failure)', () => {
+    it('given the lock is genuinely acquired and run() throws, should propagate the error and NOT invoke run a second time unlocked (no double generation)', async () => {
+      const client = makeClient([true]);
+      const pool = makePool(client);
+      const runError = new Error('placeholder insert failed');
+      // Mirrors the reviewer's repro exactly: run rejects on its first (locked) invocation
+      // only. Pre-fix, the outer catch misclassified this as lock machinery failure and
+      // called degradeToUnlocked(..., run), invoking run a second time — unlocked — which
+      // would resolve here with 'second-call-result' and outcome 'degraded'.
+      const run = vi.fn().mockRejectedValueOnce(runError).mockResolvedValueOnce('second-call-result');
+      const sleep = vi.fn(async () => {});
+
+      await expect(startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep })).rejects.toThrow(runError);
+
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
+    it('given run() throws with the lock held, should NOT emit lock-degrade telemetry (this is a run failure, not a lock failure)', async () => {
+      const client = makeClient([true]);
+      const pool = makePool(client);
+      const run = vi.fn(async () => { throw new Error('boom'); });
+      const sleep = vi.fn(async () => {});
+
+      await expect(startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep })).rejects.toThrow('boom');
+
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+      expect(mockLogPerformance).not.toHaveBeenCalled();
+    });
+
+    it('given run() throws with the lock held, the advisory lock must still be released (finally-in-withAdvisoryLock, unaffected by the fix)', async () => {
+      const client = makeClient([true]);
+      const pool = makePool(client);
+      const run = vi.fn(async () => { throw new Error('boom'); });
+
+      await expect(
+        startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep: vi.fn(async () => {}) }),
+      ).rejects.toThrow('boom');
+
+      // try-lock + unlock: the lock was genuinely acquired and released despite run() throwing.
+      expect(client.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('given run() throws and the SAME conversation is retried by the caller, a real lock-machinery failure on that retry should still degrade normally', async () => {
+      // Guards against a stale `runThrew` flag leaking across calls/loop iterations.
+      const client = makeClient([true]);
+      const pool = makePool(client);
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      const brokenPool: AdvisoryLockPool = { connect: vi.fn(async () => { throw new Error('pool exhausted'); }) };
+
+      await expect(startGenerationExclusive({ conversationId: 'conv-1', run: vi.fn(async () => { throw new Error('first call run failure'); }), pool, sleep })).rejects.toThrow(
+        'first call run failure',
+      );
+
+      const result = await startGenerationExclusive({ conversationId: 'conv-2', run, pool: brokenPool, sleep });
+      expect(result).toEqual({ outcome: 'degraded', result: 'lifecycle-handle' });
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -291,24 +291,30 @@ describe('startGenerationExclusive', () => {
         startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep: vi.fn(async () => {}) }),
       ).rejects.toThrow('boom');
 
-      // try-lock + unlock: the lock was genuinely acquired and released despite run() throwing.
-      expect(client.query).toHaveBeenCalledTimes(2);
+      // The lock was genuinely acquired despite run() throwing, and its release contract
+      // (client.release, not the raw query count) must still be honored.
+      expect(client.release).toHaveBeenCalledTimes(1);
     });
 
-    it('given run() throws and the SAME conversation is retried by the caller, a real lock-machinery failure on that retry should still degrade normally', async () => {
-      // Guards against a stale `runThrew` flag leaking across calls/loop iterations.
-      const client = makeClient([true]);
-      const pool = makePool(client);
+    it('given a prior call on the SAME conversation had run() throw, a later call that hits a genuine lock-machinery failure should still degrade normally', async () => {
+      // `runThrew` is local to each startGenerationExclusive invocation (a fresh closure per
+      // call), so nothing from a prior call's rejection can leak into the next one — this
+      // exercises that with the same conversationId, not just structural reasoning about it.
+      const firstCallClient = makeClient([true]);
+      const firstCallPool = makePool(firstCallClient);
+      await expect(
+        startGenerationExclusive({
+          conversationId: 'conv-1',
+          run: vi.fn(async () => { throw new Error('first call run failure'); }),
+          pool: firstCallPool,
+          sleep: vi.fn(async () => {}),
+        }),
+      ).rejects.toThrow('first call run failure');
+
       const run = vi.fn(async () => 'lifecycle-handle');
-      const sleep = vi.fn(async () => {});
-
       const brokenPool: AdvisoryLockPool = { connect: vi.fn(async () => { throw new Error('pool exhausted'); }) };
+      const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool: brokenPool, sleep: vi.fn(async () => {}) });
 
-      await expect(startGenerationExclusive({ conversationId: 'conv-1', run: vi.fn(async () => { throw new Error('first call run failure'); }), pool, sleep })).rejects.toThrow(
-        'first call run failure',
-      );
-
-      const result = await startGenerationExclusive({ conversationId: 'conv-2', run, pool: brokenPool, sleep });
       expect(result).toEqual({ outcome: 'degraded', result: 'lifecycle-handle' });
       expect(run).toHaveBeenCalledTimes(1);
     });

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -296,6 +296,35 @@ describe('startGenerationExclusive', () => {
       expect(client.release).toHaveBeenCalledTimes(1);
     });
 
+    it('given run() SUCCEEDS but withAdvisoryLock\'s post-run lock release then throws, should propagate that error and NOT invoke run a second time unlocked', async () => {
+      // Codex review finding on PR #2080: withAdvisoryLock's `finally` releases the Postgres
+      // session AFTER fn() resolves (packages/db/src/advisory-lock.ts:76-103). If the unlock
+      // query rejects AND the destroy-on-release fallback (`client.release(err)`) also throws,
+      // that exception is uncaught and escapes the finally block, overriding the successful
+      // return value — so `withAdvisoryLock`'s overall promise rejects despite `run` having
+      // already completed successfully. A `runThrew`-only flag (set only inside guardedRun's
+      // catch) would stay false here and this would be misclassified as `lock_error`,
+      // triggering degradeToUnlocked and a second, unlocked invocation of an already-succeeded
+      // `run`. `runSettled` (set on BOTH the success and failure paths) closes this.
+      const releaseError = new Error('release also failed');
+      const client: AdvisoryLockClient = {
+        query: vi
+          .fn()
+          .mockResolvedValueOnce({ rows: [{ acquired: true }] }) // try-lock: acquired
+          .mockRejectedValueOnce(new Error('unlock query failed')), // unlock: fails
+        release: vi.fn((err?: Error) => {
+          if (err) throw releaseError; // the destroy-on-release fallback also throws
+        }),
+      };
+      const pool = makePool(client);
+      const run = vi.fn(async () => 'lifecycle-handle');
+      const sleep = vi.fn(async () => {});
+
+      await expect(startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep })).rejects.toThrow(releaseError);
+
+      expect(run).toHaveBeenCalledTimes(1);
+    });
+
     it('given a prior call on the SAME conversation had run() throw, a later call that hits a genuine lock-machinery failure should still degrade normally', async () => {
       // `runThrew` is local to each startGenerationExclusive invocation (a fresh closure per
       // call), so nothing from a prior call's rejection can leak into the next one — this

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -28,11 +28,14 @@ import { loggers, logPerformance } from '@pagespace/lib/logging/logger-config';
  * `run` (takeover + lifecycle-create + the placeholder message-row insert, PR 2) runs exactly
  * once per call, either inside the lock or, on degrade, once unlocked. It never runs twice for
  * one `startGenerationExclusive` call — enforced below, not merely assumed: the loop tags
- * whether `run` itself threw (as opposed to the lock machinery failing), and a `run` failure
- * propagates as a genuine failure instead of triggering the unlocked fallback. Every operation
- * inside `run` is ALSO expected to catch and log its own errors (each call site's own
- * try/catch) so this path is a backstop, not the primary defense — but the backstop is real:
- * if `run` throws for any reason, this can never double-invoke it.
+ * whether `run` already SETTLED (resolved OR rejected), as opposed to the lock machinery
+ * failing before `run` was ever invoked, and a settled `run` propagates any subsequent error as
+ * a genuine failure instead of triggering the unlocked fallback — including the case where
+ * `run` itself succeeded but `withAdvisoryLock`'s post-run lock release then throws (its
+ * `finally` overriding a successful return with that new exception). Every operation inside
+ * `run` is ALSO expected to catch and log its own errors (each call site's own try/catch) so
+ * this path is a backstop, not the primary defense — but the backstop is real: once `run` has
+ * settled, this can never double-invoke it.
  */
 
 export const MAX_LOCK_BUSY_RETRIES = 3;
@@ -117,18 +120,27 @@ export async function startGenerationExclusive<T>(
   const sleep = params.sleep ?? defaultSleep;
   const lockKey = advisoryLockKeyFor(conversationId);
 
-  // Tags whether `run` itself threw, so the catch below can tell it apart from the lock
-  // machinery failing. Every operation inside `run` is expected to catch and log its own errors
-  // (see each call site), so `runThrew` firing means that contract was violated somewhere — but
-  // it must still never cause a double-invocation. Declared once, outside the retry loop: a
-  // `runThrew` catch always throws out of this function immediately (never `continue`s back
-  // into the loop), so there is no cross-iteration state to reset between retries.
-  let runThrew = false;
+  // Tags whether `run` itself already SETTLED — resolved OR rejected — so the catch below can
+  // tell that apart from the lock machinery failing before `run` was ever invoked. This must
+  // fire on success too, not just on throw: `withAdvisoryLock`'s `finally` releases the
+  // Postgres session AFTER `fn()` resolves, and if that release itself throws (e.g. the unlock
+  // query fails and the destroy-on-release fallback then also throws), that exception replaces
+  // `run`'s successful return value and surfaces here exactly like a lock failure would. Without
+  // `runSettled` covering the success path too, that would still misclassify as `lock_error` and
+  // invoke `run` a SECOND time despite it having already completed once. Every operation inside
+  // `run` is separately expected to catch and log its own errors (see each call site) — this is
+  // the backstop for whatever still gets through, from any cause, not only a thrown error.
+  // Declared once, outside the retry loop: a `runSettled` catch always throws out of this
+  // function immediately (never `continue`s back into the loop), so there is no cross-iteration
+  // state to reset between retries.
+  let runSettled = false;
   const guardedRun = async (): Promise<T> => {
     try {
-      return await run();
+      const result = await run();
+      runSettled = true;
+      return result;
     } catch (error) {
-      runThrew = true;
+      runSettled = true;
       throw error;
     }
   };
@@ -139,20 +151,23 @@ export async function startGenerationExclusive<T>(
     try {
       attempt = await withAdvisoryLock(pool, lockKey, guardedRun);
     } catch (error) {
-      if (runThrew) {
-        // `run` ran — possibly with real side effects — while the lock WAS held. Degrading
-        // to an unlocked fallback here would invoke `run` a SECOND time, unlocked: exactly
-        // the double-generation/double-billing race this lock exists to close. A `run`
-        // failure must propagate as a genuine, one-time failure instead.
+      if (runSettled) {
+        // `run` already ran to completion — successfully or not — while the lock WAS held.
+        // Degrading to an unlocked fallback here would invoke `run` a SECOND time: exactly the
+        // double-generation/double-billing race this lock exists to close. Whatever comes out
+        // of this window (a `run` failure, or a post-success lock-release failure) must
+        // propagate as a genuine, one-time failure instead — there is no result left to safely
+        // return even if `run` itself succeeded, since a throw from `withAdvisoryLock`'s
+        // `finally` discards the value it was about to resolve with.
         throw error;
       }
       // The lock connection itself failed (pool.connect() or the try-lock query threw) —
-      // NOT `run` throwing (guardedRun above would have set `runThrew`). `run` has not been
-      // invoked yet on this path. Degrade immediately rather than retry: a broken connection
-      // is not "busy" and won't resolve itself in 300ms the way lock contention might, so
-      // retrying here would only add latency to a send that must never block. See the PR
-      // board page's verification: "Lock-pool exhaustion simulation: proceeds unlocked, metric
-      // emitted, warn logged, both requests complete."
+      // NOT `run` (guardedRun above would have set `runSettled`). `run` has not been invoked
+      // yet on this path. Degrade immediately rather than retry: a broken connection is not
+      // "busy" and won't resolve itself in 300ms the way lock contention might, so retrying
+      // here would only add latency to a send that must never block. See the PR board page's
+      // verification: "Lock-pool exhaustion simulation: proceeds unlocked, metric emitted, warn
+      // logged, both requests complete."
       return degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error', error }, run);
     }
 

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -117,22 +117,24 @@ export async function startGenerationExclusive<T>(
   const sleep = params.sleep ?? defaultSleep;
   const lockKey = advisoryLockKeyFor(conversationId);
 
+  // Tags whether `run` itself threw, so the catch below can tell it apart from the lock
+  // machinery failing. Every operation inside `run` is expected to catch and log its own errors
+  // (see each call site), so `runThrew` firing means that contract was violated somewhere — but
+  // it must still never cause a double-invocation. Declared once, outside the retry loop: a
+  // `runThrew` catch always throws out of this function immediately (never `continue`s back
+  // into the loop), so there is no cross-iteration state to reset between retries.
+  let runThrew = false;
+  const guardedRun = async (): Promise<T> => {
+    try {
+      return await run();
+    } catch (error) {
+      runThrew = true;
+      throw error;
+    }
+  };
+
   let attemptsMade = 0;
   for (;;) {
-    // Tags whether THIS attempt's exception came from `run` itself, so the catch below can
-    // tell it apart from the lock machinery failing. Every operation inside `run` is expected
-    // to catch and log its own errors (see each call site), so `runThrew` firing means that
-    // contract was violated somewhere — but it must still never cause a double-invocation.
-    let runThrew = false;
-    const guardedRun = async (): Promise<T> => {
-      try {
-        return await run();
-      } catch (error) {
-        runThrew = true;
-        throw error;
-      }
-    };
-
     let attempt;
     try {
       attempt = await withAdvisoryLock(pool, lockKey, guardedRun);

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -25,9 +25,14 @@ import { loggers, logPerformance } from '@pagespace/lib/logging/logger-config';
  * never block. Both degrade paths emit the same telemetry, tagged with a `reason` so they stay
  * distinguishable (`lock_busy` vs `lock_error`) in logs/metrics.
  *
- * `fn` (takeover + lifecycle-create today; the assistant message-row insert once PR 2 lands —
- * see the seam note on the PR 2 page) runs exactly once per call, either inside the lock or,
- * on degrade, once unlocked. It never runs twice for one `startGenerationExclusive` call.
+ * `run` (takeover + lifecycle-create + the placeholder message-row insert, PR 2) runs exactly
+ * once per call, either inside the lock or, on degrade, once unlocked. It never runs twice for
+ * one `startGenerationExclusive` call — enforced below, not merely assumed: the loop tags
+ * whether `run` itself threw (as opposed to the lock machinery failing), and a `run` failure
+ * propagates as a genuine failure instead of triggering the unlocked fallback. Every operation
+ * inside `run` is ALSO expected to catch and log its own errors (each call site's own
+ * try/catch) so this path is a backstop, not the primary defense — but the backstop is real:
+ * if `run` throws for any reason, this can never double-invoke it.
  */
 
 export const MAX_LOCK_BUSY_RETRIES = 3;
@@ -114,18 +119,38 @@ export async function startGenerationExclusive<T>(
 
   let attemptsMade = 0;
   for (;;) {
+    // Tags whether THIS attempt's exception came from `run` itself, so the catch below can
+    // tell it apart from the lock machinery failing. Every operation inside `run` is expected
+    // to catch and log its own errors (see each call site), so `runThrew` firing means that
+    // contract was violated somewhere — but it must still never cause a double-invocation.
+    let runThrew = false;
+    const guardedRun = async (): Promise<T> => {
+      try {
+        return await run();
+      } catch (error) {
+        runThrew = true;
+        throw error;
+      }
+    };
+
     let attempt;
     try {
-      attempt = await withAdvisoryLock(pool, lockKey, run);
+      attempt = await withAdvisoryLock(pool, lockKey, guardedRun);
     } catch (error) {
+      if (runThrew) {
+        // `run` ran — possibly with real side effects — while the lock WAS held. Degrading
+        // to an unlocked fallback here would invoke `run` a SECOND time, unlocked: exactly
+        // the double-generation/double-billing race this lock exists to close. A `run`
+        // failure must propagate as a genuine, one-time failure instead.
+        throw error;
+      }
       // The lock connection itself failed (pool.connect() or the try-lock query threw) —
-      // NOT `run` throwing. `run` (takeover + lifecycle-create) is documented to catch and
-      // log its own errors and never throw, so this catch can only be reached by the lock
-      // machinery; `run` has not been invoked yet on this path. Degrade immediately rather
-      // than retry: a broken connection is not "busy" and won't resolve itself in 300ms the
-      // way lock contention might, so retrying here would only add latency to a send that
-      // must never block. See the PR board page's verification: "Lock-pool exhaustion
-      // simulation: proceeds unlocked, metric emitted, warn logged, both requests complete."
+      // NOT `run` throwing (guardedRun above would have set `runThrew`). `run` has not been
+      // invoked yet on this path. Degrade immediately rather than retry: a broken connection
+      // is not "busy" and won't resolve itself in 300ms the way lock contention might, so
+      // retrying here would only add latency to a send that must never block. See the PR
+      // board page's verification: "Lock-pool exhaustion simulation: proceeds unlocked, metric
+      // emitted, warn logged, both requests complete."
       return degradeToUnlocked({ conversationId, attemptsMade, reason: 'lock_error', error }, run);
     }
 


### PR DESCRIPTION
## Summary
URGENT HOTFIX for a double-generation/double-billing race reopened by PR #2076.

PR #2076 added an unguarded `db.insert()` for the assistant placeholder row directly inside `startGenerationExclusive`'s `run` closure, in both `apps/web/src/app/api/ai/chat/route.ts` and `apps/web/src/app/api/ai/global/[id]/messages/route.ts` — no try/catch, unlike the sibling operations in that closure (`takeOverConversationStreams`, `createStreamLifecycle`). The caller (`start-generation-exclusive.ts`) assumes `run` never throws: if the insert threw while the advisory lock was genuinely held, the exception was misclassified as lock-machinery failure and `degradeToUnlocked` invoked `run` a **second time, unlocked** — double generation, double billing.

Reviewer-verified and reproduced (board: `nxkkhcv8yjnuvm9ake60jg4r`, task D.1 on `tza273pegokkzpd7ut5qvxky`).

- Both routes: wrap the placeholder INSERT in its own try/catch (log-and-continue), matching its siblings in the same closure.
- `start-generation-exclusive.ts`: a `guardedRun` wrapper tags whether `run` already **settled** (resolved or rejected) — `runSettled` — so the outer catch rethrows any error surfacing after that point as a genuine failure instead of degrading to an unlocked retry. This is a structural guarantee — `run` can never double-invoke regardless of what throws inside it, not just documentation of an assumed contract.
- Self-review pass: corrected stale route.ts comments that overstated the placeholder-INSERT guarantee, and hoisted the guard above the retry loop (no cross-iteration state to reset).
- **Codex review caught a real gap** in the first version of the fix: `withAdvisoryLock` releases the Postgres session in a `finally` *after* `run()` resolves — if that release itself throws (unlock query fails + the destroy-on-release fallback also throws), the exception overrides a *successful* `run()` return, and a `runThrew`-only flag (set only on the failure path) would still misclassify it as `lock_error` and double-invoke an already-succeeded `run`. Broadened the flag to `runSettled`, set on both the success and failure paths — closes that gap too. Verified RED against the `runThrew`-only version before applying, GREEN after.

## Test plan
- [x] RED: new test mirrors the reviewer's exact repro (lock genuinely acquired, `run` rejects once then would resolve on a second call) — pre-fix, `run` was invoked twice and the call "succeeded" as a silent degraded outcome.
- [x] GREEN: post-fix, the error propagates once and `run` is called exactly once.
- [x] RED→GREEN for the Codex-found gap: lock acquired, `run` succeeds, then the unlock query + destroy-on-release fallback both throw — pre-fix this degraded and double-invoked `run`; post-fix it propagates the release error once.
- [x] 100% branch coverage on `start-generation-exclusive.ts`.
- [x] Full `chat`/`global messages` route test suites green (129 tests, including two now-strengthened regression tests that exercise the real `startGenerationExclusive` end-to-end).
- [x] `apps/web` + full monorepo `typecheck` green.
- [x] Lint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFRRMrLvWqEjUhYHTRebRy