### PR TITLE
fix(machines): a view of terminals you can actually remove

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DevelopmentSidebar.tsx
@@ -348,14 +348,21 @@ function MachineTreeSection({
   // `WorkspaceLeaves`/`WorkspaceNodeExtras` below render the SAME server-synced
   // workspace tree `MachineView`'s Terminal tab does (see this file's own doc
   // comment), but `MachineView` — the sync hook's OTHER mount point — is only
-  // mounted once the user actually navigates INTO a machine. Without mounting
-  // it here too, expanding a machine's row in this sidebar without ever
-  // visiting its page renders/acts on a never-hydrated local store: `ensureMachine`
-  // fabricates a phantom "Workspace 1", and any click/create/rename/remove in
-  // this sidebar pushes to the server from that unhydrated state. Mounted once
-  // per machine row (this component's own lifetime in the sidebar list, not
-  // tied to the tree node's expand/collapse) so it doesn't re-join the socket
-  // room or re-fetch on every expand.
+  // mounted once the user actually navigates INTO a machine. Without mounting it
+  // here too, expanding a machine's row in this sidebar without ever visiting
+  // its page would render, and push from, a never-hydrated local store.
+  //
+  // (`ensureMachine` no longer fabricates a phantom "Workspace 1" for a machine
+  // this browser hasn't hydrated — an un-hydrated machine now simply shows no
+  // rows. So the failure this guards against is narrower than it was: acting on
+  // stale local state, not inventing rows. Note this hook's own doc asks to be
+  // mounted once per machine and it is mounted twice for the machine currently
+  // open; that is idempotent — the bootstrap claim table makes the second POST a
+  // no-op — but it is not by design.)
+  //
+  // Mounted once per machine row (this component's own lifetime in the sidebar
+  // list, not tied to the tree node's expand/collapse) so it doesn't re-join the
+  // socket room or re-fetch on every expand.
   useMachineWorkspaceSync(machineId);
 
   const navigateToMachine = useCallback(() => {

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -303,9 +303,12 @@ describe('DevelopmentSidebar', () => {
     // The machine is parked on another tab — the case where the click used to do
     // nothing at all, because only the Terminal tab mounts a workspace grid.
     useMachineTabStore.getState().setTab('machine-1', 'code');
+    // Seeded explicitly: rendering the sidebar no longer fabricates a first
+    // workspace, so a machine only has rows the user actually opened.
+    useMachineWorkspaceStore.getState().ensureMachine('machine-1');
+    useMachineWorkspaceStore.getState().createWorkspace('machine-1');
     render(<DevelopmentSidebar />);
 
-    // Expand the machine to reveal its (idempotent-repaired) first workspace.
     await user.click(await screen.findByRole('button', { name: 'Expand' }));
     await user.click(await screen.findByText('Workspace 1'));
 
@@ -331,7 +334,9 @@ describe('DevelopmentSidebar', () => {
 
     await waitFor(() => {
       const machine = selectMachine('machine-1')(useMachineWorkspaceStore.getState())!;
-      expect(Object.keys(machine.workspaces).length).toBe(2);
+      // ONE, not two. This used to expect two: rendering the sidebar fabricated a
+      // "Workspace 1" for every machine, and the spawn added a second beside it.
+      expect(Object.keys(machine.workspaces).length).toBe(1);
       expect(usePendingWorkspaceStore.getState().pending).toEqual({
         machineId: 'machine-1',
         workspaceId: machine.activeWorkspaceId,

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
@@ -93,13 +93,14 @@ describe('TerminalTab', () => {
     await waitFor(() => {
       const machine = selectMachine('machine-1')(store())!;
       assert({
-        given: 'the machine row\'s single "+" trigger used to spawn a new terminal',
-        should: 'create a second, now-active workspace at machine scope',
+        given: 'the machine row\'s single "+" trigger used to spawn a new terminal on a fresh machine',
+        should:
+          'create exactly ONE workspace at machine scope — this used to expect TWO, because mounting fabricated a "Workspace 1" the user never asked for and the spawn then added a second beside it',
         actual: {
           count: Object.keys(machine.workspaces).length,
           activeScope: machine.workspaces[machine.activeWorkspaceId].scope,
         },
-        expected: { count: 2, activeScope: {} },
+        expected: { count: 1, activeScope: {} },
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -130,6 +130,13 @@ const SHARED_SESSION_WORKSPACE = aWorkspace({
 let workspace: WorkspaceState | null = SPLIT_WORKSPACE;
 /** False = no machine entry at all: the frame before `ensureMachine` commits. */
 let machineEnsured = true;
+/** Additional NON-active workspaces on the machine, listed BEFORE the active
+ * one in the machine's order — the shape that trips up any machine-wide pane
+ * lookup that assumes pane ids are globally unique. */
+let extraWorkspaces: WorkspaceState[] = [];
+beforeEach(() => {
+  extraWorkspaces = [];
+});
 
 // Only the store HOOK is faked; selectActiveWorkspace / panesOf / autoSessionName
 // stay real, so these tests exercise the same active-workspace lookup the app does
@@ -143,7 +150,14 @@ vi.mock('@/stores/machine-workspace/useMachineWorkspaceStore', async () => {
       ? {}
       : {
           m1: workspace
-            ? { workspaces: { [WORKSPACE_ID]: workspace }, order: [WORKSPACE_ID], activeWorkspaceId: WORKSPACE_ID }
+            ? {
+                workspaces: Object.fromEntries([
+                  ...extraWorkspaces.map((extra) => [extra.id, extra] as const),
+                  [WORKSPACE_ID, workspace] as const,
+                ]),
+                order: [...extraWorkspaces.map((extra) => extra.id), WORKSPACE_ID],
+                activeWorkspaceId: WORKSPACE_ID,
+              }
             : { workspaces: {}, order: [], activeWorkspaceId: '' },
         },
     selectPane,
@@ -302,6 +316,38 @@ describe('TerminalPanes (close means close)', () => {
       should: 'still kill the closed one, at ITS checkout — comparing on name alone would silently skip it',
       actual: killAgentTerminal.mock.calls,
       expected: [['m1', { ...WORKSPACE_SCOPE, name: 'claude-x' }]],
+    });
+  });
+
+  // Regression (CodeRabbit): pane ids arrive from server layouts other clients
+  // minted, so nothing guarantees they are globally unique — they are only
+  // unique within their own grid. A machine-wide id lookup finds whichever
+  // same-id pane comes FIRST in the machine's order and kills THAT pane's
+  // session instead of the one the user closed.
+  test('a same-ID pane in ANOTHER workspace is never mistaken for the closing pane', async () => {
+    workspace = SOLO_WORKSPACE; // holds pane-1 → session "solo"
+    extraWorkspaces = [
+      {
+        id: 'ws-foreign',
+        name: 'Foreign',
+        scope: WORKSPACE_SCOPE,
+        columns: [
+          { id: 'col-foreign', panes: [{ id: 'pane-1', scope: { ...WORKSPACE_SCOPE, name: 'foreign-session' } }] },
+        ],
+        activePaneId: 'pane-1',
+        pendingPickerPaneId: null,
+      },
+    ];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findByTestId('xterm');
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: "two workspaces each holding a pane with the SAME id, the foreign one first in the machine's order",
+      should: "kill the session of the pane in THIS workspace — resolving the pane machine-wide would kill the foreign workspace's session and leave the closed one running",
+      actual: killAgentTerminal.mock.calls,
+      expected: [['m1', { name: 'solo' }]],
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 import type { Socket } from 'socket.io-client';
+import { MACHINE_NODE_SCOPE } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import type { OpenTerminalScope, WorkspaceState } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 
 const mockUseMobile = vi.fn<() => boolean>();
@@ -39,6 +40,7 @@ const selectPane = vi.fn();
 const splitRight = vi.fn();
 const splitDown = vi.fn();
 const closePane = vi.fn();
+const createWorkspace = vi.fn(() => 'ws-new');
 const bindPaneTerminal = vi.fn<
   (machineId: string, workspaceId: string, paneId: string, scope: OpenTerminalScope, prompt?: string) => boolean
 >(() => true);
@@ -105,8 +107,22 @@ const JUST_SPLIT_WORKSPACE = aWorkspace({
   pendingPickerPaneId: 'pane-1',
 });
 
-/** The workspace the middle view is showing. */
-let workspace: WorkspaceState = SPLIT_WORKSPACE;
+/** Two panes showing the SAME session — `openTerminal`'s doc records that this
+ * is legal, and it is what stops close-to-kill from being a plain `X`. */
+const SHARED_SESSION_WORKSPACE = aWorkspace({
+  columns: [
+    { id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'shared' } }] },
+    { id: 'col-2', panes: [{ id: 'pane-2', scope: { name: 'shared' } }] },
+  ],
+  activePaneId: 'pane-1',
+  pendingPickerPaneId: null,
+});
+
+/** The workspace the middle view is showing — `null` means the machine has an
+ * entry but zero workspaces, which is a legal state, not a broken one. */
+let workspace: WorkspaceState | null = SPLIT_WORKSPACE;
+/** False = no machine entry at all: the frame before `ensureMachine` commits. */
+let machineEnsured = true;
 
 // Only the store HOOK is faked; selectActiveWorkspace / panesOf / autoSessionName
 // stay real, so these tests exercise the same active-workspace lookup the app does
@@ -116,13 +132,18 @@ vi.mock('@/stores/machine-workspace/useMachineWorkspaceStore', async () => {
     '@/stores/machine-workspace/useMachineWorkspaceStore',
   );
   const fakeState = () => ({
-    machines: {
-      m1: { workspaces: { [WORKSPACE_ID]: workspace }, order: [WORKSPACE_ID], activeWorkspaceId: WORKSPACE_ID },
-    },
+    machines: !machineEnsured
+      ? {}
+      : {
+          m1: workspace
+            ? { workspaces: { [WORKSPACE_ID]: workspace }, order: [WORKSPACE_ID], activeWorkspaceId: WORKSPACE_ID }
+            : { workspaces: {}, order: [], activeWorkspaceId: '' },
+        },
     selectPane,
     splitRight,
     splitDown,
     closePane,
+    createWorkspace,
     bindPaneTerminal,
     clearPanePrompt,
     dismissPicker,
@@ -147,9 +168,144 @@ const socket = {} as Socket;
 const onDesktop = () => mockUseMobile.mockReturnValue(false);
 const onMobile = () => mockUseMobile.mockReturnValue(true);
 
+describe('TerminalPanes (no terminals open)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDesktop();
+    machineEnsured = true;
+    workspace = SPLIT_WORKSPACE;
+  });
+
+  test('a machine with zero workspaces offers a New Terminal button', async () => {
+    workspace = null;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a machine whose views the user removed — a legal, converged state',
+      should:
+        'say so and offer a way back; without something to render here the app had to keep a workspace alive purely so the grid had something to draw, which is what made the last row unremovable',
+      actual: {
+        notice: screen.queryByTestId('machine-no-terminals') !== null,
+        action: screen.queryByRole('button', { name: 'New Terminal' }) !== null,
+        panes: screen.queryAllByTestId('xterm').length,
+      },
+      expected: { notice: true, action: true, panes: 0 },
+    });
+  });
+
+  test('New Terminal creates a workspace at machine scope', async () => {
+    workspace = null;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'New Terminal' }));
+
+    assert({
+      given: "the empty state's only action",
+      should: 'create a machine-scoped workspace — the button has to actually open one',
+      actual: createWorkspace.mock.calls[0],
+      expected: ['m1', MACHINE_NODE_SCOPE],
+    });
+  });
+
+  test('a machine with no entry yet renders nothing — not the empty state', async () => {
+    machineEnsured = false;
+    workspace = null;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'the frame between first render and ensureMachine committing',
+      should:
+        'render nothing — flashing "No terminals open" for one frame on every machine open is a different (and wrong) claim about the world',
+      actual: screen.queryByTestId('machine-no-terminals') !== null,
+      expected: false,
+    });
+  });
+});
+
+describe('TerminalPanes (close means close)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDesktop();
+    machineEnsured = true;
+    workspace = SPLIT_WORKSPACE;
+  });
+
+  test('closing a pane kills the session it held', async () => {
+    workspace = SOLO_WORKSPACE;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findByTestId('xterm');
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'the close control on a pane holding a session',
+      should:
+        'kill the PTY — detaching instead is what MANUFACTURES the unclaimed rows that cannot be removed from the sidebar',
+      actual: removeAgentTerminal.mock.calls.map(([name]) => name),
+      expected: ['solo'],
+    });
+  });
+
+  test('closing a pane whose session another pane still shows does NOT kill it', async () => {
+    workspace = SHARED_SESSION_WORKSPACE;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findAllByTestId('xterm');
+
+    await userEvent.click(screen.getAllByTitle('Close pane')[0]);
+
+    assert({
+      given: 'one of two panes showing the SAME session',
+      should:
+        'close the pane but leave the PTY alone — the other pane is still showing it, and pulling it out from under them would kill a terminal they are looking at',
+      actual: removeAgentTerminal.mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('a same-NAME session in a different checkout is a different session, and does not block the kill', async () => {
+    // A session's identity is the (project, branch, name) triple — that is
+    // `machine_agent_terminals`' unique index — so the same name under another
+    // branch is a DIFFERENT terminal and must not be mistaken for this one.
+    workspace = aWorkspace({
+      columns: [
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: { ...WORKSPACE_SCOPE, name: 'claude-x' } }] },
+        { id: 'col-2', panes: [{ id: 'pane-2', scope: { projectName: 'app', branchName: 'other', name: 'claude-x' } }] },
+      ],
+      activePaneId: 'pane-1',
+      pendingPickerPaneId: null,
+    });
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findAllByTestId('xterm');
+
+    await userEvent.click(screen.getAllByTitle('Close pane')[0]);
+
+    assert({
+      given: 'two panes whose sessions share a name but sit in different branches',
+      should: 'still kill the closed one — comparing on name alone would silently skip it',
+      actual: removeAgentTerminal.mock.calls.map(([name]) => name),
+      expected: ['claude-x'],
+    });
+  });
+
+  test('closing an EMPTY pane kills nothing', async () => {
+    workspace = EMPTY_WORKSPACE;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'a pane holding the picker rather than a session',
+      should: 'have no PTY to kill',
+      actual: removeAgentTerminal.mock.calls.length,
+      expected: 0,
+    });
+  });
+});
+
 describe('TerminalPanes (narrow-viewport degradation)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    machineEnsured = true;
     workspace = SPLIT_WORKSPACE;
   });
 
@@ -257,25 +413,24 @@ describe('TerminalPanes (narrow-viewport degradation)', () => {
     });
   });
 
-  test('a lone EMPTY pane on a phone renders no control chip at all', async () => {
+  test('a lone EMPTY pane on a phone can still be closed — that is how you remove the view', async () => {
     onMobile();
     workspace = EMPTY_WORKSPACE;
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     assert({
-      given: 'the only pane on a narrow viewport, empty, where it can neither split nor detach anything',
+      given: 'the only pane on a narrow viewport, empty, where a split is not offered',
       should:
-        'render no control chip — the chip is opacity-100 on touch, so an empty bordered box would sit in the corner permanently',
+        'still offer close — closing the last pane removes the workspace, so this is the gesture that discards a view the user does not want; it used to be suppressed because the workspace had nowhere to go',
       actual: {
         split: screen.queryByTitle('Split right') !== null,
         close: screen.queryByTitle('Close pane') !== null,
-        chip: document.querySelector('.backdrop-blur-sm') !== null,
       },
-      expected: { split: false, close: false, chip: false },
+      expected: { split: false, close: true },
     });
   });
 
-  test('a lone pane HOLDING a terminal can still detach it, even on a phone', async () => {
+  test('a lone pane HOLDING a terminal can still close it, even on a phone', async () => {
     onMobile();
     workspace = SOLO_WORKSPACE;
     render(<TerminalPanes machineId="m1" socket={socket} />);
@@ -284,7 +439,7 @@ describe('TerminalPanes (narrow-viewport degradation)', () => {
     assert({
       given: 'a workspace whose only pane shows a session — one that may no longer exist server-side',
       should:
-        'offer close, which detaches the terminal and hands the pane back to the picker; without it that workspace is stuck forever on a terminal that will never connect again',
+        'offer close, which kills the session and takes the workspace with it; without it that workspace is stuck forever on a terminal that will never connect again',
       actual: {
         canClose: screen.queryByTitle('Close pane') !== null,
         canSplit: screen.queryByTitle('Split right') !== null,

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -50,9 +50,16 @@ const dismissPicker = vi.fn();
 /** The spawn the picker performs — the only reason TerminalPanes touches the API. */
 const addAgentTerminal = vi.fn(async (name: string, agentType: string) => ({ name, agentType, resumed: false }));
 const removeAgentTerminal = vi.fn<(name: string) => Promise<void>>(async () => {});
+/** The close-kill path — addressed by the PANE's own scope, never through the
+ * workspace-scoped hook, whose scope can differ from the closing pane's. */
+const killAgentTerminal = vi.fn<
+  (machineId: string, scope: { projectName?: string; branchName?: string; name: string }) => Promise<void>
+>(async () => {});
 /** Records the scope the hook was asked for, so a spawn at the wrong checkout can't pass. */
 const useAgentTerminalsArgs = vi.fn<(machineId: string, projectName: string | null, branchName: string | null) => void>();
 vi.mock('@/hooks/useAgentTerminals', () => ({
+  killAgentTerminal: (machineId: string, scope: { projectName?: string; branchName?: string; name: string }) =>
+    killAgentTerminal(machineId, scope),
   useAgentTerminals: (machineId: string, projectName: string | null, branchName: string | null) => {
     useAgentTerminalsArgs(machineId, projectName, branchName);
     return {
@@ -230,7 +237,12 @@ describe('TerminalPanes (close means close)', () => {
     workspace = SPLIT_WORKSPACE;
   });
 
-  test('closing a pane kills the session it held', async () => {
+  test('closing a pane kills the session it held — addressed by the PANE\'s own scope, not the workspace\'s', async () => {
+    // The pane's session lives at MACHINE scope while its workspace is scoped
+    // to app/main — a shape a restored server layout can legitimately hold. A
+    // kill routed through the workspace-scoped hook would DELETE name "solo"
+    // under app/main: a different terminal (or nothing), leaving the one the
+    // user closed running as an unclaimed session.
     workspace = SOLO_WORKSPACE;
     render(<TerminalPanes machineId="m1" socket={socket} />);
     await screen.findByTestId('xterm');
@@ -238,11 +250,17 @@ describe('TerminalPanes (close means close)', () => {
     await userEvent.click(screen.getByTitle('Close pane'));
 
     assert({
-      given: 'the close control on a pane holding a session',
+      given: 'the close control on a pane holding a session whose scope differs from its workspace\'s',
       should:
-        'kill the PTY — detaching instead is what MANUFACTURES the unclaimed rows that cannot be removed from the sidebar',
-      actual: removeAgentTerminal.mock.calls.map(([name]) => name),
-      expected: ['solo'],
+        'kill the PTY at the pane\'s own (project, branch, name) — detaching instead is what MANUFACTURES the unclaimed rows that cannot be removed from the sidebar',
+      actual: {
+        kills: killAgentTerminal.mock.calls,
+        viaWorkspaceHook: removeAgentTerminal.mock.calls.length,
+      },
+      expected: {
+        kills: [['m1', { name: 'solo' }]],
+        viaWorkspaceHook: 0,
+      },
     });
   });
 
@@ -257,7 +275,7 @@ describe('TerminalPanes (close means close)', () => {
       given: 'one of two panes showing the SAME session',
       should:
         'close the pane but leave the PTY alone — the other pane is still showing it, and pulling it out from under them would kill a terminal they are looking at',
-      actual: removeAgentTerminal.mock.calls.length,
+      actual: killAgentTerminal.mock.calls.length,
       expected: 0,
     });
   });
@@ -281,9 +299,9 @@ describe('TerminalPanes (close means close)', () => {
 
     assert({
       given: 'two panes whose sessions share a name but sit in different branches',
-      should: 'still kill the closed one — comparing on name alone would silently skip it',
-      actual: removeAgentTerminal.mock.calls.map(([name]) => name),
-      expected: ['claude-x'],
+      should: 'still kill the closed one, at ITS checkout — comparing on name alone would silently skip it',
+      actual: killAgentTerminal.mock.calls,
+      expected: [['m1', { ...WORKSPACE_SCOPE, name: 'claude-x' }]],
     });
   });
 
@@ -296,7 +314,7 @@ describe('TerminalPanes (close means close)', () => {
     assert({
       given: 'a pane holding the picker rather than a session',
       should: 'have no PTY to kill',
-      actual: removeAgentTerminal.mock.calls.length,
+      actual: killAgentTerminal.mock.calls.length,
       expected: 0,
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -23,8 +23,11 @@ import { PICKABLE_AGENT_TYPES, type AgentRuntimeType } from '@pagespace/lib/serv
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
+  selectMachine,
   autoSessionName,
   panesOf,
+  workspacesOf,
+  sessionWorkspaceId,
   MACHINE_NODE_SCOPE,
   type MachineNodeScope,
   type OpenTerminalScope,
@@ -62,10 +65,15 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
   // The middle view IS the active workspace's grid — selecting another workspace
   // swaps this whole component's contents for that item's combination of panes.
   const workspace = useMachineWorkspaceStore(selectActiveWorkspace(machineId));
+  // Read alongside the active workspace to tell the two "no grid to draw" cases
+  // apart: no machine entry yet (one frame, pre-`ensureMachine`) vs an entry
+  // with zero workspaces (the user removed them all — a real, legal state).
+  const machine = useMachineWorkspaceStore(selectMachine(machineId));
   // Layout-affecting actions push the resulting workspace state to the server
   // (#2048); selectPane/clearPanePrompt/dismissPicker stay local-only (focus
   // and one-shot UI intent, never synced — see useMachineWorkspaceSync's doc).
-  const { splitRight, splitDown, closePane, bindPaneTerminal } = useSyncedWorkspaceActions(machineId);
+  const { splitRight, splitDown, closePane, bindPaneTerminal, createWorkspace } =
+    useSyncedWorkspaceActions(machineId);
   const selectPane = useMachineWorkspaceStore((state) => state.selectPane);
   const clearPanePrompt = useMachineWorkspaceStore((state) => state.clearPanePrompt);
   const dismissPicker = useMachineWorkspaceStore((state) => state.dismissPicker);
@@ -119,9 +127,70 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     [addAgentTerminal, removeAgentTerminal, bindPaneTerminal, workspaceId, scope.projectName, scope.branchName],
   );
 
+  /**
+   * Close means close: the pane goes, and its PTY is killed with it — the same
+   * meaning `X` has in every terminal emulator. The alternative (detach, leaving
+   * the session running) is what MANUFACTURES orphan rows: a terminal outliving
+   * the only view of it becomes an "unclaimed" session in the sidebar, which is
+   * the unremovable-listing bug this change exists to kill.
+   *
+   * Not killed when another pane still binds the same session: `openTerminal`'s
+   * doc records that a session can legitimately be shown in two panes at once,
+   * and closing one of those must not pull the PTY out from under the other.
+   * Read from the store rather than this render's `workspace`, since only the
+   * machine-wide state can see panes in the workspaces we aren't rendering.
+   */
+  const closePaneAndKill = useCallback(
+    (paneId: string) => {
+      const current = useMachineWorkspaceStore.getState().machines[machineId];
+      const machinePanes = current ? workspacesOf(current).flatMap(panesOf) : [];
+      const closing = machinePanes.find((candidate) => candidate.id === paneId)?.scope ?? null;
+
+      // Compared by `sessionWorkspaceId` — the session's real identity is the
+      // (project, branch, name) triple (that is `machine_agent_terminals`' unique
+      // index), not the name alone, which two branches could legitimately share.
+      const boundElsewhere =
+        closing !== null &&
+        machinePanes.some(
+          (candidate) =>
+            candidate.id !== paneId &&
+            candidate.scope !== null &&
+            sessionWorkspaceId(candidate.scope) === sessionWorkspaceId(closing),
+        );
+
+      closePane(workspaceId, paneId);
+      if (closing !== null && !boundElsewhere) {
+        void removeAgentTerminal(closing.name).catch(() => {
+          // The pane is already gone locally; a failed kill leaves the session
+          // discoverable as an unclaimed row (which now carries its own remove
+          // button), so this must not throw into the click handler.
+        });
+      }
+    },
+    [machineId, workspaceId, closePane, removeAgentTerminal],
+  );
+
   // Briefly undefined between this component's first render and the mounting
-  // MachineWorkspace's ensureMachine effect committing.
-  if (!workspace) return null;
+  // MachineWorkspace's ensureMachine effect committing. Distinct from "the
+  // machine has no workspaces" below — rendering the empty state here would
+  // flash "No terminals open" for one frame on every machine open.
+  if (!machine) return null;
+
+  // Zero workspaces is a legal, converged state, not a blank view to be repaired
+  // by fabricating one. This empty state is what makes removing the LAST view
+  // possible: without something to render here, the old code kept a workspace
+  // alive purely so the grid had something to draw.
+  if (!workspace) {
+    return (
+      <PaneNotice
+        testId="machine-no-terminals"
+        title="No terminals open"
+        description="Open a terminal to start working on this machine."
+        actionLabel="New Terminal"
+        onAction={() => createWorkspace(MACHINE_NODE_SCOPE)}
+      />
+    );
+  }
 
   const { activePaneId, pendingPickerPaneId, columns } = workspace;
   const scopeLabel = scopeLabelOf(scope);
@@ -136,11 +205,11 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     machineId,
     pane,
     isActive: pane.id === activeId,
-    // A lone pane can still be closed when it holds a terminal — closing it
-    // detaches the terminal and hands the pane back to the picker. Without that,
-    // a workspace whose only pane shows a session that no longer exists could
-    // never be recovered.
-    canClose: panes.length > 1 || pane.scope !== null,
+    // Every pane closes, always. The old rule (`panes.length > 1 || scope !==
+    // null`) existed to stop a lone empty pane being closed, because the
+    // workspace had nowhere to go — closing the last pane now removes the
+    // workspace itself, so there is no such dead end left to guard.
+    canClose: true,
     // A split just made this pane, so its picker takes focus — the user asked
     // for a new agent, not for a blank rectangle to go find a control in.
     pickerFocused: pane.id === pendingPickerPaneId,
@@ -152,7 +221,7 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     onSelect: () => selectPane(machineId, workspaceId, pane.id),
     onSplitRight: () => splitRight(workspaceId, pane.id),
     onSplitDown: () => splitDown(workspaceId, pane.id),
-    onClose: () => closePane(workspaceId, pane.id),
+    onClose: () => closePaneAndKill(pane.id),
     onSpawn: (agentType: AgentRuntimeType, prompt?: string) => spawnIntoPane(pane.id, agentType, prompt),
     onPickerFocused: () => dismissPicker(machineId, workspaceId, pane.id),
     onPromptSent: () => clearPanePrompt(machineId, workspaceId, pane.id),

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/select';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
-import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { useAgentTerminals, killAgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import { PICKABLE_AGENT_TYPES, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
@@ -139,6 +139,12 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
    * and closing one of those must not pull the PTY out from under the other.
    * Read from the store rather than this render's `workspace`, since only the
    * machine-wide state can see panes in the workspaces we aren't rendering.
+   *
+   * The kill is addressed by the PANE's own scope (`killAgentTerminal`), not
+   * through this component's workspace-scoped hook — a pane's checkout can
+   * differ from its workspace's, and a DELETE under the workspace scope would
+   * target a different same-named terminal (or nothing) while the one the user
+   * closed lives on.
    */
   const closePaneAndKill = useCallback(
     (paneId: string) => {
@@ -160,14 +166,14 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
 
       closePane(workspaceId, paneId);
       if (closing !== null && !boundElsewhere) {
-        void removeAgentTerminal(closing.name).catch(() => {
+        void killAgentTerminal(machineId, closing).catch(() => {
           // The pane is already gone locally; a failed kill leaves the session
           // discoverable as an unclaimed row (which now carries its own remove
           // button), so this must not throw into the click handler.
         });
       }
     },
-    [machineId, workspaceId, closePane, removeAgentTerminal],
+    [machineId, workspaceId, closePane],
   );
 
   // Briefly undefined between this component's first render and the mounting

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -149,19 +149,31 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
   const closePaneAndKill = useCallback(
     (paneId: string) => {
       const current = useMachineWorkspaceStore.getState().machines[machineId];
-      const machinePanes = current ? workspacesOf(current).flatMap(panesOf) : [];
-      const closing = machinePanes.find((candidate) => candidate.id === paneId)?.scope ?? null;
+      // The closing pane is resolved WITHIN its own workspace — a pane id is
+      // only unique within its grid (ids arrive from server layouts other
+      // clients minted, so nothing guarantees global uniqueness), and a
+      // machine-wide id lookup could match a same-id pane in another
+      // workspace and kill that pane's session instead.
+      const closingWorkspace = current?.workspaces[workspaceId];
+      const closing = closingWorkspace
+        ? (panesOf(closingWorkspace).find((candidate) => candidate.id === paneId)?.scope ?? null)
+        : null;
 
       // Compared by `sessionWorkspaceId` — the session's real identity is the
       // (project, branch, name) triple (that is `machine_agent_terminals`' unique
       // index), not the name alone, which two branches could legitimately share.
+      // "Another pane" is the (workspace, pane) TUPLE, for the same reason the
+      // lookup above is workspace-scoped.
       const boundElsewhere =
         closing !== null &&
-        machinePanes.some(
-          (candidate) =>
-            candidate.id !== paneId &&
-            candidate.scope !== null &&
-            sessionWorkspaceId(candidate.scope) === sessionWorkspaceId(closing),
+        current !== undefined &&
+        workspacesOf(current).some((candidateWorkspace) =>
+          panesOf(candidateWorkspace).some(
+            (candidate) =>
+              (candidateWorkspace.id !== workspaceId || candidate.id !== paneId) &&
+              candidate.scope !== null &&
+              sessionWorkspaceId(candidate.scope) === sessionWorkspaceId(closing),
+          ),
         );
 
       closePane(workspaceId, paneId);

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -284,6 +284,96 @@ describe('WorkspaceLeaves', () => {
     });
   });
 
+  // Regression (Codex P2): the kill must be addressed by the PANE's own
+  // (project, branch, name) scope, not the node's. A restored server layout
+  // can hold a pane whose checkout differs from its workspace's — DELETEing
+  // that pane's name under the NODE scope would kill a different same-named
+  // terminal (or nothing) while the one being removed lives on unclaimed.
+  test('removing a workspace kills each pane\'s session at the PANE\'s own scope, not the node\'s', async () => {
+    seedMachine('m1'); // machine-scope workspace at the machine node
+    const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+    const workspace = selectMachine('m1')(store())!.workspaces[workspaceId];
+    // A pane bound at a DIFFERENT checkout than its (machine-scope) workspace.
+    store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, {
+      projectName: 'app',
+      branchName: 'main',
+      name: 'wanderer',
+    });
+
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('Workspace 1')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove workspace/ }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      const killUrl = String(vi.mocked(del).mock.calls.find(([url]) => String(url).includes('name=wanderer'))?.[0] ?? '');
+      assert({
+        given: 'a machine-scope workspace holding a pane bound at app/main, remove confirmed',
+        should: 'DELETE the session under the pane\'s own project and branch — the node scope would address a different terminal',
+        actual: {
+          project: killUrl.includes('projectName=app'),
+          branch: killUrl.includes('branchName=main'),
+        },
+        expected: { project: true, branch: true },
+      });
+    });
+  });
+
+  // Same invariant as TerminalPanes' close-and-kill: a session can be shown in
+  // two panes at once (openTerminal's doc), including panes of DIFFERENT
+  // workspaces — removing one workspace must not pull the PTY out from under
+  // the other one still showing it.
+  test('removing a workspace spares a session another workspace\'s pane still shows', async () => {
+    seedMachine('m1');
+    const firstId = selectMachine('m1')(store())!.activeWorkspaceId;
+    const first = selectMachine('m1')(store())!.workspaces[firstId];
+    store().bindPaneTerminal('m1', firstId, first.activePaneId, { name: 'shared' });
+    const secondId = store().createWorkspace('m1');
+    const second = selectMachine('m1')(store())!.workspaces[secondId];
+    store().bindPaneTerminal('m1', secondId, second.activePaneId, { name: 'shared' });
+
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('Workspace 1')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove workspace/ }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => expect(Object.keys(selectMachine('m1')(store())!.workspaces)).toEqual([secondId]));
+    assert({
+      given: 'two workspaces whose panes show the SAME session, the first removed',
+      should: 'drop the workspace but leave the PTY alone — the surviving workspace is still showing it',
+      actual: vi.mocked(del).mock.calls.filter(([url]) => String(url).includes('name=shared')).length,
+      expected: 0,
+    });
+  });
+
+  test('two panes of the removed workspace showing ONE session kill it once, and the dialog counts it once', async () => {
+    seedMachine('m1');
+    const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+    const workspace = selectMachine('m1')(store())!.workspaces[workspaceId];
+    store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, { name: 'twice' });
+    store().splitRight('m1', workspaceId, workspace.activePaneId);
+    const withSplit = selectMachine('m1')(store())!.workspaces[workspaceId];
+    store().bindPaneTerminal('m1', workspaceId, withSplit.columns[1].panes[0].id, { name: 'twice' });
+
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('Workspace 1')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove workspace/ }));
+    await screen.findByText(/stops its 1 running agent/);
+    await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'one session shown in both panes of the workspace being removed',
+        should: 'DELETE it exactly once — the second call would 404 and surface a spurious failure toast',
+        actual: vi.mocked(del).mock.calls.filter(([url]) => String(url).includes('name=twice')).length,
+        expected: 1,
+      });
+    });
+  });
+
   // Regression (Codex P1): a session the server reports but that has no local
   // workspace yet (another browser, a cleared localStorage, an agent tool that
   // spawned it directly) must still be reachable and stoppable from the

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -38,6 +38,15 @@ const patchCallsTo = (url: string) =>
     ([calledUrl, options]) => calledUrl === url && (options as RequestInit | undefined)?.method === 'PATCH',
   );
 
+// `killAgentTerminal` DELETEs via `fetchWithAuth` directly (not the `del()`
+// helper) so it can read the real HTTP status — a 404 is its success state.
+// Workspace-removal kills therefore show up here; unclaimed-row removal still
+// goes through the hook's `removeAgentTerminal`, i.e. the `del` mock.
+const killCalls = () =>
+  vi.mocked(fetchWithAuth).mock.calls.filter(
+    ([, options]) => (options as RequestInit | undefined)?.method === 'DELETE',
+  );
+
 const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
 const PROJECT_NODE: MachineTreeNode = { level: 'project', projectName: 'app' };
 
@@ -244,7 +253,7 @@ describe('WorkspaceLeaves', () => {
         given: 'a workspace holding one running pane, with a sibling workspace also present, remove confirmed',
         should: 'DELETE that agent_terminal server-side, then drop the local workspace entirely (its sibling survives)',
         actual: {
-          deletedRunningAgent: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=claude-a1b2c3')),
+          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=claude-a1b2c3')),
           remainingWorkspaces: Object.keys(selectMachine('m1')(store())!.workspaces).length,
         },
         expected: { deletedRunningAgent: true, remainingWorkspaces: rows.length - 1 },
@@ -275,7 +284,7 @@ describe('WorkspaceLeaves', () => {
         should:
           'stop the agent server-side and drop the workspace — this used to EMPTY it in place instead, which left an un-removable row that New terminal then duplicated',
         actual: {
-          deletedRunningAgent: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=claude-solo')),
+          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=claude-solo')),
           workspaceCount: Object.keys(machine.workspaces).length,
           active: machine.activeWorkspaceId,
         },
@@ -307,7 +316,7 @@ describe('WorkspaceLeaves', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
 
     await waitFor(() => {
-      const killUrl = String(vi.mocked(del).mock.calls.find(([url]) => String(url).includes('name=wanderer'))?.[0] ?? '');
+      const killUrl = String(killCalls().find(([url]) => String(url).includes('name=wanderer'))?.[0] ?? '');
       assert({
         given: 'a machine-scope workspace holding a pane bound at app/main, remove confirmed',
         should: 'DELETE the session under the pane\'s own project and branch — the node scope would address a different terminal',
@@ -343,7 +352,7 @@ describe('WorkspaceLeaves', () => {
     assert({
       given: 'two workspaces whose panes show the SAME session, the first removed',
       should: 'drop the workspace but leave the PTY alone — the surviving workspace is still showing it',
-      actual: vi.mocked(del).mock.calls.filter(([url]) => String(url).includes('name=shared')).length,
+      actual: killCalls().filter(([url]) => String(url).includes('name=shared')).length,
       expected: 0,
     });
   });
@@ -368,8 +377,40 @@ describe('WorkspaceLeaves', () => {
       assert({
         given: 'one session shown in both panes of the workspace being removed',
         should: 'DELETE it exactly once — the second call would 404 and surface a spurious failure toast',
-        actual: vi.mocked(del).mock.calls.filter(([url]) => String(url).includes('name=twice')).length,
+        actual: killCalls().filter(([url]) => String(url).includes('name=twice')).length,
         expected: 1,
+      });
+    });
+  });
+
+  // A 404 on the kill means the session is already gone — this call's GOAL
+  // state. Treating it as a failure made the workspace permanently
+  // unremovable: the kill rejected, the confirm dialog stayed open, and every
+  // retry hit the same 404 — an unremovable listing, the exact bug class this
+  // PR exists to kill.
+  test('removing a workspace whose pane\'s session is already gone server-side still removes it', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async (_url, options) =>
+      (options as RequestInit | undefined)?.method === 'DELETE'
+        ? new Response(JSON.stringify({ error: 'not_found' }), { status: 404 })
+        : new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 }),
+    );
+    seedMachine('m1');
+    const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
+    const workspace = selectMachine('m1')(store())!.workspaces[workspaceId];
+    store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, { name: 'ghost' });
+
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('Workspace 1')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove workspace/ }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a workspace whose only pane references a session the server no longer has, remove confirmed',
+        should: 'treat the 404 kill as already-done and remove the workspace — not keep the dialog open on a retry loop that can never succeed',
+        actual: Object.keys(selectMachine('m1')(store())!.workspaces).length,
+        expected: 0,
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -1,10 +1,16 @@
 import { describe, test, beforeEach, vi, expect } from 'vitest';
-import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SWRConfig } from 'swr';
 import type { ReactElement } from 'react';
 import { assert } from '@/stores/__tests__/riteway';
-import { useMachineWorkspaceStore, selectMachine, sessionWorkspaceId } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import {
+  useMachineWorkspaceStore,
+  selectMachine,
+  sessionWorkspaceId,
+  workspacesOf,
+  type MachineNodeScope,
+} from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import WorkspaceLeaves, { WorkspaceNodeExtras } from './WorkspaceLeaves';
 import type { MachineTreeNode } from './MachineTree';
 
@@ -37,6 +43,14 @@ const PROJECT_NODE: MachineTreeNode = { level: 'project', projectName: 'app' };
 
 const store = () => useMachineWorkspaceStore.getState();
 
+/** A machine with one workspace at `scope`. Rendering alone no longer produces
+ * one: `ensureMachine` creates the machine's entry and nothing else, because a
+ * machine with no terminals is a legal state rather than a blank view to repair. */
+const seedMachine = (machineId: string, scope: MachineNodeScope = {}) => {
+  store().ensureMachine(machineId);
+  return store().createWorkspace(machineId, scope);
+};
+
 // A fresh SWR cache per render — without it, useAgentTerminals' SWR key
 // (machineId+scope) is IDENTICAL across every test in this file, so a
 // later test would silently see an earlier test's cached response instead
@@ -51,19 +65,45 @@ describe('WorkspaceLeaves', () => {
     useMachineWorkspaceStore.setState({ machines: {} });
   });
 
-  test('a machine this browser has never opened still shows its (auto-created) first workspace', async () => {
+  test('a machine this browser has never opened shows no workspace rows', async () => {
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
-    const row = await screen.findByText('Workspace 1');
+    await waitFor(() => expect(store().machines['m1']).toBeDefined());
     assert({
       given: 'a machine with no prior local workspace state',
-      should: 'idempotent-repair a first workspace so the node is never permanently empty',
-      actual: row.textContent,
-      expected: 'Workspace 1',
+      should:
+        'list nothing — fabricating a first workspace here invented rows for machines the user never opened, and put a removed row straight back',
+      actual: screen.queryByText('Workspace 1'),
+      expected: null,
+    });
+  });
+
+  test('removing the only workspace, then creating a new one, leaves exactly ONE row', async () => {
+    // THE REPORTED BUG. The floor made removeWorkspace a no-op on the last
+    // workspace, so the sidebar emptied its panes instead and the row survived;
+    // `+ New terminal` then added a second row beside the zombie.
+    seedMachine('m1');
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('Workspace 1')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove workspace/ }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Remove' }));
+    await waitFor(() => expect(workspacesOf(selectMachine('m1')(store())).length).toBe(0));
+
+    act(() => {
+      store().createWorkspace('m1');
+    });
+
+    assert({
+      given: 'the machine\'s only workspace removed, then a new terminal opened',
+      should: 'show exactly one row — not the un-removable zombie plus a new one',
+      actual: workspacesOf(selectMachine('m1')(store())).length,
+      expected: 1,
     });
   });
 
   test('clicking a workspace row reports its id, not its name', async () => {
+    seedMachine('m1');
     const onSelectWorkspace = vi.fn();
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={onSelectWorkspace} />);
 
@@ -87,7 +127,7 @@ describe('WorkspaceLeaves', () => {
   // first click's onSelectWorkspace must be deferred and cancelled by the
   // second click that starts the rename.
   test('double-clicking a workspace name to rename it does NOT also call onSelectWorkspace', async () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const onSelectWorkspace = vi.fn();
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={onSelectWorkspace} />);
 
@@ -102,7 +142,7 @@ describe('WorkspaceLeaves', () => {
   });
 
   test('the active workspace is marked aria-current; an inactive sibling is not', async () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const first = selectMachine('m1')(store())!.activeWorkspaceId;
     const second = store().createWorkspace('m1');
 
@@ -120,7 +160,7 @@ describe('WorkspaceLeaves', () => {
   });
 
   test('a session bound into an existing workspace via split-and-pick is not listed as its own row', async () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
     store().splitRight('m1', workspace.id, workspace.activePaneId);
     const withPane = selectMachine('m1')(store())!.workspaces[workspace.id];
@@ -142,7 +182,7 @@ describe('WorkspaceLeaves', () => {
   });
 
   test('workspaces are filtered to the node\'s own scope', async () => {
-    store().ensureMachine('m1'); // machine-scope "Workspace 1"
+    seedMachine('m1'); // machine-scope "Workspace 1"
     store().createWorkspace('m1', { projectName: 'app' }); // project-scope "Workspace 2"
 
     renderLeaves(<WorkspaceLeaves machineId="m1" node={PROJECT_NODE} onSelectWorkspace={vi.fn()} />);
@@ -157,7 +197,7 @@ describe('WorkspaceLeaves', () => {
   });
 
   test('removing an EMPTY workspace calls the store action after confirming', async () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     store().createWorkspace('m1');
 
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
@@ -183,7 +223,7 @@ describe('WorkspaceLeaves', () => {
   // it has to actually stop it, or the sidebar leaves no way back to a
   // running (and billing) Sprite.
   test('removing a workspace WITH a running pane stops that agent server-side before dropping the workspace', async () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
     store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'claude-a1b2c3' });
     // A SECOND (empty) workspace, so removing the first one actually exercises
@@ -216,8 +256,8 @@ describe('WorkspaceLeaves', () => {
   // ONLY workspace (the store always keeps at least one) — a naive "kill the
   // agent, then removeWorkspace" leaves that no-op'd workspace with a pane
   // still bound to the agent name just killed: a zombie row/grid.
-  test('removing the machine\'s ONLY workspace stops its agent but EMPTIES the workspace instead of leaving it bound to a dead agent', async () => {
-    store().ensureMachine('m1');
+  test('removing the machine\'s ONLY workspace stops its agent and removes the workspace outright', async () => {
+    seedMachine('m1');
     const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
     const workspace = selectMachine('m1')(store())!.workspaces[workspaceId];
     store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, { name: 'claude-solo' });
@@ -230,28 +270,16 @@ describe('WorkspaceLeaves', () => {
 
     await waitFor(() => {
       const machine = selectMachine('m1')(store())!;
-      const remaining = machine.workspaces[workspaceId];
-      // `pane.scope: null` is the CORRECT, expected outcome here — `??` would
-      // wrongly swallow that legitimate null into a "missing" sentinel, so
-      // presence and value are checked separately instead.
-      const pane = remaining?.columns[0]?.panes[0];
       assert({
         given: 'a machine with exactly one workspace holding a running pane, remove confirmed',
-        should: 'stop the agent server-side, then EMPTY the workspace locally rather than no-op and leave it bound to the killed agent',
+        should:
+          'stop the agent server-side and drop the workspace — this used to EMPTY it in place instead, which left an un-removable row that New terminal then duplicated',
         actual: {
           deletedRunningAgent: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=claude-solo')),
           workspaceCount: Object.keys(machine.workspaces).length,
-          stillOneWorkspace: remaining !== undefined,
-          paneExists: pane !== undefined,
-          paneScope: pane === undefined ? 'PANE_MISSING' : pane.scope,
+          active: machine.activeWorkspaceId,
         },
-        expected: {
-          deletedRunningAgent: true,
-          workspaceCount: 1,
-          stillOneWorkspace: true,
-          paneExists: true,
-          paneScope: null,
-        },
+        expected: { deletedRunningAgent: true, workspaceCount: 0, active: '' },
       });
     });
   });
@@ -292,7 +320,7 @@ describe('WorkspaceLeaves', () => {
 
   describe('inline rename', () => {
     test('double-clicking a workspace name opens an editable input, pre-filled with its current name', async () => {
-      store().ensureMachine('m1');
+      seedMachine('m1');
       renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
       const row = await screen.findByText('Workspace 1');
@@ -308,7 +336,7 @@ describe('WorkspaceLeaves', () => {
     });
 
     test('Enter commits the new name and pushes it to the server', async () => {
-      store().ensureMachine('m1');
+      seedMachine('m1');
       const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
       renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
@@ -337,7 +365,7 @@ describe('WorkspaceLeaves', () => {
     });
 
     test('Escape cancels without saving the draft', async () => {
-      store().ensureMachine('m1');
+      seedMachine('m1');
       const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
       renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
@@ -361,7 +389,7 @@ describe('WorkspaceLeaves', () => {
     // would re-enter the commit path — resurrecting the cancelled draft after
     // Escape, or firing a redundant second commit after Enter.
     test('a blur event firing immediately after Escape does not resurrect the cancelled draft', async () => {
-      store().ensureMachine('m1');
+      seedMachine('m1');
       const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
       renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
@@ -384,7 +412,7 @@ describe('WorkspaceLeaves', () => {
     });
 
     test('a blur event firing immediately after Enter does not fire a redundant second commit', async () => {
-      store().ensureMachine('m1');
+      seedMachine('m1');
       renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
       await userEvent.dblClick(await screen.findByText('Workspace 1'));
@@ -425,9 +453,34 @@ describe('WorkspaceLeaves', () => {
       should: 'render it without an adopt affordance (clicking its name does nothing) but WITH a remove button',
       actual: {
         adoptedAnything: onSelectWorkspace.mock.calls.length,
-        hasRemoveButton: within(row).queryByRole('button', { name: /Remove unsupported session legacy-cli/ }) !== null,
+        hasRemoveButton: within(row).queryByRole('button', { name: /Remove session legacy-cli/ }) !== null,
       },
       expected: { adoptedAnything: 0, hasRemoveButton: true },
+    });
+  });
+
+  // The OTHER un-removable listing: a `shell`/`claude`/`codex` orphan rendered
+  // its remove button only when `!launchable`, so a supported unclaimed session
+  // had no remove affordance at all. The only stop path was "remove the
+  // workspace holding it" — which is precisely what an unclaimed session lacks.
+  test('a LAUNCHABLE unclaimed session is removable too, not just adoptable', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      new Response(
+        JSON.stringify({
+          agentTerminals: [{ name: 'claude-orphan', agentType: 'claude', createdAt: '2026-01-01' }],
+        }),
+        { status: 200 },
+      ),
+    );
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('claude-orphan')).closest('.group') as HTMLElement;
+
+    assert({
+      given: 'an unclaimed session whose agent type IS supported',
+      should: 'still offer a remove button — it has no workspace to remove instead',
+      actual: within(row).queryByRole('button', { name: /Remove session claude-orphan/ }) !== null,
+      expected: true,
     });
   });
 
@@ -443,7 +496,7 @@ describe('WorkspaceLeaves', () => {
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
     const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
-    await userEvent.click(within(row).getByRole('button', { name: /Remove unsupported session legacy-cli/ }));
+    await userEvent.click(within(row).getByRole('button', { name: /Remove session legacy-cli/ }));
 
     await waitFor(() => {
       assert({
@@ -472,7 +525,7 @@ describe('WorkspaceLeaves', () => {
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
     const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
-    await userEvent.click(within(row).getByRole('button', { name: /Remove unsupported session legacy-cli/ }));
+    await userEvent.click(within(row).getByRole('button', { name: /Remove session legacy-cli/ }));
 
     await waitFor(() => {
       assert({
@@ -504,7 +557,7 @@ describe('WorkspaceNodeExtras', () => {
   });
 
   test('shows a running-count badge scoped to the node', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
     store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'claude-a1b2c3' });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -19,19 +19,20 @@
  * here; route to the machine first, there).
  *
  * Removing a workspace STOPS every agent its panes hold (`removeAgentTerminal`
- * per running pane) before dropping the local grid — this is the only
- * terminal-level stop/remove path left once `SessionLeaves`'s per-session
- * remove button is gone, so it must not merely hide a still-running (and
- * still-billing) agent with no row left to reach it from.
+ * per running pane) before dropping the local grid — it must not merely hide a
+ * still-running (and still-billing) agent with no row left to reach it from.
+ * Removal applies to the machine's LAST workspace too: a workspace is a view of
+ * terminals, and a view you cannot destroy is not a view. Zero workspaces is a
+ * legal state — the middle view renders an empty state for it.
  *
  * A session the SERVER reports at this scope but that isn't yet any local
- * workspace's pane — another browser, a cleared localStorage, a session an
- * agent tool spawned directly — is rendered as an "unclaimed" row too:
- * clicking it materializes (and activates) its own workspace via the store's
- * `openTerminal`, the same reconciliation the old `SessionLeaves` did
- * implicitly by always listing the server's truth. Without this, such a
- * session is unreachable from the sidebar at all — can't be opened, and (since
- * removing a workspace is the only stop path now) can't be stopped either.
+ * workspace's pane — another browser, or a session an agent tool spawned
+ * directly — is rendered as an "unclaimed" row too: clicking it materializes
+ * (and activates) its own workspace via the store's `openTerminal`, the same
+ * reconciliation the old `SessionLeaves` did implicitly by always listing the
+ * server's truth. Without this, such a session is unreachable from the sidebar
+ * at all. Every unclaimed row carries its own remove button, since the
+ * workspace-level stop path is exactly what it lacks.
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -87,7 +88,7 @@ export default function WorkspaceLeaves({
   const machine = useMachineWorkspaceStore(selectMachine(machineId));
   // Identity/layout-affecting actions push to the server (#2048); local-only
   // UI state (which row is being renamed, which is pending removal) stays here.
-  const { removeWorkspace, closePanes, openTerminal, renameWorkspace } = useSyncedWorkspaceActions(machineId);
+  const { removeWorkspace, openTerminal, renameWorkspace } = useSyncedWorkspaceActions(machineId);
   const [pendingRemove, setPendingRemove] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
@@ -123,9 +124,6 @@ export default function WorkspaceLeaves({
 
   const workspaces = workspacesOf(machine).filter((workspace) => isSameNodeScope(workspace.scope, scope));
   const pendingWorkspace = workspaces.find((workspace) => workspace.id === pendingRemove);
-  const pendingRunningPaneIds = pendingWorkspace
-    ? panesOf(pendingWorkspace).filter((pane) => pane.scope !== null).map((pane) => pane.id)
-    : [];
   const pendingRunningNames = pendingWorkspace
     ? panesOf(pendingWorkspace)
         .map((pane) => pane.scope?.name)
@@ -195,10 +193,11 @@ export default function WorkspaceLeaves({
   };
 
   /** Unlike removing a live workspace (routed through {@link ConfirmRemoveDialog}, which
-   * surfaces a thrown error as a toast), this is a one-click cleanup of an already-dead
-   * row — no confirmation step, but a failed DELETE must still be reported rather than
-   * silently no-op'ing (the row would otherwise look un-removable with no feedback why). */
-  const removeUnlaunchableSession = async (name: string) => {
+   * surfaces a thrown error as a toast), this is a one-click cleanup of a row with no
+   * workspace behind it — no confirmation step, but a failed DELETE must still be
+   * reported rather than silently no-op'ing (the row would otherwise look un-removable
+   * with no feedback why). */
+  const removeUnclaimedSession = async (name: string) => {
     try {
       await removeAgentTerminal(name);
     } catch (err) {
@@ -285,12 +284,15 @@ export default function WorkspaceLeaves({
                 {session.name}
               </span>
             </button>
-            {!launchable && (
-              <RemoveButton
-                onClick={() => void removeUnlaunchableSession(session.name)}
-                label={`Remove unsupported session ${session.name}`}
-              />
-            )}
+            {/* EVERY unclaimed row is removable, not just the unlaunchable ones.
+                A `shell`/`claude`/`codex` orphan used to have no remove button
+                at all: the only stop path was "remove the workspace holding it",
+                which by definition is the thing an unclaimed session doesn't
+                have. It was a listing you could not get rid of. */}
+            <RemoveButton
+              onClick={() => void removeUnclaimedSession(session.name)}
+              label={`Remove session ${session.name}`}
+            />
           </div>
         );
       })}
@@ -311,15 +313,12 @@ export default function WorkspaceLeaves({
           // dropping the local entry — otherwise the agent (and its billing)
           // survives with no sidebar row left to reach it from.
           await Promise.all(pendingRunningNames.map((name) => removeAgentTerminal(name)));
-          // removeWorkspace no-ops when this is the machine's ONLY workspace
-          // (a machine always keeps at least one) — empty its panes locally
-          // instead of dropping the (unchanged) workspace, or it would linger
-          // bound to the agent names just killed above.
-          if (workspacesOf(machine).length <= 1) {
-            closePanes(pendingRemove, pendingRunningPaneIds);
-          } else {
-            removeWorkspace(pendingRemove);
-          }
+          // Unconditional, including the machine's last workspace. This used to
+          // branch: `removeWorkspace` no-op'd on the last one, so the row was
+          // emptied in place instead — which left it in the sidebar, unremovable
+          // no matter how many times the user confirmed, and `+ New terminal`
+          // then added a SECOND row beside the zombie.
+          removeWorkspace(pendingRemove);
         }}
       />
     </div>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.tsx
@@ -18,9 +18,13 @@
  * only in what `onSelectWorkspace`/`onCreateWorkspace` do (activate in place
  * here; route to the machine first, there).
  *
- * Removing a workspace STOPS every agent its panes hold (`removeAgentTerminal`
- * per running pane) before dropping the local grid — it must not merely hide a
- * still-running (and still-billing) agent with no row left to reach it from.
+ * Removing a workspace STOPS every agent its panes hold (`killAgentTerminal`
+ * per running session, addressed by the PANE's own scope — a pane's checkout
+ * can differ from its workspace's) before dropping the local grid — it must
+ * not merely hide a still-running (and still-billing) agent with no row left
+ * to reach it from. Sessions another workspace's pane still shows are spared
+ * (same rule as TerminalPanes' close-and-kill: never pull a PTY out from under
+ * a pane still showing it), and two panes showing one session kill it once.
  * Removal applies to the machine's LAST workspace too: a workspace is a view of
  * terminals, and a view you cannot destroy is not a view. Zero workspaces is a
  * legal state — the middle view renders an empty state for it.
@@ -49,7 +53,7 @@ import {
   sessionWorkspaceId,
   type MachineNodeScope,
 } from '@/stores/machine-workspace/useMachineWorkspaceStore';
-import { useAgentTerminals } from '@/hooks/useAgentTerminals';
+import { useAgentTerminals, killAgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import { isAgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import type { MachineTreeNode } from './MachineTree';
@@ -115,29 +119,54 @@ export default function WorkspaceLeaves({
   }, []);
 
   const scope = nodeScopeOf(node);
-  // Every pane in a workspace runs in the WORKSPACE's own node scope (see
-  // newWorkspace), which is this node's scope — so one scoped hook covers
-  // every pane (and every server-reported session) this node could hold.
+  // Lists this node's server-reported sessions, and removes the unclaimed ones
+  // — both genuinely AT this node's scope. Kills of a workspace's panes go
+  // through `killAgentTerminal` instead: a pane's session scope can differ
+  // from its workspace's node scope (restored server layouts), and a DELETE
+  // under the wrong scope kills a different same-named terminal, or nothing.
   const { agentTerminals, removeAgentTerminal } = useAgentTerminals(machineId, scope.projectName, scope.branchName);
 
   if (!machine) return null;
 
   const workspaces = workspacesOf(machine).filter((workspace) => isSameNodeScope(workspace.scope, scope));
   const pendingWorkspace = workspaces.find((workspace) => workspace.id === pendingRemove);
-  const pendingRunningNames = pendingWorkspace
-    ? panesOf(pendingWorkspace)
-        .map((pane) => pane.scope?.name)
-        .filter((name): name is string => name !== undefined)
+  // What confirming the pending removal will actually stop: the workspace's
+  // panes' sessions, each addressed by the PANE's own scope, deduped by session
+  // identity (two panes can legitimately show one session — kill it once), and
+  // sparing any session a pane of ANOTHER workspace still shows — the same
+  // rule as TerminalPanes' close-and-kill, which must never pull a PTY out
+  // from under a pane still showing it.
+  const shownElsewhere = new Set(
+    workspacesOf(machine)
+      .filter((workspace) => workspace.id !== pendingWorkspace?.id)
+      .flatMap(panesOf)
+      .flatMap((pane) => (pane.scope ? [sessionWorkspaceId(pane.scope)] : [])),
+  );
+  const pendingKillScopes = pendingWorkspace
+    ? [
+        ...new Map(
+          panesOf(pendingWorkspace)
+            .flatMap((pane) => (pane.scope ? [pane.scope] : []))
+            .map((paneScope) => [sessionWorkspaceId(paneScope), paneScope] as const),
+        ),
+      ]
+        .filter(([id]) => !shownElsewhere.has(id))
+        .map(([, paneScope]) => paneScope)
     : [];
 
-  const localNames = new Set(
-    workspaces.flatMap((workspace) =>
-      panesOf(workspace)
-        .map((pane) => pane.scope?.name)
-        .filter((name): name is string => name !== undefined),
-    ),
+  // "Claimed" compares full session identity — the (project, branch, name)
+  // triple via `sessionWorkspaceId` — against every pane on the MACHINE, not
+  // pane names at this node alone: a same-named session at another checkout
+  // must not mask this one, and a session shown by a cross-scope pane in some
+  // other workspace is not unclaimed.
+  const localSessionIds = new Set(
+    workspacesOf(machine)
+      .flatMap(panesOf)
+      .flatMap((pane) => (pane.scope ? [sessionWorkspaceId(pane.scope)] : [])),
   );
-  const unclaimedSessions = agentTerminals.filter((terminal) => !localNames.has(terminal.name));
+  const unclaimedSessions = agentTerminals.filter(
+    (terminal) => !localSessionIds.has(sessionWorkspaceId({ ...scope, name: terminal.name })),
+  );
 
   const adopt = (name: string) => {
     openTerminal({ ...scope, name });
@@ -302,8 +331,8 @@ export default function WorkspaceLeaves({
         title="Remove workspace?"
         description={
           pendingWorkspace
-            ? pendingRunningNames.length > 0
-              ? `Remove workspace "${pendingWorkspace.name}"? This stops its ${pendingRunningNames.length} running agent${pendingRunningNames.length === 1 ? '' : 's'} — this cannot be undone.`
+            ? pendingKillScopes.length > 0
+              ? `Remove workspace "${pendingWorkspace.name}"? This stops its ${pendingKillScopes.length} running agent${pendingKillScopes.length === 1 ? '' : 's'} — this cannot be undone.`
               : `Remove workspace "${pendingWorkspace.name}"?`
             : ''
         }
@@ -311,8 +340,9 @@ export default function WorkspaceLeaves({
           if (pendingRemove === null) return;
           // Stop every running agent this workspace's panes hold BEFORE
           // dropping the local entry — otherwise the agent (and its billing)
-          // survives with no sidebar row left to reach it from.
-          await Promise.all(pendingRunningNames.map((name) => removeAgentTerminal(name)));
+          // survives with no sidebar row left to reach it from. Addressed by
+          // each pane's OWN scope (see pendingKillScopes' doc above).
+          await Promise.all(pendingKillScopes.map((paneScope) => killAgentTerminal(machineId, paneScope)));
           // Unconditional, including the machine's last workspace. This used to
           // branch: `removeWorkspace` no-op'd on the last one, so the row was
           // emptied in place instead — which left it in the sidebar, unremovable

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -38,6 +38,14 @@ function jsonResponse(body: unknown) {
   return { ok: true, json: async () => body };
 }
 
+/** A machine with one workspace open. `ensureMachine` alone no longer gets you
+ * there — it creates the entry and nothing else, since zero workspaces is a
+ * legal state rather than a blank view to repair. */
+function seedMachine(machineId: string) {
+  useMachineWorkspaceStore.getState().ensureMachine(machineId);
+  return useMachineWorkspaceStore.getState().createWorkspace(machineId);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   useMachineWorkspaceStore.setState({ machines: {} });
@@ -53,10 +61,13 @@ describe('useMachineWorkspaceSync', () => {
   // and persists across renderHook calls within a file, so reusing one id
   // across tests would silently serve an earlier test's cached response.
 
-  it('ensures the machine has a local default workspace on mount', async () => {
+  it('ensures the machine has an entry, and NO default workspace, on mount', async () => {
     renderHook(() => useMachineWorkspaceSync('m-default'));
 
-    expect(workspacesOf(selectMachine('m-default')(useMachineWorkspaceStore.getState()))).toHaveLength(1);
+    // Zero workspaces is a legal state — the middle view renders an empty state
+    // for it. Fabricating a default here is what made a removed row come back.
+    expect(selectMachine('m-default')(useMachineWorkspaceStore.getState())).toBeDefined();
+    expect(workspacesOf(selectMachine('m-default')(useMachineWorkspaceStore.getState()))).toHaveLength(0);
     // Let the in-flight SWR fetch/hydrate settle before the test tears down,
     // so its state update lands inside this test's act scope, not the next one's.
     await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
@@ -81,12 +92,17 @@ describe('useMachineWorkspaceSync', () => {
     expect(mockPost).not.toHaveBeenCalled();
   });
 
-  it('given the server reports NOT bootstrapped, POSTs this browser\'s local workspace to /bootstrap', async () => {
+  it('given the server reports NOT bootstrapped and this browser HAS local history, POSTs it to /bootstrap', async () => {
     mockFetchWithAuth.mockResolvedValue(jsonResponse({ bootstrapped: false, workspaces: [] }));
     mockPost.mockResolvedValue({
       claimed: true,
       workspaces: [{ id: 'ws-seeded', name: 'Seeded', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] }],
     });
+    // Local history to migrate — the whole reason the bootstrap claim exists.
+    // Without this the payload is empty and the claim is deliberately skipped
+    // (see the guard test below).
+    useMachineWorkspaceStore.getState().ensureMachine('m-unbootstrapped');
+    useMachineWorkspaceStore.getState().createWorkspace('m-unbootstrapped');
 
     renderHook(() => useMachineWorkspaceSync('m-unbootstrapped'));
 
@@ -99,6 +115,35 @@ describe('useMachineWorkspaceSync', () => {
     await waitFor(() => {
       const machine = selectMachine('m-unbootstrapped')(useMachineWorkspaceStore.getState());
       expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-seeded']);
+    });
+  });
+
+  it('given NOT bootstrapped but nothing local to seed, does NOT claim — it hydrates from the server instead', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: false,
+        workspaces: [
+          { id: 'ws-theirs', name: 'Theirs', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+        ],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-empty-bootstrap'));
+
+    // Claiming with an empty list would burn first-writer-wins for nothing and
+    // permanently discard the un-migrated history of a browser that HAS some.
+    // Now that ensureMachine no longer fabricates a workspace, the Development
+    // sidebar (which mounts this hook per machine row) would otherwise fire an
+    // empty claim at every machine in the drive on render.
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    expect(mockPost).not.toHaveBeenCalled();
+
+    // ...but it must still HYDRATE: the normal hydrate path is gated on
+    // `bootstrapped`, so skipping both would strand this browser on an empty
+    // machine while the server holds real rows.
+    await waitFor(() => {
+      const machine = selectMachine('m-empty-bootstrap')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-theirs']);
     });
   });
 
@@ -314,7 +359,7 @@ describe('useSyncedWorkspaceActions', () => {
   });
 
   it('removeWorkspace removes locally, then DELETEs it', () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const machine = selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState())!;
     useMachineWorkspaceStore.getState().createWorkspace(MACHINE_ID);
     const second = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[1];
@@ -335,7 +380,7 @@ describe('useSyncedWorkspaceActions', () => {
   });
 
   it('splitRight PATCHes the resulting layout via fetchWithAuth; on a real 404 status it falls back to POST-create', async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     mockFetchWithAuth.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({ error: 'not_found' }) });
 
@@ -354,7 +399,7 @@ describe('useSyncedWorkspaceActions', () => {
   });
 
   it('splitRight does NOT fall back to POST when the PATCH fails for a status OTHER than 404 — a real HTTP status check, not string-matching the error text', async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     mockFetchWithAuth.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({ error: 'error' }) });
 
@@ -373,7 +418,7 @@ describe('useSyncedWorkspaceActions', () => {
   });
 
   it('splitRight does NOT fall back to POST when the PATCH succeeds', async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
 
@@ -394,7 +439,7 @@ describe('useSyncedWorkspaceActions', () => {
   // the rename. Sending only the field this action actually changed closes
   // that hole.
   it('splitRight PATCHes columns only — the rename it never touched is not sent', async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
 
@@ -417,17 +462,18 @@ describe('useSyncedWorkspaceActions', () => {
   // EARLIER request resolving after a later one could leave the server at an
   // intermediate state. `closePanes` applies every local close first, then
   // pushes exactly once, so only the final result ever reaches the server.
-  it('closePanes closes every pane locally, then PATCHes exactly once with the final layout', async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+  it('closePane on a pane with siblings PATCHes the remaining layout', async () => {
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     useMachineWorkspaceStore.getState().splitRight(MACHINE_ID, workspace.id, workspace.activePaneId);
     const withSplit = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     const paneIds = withSplit.columns.flatMap((column) => column.panes.map((pane) => pane.id));
     expect(paneIds).toHaveLength(2);
+    mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
 
     const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
     act(() => {
-      result.current.closePanes(workspace.id, paneIds);
+      result.current.closePane(workspace.id, paneIds[1]);
     });
 
     const final = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
@@ -436,13 +482,33 @@ describe('useSyncedWorkspaceActions', () => {
     await waitFor(() => {
       const patchCalls = mockFetchWithAuth.mock.calls.filter(([, opts]) => opts?.method === 'PATCH');
       expect(patchCalls).toHaveLength(1);
-      const body = JSON.parse(patchCalls[0][1].body);
-      expect(body.columns.flatMap((column: { panes: unknown[] }) => column.panes)).toHaveLength(1);
     });
+    expect(mockDel).not.toHaveBeenCalled();
+  });
+
+  it('closePane on the LAST pane DELETEs the workspace and never PATCHes it', async () => {
+    seedMachine(MACHINE_ID);
+    const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
+
+    const { result } = renderHook(() => useSyncedWorkspaceActions(MACHINE_ID));
+    act(() => {
+      result.current.closePane(workspace.id, workspace.activePaneId);
+    });
+
+    expect(workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))).toHaveLength(0);
+    await waitFor(() => expect(mockDel).toHaveBeenCalledWith(expect.stringContaining(`workspaceId=${workspace.id}`)));
+
+    // THE LANDMINE: pushWorkspaceUpdate PATCHes and falls back to POST-create on
+    // a 404. A layout PATCH for the workspace this very call removed would 404
+    // and RE-CREATE it server-side, broadcasting the resurrected row back to
+    // every browser — including the one whose user just closed it.
+    const patchCalls = mockFetchWithAuth.mock.calls.filter(([, opts]) => opts?.method === 'PATCH');
+    expect(patchCalls).toHaveLength(0);
+    expect(mockPost).not.toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ id: workspace.id }));
   });
 
   it("renameWorkspace PATCHes name only — the layout it never touched is not sent", async () => {
-    useMachineWorkspaceStore.getState().ensureMachine(MACHINE_ID);
+    seedMachine(MACHINE_ID);
     const workspace = workspacesOf(selectMachine(MACHINE_ID)(useMachineWorkspaceStore.getState()))[0];
     mockFetchWithAuth.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ workspace: {} }) });
 

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -147,6 +147,47 @@ describe('useMachineWorkspaceSync', () => {
     });
   });
 
+  // Regression (Codex P2): the empty-payload non-claim hydrate above must stay
+  // PROVISIONAL. If it set `hydratedOnce`, a browser with no local history
+  // opening an unclaimed machine would ignore the `bootstrapped` broadcast
+  // fired when ANOTHER browser (with real un-migrated history) later wins the
+  // claim — the seeded workspaces arrive ONLY over that broadcast, so the
+  // first browser would sit on the unclaimed list until a remount.
+  it('given an empty non-claim hydrate, a LATER bootstrapped broadcast (another browser winning the claim) still applies', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: false,
+        workspaces: [
+          { id: 'ws-theirs', name: 'Theirs', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+        ],
+      }),
+    );
+
+    renderHook(() => useMachineWorkspaceSync('m-empty-then-claimed'));
+    // The provisional hydrate has demonstrably run (the unclaimed row landed),
+    // and no claim was burned for an empty payload.
+    await waitFor(() => {
+      const machine = selectMachine('m-empty-then-claimed')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-theirs']);
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+
+    act(() => {
+      mockSocket.current!._trigger('machine-workspace:bootstrapped', {
+        machineId: 'm-empty-then-claimed',
+        // bootstrapSeed re-selects ALL rows post-seed, so the broadcast carries
+        // the full canonical list — pre-existing rows included.
+        workspaces: [
+          { id: 'ws-theirs', name: 'Theirs', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+          { id: 'ws-migrated', name: 'Migrated', scope: {}, columns: [{ id: 'col-2', panes: [{ id: 'pane-2', scope: null }] }] },
+        ],
+      });
+    });
+
+    const machine = selectMachine('m-empty-then-claimed')(useMachineWorkspaceStore.getState());
+    expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-theirs', 'ws-migrated']);
+  });
+
   it('given a machine-workspace:created event for a DIFFERENT machine, ignores it', async () => {
     renderHook(() => useMachineWorkspaceSync('m-filter'));
     await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -188,6 +188,36 @@ describe('useMachineWorkspaceSync', () => {
     expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-theirs', 'ws-migrated']);
   });
 
+  // Regression: this hook is mounted more than once for the same machine
+  // (DevelopmentSidebar mounts it per machine row AND MachineView for the open
+  // machine), and the instances share one store. On an unclaimed machine with
+  // server rows, instance 1's empty-payload hydrate writes those rows into the
+  // store — so instance 2's effect reads a NON-empty local list and, without
+  // the module-level decline registry, would POST a bootstrap claim that
+  // merely echoes the server's own rows: burning first-writer-wins on nothing
+  // and permanently foreclosing a legacy browser's real history migration.
+  it('given TWO mounted instances and an unclaimed machine with server rows, neither claims the bootstrap with an echo of those rows', async () => {
+    mockFetchWithAuth.mockResolvedValue(
+      jsonResponse({
+        bootstrapped: false,
+        workspaces: [
+          { id: 'ws-theirs', name: 'Theirs', scope: {}, columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }] },
+        ],
+      }),
+    );
+
+    renderHook(() => {
+      useMachineWorkspaceSync('m-dual-mount');
+      useMachineWorkspaceSync('m-dual-mount');
+    });
+
+    await waitFor(() => {
+      const machine = selectMachine('m-dual-mount')(useMachineWorkspaceStore.getState());
+      expect(workspacesOf(machine).map((w) => w.id)).toEqual(['ws-theirs']);
+    });
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
   it('given a machine-workspace:created event for a DIFFERENT machine, ignores it', async () => {
     renderHook(() => useMachineWorkspaceSync('m-filter'));
     await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());

--- a/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
+++ b/apps/web/src/hooks/__tests__/useMachineWorkspaceSync.test.ts
@@ -29,7 +29,12 @@ vi.mock('@/hooks/usePageSocketRoom', () => ({
   usePageSocketRoom: vi.fn(),
 }));
 
-import { useMachineWorkspaceStore, selectMachine, workspacesOf } from '@/stores/machine-workspace/useMachineWorkspaceStore';
+import {
+  useMachineWorkspaceStore,
+  selectMachine,
+  sessionWorkspaceId,
+  workspacesOf,
+} from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { useMachineWorkspaceSync, useSyncedWorkspaceActions } from '../useMachineWorkspaceSync';
 
 const MACHINE_ID = 'm1';
@@ -576,6 +581,70 @@ describe('useSyncedWorkspaceActions', () => {
     const patchCalls = mockFetchWithAuth.mock.calls.filter(([, opts]) => opts?.method === 'PATCH');
     expect(patchCalls).toHaveLength(0);
     expect(mockPost).not.toHaveBeenCalledWith('/api/machines/workspaces', expect.objectContaining({ id: workspace.id }));
+  });
+
+  // Regression (CodeRabbit): pushRemoval used to swallow a failed DELETE
+  // outright — the server row survived, and the next full hydrate resurrected
+  // the locally removed workspace. Unlike a layout PATCH, a removal has no
+  // "next push" to reconcile through, so the bounded retry IS the
+  // reconciliation.
+  it('removeWorkspace retries a transiently failed DELETE, and stops once it succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      useMachineWorkspaceStore.getState().ensureMachine('m-retry');
+      const id = useMachineWorkspaceStore.getState().createWorkspace('m-retry');
+      mockDel.mockRejectedValueOnce(new Error('network'));
+
+      const { result } = renderHook(() => useSyncedWorkspaceActions('m-retry'));
+      act(() => {
+        result.current.removeWorkspace(id);
+      });
+      expect(mockDel).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+      });
+      expect(mockDel).toHaveBeenCalledTimes(2);
+
+      // The second attempt succeeded — nothing further is scheduled.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockDel).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a pending removal retry is ABANDONED if the user re-materializes the same workspace id', async () => {
+    vi.useFakeTimers();
+    try {
+      useMachineWorkspaceStore.getState().ensureMachine('m-revive');
+      // A session-derived workspace: its id is DETERMINISTIC
+      // (`sessionWorkspaceId`), so re-opening the same session re-creates the
+      // SAME id — the case a stale retry would delete out from under the user.
+      useMachineWorkspaceStore.getState().openTerminal('m-revive', { name: 's1' });
+      const id = sessionWorkspaceId({ name: 's1' });
+      mockDel.mockRejectedValue(new Error('network'));
+
+      const { result } = renderHook(() => useSyncedWorkspaceActions('m-revive'));
+      act(() => {
+        result.current.removeWorkspace(id);
+      });
+      expect(mockDel).toHaveBeenCalledTimes(1);
+
+      // The user re-opens the session before the retry fires.
+      act(() => {
+        useMachineWorkspaceStore.getState().openTerminal('m-revive', { name: 's1' });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+      expect(mockDel).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("renameWorkspace PATCHes name only — the layout it never touched is not sent", async () => {

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -43,6 +43,18 @@ function buildQuery(machineId: string, projectName?: string | null, branchName?:
  * scope would kill a different terminal that happens to share the name — or
  * nothing — while the intended one lives on as an unclaimed session.
  *
+ * A 404 is SUCCESS here, not a failure: it means the session — or the
+ * project/branch checkout that held it — is already gone server-side, which is
+ * this call's goal state. Treating it as an error made a workspace holding a
+ * stale pane permanently unremovable: the kill rejected, the confirm dialog
+ * stayed open, and retrying hit the same 404 forever — an unremovable listing,
+ * the exact bug class this surface exists to kill. Real failures (5xx,
+ * network) still throw: the agent may genuinely still be running (and
+ * billing), and silently dropping its only row would strand it. Reading the
+ * status needs `fetchWithAuth` directly — the `del()` helper throws a plain
+ * `Error` with no status attached (see `pushWorkspaceUpdate`'s doc in
+ * useMachineWorkspaceSync for the same choice).
+ *
  * Revalidates the killed scope's list afterwards so any mounted hook on that
  * scope (e.g. the sidebar's session rows) drops the dead row.
  */
@@ -51,7 +63,14 @@ export async function killAgentTerminal(
   scope: { projectName?: string | null; branchName?: string | null; name: string },
 ): Promise<void> {
   const query = buildQuery(machineId, scope.projectName, scope.branchName);
-  await del(`/api/machines/agent-terminals?${query}&name=${encodeURIComponent(scope.name)}`);
+  const response = await fetchWithAuth(
+    `/api/machines/agent-terminals?${query}&name=${encodeURIComponent(scope.name)}`,
+    { method: 'DELETE' },
+  );
+  if (!response.ok && response.status !== 404) {
+    const body: { error?: unknown } | null = await response.json().catch(() => null);
+    throw new Error(typeof body?.error === 'string' ? body.error : 'Failed to remove terminal');
+  }
   await mutate(`/api/machines/agent-terminals?${query}`);
 }
 

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback } from 'react';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 
@@ -29,6 +29,30 @@ function buildQuery(machineId: string, projectName?: string | null, branchName?:
   if (projectName) params.set('projectName', projectName);
   if (branchName) params.set('branchName', branchName);
   return params.toString();
+}
+
+/**
+ * Kills a session addressed by its OWN (project, branch, name) scope — the
+ * session's real identity (`machine_agent_terminals`' unique index).
+ *
+ * The hook's `removeAgentTerminal` below DELETEs under whatever scope the hook
+ * instance was mounted with — right for undoing a spawn that same instance
+ * just made, wrong for killing an arbitrary pane's session: a pane's scope can
+ * differ from its workspace's (a restored server layout can hold panes bound
+ * at other checkouts), and DELETEing that pane's `name` under the WORKSPACE's
+ * scope would kill a different terminal that happens to share the name — or
+ * nothing — while the intended one lives on as an unclaimed session.
+ *
+ * Revalidates the killed scope's list afterwards so any mounted hook on that
+ * scope (e.g. the sidebar's session rows) drops the dead row.
+ */
+export async function killAgentTerminal(
+  machineId: string,
+  scope: { projectName?: string | null; branchName?: string | null; name: string },
+): Promise<void> {
+  const query = buildQuery(machineId, scope.projectName, scope.branchName);
+  await del(`/api/machines/agent-terminals?${query}&name=${encodeURIComponent(scope.name)}`);
+  await mutate(`/api/machines/agent-terminals?${query}`);
 }
 
 /**

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -71,7 +71,11 @@ export async function killAgentTerminal(
     const body: { error?: unknown } | null = await response.json().catch(() => null);
     throw new Error(typeof body?.error === 'string' ? body.error : 'Failed to remove terminal');
   }
-  await mutate(`/api/machines/agent-terminals?${query}`);
+  // Fire-and-forget: the kill has already succeeded by this point, and a
+  // transient failure of the list REFETCH must not turn a completed teardown
+  // into a rejection — that would keep the remove-workspace dialog open (and
+  // fail closePaneAndKill's catch path) over a session that is already dead.
+  void mutate(`/api/machines/agent-terminals?${query}`).catch(() => {});
 }
 
 /**

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -121,7 +121,6 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
     }
 
     if (bootstrapAttempted.current) return;
-    bootstrapAttempted.current = true;
 
     const local = useMachineWorkspaceStore.getState().machines[machineId];
     const payload = (local ? workspacesOf(local) : []).map((workspace) => ({
@@ -130,6 +129,25 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
       scope: workspace.scope,
       columns: toWireColumns(workspace.columns),
     }));
+
+    // Nothing local to seed — so claim nothing. Bootstrap is first-writer-wins
+    // (one row per machine, PK machineId): claiming with an empty list would
+    // burn the claim and permanently discard the un-migrated history of a
+    // browser that DOES have some. This matters now that `ensureMachine` no
+    // longer fabricates a Workspace 1: the Development sidebar mounts this hook
+    // per machine row, so merely rendering it would otherwise fire an empty
+    // claim at every machine in the drive before the user opens any of them.
+    //
+    // Must HYDRATE, not just skip the POST: the hydrate above is gated on
+    // `data.bootstrapped`, so returning without one would leave this browser
+    // showing an empty machine while the server holds real rows.
+    if (payload.length === 0) {
+      hydratedOnce.current = true;
+      hydrateFromServer(machineId, data.workspaces);
+      return;
+    }
+
+    bootstrapAttempted.current = true;
 
     post<BootstrapResponse>('/api/machines/workspaces/bootstrap', { machineId, workspaces: payload })
       .then((res) => {
@@ -367,21 +385,15 @@ export function useSyncedWorkspaceActions(machineId: string) {
       splitDownLocal(machineId, workspaceId, fromPaneId);
       void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
     },
+    /** Closing the last pane removes the whole workspace, and that case must
+     * DELETE, not PATCH: `pushWorkspaceUpdate` falls back to POST-create on a
+     * 404, so PATCHing a workspace this very call just removed would RE-CREATE
+     * it server-side and broadcast the resurrected row back to every browser —
+     * including the one whose user just closed it. */
     closePane(workspaceId: string, paneId: string): void {
-      closePaneLocal(machineId, workspaceId, paneId);
-      void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
-    },
-    /** Closes several panes of the SAME workspace as one push, not one PATCH per
-     * pane — e.g. emptying every running pane when removing the machine's only
-     * remaining workspace. `closePane` in a loop would fire N independent
-     * fire-and-forget PATCHes with no ordering guarantee: a slower EARLIER
-     * request resolving after a later one could leave the server's layout at
-     * an intermediate (still-bound-to-a-just-killed-agent) state instead of
-     * the final fully-emptied one. Applying every local close first, then
-     * pushing once, means the single PATCH always carries the final result. */
-    closePanes(workspaceId: string, paneIds: string[]): void {
-      paneIds.forEach((paneId) => closePaneLocal(machineId, workspaceId, paneId));
-      if (paneIds.length > 0) void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
+      const removedWorkspace = closePaneLocal(machineId, workspaceId, paneId);
+      if (removedWorkspace) pushRemoval(machineId, workspaceId);
+      else void pushWorkspaceUpdate(machineId, workspaceId, { columns: true });
     },
     bindPaneTerminal(workspaceId: string, paneId: string, scope: OpenTerminalScope, pendingPrompt?: string): boolean {
       const bound = bindPaneTerminalLocal(machineId, workspaceId, paneId, scope, pendingPrompt);

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -366,10 +366,29 @@ async function pushWorkspaceUpdate(machineId: string, workspaceId: string, chang
   }).catch(() => {});
 }
 
-function pushRemoval(machineId: string, workspaceId: string): void {
+/** Fire-and-forget DELETE with bounded retries. Removal is optimistic like
+ * every other push here (the local grid already updated), but unlike a layout
+ * PATCH there is no "next push" to reconcile a transient failure — so this IS
+ * the reconciliation. If every attempt fails, the server row survives and the
+ * next full hydrate resurrects the row locally: visible and annoying, but
+ * recoverable (remove it again) — whereas rolling the local removal back would
+ * restore a grid whose PTYs were already killed, a strictly worse dead-pane
+ * state. Each retry first checks the workspace is STILL locally removed:
+ * session-derived workspace ids are deterministic (`sessionWorkspaceId`), so
+ * the user re-opening that session re-materializes the SAME id, and a stale
+ * retry would delete the new incarnation out from under them. A 404 also lands
+ * in the catch (`del()` hides the status) when another browser already removed
+ * the row — the capped retries just expire against it harmlessly. */
+function pushRemoval(machineId: string, workspaceId: string, attempt = 0): void {
   del(
     `/api/machines/workspaces?machineId=${encodeURIComponent(machineId)}&workspaceId=${encodeURIComponent(workspaceId)}`
-  ).catch(() => {});
+  ).catch(() => {
+    if (attempt >= 2) return;
+    setTimeout(() => {
+      const revived = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
+      if (!revived) pushRemoval(machineId, workspaceId, attempt + 1);
+    }, 1500 * (attempt + 1));
+  });
 }
 
 /**

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -52,6 +52,22 @@ const fetcher = (url: string) =>
     return res.json() as Promise<WorkspaceListResponse>;
   });
 
+/**
+ * Machines where this browser session already decided "nothing local to
+ * migrate — claim nothing" (the empty-payload branch below). MODULE-level, not
+ * a per-instance ref, because this hook is mounted more than once for the same
+ * machine (`DevelopmentSidebar` mounts it per machine row AND `MachineView`
+ * mounts it for the open machine) and the instances share one store: on an
+ * unbootstrapped machine whose server list is non-empty, instance 1's
+ * empty-payload hydrate writes the server's rows INTO the store, so instance
+ * 2's effect would then read a non-empty local list and POST a bootstrap claim
+ * that merely echoes the server's own rows back at it — burning the
+ * first-writer-wins claim on nothing, which permanently forecloses a legacy
+ * browser's real un-migrated history. Exactly what the empty-payload guard
+ * exists to prevent, so the decision has to be visible across instances.
+ */
+const declinedBootstraps = new Set<string>();
+
 /** Strips local-only pane state (`pendingPrompt`) before a layout crosses the
  * wire — the server's layout DTO has no such field, and a starting prompt not
  * yet typed into its PTY must never be persisted or broadcast to other browsers. */
@@ -155,9 +171,16 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
     // local list is empty, so the full-list replace cannot wipe anything, and a
     // later `bootstrapped: true` revalidation (a missed broadcast) re-enters
     // the hydrate above instead of being gated out.
-    if (payload.length === 0) {
+    if (payload.length === 0 || declinedBootstraps.has(machineId)) {
       bootstrapAttempted.current = true;
-      hydrateFromServer(machineId, data.workspaces);
+      // Only the FIRST decliner applies the provisional hydrate. A later
+      // instance (or a later effect run) re-applying it with SWR's possibly
+      // STALE cached list would full-replace away workspaces that arrived over
+      // the socket since — the store is already current; leave it alone.
+      if (!declinedBootstraps.has(machineId)) {
+        declinedBootstraps.add(machineId);
+        hydrateFromServer(machineId, data.workspaces);
+      }
       return;
     }
 

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -83,9 +83,11 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
   const socket = useSocket();
   usePageSocketRoom(machineId ?? undefined);
 
-  // Guards against retrying the bootstrap POST on every SWR revalidation once
-  // this browser has already tried it for this machine — not against the
-  // cross-browser race, which the server's claim table (not this ref) resolves.
+  // Records that this browser has made its one bootstrap decision for this
+  // machine — either it POSTed a claim, or it had nothing local to migrate and
+  // deliberately declined to (the empty-payload branch below). Guards against
+  // re-deciding on every SWR revalidation — not against the cross-browser
+  // race, which the server's claim table (not this ref) resolves.
   const bootstrapAttempted = useRef(false);
 
   // `hydrateFromServer` is a FULL-LIST replace that deliberately drops any
@@ -141,8 +143,20 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
     // Must HYDRATE, not just skip the POST: the hydrate above is gated on
     // `data.bootstrapped`, so returning without one would leave this browser
     // showing an empty machine while the server holds real rows.
+    //
+    // And the hydrate must stay PROVISIONAL — it marks the bootstrap decision
+    // (`bootstrapAttempted`: nothing to migrate, ever), NOT `hydratedOnce`.
+    // Not claiming means another browser WITH history can still win the claim
+    // later, and its seeded list arrives only as a
+    // `machine-workspace:bootstrapped` broadcast — which `onBootstrapped`
+    // ignores once `hydratedOnce` is set. Marking this hydrate final would
+    // strand this browser on the unclaimed (usually empty) list until remount.
+    // Leaving `hydratedOnce` unset here is safe: this branch only runs when the
+    // local list is empty, so the full-list replace cannot wipe anything, and a
+    // later `bootstrapped: true` revalidation (a missed broadcast) re-enters
+    // the hydrate above instead of being gated out.
     if (payload.length === 0) {
-      hydratedOnce.current = true;
+      bootstrapAttempted.current = true;
       hydrateFromServer(machineId, data.workspaces);
       return;
     }

--- a/apps/web/src/lib/development/pending-workspace.ts
+++ b/apps/web/src/lib/development/pending-workspace.ts
@@ -54,7 +54,10 @@ export function resolvePendingWorkspace(
   // user is en route. Holding is safe — see the note above on what clears it.
   if (pending.machineId !== selectedMachineId) return { type: 'wait' };
 
-  // On the machine, but its pane region hasn't mounted (and ensured a workspace set).
+  // On the machine, but its pane region hasn't mounted yet. Note `''` (a machine
+  // with no workspaces open) is NOT this case: that machine is mounted and has
+  // simply nothing active, so the intent falls through to `select` below and is
+  // held — harmlessly, per the note above — until the user opens a view.
   if (activeWorkspaceId === undefined) return { type: 'wait' };
 
   // Satisfied: the workspace is already the one on screen.

--- a/apps/web/src/lib/development/use-drain-pending-workspace.ts
+++ b/apps/web/src/lib/development/use-drain-pending-workspace.ts
@@ -27,9 +27,10 @@ export function useDrainPendingWorkspace(displayedMachineId: string | null) {
   const clearPending = usePendingWorkspaceStore((state) => state.clearPending);
   const setActiveWorkspace = useMachineWorkspaceStore((state) => state.setActiveWorkspace);
   // The machine's current `activeWorkspaceId` — undefined until its pane region
-  // has mounted and ensured a workspace set. A machine now holds many
-  // workspaces (each sidebar item owns one), and the intent converges when this
-  // matches the one the user clicked.
+  // has mounted, and `''` for a machine with no workspaces open (a legal state:
+  // the grid renders its empty state). A machine holds many workspaces (each
+  // sidebar item owns one), and the intent converges when this matches the one
+  // the user clicked.
   const activeWorkspaceId = useMachineWorkspaceStore((state) =>
     pending ? selectMachine(pending.machineId)(state)?.activeWorkspaceId : undefined,
   );

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -10,11 +10,20 @@ import {
   panesOf,
   type WorkspaceState,
 } from '../useMachineWorkspaceStore';
-import { workspacesOf, sessionWorkspaceId } from '../workspace-reducer';
+import { workspacesOf, sessionWorkspaceId, newWorkspace } from '../workspace-reducer';
 
 const store = () => useMachineWorkspaceStore.getState();
 const activeOf = (machineId: string) => selectActiveWorkspace(machineId)(store());
 const paneIds = (workspace: WorkspaceState | undefined) => (workspace ? panesOf(workspace).map((pane) => pane.id) : []);
+
+/** A machine with one workspace open — the state most of these tests want to
+ * start from. `ensureMachine` alone no longer gets you there: it creates the
+ * machine's ENTRY and nothing else, because zero workspaces is a legal state and
+ * fabricating a first one is exactly the bug this store used to have. */
+const seedMachine = (machineId: string) => {
+  store().ensureMachine(machineId);
+  return store().createWorkspace(machineId);
+};
 
 const BRANCH_SCOPE = { projectName: 'app', branchName: 'main' };
 const SESSION = { ...BRANCH_SCOPE, name: 'claude-a1b2c3' };
@@ -25,11 +34,27 @@ describe('useMachineWorkspaceStore', () => {
     useMachineWorkspaceStore.setState({ machines: {} });
   });
 
-  it('given a machine is ensured, should give it one workspace, active, holding one empty pane', () => {
+  it('given a machine is ensured, should give it an entry with NO workspaces', () => {
     store().ensureMachine('m1');
 
     assert({
       given: 'a Machine page mounting for the first time',
+      should:
+        'create the entry and open nothing — a machine with no terminals is a legal state, and fabricating a first workspace here is what made a removed row come straight back',
+      actual: {
+        hasEntry: selectMachine('m1')(store()) !== undefined,
+        workspaces: workspacesOf(selectMachine('m1')(store())).length,
+        active: selectMachine('m1')(store())?.activeWorkspaceId,
+      },
+      expected: { hasEntry: true, workspaces: 0, active: '' },
+    });
+  });
+
+  it('given a workspace created after ensureMachine, should auto-name it Workspace 1 with one empty pane', () => {
+    seedMachine('m1');
+
+    assert({
+      given: 'the user opening the first terminal on a fresh machine',
       should: 'open one auto-named workspace with a single empty pane — which is the agent picker',
       actual: {
         workspaces: workspacesOf(selectMachine('m1')(store())).length,
@@ -42,7 +67,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given ensureMachine twice, should not reset the workspaces it already has', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     store().splitRight('m1', activeOf('m1')!.id, activeOf('m1')!.activePaneId);
     const before = activeOf('m1');
 
@@ -56,12 +81,27 @@ describe('useMachineWorkspaceStore', () => {
     });
   });
 
+  it('given ensureMachine over a machine the user emptied, should NOT re-create a workspace', () => {
+    const onlyId = seedMachine('m1');
+    store().removeWorkspace('m1', onlyId);
+
+    store().ensureMachine('m1');
+
+    assert({
+      given: 'a re-mount (tab switch, re-render) after the user removed the last view',
+      should:
+        'leave it empty — re-fabricating here would make the last row impossible to remove, since every mount would put it back',
+      actual: workspacesOf(selectMachine('m1')(store())).length,
+      expected: 0,
+    });
+  });
+
   // ---------------------------------------------------------------------
   // THE FIX: selecting a workspace switches the entire middle view.
   // ---------------------------------------------------------------------
 
   it('given a second workspace is selected, should switch the WHOLE middle view to its grid', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const first = activeOf('m1')!;
     // Give the first workspace a two-pane split, so the two grids differ.
     store().splitRight('m1', first.id, first.activePaneId);
@@ -93,7 +133,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given a split, should add the pane to the ACTIVE workspace only', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const firstId = activeOf('m1')!.id;
     const secondId = store().createWorkspace('m1');
 
@@ -111,8 +151,8 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given two machines, should keep their workspaces independent', () => {
-    store().ensureMachine('m1');
-    store().ensureMachine('m2');
+    seedMachine('m1');
+    seedMachine('m2');
     store().createWorkspace('m1');
 
     assert({
@@ -131,7 +171,7 @@ describe('useMachineWorkspaceStore', () => {
   // ---------------------------------------------------------------------
 
   it('given an existing session is opened, should switch the view to that session’s own workspace', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const firstId = activeOf('m1')!.id;
 
     store().openTerminal('m1', SESSION);
@@ -157,7 +197,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given a session re-opened after panes were split into its workspace, should restore that grid', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     store().openTerminal('m1', SESSION);
     const sessionWorkspace = activeOf('m1')!;
     store().splitRight('m1', sessionWorkspace.id, sessionWorkspace.activePaneId);
@@ -178,7 +218,7 @@ describe('useMachineWorkspaceStore', () => {
   // ---------------------------------------------------------------------
 
   it('given a spawn resolves, should bind the session and its starting prompt to the pane it was picked in', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     const paneId = workspace.activePaneId;
 
@@ -194,7 +234,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given the user switches workspace while a spawn is in flight, should still bind it to the pane it was picked in', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     const paneId = workspace.activePaneId;
 
@@ -217,7 +257,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given the pane is gone when the spawn resolves, should report the bind failed', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
 
     const bound = store().bindPaneTerminal('m1', workspace.id, 'closed-pane', SESSION);
@@ -232,7 +272,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given a prompt was typed into the PTY, should clear it so a re-mount does not retype it', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, SESSION, 'fix the build');
 
@@ -262,7 +302,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given a session whose pane was closed, should show it again when its row is clicked', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     store().openTerminal('m1', SESSION);
     const workspace = activeOf('m1')!;
     // The user splits, then closes the pane the session was opened in.
@@ -280,9 +320,26 @@ describe('useMachineWorkspaceStore', () => {
     });
   });
 
-  it('given a persisted machine whose active workspace is missing, should repair it instead of rendering nothing', () => {
+  it('given a persisted machine whose active workspace is missing, should re-target the active id', () => {
     // What a bad rehydrate (or a future shape change) can leave behind: the key
     // exists, but the workspace it points at does not.
+    const workspace = { ...newWorkspace({ id: 'ws-real', name: 'W', scope: {}, firstPaneId: 'p1' }) };
+    useMachineWorkspaceStore.setState({
+      machines: { m1: { workspaces: { 'ws-real': workspace }, order: ['ws-real'], activeWorkspaceId: 'gone' } },
+    });
+
+    store().ensureMachine('m1');
+
+    assert({
+      given: 'a machine whose active workspace does not resolve, but which HAS workspaces',
+      should:
+        'point active at one that exists — a dangling id renders nothing, and there is no way for a user to clear this storage from inside the app',
+      actual: activeOf('m1')?.id,
+      expected: 'ws-real',
+    });
+  });
+
+  it('given a persisted machine with a dangling active id and NO workspaces, should settle on nothing active', () => {
     useMachineWorkspaceStore.setState({
       machines: { m1: { workspaces: {}, order: [], activeWorkspaceId: 'gone' } },
     });
@@ -290,30 +347,32 @@ describe('useMachineWorkspaceStore', () => {
     store().ensureMachine('m1');
 
     assert({
-      given: 'a machine whose active workspace does not resolve',
-      should:
-        'rebuild it — skipping on the mere presence of the key would leave the Machine page blank forever, with no way for a user to clear this storage from inside the app',
-      actual: { hasActive: activeOf('m1') !== undefined, panes: paneIds(activeOf('m1')).length },
-      expected: { hasActive: true, panes: 1 },
+      given: 'a machine whose active id dangles over an empty workspace list',
+      should: "repair to '' — the empty state renders for this, so there is nothing to fabricate",
+      actual: selectMachine('m1')(store())?.activeWorkspaceId,
+      expected: '',
     });
   });
 
-  it('given the last workspace, should refuse to remove it', () => {
-    store().ensureMachine('m1');
-    const onlyId = activeOf('m1')!.id;
+  it('given the last workspace, should remove it and leave nothing active', () => {
+    const onlyId = seedMachine('m1');
 
     store().removeWorkspace('m1', onlyId);
 
     assert({
       given: 'the only workspace a machine has',
-      should: 'keep it — the middle view has to render something',
-      actual: activeOf('m1')?.id,
-      expected: onlyId,
+      should:
+        'remove it — refusing here is what left an unremovable row in the sidebar that New terminal then duplicated',
+      actual: {
+        active: selectMachine('m1')(store())?.activeWorkspaceId,
+        count: workspacesOf(selectMachine('m1')(store())).length,
+      },
+      expected: { active: '', count: 0 },
     });
   });
 
   it('given a removed workspace, should show a neighbour', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const firstId = activeOf('m1')!.id;
     const secondId = store().createWorkspace('m1');
 
@@ -350,7 +409,7 @@ describe('useMachineWorkspaceStore', () => {
     );
 
     useMachineWorkspaceStore.persist.rehydrate();
-    store().ensureMachine('m1');
+    seedMachine('m1');
 
     assert({
       given: "a returning user whose stored workspaces were written by an older, incompatible version",
@@ -398,7 +457,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given a session SPAWNED into a workspace, should open it where it actually lives', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     // Split-and-pick: the agent was bound into a pane of THIS workspace, so it
     // has no workspace of its own.
@@ -420,7 +479,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given agents spawned into a workspace, should expose them as CHILD sessions, not sidebar rows', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     // One session opened from the sidebar (its own workspace), one spawned into it.
     store().openTerminal('m1', SESSION);
@@ -451,7 +510,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given the same state read twice, selectChildSessionIds should hand back the SAME set', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, SESSION);
 
@@ -475,7 +534,7 @@ describe('useMachineWorkspaceStore', () => {
   // ---------------------------------------------------------------------
 
   it('given renameWorkspace, should rename only the named workspace', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
 
     store().renameWorkspace('m1', workspace.id, 'Renamed');
@@ -502,7 +561,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given hydrateFromServer for an already-open workspace, should preserve local focus', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const workspace = activeOf('m1')!;
     store().splitRight('m1', workspace.id, workspace.activePaneId);
     const afterSplit = activeOf('m1')!;
@@ -522,7 +581,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given applyServerUpsert for an unseen workspace id, should add it', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const existing = activeOf('m1')!;
 
     store().applyServerUpsert('m1', {
@@ -541,7 +600,7 @@ describe('useMachineWorkspaceStore', () => {
   });
 
   it('given applyServerDelete for the active workspace, should show a neighbour', () => {
-    store().ensureMachine('m1');
+    seedMachine('m1');
     const first = activeOf('m1')!;
     const secondId = store().createWorkspace('m1');
     store().setActiveWorkspace('m1', secondId);

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -3,7 +3,6 @@ import { assert } from '@/stores/__tests__/riteway';
 import { isValidAgentTerminalName, AGENT_LAUNCH_SPECS } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   newWorkspace,
-  initialMachineWorkspaces,
   addWorkspace,
   setActiveWorkspace,
   updateWorkspace,
@@ -16,6 +15,8 @@ import {
   splitRight,
   splitDown,
   closePane,
+  closePaneIn,
+  removedWorkspaceBy,
   selectPane,
   panesOf,
   showSessionIn,
@@ -28,6 +29,7 @@ import {
   autoSessionName,
   MACHINE_NODE_SCOPE,
   type WorkspaceState,
+  type MachineWorkspacesState,
   type ServerWorkspaceDTO,
 } from '../workspace-reducer';
 
@@ -36,6 +38,15 @@ const BRANCH_SCOPE = { projectName: 'app', branchName: 'main' };
 /** A one-pane workspace — what every workspace starts as. */
 const aWorkspace = (id = 'ws-1', firstPaneId = 'pane-1'): WorkspaceState =>
   newWorkspace({ id, name: id, scope: BRANCH_SCOPE, firstPaneId });
+
+/** A machine showing exactly this one workspace. A fixture, not a production
+ * concept: the reducer used to export this to seed every machine's mandatory
+ * first workspace, but a machine now legitimately starts (and ends) with zero. */
+const initialMachineWorkspaces = (workspace: WorkspaceState): MachineWorkspacesState => ({
+  workspaces: { [workspace.id]: workspace },
+  order: [workspace.id],
+  activeWorkspaceId: workspace.id,
+});
 
 describe('newWorkspace', () => {
   it('given a workspace born empty, should open with one empty pane, ready for the picker', () => {
@@ -519,29 +530,97 @@ describe('showSessionIn — a clicked session must actually be on screen', () =>
   });
 });
 
-describe('closePane on a lone pane — detach, never dead-end', () => {
-  it('given the only pane holds a terminal, should empty it back to the picker', () => {
+describe('closePane on a lone pane — the grid level does not own this case', () => {
+  it('given the only pane of a workspace, should be a no-op at the grid level', () => {
     const workspace = assignPane(aWorkspace(), 'pane-1', { name: 'claude-a1b2c3' }, 'a prompt');
 
-    const actual = closePane(workspace, 'pane-1');
+    assert({
+      given: "a workspace's ONLY pane",
+      should:
+        'be a no-op — removing it means removing the workspace, which a WorkspaceState transition cannot do to its own container (closePaneIn owns it)',
+      actual: closePane(workspace, 'pane-1'),
+      expected: workspace,
+    });
+  });
+});
+
+describe('closePaneIn', () => {
+  it('given a pane with siblings, should close just that pane', () => {
+    const machine = initialMachineWorkspaces(splitDown(aWorkspace(), 'pane-1', 'pane-2'));
+
+    const actual = closePaneIn(machine, 'ws-1', 'pane-2');
 
     assert({
-      given: 'a workspace whose ONLY pane shows a session (one that may no longer exist server-side)',
-      should:
-        'detach the terminal and hand the pane back to the picker — refusing outright left the workspace stuck forever on a terminal that would never connect again',
-      actual: panesOf(actual)[0],
-      expected: { id: 'pane-1', scope: null, pendingPrompt: undefined },
+      given: 'one pane of a two-pane workspace',
+      should: 'close the pane and keep the workspace',
+      actual: {
+        panes: panesOf(actual.workspaces['ws-1']!).map((pane) => pane.id),
+        order: actual.order,
+      },
+      expected: { panes: ['pane-1'], order: ['ws-1'] },
     });
   });
 
-  it('given the only pane is already empty, should be a no-op', () => {
-    const workspace = aWorkspace();
+  it('given the last pane, should remove the whole workspace', () => {
+    const machine = addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1'));
+
+    const actual = closePaneIn(machine, 'ws-b', 'b1');
 
     assert({
-      given: 'a lone pane that is already the picker',
-      should: 'be a no-op — there is nothing to detach',
-      actual: closePane(workspace, 'pane-1'),
-      expected: workspace,
+      given: "the last pane of a workspace — a view with no terminals left in it",
+      should: 'remove the workspace itself, not leave an empty row behind',
+      actual: { order: actual.order, active: actual.activeWorkspaceId },
+      expected: { order: ['ws-a'], active: 'ws-a' },
+    });
+  });
+
+  it("given the last pane of the machine's last workspace, should empty the machine", () => {
+    const machine = initialMachineWorkspaces(aWorkspace());
+
+    const actual = closePaneIn(machine, 'ws-1', 'pane-1');
+
+    assert({
+      given: 'the final pane of the final workspace',
+      should: 'leave zero workspaces and nothing active — the empty state is a legal, reachable place',
+      actual: { order: actual.order, active: actual.activeWorkspaceId },
+      expected: { order: [], active: '' },
+    });
+  });
+
+  it('given an unknown pane, should be a no-op', () => {
+    const machine = initialMachineWorkspaces(aWorkspace());
+
+    assert({
+      given: 'a pane id that is not in the workspace',
+      should: 'be a no-op — an unknown pane must not remove a workspace',
+      actual: closePaneIn(machine, 'ws-1', 'nope'),
+      expected: machine,
+    });
+  });
+});
+
+describe('removedWorkspaceBy', () => {
+  it('given a close that removed the workspace, should report true', () => {
+    const before = initialMachineWorkspaces(aWorkspace());
+    const after = closePaneIn(before, 'ws-1', 'pane-1');
+
+    assert({
+      given: 'a close that took the whole workspace with it',
+      should: 'report true — the sync layer must DELETE, since PATCHing a removed workspace 404s and its fallback re-creates the row',
+      actual: removedWorkspaceBy(before, after, 'ws-1'),
+      expected: true,
+    });
+  });
+
+  it('given a close that only removed a pane, should report false', () => {
+    const before = initialMachineWorkspaces(splitDown(aWorkspace(), 'pane-1', 'pane-2'));
+    const after = closePaneIn(before, 'ws-1', 'pane-2');
+
+    assert({
+      given: 'a close that left the workspace standing',
+      should: 'report false — this is an ordinary layout PATCH',
+      actual: removedWorkspaceBy(before, after, 'ws-1'),
+      expected: false,
     });
   });
 });
@@ -563,13 +642,55 @@ describe('removeWorkspace', () => {
     });
   });
 
-  it('given the last workspace, should be a no-op', () => {
+  it('given the last workspace, should remove it and leave the machine empty', () => {
     const machine = initialMachineWorkspaces(aWorkspace());
+
+    const actual = removeWorkspace(machine, 'ws-1');
 
     assert({
       given: 'the only workspace a machine has',
-      should: 'refuse — the middle view would have nothing to render (a broken pane can be emptied instead)',
-      actual: removeWorkspace(machine, 'ws-1'),
+      should:
+        'remove it — a view you cannot destroy is not a view; the floor here is what made the last sidebar row unremovable',
+      actual: { workspaces: Object.keys(actual.workspaces), order: actual.order, active: actual.activeWorkspaceId },
+      expected: { workspaces: [], order: [], active: '' },
+    });
+  });
+
+  it('given the last workspace, should set activeWorkspaceId to the empty string exactly', () => {
+    const actual = removeWorkspace(initialMachineWorkspaces(aWorkspace()), 'ws-1');
+
+    assert({
+      given: 'a removal that empties the machine',
+      should:
+        "produce '' and not undefined — the neighbour lookup is order[-1] here, and undefined in a field typed string reads downstream as 'not mounted yet' rather than 'nothing active'",
+      actual: actual.activeWorkspaceId === '',
+      expected: true,
+    });
+  });
+
+  it('given every workspace removed one at a time, should end empty without throwing', () => {
+    const machine = addWorkspace(
+      addWorkspace(initialMachineWorkspaces(aWorkspace('ws-a', 'a1')), aWorkspace('ws-b', 'b1')),
+      aWorkspace('ws-c', 'c1')
+    );
+
+    const actual = ['ws-a', 'ws-b', 'ws-c'].reduce(removeWorkspace, machine);
+
+    assert({
+      given: 'three workspaces removed in sequence',
+      should: 'end at zero with nothing active',
+      actual: { order: actual.order, active: actual.activeWorkspaceId },
+      expected: { order: [], active: '' },
+    });
+  });
+
+  it('given an unknown workspace id, should be a no-op', () => {
+    const machine = initialMachineWorkspaces(aWorkspace());
+
+    assert({
+      given: 'an id the machine does not have',
+      should: 'be a no-op',
+      actual: removeWorkspace(machine, 'nope'),
       expected: machine,
     });
   });
@@ -608,6 +729,20 @@ describe('mergeServerWorkspaces — reconciling the server\'s workspace list', (
     scope: BRANCH_SCOPE,
     columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: null }] }],
     ...overrides,
+  });
+
+  it('given an empty server list, should converge on zero rather than keep the local rows', () => {
+    const local = initialMachineWorkspaces(aWorkspace());
+
+    const merged = mergeServerWorkspaces(local, []);
+
+    assert({
+      given: 'a server that reports this machine has no workspaces (the user removed them all)',
+      should:
+        'apply it — returning `local` here (the old fallback) meant "server has zero" could NEVER converge, since this hydrate runs once per mount and nothing prunes afterwards',
+      actual: { order: merged.order, active: merged.activeWorkspaceId },
+      expected: { order: [], active: '' },
+    });
   });
 
   it('given no local state, should build a fresh machine from the server list', () => {
@@ -723,19 +858,34 @@ describe('applyServerWorkspaceDeleted', () => {
     });
   });
 
-  it('given the machine\'s only workspace, should keep it — a machine never renders zero workspaces', () => {
+  it("given the machine's only workspace, should apply the delete", () => {
     const machine = initialMachineWorkspaces(aWorkspace());
+
+    const applied = applyServerWorkspaceDeleted(machine, 'ws-1');
 
     assert({
       given: 'a delete event for the last workspace this browser has locally',
-      should: 'be a no-op, converging once this browser\'s own next write reconciles the server',
-      actual: applyServerWorkspaceDeleted(machine, 'ws-1'),
-      expected: machine,
+      should:
+        'apply it — the old floor DROPPED this event, so a browser whose teammate removed the last view kept a phantom of it forever (nothing re-reconciles after the once-per-mount hydrate)',
+      actual: { order: applied.order, active: applied.activeWorkspaceId },
+      expected: { order: [], active: '' },
     });
   });
 });
 
 describe('sanitizeMachines — what comes back from storage is untrusted', () => {
+  it('given a persisted machine with zero workspaces, should drop the entry', () => {
+    const actual = sanitizeMachines({ m1: { workspaces: {}, order: [], activeWorkspaceId: '' } });
+
+    assert({
+      given: 'an empty machine coming back out of localStorage',
+      should:
+        'drop the entry — ensureMachine re-adds it on mount, so this is equivalent to keeping it, and the UI must therefore key its empty state on "no active workspace resolves" rather than on the entry existing',
+      actual: Object.keys(actual),
+      expected: [],
+    });
+  });
+
   it('given a workspace from an older, incompatible shape, should drop it rather than crash on render', () => {
     const persisted = {
       m1: {

--- a/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
+++ b/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
@@ -21,7 +21,6 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import {
   newWorkspace,
-  initialMachineWorkspaces,
   addWorkspace,
   updateWorkspace,
   removeWorkspace as removeWorkspaceTransition,
@@ -41,7 +40,8 @@ import {
   dismissPicker as dismissPickerTransition,
   splitRight as splitRightTransition,
   splitDown as splitDownTransition,
-  closePane as closePaneTransition,
+  closePaneIn,
+  removedWorkspaceBy,
   selectPane as selectPaneTransition,
   nodeOfTerminalScope,
   panesOf,
@@ -85,13 +85,16 @@ const PERSISTED_VERSION = 1;
 interface MachineWorkspaceStoreState {
   /** Every machine's workspaces, keyed by the Machine page's own id. */
   machines: Record<string, MachineWorkspacesState>;
-  /** Creates the machine's first workspace if it has none. Idempotent. */
+  /** Creates the machine's entry (with zero workspaces) if it has none, and
+   * re-targets an `activeWorkspaceId` that doesn't resolve. Never creates a
+   * workspace — zero is a legal state. Idempotent. */
   ensureMachine: (machineId: string) => void;
   /** A new empty workspace (auto-named), shown immediately. Returns its id. */
   createWorkspace: (machineId: string, scope?: MachineNodeScope) => string;
   /** THE FIX: switches the whole middle view to this workspace's grid. */
   setActiveWorkspace: (machineId: string, workspaceId: string) => void;
-  /** Drops a workspace and shows a neighbour. A machine keeps at least one. */
+  /** Drops a workspace and shows a neighbour — including the last one, which
+   * leaves the machine empty. */
   removeWorkspace: (machineId: string, workspaceId: string) => void;
   /** Local rename — the server-synced wrapper (`useMachineWorkspaceSync`) pushes this to the server too. */
   renameWorkspace: (machineId: string, workspaceId: string, name: string) => void;
@@ -120,7 +123,10 @@ interface MachineWorkspaceStoreState {
   dismissPicker: (machineId: string, workspaceId: string, paneId: string) => void;
   splitRight: (machineId: string, workspaceId: string, fromPaneId: string) => void;
   splitDown: (machineId: string, workspaceId: string, fromPaneId: string) => void;
-  closePane: (machineId: string, workspaceId: string, paneId: string) => void;
+  /** Closes a pane, removing its workspace if it was the last one. Returns true
+   * in that case, so the caller pushes a DELETE instead of a layout PATCH for a
+   * workspace that no longer exists. */
+  closePane: (machineId: string, workspaceId: string, paneId: string) => boolean;
   selectPane: (machineId: string, workspaceId: string, paneId: string) => void;
 }
 
@@ -158,27 +164,32 @@ export const useMachineWorkspaceStore = create<MachineWorkspaceStoreState>()(
       machines: {},
 
       ensureMachine: (machineId) => {
-        // REPAIRS, rather than merely skipping when the key exists. A machine
-        // whose active workspace doesn't resolve renders nothing at all, and if
-        // the only check were `machines[machineId]` that blank view would be
-        // permanent — there is no way for a user to clear this storage from
-        // inside the app.
+        // Creates the machine's ENTRY, never a workspace. A machine with zero
+        // workspaces is legal (the middle view renders an empty state for it),
+        // so fabricating a "Workspace 1" here would resurrect a row the user
+        // just removed — and, because this runs from every sidebar tree node,
+        // would invent workspaces for machines they never opened.
+        //
+        // The entry itself must exist even when empty: `applyToMachine` no-ops
+        // on a missing machine, so `createWorkspace`/`openTerminal` would
+        // silently do nothing without it.
         const machine = get().machines[machineId];
-        if (machine && machine.workspaces[machine.activeWorkspaceId]) return;
+        if (!machine) {
+          set((state) => ({
+            machines: { ...state.machines, [machineId]: { workspaces: {}, order: [], activeWorkspaceId: '' } },
+          }));
+          return;
+        }
 
-        set((state) => ({
-          machines: {
-            ...state.machines,
-            [machineId]: initialMachineWorkspaces(
-              newWorkspace({
-                id: crypto.randomUUID(),
-                name: 'Workspace 1',
-                scope: MACHINE_NODE_SCOPE,
-                firstPaneId: crypto.randomUUID(),
-              })
-            ),
-          },
-        }));
+        // Still REPAIRS an active id that doesn't resolve — that renders nothing
+        // at all, and there is no way for a user to clear this storage from
+        // inside the app, so a blank view would be permanent. The repair is now
+        // re-targeting to a workspace that exists (or to "none"), not minting one.
+        if (machine.workspaces[machine.activeWorkspaceId]) return;
+        set((state) => applyToMachine(state, machineId, (current) => ({
+          ...current,
+          activeWorkspaceId: current.order[0] ?? '',
+        })));
       },
 
       createWorkspace: (machineId, scope = MACHINE_NODE_SCOPE) => {
@@ -327,9 +338,17 @@ export const useMachineWorkspaceStore = create<MachineWorkspaceStoreState>()(
       },
 
       closePane: (machineId, workspaceId, paneId) => {
-        set((state) =>
-          applyToWorkspace(state, machineId, workspaceId, (workspace) => closePaneTransition(workspace, paneId))
-        );
+        const before = get().machines[machineId];
+        if (!before) return false;
+
+        const after = closePaneIn(before, workspaceId, paneId);
+        if (after === before) return false;
+
+        set((state) => ({ machines: { ...state.machines, [machineId]: after } }));
+        // Reported rather than re-derived by the caller: only the transition
+        // knows whether this pane was the workspace's last, and the sync layer
+        // must DELETE (not PATCH) when it was.
+        return removedWorkspaceBy(before, after, workspaceId);
       },
 
       selectPane: (machineId, workspaceId, paneId) => {

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -89,6 +89,12 @@ export interface MachineWorkspacesState {
   workspaces: Record<string, WorkspaceState>;
   /** Sidebar order — insertion order, stable across selection. */
   order: string[];
+  /** `''` when nothing is active — a machine with zero workspaces is a legal,
+   * converged state (the middle view renders its empty state), not a bug to
+   * repair by fabricating one. No workspace id can be `''` (`crypto.randomUUID`
+   * / `sessionWorkspaceId` both produce non-empty), so this sentinel can never
+   * collide with a real id: `workspaces['']` never resolves and
+   * `setActiveWorkspace(state, '')` correctly no-ops. */
   activeWorkspaceId: string;
 }
 
@@ -225,27 +231,22 @@ export function splitDown(state: WorkspaceState, fromPaneId: string, newPaneId: 
 }
 
 /**
- * A workspace never has zero panes, so closing the LAST one empties it instead
- * of removing it: the pane drops its terminal and goes back to offering the
- * picker. Refusing outright (the old behaviour) was a dead end — a lone pane
- * showing a session that no longer exists server-side could never be detached,
- * and the workspace was stuck on a terminal that would never connect again.
+ * Removes a pane from its grid. Closing the last pane in a column removes the
+ * column too; closing the active pane re-targets active to the first remaining
+ * pane.
  *
- * Closing the last pane in a column removes the column too; closing the active
- * pane re-targets active to the first remaining pane.
+ * A workspace never has zero panes, so the LAST pane is not this function's
+ * business — removing it means removing the workspace, which a `WorkspaceState`
+ * transition cannot do to its own container. {@link closePaneIn} owns that case
+ * and intercepts before calling here; this no-ops as a backstop rather than
+ * filtering the grid down to a `columns[0]` that isn't there.
  */
 export function closePane(state: WorkspaceState, id: string): WorkspaceState {
   const location = findPaneLocation(state, id);
   if (!location) return state;
 
   const totalPanes = state.columns.reduce((sum, column) => sum + column.panes.length, 0);
-  if (totalPanes <= 1) {
-    return mapPane(state, id, (pane) =>
-      pane.scope === null && pane.pendingPrompt === undefined
-        ? pane
-        : { ...pane, scope: null, pendingPrompt: undefined }
-    );
-  }
+  if (totalPanes <= 1) return state;
 
   const columns = state.columns
     .map((column, columnIndex) =>
@@ -275,14 +276,6 @@ export function panesOf(state: WorkspaceState): TerminalPaneState[] {
 // ---------------------------------------------------------------------------
 // Machine level — which workspaces exist, and which one the view shows
 // ---------------------------------------------------------------------------
-
-export function initialMachineWorkspaces(workspace: WorkspaceState): MachineWorkspacesState {
-  return {
-    workspaces: { [workspace.id]: workspace },
-    order: [workspace.id],
-    activeWorkspaceId: workspace.id,
-  };
-}
 
 /** Adds a workspace and shows it — a workspace is created because the user
  * asked for it, so it is what they want to be looking at. */
@@ -435,13 +428,18 @@ export function showSessionIn(
 }
 
 /**
- * Removes a workspace and shows a neighbour. A machine always keeps at least
- * one workspace, so removing the last one is a no-op — there would be nothing
- * left to render. (A workspace whose only pane holds a dead terminal is not a
- * dead end even then: closing that pane empties it back to the picker.)
+ * Removes a workspace and shows a neighbour — including the LAST one, which
+ * leaves the machine with zero workspaces and `activeWorkspaceId: ''`.
+ *
+ * A workspace is a VIEW of terminals, and a view you cannot destroy is not a
+ * view. The old "a machine always keeps at least one" floor made the last row
+ * permanently unremovable: the sidebar compensated by emptying its panes in
+ * place, so the row survived every removal attempt, and `createWorkspace` then
+ * added a SECOND row beside the zombie. Zero workspaces is the honest state,
+ * and the middle view renders an empty state for it.
  */
 export function removeWorkspace(state: MachineWorkspacesState, workspaceId: string): MachineWorkspacesState {
-  if (!state.workspaces[workspaceId] || state.order.length <= 1) return state;
+  if (!state.workspaces[workspaceId]) return state;
 
   const order = state.order.filter((id) => id !== workspaceId);
   const workspaces = { ...state.workspaces };
@@ -449,11 +447,51 @@ export function removeWorkspace(state: MachineWorkspacesState, workspaceId: stri
 
   // Falling back to the neighbour it sat next to, rather than to the first
   // workspace — closing one item should not jump the view across the sidebar.
+  // The `?? ''` carries the empty case: `order[Math.min(n, -1)]` is `order[-1]`
+  // — `undefined`, which would flow into a field typed `string` unchecked
+  // (`noUncheckedIndexedAccess` is off) and read downstream as "not mounted yet"
+  // rather than "nothing active".
   const removedIndex = state.order.indexOf(workspaceId);
-  const neighbour = order[Math.min(removedIndex, order.length - 1)];
+  const neighbour = order[Math.min(removedIndex, order.length - 1)] ?? '';
   const activeWorkspaceId = state.activeWorkspaceId === workspaceId ? neighbour : state.activeWorkspaceId;
 
   return { workspaces, order, activeWorkspaceId };
+}
+
+/**
+ * Closes a pane, removing its whole workspace when it was the last one — a view
+ * with no terminals in it is not a view, it is a row that outlived its purpose.
+ *
+ * This is an ACTION rule, not an invariant over the state: a freshly created
+ * workspace legitimately holds one pane with `scope: null` showing the picker,
+ * so "a workspace with no bound panes gets removed" would delete every
+ * workspace at birth. Only an explicit close removes anything.
+ *
+ * Returns the same state object when nothing changed, so callers can tell
+ * whether to push (and {@link removedWorkspaceBy} whether to DELETE vs PATCH).
+ */
+export function closePaneIn(
+  state: MachineWorkspacesState,
+  workspaceId: string,
+  paneId: string
+): MachineWorkspacesState {
+  const workspace = state.workspaces[workspaceId];
+  if (!workspace || !findPaneLocation(workspace, paneId)) return state;
+
+  if (panesOf(workspace).length <= 1) return removeWorkspace(state, workspaceId);
+  return updateWorkspace(state, workspaceId, (current) => closePane(current, paneId));
+}
+
+/** Did {@link closePaneIn} take the whole workspace with it? The sync layer must
+ * know: pushing a layout PATCH for a workspace that no longer exists 404s, and
+ * that route's fallback RE-CREATES it server-side — resurrecting the exact row
+ * the user just closed. */
+export function removedWorkspaceBy(
+  before: MachineWorkspacesState,
+  after: MachineWorkspacesState,
+  workspaceId: string
+): boolean {
+  return Boolean(before.workspaces[workspaceId]) && !after.workspaces[workspaceId];
 }
 
 // ---------------------------------------------------------------------------
@@ -551,12 +589,13 @@ export function mergeServerWorkspaces(
     order.push(ws.id);
   }
 
-  // Should not happen in practice — the server always has at least the
-  // workspace(s) this browser's own bootstrap call just seeded — but a
-  // machine must never end up with zero workspaces to render.
-  if (order.length === 0) return local ?? { workspaces: {}, order: [], activeWorkspaceId: '' };
-
-  const activeWorkspaceId = local && workspaces[local.activeWorkspaceId] ? local.activeWorkspaceId : order[0];
+  // An empty server list is a real, converged answer — the user removed every
+  // view — so it is applied, not treated as an impossible reading to fall back
+  // from. Keeping `local` here (the old behaviour) meant "server has zero"
+  // could NEVER converge: this hydrate runs once per mount and nothing prunes
+  // afterwards, so the phantom rows outlived every reload.
+  const activeWorkspaceId =
+    local && workspaces[local.activeWorkspaceId] ? local.activeWorkspaceId : (order[0] ?? '');
   return { workspaces, order, activeWorkspaceId };
 }
 
@@ -571,9 +610,10 @@ export function applyServerWorkspaceUpsert(state: MachineWorkspacesState, ws: Se
 }
 
 /** Reconciles an incoming `machine-workspace:deleted` event — delegates to
- * {@link removeWorkspace}, so a machine reduced to its last server-known
- * workspace keeps showing it locally (the existing "always keep ≥1" floor),
- * converging once this browser's own next write reconciles it. */
+ * {@link removeWorkspace}, which now applies to the last workspace too. Under
+ * the old floor this event was silently DROPPED for the final row, so a browser
+ * whose teammate removed the last view kept a phantom of it forever (nothing
+ * re-reconciles after the once-per-mount hydrate). */
 export function applyServerWorkspaceDeleted(state: MachineWorkspacesState, workspaceId: string): MachineWorkspacesState {
   return removeWorkspace(state, workspaceId);
 }


### PR DESCRIPTION
## The bug

A machine kept **at least one workspace, always**. That floor is the whole bug, and it produced both reported symptoms:

- `removeWorkspace` (`workspace-reducer.ts:443`) no-op'd on the last workspace, so `WorkspaceLeaves` compensated by **emptying its panes in place** — the row survived every removal attempt. An unremovable listing, no matter how many times you confirmed.
- `+ New terminal` (`NodeActionPalette.tsx:280`) then called `createWorkspace` unconditionally, minting a **second** workspace and activating it. The middle view swapped ("sorta replaces it"), but the sidebar now showed the zombie row **and** the new one. Two listings.

Both symptoms, one cause.

A second, independent unremovable path: a `shell`/`claude`/`codex` orphan rendered its remove button only when `!launchable` (`:288`), so it had **no remove button at all** — and the only stop path was "remove the workspace holding it", which is precisely what an unclaimed session lacks.

## The fix

A workspace is a **view of terminals**. A view you cannot destroy is not a view. Zero workspaces is now a legal, converged state.

- **Reducer** — drop the `>=1` floor. `activeWorkspaceId: ''` is the no-active sentinel. `mergeServerWorkspaces` applies an empty server list instead of falling back to `local` — "server has zero" could **never** converge before, since hydrate runs once per mount and nothing prunes after. `applyServerWorkspaceDeleted` now applies to the last row (it was silently dropped, so a teammate removing the last view left you a permanent phantom).
- **Store** — `ensureMachine` creates the machine's **entry** and nothing else. It still repairs a dangling `activeWorkspaceId`, by re-targeting rather than minting.
- **Empty state** — "No terminals open" + New Terminal, in `TerminalPanes`. Keyed on *"no active workspace resolves"*, not on the entry existing (`sanitizeMachines` drops empty entries on rehydrate).
- **Close means close** — closing a pane kills its PTY unless another pane shows that same session; closing the last pane removes the workspace. Detach is what **manufactured** the orphan rows.
- **Every unclaimed row is removable**, not just `!launchable` ones.

`NodeActionPalette` needed no change — once removal genuinely removes, an unconditional `createWorkspace` is correct.

## Five traps this had to step around

1. **Resurrection.** `pushWorkspaceUpdate` PATCHes and falls back to **POST-create on a 404** (`useMachineWorkspaceSync.ts:294-311`). A layout push for a workspace the close just removed would re-create it server-side and broadcast the resurrected row back — including to the browser whose user just closed it. Last-pane close routes to `pushRemoval`; a test asserts PATCH is **not** called.
2. **`order[-1]`.** Dropping the floor makes the neighbour lookup `order[Math.min(n, -1)]` → `undefined` in a field typed `string`. The repo has `strict` but **not** `noUncheckedIndexedAccess`, so it compiles and ships, and downstream reads it as *"not mounted yet"* rather than *"nothing active"*. Guarded with `?? ''`; a test asserts `=== ''` exactly (not just falsy).
3. **Empty bootstrap claims.** Now that `ensureMachine` mints nothing, the payload is usually empty — and `DevelopmentSidebar` mounts the sync hook **per machine row**, so merely rendering it would fire an empty first-writer-wins claim at every machine in the drive, permanently discarding other browsers' un-migrated history. Guarded — and it **hydrates** rather than merely skipping the POST (the normal hydrate is gated on `bootstrapped`). That hydrate is **provisional** (Codex P2): it records the bootstrap decision (`bootstrapAttempted`) but not `hydratedOnce`, so when another browser with real history later wins the claim, the `bootstrapped` broadcast — the ONLY way its seeded rows reach this browser — still applies instead of being gated out until remount. And the decision is **cross-instance** (a module-level registry): the hook is mounted more than once per machine (sidebar row + `MachineView`), and instance 1's provisional hydrate writes server rows into the shared store — a per-instance ref would let instance 2 read that non-empty list and burn the claim with an echo of the server's own rows.
4. **Kill by the pane's own scope** (Codex P2). Close-kill originally routed through the workspace-scoped `useAgentTerminals` instance — but a pane's `(project, branch)` can differ from its workspace's (restored server layouts), and a DELETE under the workspace scope would kill a different same-named terminal (or nothing) while the closed one lived on unclaimed. `killAgentTerminal(machineId, scope)` addresses the DELETE by the pane's own triple and revalidates that scope's SWR list. The sweep for this class also caught `WorkspaceLeaves`' remove-workspace kill: it now uses pane scopes too, **spares** sessions another workspace's pane still shows (the invariant close-and-kill enforces), and **dedupes** two panes showing one session; the unclaimed-row check compares full session identity machine-wide instead of pane names at the node. A kill that 404s counts as **success** — the session (or its checkout) is already gone, which is the call's goal state; treating it as failure made a workspace holding a stale pane permanently unremovable (kill rejects → dialog stays open → retry hits the same 404 forever). Real failures (5xx, network) still throw: a running, billing agent's only row must not be dropped silently. The closing pane is resolved **within its own workspace** (CodeRabbit): pane ids are only grid-unique (server layouts carry ids other clients minted), so a machine-wide id lookup could kill a same-id pane's session in another workspace; `boundElsewhere` compares `(workspace, pane)` tuples for the same reason.
5. **Removal has no "next push".** Every push here is optimistic and swallows transient failures because the next push reconciles — but nothing follows a removal, so a swallowed DELETE failure left the server row alive to resurrect the removed workspace on the next hydrate (CodeRabbit). `pushRemoval` now retries (bounded, backoff), and each retry checks the workspace is still locally removed first — session-derived workspace ids are deterministic, so a stale retry could otherwise delete a re-opened session's new incarnation. Deliberately **no rollback-on-failure**: restoring a grid whose PTYs were already killed is a strictly worse dead-pane state; the resurrected row is visible and removable again.

Session identity is the `(project, branch, name)` triple — `machine_agent_terminals`' unique index — so both the "bound elsewhere?" check and the kill itself use the full triple, not the name alone.

## Considered and rejected

- **Session-first sidebar** (sessions = only server truth, layout = pure local view state). This is PR #2031, which #2048/#2058 deliberately replaced (`machine-workspaces.ts:36-38` names the gap). It also can't work: `name` is the session's DB key, there's no update-name method, and the list route doesn't return `id` — so it loses rename, active-highlight and pane grouping. And a view holds multiple panes by design, so it can't collapse into a session.
- **Deleting the bootstrap claim table.** Not just migration machinery: workspace ids are `crypto.randomUUID()`, so per-id upsert can't dedupe — without first-writer-wins, three devices POSTing disjoint local lists yield 3x the workspaces. Structural.

## Deliberately not fixed

#2048 required the unclaimed-session row become redundant once workspaces were shared truth; #2058 shipped without it. Two server truths (`machine_agent_terminals`, `machine_workspaces`) can still disagree, so orphans remain possible via other browsers and agent-spawned sessions — kill-on-close just stops *this* path feeding it. Closing it means giving every spawn path an owning workspace server-side: its own PR.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `eslint` on all changed files — clean
- [x] **14,585 tests pass.** The 4 failing files (`activity-tools`, `grouping`, `admin-role-version`, `version-sdk-contract`) fail **identically on clean master** — verified by stashing, not assumed.
- [x] Machine surface: 26 files / 388 tests green, across 3 repeat runs.
- **Inverted** the ~8 tests that pinned the floor, including `DevelopmentSidebar.test.tsx`'s `expect(...workspaces.length).toBe(2)` — that assertion *was* the bug report.
- **Added**: the end-to-end repro (remove → New terminal → **exactly one row**); `activeWorkspaceId === ''` exactly; `pushRemoval`-not-PATCH on last-pane close; same-name-different-branch is a different session; empty-payload bootstrap does not claim but does hydrate; a later `bootstrapped` broadcast still applies after an empty non-claim hydrate; close-kill carries the pane's own scope (zero calls through the workspace-scoped hook); workspace removal kills at pane scope / spares sessions shown elsewhere / dedupes; a 404'd kill still removes the workspace; dual-mounted sync hooks never claim the bootstrap with an echo of server rows; a same-id pane in another workspace is never mistaken for the closing pane; a failed removal DELETE retries but a retry is abandoned if the same workspace id was re-materialized.

⚠️ **Not verified in a real browser** — machines need `CODE_EXECUTION_ENABLED` + live Sprites credentials. The empty state and kill-on-close are covered by component tests, not by clicking.

## Behaviour change worth flagging

Closing a pane now **kills** its agent, with no confirm step — a stray click ends a running agent. Chosen deliberately (close means close, as in every terminal emulator; detach is what creates the unremovable orphans). Note this does **not** make machines go cold any sooner: there is no idle reaper (`sprites.ts:468`), Sprites hibernate on their own, and session count is not an input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHzgVXZg69UoSYkigvAT1k
