### PR TITLE
feat(broadcast): processor email-broadcast worker + enqueue endpoint + scope

### DIFF
--- a/apps/processor/src/api/broadcast.ts
+++ b/apps/processor/src/api/broadcast.ts
@@ -1,0 +1,37 @@
+import { Router, type Router as RouterType } from 'express';
+import { queueManager } from '../server';
+
+/**
+ * Admin-console email-broadcast enqueue endpoint.
+ *
+ * The admin app mints a short-lived service token (scope `broadcast:enqueue`),
+ * creates the email_broadcasts row, then calls this to put a durable job on the
+ * pg-boss `email-broadcast` queue. Returns the jobId so the caller can record it
+ * on the broadcast row (markQueued) for traceability. Mirrors `api/erasure.ts`.
+ */
+
+const router: RouterType = Router();
+
+router.post('/enqueue', async (req, res) => {
+  const auth = req.auth;
+  if (!auth?.userId) {
+    return res.status(401).json({ error: 'Service authentication required' });
+  }
+
+  const { broadcastId } = req.body ?? {};
+  if (typeof broadcastId !== 'string' || !broadcastId) {
+    return res.status(400).json({ error: 'broadcastId is required' });
+  }
+
+  try {
+    const jobId = await queueManager.addJob('email-broadcast', { broadcastId });
+    return res.json({ success: true, jobId });
+  } catch (error) {
+    console.error('[broadcast] enqueue failed:', error);
+    return res.status(500).json({
+      error: error instanceof Error ? error.message : 'Failed to enqueue broadcast job',
+    });
+  }
+});
+
+export const broadcastRouter: RouterType = router;

--- a/apps/processor/src/api/broadcast.ts
+++ b/apps/processor/src/api/broadcast.ts
@@ -24,13 +24,27 @@ router.post('/enqueue', async (req, res) => {
   }
 
   try {
-    const jobId = await queueManager.addJob('email-broadcast', { broadcastId });
+    // singletonKey dedupes at the layer that owns job identity: a double-click
+    // or a retried POST (lost response) must not start a second concurrent walk
+    // of the same audience. The per-recipient claim ledger stays the LAST line
+    // of defence, not the only one. pg-boss releases the key once the job
+    // completes, so re-enqueueing a paused/refused broadcast still works.
+    const jobId = await queueManager.addJob(
+      'email-broadcast',
+      { broadcastId },
+      { singletonKey: broadcastId },
+    );
     return res.json({ success: true, jobId });
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to enqueue broadcast job';
+    // addJob surfaces pg-boss's null jobId (singleton conflict) as this throw.
+    if (message.includes('duplicate or rejected')) {
+      return res.status(409).json({
+        error: 'A job for this broadcast is already queued or running',
+      });
+    }
     console.error('[broadcast] enqueue failed:', error);
-    return res.status(500).json({
-      error: error instanceof Error ? error.message : 'Failed to enqueue broadcast job',
-    });
+    return res.status(500).json({ error: message });
   }
 });
 

--- a/apps/processor/src/server.ts
+++ b/apps/processor/src/server.ts
@@ -12,6 +12,7 @@ import { verifyRouter } from './api/verify';
 import avatarRouter from './api/avatar';
 import { deleteFileRouter } from './api/delete-file';
 import { erasureRouter } from './api/erasure';
+import { broadcastRouter } from './api/broadcast';
 import dotenv from 'dotenv';
 import { authenticateService, requireScope } from './middleware/auth';
 import { requireResourceBinding, requirePageBinding } from './middleware/resource-binding';
@@ -202,6 +203,7 @@ app.use('/api/avatar', authenticateService, requireScope('avatars:write'), avata
 app.use('/avatars', avatarRouter);
 app.use('/api/files', authenticateService, requireScope('files:delete'), deleteFileRouter);
 app.use('/api/erasure', authenticateService, requireScope('erasure:enqueue'), erasureRouter);
+app.use('/api/broadcast', authenticateService, requireScope('broadcast:enqueue'), broadcastRouter);
 app.use('/cache', authenticateService, requireScope('files:read'), requireResourceBinding('params'), cacheRouter);
 
 // ---------------------------------------------------------------------------

--- a/apps/processor/src/types/index.ts
+++ b/apps/processor/src/types/index.ts
@@ -93,6 +93,15 @@ export interface AccountErasureJobData {
   userId: string;
 }
 
+/**
+ * Durable admin-console email broadcast job. Carries only the broadcast id; the
+ * worker re-reads the email_broadcasts row for the authoritative state, exactly
+ * like AccountErasureJobData.
+ */
+export interface EmailBroadcastJobData {
+  broadcastId: string;
+}
+
 // Discriminated union for addJob
 export type JobDataMap = {
   'ingest-file': IngestFileJobData;
@@ -104,6 +113,7 @@ export type JobDataMap = {
   'siem-delivery': Record<string, never>;
   'account-erasure': AccountErasureJobData;
   'audit-chainer': Record<string, never>;
+  'email-broadcast': EmailBroadcastJobData;
 };
 
 export type QueueName = keyof JobDataMap;

--- a/apps/processor/src/workers/__tests__/email-broadcast-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/email-broadcast-worker.test.ts
@@ -150,11 +150,18 @@ const page = (rows: Array<{ id: string; name: string | null; email: string | nul
 const ADA = { id: 'user-ada', name: 'Ada', email: 'ada@example.com' };
 const BOB = { id: 'user-bob', name: 'Bob', email: 'bob@example.com' };
 
+/** Every worker status write carries the guard that keeps it from overturning an
+ *  admin's cancel/pause; assertions accept any guard shape that includes those. */
+const guarded = expect.objectContaining({
+  unlessStatus: expect.arrayContaining(['cancelled', 'paused']),
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockRepo.createBroadcastLedger.mockReturnValue(mockLedger);
   mockRepo.loadAlreadySentEmails.mockResolvedValue(new Set());
   mockRepo.countRecipientsByStatus.mockResolvedValue({ pending: 0, sent: 0, skipped: 0, failed: 0 });
+  mockRepo.updateStatus.mockResolvedValue(1);
   mockLedger.claim.mockResolvedValue(true);
   mockLedger.record.mockResolvedValue(undefined);
   mockLedger.onSkip.mockResolvedValue(undefined);
@@ -194,6 +201,17 @@ describe('runEmailBroadcastJob — terminal short-circuits', () => {
       expect(mockEngine.sendOne).not.toHaveBeenCalled();
     },
   );
+
+  it('stops without sending when a cancel wins the race for the in_progress transition', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    // The guarded write reports 0 rows: an operator state landed first.
+    mockRepo.updateStatus.mockResolvedValue(0);
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockResolveContent).not.toHaveBeenCalled();
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
 });
 
 describe('runEmailBroadcastJob — on-prem guard', () => {
@@ -208,6 +226,7 @@ describe('runEmailBroadcastJob — on-prem guard', () => {
       'bcast-1',
       'failed',
       expect.objectContaining({ blockedReason: expect.stringContaining('on-prem') }),
+      guarded,
     );
     expect(mockResolveAudience).not.toHaveBeenCalled();
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
@@ -227,6 +246,7 @@ describe('runEmailBroadcastJob — on-prem guard', () => {
       'bcast-1',
       'completed',
       expect.objectContaining({ completedAt: expect.any(Date) }),
+      guarded,
     );
   });
 });
@@ -242,6 +262,7 @@ describe('runEmailBroadcastJob — preflight', () => {
       'bcast-1',
       'failed',
       expect.objectContaining({ blockedReason: 'FROM_EMAIL is not set' }),
+      guarded,
     );
     expect(mockResolveAudience).not.toHaveBeenCalled();
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
@@ -259,6 +280,7 @@ describe('runEmailBroadcastJob — preflight', () => {
       expect.objectContaining({
         blockedReason: 'Broadcast is in compose mode but has no body.',
       }),
+      guarded,
     );
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
   });
@@ -266,9 +288,7 @@ describe('runEmailBroadcastJob — preflight', () => {
   it('marks failed and stops when a live body carries an unreachable link', async () => {
     mockRepo.findById.mockResolvedValue(makeBroadcast());
     mockExtractCtaUrls.mockReturnValue(['https://pagespace.ai/gone']);
-    // findUnreachableUrls is the REAL core implementation, driven by the injected
-    // fetch default — so give the URL a real failure by making it unparseable to
-    // the probe: easier to intercept via global fetch.
+    // findUnreachableUrls is the REAL core implementation, driven by global fetch.
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValue({ ok: false, status: 404 } as Response);
@@ -285,8 +305,25 @@ describe('runEmailBroadcastJob — preflight', () => {
       expect.objectContaining({
         blockedReason: expect.stringContaining('https://pagespace.ai/gone'),
       }),
+      guarded,
     );
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale blockedReason when a refused broadcast is re-run after the config fix', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ status: 'failed' }));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    // Without this, the earlier refusal ('FROM_EMAIL is not set…') survives onto
+    // a row that then completes, and the admin UI shows a successful send
+    // annotated with a blocking reason.
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'in_progress',
+      expect.objectContaining({ blockedReason: null, lastError: null }),
+      expect.anything(),
+    );
   });
 });
 
@@ -302,11 +339,10 @@ describe('runEmailBroadcastJob — resume', () => {
     expect(mockEngine.sendOne).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'user-bob', email: 'bob@example.com' }),
     );
-    // The skip is persisted with its reason so the admin sees WHY, and the resumed
-    // recipient is never claimed (claim happens only on the send path).
-    expect(mockLedger.onSkip).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'user-ada', reason: 'already-sent' }),
-    );
+    // 'already-sent' skips are deliberately NOT persisted: Ada's ledger row is
+    // already `sent` (recordSkip's guard would refuse the demotion anyway), and a
+    // 49k-sent resume must not burn one no-op round trip per mailed recipient.
+    expect(mockLedger.onSkip).not.toHaveBeenCalled();
     expect(mockLedger.claim).toHaveBeenCalledTimes(1);
     expect(mockLedger.record).toHaveBeenCalledTimes(1);
     expect(mockLedger.record).toHaveBeenCalledWith(
@@ -316,7 +352,54 @@ describe('runEmailBroadcastJob — resume', () => {
       'bcast-1',
       'completed',
       expect.objectContaining({ completedAt: expect.any(Date) }),
+      guarded,
     );
+  });
+
+  it('still persists non-resume skips (opted-out) through the ledger', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockLoadOptedOut.mockResolvedValue(new Set(['user-ada']));
+    mockResolveAudience.mockResolvedValue(page([ADA, BOB]));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockLedger.onSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-ada', reason: 'opted-out' }),
+    );
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runEmailBroadcastJob — canary sendLimit', () => {
+  it('stops at sendLimit attempts within a run', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ sendLimit: 1 }));
+    mockResolveAudience
+      .mockResolvedValueOnce(page([ADA, BOB], 'user-bob'))
+      .mockResolvedValue(page([], null));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
+    // The limit break happens before a second page is fetched.
+    expect(mockResolveAudience).toHaveBeenCalledTimes(1);
+    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
+    expect(steps).toContain('send-limit');
+  });
+
+  it('counts attempts from PRIOR runs against the budget, so a retry cannot escalate a canary', async () => {
+    // A 2-person canary whose first attempt sent 1 and failed 1: the pg-boss
+    // retry must attempt NOTHING — a per-process counter would hand it a fresh
+    // budget of 2 brand-new people per retry, walking far past the cap.
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ sendLimit: 2 }));
+    mockRepo.countRecipientsByStatus.mockResolvedValue({ pending: 0, sent: 1, skipped: 0, failed: 1 });
+    mockRepo.loadAlreadySentEmails.mockResolvedValue(new Set(['ada@example.com']));
+    mockResolveAudience.mockResolvedValue(page([ADA, BOB]));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
+    expect(steps).toContain('send-limit');
   });
 });
 
@@ -341,21 +424,60 @@ describe('runEmailBroadcastJob — send failures', () => {
       'bcast-1',
       'failed',
       expect.objectContaining({ lastError: expect.stringContaining('1 recipient(s) failed') }),
+      guarded,
     );
     // The address is redacted before it can land on the row.
     const failedCall = mockRepo.updateStatus.mock.calls.find(([, status]) => status === 'failed');
     expect(failedCall?.[2]?.lastError).not.toContain('ada@example.com');
   });
 
-  it('does not mail a recipient another worker has claimed', async () => {
+  it('does not mail a claimed recipient, and does NOT declare the broadcast completed over them', async () => {
     mockRepo.findById.mockResolvedValue(makeBroadcast());
     mockResolveAudience.mockResolvedValue(page([ADA]));
     mockLedger.claim.mockResolvedValue(false);
 
-    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+    // The rival's outcome is unknown: it may have died mid-send. Completing here
+    // would strand the recipient as pending forever (the terminal short-circuit
+    // drops every future job). Retry instead — the resume set makes it cheap.
+    await expect(runEmailBroadcastJob({ broadcastId: 'bcast-1' })).rejects.toThrow(
+      /claimed by another worker/,
+    );
 
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
     expect(mockLedger.record).not.toHaveBeenCalled();
+    expect(mockRepo.updateStatus).not.toHaveBeenCalledWith(
+      'bcast-1',
+      'completed',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});
+
+describe('runEmailBroadcastJob — mid-run cancel/pause', () => {
+  it('halts between pages when the admin cancels, and never overwrites the cancel', async () => {
+    // Job-start read is 'queued'; the page-2 pre-flight read sees the cancel.
+    mockRepo.findById
+      .mockResolvedValueOnce(makeBroadcast())
+      .mockResolvedValueOnce(makeBroadcast())
+      .mockResolvedValue(makeBroadcast({ status: 'cancelled' }));
+    mockResolveAudience
+      .mockResolvedValueOnce(page([ADA], 'user-ada'))
+      .mockResolvedValue(page([BOB], null));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    // Page 1 was sent before the cancel; page 2 must never be fetched or mailed.
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
+    expect(mockEngine.sendOne).toHaveBeenCalledWith(expect.objectContaining({ userId: 'user-ada' }));
+    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
+    expect(steps).toContain('halted');
+    expect(mockRepo.updateStatus).not.toHaveBeenCalledWith(
+      'bcast-1',
+      'completed',
+      expect.anything(),
+      expect.anything(),
+    );
   });
 });
 
@@ -381,6 +503,7 @@ describe('runEmailBroadcastJob — dry run', () => {
       'bcast-1',
       'completed',
       expect.objectContaining({ completedAt: expect.any(Date) }),
+      guarded,
     );
   });
 });
@@ -420,21 +543,6 @@ describe('runEmailBroadcastJob — pagination, counts and step results', () => {
     const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
     expect(steps).toEqual(expect.arrayContaining(['batch-1', 'batch-2', 'finalize']));
   });
-
-  it('stops at sendLimit attempts (a canary cannot walk the whole audience)', async () => {
-    mockRepo.findById.mockResolvedValue(makeBroadcast({ sendLimit: 1 }));
-    mockResolveAudience
-      .mockResolvedValueOnce(page([ADA, BOB], 'user-bob'))
-      .mockResolvedValue(page([], null));
-
-    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
-
-    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
-    // The limit break happens before a second page is fetched.
-    expect(mockResolveAudience).toHaveBeenCalledTimes(1);
-    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
-    expect(steps).toContain('send-limit');
-  });
 });
 
 describe('runEmailBroadcastJob — suppression read', () => {
@@ -448,6 +556,7 @@ describe('runEmailBroadcastJob — suppression read', () => {
       'bcast-1',
       'failed',
       expect.objectContaining({ lastError: 'Resend 500' }),
+      guarded,
     );
     expect(mockEngine.sendOne).not.toHaveBeenCalled();
   });

--- a/apps/processor/src/workers/__tests__/email-broadcast-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/email-broadcast-worker.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Unit tests for the durable email-broadcast worker.
+ *
+ * Every @pagespace/lib collaborator that touches the outside world (repository,
+ * audience queries, engine, suppression read, PII decrypt) is mocked, matching
+ * account-erasure-worker.test.ts — vitest can't intercept @pagespace/db/db from
+ * within lib's compiled dist, so partial-mocking would hit a live Postgres.
+ * `services/broadcast/core` is deliberately REAL: `runBroadcast` is the pure
+ * orchestrator whose decide→claim→send→record semantics these tests exist to
+ * prove the worker wires correctly (resume skips, rate-limit failures recorded
+ * `failed` not `sent`, dry runs sending nothing).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockRepo,
+  mockLedger,
+  mockResolveAudience,
+  mockLoadOptedOut,
+  mockLoadRightsRestricted,
+  mockResolveContent,
+  mockExtractCtaUrls,
+  mockRenderMarkdown,
+  mockCreateEngine,
+  mockEngine,
+  mockListSuppressed,
+  mockIsOnPrem,
+} = vi.hoisted(() => {
+  const mockLedger = {
+    claim: vi.fn(),
+    record: vi.fn(),
+    onSkip: vi.fn(),
+    onFailure: vi.fn(),
+  };
+  const mockRepo = {
+    findById: vi.fn(),
+    findTemplateById: vi.fn(),
+    incrementAttempts: vi.fn(),
+    updateStatus: vi.fn(),
+    appendStepResult: vi.fn(),
+    updateCounts: vi.fn(),
+    loadAlreadySentEmails: vi.fn(),
+    countRecipientsByStatus: vi.fn(),
+    createBroadcastLedger: vi.fn(() => mockLedger),
+  };
+  const mockEngine = {
+    name: 'transactional',
+    preflight: vi.fn(),
+    sendOne: vi.fn(),
+    renderOne: vi.fn(),
+  };
+  return {
+    mockRepo,
+    mockLedger,
+    mockResolveAudience: vi.fn(),
+    mockLoadOptedOut: vi.fn(),
+    mockLoadRightsRestricted: vi.fn(),
+    mockResolveContent: vi.fn(),
+    mockExtractCtaUrls: vi.fn(),
+    mockRenderMarkdown: vi.fn(),
+    mockCreateEngine: vi.fn(() => mockEngine),
+    mockEngine,
+    mockListSuppressed: vi.fn(),
+    mockIsOnPrem: vi.fn(),
+  };
+});
+
+vi.mock('@pagespace/lib/repositories/broadcast-repository', () => ({
+  broadcastRepository: mockRepo,
+}));
+
+vi.mock('@pagespace/lib/services/broadcast/audience', () => ({
+  resolveAudience: mockResolveAudience,
+  loadOptedOutUserIds: mockLoadOptedOut,
+  loadRightsRestrictedUserIds: mockLoadRightsRestricted,
+}));
+
+vi.mock('@pagespace/lib/services/broadcast/content', () => ({
+  resolveBroadcastContent: mockResolveContent,
+  extractCtaUrls: mockExtractCtaUrls,
+  renderMarkdownToSafeHtml: mockRenderMarkdown,
+}));
+
+vi.mock('@pagespace/lib/services/broadcast/transactional-engine', () => ({
+  createTransactionalEngine: mockCreateEngine,
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/resend-suppression-client', () => ({
+  listSuppressedEmails: mockListSuppressed,
+}));
+
+vi.mock('@pagespace/lib/auth/user-repository', () => ({
+  decryptUserRow: vi.fn(async (row: unknown) => row),
+}));
+
+vi.mock('@pagespace/lib/validators/email', () => ({
+  isValidEmail: (email: string) => email.includes('@'),
+}));
+
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isOnPrem: mockIsOnPrem,
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { runEmailBroadcastJob } from '../email-broadcast-worker';
+
+interface TestBroadcast {
+  id: string;
+  subject: string;
+  contentMode: 'compose' | 'template';
+  templateId: string | null;
+  bodyMarkdown: string | null;
+  notificationType: string;
+  audienceDefinition: Record<string, unknown>;
+  status: string;
+  dryRun: boolean;
+  sendLimit: number | null;
+  delayMs: number;
+  attempts: number;
+  startedAt: Date | null;
+}
+
+function makeBroadcast(overrides: Partial<TestBroadcast> = {}): TestBroadcast {
+  return {
+    id: 'bcast-1',
+    subject: 'Big news',
+    contentMode: 'compose',
+    templateId: null,
+    bodyMarkdown: 'Hello **world**',
+    notificationType: 'PRODUCT_UPDATE',
+    audienceDefinition: {},
+    status: 'queued',
+    dryRun: false,
+    sendLimit: null,
+    delayMs: 0,
+    attempts: 0,
+    startedAt: null,
+    ...overrides,
+  };
+}
+
+const page = (rows: Array<{ id: string; name: string | null; email: string | null }>, nextCursor: string | null = null) => ({
+  rows,
+  nextCursor,
+});
+
+const ADA = { id: 'user-ada', name: 'Ada', email: 'ada@example.com' };
+const BOB = { id: 'user-bob', name: 'Bob', email: 'bob@example.com' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRepo.createBroadcastLedger.mockReturnValue(mockLedger);
+  mockRepo.loadAlreadySentEmails.mockResolvedValue(new Set());
+  mockRepo.countRecipientsByStatus.mockResolvedValue({ pending: 0, sent: 0, skipped: 0, failed: 0 });
+  mockLedger.claim.mockResolvedValue(true);
+  mockLedger.record.mockResolvedValue(undefined);
+  mockLedger.onSkip.mockResolvedValue(undefined);
+  mockLedger.onFailure.mockResolvedValue(undefined);
+  mockLoadOptedOut.mockResolvedValue(new Set());
+  mockLoadRightsRestricted.mockResolvedValue(new Set());
+  mockListSuppressed.mockResolvedValue(new Set());
+  mockIsOnPrem.mockReturnValue(false);
+  mockResolveContent.mockImplementation(async (b: TestBroadcast) => ({
+    subject: b.subject,
+    bodyMarkdown: b.bodyMarkdown ?? '',
+  }));
+  mockRenderMarkdown.mockReturnValue('<p>Hello <strong>world</strong></p>');
+  mockExtractCtaUrls.mockReturnValue([]);
+  mockCreateEngine.mockReturnValue(mockEngine);
+  mockEngine.preflight.mockResolvedValue({ ok: true });
+  mockEngine.sendOne.mockResolvedValue(undefined);
+  mockEngine.renderOne.mockResolvedValue('<html>rendered</html>');
+  mockResolveAudience.mockResolvedValue(page([]));
+});
+
+describe('runEmailBroadcastJob — terminal short-circuits', () => {
+  it('drops the job when the broadcast row is gone', async () => {
+    mockRepo.findById.mockResolvedValue(null);
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+    expect(mockRepo.incrementAttempts).not.toHaveBeenCalled();
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+
+  it.each(['completed', 'cancelled', 'paused'] as const)(
+    'does nothing when the broadcast is already %s',
+    async (status) => {
+      mockRepo.findById.mockResolvedValue(makeBroadcast({ status }));
+      await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+      expect(mockRepo.incrementAttempts).not.toHaveBeenCalled();
+      expect(mockResolveAudience).not.toHaveBeenCalled();
+      expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    },
+  );
+});
+
+describe('runEmailBroadcastJob — on-prem guard', () => {
+  it('refuses a live run on-prem (failed + blockedReason), sending nothing and NOT throwing', async () => {
+    mockIsOnPrem.mockReturnValue(true);
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ dryRun: false }));
+
+    // Returns (not throws): retrying a deployment-mode problem just re-fails it.
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({ blockedReason: expect.stringContaining('on-prem') }),
+    );
+    expect(mockResolveAudience).not.toHaveBeenCalled();
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    expect(mockEngine.renderOne).not.toHaveBeenCalled();
+  });
+
+  it('still allows a dry run on-prem (renders, sends nothing)', async () => {
+    mockIsOnPrem.mockReturnValue(true);
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ dryRun: true }));
+    mockResolveAudience.mockResolvedValue(page([ADA]));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    expect(mockEngine.renderOne).toHaveBeenCalledTimes(1);
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'completed',
+      expect.objectContaining({ completedAt: expect.any(Date) }),
+    );
+  });
+});
+
+describe('runEmailBroadcastJob — preflight', () => {
+  it('marks failed with the engine preflight reason and stops', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockEngine.preflight.mockResolvedValue({ ok: false, reason: 'FROM_EMAIL is not set' });
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({ blockedReason: 'FROM_EMAIL is not set' }),
+    );
+    expect(mockResolveAudience).not.toHaveBeenCalled();
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+
+  it('marks failed when content cannot be resolved', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ bodyMarkdown: null }));
+    mockResolveContent.mockRejectedValue(new Error('Broadcast is in compose mode but has no body.'));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({
+        blockedReason: 'Broadcast is in compose mode but has no body.',
+      }),
+    );
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+
+  it('marks failed and stops when a live body carries an unreachable link', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockExtractCtaUrls.mockReturnValue(['https://pagespace.ai/gone']);
+    // findUnreachableUrls is the REAL core implementation, driven by the injected
+    // fetch default — so give the URL a real failure by making it unparseable to
+    // the probe: easier to intercept via global fetch.
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: false, status: 404 } as Response);
+
+    try {
+      await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({
+        blockedReason: expect.stringContaining('https://pagespace.ai/gone'),
+      }),
+    );
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+});
+
+describe('runEmailBroadcastJob — resume', () => {
+  it('skips already-sent recipients and mails only the remainder', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockRepo.loadAlreadySentEmails.mockResolvedValue(new Set(['ada@example.com']));
+    mockResolveAudience.mockResolvedValue(page([ADA, BOB]));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
+    expect(mockEngine.sendOne).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-bob', email: 'bob@example.com' }),
+    );
+    // The skip is persisted with its reason so the admin sees WHY, and the resumed
+    // recipient is never claimed (claim happens only on the send path).
+    expect(mockLedger.onSkip).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-ada', reason: 'already-sent' }),
+    );
+    expect(mockLedger.claim).toHaveBeenCalledTimes(1);
+    expect(mockLedger.record).toHaveBeenCalledTimes(1);
+    expect(mockLedger.record).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-bob', email: 'bob@example.com' }),
+    );
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'completed',
+      expect.objectContaining({ completedAt: expect.any(Date) }),
+    );
+  });
+});
+
+describe('runEmailBroadcastJob — send failures', () => {
+  it('records a rate-limit throw as a per-recipient failure (never sent) and rethrows for pg-boss retry', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockResolveAudience.mockResolvedValue(page([ADA]));
+    mockEngine.sendOne.mockRejectedValue(
+      new Error('Too many emails sent to ada@example.com. Please try again later.'),
+    );
+
+    await expect(runEmailBroadcastJob({ broadcastId: 'bcast-1' })).rejects.toThrow(
+      /finished with failures/,
+    );
+
+    expect(mockLedger.onFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-ada', email: 'ada@example.com' }),
+    );
+    // The one write that must never happen on a failed send:
+    expect(mockLedger.record).not.toHaveBeenCalled();
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({ lastError: expect.stringContaining('1 recipient(s) failed') }),
+    );
+    // The address is redacted before it can land on the row.
+    const failedCall = mockRepo.updateStatus.mock.calls.find(([, status]) => status === 'failed');
+    expect(failedCall?.[2]?.lastError).not.toContain('ada@example.com');
+  });
+
+  it('does not mail a recipient another worker has claimed', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockResolveAudience.mockResolvedValue(page([ADA]));
+    mockLedger.claim.mockResolvedValue(false);
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    expect(mockLedger.record).not.toHaveBeenCalled();
+  });
+});
+
+describe('runEmailBroadcastJob — dry run', () => {
+  it('renders every recipient, sends nothing, and writes no recipient rows', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ dryRun: true }));
+    mockResolveAudience.mockResolvedValue(page([ADA, BOB]));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+    expect(mockEngine.renderOne).toHaveBeenCalledTimes(2);
+    // No ledger traffic at all on a dry run: no claims, no sent rows, no skip rows.
+    expect(mockLedger.claim).not.toHaveBeenCalled();
+    expect(mockLedger.record).not.toHaveBeenCalled();
+    expect(mockLedger.onSkip).not.toHaveBeenCalled();
+    // Counts still advance (from the in-memory tally, not the ledger).
+    expect(mockRepo.updateCounts).toHaveBeenCalledWith(
+      'bcast-1',
+      expect.objectContaining({ totalTargeted: 2, sentCount: 2, failedCount: 0 }),
+    );
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'completed',
+      expect.objectContaining({ completedAt: expect.any(Date) }),
+    );
+  });
+});
+
+describe('runEmailBroadcastJob — pagination, counts and step results', () => {
+  it('walks the keyset pages, updating counts + step results after each batch', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockResolveAudience
+      .mockResolvedValueOnce(page([ADA], 'user-ada'))
+      .mockResolvedValueOnce(page([BOB], null));
+    mockRepo.countRecipientsByStatus
+      .mockResolvedValueOnce({ pending: 0, sent: 1, skipped: 0, failed: 0 })
+      .mockResolvedValueOnce({ pending: 0, sent: 2, skipped: 0, failed: 0 });
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    // Second resolve continues from the first page's cursor.
+    expect(mockResolveAudience).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({ after: 'user-ada' }),
+    );
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(2);
+
+    // Live counts are recomputed from the ledger after every page.
+    expect(mockRepo.updateCounts).toHaveBeenNthCalledWith(
+      1,
+      'bcast-1',
+      expect.objectContaining({ totalTargeted: 1, sentCount: 1 }),
+    );
+    expect(mockRepo.updateCounts).toHaveBeenNthCalledWith(
+      2,
+      'bcast-1',
+      expect.objectContaining({ totalTargeted: 2, sentCount: 2 }),
+    );
+
+    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
+    expect(steps).toEqual(expect.arrayContaining(['batch-1', 'batch-2', 'finalize']));
+  });
+
+  it('stops at sendLimit attempts (a canary cannot walk the whole audience)', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast({ sendLimit: 1 }));
+    mockResolveAudience
+      .mockResolvedValueOnce(page([ADA, BOB], 'user-bob'))
+      .mockResolvedValue(page([], null));
+
+    await runEmailBroadcastJob({ broadcastId: 'bcast-1' });
+
+    expect(mockEngine.sendOne).toHaveBeenCalledTimes(1);
+    // The limit break happens before a second page is fetched.
+    expect(mockResolveAudience).toHaveBeenCalledTimes(1);
+    const steps = mockRepo.appendStepResult.mock.calls.map(([, r]) => r.step);
+    expect(steps).toContain('send-limit');
+  });
+});
+
+describe('runEmailBroadcastJob — suppression read', () => {
+  it('surfaces an unreadable suppression list as a retryable throw', async () => {
+    mockRepo.findById.mockResolvedValue(makeBroadcast());
+    mockListSuppressed.mockRejectedValue(new Error('Resend 500'));
+
+    await expect(runEmailBroadcastJob({ broadcastId: 'bcast-1' })).rejects.toThrow('Resend 500');
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+      'bcast-1',
+      'failed',
+      expect.objectContaining({ lastError: 'Resend 500' }),
+    );
+    expect(mockEngine.sendOne).not.toHaveBeenCalled();
+  });
+});

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -233,14 +233,34 @@ describe('QueueManager', () => {
 
       await qm.addJob('email-broadcast', { broadcastId: 'bcast-1' });
 
-      // sendEmail's per-recipient limiter blocks for an hour; the default 3×5s
-      // policy would exhaust every retry in seconds and strand rate-limited
-      // recipients as `failed` forever. Exponential backoff from 60s crosses
-      // the window.
+      // sendEmail's per-recipient limiter blocks for roughly an hour; the default
+      // 3×5s policy would exhaust every retry in seconds and strand rate-limited
+      // recipients as `failed` forever. Exponential backoff from 60s crosses the
+      // window. expireInSeconds must dwarf the longest legitimate attempt: the
+      // pg-boss default of 15 minutes would fail a long-running send mid-flight
+      // and start a concurrent duplicate run.
       expect(mockBossSend).toHaveBeenCalledWith(
         'email-broadcast',
         { broadcastId: 'bcast-1' },
-        expect.objectContaining({ retryLimit: 10, retryDelay: 60, retryBackoff: true })
+        expect.objectContaining({
+          retryLimit: 10,
+          retryDelay: 60,
+          retryBackoff: true,
+          expireInSeconds: 6 * 60 * 60,
+        })
+      );
+    });
+
+    it('lets caller options (e.g. singletonKey) pass through and win over queue defaults', async () => {
+      const qm = new QueueManager();
+      await qm.initialize();
+
+      await qm.addJob('email-broadcast', { broadcastId: 'bcast-1' }, { singletonKey: 'bcast-1' });
+
+      expect(mockBossSend).toHaveBeenCalledWith(
+        'email-broadcast',
+        { broadcastId: 'bcast-1' },
+        expect.objectContaining({ singletonKey: 'bcast-1', retryLimit: 10 })
       );
     });
 

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -227,6 +227,23 @@ describe('QueueManager', () => {
       })).rejects.toThrow('Failed to queue job on ingest-file');
     });
 
+    it('gives email-broadcast a retry policy that outlasts the one-hour email rate limiter', async () => {
+      const qm = new QueueManager();
+      await qm.initialize();
+
+      await qm.addJob('email-broadcast', { broadcastId: 'bcast-1' });
+
+      // sendEmail's per-recipient limiter blocks for an hour; the default 3×5s
+      // policy would exhaust every retry in seconds and strand rate-limited
+      // recipients as `failed` forever. Exponential backoff from 60s crosses
+      // the window.
+      expect(mockBossSend).toHaveBeenCalledWith(
+        'email-broadcast',
+        { broadcastId: 'bcast-1' },
+        expect.objectContaining({ retryLimit: 10, retryDelay: 60, retryBackoff: true })
+      );
+    });
+
     it('sets higher priority for image-optimize queue', async () => {
       const qm = new QueueManager();
       await qm.initialize();

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -45,6 +45,11 @@ vi.mock('../audit-chainer-worker', () => ({
   processAuditChainer: vi.fn().mockResolvedValue({ outcome: 'idle', drained: 0 }),
 }));
 
+// Mock email broadcast worker (dynamically imported by queue-manager)
+vi.mock('../email-broadcast-worker', () => ({
+  runEmailBroadcastJob: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock workers
 vi.mock('../text-extractor', () => ({
   needsTextExtraction: vi.fn().mockReturnValue(false),
@@ -118,7 +123,7 @@ describe('QueueManager', () => {
       await qm.initialize();
 
       expect(mockBossStart).toHaveBeenCalledTimes(1);
-      expect(mockBossWork).toHaveBeenCalledTimes(9);
+      expect(mockBossWork).toHaveBeenCalledTimes(10);
       expect(mockBossWork.mock.calls[0][0]).toBe('ingest-file');
       expect(mockBossWork.mock.calls[1][0]).toBe('image-optimize');
       expect(mockBossWork.mock.calls[2][0]).toBe('text-extract');
@@ -128,7 +133,8 @@ describe('QueueManager', () => {
       expect(mockBossWork.mock.calls[6][0]).toBe('pull-verify');
       expect(mockBossWork.mock.calls[7][0]).toBe('account-erasure');
       expect(mockBossWork.mock.calls[8][0]).toBe('audit-chainer');
-      expect(mockBossCreateQueue).toHaveBeenCalledTimes(9);
+      expect(mockBossWork.mock.calls[9][0]).toBe('email-broadcast');
+      expect(mockBossCreateQueue).toHaveBeenCalledTimes(10);
       expect(mockBossCreateQueue).toHaveBeenCalledWith('ingest-file');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('pull-verify');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('image-optimize');
@@ -138,6 +144,7 @@ describe('QueueManager', () => {
       expect(mockBossCreateQueue).toHaveBeenCalledWith('siem-delivery');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('account-erasure');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('audit-chainer');
+      expect(mockBossCreateQueue).toHaveBeenCalledWith('email-broadcast');
       expect(mockBossSchedule).toHaveBeenCalledWith('siem-delivery', '*/30 * * * * *', {}, { retryLimit: 0 });
       // Same cadence + no-stack pattern as siem-delivery: retryLimit 0 so
       // overlapping scheduled runs never pile up; the advisory lock inside
@@ -353,6 +360,7 @@ describe('QueueManager', () => {
       expect(status['ocr-process']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
       expect(status['siem-delivery']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
       expect(status['audit-chainer']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
+      expect(status['email-broadcast']).toEqual({ active: 0, pending: 0, completed: 0, failed: 0 });
     });
 
     it('maps queue states correctly', async () => {

--- a/apps/processor/src/workers/email-broadcast-worker.ts
+++ b/apps/processor/src/workers/email-broadcast-worker.ts
@@ -15,12 +15,18 @@
  *    `broadcast:<id>:<userId>` idempotency key backstop the races.
  *  - A refusal (on-prem live send, failed preflight, unresolvable content,
  *    unreachable CTA) is terminal-for-retry: the row is marked `failed` with the
- *    reason and the worker RETURNS, because retrying a config problem just
- *    re-fails it.
+ *    reason in `blockedReason` and the worker RETURNS, because retrying a config
+ *    problem just re-fails it. Retryable failures set `lastError` and THROW.
  *  - Per-recipient send failures — including sendEmail's 3/hr rate-limit throw —
  *    are recorded `failed` (never `sent`) by the ledger and the run continues;
  *    the terminal `failed` + rethrow at the end is what makes pg-boss come back
  *    for them.
+ *  - Cancel/pause: the worker re-reads the row before every page and halts when
+ *    an admin has cancelled or paused the broadcast, and every status write it
+ *    makes refuses to overturn those two states. Halting ENDS the pg-boss job
+ *    (a paused job deliberately does not burn retries waiting) — resuming a
+ *    paused broadcast means re-enqueueing it via POST /api/broadcast/enqueue,
+ *    which is safe because the ledger resume set skips everyone already mailed.
  */
 
 import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
@@ -28,7 +34,7 @@ import {
   findUnreachableUrls,
   resolveBaseUrl,
   runBroadcast,
-  type BroadcastResult,
+  ON_PREM_LIVE_SEND_REFUSAL,
   type SkipReason,
 } from '@pagespace/lib/services/broadcast/core';
 import {
@@ -51,19 +57,14 @@ import type { EmailBroadcastJobData } from '../types';
 /** Audience page size for the keyset walk — never materialize the whole table. */
 const AUDIENCE_PAGE_SIZE = 500;
 
+/**
+ * The admin-set states this worker must never overturn. An operator's cancel or
+ * pause can land at any instant between one of our reads and one of our writes;
+ * every status write below carries this guard so the race loses to the human.
+ */
+const OPERATOR_STATES = ['cancelled', 'paused'] as const;
+
 const nowIso = () => new Date().toISOString();
-
-const emptySkips = (): Record<SkipReason, number> => ({
-  'invalid-email': 0,
-  'already-sent': 0,
-  suppressed: 0,
-  'opted-out': 0,
-  'rights-restricted': 0,
-});
-
-function addSkips(into: Record<SkipReason, number>, from: Record<SkipReason, number>): void {
-  for (const key of Object.keys(from) as SkipReason[]) into[key] += from[key];
-}
 
 const totalSkips = (skips: Record<SkipReason, number>) =>
   Object.values(skips).reduce((a, b) => a + b, 0);
@@ -71,7 +72,8 @@ const totalSkips = (skips: Record<SkipReason, number>) =>
 /**
  * Mark the broadcast failed for a reason no retry can fix, and record the step
  * that refused. Returning (not throwing) afterwards is what keeps pg-boss from
- * re-running a config problem.
+ * re-running a config problem. Refusals live in `blockedReason` (a terminal
+ * diagnosis), never `lastError` (a retryable one).
  */
 async function refuse(broadcastId: string, step: string, reason: string): Promise<void> {
   console.error(`[email-broadcast] ${broadcastId} refused at ${step}: ${reason}`);
@@ -81,10 +83,12 @@ async function refuse(broadcastId: string, step: string, reason: string): Promis
     detail: reason,
     at: nowIso(),
   });
-  await broadcastRepository.updateStatus(broadcastId, 'failed', {
-    blockedReason: reason,
-    completedAt: new Date(),
-  });
+  await broadcastRepository.updateStatus(
+    broadcastId,
+    'failed',
+    { blockedReason: reason, completedAt: new Date() },
+    { unlessStatus: [...OPERATOR_STATES] },
+  );
 }
 
 export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise<void> {
@@ -100,6 +104,10 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
     broadcast.status === 'cancelled' ||
     broadcast.status === 'paused'
   ) {
+    // Returning completes the pg-boss job, ending any retry chain. For
+    // cancelled/completed that is exactly right; for paused it is a deliberate
+    // trade — a pause of unknown length must not sit burning retries — so
+    // resuming is a fresh enqueue (see module doc), not a retry.
     console.log(`[email-broadcast] broadcast ${broadcastId} is ${broadcast.status}; nothing to do`);
     return;
   }
@@ -110,21 +118,31 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
 
   // On-prem guard FIRST, before any status transition or provider read. sendEmail
   // is a silent no-op on-prem, so a "successful" live run would record everyone as
-  // sent while sending nothing — poisoning the ledger for the real send.
+  // sent while sending nothing — poisoning the ledger for the real send. The
+  // reason text is core's own (preflight repeats this check); refusing here just
+  // spares the row a doomed in_progress transition.
   if (live && isOnPrem()) {
-    await refuse(
-      broadcastId,
-      'preflight',
-      'DEPLOYMENT_MODE is on-prem, where sendEmail() silently drops mail. The run would send ' +
-        'nothing while recording every recipient as already-sent.',
-    );
+    await refuse(broadcastId, 'preflight', ON_PREM_LIVE_SEND_REFUSAL);
     return;
   }
 
-  await broadcastRepository.updateStatus(broadcastId, 'in_progress', {
-    ...(broadcast.startedAt ? {} : { startedAt: new Date() }),
-    lastError: null,
-  });
+  // blockedReason is cleared here for the refused-then-rerun path: a broadcast
+  // refused for a since-fixed config problem (say FROM_EMAIL) is re-enqueued, and
+  // a stale refusal must not survive onto a row that then completes.
+  const advanced = await broadcastRepository.updateStatus(
+    broadcastId,
+    'in_progress',
+    {
+      startedAt: broadcast.startedAt ?? new Date(),
+      lastError: null,
+      blockedReason: null,
+    },
+    { unlessStatus: [...OPERATOR_STATES, 'completed'] },
+  );
+  if (advanced === 0) {
+    console.log(`[email-broadcast] ${broadcastId} was cancelled/paused/completed before start`);
+    return;
+  }
 
   // --- Resolve what this broadcast says (compose vs template). A failure here
   // means the admin's intent is ambiguous; the safe reading is "don't send". ---
@@ -168,7 +186,12 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
     suppressed = await listSuppressedEmails();
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
-    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError: msg });
+    await broadcastRepository.updateStatus(
+      broadcastId,
+      'failed',
+      { lastError: msg },
+      { unlessStatus: [...OPERATOR_STATES] },
+    );
     throw error;
   }
 
@@ -216,24 +239,48 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
     broadcastRepository.loadAlreadySentEmails(broadcastId),
   ]);
 
+  // The canary budget counts attempts across EVERY run of this broadcast, so it
+  // has to start from the ledger, not from zero: this worker rethrows when
+  // recipients fail, pg-boss retries with backoff, and a per-process counter
+  // would hand each retry a fresh budget — a 25-person canary quietly walking
+  // 250 people across ten retries. Ledger rows that consumed budget are exactly
+  // the sent + failed ones (skips never count; dry runs write no rows and send
+  // nothing, so zero is right for them).
+  const priorAttempts =
+    live && broadcast.sendLimit !== null
+      ? await broadcastRepository
+          .countRecipientsByStatus(broadcastId)
+          .then((c) => c.sent + c.failed)
+      : 0;
+
   // The durable ledger for this run: claim-before-send (DB-clock lease) plus the
   // sent/skip/failure records. This — not the in-memory set — is the double-send guard.
   const ledger = broadcastRepository.createBroadcastLedger(broadcastId, broadcast.notificationType);
 
   // --- The send, one keyset page at a time. ---
-  const totals: BroadcastResult = {
-    sent: 0,
-    attempted: 0,
-    skipped: emptySkips(),
-    claimedElsewhere: 0,
-    errors: [],
-  };
+  const totals = { sent: 0, attempted: 0, skipped: 0, claimedElsewhere: 0 };
+  const errors: string[] = [];
   let totalTargeted = 0;
   let cursor: string | null = null;
   let batch = 0;
 
   try {
     do {
+      // Honour a mid-run cancel/pause before every page: a multi-hour live send
+      // must stop when the admin says stop, not when the audience runs out.
+      const current = await broadcastRepository.findById(broadcastId);
+      const halt = !current ? 'row deleted' : OPERATOR_STATES.find((s) => s === current.status);
+      if (halt) {
+        console.log(`[email-broadcast] ${broadcastId} halted mid-run (${halt})`);
+        await broadcastRepository.appendStepResult(broadcastId, {
+          step: 'halted',
+          status: 'skipped',
+          detail: `stopped after batch ${batch}: broadcast is ${halt}`,
+          at: nowIso(),
+        });
+        return;
+      }
+
       const page = await resolveAudience(broadcast.audienceDefinition, {
         limit: AUDIENCE_PAGE_SIZE,
         after: cursor,
@@ -243,10 +290,10 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
       totalTargeted += page.rows.length;
       batch++;
 
-      // The canary cap counts ATTEMPTS across the whole run, not per page.
       const remainingLimit =
-        broadcast.sendLimit === null ? null : Math.max(0, broadcast.sendLimit - totals.attempted);
-      if (remainingLimit !== null && remainingLimit === 0) break;
+        broadcast.sendLimit === null
+          ? null
+          : broadcast.sendLimit - priorAttempts - totals.attempted;
 
       const result = await runBroadcast({
         live,
@@ -267,7 +314,14 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
         // (record is never invoked on a dry run — the live gate precedes it.)
         claim: live ? ledger.claim : undefined,
         record: ledger.record,
-        onSkip: live ? ledger.onSkip : undefined,
+        // 'already-sent' skips are deliberately not persisted: they only arise on
+        // a resumed run (users.emailBidx keeps addresses unique), where the row is
+        // already `sent` — recordSkip's own guard would refuse the demotion — and
+        // a 49k-sent resume would otherwise burn one guaranteed-no-op round trip
+        // per already-mailed recipient before reaching the ones it exists to retry.
+        onSkip: live
+          ? (skip) => (skip.reason === 'already-sent' ? Promise.resolve() : ledger.onSkip(skip))
+          : undefined,
         onFailure: live ? ledger.onFailure : undefined,
         now: nowIso,
         sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
@@ -277,29 +331,22 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
 
       totals.sent += result.sent;
       totals.attempted += result.attempted;
+      totals.skipped += totalSkips(result.skipped);
       totals.claimedElsewhere += result.claimedElsewhere;
-      totals.errors.push(...result.errors);
-      addSkips(totals.skipped, result.skipped);
+      errors.push(...result.errors);
 
       // Progress after every page, so the admin UI polls live numbers. Live counts
       // come from the ledger (a retry re-walks part of the audience; recounting is
       // what keeps the numbers true); a dry run has no ledger rows to count.
-      if (live) {
-        const counts = await broadcastRepository.countRecipientsByStatus(broadcastId);
-        await broadcastRepository.updateCounts(broadcastId, {
-          totalTargeted,
-          sentCount: counts.sent,
-          skippedCount: counts.skipped,
-          failedCount: counts.failed,
-        });
-      } else {
-        await broadcastRepository.updateCounts(broadcastId, {
-          totalTargeted,
-          sentCount: totals.sent,
-          skippedCount: totalSkips(totals.skipped),
-          failedCount: totals.errors.length,
-        });
-      }
+      const counts = live
+        ? await broadcastRepository.countRecipientsByStatus(broadcastId)
+        : { sent: totals.sent, skipped: totals.skipped, failed: errors.length };
+      await broadcastRepository.updateCounts(broadcastId, {
+        totalTargeted,
+        sentCount: counts.sent,
+        skippedCount: counts.skipped,
+        failedCount: counts.failed,
+      });
       await broadcastRepository.appendStepResult(broadcastId, {
         step: `batch-${batch}`,
         status: result.errors.length > 0 ? 'failed' : 'ok',
@@ -310,11 +357,16 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
         at: nowIso(),
       });
 
-      if (broadcast.sendLimit !== null && totals.attempted >= broadcast.sendLimit) {
+      if (
+        broadcast.sendLimit !== null &&
+        priorAttempts + totals.attempted >= broadcast.sendLimit
+      ) {
         await broadcastRepository.appendStepResult(broadcastId, {
           step: 'send-limit',
           status: 'ok',
-          detail: `stopped at sendLimit=${broadcast.sendLimit} attempts`,
+          detail:
+            `stopped at sendLimit=${broadcast.sendLimit} attempts` +
+            (priorAttempts > 0 ? ` (${priorAttempts} from earlier runs)` : ''),
           at: nowIso(),
         });
         break;
@@ -325,29 +377,64 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
     // surface the reason on the row, then let pg-boss retry with backoff. The
     // resume set + claims make the retry pick up where this attempt stopped.
     const msg = error instanceof Error ? error.message : String(error);
-    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError: msg });
+    await broadcastRepository.updateStatus(
+      broadcastId,
+      'failed',
+      { lastError: msg },
+      { unlessStatus: [...OPERATOR_STATES] },
+    );
     throw error;
   }
 
   const summary =
     `sent=${totals.sent} attempted=${totals.attempted} targeted=${totalTargeted} ` +
-    `skipped=${totalSkips(totals.skipped)} failed=${totals.errors.length} ` +
+    `skipped=${totals.skipped} failed=${errors.length} ` +
     `claimedElsewhere=${totals.claimedElsewhere}`;
 
-  if (totals.errors.length > 0) {
-    // Per-recipient failures (rate limits, provider errors) are retryable: they are
-    // recorded `failed` in the ledger, never `sent`, so the rethrow below makes
-    // pg-boss re-run the job and re-attempt exactly them.
+  // Recipients a rival worker held when we walked past them have an UNKNOWN
+  // outcome: the rival may finish sending — or may have died mid-send, leaving a
+  // lease that expires in minutes and a recipient nobody will ever return for if
+  // this run declares the broadcast `completed` (the terminal short-circuit would
+  // then drop every future job for it). Not `completed`, so: retry. The retry
+  // re-walks cheaply (resume set skips everyone sent) and either finds the rival
+  // recorded them `sent` — clean finish — or reclaims them once the lease lapses.
+  if (errors.length === 0 && totals.claimedElsewhere > 0) {
     const lastError =
-      `${totals.errors.length} recipient(s) failed; ` +
-      `latest: ${totals.errors[totals.errors.length - 1]}`;
+      `${totals.claimedElsewhere} recipient(s) were claimed by another worker; ` +
+      'retrying to confirm their outcome';
     await broadcastRepository.appendStepResult(broadcastId, {
       step: 'finalize',
       status: 'failed',
       detail: summary,
       at: nowIso(),
     });
-    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError });
+    await broadcastRepository.updateStatus(
+      broadcastId,
+      'failed',
+      { lastError },
+      { unlessStatus: [...OPERATOR_STATES] },
+    );
+    throw new Error(`email-broadcast ${broadcastId}: ${lastError}`);
+  }
+
+  if (errors.length > 0) {
+    // Per-recipient failures (rate limits, provider errors) are retryable: they are
+    // recorded `failed` in the ledger, never `sent`, and the rethrow below makes
+    // pg-boss re-run the job and re-attempt exactly them.
+    const lastError =
+      `${errors.length} recipient(s) failed; latest: ${errors[errors.length - 1]}`;
+    await broadcastRepository.appendStepResult(broadcastId, {
+      step: 'finalize',
+      status: 'failed',
+      detail: summary,
+      at: nowIso(),
+    });
+    await broadcastRepository.updateStatus(
+      broadcastId,
+      'failed',
+      { lastError },
+      { unlessStatus: [...OPERATOR_STATES] },
+    );
     throw new Error(`email-broadcast ${broadcastId} finished with failures: ${lastError}`);
   }
 
@@ -357,9 +444,11 @@ export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise
     detail: summary,
     at: nowIso(),
   });
-  await broadcastRepository.updateStatus(broadcastId, 'completed', {
-    completedAt: new Date(),
-    lastError: null,
-  });
+  await broadcastRepository.updateStatus(
+    broadcastId,
+    'completed',
+    { completedAt: new Date(), lastError: null },
+    { unlessStatus: [...OPERATOR_STATES] },
+  );
   console.log(`[email-broadcast] ${broadcastId} -> completed (${summary})`);
 }

--- a/apps/processor/src/workers/email-broadcast-worker.ts
+++ b/apps/processor/src/workers/email-broadcast-worker.ts
@@ -1,0 +1,365 @@
+/**
+ * Durable admin-console email-broadcast worker.
+ *
+ * pg-boss invokes this for each `email-broadcast` job. It re-reads the
+ * email_broadcasts row for the authoritative state (the job payload carries only
+ * the id), wires the concrete side effects — the transactional engine, the
+ * broadcast_recipients ledger, the audience keyset walk — and hands each page of
+ * rows to the pure `runBroadcast` orchestrator from @pagespace/lib.
+ *
+ * The safety contract, in one place:
+ *  - A thrown error propagates to pg-boss and the job retries with backoff. A
+ *    retry is safe because resume state lives in the ledger: already-sent
+ *    addresses are loaded up front, each recipient is CLAIMED (DB-clock lease)
+ *    before the provider call, and `UNIQUE(broadcastId, userId)` plus the
+ *    `broadcast:<id>:<userId>` idempotency key backstop the races.
+ *  - A refusal (on-prem live send, failed preflight, unresolvable content,
+ *    unreachable CTA) is terminal-for-retry: the row is marked `failed` with the
+ *    reason and the worker RETURNS, because retrying a config problem just
+ *    re-fails it.
+ *  - Per-recipient send failures — including sendEmail's 3/hr rate-limit throw —
+ *    are recorded `failed` (never `sent`) by the ledger and the run continues;
+ *    the terminal `failed` + rethrow at the end is what makes pg-boss come back
+ *    for them.
+ */
+
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import {
+  findUnreachableUrls,
+  resolveBaseUrl,
+  runBroadcast,
+  type BroadcastResult,
+  type SkipReason,
+} from '@pagespace/lib/services/broadcast/core';
+import {
+  resolveAudience,
+  loadOptedOutUserIds,
+  loadRightsRestrictedUserIds,
+} from '@pagespace/lib/services/broadcast/audience';
+import {
+  extractCtaUrls,
+  renderMarkdownToSafeHtml,
+  resolveBroadcastContent,
+} from '@pagespace/lib/services/broadcast/content';
+import { createTransactionalEngine } from '@pagespace/lib/services/broadcast/transactional-engine';
+import { listSuppressedEmails } from '@pagespace/lib/compliance/erasure/resend-suppression-client';
+import { decryptUserRow } from '@pagespace/lib/auth/user-repository';
+import { isValidEmail } from '@pagespace/lib/validators/email';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import type { EmailBroadcastJobData } from '../types';
+
+/** Audience page size for the keyset walk — never materialize the whole table. */
+const AUDIENCE_PAGE_SIZE = 500;
+
+const nowIso = () => new Date().toISOString();
+
+const emptySkips = (): Record<SkipReason, number> => ({
+  'invalid-email': 0,
+  'already-sent': 0,
+  suppressed: 0,
+  'opted-out': 0,
+  'rights-restricted': 0,
+});
+
+function addSkips(into: Record<SkipReason, number>, from: Record<SkipReason, number>): void {
+  for (const key of Object.keys(from) as SkipReason[]) into[key] += from[key];
+}
+
+const totalSkips = (skips: Record<SkipReason, number>) =>
+  Object.values(skips).reduce((a, b) => a + b, 0);
+
+/**
+ * Mark the broadcast failed for a reason no retry can fix, and record the step
+ * that refused. Returning (not throwing) afterwards is what keeps pg-boss from
+ * re-running a config problem.
+ */
+async function refuse(broadcastId: string, step: string, reason: string): Promise<void> {
+  console.error(`[email-broadcast] ${broadcastId} refused at ${step}: ${reason}`);
+  await broadcastRepository.appendStepResult(broadcastId, {
+    step,
+    status: 'failed',
+    detail: reason,
+    at: nowIso(),
+  });
+  await broadcastRepository.updateStatus(broadcastId, 'failed', {
+    blockedReason: reason,
+    completedAt: new Date(),
+  });
+}
+
+export async function runEmailBroadcastJob(data: EmailBroadcastJobData): Promise<void> {
+  const { broadcastId } = data;
+
+  const broadcast = await broadcastRepository.findById(broadcastId);
+  if (!broadcast) {
+    console.warn(`[email-broadcast] broadcast ${broadcastId} not found; dropping job`);
+    return;
+  }
+  if (
+    broadcast.status === 'completed' ||
+    broadcast.status === 'cancelled' ||
+    broadcast.status === 'paused'
+  ) {
+    console.log(`[email-broadcast] broadcast ${broadcastId} is ${broadcast.status}; nothing to do`);
+    return;
+  }
+
+  await broadcastRepository.incrementAttempts(broadcastId);
+
+  const live = !broadcast.dryRun;
+
+  // On-prem guard FIRST, before any status transition or provider read. sendEmail
+  // is a silent no-op on-prem, so a "successful" live run would record everyone as
+  // sent while sending nothing — poisoning the ledger for the real send.
+  if (live && isOnPrem()) {
+    await refuse(
+      broadcastId,
+      'preflight',
+      'DEPLOYMENT_MODE is on-prem, where sendEmail() silently drops mail. The run would send ' +
+        'nothing while recording every recipient as already-sent.',
+    );
+    return;
+  }
+
+  await broadcastRepository.updateStatus(broadcastId, 'in_progress', {
+    ...(broadcast.startedAt ? {} : { startedAt: new Date() }),
+    lastError: null,
+  });
+
+  // --- Resolve what this broadcast says (compose vs template). A failure here
+  // means the admin's intent is ambiguous; the safe reading is "don't send". ---
+  let content: { subject: string; bodyMarkdown: string };
+  try {
+    content = await resolveBroadcastContent(broadcast, async (templateId) => {
+      const template = await broadcastRepository.findTemplateById(templateId);
+      return template
+        ? {
+            subject: template.subject,
+            bodyMarkdown: template.bodyMarkdown,
+            isActive: template.isActive,
+          }
+        : null;
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    await refuse(broadcastId, 'resolve-content', msg);
+    return;
+  }
+
+  const baseUrl = resolveBaseUrl();
+  const fromEmail = process.env.FROM_EMAIL;
+  const postalAddress = process.env.COMPANY_POSTAL_ADDRESS?.trim() || undefined;
+
+  const engine = createTransactionalEngine({
+    broadcastId,
+    subject: content.subject,
+    bodyMarkdown: content.bodyMarkdown,
+    notificationType: broadcast.notificationType,
+    baseUrl,
+    postalAddress,
+  });
+
+  // --- Exclusion sets. The suppression read is deliberately loud: a SHORT list
+  // looks exactly like a complete one, so an unreadable list throws (transient →
+  // pg-boss retry), while an unconfigured one returns null and preflight refuses
+  // the live send below. ---
+  let suppressed: Set<string> | null;
+  try {
+    suppressed = await listSuppressedEmails();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError: msg });
+    throw error;
+  }
+
+  const preflightResult = await engine.preflight({
+    live,
+    suppressed,
+    isOnPrem: isOnPrem(),
+    fromEmail,
+  });
+  if (!preflightResult.ok) {
+    await refuse(broadcastId, 'preflight', preflightResult.reason);
+    return;
+  }
+
+  // --- CTA reachability, only when the authored content actually carries links.
+  // Extracted from the BODY html (not the full shell) so the per-recipient
+  // unsubscribe link — a placeholder until a token is minted — is never probed. ---
+  if (live) {
+    const ctaUrls = extractCtaUrls(renderMarkdownToSafeHtml(content.bodyMarkdown));
+    if (ctaUrls.length > 0) {
+      const unreachable = await findUnreachableUrls(ctaUrls);
+      if (unreachable.length > 0) {
+        await refuse(
+          broadcastId,
+          'link-check',
+          `email links did not resolve: ${unreachable.join(', ')}`,
+        );
+        return;
+      }
+      await broadcastRepository.appendStepResult(broadcastId, {
+        step: 'link-check',
+        status: 'ok',
+        detail: `${ctaUrls.length} link(s) reachable`,
+        at: nowIso(),
+      });
+    }
+  }
+
+  const [optedOut, rightsRestricted, alreadySent] = await Promise.all([
+    loadOptedOutUserIds(broadcast.notificationType),
+    loadRightsRestrictedUserIds(),
+    // Keyed by normalized ADDRESS — what decideRecipient compares against. This is
+    // the resume set: a retry walks the same audience and skips everyone a prior
+    // attempt already mailed.
+    broadcastRepository.loadAlreadySentEmails(broadcastId),
+  ]);
+
+  // The durable ledger for this run: claim-before-send (DB-clock lease) plus the
+  // sent/skip/failure records. This — not the in-memory set — is the double-send guard.
+  const ledger = broadcastRepository.createBroadcastLedger(broadcastId, broadcast.notificationType);
+
+  // --- The send, one keyset page at a time. ---
+  const totals: BroadcastResult = {
+    sent: 0,
+    attempted: 0,
+    skipped: emptySkips(),
+    claimedElsewhere: 0,
+    errors: [],
+  };
+  let totalTargeted = 0;
+  let cursor: string | null = null;
+  let batch = 0;
+
+  try {
+    do {
+      const page = await resolveAudience(broadcast.audienceDefinition, {
+        limit: AUDIENCE_PAGE_SIZE,
+        after: cursor,
+      });
+      cursor = page.nextCursor;
+      if (page.rows.length === 0) break;
+      totalTargeted += page.rows.length;
+      batch++;
+
+      // The canary cap counts ATTEMPTS across the whole run, not per page.
+      const remainingLimit =
+        broadcast.sendLimit === null ? null : Math.max(0, broadcast.sendLimit - totals.attempted);
+      if (remainingLimit !== null && remainingLimit === 0) break;
+
+      const result = await runBroadcast({
+        live,
+        limit: remainingLimit,
+        delayMs: broadcast.delayMs,
+        rows: page.rows,
+        decrypt: (row) => decryptUserRow(row),
+        isValidEmail,
+        // Shared across pages on purpose: runBroadcast adds each sent address, so
+        // two accounts sharing one address in different pages still get one email.
+        alreadySent,
+        suppressed,
+        optedOut,
+        rightsRestricted,
+        sendOne: (r) => engine.sendOne(r),
+        renderOne: (r) => engine.renderOne(r),
+        // Ledger hooks only bind a live run: a dry run must leave no recipient rows.
+        // (record is never invoked on a dry run — the live gate precedes it.)
+        claim: live ? ledger.claim : undefined,
+        record: ledger.record,
+        onSkip: live ? ledger.onSkip : undefined,
+        onFailure: live ? ledger.onFailure : undefined,
+        now: nowIso,
+        sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        log: (message) => console.log(`[email-broadcast] ${broadcastId} ${message}`),
+        logError: (message) => console.error(`[email-broadcast] ${broadcastId} ${message}`),
+      });
+
+      totals.sent += result.sent;
+      totals.attempted += result.attempted;
+      totals.claimedElsewhere += result.claimedElsewhere;
+      totals.errors.push(...result.errors);
+      addSkips(totals.skipped, result.skipped);
+
+      // Progress after every page, so the admin UI polls live numbers. Live counts
+      // come from the ledger (a retry re-walks part of the audience; recounting is
+      // what keeps the numbers true); a dry run has no ledger rows to count.
+      if (live) {
+        const counts = await broadcastRepository.countRecipientsByStatus(broadcastId);
+        await broadcastRepository.updateCounts(broadcastId, {
+          totalTargeted,
+          sentCount: counts.sent,
+          skippedCount: counts.skipped,
+          failedCount: counts.failed,
+        });
+      } else {
+        await broadcastRepository.updateCounts(broadcastId, {
+          totalTargeted,
+          sentCount: totals.sent,
+          skippedCount: totalSkips(totals.skipped),
+          failedCount: totals.errors.length,
+        });
+      }
+      await broadcastRepository.appendStepResult(broadcastId, {
+        step: `batch-${batch}`,
+        status: result.errors.length > 0 ? 'failed' : 'ok',
+        detail:
+          `rows=${page.rows.length} sent=${result.sent} attempted=${result.attempted} ` +
+          `skipped=${totalSkips(result.skipped)} failed=${result.errors.length} ` +
+          `claimedElsewhere=${result.claimedElsewhere}`,
+        at: nowIso(),
+      });
+
+      if (broadcast.sendLimit !== null && totals.attempted >= broadcast.sendLimit) {
+        await broadcastRepository.appendStepResult(broadcastId, {
+          step: 'send-limit',
+          status: 'ok',
+          detail: `stopped at sendLimit=${broadcast.sendLimit} attempts`,
+          at: nowIso(),
+        });
+        break;
+      }
+    } while (cursor !== null);
+  } catch (error) {
+    // A LedgerWriteFailed (send recorded nowhere) or any other unexpected throw:
+    // surface the reason on the row, then let pg-boss retry with backoff. The
+    // resume set + claims make the retry pick up where this attempt stopped.
+    const msg = error instanceof Error ? error.message : String(error);
+    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError: msg });
+    throw error;
+  }
+
+  const summary =
+    `sent=${totals.sent} attempted=${totals.attempted} targeted=${totalTargeted} ` +
+    `skipped=${totalSkips(totals.skipped)} failed=${totals.errors.length} ` +
+    `claimedElsewhere=${totals.claimedElsewhere}`;
+
+  if (totals.errors.length > 0) {
+    // Per-recipient failures (rate limits, provider errors) are retryable: they are
+    // recorded `failed` in the ledger, never `sent`, so the rethrow below makes
+    // pg-boss re-run the job and re-attempt exactly them.
+    const lastError =
+      `${totals.errors.length} recipient(s) failed; ` +
+      `latest: ${totals.errors[totals.errors.length - 1]}`;
+    await broadcastRepository.appendStepResult(broadcastId, {
+      step: 'finalize',
+      status: 'failed',
+      detail: summary,
+      at: nowIso(),
+    });
+    await broadcastRepository.updateStatus(broadcastId, 'failed', { lastError });
+    throw new Error(`email-broadcast ${broadcastId} finished with failures: ${lastError}`);
+  }
+
+  await broadcastRepository.appendStepResult(broadcastId, {
+    step: 'finalize',
+    status: 'ok',
+    detail: summary,
+    at: nowIso(),
+  });
+  await broadcastRepository.updateStatus(broadcastId, 'completed', {
+    completedAt: new Date(),
+    lastError: null,
+  });
+  console.log(`[email-broadcast] ${broadcastId} -> completed (${summary})`);
+}

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -11,6 +11,7 @@ import type {
   VideoProcessJobData,
   PullVerifyJobData,
   AccountErasureJobData,
+  EmailBroadcastJobData,
   TextExtractResult,
   IngestResult,
 } from '../types';
@@ -88,6 +89,7 @@ export class QueueManager {
       await this.boss.createQueue('siem-delivery');
       await this.boss.createQueue('account-erasure');
       await this.boss.createQueue('audit-chainer');
+      await this.boss.createQueue('email-broadcast');
       console.log('PgBoss queues created/verified');
     } catch (err) {
       console.warn('Queue creation warning:', err instanceof Error ? err.message : err);
@@ -270,6 +272,18 @@ export class QueueManager {
     // Every 30 seconds, retryLimit 0 so overlapping runs won't stack (same
     // schedule contract as siem-delivery).
     await this.boss.schedule('audit-chainer', '*/30 * * * * *', {}, { retryLimit: 0 });
+
+    // Durable admin-console email broadcast. Retries with backoff on throw; the
+    // claim-before-send lease + UNIQUE(broadcastId, userId) ledger make a retry
+    // resume from where the last attempt stopped instead of double-sending.
+    const { runEmailBroadcastJob } = await import('./email-broadcast-worker');
+    await this.boss.work('email-broadcast',
+      async ([job]) => {
+        console.log(`Processing email-broadcast job: ${job.id}`);
+        await runEmailBroadcastJob(job.data as EmailBroadcastJobData);
+        return { success: true };
+      }
+    );
   }
 
   async addJob<Q extends QueueName>(
@@ -323,7 +337,7 @@ export class QueueManager {
   }
 
   getQueueStatus(): Record<QueueName, QueueStats> {
-    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure', 'audit-chainer'];
+    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery', 'account-erasure', 'audit-chainer', 'email-broadcast'];
     const perQueue = this.cachedStates?.queues ?? {};
 
     const status = {} as Record<QueueName, QueueStats>;

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -294,15 +294,26 @@ export class QueueManager {
     if (!this.boss) throw new Error('Queue manager not initialized');
 
     // Set priority based on queue type
-    const priority = queue === 'image-optimize' ? 100 : 
-                    queue === 'text-extract' ? 50 : 
+    const priority = queue === 'image-optimize' ? 100 :
+                    queue === 'text-extract' ? 50 :
                     queue === 'ingest-file' ? 60 : 10;
+
+    // Retry policy. email-broadcast needs one that outlasts sendEmail's
+    // per-recipient rate limiter: that limiter blocks for a full HOUR, the
+    // worker surfaces blocked recipients as a terminal throw, and the default
+    // 3×5s policy would burn every retry within seconds — leaving those
+    // recipients recorded `failed` with no automatic retry ever reaching them.
+    // Exponential backoff from 60s (60+120+240+…+30720s over 10 retries) keeps
+    // retrying well past the one-hour window.
+    const retryPolicy: Pick<PgBoss.SendOptions, 'retryLimit' | 'retryDelay' | 'retryBackoff'> =
+      queue === 'email-broadcast'
+        ? { retryLimit: 10, retryDelay: 60, retryBackoff: true }
+        : { retryLimit: 3, retryDelay: 5 };
 
     const jobOptions = {
       ...options,
       priority,
-      retryLimit: 3,
-      retryDelay: 5
+      ...retryPolicy,
     };
     
     const jobId = await this.boss.send(queue, data, jobOptions);

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -299,21 +299,37 @@ export class QueueManager {
                     queue === 'ingest-file' ? 60 : 10;
 
     // Retry policy. email-broadcast needs one that outlasts sendEmail's
-    // per-recipient rate limiter: that limiter blocks for a full HOUR, the
+    // per-recipient rate limiter: that limiter blocks for roughly an hour, the
     // worker surfaces blocked recipients as a terminal throw, and the default
     // 3×5s policy would burn every retry within seconds — leaving those
     // recipients recorded `failed` with no automatic retry ever reaching them.
-    // Exponential backoff from 60s (60+120+240+…+30720s over 10 retries) keeps
-    // retrying well past the one-hour window.
-    const retryPolicy: Pick<PgBoss.SendOptions, 'retryLimit' | 'retryDelay' | 'retryBackoff'> =
+    // Exponential backoff from 60s (60+120+…+30720s over 10 retries) reaches
+    // multi-hour gaps by the later retries; the early ones may still find the
+    // limiter's sliding window closed (each denied attempt nudges it forward),
+    // which is why the tail of the schedule matters more than the head.
+    //
+    // expireInSeconds must dwarf the longest legitimate attempt: pg-boss's
+    // default is 15 MINUTES, after which it fails the still-running job and
+    // dispatches a retry that runs CONCURRENTLY with the original handler —
+    // duplicate audience walks racing each other and the retry budget burning
+    // on timeouts. Six hours covers ~40k recipients at the default 120ms
+    // inter-send delay plus provider round-trips. The trade-off is crash
+    // recovery: a SIGKILLed worker's job waits out this expiration before
+    // retrying, which is acceptable for a queue this infrequent.
+    const retryPolicy: Pick<
+      PgBoss.SendOptions,
+      'retryLimit' | 'retryDelay' | 'retryBackoff' | 'expireInSeconds'
+    > =
       queue === 'email-broadcast'
-        ? { retryLimit: 10, retryDelay: 60, retryBackoff: true }
+        ? { retryLimit: 10, retryDelay: 60, retryBackoff: true, expireInSeconds: 6 * 60 * 60 }
         : { retryLimit: 3, retryDelay: 5 };
 
+    // Caller options win over the per-queue defaults (a caller that passes
+    // retryLimit/singletonKey knows something this table doesn't).
     const jobOptions = {
-      ...options,
       priority,
       ...retryPolicy,
+      ...options,
     };
     
     const jobId = await this.boss.send(queue, data, jobOptions);

--- a/packages/lib/src/repositories/broadcast-repository.ts
+++ b/packages/lib/src/repositories/broadcast-repository.ts
@@ -7,7 +7,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, desc, eq, inArray, sql } from '@pagespace/db/operators';
+import { and, desc, eq, inArray, notInArray, sql } from '@pagespace/db/operators';
 import {
   broadcastTemplates,
   emailBroadcasts,
@@ -90,15 +90,31 @@ export const broadcastRepository = {
     return row ?? null;
   },
 
+  /**
+   * Write a status (plus patch fields).
+   *
+   * `unlessStatus` makes the write conditional, for the same race `markQueued`
+   * guards: the durable worker reads the row once per page, so an admin's
+   * cancel/pause can land between that read and the worker's own write — and an
+   * unconditional `completed` would silently overturn the operator's decision.
+   * Returns rows updated; 0 means the guard rejected it and the caller must
+   * treat the OTHER status as the truth (typically: stop sending).
+   */
   updateStatus: async (
     id: string,
     status: EmailBroadcastStatus,
     patch: UpdateBroadcastStatusPatch = {},
-  ): Promise<void> => {
-    await db
+    opts: { unlessStatus?: EmailBroadcastStatus[] } = {},
+  ): Promise<number> => {
+    const where = opts.unlessStatus?.length
+      ? and(eq(emailBroadcasts.id, id), notInArray(emailBroadcasts.status, opts.unlessStatus))
+      : eq(emailBroadcasts.id, id);
+    const rows = await db
       .update(emailBroadcasts)
       .set({ status, updatedAt: new Date(), ...patch })
-      .where(eq(emailBroadcasts.id, id));
+      .where(where)
+      .returning({ id: emailBroadcasts.id });
+    return rows.length;
   },
 
   /**

--- a/packages/lib/src/services/broadcast/__tests__/core.test.ts
+++ b/packages/lib/src/services/broadcast/__tests__/core.test.ts
@@ -402,6 +402,28 @@ describe('runBroadcast — undecryptable rows', () => {
     expect(out.errors).toEqual(['user u1: could not decrypt PII: bad ciphertext']);
     expect(h.sent).toEqual(['ada@example.com']);
   });
+
+  it('should report the undecryptable row through onFailure, so a durable ledger records it', async () => {
+    // Without a ledger row this user is invisible in the admin's failed count —
+    // lastError's message would be the only trace of who a run could never reach.
+    const failures: Array<{ userId: string; email: string; error: string }> = [];
+    const { result } = run([user('u1', 'bad@example.com'), user('u2', 'ada@example.com')], {
+      decrypt: async (row: BroadcastUser) => {
+        if (row.id === 'u1') throw new Error('bad ciphertext');
+        return row;
+      },
+      onFailure: async (f) => {
+        failures.push(f);
+      },
+    });
+
+    await result;
+
+    // Empty email on purpose: the address IS the thing that would not decrypt.
+    expect(failures).toEqual([
+      { userId: 'u1', email: '', error: 'could not decrypt PII: bad ciphertext' },
+    ]);
+  });
 });
 
 describe('runBroadcast — durable observers', () => {

--- a/packages/lib/src/services/broadcast/__tests__/transactional-engine.test.ts
+++ b/packages/lib/src/services/broadcast/__tests__/transactional-engine.test.ts
@@ -134,6 +134,17 @@ describe('transactional engine — renderOne', () => {
     expect(generateUnsubscribeToken).not.toHaveBeenCalled();
     expect(sendEmail).not.toHaveBeenCalled();
   });
+
+  it('should render once per engine and reuse it — a dry run calls this once per audience row', async () => {
+    // The output carries the placeholder token, not the recipient's, so it is
+    // byte-identical for everyone; a 50k-row dry run must not pay 50k renders.
+    const engine = createTransactionalEngine(config);
+    const first = engine.renderOne(recipient);
+    const second = engine.renderOne({ userId: 'u2', userName: 'Grace', email: 'grace@example.com' });
+
+    expect(second).toBe(first);
+    expect(await first).toContain('<strong>world</strong>');
+  });
 });
 
 describe('transactional engine — preflight', () => {

--- a/packages/lib/src/services/broadcast/core.ts
+++ b/packages/lib/src/services/broadcast/core.ts
@@ -197,6 +197,17 @@ export function listUnsubscribeHeaders(unsubscribeUrl: string): Record<string, s
 export type PreflightResult = { ok: true } | { ok: false; reason: string };
 
 /**
+ * Why an on-prem deployment may never run a LIVE broadcast. Exported so the one
+ * caller that must refuse before `preflight` can run (the durable worker, which
+ * checks this before any status transition or provider read) states the same
+ * reason `preflight` does — two hand-typed copies of this text had already
+ * drifted apart once.
+ */
+export const ON_PREM_LIVE_SEND_REFUSAL =
+  'DEPLOYMENT_MODE is on-prem, where sendEmail() silently drops mail. The run would send\n' +
+  '   nothing while recording everyone as already-sent, poisoning the ledger for the real send.';
+
+/**
  * The guards that stand between a mistake and an unrecoverable mass email.
  * Pure, so each one can be pinned by a test — they are the whole safety story,
  * and "we never actually ran the guard" is not something you learn afterwards.
@@ -236,12 +247,7 @@ export function preflight(input: {
     // sendEmail() is a silent no-op on-prem. A "successful" live run would print
     // a tick per recipient and record a ledger entry for each, sending nothing and
     // permanently marking those people as already-mailed. Refuse instead.
-    return {
-      ok: false,
-      reason:
-        'DEPLOYMENT_MODE is on-prem, where sendEmail() silently drops mail. The run would send\n' +
-        '   nothing while recording everyone as already-sent, poisoning the ledger for the real send.',
-    };
+    return { ok: false, reason: ON_PREM_LIVE_SEND_REFUSAL };
   }
 
   if (!input.fromEmail?.trim()) {
@@ -486,9 +492,10 @@ export async function runBroadcast(input: {
     reason: SkipReason;
   }) => Promise<void>;
   /**
-   * Optional: called for every send that failed, so a durable caller can persist the
-   * error for the admin UI. The recipient is deliberately NOT recorded as sent, so a
-   * retry picks them up again.
+   * Optional: called for every recipient that failed — a send that threw, or a row
+   * whose PII would not decrypt (then with an empty `email`) — so a durable caller
+   * can persist the error for the admin UI. The recipient is deliberately NOT
+   * recorded as sent, so a retry picks them up again.
    */
   onFailure?: (failure: {
     userId: string;
@@ -518,6 +525,17 @@ export async function runBroadcast(input: {
       const msg = error instanceof Error ? error.message : String(error);
       errors.push(`user ${row.id}: could not decrypt PII: ${msg}`);
       input.logError(`  ✗ Skipping user ${row.id}: could not decrypt PII: ${msg}`);
+      if (input.onFailure) {
+        // Persist it like any other per-recipient failure (empty address — the
+        // address IS what we could not decrypt): without a ledger row this user
+        // is invisible in the admin's failed count, and lastError's masked
+        // message is the only trace of who a durable run could never reach.
+        await input.onFailure({
+          userId: row.id,
+          email: '',
+          error: `could not decrypt PII: ${msg}`,
+        });
+      }
       continue;
     }
 

--- a/packages/lib/src/services/broadcast/transactional-engine.ts
+++ b/packages/lib/src/services/broadcast/transactional-engine.ts
@@ -47,6 +47,13 @@ export function createTransactionalEngine(config: TransactionalEngineConfig): Br
   const unsubscribeUrlFor = (token: string) =>
     `${config.baseUrl}/api/notifications/unsubscribe/${token}`;
 
+  // renderOne's output carries the placeholder token, not a recipient's, so it is
+  // byte-identical for every recipient — and a dry run calls it once per audience
+  // row. Render once; a 50k-recipient preview should not pay 50k markdown-parse +
+  // SSR passes to recompute one constant string. (Not reused across engines: the
+  // cache lives and dies with this config closure.)
+  let renderedPreview: Promise<string> | null = null;
+
   return {
     name: 'transactional',
 
@@ -87,13 +94,19 @@ export function createTransactionalEngine(config: TransactionalEngineConfig): Br
 
     /** Dry-run: render the real email so a content error still surfaces, and send nothing. */
     renderOne(): Promise<string> {
-      return renderBroadcastEmail({
+      renderedPreview ??= renderBroadcastEmail({
         subject: config.subject,
         bodyMarkdown: config.bodyMarkdown,
         // A dry run mints no token: that would be a DB write per previewed recipient.
         unsubscribeUrl: unsubscribeUrlFor('<token>'),
         postalAddress: config.postalAddress,
+      }).catch((error) => {
+        // A failed render must not be cached: the next call should retry, not
+        // replay a stale rejection after the operator fixes the content.
+        renderedPreview = null;
+        throw error;
       });
+      return renderedPreview;
     },
   };
 }

--- a/packages/lib/src/services/validated-service-token.ts
+++ b/packages/lib/src/services/validated-service-token.ts
@@ -36,7 +36,8 @@ export type ServiceScope =
   | 'avatars:write'
   | 'avatars:write:any'
   | 'queue:read'
-  | 'erasure:enqueue';
+  | 'erasure:enqueue'
+  | 'broadcast:enqueue';
 
 // Duration bounds for service tokens
 const DEFAULT_EXPIRY_MS = 5 * 60 * 1000;        // 5 minutes default
@@ -332,6 +333,12 @@ function filterScopesByPermissions(
       // The security boundary is the web route that mints it; the processor
       // endpoint is internal-only.
       case 'erasure:enqueue':
+        return permissions.isOwner;
+
+      // Broadcast enqueue is minted by the admin console against the admin's own
+      // user resource, same shape as erasure:enqueue: the admin-gated route that
+      // mints it is the security boundary; the processor endpoint is internal-only.
+      case 'broadcast:enqueue':
         return permissions.isOwner;
 
       default:


### PR DESCRIPTION
## Summary

Task 2 of ~4 for admin-console email broadcasts (plan: swirling-wishing-kahn, Phase 1 item 3). Builds the durable background-job engine on the merged foundation (#2090), mirroring the GDPR-erasure durable-job pattern file-for-file: scoped service token → processor endpoint → pg-boss queue → worker that writes progress back to the DB row.

**Scope boundary:** this PR deliberately does NOT touch `apps/admin` — the admin enqueue helper, routes, and UI are a separate agent's task (3+4). They will consume the `broadcast:enqueue` scope and `POST /api/broadcast/enqueue` shipped here.

## What's in it

- **Scope** — `'broadcast:enqueue'` added to the `ServiceScope` union and `filterScopesByPermissions` (owner-gated, exactly like `erasure:enqueue`) in `packages/lib/src/services/validated-service-token.ts`.
- **Job type** — `EmailBroadcastJobData { broadcastId }` + `JobDataMap['email-broadcast']`; the worker re-reads the `email_broadcasts` row for authoritative state, like `AccountErasureJobData`.
- **Queue** — `email-broadcast` created in `setupQueues`, worker registered in `startWorkers` (dynamic import), reported by `getQueueStatus`.
- **Worker** (`apps/processor/src/workers/email-broadcast-worker.ts`):
  - Short-circuits terminal rows (`completed`/`cancelled`/`paused`); `incrementAttempts` otherwise.
  - **On-prem guard first**: a live run is refused (`failed` + `blockedReason`) because `sendEmail` is a silent no-op on-prem — a "successful" run would mark everyone sent while sending nothing. Dry runs still render.
  - Resolves compose/template content via `resolveBroadcastContent`; refusals (ambiguous content, failed preflight, unreachable CTA) are terminal-for-retry: row marked `failed` with the reason, no rethrow.
  - Engine preflight (`localhost` base URL, null suppression audience, missing `FROM_EMAIL`, on-prem) via the injected `transactionalEngine`; CTA reachability probes **body links only**, so the per-recipient unsubscribe placeholder is never probed.
  - **Keyset-paginates** the audience (`WHERE id > cursor ORDER BY id LIMIT 500`) — never materializes the whole table; each row decrypted via `decryptUserRow` only for the page in hand.
  - Drives the pure `runBroadcast` core with `createBroadcastLedger` — **claim-before-send with the DB-clock lease is the double-send guard** — plus `loadAlreadySentEmails` as the resume set and the `broadcast:<id>:<userId>` idempotency key as backstop.
  - `sendEmail`'s 3/hr rate-limit throw = retryable per-recipient failure: recorded `failed`, never `sent`; run continues; terminal `failed` + rethrow hands the job to pg-boss retry, which resumes safely.
  - `updateCounts` (recomputed from the ledger on live runs, so a retry never double-counts) + `appendStepResult` after every page; terminal `completed`/`failed`.
  - Ledger hooks bind only live runs — a dry run renders every recipient, sends nothing, and writes **no** recipient rows.
- **Endpoint** — `apps/processor/src/api/broadcast.ts` (copy of `api/erasure.ts`): `POST /enqueue` → `queueManager.addJob('email-broadcast', { broadcastId })` → `{ jobId }`; mounted in `server.ts` with `authenticateService + requireScope('broadcast:enqueue')`.

- **Retry policy** — `addJob` applies a queue-specific policy: `email-broadcast` jobs get `retryLimit: 10, retryDelay: 60s, retryBackoff: true` (exponential, cumulative coverage well past one hour), because `sendEmail`'s per-recipient rate limiter blocks for a full hour and the default 3×5s policy would exhaust every retry within seconds — stranding rate-limited recipients as `failed` with no automatic retry ever reaching them. Other queues keep the existing 3×5s policy.

- **Hardening (adversarial review round)** — `expireInSeconds: 6h` on the queue policy (pg-boss's 15-minute default would fail a long send mid-attempt and spawn concurrent duplicates); ledger-derived canary budget (`sendLimit` counts sent+failed rows across ALL attempts, so retries can't escalate a canary); mid-run cancel/pause honored via a per-page status re-read + guarded status writes (`updateStatus … unlessStatus`) that never overturn an operator's cancel/pause; `claimedElsewhere > 0` finalizes as retry instead of `completed` (a dead rival would otherwise strand recipients under a completed broadcast); `singletonKey: broadcastId` at enqueue (409 on duplicate); stale `blockedReason` cleared on rerun; undecryptable rows recorded via `onFailure`; memoized dry-run render; `already-sent` resume skips no longer burn a no-op DB round trip each.

## Tests

19 unit tests (`email-broadcast-worker.test.ts`) run the **real** `runBroadcast` orchestrator with all lib I/O mocked (same style as `account-erasure-worker.test.ts`): on-prem live refusal (+ dry-run allowed), preflight/content/link-check refusals, resume skips already-sent, claim-lost leaves the recipient alone, rate-limit throw records `failed` not `sent` (address redacted off the row), dry run writes no ledger rows, pagination counts/stepResults advance per batch, canary `sendLimit` stops the walk, unreadable suppression list throws for retry. Queue-manager tests updated for the tenth queue, plus a test pinning the email-broadcast retry policy.

## Verification

- `bun run typecheck` — 16/16 tasks clean across the monorepo
- `bun run lint` — clean on `@pagespace/processor` and `@pagespace/lib`
- Processor unit suite: 1078 passed; the only failures are the pre-existing magika `content-detector` fixture tests, which fail identically on a clean checkout of this branch's base (verified via stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167odnPChYLkkxPZqWpc8Di

