### PR TITLE
fix(auth): device-scoped login revocation + device-refresh session retirement

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -72,12 +72,14 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       scopes: ['*'],
       expiresAt: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
     }),
+    revokeSessionByHash: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('192.168.1.1'),
   appendSessionCookie: vi.fn(),
+  getSessionFromCookies: vi.fn(() => null),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -103,6 +103,8 @@ vi.mock('@/lib/onboarding/home-drive', () => ({
 
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  isSafeReturnUrl: vi.fn(() => true),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
@@ -141,7 +143,7 @@ import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, revokeSessionsForLogin } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
@@ -490,28 +492,17 @@ describe('POST /api/auth/apple/native', () => {
   });
 
   describe('session management', () => {
-    it('revokes existing sessions before creating new one', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
-
+    it('revokes prior sessions scoped to the request deviceId (device-scoped, not nuclear)', async () => {
       await POST(createNativeRequest(validPayload));
 
-      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith('new-user-id', 'new_login');
-      expect(loggers.auth.info).toHaveBeenCalledWith(
-        'Revoked existing sessions on native Apple OAuth login',
-        { userId: 'new-user-id', count: 2, platform: 'ios' }
+      // deviceId is required by the schema, so the helper always receives it and
+      // revokes only THIS device's sessions — other devices stay signed in.
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith(
+        'new-user-id',
+        'device-123',
+        'new_login',
+        'Apple native',
       );
-    });
-
-    it('does not log when no sessions were revoked', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
-
-      await POST(createNativeRequest(validPayload));
-
-      const logCalls = vi.mocked(loggers.auth.info).mock.calls;
-      const revokedLogCall = logCalls.find(
-        (call) => call[0] === 'Revoked existing sessions on native Apple OAuth login'
-      );
-      expect(revokedLogCall).toBeUndefined();
     });
 
     it('returns 500 when session validation fails', async () => {

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -10,7 +10,7 @@ import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
-import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
+import { getClientIP, isSafeReturnUrl, revokeSessionsForLogin } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import {
   checkDistributedRateLimit,
@@ -182,16 +182,11 @@ export async function POST(req: Request) {
       });
     });
 
-    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
-    // new one. Admin-console sessions are scoped separately and left intact.
-    const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
-    if (revokedCount > 0) {
-      loggers.auth.info('Revoked existing sessions on native Apple OAuth login', {
-        userId: user.id,
-        count: revokedCount,
-        platform,
-      });
-    }
+    // SESSION FIXATION PREVENTION: Revoke prior sessions before creating a new
+    // one, scoped to THIS device (deviceId is required by the schema) so a native
+    // login no longer nukes the user's other devices. Admin-console sessions are
+    // scoped separately and left intact.
+    await revokeSessionsForLogin(user.id, deviceId, 'new_login', 'Apple native');
 
     // Create session
     const sessionToken = await sessionService.createSession({

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
@@ -8,6 +8,7 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({ sessionId: 'sid_123' }),
+    revokeSessionByHash: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -59,6 +60,7 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
   appendSessionCookie: vi.fn(),
+  getSessionFromCookies: vi.fn(() => null),
 }));
 
 import { POST } from '../refresh/route';

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -91,6 +91,7 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       type: 'user',
       scopes: ['*'],
     }),
+    revokeSessionByHash: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -101,6 +102,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn(() => '127.0.0.1'),
   appendSessionCookie: vi.fn(),
+  getSessionFromCookies: vi.fn(() => null),
 }));
 
 import { POST } from '../route';
@@ -112,7 +114,8 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { getClientIP, appendSessionCookie } from '@/lib/auth';
+import { getClientIP, appendSessionCookie, getSessionFromCookies } from '@/lib/auth';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 
 const mockUser = {
   id: 'user-123',
@@ -172,7 +175,12 @@ describe('POST /api/auth/device/refresh', () => {
       type: 'user',
       scopes: ['*'],
     } as never);
+    vi.mocked(sessionService.revokeSessionByHash).mockResolvedValue(undefined);
 
+    // No replaced session cookie by default (existing tests exercise the
+    // no-cookie path); retirement tests override this per-case.
+    vi.mocked(getSessionFromCookies).mockReturnValue(null);
+    vi.mocked(hashToken).mockReturnValue('hashed-old-session');
   });
 
   describe('input validation', () => {
@@ -619,6 +627,104 @@ describe('POST /api/auth/device/refresh', () => {
           platform: 'desktop',
           appVersion: '2.0.0',
         })
+      );
+    });
+  });
+
+  describe('replaced-session retirement', () => {
+    it('revokes the session the refresh replaces (same user) with replaced_by_refresh — web', async () => {
+      vi.mocked(validateDeviceToken).mockResolvedValue({
+        ...mockDeviceRecord,
+        platform: 'web',
+      } as never);
+      vi.mocked(getSessionFromCookies).mockReturnValue('old-web-session-token');
+
+      const request = createRefreshRequest(validRefreshPayload, {
+        Cookie: 'session=old-web-session-token',
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      // Ownership resolved via the old cookie's session (same user-123), then
+      // revoked by its hash.
+      expect(hashToken).toHaveBeenCalledWith('old-web-session-token');
+      expect(sessionService.revokeSessionByHash).toHaveBeenCalledWith(
+        'hashed-old-session',
+        'replaced_by_refresh',
+      );
+    });
+
+    it('revokes the replaced session on the desktop branch too', async () => {
+      vi.mocked(getSessionFromCookies).mockReturnValue('old-desktop-session-token');
+
+      const request = createRefreshRequest(validRefreshPayload, {
+        Cookie: 'session=old-desktop-session-token',
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(sessionService.revokeSessionByHash).toHaveBeenCalledWith(
+        'hashed-old-session',
+        'replaced_by_refresh',
+      );
+    });
+
+    it('does NOT revoke anything when no session cookie accompanies the refresh', async () => {
+      vi.mocked(getSessionFromCookies).mockReturnValue(null);
+
+      const request = createRefreshRequest(validRefreshPayload);
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(sessionService.revokeSessionByHash).not.toHaveBeenCalled();
+    });
+
+    it('does NOT revoke when the old cookie session belongs to a different user', async () => {
+      vi.mocked(getSessionFromCookies).mockReturnValue('someone-elses-token');
+      // First validateSession call is for the new session (user-123); the second
+      // (owner lookup for the old token) resolves to a different user.
+      vi.mocked(sessionService.validateSession)
+        .mockResolvedValueOnce({
+          sessionId: 'mock-session-id',
+          userId: 'user-123',
+          userRole: 'user',
+          tokenVersion: 0,
+          type: 'user',
+          scopes: ['*'],
+        } as never)
+        .mockResolvedValueOnce({
+          sessionId: 'other-session-id',
+          userId: 'other-user',
+          userRole: 'user',
+          tokenVersion: 0,
+          type: 'user',
+          scopes: ['*'],
+        } as never);
+
+      const request = createRefreshRequest(validRefreshPayload, {
+        Cookie: 'session=someone-elses-token',
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(sessionService.revokeSessionByHash).not.toHaveBeenCalled();
+    });
+
+    it('never fails the refresh when the retirement revoke throws', async () => {
+      vi.mocked(getSessionFromCookies).mockReturnValue('old-web-session-token');
+      vi.mocked(sessionService.revokeSessionByHash).mockRejectedValue(new Error('db down'));
+
+      const request = createRefreshRequest(validRefreshPayload, {
+        Cookie: 'session=old-web-session-token',
+      });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.deviceToken).toBe('ps_dev_valid_token');
+      expect(loggers.auth.warn).toHaveBeenCalledWith(
+        'Failed to retire replaced session on device refresh',
+        expect.objectContaining({ error: 'db down' }),
       );
     });
   });

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -14,7 +14,8 @@ import { sessionService } from '@pagespace/lib/auth/session-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { getClientIP, appendSessionCookie } from '@/lib/auth';
+import { getClientIP, appendSessionCookie, getSessionFromCookies } from '@/lib/auth';
+import { retireReplacedSession } from '@/lib/auth/session-retirement';
 
 const deviceRefreshSchema = z.object({
   deviceToken: z.string().min(1, { message: 'Device token is required' }),
@@ -35,6 +36,21 @@ export async function POST(req: Request) {
     const { deviceToken, deviceId, userAgent, appVersion } = validation.data;
 
     const clientIP = getClientIP(req);
+
+    // The session cookie the desktop/web client is carrying is the one this
+    // refresh replaces. Capture it now so we can retire it after the new session
+    // is created — proactive refreshes fire every ~15 min and, left unretired,
+    // pile up thousands of live sessions per account (turning a single login into
+    // a "revocation storm"). Retirement is best-effort and never fails the refresh.
+    const replacedSessionToken = getSessionFromCookies(req.headers.get('cookie'));
+    const retireReplaced = (userId: string): Promise<unknown> =>
+      retireReplacedSession(replacedSessionToken, userId, {
+        getSessionOwnerId: async (token) =>
+          (await sessionService.validateSession(token))?.userId ?? null,
+        hashToken,
+        revokeByHash: (tokenHash, reason) => sessionService.revokeSessionByHash(tokenHash, reason),
+        logWarn: (message, meta) => loggers.auth.warn(message, meta),
+      });
 
     // Distributed rate limiting by IP address for device refresh attempts
     const distributedIpLimit = await checkDistributedRateLimit(
@@ -180,6 +196,11 @@ export async function POST(req: Request) {
         loggers.auth.error('Failed to validate newly created session during web device refresh');
         return Response.json({ error: 'Failed to generate session.' }, { status: 500 });
       }
+
+      // Retire the session this refresh just replaced (best-effort; the new
+      // session already exists, so a failure here never breaks the refresh).
+      await retireReplaced(user.id);
+
       const csrfToken = generateCSRFToken(sessionClaims.sessionId);
 
       const headers = new Headers();
@@ -210,6 +231,10 @@ export async function POST(req: Request) {
       loggers.auth.error('Failed to validate newly created session during device refresh');
       return Response.json({ error: 'Failed to generate session.' }, { status: 500 });
     }
+
+    // Retire the session this refresh just replaced (best-effort; the new
+    // session already exists, so a failure here never breaks the refresh).
+    await retireReplaced(user.id);
 
     const csrfToken = generateCSRFToken(sessionClaims.sessionId);
 

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -139,6 +139,8 @@ vi.mock('@/lib/onboarding/home-drive', () => ({
 
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn(() => '127.0.0.1'),
+  isSafeReturnUrl: vi.fn(() => true),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
@@ -158,7 +160,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, revokeSessionsForLogin } from '@/lib/auth';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 
 const mockNewUser = {
@@ -588,15 +590,17 @@ describe('POST /api/auth/google/native', () => {
   });
 
   describe('session management', () => {
-    it('should revoke existing sessions before creating new one (session fixation prevention)', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
-
+    it('should revoke prior sessions scoped to the request deviceId (device-scoped, not nuclear)', async () => {
       const request = createNativeRequest(validNativePayload);
       await POST(request);
 
-      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith(
+      // deviceId is required by the schema, so the helper always receives it and
+      // revokes only THIS device's sessions — other devices stay signed in.
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith(
         mockNewUser.id,
-        'new_login'
+        'device-123',
+        'new_login',
+        'Google native',
       );
     });
 

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -10,7 +10,7 @@ import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
-import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
+import { getClientIP, isSafeReturnUrl, revokeSessionsForLogin } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import {
@@ -205,16 +205,11 @@ export async function POST(req: Request) {
       });
     });
 
-    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
-    // new one. Admin-console sessions are scoped separately and left intact.
-    const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
-    if (revokedCount > 0) {
-      loggers.auth.info('Revoked existing sessions on native Google OAuth login', {
-        userId: user.id,
-        count: revokedCount,
-        platform,
-      });
-    }
+    // SESSION FIXATION PREVENTION: Revoke prior sessions before creating a new
+    // one, scoped to THIS device (deviceId is required by the schema) so a native
+    // login no longer nukes the user's other devices. Admin-console sessions are
+    // scoped separately and left intact.
+    await revokeSessionsForLogin(user.id, deviceId, 'new_login', 'Google native');
 
     // Create session
     const sessionToken = await sessionService.createSession({

--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -97,6 +97,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 vi.mock('@/lib/auth', () => ({
   validateLoginCSRFToken: vi.fn().mockReturnValue(true),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 vi.mock('@/lib/auth/cookie-config', () => ({
   appendSessionCookie: vi.fn(),

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -84,6 +84,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -90,6 +90,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 
 vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
@@ -134,7 +135,7 @@ import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, revokeSessionsForLogin } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionHomeDriveIfNeeded } from '@/lib/onboarding/home-drive';
 import { consumeAnyInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
@@ -323,31 +324,37 @@ describe('GET /api/auth/magic-link/verify', () => {
   });
 
   describe('session management', () => {
-    it('revokes existing sessions before creating new one', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
-
+    it('revokes prior sessions with no deviceId for a web (cross-device) magic link', async () => {
       await GET(createVerifyRequest('valid-token'));
 
-      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith(
+      // A web magic link carries no device metadata; the helper receives
+      // undefined and applies its legacy all-web-session fallback internally.
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith(
         'test-user-id',
-        'magic_link_login'
-      );
-      expect(loggers.auth.info).toHaveBeenCalledWith(
-        'Revoked existing sessions on magic link login',
-        expect.objectContaining({ count: 2 })
+        undefined,
+        'magic_link_login',
+        'magic-link',
       );
     });
 
-    it('does not log when no sessions were revoked', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
+    it('scopes revocation to the desktop deviceId when the magic link carries desktop metadata', async () => {
+      vi.mocked(verifyMagicLinkToken).mockResolvedValue({
+        ok: true,
+        data: {
+          userId: 'test-user-id',
+          isNewUser: false,
+          metadata: JSON.stringify({ platform: 'desktop', deviceId: 'desk-device-1' }),
+        },
+      });
 
       await GET(createVerifyRequest('valid-token'));
 
-      const logCalls = vi.mocked(loggers.auth.info).mock.calls;
-      const revokedLogCall = logCalls.find(
-        (call) => call[0] === 'Revoked existing sessions on magic link login'
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith(
+        'test-user-id',
+        'desk-device-1',
+        'magic_link_login',
+        'magic-link',
       );
-      expect(revokedLogCall).toBeUndefined();
     });
 
     it('creates session with correct params', async () => {

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -18,7 +18,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { reportAuthFailure } from '@pagespace/lib/security/auth-anomaly-reporter';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, revokeSessionsForLogin } from '@/lib/auth';
 import { isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from '@/lib/auth/auth-helpers';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveAppUrl } from '@pagespace/lib/services/email-service';
@@ -128,15 +128,12 @@ export async function GET(req: Request) {
     }
     const boundInviteToken = parsedMeta?.inviteToken;
 
-    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
-    // new one. Admin-console sessions are scoped separately and left intact.
-    const revokedCount = await sessionService.revokeWebUserSessions(userId, 'magic_link_login');
-    if (revokedCount > 0) {
-      loggers.auth.info('Revoked existing sessions on magic link login', {
-        userId,
-        count: revokedCount,
-      });
-    }
+    // SESSION FIXATION PREVENTION: Revoke prior sessions before creating a new
+    // one. Scope to the desktop device when the magic link carries a deviceId; a
+    // cross-device email link cannot identify the device, so the helper falls
+    // back to the legacy all-web-session revoke. Admin-console sessions are scoped
+    // separately and left intact.
+    await revokeSessionsForLogin(userId, desktopMeta?.deviceId, 'magic_link_login', 'magic-link');
 
     // Mark email as verified (idempotent for existing users)
     try {

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -84,6 +84,7 @@ vi.mock('@/lib/auth', () => ({
   validateLoginCSRFToken: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
   createDeviceToken: vi.fn().mockResolvedValue('ps_dev_mock_token'),
+  revokeSessionsForLogin: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
@@ -126,7 +127,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
-import { validateLoginCSRFToken, getClientIP, createDeviceToken } from '@/lib/auth';
+import { validateLoginCSRFToken, getClientIP, createDeviceToken, revokeSessionsForLogin } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 
 const validPayload = {
@@ -193,10 +194,12 @@ describe('POST /api/auth/passkey/authenticate', () => {
       expect(csrfCookie).toContain('mock-csrf-token');
     });
 
-    it('revokes existing sessions before creating new one', async () => {
+    it('revokes prior sessions via the device-scoped helper before creating new one', async () => {
       await POST(createRequest());
 
-      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith('user-1', 'passkey_login');
+      // No deviceId in the default payload → helper receives undefined and applies
+      // its legacy all-web-session fallback internally.
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', undefined, 'passkey_login', 'passkey');
       expect(sessionService.createSession).toHaveBeenCalledWith(expect.objectContaining({
         userId: 'user-1',
         type: 'user',
@@ -204,26 +207,10 @@ describe('POST /api/auth/passkey/authenticate', () => {
       }));
     });
 
-    it('logs when existing sessions are revoked', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(3);
+    it('scopes revocation to the supplied deviceId (does not nuke other devices)', async () => {
+      await POST(createRequest({ ...validPayload, platform: 'web', deviceId: 'device-A' }));
 
-      await POST(createRequest());
-
-      expect(loggers.auth.info).toHaveBeenCalledWith('Revoked all sessions on passkey login', expect.objectContaining({
-        userId: 'user-1',
-        count: 3,
-      }));
-    });
-
-    it('does not log when no sessions are revoked', async () => {
-      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
-
-      await POST(createRequest());
-
-      expect(loggers.auth.info).not.toHaveBeenCalledWith(
-        'Revoked all sessions on passkey login',
-        expect.objectContaining({ userId: 'user-1' }),
-      );
+      expect(revokeSessionsForLogin).toHaveBeenCalledWith('user-1', 'device-A', 'passkey_login', 'passkey');
     });
 
     it('passes clientIP as createdByIp when not unknown', async () => {

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -18,7 +18,7 @@ import {
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
-import { validateLoginCSRFToken, getClientIP, createDeviceToken } from '@/lib/auth';
+import { validateLoginCSRFToken, getClientIP, createDeviceToken, revokeSessionsForLogin } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
@@ -214,12 +214,12 @@ export async function POST(req: Request) {
     // attempts / lock for this account.
     await resetFailedLoginAttempts(userId);
 
-    // Passkey is the strongest auth flow — hard-reset web sessions across devices
-    // (admin-console sessions are scoped separately and left intact).
-    const revokedCount = await sessionService.revokeWebUserSessions(userId, 'passkey_login');
-    if (revokedCount > 0) {
-      loggers.auth.info('Revoked all sessions on passkey login', { userId, count: revokedCount });
-    }
+    // Revoke prior sessions scoped to THIS device when the client supplies a
+    // deviceId (multi-device safe — a passkey login on one device no longer logs
+    // the user out everywhere). Old clients that send no deviceId keep the legacy
+    // all-web-session revoke via the helper's fallback. Admin-console sessions are
+    // scoped separately and always left intact.
+    await revokeSessionsForLogin(userId, deviceId, 'passkey_login', 'passkey');
 
     // Create new session
     const sessionToken = await sessionService.createSession({

--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -102,7 +102,16 @@ export function PasskeyLoginButton({
       // Refresh CSRF token to avoid expiry after sitting on the page
       const freshToken = refreshToken ? (await refreshToken() ?? csrfToken) : csrfToken;
 
-      const platformFields = await getDevicePlatformFields();
+      // Web path: send a stable per-browser device identity (mirrors the OAuth
+      // sign-in flow). This scopes the login's session revocation to THIS browser
+      // instead of nuking every device, and lets the route mint a web device
+      // token at login so silent session recovery works immediately.
+      const { getOrCreateDeviceId, getDeviceName } = await import('@/lib/analytics');
+      const platformFields = {
+        platform: 'web' as const,
+        deviceId: getOrCreateDeviceId(),
+        deviceName: getDeviceName(),
+      };
 
       // Get authentication options
       const optionsRes = await fetch('/api/auth/passkey/authenticate/options', {

--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -180,6 +180,20 @@ export function PasskeyLoginButton({
 
       if (await handleDesktopAuthResponse(verifyData)) return;
 
+      // Web: now that we send a deviceId, the route mints/regenerates a web
+      // device token and returns it here. Persist it (rotating any prior token)
+      // so silent session recovery via /api/auth/device/refresh keeps working —
+      // otherwise a passkey login would leave a now-stale token in localStorage.
+      if (verifyData.deviceToken) {
+        try {
+          localStorage.setItem('deviceToken', verifyData.deviceToken);
+        } catch (storageError) {
+          // Storage may fail in private browsing or when quota is exceeded;
+          // log but never block sign-in.
+          console.warn('Failed to store device token:', storageError);
+        }
+      }
+
       // When the request carried an invite, the server already encoded the
       // correct landing path (drive on success, /dashboard?inviteError=… on
       // race). Honour the server URL for invite flows; otherwise fall back to

--- a/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
+++ b/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
@@ -240,4 +240,29 @@ describe('PasskeyLoginButton — web path (regression guard)', () => {
     expect(body.deviceId).toBe('web-device-id');
     expect(body.deviceName).toBe('Web Browser');
   });
+
+  it('persists the device token the route returns so silent recovery keeps working', async () => {
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'assertion' } as never);
+    global.fetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ options: { challenge: 'ch', allowCredentials: [{ id: 'cred' }] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          redirectUrl: '/dashboard',
+          csrfToken: 'c',
+          deviceToken: 'ps_dev_web_rotated',
+        }),
+      }) as unknown as typeof fetch;
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" onSuccess={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(setItemSpy).toHaveBeenCalledWith('deviceToken', 'ps_dev_web_rotated');
+    setItemSpy.mockRestore();
+  });
 });

--- a/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
+++ b/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
@@ -30,6 +30,12 @@ vi.mock('@/lib/desktop-auth', () => ({
   handleDesktopAuthResponse: vi.fn(),
 }));
 
+// The web path sends a stable per-browser device identity from analytics.
+vi.mock('@/lib/analytics', () => ({
+  getOrCreateDeviceId: vi.fn(() => 'web-device-id'),
+  getDeviceName: vi.fn(() => 'Web Browser'),
+}));
+
 import { PasskeyLoginButton } from '../PasskeyLoginButton';
 import { startAuthentication } from '@simplewebauthn/browser';
 import { isDesktopPlatform, getDevicePlatformFields } from '@/lib/desktop-auth';
@@ -206,5 +212,32 @@ describe('PasskeyLoginButton — web path (regression guard)', () => {
     expect((window as unknown as { electron?: ElectronBridge }).electron).toBeUndefined();
     // Ensure the component actually mounted (sanity check).
     expect(container).toBeTruthy();
+  });
+
+  it('sends a stable per-browser device identity in the verify request body', async () => {
+    // Full happy-path plumbing so the verify POST actually fires.
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'assertion' } as never);
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ options: { challenge: 'ch', allowCredentials: [{ id: 'cred' }] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, redirectUrl: '/dashboard', csrfToken: 'c' }),
+      });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" onSuccess={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    const verifyCall = fetchSpy.mock.calls.find(
+      ([url]) => url === '/api/auth/passkey/authenticate',
+    );
+    expect(verifyCall).toBeDefined();
+    const body = JSON.parse((verifyCall![1] as { body: string }).body);
+    expect(body.platform).toBe('web');
+    expect(body.deviceId).toBe('web-device-id');
+    expect(body.deviceName).toBe('Web Browser');
   });
 });

--- a/apps/web/src/lib/auth/__tests__/session-retirement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/session-retirement.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  retireReplacedSession,
+  REPLACED_BY_REFRESH_REASON,
+  type SessionRetirementDeps,
+} from '../session-retirement';
+
+const makeDeps = (overrides: Partial<SessionRetirementDeps> = {}): SessionRetirementDeps => ({
+  getSessionOwnerId: vi.fn().mockResolvedValue('user-1'),
+  hashToken: vi.fn((t: string) => `hash(${t})`),
+  revokeByHash: vi.fn().mockResolvedValue(undefined),
+  logWarn: vi.fn(),
+  ...overrides,
+});
+
+describe('retireReplacedSession', () => {
+  it('returns no_session_cookie and revokes nothing when no old token is present', async () => {
+    const deps = makeDeps();
+
+    expect(await retireReplacedSession(null, 'user-1', deps)).toBe('no_session_cookie');
+    expect(await retireReplacedSession(undefined, 'user-1', deps)).toBe('no_session_cookie');
+    expect(await retireReplacedSession('', 'user-1', deps)).toBe('no_session_cookie');
+
+    expect(deps.getSessionOwnerId).not.toHaveBeenCalled();
+    expect(deps.revokeByHash).not.toHaveBeenCalled();
+  });
+
+  it('revokes the old session by hash with replaced_by_refresh when it belongs to the same user', async () => {
+    const deps = makeDeps();
+
+    const outcome = await retireReplacedSession('old-token', 'user-1', deps);
+
+    expect(outcome).toBe('revoked');
+    expect(deps.hashToken).toHaveBeenCalledWith('old-token');
+    expect(deps.revokeByHash).toHaveBeenCalledWith('hash(old-token)', REPLACED_BY_REFRESH_REASON);
+    expect(deps.logWarn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT revoke when the old session belongs to a different user', async () => {
+    const deps = makeDeps({ getSessionOwnerId: vi.fn().mockResolvedValue('other-user') });
+
+    const outcome = await retireReplacedSession('old-token', 'user-1', deps);
+
+    expect(outcome).toBe('not_same_user');
+    expect(deps.revokeByHash).not.toHaveBeenCalled();
+  });
+
+  it('does NOT revoke when the old session resolves to no owner (inactive/expired)', async () => {
+    const deps = makeDeps({ getSessionOwnerId: vi.fn().mockResolvedValue(null) });
+
+    const outcome = await retireReplacedSession('old-token', 'user-1', deps);
+
+    expect(outcome).toBe('not_same_user');
+    expect(deps.revokeByHash).not.toHaveBeenCalled();
+  });
+
+  it('swallows and logs when owner resolution throws (never fails the refresh)', async () => {
+    const deps = makeDeps({
+      getSessionOwnerId: vi.fn().mockRejectedValue(new Error('db down')),
+    });
+
+    const outcome = await retireReplacedSession('old-token', 'user-1', deps);
+
+    expect(outcome).toBe('revoke_failed');
+    expect(deps.revokeByHash).not.toHaveBeenCalled();
+    expect(deps.logWarn).toHaveBeenCalledWith(
+      'Failed to retire replaced session on device refresh',
+      expect.objectContaining({ error: 'db down' }),
+    );
+  });
+
+  it('swallows and logs when the revoke itself throws', async () => {
+    const deps = makeDeps({
+      revokeByHash: vi.fn().mockRejectedValue('boom'),
+    });
+
+    const outcome = await retireReplacedSession('old-token', 'user-1', deps);
+
+    expect(outcome).toBe('revoke_failed');
+    expect(deps.logWarn).toHaveBeenCalledWith(
+      'Failed to retire replaced session on device refresh',
+      expect.objectContaining({ error: 'boom' }),
+    );
+  });
+});

--- a/apps/web/src/lib/auth/session-retirement.ts
+++ b/apps/web/src/lib/auth/session-retirement.ts
@@ -1,0 +1,65 @@
+/**
+ * Functional core for device-refresh session housekeeping.
+ *
+ * A proactive device refresh mints a replacement session every ~15 minutes. Left
+ * unchecked the old sessions accumulate (thousands per account), which turns a
+ * single interactive login into a thousand-session "revocation storm". This pure
+ * decision function retires the exact session a refresh replaces — and ONLY that
+ * one, and ONLY when it belongs to the same user — with every side effect injected
+ * so the branch table can be covered without a database.
+ */
+
+export interface SessionRetirementDeps {
+  /** Resolve the owning userId of a live session token, or null if none/inactive. */
+  getSessionOwnerId: (token: string) => Promise<string | null>;
+  /** Hash a session token to its stored form. */
+  hashToken: (token: string) => string;
+  /** Revoke a session by its token hash. */
+  revokeByHash: (tokenHash: string, reason: string) => Promise<void>;
+  /** Structured warn logger — retirement must never fail the refresh. */
+  logWarn: (message: string, meta: Record<string, unknown>) => void;
+}
+
+export type RetirementOutcome =
+  | 'no_session_cookie'
+  | 'not_same_user'
+  | 'revoked'
+  | 'revoke_failed';
+
+export const REPLACED_BY_REFRESH_REASON = 'replaced_by_refresh';
+
+/**
+ * Retire the session a device refresh is replacing.
+ *
+ * - No old cookie present → nothing to retire (`no_session_cookie`).
+ * - Old session resolves to a different (or no) user → leave it alone
+ *   (`not_same_user`); never revoke another user's session on the strength of a
+ *   cookie the request happened to carry.
+ * - Old session belongs to the same user → revoke it by hash (`revoked`).
+ * - Any effect throws → swallow, log, and report `revoke_failed`; the caller
+ *   must still complete the refresh.
+ */
+export async function retireReplacedSession(
+  oldSessionToken: string | null | undefined,
+  newSessionUserId: string,
+  deps: SessionRetirementDeps,
+): Promise<RetirementOutcome> {
+  if (!oldSessionToken) {
+    return 'no_session_cookie';
+  }
+
+  try {
+    const ownerId = await deps.getSessionOwnerId(oldSessionToken);
+    if (ownerId !== newSessionUserId) {
+      return 'not_same_user';
+    }
+
+    await deps.revokeByHash(deps.hashToken(oldSessionToken), REPLACED_BY_REFRESH_REASON);
+    return 'revoked';
+  } catch (error) {
+    deps.logWarn('Failed to retire replaced session on device refresh', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return 'revoke_failed';
+  }
+}

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -150,6 +150,15 @@ export class SessionService {
     await sessionRepository.revokeByHash(tokenHash, reason);
   }
 
+  /**
+   * Revoke a single session by its already-hashed token. Used when the caller
+   * has computed the hash itself (e.g. device refresh retiring the session it
+   * replaces) and must not re-hash a raw token.
+   */
+  async revokeSessionByHash(tokenHash: string, reason: string): Promise<void> {
+    await sessionRepository.revokeByHash(tokenHash, reason);
+  }
+
   async revokeAllUserSessions(userId: string, reason: string): Promise<number> {
     return sessionRepository.revokeAllForUser(userId, reason);
   }


### PR DESCRIPTION
## Why

Production regression: logging in on **any** device logged the user out on **every** device. Verified against prod — one admin account had 1,107 sessions revoked in a single day (reason `new_login`); another had 97 browser sessions killed by `passkey_login`, dropping average session lifetime to 28.7h against an intended 7 days.

Two bugs combined:

1. **All-device nuclear revoke on login.** Passkey, magic-link, and native iOS Google/Apple logins called `sessionService.revokeWebUserSessions(userId, reason)`, which revokes every non-admin session on every device. The Google/Apple **web** OAuth callbacks were already fixed months ago to use the device-scoped helper `revokeSessionsForLogin`; these four routes never got it — the native routes even *require* `deviceId` in their schema and then ignored it.
2. **Device-refresh session accumulation.** `POST /api/auth/device/refresh` minted a replacement session every ~15 min (desktop proactive refresh) without retiring the one it replaced — 8,784 accumulated sessions on one account. That is what turned a single login into a thousand-session revocation event.

This pairs with the signin silent-recovery PR (the other half of the logout storm — middleware first-activated on 7/7 and started bouncing cookie-less-but-recoverable navigations to `/auth/signin`).

## What

**Device-scoped revocation** — swap the nuclear revoke for `revokeSessionsForLogin(userId, deviceId, reason, provider)` in:
- `passkey/authenticate/route.ts` — `deviceId` from the request (`passkey_login`, provider `passkey`)
- `google/native/route.ts` — required `deviceId` (`new_login`, provider `Google native`)
- `apple/native/route.ts` — required `deviceId` (`new_login`, provider `Apple native`)
- `magic-link/verify/route.ts` — scoped to `desktopMeta?.deviceId` when present; a cross-device email link has no device id, so the helper falls back to today's all-web-session revoke

Callers that send **no** `deviceId` (legacy clients) keep the legacy nuclear behavior via the helper's fallback — unchanged for old clients.

**Web passkey client sends a device identity** — `PasskeyLoginButton.tsx` web path now sends `platform: 'web'`, `deviceId: getOrCreateDeviceId()`, `deviceName: getDeviceName()` (mirrors `useOAuthSignIn`). This scopes the login's revocation to the browser and lets the route mint a web device token at login, so silent session recovery works immediately. (Desktop/external ceremonies already carry `deviceId`.) The web success path also **persists the returned `deviceToken` to `localStorage`** (mirroring Google One Tap): because sending a `deviceId` makes the route rotate an existing web device token's stored hash, not saving it would leave a stale token and break `/api/auth/device/refresh` recovery.

**Device-refresh retires the session it replaces** — `device/refresh/route.ts` now revokes the specific session the request is replacing (`replaced_by_refresh`), hashing the incoming session cookie and revoking by hash **only** when that session belongs to the same user. Nothing is revoked when no cookie accompanies the request. Race-safe: the old session is retired *after* the new one is created, and a failed retire never fails the refresh (logged and swallowed). The decision lives in a pure functional-core module (`lib/auth/session-retirement.ts`) with all effects injected and full branch coverage.

## Tests

- New pure module `session-retirement.test.ts` (6 tests, all branches).
- Per-route unit tests updated/added: device-scoped revocation asserts `revokeSessionsForLogin` with the right `deviceId`; no-`deviceId` keeps legacy behavior; magic-link desktop metadata scopes to its `deviceId`.
- `device/refresh` retirement tests: same-user cookie → revoked; no cookie → nothing revoked; different user → not revoked; revoke failure → refresh still succeeds.
- `PasskeyLoginButton` web path sends the device identity in the verify body.

Epic task: `iezn4thqnqdx0ac8h8jpp6ar` (PageSpace Features board).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjG8yenrio8HCjHhifMr8W
