### PR TITLE
feat(broadcast): admin API routes + shared Zod schema + enqueue helper

### DIFF
--- a/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
@@ -192,6 +192,20 @@ describe('/api/admin/broadcasts/[id]', () => {
       });
     });
 
+    it('returns 200 when the step-result note fails — the status write IS the intervention', async () => {
+      mockRepo.findById.mockResolvedValue(baseBroadcast);
+      mockRepo.updateStatus.mockResolvedValue(1);
+      mockRepo.appendStepResult.mockRejectedValue(new Error('db blip'));
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Wrong audience' }), context);
+      const body = await response.json();
+
+      // A 500 here would misreport a cancel that DID land, and its retry hits
+      // the no-op branch anyway. The reason survives in the audit log.
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ id: 'bc_1', status: 'cancelled' });
+    });
+
     it('409s when the broadcast reached a terminal state first', async () => {
       mockRepo.findById.mockResolvedValue({ ...baseBroadcast, status: 'completed' });
       mockRepo.updateStatus.mockResolvedValue(0);

--- a/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { createId } from '@paralleldrive/cuid2';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import type { EmailBroadcast } from '@pagespace/db/schema/email-broadcasts';
+
+/**
+ * Tests for GET/POST /api/admin/broadcasts/[id] — the progress-polling shape and
+ * the cancel/pause intervention, including the terminal-state guard (a finished
+ * broadcast reports 409 with its real status instead of being dragged back).
+ */
+
+vi.mock('@pagespace/lib/repositories/broadcast-repository', () => ({
+  broadcastRepository: {
+    findById: vi.fn(),
+    updateStatus: vi.fn(),
+    appendStepResult: vi.fn(),
+  },
+}));
+
+import { GET, POST } from '../route';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+
+const mockRepo = vi.mocked(broadcastRepository);
+
+const baseBroadcast = {
+  id: 'bc_1',
+  subject: 'Launch update',
+  engine: 'transactional',
+  contentMode: 'compose',
+  templateId: null,
+  bodyMarkdown: 'Body',
+  notificationType: 'PRODUCT_UPDATE',
+  audienceDefinition: {},
+  status: 'in_progress',
+  dryRun: false,
+  sendLimit: null,
+  delayMs: 120,
+  totalTargeted: 100,
+  sentCount: 40,
+  skippedCount: 3,
+  failedCount: 1,
+  stepResults: [{ step: 'link-check', status: 'ok', at: '2026-07-16T12:00:00.000Z' }],
+  jobId: 'job_1',
+  attempts: 1,
+  lastError: null,
+  blockedReason: null,
+  createdByUserId: null,
+  startedAt: new Date('2026-07-16T12:00:00Z'),
+  completedAt: null,
+  createdAt: new Date('2026-07-16T11:59:00Z'),
+  updatedAt: new Date('2026-07-16T12:00:00Z'),
+} as EmailBroadcast;
+
+describe('/api/admin/broadcasts/[id]', () => {
+  let adminUserId: string;
+  const adminSessionToken = 'mock_admin_session_token';
+  const mockSessionId = 'mock-session-id';
+  let adminCsrfToken: string;
+
+  const context = { params: Promise.resolve({ id: 'bc_1' }) };
+
+  const getRequest = () =>
+    new NextRequest('http://localhost/api/admin/broadcasts/bc_1', {
+      headers: { Cookie: `admin_session=${adminSessionToken}` },
+    });
+
+  const postRequest = (body: unknown) =>
+    new NextRequest('http://localhost/api/admin/broadcasts/bc_1', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: `admin_session=${adminSessionToken}`,
+        'X-CSRF-Token': adminCsrfToken,
+      },
+      body: JSON.stringify(body),
+    });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const [adminUser] = await db
+      .insert(users)
+      .values({
+        id: createId(),
+        name: 'Broadcast Admin',
+        email: `broadcast-admin-${Date.now()}-${createId().slice(0, 6)}@example.com`,
+        provider: 'email',
+        role: 'admin',
+        tokenVersion: 1,
+        adminRoleVersion: 0,
+      })
+      .returning();
+    adminUserId = adminUser.id;
+
+    vi.spyOn(sessionService, 'validateSession').mockResolvedValue({
+      sessionId: mockSessionId,
+      userId: adminUserId,
+      userRole: 'admin',
+      tokenVersion: 1,
+      adminRoleVersion: 0,
+      type: 'user',
+      scopes: ['*'],
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+    adminCsrfToken = generateCSRFToken(mockSessionId);
+  });
+
+  afterEach(async () => {
+    try {
+      await db.delete(users).where(eq(users.id, adminUserId));
+    } catch {
+      // Swallow cleanup errors to avoid masking test failures
+    }
+  });
+
+  describe('GET — progress polling', () => {
+    it('returns the frozen status shape', async () => {
+      mockRepo.findById.mockResolvedValue(baseBroadcast);
+
+      const response = await GET(getRequest(), context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toMatchObject({
+        id: 'bc_1',
+        subject: 'Launch update',
+        status: 'in_progress',
+        engine: 'transactional',
+        contentMode: 'compose',
+        dryRun: false,
+        sendLimit: null,
+        delayMs: 120,
+        totalTargeted: 100,
+        sentCount: 40,
+        skippedCount: 3,
+        failedCount: 1,
+        attempts: 1,
+        lastError: null,
+        blockedReason: null,
+        completedAt: null,
+      });
+      expect(body.stepResults).toHaveLength(1);
+    });
+
+    it('404s for an unknown broadcast', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      const response = await GET(getRequest(), context);
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('POST — cancel/pause', () => {
+    it('cancels an active broadcast and records the reason', async () => {
+      mockRepo.findById.mockResolvedValue(baseBroadcast);
+      mockRepo.updateStatus.mockResolvedValue(1);
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Wrong audience' }), context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ id: 'bc_1', status: 'cancelled' });
+      expect(mockRepo.updateStatus).toHaveBeenCalledWith(
+        'bc_1',
+        'cancelled',
+        expect.objectContaining({ completedAt: expect.any(Date) }),
+        { unlessStatus: ['completed', 'failed', 'cancelled'] },
+      );
+      expect(mockRepo.appendStepResult).toHaveBeenCalledWith(
+        'bc_1',
+        expect.objectContaining({ step: 'cancel', detail: 'Wrong audience' }),
+      );
+    });
+
+    it('pauses an active broadcast', async () => {
+      mockRepo.findById.mockResolvedValue(baseBroadcast);
+      mockRepo.updateStatus.mockResolvedValue(1);
+
+      const response = await POST(postRequest({ action: 'pause', reason: 'Checking a complaint' }), context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ id: 'bc_1', status: 'paused' });
+      expect(mockRepo.updateStatus).toHaveBeenCalledWith('bc_1', 'paused', {}, {
+        unlessStatus: ['completed', 'failed', 'cancelled'],
+      });
+    });
+
+    it('409s when the broadcast reached a terminal state first', async () => {
+      mockRepo.findById.mockResolvedValue({ ...baseBroadcast, status: 'completed' });
+      mockRepo.updateStatus.mockResolvedValue(0);
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Too late' }), context);
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.status).toBe('completed');
+      expect(mockRepo.appendStepResult).not.toHaveBeenCalled();
+    });
+
+    it('treats repeating a landed intervention as a no-op', async () => {
+      mockRepo.findById.mockResolvedValue({ ...baseBroadcast, status: 'cancelled' });
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Again' }), context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ id: 'bc_1', status: 'cancelled' });
+      expect(mockRepo.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects an action without a reason', async () => {
+      const response = await POST(postRequest({ action: 'cancel' }), context);
+
+      expect(response.status).toBe(400);
+      expect(mockRepo.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('404s for an unknown broadcast', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Gone' }), context);
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/__tests__/route.test.ts
@@ -170,7 +170,7 @@ describe('/api/admin/broadcasts/[id]', () => {
         'bc_1',
         'cancelled',
         expect.objectContaining({ completedAt: expect.any(Date) }),
-        { unlessStatus: ['completed', 'failed', 'cancelled'] },
+        { unlessStatus: ['completed', 'cancelled'] },
       );
       expect(mockRepo.appendStepResult).toHaveBeenCalledWith(
         'bc_1',
@@ -188,8 +188,22 @@ describe('/api/admin/broadcasts/[id]', () => {
       expect(response.status).toBe(200);
       expect(body).toEqual({ id: 'bc_1', status: 'paused' });
       expect(mockRepo.updateStatus).toHaveBeenCalledWith('bc_1', 'paused', {}, {
-        unlessStatus: ['completed', 'failed', 'cancelled'],
+        unlessStatus: ['completed', 'cancelled'],
       });
+    });
+
+    it('cancels a FAILED broadcast — pg-boss may still be retrying it', async () => {
+      mockRepo.findById.mockResolvedValue({ ...baseBroadcast, status: 'failed' });
+      mockRepo.updateStatus.mockResolvedValue(1);
+
+      const response = await POST(postRequest({ action: 'cancel', reason: 'Stop the retries' }), context);
+      const body = await response.json();
+
+      // The worker writes 'failed' + rethrows so pg-boss retries; a 'failed'
+      // row is often a live send between attempts. Refusing to cancel it would
+      // let the next retry resume mailing after the operator said stop.
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ id: 'bc_1', status: 'cancelled' });
     });
 
     it('returns 200 when the step-result note fails — the status write IS the intervention', async () => {

--- a/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
@@ -98,12 +98,25 @@ export const POST = withAdminAuth<RouteContext>(async (admin, request, context) 
       );
     }
 
-    await broadcastRepository.appendStepResult(id, {
-      step: action,
-      status: 'ok',
-      detail: reason,
-      at: new Date().toISOString(),
-    });
+    // The status write above IS the intervention — the worker yields to it
+    // mid-run — and it has landed. The step note is UI-facing evidence, and the
+    // durable record of who/why is the auditRequest below; so a note failure is
+    // logged, not surfaced. A 500 here would misreport a cancel that DID land,
+    // and the retry it invites would hit the no-op branch anyway.
+    try {
+      await broadcastRepository.appendStepResult(id, {
+        step: action,
+        status: 'ok',
+        detail: reason,
+        at: new Date().toISOString(),
+      });
+    } catch (error) {
+      loggers.api.warn('Broadcast intervention step-result append failed', {
+        broadcastId: id,
+        action,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
 
     loggers.api.info('Admin broadcast intervention', {
       adminId: admin.id,

--- a/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth';
+import { broadcastActionSchema } from '@/lib/broadcasts/schema';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import type { EmailBroadcastStatus } from '@pagespace/db/schema/email-broadcasts';
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+/**
+ * GET  /api/admin/broadcasts/[id] — status/counts/stepResults for progress polling.
+ * POST /api/admin/broadcasts/[id] — cancel or pause an active broadcast.
+ *
+ * Cancel/pause go through `updateStatus` with a terminal-state guard: the worker
+ * checks the row's status mid-run (between pages and per recipient), so writing
+ * `cancelled`/`paused` here IS the intervention — but a broadcast that already
+ * finished must not be dragged out of its terminal state, so the conditional
+ * write refuses and this route reports the real status instead.
+ */
+
+const TERMINAL_STATES: EmailBroadcastStatus[] = ['completed', 'failed', 'cancelled'];
+
+export const GET = withAdminAuth<RouteContext>(async (_admin, _request, context) => {
+  try {
+    const { id } = await context.params;
+    const broadcast = await broadcastRepository.findById(id);
+    if (!broadcast) {
+      return NextResponse.json({ error: 'Broadcast not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      id: broadcast.id,
+      subject: broadcast.subject,
+      status: broadcast.status,
+      engine: broadcast.engine,
+      contentMode: broadcast.contentMode,
+      dryRun: broadcast.dryRun,
+      sendLimit: broadcast.sendLimit,
+      delayMs: broadcast.delayMs,
+      totalTargeted: broadcast.totalTargeted,
+      sentCount: broadcast.sentCount,
+      skippedCount: broadcast.skippedCount,
+      failedCount: broadcast.failedCount,
+      stepResults: broadcast.stepResults ?? [],
+      attempts: broadcast.attempts,
+      lastError: broadcast.lastError,
+      blockedReason: broadcast.blockedReason,
+      createdAt: broadcast.createdAt,
+      startedAt: broadcast.startedAt,
+      completedAt: broadcast.completedAt,
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching broadcast', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to fetch broadcast' }, { status: 500 });
+  }
+});
+
+export const POST = withAdminAuth<RouteContext>(async (admin, request, context) => {
+  try {
+    const { id } = await context.params;
+
+    const parsed = broadcastActionSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid action request', details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+    const { action, reason } = parsed.data;
+
+    const broadcast = await broadcastRepository.findById(id);
+    if (!broadcast) {
+      return NextResponse.json({ error: 'Broadcast not found' }, { status: 404 });
+    }
+
+    const targetStatus: EmailBroadcastStatus = action === 'cancel' ? 'cancelled' : 'paused';
+
+    // Repeating an intervention that already took effect is a no-op, not an error.
+    if (broadcast.status === targetStatus) {
+      return NextResponse.json({ id, status: targetStatus });
+    }
+
+    const updated = await broadcastRepository.updateStatus(
+      id,
+      targetStatus,
+      action === 'cancel' ? { completedAt: new Date() } : {},
+      { unlessStatus: TERMINAL_STATES },
+    );
+
+    if (updated === 0) {
+      // The guard refused: the broadcast reached a terminal state first. Report
+      // the truth rather than pretend the intervention landed.
+      const current = await broadcastRepository.findById(id);
+      return NextResponse.json(
+        { error: `Broadcast is already ${current?.status ?? 'finished'}`, status: current?.status },
+        { status: 409 },
+      );
+    }
+
+    await broadcastRepository.appendStepResult(id, {
+      step: action,
+      status: 'ok',
+      detail: reason,
+      at: new Date().toISOString(),
+    });
+
+    loggers.api.info('Admin broadcast intervention', {
+      adminId: admin.id,
+      broadcastId: id,
+      action,
+      reason,
+    });
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: admin.id,
+      resourceType: 'broadcast',
+      resourceId: id,
+      details: { source: 'admin', action: `broadcast_${action}`, reason },
+    });
+
+    return NextResponse.json({ id, status: targetStatus });
+  } catch (error) {
+    loggers.api.error('Error updating broadcast', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to update broadcast' }, { status: 500 });
+  }
+});

--- a/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { withAdminAuth } from '@/lib/auth';
 import { broadcastActionSchema } from '@/lib/broadcasts/schema';
+import { appendStepResultBestEffort } from '@/lib/broadcast/step-results';
 import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -12,14 +13,21 @@ type RouteContext = { params: Promise<{ id: string }> };
  * GET  /api/admin/broadcasts/[id] — status/counts/stepResults for progress polling.
  * POST /api/admin/broadcasts/[id] — cancel or pause an active broadcast.
  *
- * Cancel/pause go through `updateStatus` with a terminal-state guard: the worker
- * checks the row's status mid-run (between pages and per recipient), so writing
+ * Cancel/pause go through `updateStatus` with a guard: the worker checks the
+ * row's status mid-run (between pages and per recipient), so writing
  * `cancelled`/`paused` here IS the intervention — but a broadcast that already
- * finished must not be dragged out of its terminal state, so the conditional
+ * finished must not be dragged out of its settled state, so the conditional
  * write refuses and this route reports the real status instead.
+ *
+ * `failed` is deliberately NOT in the blocked set. The worker writes `failed`
+ * and RETHROWS on per-recipient failures, which makes pg-boss retry — so a
+ * `failed` row is frequently a live send between attempts, and refusing to
+ * cancel it would let the next retry resume mailing after the operator said
+ * stop. Cancelling a row whose retries are actually exhausted is harmless:
+ * the operator's intent is recorded and `lastError` survives.
  */
 
-const TERMINAL_STATES: EmailBroadcastStatus[] = ['completed', 'failed', 'cancelled'];
+const INTERVENTION_BLOCKED_STATES: EmailBroadcastStatus[] = ['completed', 'cancelled'];
 
 export const GET = withAdminAuth<RouteContext>(async (_admin, _request, context) => {
   try {
@@ -85,11 +93,11 @@ export const POST = withAdminAuth<RouteContext>(async (admin, request, context) 
       id,
       targetStatus,
       action === 'cancel' ? { completedAt: new Date() } : {},
-      { unlessStatus: TERMINAL_STATES },
+      { unlessStatus: INTERVENTION_BLOCKED_STATES },
     );
 
     if (updated === 0) {
-      // The guard refused: the broadcast reached a terminal state first. Report
+      // The guard refused: the broadcast reached a settled state first. Report
       // the truth rather than pretend the intervention landed.
       const current = await broadcastRepository.findById(id);
       return NextResponse.json(
@@ -101,22 +109,14 @@ export const POST = withAdminAuth<RouteContext>(async (admin, request, context) 
     // The status write above IS the intervention — the worker yields to it
     // mid-run — and it has landed. The step note is UI-facing evidence, and the
     // durable record of who/why is the auditRequest below; so a note failure is
-    // logged, not surfaced. A 500 here would misreport a cancel that DID land,
-    // and the retry it invites would hit the no-op branch anyway.
-    try {
-      await broadcastRepository.appendStepResult(id, {
-        step: action,
-        status: 'ok',
-        detail: reason,
-        at: new Date().toISOString(),
-      });
-    } catch (error) {
-      loggers.api.warn('Broadcast intervention step-result append failed', {
-        broadcastId: id,
-        action,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    // logged (inside the helper), not surfaced. A 500 here would misreport a
+    // cancel that DID land, and the retry it invites would hit the no-op branch.
+    await appendStepResultBestEffort(id, {
+      step: action,
+      status: 'ok',
+      detail: reason,
+      at: new Date().toISOString(),
+    });
 
     loggers.api.info('Admin broadcast intervention', {
       adminId: admin.id,

--- a/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
@@ -396,6 +396,28 @@ describe('/api/admin/broadcasts', () => {
       expect(body.duplicateOf).toBe('bc_active');
       expect(mockRepo.create).not.toHaveBeenCalled();
       expect(mockEnqueue).not.toHaveBeenCalled();
+      // 'failed' is queried as active: the worker writes failed + rethrows so
+      // pg-boss retries — a failed row is often a live send between attempts.
+      expect(mockRepo.listByStatus).toHaveBeenCalledWith([
+        'pending',
+        'queued',
+        'in_progress',
+        'paused',
+        'failed',
+      ]);
+    });
+
+    it('409s a same-subject create while a FAILED broadcast awaits its pg-boss retry', async () => {
+      mockRepo.listByStatus.mockResolvedValue([
+        { id: 'bc_failed', subject: 'Launch update', status: 'failed', dryRun: false } as never,
+      ]);
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(body.duplicateOf).toBe('bc_failed');
+      expect(mockRepo.create).not.toHaveBeenCalled();
     });
 
     it('lets allowDuplicate deliberately bypass the active-duplicate guard', async () => {

--- a/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
@@ -124,6 +124,9 @@ describe('/api/admin/broadcasts', () => {
       expiresAt: new Date(Date.now() + 3600000),
     });
     adminCsrfToken = generateCSRFToken(mockSessionId);
+
+    // The live path consults the active-duplicate guard before creating.
+    mockRepo.listByStatus.mockResolvedValue([]);
   });
 
   afterEach(async () => {
@@ -357,12 +360,56 @@ describe('/api/admin/broadcasts', () => {
       expect(mockRepo.markQueued).not.toHaveBeenCalled();
     });
 
-    it('refuses a live send on the unshipped resend_broadcast engine', async () => {
+    it('refuses a live send on the unshipped resend_broadcast engine at the schema', async () => {
       const response = await POST(postRequest({ ...liveBody, engine: 'resend_broadcast' }));
+      const body = await response.json();
 
+      // Schema-level, so the composer form flags it at validation time too.
       expect(response.status).toBe(400);
+      expect(body.details.engine).toBeDefined();
       expect(mockRepo.create).not.toHaveBeenCalled();
       expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('allows a DRY RUN on the resend_broadcast engine — preview is engine-independent', async () => {
+      mockCountAudience.mockResolvedValue(1);
+
+      const response = await POST(
+        postRequest({ ...liveBody, engine: 'resend_broadcast', dryRun: true }),
+      );
+
+      expect(response.status).toBe(200);
+    });
+
+    it('409s a live create whose subject matches a still-active broadcast', async () => {
+      mockRepo.listByStatus.mockResolvedValue([
+        { id: 'bc_active', subject: 'Launch update', status: 'in_progress', dryRun: false } as never,
+      ]);
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      // A double-clicked Send or proxy-retried POST creates a FRESH row with a
+      // fresh singletonKey — nothing downstream dedupes it, so the guard here
+      // is what stands between the audience and a double blast.
+      expect(response.status).toBe(409);
+      expect(body.duplicateOf).toBe('bc_active');
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('lets allowDuplicate deliberately bypass the active-duplicate guard', async () => {
+      mockRepo.listByStatus.mockResolvedValue([
+        { id: 'bc_active', subject: 'Launch update', status: 'in_progress', dryRun: false } as never,
+      ]);
+      mockRepo.create.mockResolvedValue({ id: 'bc_2' } as never);
+      mockEnqueue.mockResolvedValue({ jobId: 'job_2' });
+      mockRepo.markQueued.mockResolvedValue(1);
+
+      const response = await POST(postRequest({ ...liveBody, allowDuplicate: true }));
+
+      expect(response.status).toBe(202);
+      expect(mockRepo.create).toHaveBeenCalled();
     });
   });
 

--- a/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
@@ -55,14 +55,23 @@ vi.mock('@pagespace/lib/services/broadcast/audience', () => ({
   countAudience: vi.fn(),
 }));
 
-vi.mock('@/lib/broadcast/enqueue', () => ({
-  enqueueBroadcast: vi.fn(),
-}));
+vi.mock('@/lib/broadcast/enqueue', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/broadcast/enqueue')>('@/lib/broadcast/enqueue');
+  return {
+    BroadcastNotEnqueuedError: actual.BroadcastNotEnqueuedError,
+    BroadcastEnqueueUnconfirmedError: actual.BroadcastEnqueueUnconfirmedError,
+    enqueueBroadcast: vi.fn(),
+  };
+});
 
 import { POST, GET } from '../route';
 import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
 import { countAudience } from '@pagespace/lib/services/broadcast/audience';
-import { enqueueBroadcast } from '@/lib/broadcast/enqueue';
+import {
+  BroadcastEnqueueUnconfirmedError,
+  BroadcastNotEnqueuedError,
+  enqueueBroadcast,
+} from '@/lib/broadcast/enqueue';
 
 const mockRepo = vi.mocked(broadcastRepository);
 const mockCountAudience = vi.mocked(countAudience);
@@ -233,7 +242,7 @@ describe('/api/admin/broadcasts', () => {
       const body = await response.json();
 
       expect(response.status).toBe(202);
-      expect(body).toEqual({ broadcastId: 'bc_1', jobId: 'job_1' });
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: 'job_1', enqueue: 'confirmed' });
 
       expect(mockRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -241,6 +250,7 @@ describe('/api/admin/broadcasts', () => {
           engine: 'transactional',
           contentMode: 'compose',
           bodyMarkdown: 'We shipped something.',
+          templateId: null,
           dryRun: false,
           sendLimit: 5,
           delayMs: 120,
@@ -252,9 +262,26 @@ describe('/api/admin/broadcasts', () => {
       expect(mockRepo.markFailed).not.toHaveBeenCalled();
     });
 
-    it('marks the broadcast failed when the enqueue throws', async () => {
+    it('drops a stale templateId from a compose-mode create', async () => {
       mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
-      mockEnqueue.mockRejectedValue(new Error('processor unreachable'));
+      mockEnqueue.mockResolvedValue({ jobId: 'job_1' });
+      mockRepo.markQueued.mockResolvedValue(1);
+
+      const response = await POST(postRequest({ ...liveBody, templateId: 'tpl_deleted' }));
+
+      expect(response.status).toBe(202);
+      // A compose send never read the template, so it must not reference one —
+      // a stale/deleted id would otherwise break the insert on the FK or record
+      // a template this send never used.
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ contentMode: 'compose', templateId: null }),
+      );
+    });
+
+    it('marks the broadcast failed when the enqueue definitely did not land', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockRejectedValue(new BroadcastNotEnqueuedError('processor refused: 401'));
+      mockRepo.markFailed.mockResolvedValue(1);
 
       const response = await POST(postRequest(liveBody));
       const body = await response.json();
@@ -263,8 +290,70 @@ describe('/api/admin/broadcasts', () => {
       expect(body.broadcastId).toBe('bc_1');
       expect(mockRepo.markFailed).toHaveBeenCalledWith(
         'bc_1',
-        expect.stringContaining('processor unreachable'),
+        expect.stringContaining('processor refused'),
       );
+      expect(mockRepo.markQueued).not.toHaveBeenCalled();
+    });
+
+    it('does NOT fail the row on an unconfirmed enqueue — a job may exist', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockRejectedValue(
+        new BroadcastEnqueueUnconfirmedError('timeout; retry: timeout'),
+      );
+      mockRepo.appendStepResult.mockResolvedValue(undefined);
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      // 202, not 500: a 500 invites a retried POST, which creates a FRESH row
+      // with a fresh singletonKey — a genuine second mass send.
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: null, enqueue: 'unconfirmed' });
+      expect(mockRepo.markFailed).not.toHaveBeenCalled();
+      expect(mockRepo.markQueued).not.toHaveBeenCalled();
+      expect(mockRepo.appendStepResult).toHaveBeenCalledWith(
+        'bc_1',
+        expect.objectContaining({ step: 'enqueue', status: 'failed' }),
+      );
+    });
+
+    it('reconciles when markFailed reports the worker already advanced the row', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockRejectedValue(new BroadcastNotEnqueuedError('processor refused: 400'));
+      mockRepo.markFailed.mockResolvedValue(0);
+      mockRepo.findById.mockResolvedValue({ id: 'bc_1', jobId: 'job_prior', status: 'in_progress' } as never);
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      // markFailed's guard refusing means a job exists and is sending — report
+      // that send instead of a retryable failure.
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: 'job_prior', enqueue: 'confirmed' });
+    });
+
+    it('still returns 202 when markQueued bookkeeping fails after a successful enqueue', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockResolvedValue({ jobId: 'job_1' });
+      mockRepo.markQueued.mockRejectedValue(new Error('db blip'));
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: 'job_1', enqueue: 'confirmed' });
+      expect(mockRepo.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('treats a deduped enqueue (job already queued) as confirmed with an unknown jobId', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockResolvedValue({ jobId: null });
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: null, enqueue: 'confirmed' });
       expect(mockRepo.markQueued).not.toHaveBeenCalled();
     });
 

--- a/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/__tests__/route.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { createId } from '@paralleldrive/cuid2';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+
+/**
+ * Tests for POST/GET /api/admin/broadcasts.
+ *
+ * The contract under test (frozen for the admin UI):
+ *  - dry-run returns { dryRun, audienceCount, previewHtml, subject } and touches
+ *    NOTHING durable — no row, no recipients, no processor job;
+ *  - live create runs create → enqueueBroadcast → markQueued and returns
+ *    { broadcastId, jobId } (202), with markFailed when the enqueue throws;
+ *  - non-admin callers are rejected by withAdminAuth;
+ *  - malformed bodies are rejected by the shared Zod schema.
+ *
+ * Auth follows the gift-subscription test style: a real admin row in the DB
+ * (validateAdminAccess reads it), a mocked sessionService, a real CSRF token.
+ * The repository, audience count, and enqueue helper are mocked — content
+ * resolution and email rendering run REAL so previewHtml is evidence about the
+ * exact email the worker would ship.
+ */
+
+vi.mock('@pagespace/lib/repositories/broadcast-repository', () => ({
+  broadcastRepository: {
+    create: vi.fn(),
+    findById: vi.fn(),
+    markQueued: vi.fn(),
+    markFailed: vi.fn(),
+    updateStatus: vi.fn(),
+    incrementAttempts: vi.fn(),
+    appendStepResult: vi.fn(),
+    updateCounts: vi.fn(),
+    listByStatus: vi.fn(),
+    listRecent: vi.fn(),
+    loadAlreadySentUserIds: vi.fn(),
+    loadAlreadySentEmails: vi.fn(),
+    createBroadcastLedger: vi.fn(),
+    claimRecipient: vi.fn(),
+    recordSent: vi.fn(),
+    recordSkip: vi.fn(),
+    recordFailure: vi.fn(),
+    countRecipientsByStatus: vi.fn(),
+    listTemplates: vi.fn(),
+    findTemplateById: vi.fn(),
+    createTemplate: vi.fn(),
+  },
+}));
+
+vi.mock('@pagespace/lib/services/broadcast/audience', () => ({
+  countAudience: vi.fn(),
+}));
+
+vi.mock('@/lib/broadcast/enqueue', () => ({
+  enqueueBroadcast: vi.fn(),
+}));
+
+import { POST, GET } from '../route';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import { countAudience } from '@pagespace/lib/services/broadcast/audience';
+import { enqueueBroadcast } from '@/lib/broadcast/enqueue';
+
+const mockRepo = vi.mocked(broadcastRepository);
+const mockCountAudience = vi.mocked(countAudience);
+const mockEnqueue = vi.mocked(enqueueBroadcast);
+
+describe('/api/admin/broadcasts', () => {
+  let adminUserId: string;
+  const adminSessionToken = 'mock_admin_session_token';
+  const mockSessionId = 'mock-session-id';
+  let adminCsrfToken: string;
+
+  const authedHeaders = () => ({
+    'Content-Type': 'application/json',
+    Cookie: `admin_session=${adminSessionToken}`,
+    'X-CSRF-Token': adminCsrfToken,
+  });
+
+  const postRequest = (body: unknown, headers?: Record<string, string>) =>
+    new NextRequest('http://localhost/api/admin/broadcasts', {
+      method: 'POST',
+      headers: headers ?? authedHeaders(),
+      body: JSON.stringify(body),
+    });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const [adminUser] = await db
+      .insert(users)
+      .values({
+        id: createId(),
+        name: 'Broadcast Admin',
+        email: `broadcast-admin-${Date.now()}-${createId().slice(0, 6)}@example.com`,
+        provider: 'email',
+        role: 'admin',
+        tokenVersion: 1,
+        adminRoleVersion: 0,
+      })
+      .returning();
+    adminUserId = adminUser.id;
+
+    vi.spyOn(sessionService, 'validateSession').mockResolvedValue({
+      sessionId: mockSessionId,
+      userId: adminUserId,
+      userRole: 'admin',
+      tokenVersion: 1,
+      adminRoleVersion: 0,
+      type: 'user',
+      scopes: ['*'],
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+    adminCsrfToken = generateCSRFToken(mockSessionId);
+  });
+
+  afterEach(async () => {
+    try {
+      await db.delete(users).where(eq(users.id, adminUserId));
+    } catch {
+      // Swallow cleanup errors to avoid masking test failures
+    }
+  });
+
+  describe('POST — dry run', () => {
+    it('returns audienceCount + previewHtml and touches nothing durable', async () => {
+      mockCountAudience.mockResolvedValue(220);
+
+      const response = await POST(
+        postRequest({
+          subject: 'Launch update',
+          contentMode: 'compose',
+          bodyMarkdown: '# Hello\n\nWe [shipped](https://pagespace.ai/blog) something.',
+          audienceDefinition: { planTiers: ['pro'] },
+          dryRun: true,
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.dryRun).toBe(true);
+      expect(body.audienceCount).toBe(220);
+      expect(body.subject).toBe('Launch update');
+      // The REAL renderer ran: authored content + mandatory unsubscribe footer.
+      expect(body.previewHtml).toContain('Hello');
+      expect(body.previewHtml).toContain('https://pagespace.ai/blog');
+      expect(body.previewHtml.toLowerCase()).toContain('unsubscribe');
+
+      expect(mockCountAudience).toHaveBeenCalledWith({ planTiers: ['pro'] });
+
+      // Nothing durable: no row, no job, no recipient ledger writes.
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+      expect(mockRepo.markQueued).not.toHaveBeenCalled();
+      expect(mockRepo.recordSent).not.toHaveBeenCalled();
+      expect(mockRepo.recordSkip).not.toHaveBeenCalled();
+      expect(mockRepo.recordFailure).not.toHaveBeenCalled();
+      expect(mockRepo.claimRecipient).not.toHaveBeenCalled();
+      expect(mockRepo.createBroadcastLedger).not.toHaveBeenCalled();
+    });
+
+    it('resolves template content for a template dry run', async () => {
+      mockCountAudience.mockResolvedValue(3);
+      mockRepo.findTemplateById.mockResolvedValue({
+        id: 'tpl_1',
+        name: 'Monthly',
+        subject: 'Template subject',
+        bodyMarkdown: 'Template **body** text',
+        isActive: true,
+        createdByUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const response = await POST(
+        postRequest({
+          contentMode: 'template',
+          templateId: 'tpl_1',
+          dryRun: true,
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      // No override subject supplied → the template's own subject wins.
+      expect(body.subject).toBe('Template subject');
+      expect(body.previewHtml).toContain('body');
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects a dry run against an inactive template', async () => {
+      mockRepo.findTemplateById.mockResolvedValue({
+        id: 'tpl_1',
+        name: 'Retired',
+        subject: 'Old',
+        bodyMarkdown: 'Old body',
+        isActive: false,
+        createdByUserId: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const response = await POST(
+        postRequest({ contentMode: 'template', templateId: 'tpl_1', dryRun: true }),
+      );
+
+      expect(response.status).toBe(400);
+      expect(mockCountAudience).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST — live create', () => {
+    const liveBody = {
+      subject: 'Launch update',
+      contentMode: 'compose',
+      bodyMarkdown: 'We shipped something.',
+      audienceDefinition: {},
+      dryRun: false,
+      sendLimit: 5,
+      delayMs: 120,
+    };
+
+    it('creates the row, enqueues the job, and marks it queued', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockResolvedValue({ jobId: 'job_1' });
+      mockRepo.markQueued.mockResolvedValue(1);
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(202);
+      expect(body).toEqual({ broadcastId: 'bc_1', jobId: 'job_1' });
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: 'Launch update',
+          engine: 'transactional',
+          contentMode: 'compose',
+          bodyMarkdown: 'We shipped something.',
+          dryRun: false,
+          sendLimit: 5,
+          delayMs: 120,
+          createdByUserId: adminUserId,
+        }),
+      );
+      expect(mockEnqueue).toHaveBeenCalledWith({ broadcastId: 'bc_1', callerUserId: adminUserId });
+      expect(mockRepo.markQueued).toHaveBeenCalledWith('bc_1', 'job_1');
+      expect(mockRepo.markFailed).not.toHaveBeenCalled();
+    });
+
+    it('marks the broadcast failed when the enqueue throws', async () => {
+      mockRepo.create.mockResolvedValue({ id: 'bc_1' } as never);
+      mockEnqueue.mockRejectedValue(new Error('processor unreachable'));
+
+      const response = await POST(postRequest(liveBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.broadcastId).toBe('bc_1');
+      expect(mockRepo.markFailed).toHaveBeenCalledWith(
+        'bc_1',
+        expect.stringContaining('processor unreachable'),
+      );
+      expect(mockRepo.markQueued).not.toHaveBeenCalled();
+    });
+
+    it('refuses a live send on the unshipped resend_broadcast engine', async () => {
+      const response = await POST(postRequest({ ...liveBody, engine: 'resend_broadcast' }));
+
+      expect(response.status).toBe(400);
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST — validation', () => {
+    it('rejects a compose broadcast without a body', async () => {
+      const response = await POST(
+        postRequest({ subject: 'No body', contentMode: 'compose', dryRun: true }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.details.bodyMarkdown).toBeDefined();
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a template broadcast without a templateId', async () => {
+      const response = await POST(postRequest({ contentMode: 'template', dryRun: true }));
+
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects a body that does not state dryRun', async () => {
+      const response = await POST(
+        postRequest({ subject: 'Hi', contentMode: 'compose', bodyMarkdown: 'x' }),
+      );
+
+      expect(response.status).toBe(400);
+    });
+
+    it('rejects an inverted signup window', async () => {
+      const response = await POST(
+        postRequest({
+          subject: 'Hi',
+          contentMode: 'compose',
+          bodyMarkdown: 'x',
+          dryRun: true,
+          audienceDefinition: {
+            signupAfter: '2026-02-01T00:00:00Z',
+            signupBefore: '2026-01-01T00:00:00Z',
+          },
+        }),
+      );
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('POST — auth', () => {
+    it('rejects an unauthenticated caller', async () => {
+      const response = await POST(
+        postRequest(
+          { subject: 'Hi', contentMode: 'compose', bodyMarkdown: 'x', dryRun: true },
+          { 'Content-Type': 'application/json' },
+        ),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Forbidden: Admin access required');
+      expect(mockRepo.create).not.toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('rejects a mutating call without a CSRF token', async () => {
+      const response = await POST(
+        postRequest(
+          { subject: 'Hi', contentMode: 'compose', bodyMarkdown: 'x', dryRun: true },
+          {
+            'Content-Type': 'application/json',
+            Cookie: `admin_session=${adminSessionToken}`,
+          },
+        ),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.code).toBe('CSRF_TOKEN_MISSING');
+    });
+  });
+
+  describe('GET — list', () => {
+    it('returns the frozen list shape', async () => {
+      const createdAt = new Date('2026-07-16T12:00:00Z');
+      mockRepo.listRecent.mockResolvedValue([
+        {
+          id: 'bc_1',
+          subject: 'Launch update',
+          status: 'completed',
+          engine: 'transactional',
+          dryRun: false,
+          totalTargeted: 220,
+          sentCount: 218,
+          skippedCount: 2,
+          failedCount: 0,
+          createdAt,
+        } as never,
+      ]);
+
+      const response = await GET(
+        new NextRequest('http://localhost/api/admin/broadcasts', {
+          headers: { Cookie: `admin_session=${adminSessionToken}` },
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.broadcasts).toEqual([
+        {
+          id: 'bc_1',
+          subject: 'Launch update',
+          status: 'completed',
+          engine: 'transactional',
+          dryRun: false,
+          totalTargeted: 220,
+          sentCount: 218,
+          skippedCount: 2,
+          failedCount: 0,
+          createdAt: createdAt.toISOString(),
+        },
+      ]);
+    });
+  });
+});

--- a/apps/admin/src/app/api/admin/broadcasts/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/route.ts
@@ -1,0 +1,200 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth';
+import { broadcastCreateSchema } from '@/lib/broadcasts/schema';
+import { enqueueBroadcast } from '@/lib/broadcast/enqueue';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import { countAudience } from '@pagespace/lib/services/broadcast/audience';
+import {
+  renderBroadcastEmail,
+  resolveBroadcastContent,
+} from '@pagespace/lib/services/broadcast/content';
+import { resolveBaseUrl } from '@pagespace/lib/services/broadcast/core';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import type { BroadcastAudienceDefinition } from '@pagespace/db/schema/email-broadcasts';
+
+/**
+ * POST /api/admin/broadcasts — create a broadcast (dry-run or live).
+ * GET  /api/admin/broadcasts — recent broadcasts for the list page.
+ *
+ * Dry-run touches NOTHING durable: no row, no recipients, no job — it answers
+ * "who would this reach and what would it look like" and stops. Only a live
+ * create writes the row and enqueues the processor job, mirroring the erasure
+ * route's create → enqueue → markQueued (markFailed on enqueue error) shape.
+ */
+
+/** Resolve compose/template content through the SAME code path the worker uses,
+ *  so the preview is evidence about the email that will actually ship. */
+async function resolveContent(parsed: {
+  contentMode: 'compose' | 'template';
+  subject: string;
+  bodyMarkdown?: string;
+  templateId?: string;
+}) {
+  return resolveBroadcastContent(
+    {
+      contentMode: parsed.contentMode,
+      subject: parsed.subject,
+      bodyMarkdown: parsed.bodyMarkdown ?? null,
+      templateId: parsed.templateId ?? null,
+    },
+    async (templateId) => {
+      const template = await broadcastRepository.findTemplateById(templateId);
+      return template
+        ? {
+            subject: template.subject,
+            bodyMarkdown: template.bodyMarkdown,
+            isActive: template.isActive,
+          }
+        : null;
+    },
+  );
+}
+
+export const POST = withAdminAuth(async (admin, request) => {
+  try {
+    const parsed = broadcastCreateSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid broadcast request', details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+    const input = parsed.data;
+    const audienceDefinition: BroadcastAudienceDefinition = input.audienceDefinition;
+
+    // Resolve content BEFORE any write for both modes: an inactive template or
+    // an empty body means the admin's intent is ambiguous, and the safe reading
+    // of an ambiguous mass email is "don't send it" — or store it.
+    let content: { subject: string; bodyMarkdown: string };
+    try {
+      content = await resolveContent(input);
+    } catch (error) {
+      return NextResponse.json(
+        { error: error instanceof Error ? error.message : 'Broadcast content is not resolvable' },
+        { status: 400 },
+      );
+    }
+
+    if (input.dryRun) {
+      const [audienceCount, previewHtml] = await Promise.all([
+        countAudience(audienceDefinition),
+        renderBroadcastEmail({
+          subject: content.subject,
+          bodyMarkdown: content.bodyMarkdown,
+          // Per-recipient tokens are minted at send time; the preview carries a
+          // placeholder with the real link's shape.
+          unsubscribeUrl: `${resolveBaseUrl()}/api/notifications/unsubscribe/preview`,
+          postalAddress: process.env.COMPANY_POSTAL_ADDRESS?.trim() || undefined,
+        }),
+      ]);
+
+      auditRequest(request, {
+        eventType: 'data.read',
+        userId: admin.id,
+        resourceType: 'broadcast',
+        resourceId: 'dry-run',
+        details: { source: 'admin', action: 'broadcast_dry_run', audienceCount, audienceDefinition },
+      });
+
+      return NextResponse.json({
+        dryRun: true,
+        audienceCount,
+        previewHtml,
+        subject: content.subject,
+      });
+    }
+
+    // The worker drives the transactional engine unconditionally; until the
+    // Phase-2 engine exists, a live resend_broadcast send would silently go out
+    // transactionally — refuse rather than mis-send.
+    if (input.engine === 'resend_broadcast') {
+      return NextResponse.json(
+        { error: 'The resend_broadcast engine is not available yet. Use "transactional".' },
+        { status: 400 },
+      );
+    }
+
+    const broadcast = await broadcastRepository.create({
+      subject: content.subject,
+      engine: input.engine,
+      contentMode: input.contentMode,
+      templateId: input.templateId ?? null,
+      bodyMarkdown: input.bodyMarkdown ?? null,
+      audienceDefinition,
+      dryRun: false,
+      sendLimit: input.sendLimit ?? null,
+      delayMs: input.delayMs,
+      createdByUserId: admin.id,
+    });
+
+    let jobId: string;
+    try {
+      ({ jobId } = await enqueueBroadcast({ broadcastId: broadcast.id, callerUserId: admin.id }));
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      await broadcastRepository.markFailed(broadcast.id, `enqueue failed: ${msg}`);
+      loggers.api.error('Broadcast enqueue failed', error instanceof Error ? error : undefined);
+      return NextResponse.json(
+        { error: 'Failed to enqueue broadcast job', broadcastId: broadcast.id },
+        { status: 500 },
+      );
+    }
+
+    await broadcastRepository.markQueued(broadcast.id, jobId);
+
+    loggers.api.info('Admin created live broadcast', {
+      adminId: admin.id,
+      broadcastId: broadcast.id,
+      jobId,
+      engine: input.engine,
+      sendLimit: input.sendLimit ?? null,
+    });
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: admin.id,
+      resourceType: 'broadcast',
+      resourceId: broadcast.id,
+      details: {
+        source: 'admin',
+        action: 'broadcast_create_live',
+        subject: content.subject,
+        engine: input.engine,
+        contentMode: input.contentMode,
+        audienceDefinition,
+        sendLimit: input.sendLimit ?? null,
+        delayMs: input.delayMs ?? null,
+        jobId,
+      },
+    });
+
+    return NextResponse.json({ broadcastId: broadcast.id, jobId }, { status: 202 });
+  } catch (error) {
+    loggers.api.error('Error creating broadcast', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to create broadcast' }, { status: 500 });
+  }
+});
+
+export const GET = withAdminAuth(async () => {
+  try {
+    const rows = await broadcastRepository.listRecent();
+    return NextResponse.json({
+      broadcasts: rows.map((row) => ({
+        id: row.id,
+        subject: row.subject,
+        status: row.status,
+        engine: row.engine,
+        dryRun: row.dryRun,
+        totalTargeted: row.totalTargeted,
+        sentCount: row.sentCount,
+        skippedCount: row.skippedCount,
+        failedCount: row.failedCount,
+        createdAt: row.createdAt,
+      })),
+    });
+  } catch (error) {
+    loggers.api.error('Error listing broadcasts', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to list broadcasts' }, { status: 500 });
+  }
+});

--- a/apps/admin/src/app/api/admin/broadcasts/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/route.ts
@@ -111,12 +111,18 @@ export const POST = withAdminAuth(async (admin, request) => {
     // two rows mean the whole audience is mailed twice. An active broadcast
     // with the same resolved subject is almost always the same intent, so
     // refuse it unless the admin explicitly says the duplicate is deliberate.
+    // 'failed' counts as active for the same reason the cancel route may
+    // cancel it: the worker writes 'failed' + rethrows so pg-boss retries,
+    // meaning a failed row is often a live send between attempts. A row whose
+    // retries are truly exhausted needs allowDuplicate — a deliberate re-send,
+    // not an accidental double blast during retry backoff.
     if (!input.allowDuplicate) {
       const active = await broadcastRepository.listByStatus([
         'pending',
         'queued',
         'in_progress',
         'paused',
+        'failed',
       ]);
       const duplicate = active.find((b) => !b.dryRun && b.subject === content.subject);
       if (duplicate) {

--- a/apps/admin/src/app/api/admin/broadcasts/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server';
 import { withAdminAuth } from '@/lib/auth';
 import { broadcastCreateSchema } from '@/lib/broadcasts/schema';
-import { enqueueBroadcast } from '@/lib/broadcast/enqueue';
+import {
+  BroadcastEnqueueUnconfirmedError,
+  enqueueBroadcast,
+} from '@/lib/broadcast/enqueue';
 import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
 import { countAudience } from '@pagespace/lib/services/broadcast/audience';
 import {
@@ -49,6 +52,24 @@ async function resolveContent(parsed: {
         : null;
     },
   );
+}
+
+/** Best-effort progress-trail note. The trail is UI-facing evidence, not the
+ *  audit record (auditRequest is) — its failure must never fail the request. */
+async function appendStepResultSafe(broadcastId: string, detail: string): Promise<void> {
+  try {
+    await broadcastRepository.appendStepResult(broadcastId, {
+      step: 'enqueue',
+      status: 'failed',
+      detail,
+      at: new Date().toISOString(),
+    });
+  } catch (error) {
+    loggers.api.warn('Broadcast step-result append failed', {
+      broadcastId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 export const POST = withAdminAuth(async (admin, request) => {
@@ -119,8 +140,12 @@ export const POST = withAdminAuth(async (admin, request) => {
       subject: content.subject,
       engine: input.engine,
       contentMode: input.contentMode,
-      templateId: input.templateId ?? null,
-      bodyMarkdown: input.bodyMarkdown ?? null,
+      // Only the field the active mode reads is stored. The other one may hold
+      // stale form state (e.g. a template id kept after switching to compose),
+      // and persisting it would either break the insert on a deleted template
+      // FK or record a reference to a template this send never used.
+      templateId: input.contentMode === 'template' ? (input.templateId ?? null) : null,
+      bodyMarkdown: input.contentMode === 'compose' ? (input.bodyMarkdown ?? null) : null,
       audienceDefinition,
       dryRun: false,
       sendLimit: input.sendLimit ?? null,
@@ -128,12 +153,64 @@ export const POST = withAdminAuth(async (admin, request) => {
       createdByUserId: admin.id,
     });
 
-    let jobId: string;
+    const recordAudit = (details: Record<string, unknown>) =>
+      auditRequest(request, {
+        eventType: 'data.write',
+        userId: admin.id,
+        resourceType: 'broadcast',
+        resourceId: broadcast.id,
+        details: {
+          source: 'admin',
+          action: 'broadcast_create_live',
+          subject: content.subject,
+          engine: input.engine,
+          contentMode: input.contentMode,
+          audienceDefinition,
+          sendLimit: input.sendLimit ?? null,
+          delayMs: input.delayMs ?? null,
+          ...details,
+        },
+      });
+
+    // jobId is null when the processor deduped the enqueue (a job for this
+    // broadcast already exists — same outcome, id unknown).
+    let jobId: string | null;
     try {
       ({ jobId } = await enqueueBroadcast({ broadcastId: broadcast.id, callerUserId: admin.id }));
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
-      await broadcastRepository.markFailed(broadcast.id, `enqueue failed: ${msg}`);
+
+      if (error instanceof BroadcastEnqueueUnconfirmedError) {
+        // A job MAY exist. Failing the row would be a lie the worker ignores
+        // (it yields only to cancelled/paused/completed) — mail could go out
+        // under a status that told the admin the send died, inviting a second
+        // broadcast. Report accepted-but-unconfirmed and point at the status
+        // page, where a landed job shows progress and a lost one stays pending.
+        await appendStepResultSafe(broadcast.id, `enqueue unconfirmed: ${msg}`);
+        loggers.api.warn('Broadcast enqueue unconfirmed — job may exist', {
+          broadcastId: broadcast.id,
+          error: msg,
+        });
+        recordAudit({ jobId: null, enqueue: 'unconfirmed' });
+        return NextResponse.json(
+          { broadcastId: broadcast.id, jobId: null, enqueue: 'unconfirmed' },
+          { status: 202 },
+        );
+      }
+
+      // Definitely not enqueued (token minting failed or the processor refused
+      // the request) — the one case where failing the row is safe and honest.
+      const failed = await broadcastRepository.markFailed(broadcast.id, `enqueue failed: ${msg}`);
+      if (failed === 0) {
+        // markFailed's guard refused: the worker already advanced the row, so a
+        // job exists after all. Report the send that is actually happening.
+        const row = await broadcastRepository.findById(broadcast.id);
+        recordAudit({ jobId: row?.jobId ?? null, enqueue: 'confirmed' });
+        return NextResponse.json(
+          { broadcastId: broadcast.id, jobId: row?.jobId ?? null, enqueue: 'confirmed' },
+          { status: 202 },
+        );
+      }
       loggers.api.error('Broadcast enqueue failed', error instanceof Error ? error : undefined);
       return NextResponse.json(
         { error: 'Failed to enqueue broadcast job', broadcastId: broadcast.id },
@@ -141,7 +218,20 @@ export const POST = withAdminAuth(async (admin, request) => {
       );
     }
 
-    await broadcastRepository.markQueued(broadcast.id, jobId);
+    if (jobId !== null) {
+      try {
+        await broadcastRepository.markQueued(broadcast.id, jobId);
+      } catch (error) {
+        // Bookkeeping only: the job IS live and the worker advances the row on
+        // its own. A 500 here would invite a retried POST — a fresh row with a
+        // fresh singletonKey, i.e. a genuine second mass send.
+        loggers.api.warn('markQueued failed after successful enqueue — worker will advance the row', {
+          broadcastId: broadcast.id,
+          jobId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     loggers.api.info('Admin created live broadcast', {
       adminId: admin.id,
@@ -151,25 +241,12 @@ export const POST = withAdminAuth(async (admin, request) => {
       sendLimit: input.sendLimit ?? null,
     });
 
-    auditRequest(request, {
-      eventType: 'data.write',
-      userId: admin.id,
-      resourceType: 'broadcast',
-      resourceId: broadcast.id,
-      details: {
-        source: 'admin',
-        action: 'broadcast_create_live',
-        subject: content.subject,
-        engine: input.engine,
-        contentMode: input.contentMode,
-        audienceDefinition,
-        sendLimit: input.sendLimit ?? null,
-        delayMs: input.delayMs ?? null,
-        jobId,
-      },
-    });
+    recordAudit({ jobId, enqueue: 'confirmed' });
 
-    return NextResponse.json({ broadcastId: broadcast.id, jobId }, { status: 202 });
+    return NextResponse.json(
+      { broadcastId: broadcast.id, jobId, enqueue: 'confirmed' },
+      { status: 202 },
+    );
   } catch (error) {
     loggers.api.error('Error creating broadcast', error instanceof Error ? error : undefined);
     return NextResponse.json({ error: 'Failed to create broadcast' }, { status: 500 });

--- a/apps/admin/src/app/api/admin/broadcasts/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { withAdminAuth } from '@/lib/auth';
-import { broadcastCreateSchema } from '@/lib/broadcasts/schema';
+import { broadcastCreateSchema, type BroadcastCreateInput } from '@/lib/broadcasts/schema';
 import {
   BroadcastEnqueueUnconfirmedError,
   enqueueBroadcast,
 } from '@/lib/broadcast/enqueue';
+import { appendStepResultBestEffort } from '@/lib/broadcast/step-results';
 import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
 import { countAudience } from '@pagespace/lib/services/broadcast/audience';
 import {
@@ -28,12 +29,9 @@ import type { BroadcastAudienceDefinition } from '@pagespace/db/schema/email-bro
 
 /** Resolve compose/template content through the SAME code path the worker uses,
  *  so the preview is evidence about the email that will actually ship. */
-async function resolveContent(parsed: {
-  contentMode: 'compose' | 'template';
-  subject: string;
-  bodyMarkdown?: string;
-  templateId?: string;
-}) {
+async function resolveContent(
+  parsed: Pick<BroadcastCreateInput, 'contentMode' | 'subject' | 'bodyMarkdown' | 'templateId'>,
+) {
   return resolveBroadcastContent(
     {
       contentMode: parsed.contentMode,
@@ -52,24 +50,6 @@ async function resolveContent(parsed: {
         : null;
     },
   );
-}
-
-/** Best-effort progress-trail note. The trail is UI-facing evidence, not the
- *  audit record (auditRequest is) — its failure must never fail the request. */
-async function appendStepResultSafe(broadcastId: string, detail: string): Promise<void> {
-  try {
-    await broadcastRepository.appendStepResult(broadcastId, {
-      step: 'enqueue',
-      status: 'failed',
-      detail,
-      at: new Date().toISOString(),
-    });
-  } catch (error) {
-    loggers.api.warn('Broadcast step-result append failed', {
-      broadcastId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
 }
 
 export const POST = withAdminAuth(async (admin, request) => {
@@ -126,26 +106,38 @@ export const POST = withAdminAuth(async (admin, request) => {
       });
     }
 
-    // The worker drives the transactional engine unconditionally; until the
-    // Phase-2 engine exists, a live resend_broadcast send would silently go out
-    // transactionally — refuse rather than mis-send.
-    if (input.engine === 'resend_broadcast') {
-      return NextResponse.json(
-        { error: 'The resend_broadcast engine is not available yet. Use "transactional".' },
-        { status: 400 },
-      );
+    // Double-click and proxy-retry protection: each POST creates a FRESH row
+    // with a fresh singletonKey, so nothing downstream dedupes two creates —
+    // two rows mean the whole audience is mailed twice. An active broadcast
+    // with the same resolved subject is almost always the same intent, so
+    // refuse it unless the admin explicitly says the duplicate is deliberate.
+    if (!input.allowDuplicate) {
+      const active = await broadcastRepository.listByStatus([
+        'pending',
+        'queued',
+        'in_progress',
+        'paused',
+      ]);
+      const duplicate = active.find((b) => !b.dryRun && b.subject === content.subject);
+      if (duplicate) {
+        return NextResponse.json(
+          {
+            error: `A broadcast with this subject is already ${duplicate.status}. Pass allowDuplicate to send anyway.`,
+            duplicateOf: duplicate.id,
+          },
+          { status: 409 },
+        );
+      }
     }
 
+    // Cross-mode fields (a stale templateId on a compose send, a leftover body
+    // on a template send) were already dropped by the schema's transform.
     const broadcast = await broadcastRepository.create({
       subject: content.subject,
       engine: input.engine,
       contentMode: input.contentMode,
-      // Only the field the active mode reads is stored. The other one may hold
-      // stale form state (e.g. a template id kept after switching to compose),
-      // and persisting it would either break the insert on a deleted template
-      // FK or record a reference to a template this send never used.
-      templateId: input.contentMode === 'template' ? (input.templateId ?? null) : null,
-      bodyMarkdown: input.contentMode === 'compose' ? (input.bodyMarkdown ?? null) : null,
+      templateId: input.templateId ?? null,
+      bodyMarkdown: input.bodyMarkdown ?? null,
       audienceDefinition,
       dryRun: false,
       sendLimit: input.sendLimit ?? null,
@@ -186,7 +178,12 @@ export const POST = withAdminAuth(async (admin, request) => {
         // under a status that told the admin the send died, inviting a second
         // broadcast. Report accepted-but-unconfirmed and point at the status
         // page, where a landed job shows progress and a lost one stays pending.
-        await appendStepResultSafe(broadcast.id, `enqueue unconfirmed: ${msg}`);
+        await appendStepResultBestEffort(broadcast.id, {
+          step: 'enqueue',
+          status: 'failed',
+          detail: `enqueue unconfirmed: ${msg}`,
+          at: new Date().toISOString(),
+        });
         loggers.api.warn('Broadcast enqueue unconfirmed — job may exist', {
           broadcastId: broadcast.id,
           error: msg,

--- a/apps/admin/src/app/api/admin/broadcasts/templates/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/templates/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { createId } from '@paralleldrive/cuid2';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+
+/** Tests for GET/POST /api/admin/broadcasts/templates — the phase-1 template library. */
+
+vi.mock('@pagespace/lib/repositories/broadcast-repository', () => ({
+  broadcastRepository: {
+    listTemplates: vi.fn(),
+    createTemplate: vi.fn(),
+  },
+}));
+
+import { GET, POST } from '../route';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+
+const mockRepo = vi.mocked(broadcastRepository);
+
+describe('/api/admin/broadcasts/templates', () => {
+  let adminUserId: string;
+  const adminSessionToken = 'mock_admin_session_token';
+  const mockSessionId = 'mock-session-id';
+  let adminCsrfToken: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    const [adminUser] = await db
+      .insert(users)
+      .values({
+        id: createId(),
+        name: 'Broadcast Admin',
+        email: `broadcast-admin-${Date.now()}-${createId().slice(0, 6)}@example.com`,
+        provider: 'email',
+        role: 'admin',
+        tokenVersion: 1,
+        adminRoleVersion: 0,
+      })
+      .returning();
+    adminUserId = adminUser.id;
+
+    vi.spyOn(sessionService, 'validateSession').mockResolvedValue({
+      sessionId: mockSessionId,
+      userId: adminUserId,
+      userRole: 'admin',
+      tokenVersion: 1,
+      adminRoleVersion: 0,
+      type: 'user',
+      scopes: ['*'],
+      expiresAt: new Date(Date.now() + 3600000),
+    });
+    adminCsrfToken = generateCSRFToken(mockSessionId);
+  });
+
+  afterEach(async () => {
+    try {
+      await db.delete(users).where(eq(users.id, adminUserId));
+    } catch {
+      // Swallow cleanup errors to avoid masking test failures
+    }
+  });
+
+  it('GET lists active templates', async () => {
+    const createdAt = new Date('2026-07-01T00:00:00Z');
+    mockRepo.listTemplates.mockResolvedValue([
+      {
+        id: 'tpl_1',
+        name: 'Monthly',
+        subject: 'Monthly update',
+        bodyMarkdown: 'Body',
+        isActive: true,
+        createdByUserId: null,
+        createdAt,
+        updatedAt: createdAt,
+      },
+    ]);
+
+    const response = await GET(
+      new NextRequest('http://localhost/api/admin/broadcasts/templates', {
+        headers: { Cookie: `admin_session=${adminSessionToken}` },
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockRepo.listTemplates).toHaveBeenCalledWith(true);
+    expect(body.templates).toEqual([
+      {
+        id: 'tpl_1',
+        name: 'Monthly',
+        subject: 'Monthly update',
+        bodyMarkdown: 'Body',
+        isActive: true,
+        createdAt: createdAt.toISOString(),
+        updatedAt: createdAt.toISOString(),
+      },
+    ]);
+  });
+
+  it('POST creates a template attributed to the admin', async () => {
+    const createdAt = new Date('2026-07-16T00:00:00Z');
+    mockRepo.createTemplate.mockResolvedValue({
+      id: 'tpl_2',
+      name: 'Launch',
+      subject: 'We shipped',
+      bodyMarkdown: 'Details…',
+      isActive: true,
+      createdByUserId: 'admin',
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    const response = await POST(
+      new NextRequest('http://localhost/api/admin/broadcasts/templates', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `admin_session=${adminSessionToken}`,
+          'X-CSRF-Token': adminCsrfToken,
+        },
+        body: JSON.stringify({ name: 'Launch', subject: 'We shipped', bodyMarkdown: 'Details…' }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.template.id).toBe('tpl_2');
+    expect(mockRepo.createTemplate).toHaveBeenCalledWith({
+      name: 'Launch',
+      subject: 'We shipped',
+      bodyMarkdown: 'Details…',
+      isActive: true,
+      createdByUserId: adminUserId,
+    });
+  });
+
+  it('POST rejects a template without a body', async () => {
+    const response = await POST(
+      new NextRequest('http://localhost/api/admin/broadcasts/templates', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: `admin_session=${adminSessionToken}`,
+          'X-CSRF-Token': adminCsrfToken,
+        },
+        body: JSON.stringify({ name: 'Launch', subject: 'We shipped' }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockRepo.createTemplate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/admin/src/app/api/admin/broadcasts/templates/route.ts
+++ b/apps/admin/src/app/api/admin/broadcasts/templates/route.ts
@@ -1,0 +1,81 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth';
+import { templateCreateSchema } from '@/lib/broadcasts/schema';
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+/**
+ * GET  /api/admin/broadcasts/templates — active templates for the composer picker.
+ * POST /api/admin/broadcasts/templates — save a reusable template.
+ *
+ * Phase-1 minimal template library: list + create. Retiring/editing templates is
+ * a follow-up; `resolveBroadcastContent` already refuses inactive templates at
+ * send time, so deactivation (when it ships) is honored without route changes.
+ */
+
+export const GET = withAdminAuth(async () => {
+  try {
+    const templates = await broadcastRepository.listTemplates(true);
+    return NextResponse.json({
+      templates: templates.map((template) => ({
+        id: template.id,
+        name: template.name,
+        subject: template.subject,
+        bodyMarkdown: template.bodyMarkdown,
+        isActive: template.isActive,
+        createdAt: template.createdAt,
+        updatedAt: template.updatedAt,
+      })),
+    });
+  } catch (error) {
+    loggers.api.error('Error listing broadcast templates', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to list templates' }, { status: 500 });
+  }
+});
+
+export const POST = withAdminAuth(async (admin, request) => {
+  try {
+    const parsed = templateCreateSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid template request', details: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const template = await broadcastRepository.createTemplate({
+      name: parsed.data.name,
+      subject: parsed.data.subject,
+      bodyMarkdown: parsed.data.bodyMarkdown,
+      isActive: parsed.data.isActive,
+      createdByUserId: admin.id,
+    });
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: admin.id,
+      resourceType: 'broadcast_template',
+      resourceId: template.id,
+      details: { source: 'admin', action: 'broadcast_template_create', name: template.name },
+    });
+
+    return NextResponse.json(
+      {
+        template: {
+          id: template.id,
+          name: template.name,
+          subject: template.subject,
+          bodyMarkdown: template.bodyMarkdown,
+          isActive: template.isActive,
+          createdAt: template.createdAt,
+          updatedAt: template.updatedAt,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (error) {
+    loggers.api.error('Error creating broadcast template', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Failed to create template' }, { status: 500 });
+  }
+});

--- a/apps/admin/src/lib/broadcast/__tests__/enqueue.test.ts
+++ b/apps/admin/src/lib/broadcast/__tests__/enqueue.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Tests for the enqueue helper's failure CLASSIFICATION — the logic that keeps
+ * an ambiguous transport failure from being reported as "definitely failed"
+ * (which would let the worker send mail under a `failed` status and invite the
+ * admin to create a duplicate broadcast).
+ *
+ * The reconciliation retry leans on the processor's `singletonKey: broadcastId`
+ * dedupe: re-POSTing the same id cannot start a second concurrent job, and its
+ * 409 is positive proof the lost first attempt landed.
+ */
+
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+  createUserServiceToken: vi.fn().mockResolvedValue({ token: 'svc-token' }),
+}));
+
+import {
+  BroadcastEnqueueUnconfirmedError,
+  BroadcastNotEnqueuedError,
+  enqueueBroadcast,
+} from '../enqueue';
+import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token';
+
+const params = { broadcastId: 'bc_1', callerUserId: 'admin_1' };
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+describe('enqueueBroadcast', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createUserServiceToken).mockResolvedValue({ token: 'svc-token' } as never);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the jobId on a clean 200', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { success: true, jobId: 'job_1' }));
+
+    await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: 'job_1' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(createUserServiceToken).toHaveBeenCalledWith('admin_1', ['broadcast:enqueue'], '2m');
+  });
+
+  it('treats a 409 (singletonKey dedupe) as success with an unknown jobId', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(409, { error: 'already queued' }));
+
+    await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: null });
+  });
+
+  it('throws NotEnqueued on a non-409 4xx — the processor examined and refused', async () => {
+    fetchMock.mockResolvedValue(jsonResponse(401, { error: 'bad scope' }));
+
+    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastNotEnqueuedError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws NotEnqueued when token minting fails — no request ever left', async () => {
+    vi.mocked(createUserServiceToken).mockRejectedValue(new Error('no such user'));
+
+    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastNotEnqueuedError);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('recovers a lost response via the reconciliation retry: network error then 409', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(jsonResponse(409, { error: 'already queued' }));
+
+    // The 409 proves the first attempt landed: confirmed, id unknown.
+    await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: null });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('recovers a dropped first attempt via the retry: network error then 200', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('socket hang up'))
+      .mockResolvedValueOnce(jsonResponse(200, { success: true, jobId: 'job_2' }));
+
+    await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: 'job_2' });
+  });
+
+  it('converts an ambiguous 5xx into a definite refusal when the retry 4xxes', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(502, { error: 'bad gateway' }))
+      .mockResolvedValueOnce(jsonResponse(400, { error: 'broadcastId is required' }));
+
+    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastNotEnqueuedError);
+  });
+
+  it('throws Unconfirmed only when both attempts fail ambiguously', async () => {
+    fetchMock.mockRejectedValue(new Error('timeout'));
+
+    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastEnqueueUnconfirmedError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a 2xx with no jobId in the body as ambiguous, not success', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, { success: true }))
+      .mockResolvedValueOnce(jsonResponse(409, { error: 'already queued' }));
+
+    await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: null });
+  });
+});

--- a/apps/admin/src/lib/broadcast/__tests__/enqueue.test.ts
+++ b/apps/admin/src/lib/broadcast/__tests__/enqueue.test.ts
@@ -86,12 +86,15 @@ describe('enqueueBroadcast', () => {
     await expect(enqueueBroadcast(params)).resolves.toEqual({ jobId: 'job_2' });
   });
 
-  it('converts an ambiguous 5xx into a definite refusal when the retry 4xxes', async () => {
+  it('a refusal AFTER an ambiguous attempt stays unconfirmed — the first job may be live', async () => {
+    // First POST: proxy 502 sent after the processor may have committed addJob.
+    // Retry: a 4xx proves only the RETRY created nothing. Downgrading to
+    // NotEnqueued would let the caller mark a sending broadcast 'failed'.
     fetchMock
       .mockResolvedValueOnce(jsonResponse(502, { error: 'bad gateway' }))
       .mockResolvedValueOnce(jsonResponse(400, { error: 'broadcastId is required' }));
 
-    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastNotEnqueuedError);
+    await expect(enqueueBroadcast(params)).rejects.toBeInstanceOf(BroadcastEnqueueUnconfirmedError);
   });
 
   it('throws Unconfirmed only when both attempts fail ambiguously', async () => {

--- a/apps/admin/src/lib/broadcast/enqueue.ts
+++ b/apps/admin/src/lib/broadcast/enqueue.ts
@@ -1,0 +1,48 @@
+import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token';
+
+/**
+ * Enqueue a durable email-broadcast job on the processor.
+ *
+ * Mirrors `apps/web/src/lib/erasure/enqueue.ts` — the proven admin-route →
+ * scoped-service-token → processor pg-boss shape. Mints a short-lived
+ * `broadcast:enqueue` token against the calling ADMIN's own user resource and
+ * hands the broadcastId to `POST ${PROCESSOR_URL}/api/broadcast/enqueue`.
+ * Returns the jobId for `broadcastRepository.markQueued`.
+ *
+ * NOTE: the admin app makes no other processor calls, so PROCESSOR_URL must be
+ * set in its deployment env (see fly.admin.toml). The docker default matches
+ * the compose service name, same as the erasure helper.
+ */
+
+const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
+
+export interface EnqueueBroadcastParams {
+  /** The email_broadcasts row id the worker will send against. */
+  broadcastId: string;
+  /** The authenticated admin minting the token. */
+  callerUserId: string;
+}
+
+export async function enqueueBroadcast(params: EnqueueBroadcastParams): Promise<{ jobId: string }> {
+  const { token } = await createUserServiceToken(params.callerUserId, ['broadcast:enqueue'], '2m');
+
+  const res = await fetch(`${PROCESSOR_URL}/api/broadcast/enqueue`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ broadcastId: params.broadcastId }),
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Processor broadcast enqueue failed: ${res.status} ${detail}`);
+  }
+
+  const json = (await res.json()) as { jobId?: string };
+  if (!json.jobId) {
+    throw new Error('Processor broadcast enqueue returned no jobId');
+  }
+  return { jobId: json.jobId };
+}

--- a/apps/admin/src/lib/broadcast/enqueue.ts
+++ b/apps/admin/src/lib/broadcast/enqueue.ts
@@ -119,6 +119,27 @@ async function postEnqueue(broadcastId: string, token: string): Promise<AttemptO
   return { kind: 'ok', jobId: json.jobId };
 }
 
+/**
+ * Map one attempt's outcome to a result, or null when it settles nothing.
+ *
+ * `refusalIsProof` is the whole subtlety: a refusal only proves "no job exists"
+ * while NO earlier attempt is unaccounted for. After an ambiguous attempt (say
+ * a proxy 502 sent after addJob committed), a 4xx on the retry proves only that
+ * the RETRY created nothing — the first attempt's job may be live, so treating
+ * that refusal as proof would let the caller mark a sending broadcast `failed`.
+ */
+function settle(
+  outcome: AttemptOutcome,
+  opts: { refusalIsProof: boolean },
+): EnqueueBroadcastResult | null {
+  if (outcome.kind === 'ok') return { jobId: outcome.jobId };
+  if (outcome.kind === 'deduped') return { jobId: null };
+  if (outcome.kind === 'refused' && opts.refusalIsProof) {
+    throw new BroadcastNotEnqueuedError(`Processor broadcast enqueue refused: ${outcome.detail}`);
+  }
+  return null;
+}
+
 export async function enqueueBroadcast(params: EnqueueBroadcastParams): Promise<EnqueueBroadcastResult> {
   // A minting failure happens before any request leaves the process — the one
   // failure that is unambiguous by construction.
@@ -131,23 +152,24 @@ export async function enqueueBroadcast(params: EnqueueBroadcastParams): Promise<
   }
 
   const first = await postEnqueue(params.broadcastId, token);
-  if (first.kind === 'ok') return { jobId: first.jobId };
-  if (first.kind === 'deduped') return { jobId: null };
-  if (first.kind === 'refused') {
-    throw new BroadcastNotEnqueuedError(`Processor broadcast enqueue refused: ${first.detail}`);
-  }
+  const settledFirst = settle(first, { refusalIsProof: true });
+  if (settledFirst) return settledFirst;
 
-  // Ambiguous → reconcile with one retry. The singletonKey makes this safe (a
-  // landed first attempt yields 409, not a second job), and every outcome but
-  // another transport failure converts the ambiguity into a definite answer.
+  // Ambiguous → reconcile with one retry: a landed first attempt normally
+  // yields 409, not a second job. The narrow window where it doesn't — the
+  // first job already ran to completion, releasing the singletonKey — is
+  // still safe end to end: a completed row makes the worker yield, a refused
+  // row just re-refuses, and a mid-send failure re-walks behind the
+  // per-recipient claim ledger, which is exactly the designed resume path.
   const second = await postEnqueue(params.broadcastId, token);
-  if (second.kind === 'ok') return { jobId: second.jobId };
-  if (second.kind === 'deduped') return { jobId: null };
-  if (second.kind === 'refused') {
-    throw new BroadcastNotEnqueuedError(`Processor broadcast enqueue refused: ${second.detail}`);
-  }
+  const settledSecond = settle(second, { refusalIsProof: false });
+  if (settledSecond) return settledSecond;
 
+  // Reaching here means neither attempt settled: `first` can only be ambiguous
+  // (ok/deduped returned, refused threw) and `second` ambiguous or refused.
+  const detailOf = (o: AttemptOutcome) =>
+    o.kind === 'refused' || o.kind === 'ambiguous' ? o.detail : o.kind;
   throw new BroadcastEnqueueUnconfirmedError(
-    `Processor broadcast enqueue unconfirmed: ${first.detail}; retry: ${second.detail}`,
+    `Processor broadcast enqueue unconfirmed: ${detailOf(first)}; retry: ${detailOf(second)}`,
   );
 }

--- a/apps/admin/src/lib/broadcast/enqueue.ts
+++ b/apps/admin/src/lib/broadcast/enqueue.ts
@@ -7,7 +7,25 @@ import { createUserServiceToken } from '@pagespace/lib/services/validated-servic
  * scoped-service-token → processor pg-boss shape. Mints a short-lived
  * `broadcast:enqueue` token against the calling ADMIN's own user resource and
  * hands the broadcastId to `POST ${PROCESSOR_URL}/api/broadcast/enqueue`.
- * Returns the jobId for `broadcastRepository.markQueued`.
+ *
+ * Unlike the erasure helper, failures here are CLASSIFIED, because the caller's
+ * wrong reaction to an ambiguous failure is a duplicate mass email: marking the
+ * row failed while a job actually landed leaves the worker free to send it
+ * anyway (it only yields to cancelled/paused/completed), with the UI telling
+ * the admin the send died — an invitation to create a second broadcast.
+ *
+ *  - `BroadcastNotEnqueuedError`: definitely NO job exists (token minting
+ *    failed, or the processor answered a non-409 4xx after examining the
+ *    request). Safe to mark the row failed and let the admin retry.
+ *  - `BroadcastEnqueueUnconfirmedError`: a job MAY exist (network error,
+ *    timeout, 5xx, unparseable response). The caller must not fail the row and
+ *    must not invite a retry.
+ *
+ * Ambiguity is first RESOLVED rather than reported: the processor enqueues with
+ * `singletonKey: broadcastId`, so re-POSTing the same id cannot start a second
+ * concurrent job — and its 409 is positive proof the lost first attempt landed.
+ * One reconciliation retry therefore converts most ambiguous failures into a
+ * definite answer.
  *
  * NOTE: the admin app makes no other processor calls, so PROCESSOR_URL must be
  * set in its deployment env (see fly.admin.toml). The docker default matches
@@ -16,6 +34,25 @@ import { createUserServiceToken } from '@pagespace/lib/services/validated-servic
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
 
+/** Bounded so a hung processor stalls the admin request for seconds, not forever. */
+const ENQUEUE_TIMEOUT_MS = 10_000;
+
+/** Definitely not enqueued — no job exists; the row may safely be failed. */
+export class BroadcastNotEnqueuedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BroadcastNotEnqueuedError';
+  }
+}
+
+/** The enqueue MAY have landed — a job may exist; do not fail the row. */
+export class BroadcastEnqueueUnconfirmedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BroadcastEnqueueUnconfirmedError';
+  }
+}
+
 export interface EnqueueBroadcastParams {
   /** The email_broadcasts row id the worker will send against. */
   broadcastId: string;
@@ -23,26 +60,94 @@ export interface EnqueueBroadcastParams {
   callerUserId: string;
 }
 
-export async function enqueueBroadcast(params: EnqueueBroadcastParams): Promise<{ jobId: string }> {
-  const { token } = await createUserServiceToken(params.callerUserId, ['broadcast:enqueue'], '2m');
+export interface EnqueueBroadcastResult {
+  /**
+   * The pg-boss jobId, or null when the processor deduped the request (a job
+   * for this broadcast already exists — same outcome, id unknown).
+   */
+  jobId: string | null;
+}
 
-  const res = await fetch(`${PROCESSOR_URL}/api/broadcast/enqueue`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({ broadcastId: params.broadcastId }),
-  });
+type AttemptOutcome =
+  | { kind: 'ok'; jobId: string }
+  | { kind: 'deduped' }
+  | { kind: 'refused'; detail: string }
+  | { kind: 'ambiguous'; detail: string };
+
+async function postEnqueue(broadcastId: string, token: string): Promise<AttemptOutcome> {
+  let res: Response;
+  try {
+    res = await fetch(`${PROCESSOR_URL}/api/broadcast/enqueue`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ broadcastId }),
+      signal: AbortSignal.timeout(ENQUEUE_TIMEOUT_MS),
+    });
+  } catch (error) {
+    // Network error or timeout: the request may or may not have reached the
+    // processor before dying. Nothing can be concluded from here.
+    const detail = error instanceof Error ? error.message : String(error);
+    return { kind: 'ambiguous', detail };
+  }
+
+  // singletonKey conflict: a job for this broadcast is ALREADY queued/running.
+  // For an enqueue that's success, not failure — just with an unknown jobId.
+  if (res.status === 409) return { kind: 'deduped' };
 
   if (!res.ok) {
     const detail = await res.text().catch(() => '');
-    throw new Error(`Processor broadcast enqueue failed: ${res.status} ${detail}`);
+    // A non-409 4xx means the processor examined the request and refused it —
+    // no job was created. A 5xx could have crashed after addJob succeeded.
+    return res.status < 500
+      ? { kind: 'refused', detail: `${res.status} ${detail}` }
+      : { kind: 'ambiguous', detail: `${res.status} ${detail}` };
   }
 
-  const json = (await res.json()) as { jobId?: string };
-  if (!json.jobId) {
-    throw new Error('Processor broadcast enqueue returned no jobId');
+  let json: { jobId?: string };
+  try {
+    json = (await res.json()) as { jobId?: string };
+  } catch {
+    // 2xx but the body was lost/garbled: the job exists, the id didn't survive.
+    return { kind: 'ambiguous', detail: '2xx response with unreadable body' };
   }
-  return { jobId: json.jobId };
+  if (!json.jobId) {
+    return { kind: 'ambiguous', detail: '2xx response with no jobId' };
+  }
+  return { kind: 'ok', jobId: json.jobId };
+}
+
+export async function enqueueBroadcast(params: EnqueueBroadcastParams): Promise<EnqueueBroadcastResult> {
+  // A minting failure happens before any request leaves the process — the one
+  // failure that is unambiguous by construction.
+  let token: string;
+  try {
+    ({ token } = await createUserServiceToken(params.callerUserId, ['broadcast:enqueue'], '2m'));
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new BroadcastNotEnqueuedError(`service token minting failed: ${detail}`);
+  }
+
+  const first = await postEnqueue(params.broadcastId, token);
+  if (first.kind === 'ok') return { jobId: first.jobId };
+  if (first.kind === 'deduped') return { jobId: null };
+  if (first.kind === 'refused') {
+    throw new BroadcastNotEnqueuedError(`Processor broadcast enqueue refused: ${first.detail}`);
+  }
+
+  // Ambiguous → reconcile with one retry. The singletonKey makes this safe (a
+  // landed first attempt yields 409, not a second job), and every outcome but
+  // another transport failure converts the ambiguity into a definite answer.
+  const second = await postEnqueue(params.broadcastId, token);
+  if (second.kind === 'ok') return { jobId: second.jobId };
+  if (second.kind === 'deduped') return { jobId: null };
+  if (second.kind === 'refused') {
+    throw new BroadcastNotEnqueuedError(`Processor broadcast enqueue refused: ${second.detail}`);
+  }
+
+  throw new BroadcastEnqueueUnconfirmedError(
+    `Processor broadcast enqueue unconfirmed: ${first.detail}; retry: ${second.detail}`,
+  );
 }

--- a/apps/admin/src/lib/broadcast/step-results.ts
+++ b/apps/admin/src/lib/broadcast/step-results.ts
@@ -1,0 +1,29 @@
+import { broadcastRepository } from '@pagespace/lib/repositories/broadcast-repository';
+import type { BroadcastStepResult } from '@pagespace/db/schema/email-broadcasts';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+/**
+ * Append to a broadcast's progress trail WITHOUT letting the append fail the
+ * request. Admin routes record step notes as UI-facing evidence — the durable
+ * who/why record is the auditRequest entry — and a 500 thrown for a failed
+ * note would misreport an intervention or enqueue that DID land, inviting the
+ * retry these routes exist to prevent.
+ *
+ * Deliberately NOT how the worker writes step results: there, a throw is
+ * wanted, because pg-boss retries the job. The swallow-and-warn policy is an
+ * admin-route decision, named once here so the routes cannot drift apart.
+ */
+export async function appendStepResultBestEffort(
+  broadcastId: string,
+  entry: BroadcastStepResult,
+): Promise<void> {
+  try {
+    await broadcastRepository.appendStepResult(broadcastId, entry);
+  } catch (error) {
+    loggers.api.warn('Broadcast step-result append failed', {
+      broadcastId,
+      step: entry.step,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/apps/admin/src/lib/broadcasts/schema.ts
+++ b/apps/admin/src/lib/broadcasts/schema.ts
@@ -14,17 +14,30 @@ import { z } from 'zod/v4';
  * representable here; `audience.ts` applies them in code on every resolve.
  */
 
-export const audienceDefinitionSchema = z.object({
-  /** The ONLY standard exclusion an operator may lift, opt-in per broadcast. */
-  includeUnverified: z.boolean().optional(),
-  /** `users.subscriptionTier` values to include. Absent/empty = every tier. */
-  planTiers: z.array(z.string().trim().min(1)).max(50).optional(),
-  /** ISO-8601 instants bounding `users.createdAt` (inclusive). */
-  signupAfter: z.iso.datetime({ offset: true }).optional(),
-  signupBefore: z.iso.datetime({ offset: true }).optional(),
-  /** Hand-picked recipients — still subject to every standard exclusion. */
-  userIds: z.array(z.string().trim().min(1)).max(10000).optional(),
-});
+export const audienceDefinitionSchema = z
+  .object({
+    /** The ONLY standard exclusion an operator may lift, opt-in per broadcast. */
+    includeUnverified: z.boolean().optional(),
+    /** `users.subscriptionTier` values to include. Absent/empty = every tier. */
+    planTiers: z.array(z.string().trim().min(1)).max(50).optional(),
+    /** ISO-8601 instants bounding `users.createdAt` (inclusive). */
+    signupAfter: z.iso.datetime({ offset: true }).optional(),
+    signupBefore: z.iso.datetime({ offset: true }).optional(),
+    /** Hand-picked recipients — still subject to every standard exclusion. */
+    userIds: z.array(z.string().trim().min(1)).max(10000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    // Lives HERE rather than only on the create schema so every consumer of the
+    // audience contract rejects an inverted window — a definition that quietly
+    // resolves to zero recipients is a validation failure, not a targeting choice.
+    if (value.signupAfter && value.signupBefore && new Date(value.signupAfter) > new Date(value.signupBefore)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['signupBefore'],
+        message: 'signupBefore must not precede signupAfter.',
+      });
+    }
+  });
 
 export type AudienceDefinitionInput = z.infer<typeof audienceDefinitionSchema>;
 
@@ -34,6 +47,14 @@ export type AudienceDefinitionInput = z.infer<typeof audienceDefinitionSchema>;
  * `subject` may be empty ONLY in template mode: `resolveBroadcastContent` falls
  * back to the template's own subject, so an admin can reuse a template without
  * retyping (or overriding) its subject line. Compose mode has no fallback.
+ *
+ * The output is NORMALIZED by the trailing transform: only the field the active
+ * contentMode reads survives parsing (`templateId` in template mode,
+ * `bodyMarkdown` in compose mode). Stale cross-mode form state — a template id
+ * kept after switching to compose — must never reach persistence, where it
+ * would break the insert on a deleted-template FK or record a template the
+ * send never used. Normalizing in the schema means every consumer of a parsed
+ * value inherits the invariant instead of re-asserting it.
  */
 export const broadcastCreateSchema = z
   .object({
@@ -49,6 +70,12 @@ export const broadcastCreateSchema = z
     sendLimit: z.number().int().min(1).max(1000000).optional(),
     /** Pause between sends. Bounded so a typo can't stall a job for hours per recipient. */
     delayMs: z.number().int().min(0).max(60000).optional(),
+    /**
+     * Escape hatch for the active-duplicate guard: a live create whose subject
+     * matches a still-active broadcast is refused (409) unless this is set —
+     * a double-clicked Send or a proxy-retried POST must not mail everyone twice.
+     */
+    allowDuplicate: z.boolean().default(false),
   })
   .superRefine((value, ctx) => {
     if (value.contentMode === 'compose') {
@@ -74,15 +101,23 @@ export const broadcastCreateSchema = z
       });
     }
 
-    const { signupAfter, signupBefore } = value.audienceDefinition;
-    if (signupAfter && signupBefore && new Date(signupAfter) > new Date(signupBefore)) {
+    // Phase 1 ships the transactional engine only. Enforced in the SHARED
+    // schema — not just the route — so the composer form flags a live
+    // resend_broadcast send at validation time instead of after a round trip.
+    // (Dry runs are engine-independent: count + preview render the same.)
+    if (value.engine === 'resend_broadcast' && !value.dryRun) {
       ctx.addIssue({
         code: 'custom',
-        path: ['audienceDefinition', 'signupBefore'],
-        message: 'signupBefore must not precede signupAfter.',
+        path: ['engine'],
+        message: 'The resend_broadcast engine is not available yet. Use "transactional".',
       });
     }
-  });
+  })
+  .transform((value) => ({
+    ...value,
+    templateId: value.contentMode === 'template' ? value.templateId : undefined,
+    bodyMarkdown: value.contentMode === 'compose' ? value.bodyMarkdown : undefined,
+  }));
 
 export type BroadcastCreateInput = z.infer<typeof broadcastCreateSchema>;
 

--- a/apps/admin/src/lib/broadcasts/schema.ts
+++ b/apps/admin/src/lib/broadcasts/schema.ts
@@ -1,0 +1,105 @@
+import { z } from 'zod/v4';
+
+/**
+ * The shared validation contract for admin email broadcasts.
+ *
+ * CLIENT-SAFE ON PURPOSE: this module imports zod and nothing else, so the
+ * composer form and the API route handlers parse the exact same schema. A form
+ * that validates differently than the route is a form that lies to the admin
+ * about what will be accepted.
+ *
+ * Mirrors `BroadcastAudienceDefinition` in `@pagespace/db/schema/email-broadcasts`
+ * (not imported — that module pulls drizzle into the client bundle). Standard
+ * exclusions (opted-out, GDPR-restricted, suspended) are deliberately NOT
+ * representable here; `audience.ts` applies them in code on every resolve.
+ */
+
+export const audienceDefinitionSchema = z.object({
+  /** The ONLY standard exclusion an operator may lift, opt-in per broadcast. */
+  includeUnverified: z.boolean().optional(),
+  /** `users.subscriptionTier` values to include. Absent/empty = every tier. */
+  planTiers: z.array(z.string().trim().min(1)).max(50).optional(),
+  /** ISO-8601 instants bounding `users.createdAt` (inclusive). */
+  signupAfter: z.iso.datetime({ offset: true }).optional(),
+  signupBefore: z.iso.datetime({ offset: true }).optional(),
+  /** Hand-picked recipients — still subject to every standard exclusion. */
+  userIds: z.array(z.string().trim().min(1)).max(10000).optional(),
+});
+
+export type AudienceDefinitionInput = z.infer<typeof audienceDefinitionSchema>;
+
+/**
+ * POST /api/admin/broadcasts body.
+ *
+ * `subject` may be empty ONLY in template mode: `resolveBroadcastContent` falls
+ * back to the template's own subject, so an admin can reuse a template without
+ * retyping (or overriding) its subject line. Compose mode has no fallback.
+ */
+export const broadcastCreateSchema = z
+  .object({
+    subject: z.string().trim().max(200).default(''),
+    engine: z.enum(['transactional', 'resend_broadcast']).default('transactional'),
+    contentMode: z.enum(['compose', 'template']),
+    templateId: z.string().trim().min(1).optional(),
+    bodyMarkdown: z.string().trim().min(1).max(100000).optional(),
+    audienceDefinition: audienceDefinitionSchema.default({}),
+    /** Never defaulted: the caller must SAY whether this is a rehearsal or a send. */
+    dryRun: z.boolean(),
+    /** Canary cap — counts attempts, not successes. */
+    sendLimit: z.number().int().min(1).max(1000000).optional(),
+    /** Pause between sends. Bounded so a typo can't stall a job for hours per recipient. */
+    delayMs: z.number().int().min(0).max(60000).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.contentMode === 'compose') {
+      if (!value.subject) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['subject'],
+          message: 'A composed broadcast needs a subject.',
+        });
+      }
+      if (!value.bodyMarkdown) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['bodyMarkdown'],
+          message: 'A composed broadcast needs a markdown body.',
+        });
+      }
+    } else if (!value.templateId) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['templateId'],
+        message: 'A template broadcast must name a template.',
+      });
+    }
+
+    const { signupAfter, signupBefore } = value.audienceDefinition;
+    if (signupAfter && signupBefore && new Date(signupAfter) > new Date(signupBefore)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['audienceDefinition', 'signupBefore'],
+        message: 'signupBefore must not precede signupAfter.',
+      });
+    }
+  });
+
+export type BroadcastCreateInput = z.infer<typeof broadcastCreateSchema>;
+
+/** POST /api/admin/broadcasts/[id] body — operator intervention on a live send. */
+export const broadcastActionSchema = z.object({
+  action: z.enum(['cancel', 'pause']),
+  reason: z.string().trim().min(1, 'A reason is required').max(500),
+});
+
+export type BroadcastActionInput = z.infer<typeof broadcastActionSchema>;
+
+/** POST /api/admin/broadcasts/templates body. */
+export const templateCreateSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  subject: z.string().trim().min(1).max(200),
+  bodyMarkdown: z.string().trim().min(1).max(100000),
+  isActive: z.boolean().default(true),
+});
+
+export type TemplateCreateInput = z.infer<typeof templateCreateSchema>;


### PR DESCRIPTION
Task 3 of 4 of the admin-console email-broadcast epic (plan: swirling-wishing-kahn). Builds on the merged foundation (#2090) and processor worker/enqueue endpoint (#2094). The admin UI (task 4) builds against the contracts below — **these shapes are frozen**.

## What's here

- **`apps/admin/src/lib/broadcasts/schema.ts`** — client-safe shared Zod v4 schema (imports zod and nothing else, so the UI form parses the identical contract).
- **`apps/admin/src/lib/broadcast/enqueue.ts`** — `enqueueBroadcast({broadcastId, callerUserId}) → {jobId}`; mints a 2-minute `broadcast:enqueue` user service token and POSTs to `${PROCESSOR_URL}/api/broadcast/enqueue` (mirrors the erasure helper file-for-file).
- **`apps/admin/src/app/api/admin/broadcasts/**`** — the three route files below. All handlers are wrapped in `withAdminAuth` (browser admin session + adminRoleVersion check + CSRF on mutations) and write detailed `auditRequest` entries.

## Frozen API contracts (build the UI against these)

### Shared schema (`@/lib/broadcasts/schema`)

```ts
audienceDefinitionSchema = {
  includeUnverified?: boolean,        // the only liftable standard exclusion
  planTiers?: string[],               // users.subscriptionTier values; empty/absent = all
  signupAfter?: string,  signupBefore?: string,   // ISO-8601 datetimes (Z or offset), inclusive
  userIds?: string[],                 // hand-picked; still subject to standard exclusions
}

broadcastCreateSchema = {
  subject: string (≤200, default ''), // REQUIRED for compose; optional for template
                                      // (empty → the template's own subject is used)
  engine: 'transactional' | 'resend_broadcast' (default 'transactional'),
  contentMode: 'compose' | 'template',
  templateId?: string,                // required when contentMode='template'
  bodyMarkdown?: string (≤100k),      // required when contentMode='compose'
  audienceDefinition: audienceDefinitionSchema (default {}),
  dryRun: boolean,                    // REQUIRED, never defaulted — the caller must say
  sendLimit?: number (int ≥1),        // canary cap, counts attempts
  delayMs?: number (int 0–60000),     // per-recipient delay; server default 120
  allowDuplicate: boolean (default false), // bypasses the active-duplicate 409 (see below)
}

broadcastActionSchema = { action: 'cancel' | 'pause', reason: string (1–500) }

templateCreateSchema = { name: string(1–200), subject: string(1–200), bodyMarkdown: string(1–100k), isActive: boolean (default true) }
```

Cross-field rules enforced by the schema: compose ⇒ `subject` + `bodyMarkdown` present; template ⇒ `templateId` present; `signupAfter ≤ signupBefore` (enforced inside `audienceDefinitionSchema` itself, so direct consumers inherit it); **live (`dryRun:false`) + `engine:'resend_broadcast'` is a schema-level rejection** (the composer form flags it at validation time — dry-run previews stay allowed since they're engine-independent). The schema's output is **normalized by a transform**: `templateId` survives only in template mode and `bodyMarkdown` only in compose mode, so stale cross-mode form state never reaches the server or persistence.

### `POST /api/admin/broadcasts` (body: `broadcastCreateSchema`)

**Dry-run (`dryRun: true`)** — touches nothing durable (no row, no recipients, no job):
```
200 { dryRun: true, audienceCount: number, previewHtml: string, subject: string }
```
`previewHtml` is the full rendered email (same code path the worker sends through, unsubscribe link is a placeholder) — render it in a sandboxed iframe (`<iframe sandbox="" srcDoc={previewHtml}>`). `subject` is the *resolved* subject (matters in template mode). `audienceCount` is the raw targeting count (opt-outs/GDPR skips are subtracted at send time as counted skips).

**Live (`dryRun: false`)**:
```
202 { broadcastId: string, jobId: string | null, enqueue: 'confirmed' | 'unconfirmed' }
400 { error }                                  // unresolvable content (missing/inactive template, empty body)
409 { error, duplicateOf: string }             // a non-dry-run broadcast with this subject is already
                                               // pending/queued/in_progress/paused/failed — double-click/
                                               // proxy-retry protection ('failed' counts: pg-boss may still be
                                               // retrying it); pass allowDuplicate:true to send anyway
500 { error, broadcastId }                     // row created but enqueue DEFINITELY failed → row marked 'failed'
```
On 202, navigate to `/broadcasts/[broadcastId]` regardless. `enqueue: 'confirmed'` with `jobId: null` means the processor deduped the request (a job already exists — same outcome, id unknown). `enqueue: 'unconfirmed'` means the enqueue result was lost after two attempts: a job MAY exist, the row is left `pending`, and the status page is the truth (a landed job shows progress; a lost one stays `pending`) — show a warning banner, do NOT offer a one-click re-send. Operator resolution for a stuck-`pending` row (the step note records why): cancel it via the [id] route, then create a new broadcast — if the lost job later surfaces it yields to `cancelled`, so this path is safe. A 500 is only returned when NO job exists (processor refused / token minting failed), so retrying the POST after a 500 is safe. Cross-mode fields are dropped server-side: a compose create never stores `templateId`, a template create never stores `bodyMarkdown`.

Common to both: `400 { error, details: fieldErrors }` on Zod failure; `403` from withAdminAuth (non-admin / CSRF).

### `GET /api/admin/broadcasts`
```
200 { broadcasts: [{ id, subject, status, engine, dryRun,
                     totalTargeted, sentCount, skippedCount, failedCount, createdAt }] }
```
Most-recent-first, capped at 100. `status ∈ draft|pending|queued|in_progress|paused|completed|failed|cancelled`.

### `GET /api/admin/broadcasts/[id]` (progress polling)
```
200 { id, subject, status, engine, contentMode, dryRun, sendLimit, delayMs,
      totalTargeted, sentCount, skippedCount, failedCount,
      stepResults: [{step, status:'ok'|'skipped'|'failed', detail?, at}],   // [] if none yet
      attempts, lastError, blockedReason, createdAt, startedAt, completedAt }
404 { error }
```
Terminal states for polling cutoff: `completed | failed | cancelled`.

### `POST /api/admin/broadcasts/[id]` (body: `broadcastActionSchema`)
```
200 { id, status: 'cancelled' | 'paused' }     // also returned for a repeat of a landed intervention (no-op)
409 { error, status }                          // broadcast reached a terminal state first — status is the truth
404 { error }
```
Cancel/pause write through `updateStatus`'s guard — blocked only for `completed`/`cancelled`. **`failed` IS cancellable/pausable on purpose**: the worker writes `failed` + rethrows so pg-boss retries, meaning a `failed` row is often a live send between attempts, and the operator's stop must reach it. The worker checks the row mid-run, so the status write IS the intervention. The reason lands in `stepResults` and the audit log. (Resume/unpause is deliberately absent — per the worker's design, unpause = re-enqueue, a follow-up.)

### `GET /api/admin/broadcasts/templates`
```
200 { templates: [{ id, name, subject, bodyMarkdown, isActive, createdAt, updatedAt }] }   // active only
```

### `POST /api/admin/broadcasts/templates` (body: `templateCreateSchema`)
```
201 { template: { id, name, subject, bodyMarkdown, isActive, createdAt, updatedAt } }
400 { error, details }
```

## Deployment note (action needed at deploy time)

The admin app makes its **first-ever processor call** here. `PROCESSOR_URL` was not in its env; added in **PageSpace-Deploy** `fly/fly.admin.toml`:
```toml
PROCESSOR_URL = "http://pagespace-processor.internal:3003"
```
(Committed separately in that repo. Local/docker falls back to `http://processor:3003`, same as the erasure helper. Token minting uses `SESSION_SECRET` + shared DB, which the admin app already has.) No tenant-compose change needed — the admin console doesn't ship in tenant deployments.

## Safety decisions

- Dry-run is a pure read: no `email_broadcasts` row, no `broadcast_recipients`, no job — verified by tests.
- Content is resolved through `resolveBroadcastContent` (the worker's own path) *before* any write, so an inactive template or empty body 400s instead of creating a doomed row.
- Live `resend_broadcast` is refused with 400: the worker drives the transactional engine unconditionally today, so accepting it would silently mis-send.
- `markQueued`/`markFailed` keep their status guards (enqueue-vs-worker races can't regress a live row).

## Known follow-ups (out of this PR's file scope, flagged during self-review)

- **Worker engine check**: `email-broadcast-worker.ts` drives the transactional engine without reading `broadcast.engine`. The schema guard covers the only creator today (this API), but the worker should refuse engines it doesn't implement before Phase 2 adds one (`packages/processor`, owned by #2094's lineage).
- **Resume/unpause**: pause halts the job and releases the singletonKey; resuming needs a status flip + re-enqueue endpoint. Explicitly deferred by the plan ("Follow-ups: … wired pause/resume"). Until then pause is one-way in-app (cancel remains available) — the UI should say so.
- **Template-loader dedup**: the `findTemplateById → BroadcastTemplateContent` adapter closure exists in both this route and the worker; its shared home is `packages/lib/services/broadcast/content.ts`.
- **DB-level create idempotency**: the active-duplicate subject guard is a heuristic; a client-supplied idempotency key with a unique column would be the principled fix (needs a `packages/db` migration).

## Tests (43, all passing)

`apps/admin/src/app/api/admin/broadcasts/{__tests__,[id]/__tests__,templates/__tests__}` — gift-subscription style (real DB admin row, mocked session, real CSRF token; repository/audience-count/enqueue mocked, content rendering REAL so `previewHtml` is checked against actual output): dry-run returns count+preview and writes nothing; live create → enqueue → markQueued; markFailed on enqueue error; resend_broadcast refusal; terminal-state 409; no-op repeat; Zod rejections; 403 without session and without CSRF.

`bun run typecheck` clean monorepo-wide (16/16 turbo tasks); eslint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbwCeJgeMazQNiKkdJJney

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin broadcast creation with dry-run previews, audience counts, and rendered email content.
  * Added live broadcast sending with queue status and failure reporting.
  * Added broadcast history and detailed progress/status views.
  * Added controls to pause or cancel in-progress broadcasts.
  * Added an active template library for creating and reusing email content.
* **Bug Fixes**
  * Improved validation and error handling for invalid requests, unsupported sending options, and unavailable broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
