### PR TITLE
fix(auth): signin page silently recovers an existing session before showing the form

### DIFF
--- a/apps/web/src/app/auth/signin/__tests__/signin-recovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/signin-recovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { decideSigninRecovery, type SigninRecoveryInput } from '../signin-recovery';
+
+// The signin page attempts a silent session recovery before it ever shows the form:
+// a live session cookie should redirect the user onward, and an expired cookie backed
+// by a valid device token should refresh silently. decideSigninRecovery is the pure
+// core of that flow — the shell feeds it observations one at a time (undefined = "not
+// observed yet") and performs whatever action it returns until a terminal action.
+//
+// Regression context: middleware began redirecting cookieless navigations to /auth/signin
+// on 2026-07-07, which killed the app's own JS-level device-token recovery. This restores
+// it at the one page every bounced user now lands on.
+
+const base: SigninRecoveryInput = {
+  isNativeShell: false,
+  authFailedPermanently: false,
+  meAuthenticated: undefined,
+  hasDeviceToken: false,
+  refreshSucceeded: undefined,
+};
+
+describe('decideSigninRecovery', () => {
+  it('skips recovery entirely inside a native shell (desktop/Capacitor own their session)', () => {
+    // Native shells manage sessions via bearer tokens / keychain, not cookies — the store's
+    // loadSession already handles them, so the web recovery must stay out of the way.
+    expect(decideSigninRecovery({ ...base, isNativeShell: true })).toEqual({ type: 'skip' });
+    // Native wins even when other signals would otherwise drive recovery.
+    expect(
+      decideSigninRecovery({ ...base, isNativeShell: true, meAuthenticated: true }),
+    ).toEqual({ type: 'skip' });
+  });
+
+  it('shows the form immediately when auth has permanently failed (never retry — that is the loop)', () => {
+    expect(
+      decideSigninRecovery({ ...base, authFailedPermanently: true }),
+    ).toEqual({ type: 'show-form' });
+    // A dead-permanent flag must short-circuit even if a device token is present.
+    expect(
+      decideSigninRecovery({ ...base, authFailedPermanently: true, hasDeviceToken: true }),
+    ).toEqual({ type: 'show-form' });
+  });
+
+  it('checks the current session first, before any other observation exists', () => {
+    expect(decideSigninRecovery(base)).toEqual({ type: 'check-me' });
+  });
+
+  it('redirects when the session is already live', () => {
+    expect(
+      decideSigninRecovery({ ...base, meAuthenticated: true }),
+    ).toEqual({ type: 'redirect' });
+  });
+
+  it('shows the form when the session is dead and there is no device token to recover from', () => {
+    expect(
+      decideSigninRecovery({ ...base, meAuthenticated: false, hasDeviceToken: false }),
+    ).toEqual({ type: 'show-form' });
+  });
+
+  it('attempts a device-token refresh when the session is dead but a device token exists', () => {
+    expect(
+      decideSigninRecovery({ ...base, meAuthenticated: false, hasDeviceToken: true }),
+    ).toEqual({ type: 'refresh' });
+  });
+
+  it('redirects after a device-token refresh succeeds', () => {
+    expect(
+      decideSigninRecovery({
+        ...base,
+        meAuthenticated: false,
+        hasDeviceToken: true,
+        refreshSucceeded: true,
+      }),
+    ).toEqual({ type: 'redirect' });
+  });
+
+  it('shows the form after a device-token refresh fails (revoked/expired token — no loop)', () => {
+    expect(
+      decideSigninRecovery({
+        ...base,
+        meAuthenticated: false,
+        hasDeviceToken: true,
+        refreshSucceeded: false,
+      }),
+    ).toEqual({ type: 'show-form' });
+  });
+});

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -162,6 +162,50 @@ describe('useSigninRecovery', () => {
     expect(replace).not.toHaveBeenCalledWith('/dashboard');
   });
 
+  it('fails open to the form if the device-token refresh rejects (never strands on loading)', async () => {
+    // The driver is best-effort: a thrown rejection anywhere must fall back to the form
+    // rather than leave the page stuck on the loading state forever.
+    mockMe(false);
+    localStorage.setItem('deviceToken', 'dt_valid');
+    refreshAuthSession.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('fails open to the form if the /api/auth/me fetch itself rejects', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    );
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('runs recovery only once even if the component re-renders while ready stays true', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: false }) as Response);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { rerender, result } = renderHook(
+      ({ n }: { n: number }) => useSigninRecovery(`/dashboard?r=${n}`, true),
+      { initialProps: { n: 1 } },
+    );
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    // A re-render with ready still true (e.g. a searchParams-driven update) must not re-run.
+    rerender({ n: 2 });
+    await Promise.resolve();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('completes recovery under React StrictMode (does not get stuck on loading)', async () => {
     mockMe(false); // unrecoverable → terminal 'show-form' → recovering flips false
 

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StrictMode } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSigninRecovery } from '../useSigninRecovery';
 
 // Shell-level coverage for the recovery effect. The DECISION branches live in
 // signin-recovery.test.ts; here we assert the effects are wired to the right actions:
 // a live /api/auth/me redirects, an expired cookie + device token refreshes then redirects,
-// and an unrecoverable state renders the form.
+// and an unrecoverable state renders the form. We also cover the two subtleties the shell
+// alone carries: it must not start before the redirect destination is resolved (readiness),
+// and it must survive React StrictMode's dev mount probe.
 
 const replace = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -52,7 +55,7 @@ describe('useSigninRecovery', () => {
   it('redirects to the next path when the session is already live', async () => {
     mockMe(true);
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard/deep'));
+    const { result } = renderHook(() => useSigninRecovery('/dashboard/deep', true));
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard/deep'));
     // Stays in the recovering state through the navigation so the form never flashes.
@@ -62,7 +65,7 @@ describe('useSigninRecovery', () => {
   it('defaults to /dashboard when no next path is resolved', async () => {
     mockMe(true);
 
-    renderHook(() => useSigninRecovery(undefined));
+    renderHook(() => useSigninRecovery(undefined, true));
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
   });
@@ -72,7 +75,7 @@ describe('useSigninRecovery', () => {
     localStorage.setItem('deviceToken', 'dt_valid');
     refreshAuthSession.mockResolvedValue({ success: true, shouldLogout: false });
 
-    renderHook(() => useSigninRecovery('/dashboard'));
+    renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
     expect(refreshAuthSession).toHaveBeenCalledTimes(1);
@@ -81,7 +84,7 @@ describe('useSigninRecovery', () => {
   it('renders the form (no redirect) when the cookie is expired and there is no device token', async () => {
     mockMe(false);
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(result.current.recovering).toBe(false));
     expect(replace).not.toHaveBeenCalled();
@@ -93,7 +96,7 @@ describe('useSigninRecovery', () => {
     localStorage.setItem('deviceToken', 'dt_revoked');
     refreshAuthSession.mockResolvedValue({ success: false, shouldLogout: true });
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(result.current.recovering).toBe(false));
     expect(replace).not.toHaveBeenCalled();
@@ -106,7 +109,7 @@ describe('useSigninRecovery', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(result.current.recovering).toBe(false));
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -118,10 +121,56 @@ describe('useSigninRecovery', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(result.current.recovering).toBe(false));
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('does not start recovery until ready — no /api/auth/me while the destination is unresolved', async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
+    vi.stubGlobal('fetch', fetchSpy);
+
+    renderHook(() => useSigninRecovery(undefined, false));
+
+    // Give any (incorrectly-scheduled) effect a chance to run.
+    await Promise.resolve();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects to the deep link resolved after mount, not the default dashboard', async () => {
+    // Mirrors the middleware-rewrite flow: nextPath is undefined until browserPath resolves,
+    // at which point `ready` flips true and the resolved deep link is available.
+    mockMe(true);
+
+    const { rerender } = renderHook(
+      ({ nextPath, ready }: { nextPath: string | undefined; ready: boolean }) =>
+        useSigninRecovery(nextPath, ready),
+      { initialProps: { nextPath: undefined as string | undefined, ready: false } },
+    );
+
+    // First render: destination not yet known, recovery must not have started.
+    await Promise.resolve();
+    expect(replace).not.toHaveBeenCalled();
+
+    // browserPath resolves → ready flips true with the recovered deep link.
+    rerender({ nextPath: '/dashboard/drv_abc/pg_xyz', ready: true });
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard/drv_abc/pg_xyz'));
+    expect(replace).not.toHaveBeenCalledWith('/dashboard');
+  });
+
+  it('completes recovery under React StrictMode (does not get stuck on loading)', async () => {
+    mockMe(false); // unrecoverable → terminal 'show-form' → recovering flips false
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard', true), {
+      wrapper: StrictMode,
+    });
+
+    // Under StrictMode the effect is set up, torn down, then set up again on mount. The
+    // second run must complete rather than being stranded by a latched guard.
+    await waitFor(() => expect(result.current.recovering).toBe(false));
   });
 });

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSigninRecovery } from '../useSigninRecovery';
+
+// Shell-level coverage for the recovery effect. The DECISION branches live in
+// signin-recovery.test.ts; here we assert the effects are wired to the right actions:
+// a live /api/auth/me redirects, an expired cookie + device token refreshes then redirects,
+// and an unrecoverable state renders the form.
+
+const replace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+}));
+
+const refreshAuthSession = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  refreshAuthSession: () => refreshAuthSession(),
+}));
+
+const isCapacitorApp = vi.fn(() => false);
+vi.mock('@/lib/capacitor-bridge', () => ({
+  isCapacitorApp: () => isCapacitorApp(),
+}));
+
+let authFailedPermanently = false;
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: { getState: () => ({ authFailedPermanently }) },
+}));
+
+function mockMe(ok: boolean) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok }) as Response),
+  );
+}
+
+beforeEach(() => {
+  replace.mockClear();
+  refreshAuthSession.mockReset();
+  isCapacitorApp.mockReturnValue(false);
+  authFailedPermanently = false;
+  localStorage.clear();
+  // Default: window.electron absent (pure web).
+  delete (window as unknown as { electron?: unknown }).electron;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('useSigninRecovery', () => {
+  it('redirects to the next path when the session is already live', async () => {
+    mockMe(true);
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard/deep'));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard/deep'));
+    // Stays in the recovering state through the navigation so the form never flashes.
+    expect(result.current.recovering).toBe(true);
+  });
+
+  it('defaults to /dashboard when no next path is resolved', async () => {
+    mockMe(true);
+
+    renderHook(() => useSigninRecovery(undefined));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+  });
+
+  it('refreshes via the device token then redirects when the cookie is expired', async () => {
+    mockMe(false);
+    localStorage.setItem('deviceToken', 'dt_valid');
+    refreshAuthSession.mockResolvedValue({ success: true, shouldLogout: false });
+
+    renderHook(() => useSigninRecovery('/dashboard'));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+    expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the form (no redirect) when the cookie is expired and there is no device token', async () => {
+    mockMe(false);
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(replace).not.toHaveBeenCalled();
+    expect(refreshAuthSession).not.toHaveBeenCalled();
+  });
+
+  it('renders the form when the device-token refresh fails, without looping', async () => {
+    mockMe(false);
+    localStorage.setItem('deviceToken', 'dt_revoked');
+    refreshAuthSession.mockResolvedValue({ success: false, shouldLogout: true });
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(replace).not.toHaveBeenCalled();
+    expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the form immediately when auth has permanently failed (no /api/auth/me, no loop)', async () => {
+    authFailedPermanently = true;
+    localStorage.setItem('deviceToken', 'dt_valid');
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('skips recovery in a native shell and renders the form', async () => {
+    isCapacitorApp.mockReturnValue(true);
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const { result } = renderHook(() => useSigninRecovery('/dashboard'));
+
+    await waitFor(() => expect(result.current.recovering).toBe(false));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -43,7 +43,12 @@ function SignInForm() {
   // Silent session recovery: before showing the form, try to heal the session (live cookie
   // → redirect; expired cookie + device token → refresh → redirect). This restores the
   // recovery the 2026-07-07 middleware change defeated. See ./signin-recovery.ts.
-  const { recovering } = useSigninRecovery(nextPath);
+  //
+  // Gate on `browserPath` being resolved: under a middleware rewrite the deep link lives in
+  // the browser URL (read post-mount above), so `nextPath` is undefined on the first render.
+  // Starting recovery before then would redirect a recovered user to the default dashboard
+  // instead of the page they originally opened.
+  const { recovering } = useSigninRecovery(nextPath, browserPath !== null);
 
   const {
     handleGoogleSignIn,

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -23,6 +23,21 @@ import { resolveSigninNext } from "@/lib/auth/resolve-signin-next";
 import { detectInAppBrowser, getPreferredBrowserName } from "@/lib/auth/browser-detection";
 import { useSigninRecovery } from "./useSigninRecovery";
 
+// Shared loading shell: the Suspense fallback (searchParams boundary) and the in-flight
+// silent-recovery state render the same minimal screen, so users never see it change shape.
+function AuthLoading() {
+  return (
+    <AuthShell>
+      <div className="text-center">
+        <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+          Welcome back
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
+      </div>
+    </AuthShell>
+  );
+}
+
 function SignInForm() {
   const [showMagicLink, setShowMagicLink] = useState(false);
   const [inAppInfo, setInAppInfo] = useState<{ isInApp: boolean; appName: string | undefined }>({ isInApp: false, appName: undefined });
@@ -130,16 +145,7 @@ function SignInForm() {
   // While silent recovery is in flight, show a minimal loading state rather than the form,
   // so a user who is about to be auto-redirected never sees the form flash.
   if (recovering) {
-    return (
-      <AuthShell>
-        <div className="text-center">
-          <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
-            Welcome back
-          </h1>
-          <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
-        </div>
-      </AuthShell>
-    );
+    return <AuthLoading />;
   }
 
   // On-prem: passkey + magic link sign-in (no OAuth)
@@ -331,18 +337,7 @@ function SignInForm() {
 
 export default function SignIn() {
   return (
-    <Suspense
-      fallback={
-        <AuthShell>
-          <div className="text-center">
-            <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
-              Welcome back
-            </h1>
-            <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
-          </div>
-        </AuthShell>
-      }
-    >
+    <Suspense fallback={<AuthLoading />}>
       <SignInForm />
     </Suspense>
   );

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -21,6 +21,7 @@ import { useOAuthSignIn } from "@/hooks/useOAuthSignIn";
 import { isOnPrem } from "@/lib/deployment-mode";
 import { resolveSigninNext } from "@/lib/auth/resolve-signin-next";
 import { detectInAppBrowser, getPreferredBrowserName } from "@/lib/auth/browser-detection";
+import { useSigninRecovery } from "./useSigninRecovery";
 
 function SignInForm() {
   const [showMagicLink, setShowMagicLink] = useState(false);
@@ -38,6 +39,12 @@ function SignInForm() {
   }, []);
 
   const nextPath = resolveSigninNext({ paramNext: searchParams.get('next'), browserPath });
+
+  // Silent session recovery: before showing the form, try to heal the session (live cookie
+  // → redirect; expired cookie + device token → refresh → redirect). This restores the
+  // recovery the 2026-07-07 middleware change defeated. See ./signin-recovery.ts.
+  const { recovering } = useSigninRecovery(nextPath);
+
   const {
     handleGoogleSignIn,
     handleAppleSignIn,
@@ -114,6 +121,21 @@ function SignInForm() {
       setShowMagicLink(true);
     }
   }, []);
+
+  // While silent recovery is in flight, show a minimal loading state rather than the form,
+  // so a user who is about to be auto-redirected never sees the form flash.
+  if (recovering) {
+    return (
+      <AuthShell>
+        <div className="text-center">
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Welcome back
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">Loading...</p>
+        </div>
+      </AuthShell>
+    );
+  }
 
   // On-prem: passkey + magic link sign-in (no OAuth)
   if (onPrem) {

--- a/apps/web/src/app/auth/signin/signin-recovery.ts
+++ b/apps/web/src/app/auth/signin/signin-recovery.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure decision core for the signin page's silent session recovery.
+ *
+ * WHY THIS EXISTS. On 2026-07-07 middleware began intercepting any page navigation that
+ * arrives without a session cookie and redirecting it to /auth/signin, *before* the app's
+ * own JavaScript can run. That JS used to silently recover the session — an expired 7-day
+ * cookie was invisible, the page loaded, a 401 came back, and AuthFetch minted a fresh
+ * session from the localStorage device token. The middleware redirect now lands those users
+ * on the signin form instead, so they re-authenticate by hand (which then revokes their
+ * other devices — a logout storm). This restores the recovery at the page every bounced
+ * user now lands on: before showing the form, try to heal the session.
+ *
+ * FUNCTIONAL CORE. This module holds only the decision. The shell (useSigninRecovery) owns
+ * every effect — fetching /api/auth/me, reading localStorage, running the refresh, calling
+ * the router — and feeds the observations back here one at a time. `undefined` means "not
+ * observed yet", which is how the shell drives the machine forward: it keeps calling this
+ * with more filled-in fields until it gets a terminal action.
+ */
+
+export interface SigninRecoveryInput {
+  /**
+   * Desktop (Electron) or Capacitor (iOS) shell. Those shells authenticate with bearer
+   * tokens / keychain, not the web session cookie, and the auth store already recovers
+   * them — web cookie recovery must never run there.
+   */
+  isNativeShell: boolean;
+  /**
+   * The auth store's permanent-failure flag. When set, a session has already definitively
+   * failed (revoked token, detected loop) and must not be retried — retrying is the loop.
+   */
+  authFailedPermanently: boolean;
+  /** Result of GET /api/auth/me; undefined until the shell has checked. */
+  meAuthenticated: boolean | undefined;
+  /** Whether a device token exists in localStorage to recover an expired cookie from. */
+  hasDeviceToken: boolean;
+  /** Result of the device-token refresh; undefined until the shell has attempted it. */
+  refreshSucceeded: boolean | undefined;
+}
+
+export type SigninRecoveryAction =
+  /** Native shell: don't run web recovery at all — render the form as today. */
+  | { type: 'skip' }
+  /** Observe the current session via GET /api/auth/me. */
+  | { type: 'check-me' }
+  /** Attempt the device-token refresh (reuses AuthFetch's refresh machinery). */
+  | { type: 'refresh' }
+  /** A session is (or became) live — navigate the user onward. */
+  | { type: 'redirect' }
+  /** Recovery is exhausted — render the sign-in form. */
+  | { type: 'show-form' };
+
+/**
+ * Given what the shell has observed so far, decide the next recovery action.
+ *
+ * The progression, once past the two guards, is: check the session → if live, redirect →
+ * else if a device token exists, refresh → if the refresh succeeds, redirect, otherwise
+ * show the form. A missing device token or a failed refresh both terminate at the form,
+ * and nothing here ever loops back to an earlier step, so the shell (which runs each
+ * action once) cannot spin.
+ */
+export function decideSigninRecovery(input: SigninRecoveryInput): SigninRecoveryAction {
+  const { isNativeShell, authFailedPermanently, meAuthenticated, hasDeviceToken, refreshSucceeded } =
+    input;
+
+  if (isNativeShell) return { type: 'skip' };
+
+  // A definitively-dead session must not be retried; that retry IS the loop the store guards.
+  if (authFailedPermanently) return { type: 'show-form' };
+
+  // Step 1 — is the current session live?
+  if (meAuthenticated === undefined) return { type: 'check-me' };
+  if (meAuthenticated) return { type: 'redirect' };
+
+  // Step 2 — the session is dead; can we recover it from a device token?
+  if (!hasDeviceToken) return { type: 'show-form' };
+  if (refreshSucceeded === undefined) return { type: 'refresh' };
+
+  return refreshSucceeded ? { type: 'redirect' } : { type: 'show-form' };
+}

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { refreshAuthSession } from '@/lib/auth/auth-fetch';
+import { isCapacitorApp } from '@/lib/capacitor-bridge';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { decideSigninRecovery, type SigninRecoveryInput } from './signin-recovery';
+
+const DEFAULT_NEXT = '/dashboard';
+
+function isNativeShell(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!window.electron?.isDesktop || isCapacitorApp();
+}
+
+function hasDeviceToken(): boolean {
+  return typeof localStorage !== 'undefined' && !!localStorage.getItem('deviceToken');
+}
+
+async function checkMeAuthenticated(): Promise<boolean> {
+  try {
+    const response = await fetch('/api/auth/me', { credentials: 'include' });
+    return response.ok;
+  } catch {
+    // Network error — treat as unauthenticated and fall through to the device-token path.
+    return false;
+  }
+}
+
+/**
+ * Imperative shell for silent session recovery on the signin page.
+ *
+ * Runs the effects — GET /api/auth/me, reading the device token, the AuthFetch refresh,
+ * the router navigation — and defers every decision to the pure `decideSigninRecovery`
+ * core. See ./signin-recovery.ts for why this exists (the 2026-07-07 middleware change
+ * that started bouncing recoverable sessions to the signin form).
+ *
+ * Returns `recovering`: while true, the page shows a minimal loading state instead of the
+ * form, so a user who is about to be redirected never sees the form flash. It flips to
+ * false only when recovery lands on the form (or is skipped in a native shell); on a
+ * redirect it stays true through the navigation.
+ *
+ * Runs exactly once per mount (`startedRef`), so a failed recovery cannot retrigger itself.
+ */
+export function useSigninRecovery(nextPath: string | undefined): { recovering: boolean } {
+  const router = useRouter();
+  const [recovering, setRecovering] = useState(true);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    let cancelled = false;
+
+    const run = async () => {
+      const observed: SigninRecoveryInput = {
+        isNativeShell: isNativeShell(),
+        // Read fresh from the store rather than subscribing: this effect runs once and must
+        // see the flag's value at mount, not restart when it later changes.
+        authFailedPermanently: useAuthStore.getState().authFailedPermanently,
+        meAuthenticated: undefined,
+        hasDeviceToken: hasDeviceToken(),
+        refreshSucceeded: undefined,
+      };
+
+      // Drive the pure machine: perform each action, feed the result back, repeat until
+      // a terminal action. The machine never loops back to an earlier step, and every
+      // effect below is a strictly-forward observation, so this cannot spin.
+      for (;;) {
+        if (cancelled) return;
+        const action = decideSigninRecovery(observed);
+
+        switch (action.type) {
+          case 'skip':
+          case 'show-form':
+            if (!cancelled) setRecovering(false);
+            return;
+
+          case 'redirect':
+            // Keep `recovering` true through the navigation so the form never flashes.
+            router.replace(nextPath ?? DEFAULT_NEXT);
+            return;
+
+          case 'check-me':
+            observed.meAuthenticated = await checkMeAuthenticated();
+            break;
+
+          case 'refresh': {
+            const result = await refreshAuthSession();
+            observed.refreshSucceeded = result.success;
+            break;
+          }
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+    // Intentionally mount-only: nextPath is captured at mount, and recovery must not restart.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { recovering };
+}

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { refreshAuthSession } from '@/lib/auth/auth-fetch';
 import { isCapacitorApp } from '@/lib/capacitor-bridge';
@@ -41,16 +41,29 @@ async function checkMeAuthenticated(): Promise<boolean> {
  * false only when recovery lands on the form (or is skipped in a native shell); on a
  * redirect it stays true through the navigation.
  *
- * Runs exactly once per mount (`startedRef`), so a failed recovery cannot retrigger itself.
+ * READINESS. Recovery must not begin until `ready` is true. The signin page resolves the
+ * post-recovery destination (`nextPath`) from the browser URL in a mount effect, so on the
+ * very first render it is not yet known — for a middleware *rewrite* (the iOS/deep-link
+ * flow, see resolve-signin-next.ts) `nextPath` is `undefined` until that effect runs.
+ * Starting earlier would capture the unresolved destination and silently redirect a
+ * recovered user to `/dashboard` instead of the page they originally opened. Gating on
+ * `ready` guarantees the destination is resolved before the one-shot recovery starts.
+ *
+ * STRICTMODE. The effect keys on `ready` (not a persisted ref), so it is safe under React
+ * StrictMode's dev mount probe: the `cancelled` cleanup aborts the discarded first run and
+ * the re-run starts fresh, rather than a ref latching `true` and stranding the page on the
+ * loading state. Recovery still runs once per real mount because `ready` flips false→true
+ * exactly once (`browserPath` is set a single time).
  */
-export function useSigninRecovery(nextPath: string | undefined): { recovering: boolean } {
+export function useSigninRecovery(
+  nextPath: string | undefined,
+  ready: boolean,
+): { recovering: boolean } {
   const router = useRouter();
   const [recovering, setRecovering] = useState(true);
-  const startedRef = useRef(false);
 
   useEffect(() => {
-    if (startedRef.current) return;
-    startedRef.current = true;
+    if (!ready) return;
 
     let cancelled = false;
 
@@ -58,7 +71,7 @@ export function useSigninRecovery(nextPath: string | undefined): { recovering: b
       const observed: SigninRecoveryInput = {
         isNativeShell: isNativeShell(),
         // Read fresh from the store rather than subscribing: this effect runs once and must
-        // see the flag's value at mount, not restart when it later changes.
+        // see the flag's value when recovery starts, not restart when it later changes.
         authFailedPermanently: useAuthStore.getState().authFailedPermanently,
         meAuthenticated: undefined,
         hasDeviceToken: hasDeviceToken(),
@@ -101,9 +114,10 @@ export function useSigninRecovery(nextPath: string | undefined): { recovering: b
     return () => {
       cancelled = true;
     };
-    // Intentionally mount-only: nextPath is captured at mount, and recovery must not restart.
+    // Starts once, when `ready` flips true; `nextPath` is fully resolved by then and stable
+    // thereafter (browserPath is set a single time), so it is intentionally not a dependency.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [ready]);
 
   return { recovering };
 }

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -9,7 +9,7 @@ import { decideSigninRecovery, type SigninRecoveryInput } from './signin-recover
 
 const DEFAULT_NEXT = '/dashboard';
 
-function isNativeShell(): boolean {
+function detectNativeShell(): boolean {
   if (typeof window === 'undefined') return false;
   return !!window.electron?.isDesktop || isCapacitorApp();
 }
@@ -69,7 +69,7 @@ export function useSigninRecovery(
 
     const run = async () => {
       const observed: SigninRecoveryInput = {
-        isNativeShell: isNativeShell(),
+        isNativeShell: detectNativeShell(),
         // Read fresh from the store rather than subscribing: this effect runs once and must
         // see the flag's value when recovery starts, not restart when it later changes.
         authFailedPermanently: useAuthStore.getState().authFailedPermanently,
@@ -109,7 +109,13 @@ export function useSigninRecovery(
       }
     };
 
-    void run();
+    // Fail open: recovery is best-effort, so an unexpected rejection anywhere in the driver
+    // must fall back to showing the form — never strand the page on the loading state (this
+    // is the app's primary auth entry point). `refreshAuthSession` resolves a result today,
+    // but its type makes no never-throw guarantee, and neither does a dynamic import inside it.
+    void run().catch(() => {
+      if (!cancelled) setRecovering(false);
+    });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## The regression (why users get logged out constantly since ~July 8)

On **2026-07-07** commit `d57701900` registered `apps/web/src/middleware.ts` for the first time in any build. It now intercepts any page navigation **without a session cookie** and redirects to `/auth/signin` (`middleware.ts:366`) **before the app's own JavaScript can run**.

That JS was doing invisible work. Web sessions are a fixed 7-day cookie with no sliding renewal, so an expired cookie used to be harmless: the page still loaded, got a 401, and `AuthFetch.refreshWebSession` silently minted a fresh session from `localStorage.deviceToken` via `POST /api/auth/device/refresh` (the main prod account has 8,784 such silent `device-refresh` sessions since April). The middleware redirect now lands those users on the sign-in form instead — and the form never checked for a recoverable session, so they re-authenticate by hand, which fires an all-device session revoke (fixed separately) → logout storm.

`SameSite=Strict` (prod, `COOKIE_DOMAIN` unset — `cookie-config.ts:47`) compounds it: navigations arriving from external origins (Slack, email, GitHub) don't carry the cookie at all, so even fully-authenticated users get bounced.

## The fix

This PR fixes the **trigger**: the sign-in page now attempts silent recovery before rendering the form.

On mount, before showing the form:
1. `GET /api/auth/me` — if authenticated, redirect (client router) to the resolved next path (`resolveSigninNext`, default `/dashboard`).
2. If the cookie is dead but `localStorage.deviceToken` exists, run the existing `AuthFetch` device-token refresh (reused, not reimplemented) and redirect on success.
3. Only if both fail — or in a native shell, or after a permanent auth failure — render the form exactly as today.

While recovery is in flight the page shows a minimal loading state, so users who are about to be auto-redirected never see the form flash. This heals every entry path that now lands on signin (expired cookie **and** Strict-cookie external arrivals) without touching middleware's security posture.

### Design
- **Functional core / imperative shell.** `signin-recovery.ts` holds the pure decision (`decideSigninRecovery`) with **100% branch coverage**; `useSigninRecovery.ts` is the shell (fetch, localStorage, refresh, router). It runs **once per mount**, so a failed recovery cannot retrigger itself, and it respects `authFailedPermanently` (never retries a known-dead session — that retry is the loop the store guards).
- **Native shells unaffected.** Electron (`window.electron?.isDesktop`) and Capacitor iOS (`isCapacitorApp()`) skip web recovery — the auth store already handles their bearer/keychain sessions.

### Tests
- `signin-recovery.test.ts` — 8 tests, 100% branch coverage of the pure core.
- `useSigninRecovery.test.ts` — 7 tests covering the acceptance scenarios (live session → redirect; expired cookie + device token → refresh → redirect; no token → form; failed refresh → form, no loop; permanent-failure → form with no `/api/auth/me`; native shell → skip).
- `bun run typecheck` green.

Pairs with the **device-scoped login revocation** PR (the amplifier — nuclear all-device revoke on every re-login). Epic task `iezn4thqnqdx0ac8h8jpp6ar` (PageSpace Features board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added silent session recovery to the sign-in page.
  * Automatically redirects users with an active session.
  * Attempts device-based session refresh when cookies expire.
  * Displays the sign-in form when recovery is unavailable or unsuccessful.
  * Prevents sign-in form flashing during recovery and supports native app behavior.

* **Tests**
  * Added coverage for session checks, refresh outcomes, permanent failures, and native shells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Review-driven updates (592fb127d)

Two automated-review findings on the recovery hook, both fixed:

1. **Deep-link preservation (Codex P2 / CodeRabbit Major).** The page resolves the post-recovery destination from the browser URL in a mount effect, so under a middleware *rewrite* `nextPath` is `undefined` on the first render. The mount-only hook captured that value, redirecting a recovered user to `/dashboard` instead of their deep link. The hook now takes a `ready` flag (`browserPath !== null`) and starts recovery only once the destination is resolved.
2. **StrictMode strand (CodeRabbit Minor).** `reactStrictMode` defaults to `true` on Next.js 15; the `startedRef` guard latched `true` across StrictMode's dev mount probe and stranded the page on the loading state. Removed `startedRef` and keyed the effect on `ready` — the `cancelled` cleanup aborts the discarded first run and the re-run completes. Recovery still runs once per real mount.

Added tests: deep-link-resolved-after-mount, `ready`-gating, and a StrictMode regression test (18 signin tests total, all green).
