### PR TITLE
fix(scripts): coverage-ratchet sentinel matching immune to prose mentions + write sanity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       # never sees them. Scoped to backfill-* because the older tenant-* and
       # changelog-* suites in that config are broken independently of CI.
       - name: Run backfill script tests
-        run: cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/backfill-legacy-ciphertext-reencrypt.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts
+        run: cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/backfill-legacy-ciphertext-reencrypt.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts __tests__/coverage-ratchet-sentinel.test.ts
 
       - name: Coverage report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,10 @@ jobs:
 
       # Backfill scripts have their own vitest context (scripts/vitest.config.ts)
       # and are not part of any workspace package, so the turbo test pipeline
-      # never sees them. Scoped to backfill-* because the older tenant-* and
-      # changelog-* suites in that config are broken independently of CI.
+      # never sees them. Explicitly listed by file (not a glob) because the
+      # older tenant-* and changelog-* suites in that config are broken
+      # independently of CI — a new one-off scripts/__tests__ file must be
+      # added to this list by hand to actually run here.
       - name: Run backfill script tests
         run: cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/backfill-legacy-ciphertext-reencrypt.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts __tests__/coverage-ratchet-sentinel.test.ts
 

--- a/scripts/__tests__/coverage-ratchet-sentinel.test.ts
+++ b/scripts/__tests__/coverage-ratchet-sentinel.test.ts
@@ -1,10 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import {
   matchThresholdBlock,
   buildThresholdBlock,
+  parseThresholds,
   assertValidSyntax,
 } from '../lib/coverage-ratchet-sentinel.mjs';
 
@@ -76,6 +74,65 @@ describe('matchThresholdBlock', () => {
   it('returns null when no thresholds block exists at all', () => {
     expect(matchThresholdBlock('export default {}')).toBeNull();
   });
+
+  it('throws instead of guessing when two well-formed sentinel blocks exist', () => {
+    const twoSentinels = `thresholds: {
+        /* ratchet:start */
+        lines: 44,
+        branches: 85,
+        functions: 56,
+        statements: 44,
+        /* ratchet:end */
+      },
+      other: {
+        /* ratchet:start */
+        lines: 1,
+        branches: 2,
+        functions: 3,
+        statements: 4,
+        /* ratchet:end */
+      },`;
+
+    expect(() => matchThresholdBlock(twoSentinels)).toThrow(/2 ratchet:start\/ratchet:end sentinel blocks/);
+  });
+
+  it('throws instead of silently falling back to the corrupting plain match when the sentinel is malformed', () => {
+    // Trailing text on the ratchet:end line (e.g. from an autoformatter) means
+    // the marker no longer occupies its own line — this must NOT silently
+    // fall back to PLAIN_REGEX, which would truncate at the first `}` in the
+    // per-glob keys below and corrupt the config exactly like the original bug.
+    const malformed = `thresholds: {
+        /* ratchet:start */
+        lines: 44,
+        branches: 85,
+        functions: 56,
+        statements: 44,
+        /* ratchet:end */ // do not edit
+        'src/lib/foo/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+      },`;
+
+    expect(() => matchThresholdBlock(malformed)).toThrow(/not a well-formed sentinel block/);
+  });
+});
+
+describe('parseThresholds', () => {
+  it('extracts all four numeric thresholds from a block of text', () => {
+    expect(parseThresholds('lines: 44,\nbranches: 85,\nfunctions: 56,\nstatements: 44,')).toEqual({
+      lines: 44,
+      branches: 85,
+      functions: 56,
+      statements: 44,
+    });
+  });
+
+  it('defaults missing keys to 0', () => {
+    expect(parseThresholds('lines: 44,')).toEqual({
+      lines: 44,
+      branches: 0,
+      functions: 0,
+      statements: 0,
+    });
+  });
 });
 
 describe('buildThresholdBlock', () => {
@@ -83,11 +140,11 @@ describe('buildThresholdBlock', () => {
     const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
     const block = buildThresholdBlock({
       isSentinel: true,
-      indent: found.match[1],
+      indent: found.indent,
       thresholds: { lines: 60, branches: 90, functions: 70, statements: 60 },
     });
 
-    expect(block.startsWith(`${found.match[1]}/* ratchet:start */`)).toBe(true);
+    expect(block.startsWith(`${found.indent}/* ratchet:start */`)).toBe(true);
     expect(block).toContain('lines: 60,');
     expect(block.endsWith('/* ratchet:end */')).toBe(true);
   });
@@ -96,7 +153,7 @@ describe('buildThresholdBlock', () => {
     const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
     const block = buildThresholdBlock({
       isSentinel: true,
-      indent: found.match[1],
+      indent: found.indent,
       thresholds: { lines: 60, branches: 90, functions: 70, statements: 60 },
     });
     const rewritten = CONFIG_WITH_PROSE_MENTION.replace(found.regex, block);
@@ -110,24 +167,12 @@ describe('buildThresholdBlock', () => {
 });
 
 describe('assertValidSyntax', () => {
-  let dir: string;
-
   it('does not throw on valid source', () => {
-    dir = mkdtempSync(join(tmpdir(), 'ratchet-sentinel-test-'));
-    try {
-      expect(() => assertValidSyntax('export default { foo: 1 };\n', 'test-pkg', dir)).not.toThrow();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    expect(() => assertValidSyntax('export default { foo: 1 };\n', 'test-pkg')).not.toThrow();
   });
 
   it('throws on a corrupted rewrite (unterminated block comment)', () => {
-    dir = mkdtempSync(join(tmpdir(), 'ratchet-sentinel-test-'));
-    try {
-      const corrupted = 'export default {\n  /* ratchet:end */ markers below are load-bearing:\n';
-      expect(() => assertValidSyntax(corrupted, 'test-pkg', dir)).toThrow(/test-pkg/);
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    const corrupted = 'export default {\n  /* ratchet:end */ markers below are load-bearing:\n';
+    expect(() => assertValidSyntax(corrupted, 'test-pkg')).toThrow(/test-pkg/);
   });
 });

--- a/scripts/__tests__/coverage-ratchet-sentinel.test.ts
+++ b/scripts/__tests__/coverage-ratchet-sentinel.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  matchThresholdBlock,
+  buildThresholdBlock,
+  assertValidSyntax,
+} from '../lib/coverage-ratchet-sentinel.mjs';
+
+// Mirrors the real corrupting comment from apps/web/vitest.config.ts (#2075):
+// a prose line that mentions the marker text literally, directly above the
+// real sentinel-delimited threshold block.
+const CONFIG_WITH_PROSE_MENTION = `export default defineConfig({
+  test: {
+    coverage: {
+      thresholds: {
+        // The /* ratchet:start */.../* ratchet:end */ markers below are load-bearing:
+        // some-script.mjs matches this exact comment-delimited region
+        /* ratchet:start */
+        lines: 44,
+        branches: 85,
+        functions: 56,
+        statements: 44,
+        /* ratchet:end */
+        'src/lib/foo/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+      },
+    },
+  },
+})
+`;
+
+const CONFIG_WITHOUT_SENTINEL = `export default defineConfig({
+  test: {
+    coverage: {
+      thresholds: {
+        lines: 50,
+        branches: 89,
+        functions: 66,
+        statements: 50,
+      },
+    },
+  },
+})
+`;
+
+describe('matchThresholdBlock', () => {
+  it('ignores marker text embedded in prose and finds the real sentinel block', () => {
+    const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION);
+
+    expect(found).not.toBeNull();
+    expect(found!.isSentinel).toBe(true);
+    expect(found!.match[0]).toContain('lines: 44,');
+    expect(found!.match[0]).toContain('statements: 44,');
+    // The fake span from the prose line must not be what matched.
+    expect(found!.match[0]).not.toContain('markers below are load-bearing');
+  });
+
+  it('extracts the real numeric thresholds, not zeros from a fake match', () => {
+    const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
+    const lines = parseInt(found.match[0].match(/lines:\s*(\d+)/)?.[1] ?? '0');
+    const branches = parseInt(found.match[0].match(/branches:\s*(\d+)/)?.[1] ?? '0');
+
+    expect(lines).toBe(44);
+    expect(branches).toBe(85);
+  });
+
+  it('falls back to the plain thresholds block when there is no sentinel', () => {
+    const found = matchThresholdBlock(CONFIG_WITHOUT_SENTINEL);
+
+    expect(found).not.toBeNull();
+    expect(found!.isSentinel).toBe(false);
+    expect(found!.match[0]).toContain('lines: 50,');
+  });
+
+  it('returns null when no thresholds block exists at all', () => {
+    expect(matchThresholdBlock('export default {}')).toBeNull();
+  });
+});
+
+describe('buildThresholdBlock', () => {
+  it('preserves the sentinel start marker\'s original indentation', () => {
+    const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
+    const block = buildThresholdBlock({
+      isSentinel: true,
+      indent: found.match[1],
+      thresholds: { lines: 60, branches: 90, functions: 70, statements: 60 },
+    });
+
+    expect(block.startsWith(`${found.match[1]}/* ratchet:start */`)).toBe(true);
+    expect(block).toContain('lines: 60,');
+    expect(block.endsWith('/* ratchet:end */')).toBe(true);
+  });
+
+  it('round-trips through a real rewrite without corrupting the surrounding config', () => {
+    const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
+    const block = buildThresholdBlock({
+      isSentinel: true,
+      indent: found.match[1],
+      thresholds: { lines: 60, branches: 90, functions: 70, statements: 60 },
+    });
+    const rewritten = CONFIG_WITH_PROSE_MENTION.replace(found.regex, block);
+
+    // The prose comment line and the trailing per-glob key must survive untouched.
+    expect(rewritten).toContain('markers below are load-bearing');
+    expect(rewritten).toContain("'src/lib/foo/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },");
+    expect(rewritten).toContain('lines: 60,');
+    expect(rewritten).not.toContain('lines: 44,');
+  });
+});
+
+describe('assertValidSyntax', () => {
+  let dir: string;
+
+  it('does not throw on valid source', () => {
+    dir = mkdtempSync(join(tmpdir(), 'ratchet-sentinel-test-'));
+    try {
+      expect(() => assertValidSyntax('export default { foo: 1 };\n', 'test-pkg', dir)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on a corrupted rewrite (unterminated block comment)', () => {
+    dir = mkdtempSync(join(tmpdir(), 'ratchet-sentinel-test-'));
+    try {
+      const corrupted = 'export default {\n  /* ratchet:end */ markers below are load-bearing:\n';
+      expect(() => assertValidSyntax(corrupted, 'test-pkg', dir)).toThrow(/test-pkg/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/__tests__/coverage-ratchet-sentinel.test.ts
+++ b/scripts/__tests__/coverage-ratchet-sentinel.test.ts
@@ -56,11 +56,8 @@ describe('matchThresholdBlock', () => {
 
   it('extracts the real numeric thresholds, not zeros from a fake match', () => {
     const found = matchThresholdBlock(CONFIG_WITH_PROSE_MENTION)!;
-    const lines = parseInt(found.match[0].match(/lines:\s*(\d+)/)?.[1] ?? '0');
-    const branches = parseInt(found.match[0].match(/branches:\s*(\d+)/)?.[1] ?? '0');
 
-    expect(lines).toBe(44);
-    expect(branches).toBe(85);
+    expect(parseThresholds(found.match[0])).toEqual({ lines: 44, branches: 85, functions: 56, statements: 44 });
   });
 
   it('falls back to the plain thresholds block when there is no sentinel', () => {

--- a/scripts/__tests__/coverage-ratchet-sentinel.test.ts
+++ b/scripts/__tests__/coverage-ratchet-sentinel.test.ts
@@ -175,4 +175,14 @@ describe('assertValidSyntax', () => {
     const corrupted = 'export default {\n  /* ratchet:end */ markers below are load-bearing:\n';
     expect(() => assertValidSyntax(corrupted, 'test-pkg')).toThrow(/test-pkg/);
   });
+
+  it('accepts TS-only syntax (satisfies, type assertions) that a JS-only check would wrongly reject', () => {
+    const tsOnlySyntax = `
+      interface Thresholds { lines: number }
+      const t = { lines: 44 } satisfies Thresholds;
+      const u = t as Thresholds;
+      export default t;
+    `;
+    expect(() => assertValidSyntax(tsOnlySyntax, 'test-pkg')).not.toThrow();
+  });
 });

--- a/scripts/__tests__/coverage-ratchet-sentinel.test.ts
+++ b/scripts/__tests__/coverage-ratchet-sentinel.test.ts
@@ -75,6 +75,15 @@ describe('matchThresholdBlock', () => {
     expect(matchThresholdBlock('export default {}')).toBeNull();
   });
 
+  it('matches a well-formed sentinel block with CRLF line endings (Windows/core.autocrlf checkouts)', () => {
+    const crlfConfig = CONFIG_WITH_PROSE_MENTION.replace(/\n/g, '\r\n');
+    const found = matchThresholdBlock(crlfConfig);
+
+    expect(found).not.toBeNull();
+    expect(found!.isSentinel).toBe(true);
+    expect(found!.match[0]).toContain('lines: 44,');
+  });
+
   it('throws instead of guessing when two well-formed sentinel blocks exist', () => {
     const twoSentinels = `thresholds: {
         /* ratchet:start */

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -10,10 +10,12 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { matchThresholdBlock, buildThresholdBlock, assertValidSyntax } from './lib/coverage-ratchet-sentinel.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const dryRun = process.argv.includes('--dry-run');
+let hadError = false;
 
 const packages = [
   { name: 'apps/web', config: 'apps/web/vitest.config.ts', summary: 'apps/web/coverage/coverage-summary.json' },
@@ -46,22 +48,14 @@ for (const pkg of packages) {
     statements: Math.floor(t.statements.pct),
   };
 
-  // Match the sentinel-marked ratchet region first — packages with per-glob
-  // threshold keys after the four ratcheted scalars (e.g. apps/web's 100%
-  // gates on new pure modules) would otherwise have `[^}]+` stop at the
-  // glob sub-objects' first `}`, truncating the match and corrupting the
-  // rewrite. Fall back to the plain block match for packages with no
-  // sentinel, so processor/realtime/db/lib keep working unchanged.
-  const sentinelRegex = /\/\* ratchet:start \*\/[\s\S]*?\/\* ratchet:end \*\//;
-  const plainRegex = /thresholds:\s*\{[^}]+\}/s;
-  const sentinelMatch = config.match(sentinelRegex);
-  const match = sentinelMatch ?? config.match(plainRegex);
-  const thresholdRegex = sentinelMatch ? sentinelRegex : plainRegex;
+  const found = matchThresholdBlock(config);
 
-  if (!match) {
+  if (!found) {
     console.log(`[skip] ${pkg.name}: no thresholds block found in vitest config`);
     continue;
   }
+
+  const { match, regex: thresholdRegex, isSentinel } = found;
 
   // Extract current thresholds
   const currentLines = parseInt(match[0].match(/lines:\s*(\d+)/)?.[1] ?? '0');
@@ -88,14 +82,23 @@ for (const pkg of packages) {
     continue;
   }
 
-  // The sentinel rewrite preserves everything after `ratchet:end` (the
-  // per-glob 100% keys) — only the four ratcheted scalars inside the markers
-  // are replaced.
-  const newBlock = sentinelMatch
-    ? `/* ratchet:start */\n        lines: ${finalThresholds.lines},\n        branches: ${finalThresholds.branches},\n        functions: ${finalThresholds.functions},\n        statements: ${finalThresholds.statements},\n        /* ratchet:end */`
-    : `thresholds: {\n        lines: ${finalThresholds.lines},\n        branches: ${finalThresholds.branches},\n        functions: ${finalThresholds.functions},\n        statements: ${finalThresholds.statements},\n      }`;
+  const newBlock = buildThresholdBlock({
+    isSentinel,
+    indent: isSentinel ? match[1] : '',
+    thresholds: finalThresholds,
+  });
 
-  config = config.replace(thresholdRegex, newBlock);
+  const newConfig = config.replace(thresholdRegex, newBlock);
+
+  try {
+    assertValidSyntax(newConfig, pkg.name, root);
+  } catch (err) {
+    console.error(`[fail] ${err.message}`);
+    hadError = true;
+    continue;
+  }
+
+  config = newConfig;
 
   if (dryRun) {
     console.log(`[dry]  ${pkg.name}: would update thresholds:`);
@@ -112,3 +115,7 @@ for (const pkg of packages) {
 }
 
 console.log(`\n${dryRun ? 'Would update' : 'Updated'} ${updated} package(s).`);
+
+if (hadError) {
+  process.exit(1);
+}

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -10,7 +10,7 @@
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { matchThresholdBlock, buildThresholdBlock, assertValidSyntax } from './lib/coverage-ratchet-sentinel.mjs';
+import { matchThresholdBlock, buildThresholdBlock, parseThresholds, assertValidSyntax } from './lib/coverage-ratchet-sentinel.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -48,20 +48,28 @@ for (const pkg of packages) {
     statements: Math.floor(t.statements.pct),
   };
 
-  const found = matchThresholdBlock(config);
+  let found;
+  try {
+    found = matchThresholdBlock(config);
+  } catch (err) {
+    console.error(`[fail] ${pkg.name}: ${err.message}`);
+    hadError = true;
+    continue;
+  }
 
   if (!found) {
     console.log(`[skip] ${pkg.name}: no thresholds block found in vitest config`);
     continue;
   }
 
-  const { match, regex: thresholdRegex, isSentinel } = found;
+  const { match, regex: thresholdRegex, isSentinel, indent } = found;
 
-  // Extract current thresholds
-  const currentLines = parseInt(match[0].match(/lines:\s*(\d+)/)?.[1] ?? '0');
-  const currentBranches = parseInt(match[0].match(/branches:\s*(\d+)/)?.[1] ?? '0');
-  const currentFunctions = parseInt(match[0].match(/functions:\s*(\d+)/)?.[1] ?? '0');
-  const currentStatements = parseInt(match[0].match(/statements:\s*(\d+)/)?.[1] ?? '0');
+  const {
+    lines: currentLines,
+    branches: currentBranches,
+    functions: currentFunctions,
+    statements: currentStatements,
+  } = parseThresholds(match[0]);
 
   // Only ratchet UP, never down
   const finalThresholds = {
@@ -82,16 +90,12 @@ for (const pkg of packages) {
     continue;
   }
 
-  const newBlock = buildThresholdBlock({
-    isSentinel,
-    indent: isSentinel ? match[1] : '',
-    thresholds: finalThresholds,
-  });
+  const newBlock = buildThresholdBlock({ isSentinel, indent, thresholds: finalThresholds });
 
   const newConfig = config.replace(thresholdRegex, newBlock);
 
   try {
-    assertValidSyntax(newConfig, pkg.name, root);
+    assertValidSyntax(newConfig, pkg.name);
   } catch (err) {
     console.error(`[fail] ${err.message}`);
     hadError = true;

--- a/scripts/lib/coverage-ratchet-sentinel.mjs
+++ b/scripts/lib/coverage-ratchet-sentinel.mjs
@@ -3,16 +3,18 @@
  * matching, rewriting, and pre-write syntax check.
  */
 
-import { writeFileSync, unlinkSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // Markers must occupy their own line (only leading/trailing whitespace besides
 // the marker) — real usage always looks like that, whereas a prose comment
 // mentioning the markers (e.g. "the /* ratchet:start */.../* ratchet:end */
 // markers below are load-bearing") has other text sharing the line and is
 // correctly rejected.
-export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\r?\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*\r?$/m;
+export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*$/m;
+const SENTINEL_REGEX_GLOBAL = new RegExp(SENTINEL_REGEX.source, `${SENTINEL_REGEX.flags}g`);
 
 export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
 
@@ -22,14 +24,34 @@ export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
 // sub-objects' first `}`, truncating the match and corrupting the rewrite.
 // Fall back to the plain block match for packages with no sentinel, so
 // processor/realtime/db/lib keep working unchanged.
+//
+// Two "refuse to guess" guards beyond the line-anchoring above:
+//  - More than one well-formed sentinel block in the same file is ambiguous
+//    (which one is real?) — error instead of silently taking the first match.
+//  - Marker text present but NOT forming a well-formed block (e.g. an
+//    autoformatter appends a trailing comment to the `ratchet:end` line) must
+//    NOT silently fall back to the plain match — that fallback is only safe
+//    for configs that never intended to use a sentinel at all, and applying
+//    it to a malformed sentinel reproduces the original truncation bug on
+//    apps/web's per-glob keys.
 export function matchThresholdBlock(config) {
+  const sentinelSpans = config.match(SENTINEL_REGEX_GLOBAL);
+  if (sentinelSpans && sentinelSpans.length > 1) {
+    throw new Error(`found ${sentinelSpans.length} ratchet:start/ratchet:end sentinel blocks — expected at most one; refusing to guess which is real`);
+  }
+
   const sentinelMatch = config.match(SENTINEL_REGEX);
   if (sentinelMatch) {
-    return { match: sentinelMatch, regex: SENTINEL_REGEX, isSentinel: true };
+    return { match: sentinelMatch, regex: SENTINEL_REGEX, isSentinel: true, indent: sentinelMatch[1] };
   }
+
+  if (config.includes('ratchet:start') || config.includes('ratchet:end')) {
+    throw new Error('found "ratchet:start"/"ratchet:end" marker text that is not a well-formed sentinel block (each marker must occupy its own line) — refusing to fall back to the plain thresholds match, which would corrupt the per-glob keys after it');
+  }
+
   const plainMatch = config.match(PLAIN_REGEX);
   if (plainMatch) {
-    return { match: plainMatch, regex: PLAIN_REGEX, isSentinel: false };
+    return { match: plainMatch, regex: PLAIN_REGEX, isSentinel: false, indent: '' };
   }
   return null;
 }
@@ -44,18 +66,29 @@ export function buildThresholdBlock({ isSentinel, indent, thresholds }) {
     : `thresholds: {\n        lines: ${lines},\n        branches: ${branches},\n        functions: ${functions},\n        statements: ${statements},\n      }`;
 }
 
-// Writes `source` to a throwaway .mjs file and runs `node --check` on it —
-// catches any rewrite that produces unparseable output (e.g. a sentinel match
-// landing mid-comment/mid-token) before it ever reaches disk, rather than
-// trusting the regex match alone.
-export function assertValidSyntax(source, label, tmpDir) {
-  const checkPath = resolve(tmpDir, `.coverage-ratchet-check-${process.pid}.mjs`);
-  writeFileSync(checkPath, source);
+// Extracts the current numeric thresholds from a matched block's text.
+export function parseThresholds(matchText) {
+  return {
+    lines: parseInt(matchText.match(/lines:\s*(\d+)/)?.[1] ?? '0'),
+    branches: parseInt(matchText.match(/branches:\s*(\d+)/)?.[1] ?? '0'),
+    functions: parseInt(matchText.match(/functions:\s*(\d+)/)?.[1] ?? '0'),
+    statements: parseInt(matchText.match(/statements:\s*(\d+)/)?.[1] ?? '0'),
+  };
+}
+
+// Writes `source` to a throwaway .mjs file (in the OS temp dir, never the
+// repo) and runs `node --check` on it — catches any rewrite that produces
+// unparseable output (e.g. a sentinel match landing mid-comment/mid-token)
+// before it ever reaches disk, rather than trusting the regex match alone.
+export function assertValidSyntax(source, label) {
+  const dir = mkdtempSync(join(tmpdir(), 'coverage-ratchet-check-'));
+  const checkPath = join(dir, 'check.mjs');
   try {
+    writeFileSync(checkPath, source);
     execFileSync(process.execPath, ['--check', checkPath], { stdio: 'pipe' });
   } catch (err) {
     throw new Error(`${label}: rewritten config fails a syntax check — refusing to write.\n${err.stderr?.toString() ?? err.message}`);
   } finally {
-    unlinkSync(checkPath);
+    rmSync(dir, { recursive: true, force: true });
   }
 }

--- a/scripts/lib/coverage-ratchet-sentinel.mjs
+++ b/scripts/lib/coverage-ratchet-sentinel.mjs
@@ -1,0 +1,61 @@
+/**
+ * Pure, unit-testable pieces of scripts/coverage-ratchet.mjs's threshold-block
+ * matching, rewriting, and pre-write syntax check.
+ */
+
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+// Markers must occupy their own line (only leading/trailing whitespace besides
+// the marker) — real usage always looks like that, whereas a prose comment
+// mentioning the markers (e.g. "the /* ratchet:start */.../* ratchet:end */
+// markers below are load-bearing") has other text sharing the line and is
+// correctly rejected.
+export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\r?\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*\r?$/m;
+
+export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
+
+// Match the sentinel-marked ratchet region first — packages with per-glob
+// threshold keys after the four ratcheted scalars (e.g. apps/web's 100% gates
+// on new pure modules) would otherwise have `[^}]+` stop at the glob
+// sub-objects' first `}`, truncating the match and corrupting the rewrite.
+// Fall back to the plain block match for packages with no sentinel, so
+// processor/realtime/db/lib keep working unchanged.
+export function matchThresholdBlock(config) {
+  const sentinelMatch = config.match(SENTINEL_REGEX);
+  if (sentinelMatch) {
+    return { match: sentinelMatch, regex: SENTINEL_REGEX, isSentinel: true };
+  }
+  const plainMatch = config.match(PLAIN_REGEX);
+  if (plainMatch) {
+    return { match: plainMatch, regex: PLAIN_REGEX, isSentinel: false };
+  }
+  return null;
+}
+
+// The sentinel rewrite preserves everything after `ratchet:end` (the per-glob
+// 100% keys) and the start marker's original indentation — only the four
+// ratcheted scalars inside the markers are replaced.
+export function buildThresholdBlock({ isSentinel, indent, thresholds }) {
+  const { lines, branches, functions, statements } = thresholds;
+  return isSentinel
+    ? `${indent}/* ratchet:start */\n        lines: ${lines},\n        branches: ${branches},\n        functions: ${functions},\n        statements: ${statements},\n        /* ratchet:end */`
+    : `thresholds: {\n        lines: ${lines},\n        branches: ${branches},\n        functions: ${functions},\n        statements: ${statements},\n      }`;
+}
+
+// Writes `source` to a throwaway .mjs file and runs `node --check` on it —
+// catches any rewrite that produces unparseable output (e.g. a sentinel match
+// landing mid-comment/mid-token) before it ever reaches disk, rather than
+// trusting the regex match alone.
+export function assertValidSyntax(source, label, tmpDir) {
+  const checkPath = resolve(tmpDir, `.coverage-ratchet-check-${process.pid}.mjs`);
+  writeFileSync(checkPath, source);
+  try {
+    execFileSync(process.execPath, ['--check', checkPath], { stdio: 'pipe' });
+  } catch (err) {
+    throw new Error(`${label}: rewritten config fails a syntax check — refusing to write.\n${err.stderr?.toString() ?? err.message}`);
+  } finally {
+    unlinkSync(checkPath);
+  }
+}

--- a/scripts/lib/coverage-ratchet-sentinel.mjs
+++ b/scripts/lib/coverage-ratchet-sentinel.mjs
@@ -9,8 +9,10 @@ import ts from 'typescript';
 // the marker) — real usage always looks like that, whereas a prose comment
 // mentioning the markers (e.g. "the /* ratchet:start */.../* ratchet:end */
 // markers below are load-bearing") has other text sharing the line and is
-// correctly rejected.
-export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*$/m;
+// correctly rejected. `\r?` tolerates CRLF line endings: .gitattributes does
+// not force LF for .ts files, so a Windows/core.autocrlf checkout can have
+// \r\n here even though the repo's own files are LF.
+export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\r?\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*\r?$/m;
 const SENTINEL_REGEX_GLOBAL = new RegExp(SENTINEL_REGEX.source, `${SENTINEL_REGEX.flags}g`);
 
 export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;

--- a/scripts/lib/coverage-ratchet-sentinel.mjs
+++ b/scripts/lib/coverage-ratchet-sentinel.mjs
@@ -12,10 +12,10 @@ import ts from 'typescript';
 // correctly rejected. `\r?` tolerates CRLF line endings: .gitattributes does
 // not force LF for .ts files, so a Windows/core.autocrlf checkout can have
 // \r\n here even though the repo's own files are LF.
-export const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\r?\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*\r?$/m;
+const SENTINEL_REGEX = /^([ \t]*)\/\* ratchet:start \*\/[ \t]*\r?\n[\s\S]*?^[ \t]*\/\* ratchet:end \*\/[ \t]*\r?$/m;
 const SENTINEL_REGEX_GLOBAL = new RegExp(SENTINEL_REGEX.source, `${SENTINEL_REGEX.flags}g`);
 
-export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
+const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
 
 // Match the sentinel-marked ratchet region first — packages with per-glob
 // threshold keys after the four ratcheted scalars (e.g. apps/web's 100% gates
@@ -34,12 +34,12 @@ export const PLAIN_REGEX = /thresholds:\s*\{[^}]+\}/s;
 //    it to a malformed sentinel reproduces the original truncation bug on
 //    apps/web's per-glob keys.
 export function matchThresholdBlock(config) {
-  const sentinelSpans = config.match(SENTINEL_REGEX_GLOBAL);
-  if (sentinelSpans && sentinelSpans.length > 1) {
-    throw new Error(`found ${sentinelSpans.length} ratchet:start/ratchet:end sentinel blocks — expected at most one; refusing to guess which is real`);
+  const sentinelMatches = [...config.matchAll(SENTINEL_REGEX_GLOBAL)];
+  if (sentinelMatches.length > 1) {
+    throw new Error(`found ${sentinelMatches.length} ratchet:start/ratchet:end sentinel blocks — expected at most one; refusing to guess which is real`);
   }
 
-  const sentinelMatch = config.match(SENTINEL_REGEX);
+  const sentinelMatch = sentinelMatches[0];
   if (sentinelMatch) {
     return { match: sentinelMatch, regex: SENTINEL_REGEX, isSentinel: true, indent: sentinelMatch[1] };
   }

--- a/scripts/lib/coverage-ratchet-sentinel.mjs
+++ b/scripts/lib/coverage-ratchet-sentinel.mjs
@@ -3,10 +3,7 @@
  * matching, rewriting, and pre-write syntax check.
  */
 
-import { writeFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { execFileSync } from 'node:child_process';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import ts from 'typescript';
 
 // Markers must occupy their own line (only leading/trailing whitespace besides
 // the marker) — real usage always looks like that, whereas a prose comment
@@ -76,19 +73,19 @@ export function parseThresholds(matchText) {
   };
 }
 
-// Writes `source` to a throwaway .mjs file (in the OS temp dir, never the
-// repo) and runs `node --check` on it — catches any rewrite that produces
-// unparseable output (e.g. a sentinel match landing mid-comment/mid-token)
-// before it ever reaches disk, rather than trusting the regex match alone.
+// Runs a TypeScript syntax-only check (no type-checking, no file I/O, no
+// subprocess) on the rewritten config string — catches any rewrite that
+// produces unparseable output (e.g. a sentinel match landing mid-comment/
+// mid-token) before it ever reaches disk, rather than trusting the regex
+// match alone. Uses the TypeScript parser rather than `node --check` because
+// these are .ts files: a config using TS-only syntax (`satisfies`, a type
+// assertion, a generic) is valid input that a JS-only syntax check would
+// wrongly reject.
 export function assertValidSyntax(source, label) {
-  const dir = mkdtempSync(join(tmpdir(), 'coverage-ratchet-check-'));
-  const checkPath = join(dir, 'check.mjs');
-  try {
-    writeFileSync(checkPath, source);
-    execFileSync(process.execPath, ['--check', checkPath], { stdio: 'pipe' });
-  } catch (err) {
-    throw new Error(`${label}: rewritten config fails a syntax check — refusing to write.\n${err.stderr?.toString() ?? err.message}`);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
+  const { diagnostics } = ts.transpileModule(source, { reportDiagnostics: true });
+  const errors = (diagnostics ?? []).filter((d) => d.category === ts.DiagnosticCategory.Error);
+  if (errors.length > 0) {
+    const messages = errors.map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n')).join('\n');
+    throw new Error(`${label}: rewritten config fails a syntax check — refusing to write.\n${messages}`);
   }
 }

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: false,
     testTimeout: 30_000,
     hookTimeout: 60_000,
-    include: ['__tests__/tenant-*.test.ts', '__tests__/cutover-*.test.ts', '__tests__/changelog-*.test.ts', '__tests__/backfill-*.test.ts', '__tests__/promote-admin.test.ts', '__tests__/setup-onprem-admin.test.ts'],
+    include: ['__tests__/tenant-*.test.ts', '__tests__/cutover-*.test.ts', '__tests__/changelog-*.test.ts', '__tests__/backfill-*.test.ts', '__tests__/promote-admin.test.ts', '__tests__/setup-onprem-admin.test.ts', '__tests__/coverage-ratchet-*.test.ts'],
     pool: 'forks',
     poolOptions: {
       forks: { singleFork: true },


### PR DESCRIPTION
## Summary

Fixes a reviewer-caught defect from #2075: `scripts/coverage-ratchet.mjs`'s
sentinel-region regex was fooled by `apps/web/vitest.config.ts`'s own
explanatory comment, which contains the literal substrings
`/* ratchet:start */` and `/* ratchet:end */` inside a single-line prose
comment. The non-greedy regex matched that fake 40-char span instead of the
real threshold block below it.

Consequences (both verified independently before this fix):
- `--dry-run` reported fabricated current thresholds (`0` instead of the
  real `44/85/56/44`) — it exited clean while lying about the underlying state.
- A real (non-dry-run) invocation would rewrite the fake span in place,
  producing unparseable syntax and breaking every test in `apps/web`.

This PR went through a self-triggered multi-angle review (8 finder agents),
two rounds of external bot review (CodeRabbit, Codex), and a final
`/simplify` cleanup pass — all real findings across those passes are fixed
here, across five commits.

## Fix

- `sentinelRegex` requires the `ratchet:start`/`ratchet:end` markers to
  occupy their own line (only leading/trailing whitespace besides the
  marker, CRLF-tolerant for Windows/`core.autocrlf` checkouts). Real usage
  always looks like that; a prose line mentioning the markers has other text
  sharing the line and is correctly rejected.
- **Two "refuse to guess" guards** beyond the line-anchoring:
  - More than one well-formed sentinel block in the same config file throws
    (ambiguous — which one is real?) instead of silently taking the first match.
  - Marker text present but NOT forming a well-formed block (e.g. an
    autoformatter appends a trailing comment to the `ratchet:end` line)
    throws instead of silently falling back to the plain thresholds match —
    that fallback is only safe for configs with no sentinel at all.
- **Pre-write syntax check**: before any write (dry-run or real), the
  rewritten config string is validated as parseable TypeScript via
  `ts.transpileModule()` (in-process, no file I/O, no subprocess — correctly
  TS-aware, unlike an earlier iteration that ran `node --check` on a renamed
  `.mjs` file and would have wrongly rejected TS-only syntax like
  `satisfies` or a type assertion, per Codex review feedback).
- Extracted all of this into `scripts/lib/coverage-ratchet-sentinel.mjs`
  (`matchThresholdBlock`, `buildThresholdBlock`, `parseThresholds`,
  `assertValidSyntax`) so it's directly unit-testable; a final `/simplify`
  pass consolidated a double regex scan into one `matchAll()` and removed
  two unused exports.
- 14 unit tests in `scripts/__tests__/coverage-ratchet-sentinel.test.ts`,
  wired into `scripts/vitest.config.ts`'s include glob and the CI
  backfill-script test step.

Board: D.1 (`arn4y1wscy7w5rptcc40xilg`) and leaf 3.9
(`lrkb1gu9j3qxtu4eqafsqplo`) on E1 PR3 flipped to completed with a note on
the PR page (`osazdx1f2zxo5dmeylyxs0qo`).

## Review status

- CodeRabbit: passed (rate-limited on deep incremental review, no blocking
  status at any point).
- Codex (`chatgpt-codex-connector`): two real findings across two review
  rounds — a P2 (JS-only syntax check on a `.ts` config) and a P3 (missing
  CRLF tolerance) — both fixed and confirmed clean on re-review of the
  exact fix commits ("Didn't find any major issues"). Both threads resolved
  after reviewer-verified fixes.
- Self-review: 8-angle finder pass caught a real bug (temp file written to
  repo root instead of OS temp dir) independently confirmed by 5 of 8
  finder agents; a follow-up `/simplify` pass found four minor cleanups,
  two of which were applied.

## Test plan

- [x] `bun run typecheck` — 16/16 tasks green (verified after every commit)
- [x] `bunx vitest run __tests__/coverage-ratchet-sentinel.test.ts` (from
      `scripts/`) — 14/14 passing
- [x] `node scripts/coverage-ratchet.mjs --dry-run` before fix: reported
      `lines: 0 -> 60` (fabricated); after fix: `lines: 44 -> 60` (real)
- [x] Real (non-dry-run) run against a disposable copy of
      `apps/web/vitest.config.ts`: minimal diff (only the 4 scalars change,
      indentation/comments preserved), file still passes `node --check`
- [x] CI: Lint & TypeScript Check and Unit Tests both green on the final commit
- [x] Branch merged with `master` (no conflicts), `mergeStateStatus: CLEAN`
- [x] Both review threads resolved after reviewer re-verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEdW8TG2KMWjB5wTf5qB31