### PR TITLE
fix(ai): don't merge a bootstrapped own stream into the useChat array (5A follow-up)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -747,7 +747,7 @@ const GlobalAssistantView: React.FC = () => {
         // it raw would hand useOwnStreamMirror an array whose newest row is somebody else's
         // finished message (see mergeServerMessagesWithOwnStream). Merging applies the undo AND
         // keeps our own live bubble last, which is what the mirror needs.
-        const merged = mergeServerMessagesWithOwnStream(data.messages, currentConversationId);
+        const merged = mergeServerMessagesWithOwnStream(data.messages, currentConversationId, currentMessagesRef.current);
         if (selectedAgent) {
           setAgentMessages(merged);
           setAgentStoreMessages(merged);
@@ -804,7 +804,7 @@ const GlobalAssistantView: React.FC = () => {
       // then hand the mirror an array whose newest row is the PREVIOUS turn's reply. Merging asks
       // the question at the write instead, and keeps our own live bubble last.
       const serverMessages: UIMessage[] = Array.isArray(data) ? data : (data.messages ?? []);
-      const merged = mergeServerMessagesWithOwnStream(serverMessages, conversationId);
+      const merged = mergeServerMessagesWithOwnStream(serverMessages, conversationId, currentMessagesRef.current);
       if (agentId) {
         setAgentMessages(merged);
         setAgentStoreMessages(merged);

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -374,7 +374,6 @@ const SidebarChatTab: React.FC = () => {
   // displayIsStreaming, which also covers streams this surface merely shows a Stop button for.
   // `activeStream` is already conversation-scoped, so `isOwn === true` is exactly that question.
   const isOwnStreamForCurrentConversation = activeStream?.isOwn === true;
-  // Read after an await by handleUndoSuccess, which resolves long after its closure was built.
 
   const remoteStreamingUser = !displayIsStreaming
     ? remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
@@ -1246,7 +1245,7 @@ const SidebarChatTab: React.FC = () => {
           // would hand useOwnStreamMirror an array whose newest row is somebody else's finished
           // message (see mergeServerMessagesWithOwnStream). Merging applies the undo and keeps our
           // own live bubble last.
-          setMessages(mergeServerMessagesWithOwnStream(data.messages, currentConversationId));
+          setMessages(mergeServerMessagesWithOwnStream(data.messages, currentConversationId, currentMessagesRef.current));
         }
       } catch (error) {
         console.error('Failed to refresh messages after undo:', error);

--- a/apps/web/src/hooks/__tests__/mergeServerMessagesWithOwnStream.test.ts
+++ b/apps/web/src/hooks/__tests__/mergeServerMessagesWithOwnStream.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { UIMessage } from 'ai';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { mergeServerMessagesWithOwnStream } from '@/hooks/useActiveStream';
+
+// The real store: this helper's whole job is reading it, and there is no process boundary to fake.
+const seedStream = (over: { messageId: string; conversationId: string; isOwn: boolean }) => {
+  usePendingStreamsStore.getState().addStream({
+    pageId: 'page-1',
+    triggeredBy: { userId: 'u1', displayName: 'Me' },
+    startedAt: '2024-01-01T00:00:00.000Z',
+    parts: [{ type: 'text', text: 'live so far' }],
+    ...over,
+  });
+};
+
+const msg = (id: string, role: 'user' | 'assistant'): UIMessage =>
+  ({ id, role, parts: [{ type: 'text', text: id }] }) as UIMessage;
+
+describe('mergeServerMessagesWithOwnStream', () => {
+  beforeEach(() => {
+    usePendingStreamsStore.setState({ streams: new Map() });
+  });
+
+  it('given no own stream for the conversation, should return the server list untouched', () => {
+    const server = [msg('u1', 'user'), msg('a1', 'assistant')];
+    expect(mergeServerMessagesWithOwnStream(server, 'conv-C', [])).toBe(server);
+  });
+
+  it('given no conversation resolved, should return the server list untouched', () => {
+    seedStream({ messageId: 'm1', conversationId: 'conv-C', isOwn: true });
+    const server = [msg('u1', 'user')];
+    expect(mergeServerMessagesWithOwnStream(server, null, [msg('m1', 'assistant')])).toBe(server);
+  });
+
+  // THE reason this helper exists. A whole-array write landing mid-send hands useOwnStreamMirror an
+  // array whose newest row is somebody else's message — the previous turn's, or another TAB of this
+  // same user (`isOwn` is browserSessionId-scoped, so no collaborator needed). The mirror reads
+  // that as the SDK renaming our stream, re-targets onto a finished message, and Stop then aborts
+  // an id the server has no stream for: not_found, silent, while the generation keeps billing.
+  it('given we are locally streaming and the DB history ends with a FOREIGN assistant, should put OUR message last', () => {
+    seedStream({ messageId: 'mine', conversationId: 'conv-C', isOwn: true });
+    const server = [msg('u1', 'user'), msg('their-finished-reply', 'assistant')];
+
+    const merged = mergeServerMessagesWithOwnStream(server, 'conv-C', [msg('mine', 'assistant')]);
+
+    expect(merged[merged.length - 1].id).toBe('mine');
+    expect(merged.map((m) => m.id)).toEqual(['u1', 'their-finished-reply', 'mine']);
+  });
+
+  // THE case that must NOT merge. A stream this tab is not locally producing — rejoined by the
+  // bootstrap after a refresh — renders straight from the pending-streams store, and both renderers
+  // drop a store stream whose messageId already appears in `messages`. Synthesizing that id INTO
+  // `messages` dedupes the live bubble out of the renderer and freezes it at the merged snapshot
+  // for the rest of the generation. (Not merging cannot mislead the mirror either: it never latches
+  // while our status is idle, which is precisely when a stream is bootstrapped rather than local.)
+  it('given the own stream is BOOTSTRAPPED (not in our local array), should NOT merge — that would freeze its live bubble', () => {
+    seedStream({ messageId: 'rejoined', conversationId: 'conv-C', isOwn: true });
+    const server = [msg('u1', 'user')];
+
+    // Our local array does not contain the stream: useChat is idle, the store is the live bubble.
+    expect(mergeServerMessagesWithOwnStream(server, 'conv-C', [msg('u1', 'user')])).toBe(server);
+  });
+
+  it('given a REMOTE stream for the conversation, should not merge it — it is not ours to reconcile', () => {
+    seedStream({ messageId: 'theirs', conversationId: 'conv-C', isOwn: false });
+    const server = [msg('u1', 'user')];
+    expect(mergeServerMessagesWithOwnStream(server, 'conv-C', [msg('theirs', 'assistant')])).toBe(server);
+  });
+
+  it('given an own stream in a DIFFERENT conversation, should not merge it', () => {
+    seedStream({ messageId: 'mine', conversationId: 'conv-OTHER', isOwn: true });
+    const server = [msg('u1', 'user')];
+    expect(mergeServerMessagesWithOwnStream(server, 'conv-C', [msg('mine', 'assistant')])).toBe(server);
+  });
+});

--- a/apps/web/src/hooks/useActiveStream.ts
+++ b/apps/web/src/hooks/useActiveStream.ts
@@ -81,24 +81,25 @@ export const getActiveStreamById = (messageId: string): PendingStream | undefine
   usePendingStreamsStore.getState().streams.get(messageId);
 
 /**
- * Facade — reconcile a freshly-loaded server message list with this tab's own in-flight stream,
- * for the surfaces that still write DB history into a useChat array.
+ * Facade — reconcile a freshly-loaded server message list with this tab's own LOCALLY-STREAMING
+ * message, for the surfaces that still write DB history into a useChat array.
  *
- * Two things break when a whole-array write lands mid-stream, and merging fixes both:
+ * WHY MERGE AT ALL. A whole-array write landing mid-send hands `useOwnStreamMirror` an array whose
+ * newest row is somebody else's message — the previous turn's reply, or another TAB of this same
+ * user (`isOwn` is browserSessionId-scoped, so no collaborator is needed). The mirror reads that as
+ * the SDK renaming our stream, re-targets onto a finished message, and Stop then aborts an id the
+ * server has no stream for: user-scoped, so `not_found`, on which reportAbortOutcome is silent by
+ * design, while the generation keeps running its write tools and keeps billing. Merging keeps our
+ * own message last, which is the one thing the mirror needs.
  *
- *  - The live bubble disappears (the DB does not have a finished row for a stream still running).
- *  - Worse, `useOwnStreamMirror` reads that array to find its own live stream. If the array's
- *    newest row is some OTHER assistant message — the previous turn's reply, or another TAB of
- *    this same user (`isOwn` is browserSessionId-scoped, so no collaborator is needed) — the
- *    mirror reads it as the SDK renaming our stream, re-targets onto a finished message, and Stop
- *    then aborts an id the server has no stream for: user-scoped, so `not_found`, on which
- *    reportAbortOutcome is silent by design, while the generation keeps running its write tools
- *    and keeps billing.
- *
- * Merging is strictly better than skipping the write: skipping keeps the live bubble but drops
- * whatever the load was for (an undo the user just confirmed, a cross-tab edit), which on a
- * destructive action reads as "it didn't work". This applies the server's truth AND keeps our own
- * stream last, which is what the mirror needs.
+ * WHY ONLY WHEN THE STREAM IS IN THE LOCAL ARRAY. A stream this tab is NOT locally producing — one
+ * rejoined by the bootstrap after a refresh — renders straight from the pending-streams store, and
+ * both renderers drop a store stream whose messageId already appears in `messages`
+ * (dedupRemoteStreams / ChatMessagesArea's visibleRemoteStreams). Synthesizing that id INTO
+ * `messages` therefore dedupes the live bubble out of the renderer and freezes it at the merged
+ * snapshot for the rest of the generation. Merging is for the locally-streaming case only; for a
+ * bootstrapped stream a raw write is provably safe, because the mirror never latches while our
+ * status is idle and so cannot re-target at all.
  *
  * A one-off `getState()` snapshot, not a subscription: every caller runs this inside an async
  * callback after its fetch resolves, where the current store is exactly what it wants.
@@ -106,11 +107,15 @@ export const getActiveStreamById = (messageId: string): PendingStream | undefine
 export const mergeServerMessagesWithOwnStream = (
   serverMessages: UIMessage[],
   conversationId: string | null,
+  /** This chat's current useChat array — the test for "are we the ones producing this stream". */
+  localMessages: readonly { id: string }[],
 ): UIMessage[] => {
   if (!conversationId) return serverMessages;
   const ownStream = Array.from(usePendingStreamsStore.getState().streams.values())
     .find((s) => s.isOwn && s.conversationId === conversationId);
-  return ownStream
-    ? mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt)
-    : serverMessages;
+  if (!ownStream) return serverMessages;
+  // Not in our array => not locally produced (a bootstrapped rejoin). See above: merging would
+  // freeze its bubble, and not merging cannot mislead the mirror.
+  if (!localMessages.some((m) => m.id === ownStream.messageId)) return serverMessages;
+  return mergeServerAndPending(serverMessages, ownStream.parts, ownStream.messageId, ownStream.startedAt);
 };


### PR DESCRIPTION
Follow-up to **#2089** (merged as `a485ac2e`). Fixes a regression that PR's own final commit (`e6971d4a`) introduced, found by a further adversarial pass **after** the merge.

## The defect

`e6971d4a` made three whole-array writers (`handleUndoSuccess` ×2, `handlePullUpRefresh`) **merge** our own stream back in rather than skip the write. That is correct for a stream this tab is **locally producing**. It is wrong for one the **bootstrap rejoined** after a refresh:

- A rejoined bubble renders straight from the pending-streams store.
- Both renderers drop a store stream whose `messageId` already appears in `messages` (`dedupRemoteStreams` / `ChatMessagesArea.visibleRemoteStreams`).
- `mergeServerAndPending` synthesizes a message under **exactly that id** → the live bubble is deduped out of the renderer and **freezes at the merged snapshot** for the rest of the generation.

**Reachable and ungated:** reload the dashboard mid-generation (bubble rejoins and streams), then undo an earlier message — `handleUndoSuccess` has no streaming gate — and the bubble stops mid-word until completion.

**Severity: low/medium.** UI-only. Stop is unaffected (the store entry is untouched), and it self-heals at completion. Recording it plainly rather than quietly.

`GlobalAssistantView.tsx:776-783` documents this hazard *exactly* — *"merging here would FREEZE the live bubble... the rejoined stream would be deduped away and stop updating until completion."* I merged directly beneath that comment. It was right; I read past it.

## The fix

`mergeServerMessagesWithOwnStream` now merges only when the own stream is present in **this chat's local array** — precisely the locally-streaming case it exists for. For a bootstrapped stream a raw write is provably safe anyway: `useOwnStreamMirror` never latches while our status is idle, so it cannot re-target regardless of what the array holds.

The merge is still needed for the local case, for the reason #2089 added it: a whole-array write landing mid-send otherwise hands the mirror an array whose newest row is somebody else's message — the previous turn's, or **another tab of the same user** (`isOwn` is browserSessionId-scoped, so no collaborator is needed) — and the mirror re-targets onto a finished message, leaving Stop to abort an id the server has no stream for: `not_found`, silent by design, while the generation keeps running its write tools and **billing**.

## Tests

The helper shipped with **no coverage** despite gating three whole-array writers. Adds 6 tests against the real zustand store, covering both directions:
- must merge: DB history ending in a foreign assistant → **ours last** (what the mirror needs)
- must not merge: bootstrapped stream → server list returned untouched
- plus remote-stream, other-conversation, no-stream and no-conversation cases

**Mutation-verified:** merging regardless fails the bootstrap test.

Also drops an orphaned comment left behind by the ref this replaced.

## Validation

`bun run typecheck` · `bun run lint` — clean. 259/260 test files pass; the one failure (`activity-tools`: `role "test" does not exist`) is a pre-existing DB-environment failure, verified failing identically on clean master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNj9Vsv8NCpkWtizquUa9k