### PR TITLE
test(ai): close R.4 coverage gaps (advisory-lock, checkpoint-serialize, poll-fallback) + notify mentions on interrupted replies

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -683,6 +683,118 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     });
   });
 
+  // PR #2097, Codex P2 finding: the route has THREE writes that can flip the assistant
+  // placeholder out of 'streaming' (execute-end, onFinish, and the outer-catch cleanup), but
+  // only onFinish carried mentionNotify. execute-end's own docblock says "when onFinish never
+  // runs, this write stands as the sole record" — in that documented gap the @mention
+  // notification was permanently lost, and materialize-interrupted-stream's CAS-gated notify
+  // (which assumes "the route flipped it ⇒ the route notified") could never recover it.
+  // Contract: whichever terminal write lands FIRST carries the mention gate, exactly once per
+  // request.
+  describe('mention notification exactly-once across terminal writes', () => {
+    const sharedConversation = () => {
+      mockGetConversation.mockResolvedValueOnce({
+        id: CONV_ID, userId: 'user-1', isShared: true,
+      });
+    };
+
+    const assistantSaves = () =>
+      mockSaveMessageToDatabase.mock.calls.filter((c: { role?: string }[]) => c[0]?.role === 'assistant');
+
+    it('given onFinish never runs (its documented failure mode), the execute-end save carries mentionNotify', async () => {
+      sharedConversation();
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      const saves = assistantSaves();
+      expect(saves.length).toBeGreaterThan(0);
+      expect(saves[0][0].mentionNotify).toEqual({
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-1',
+        mentionerName: 'Test Page',
+      });
+    });
+
+    it('given both execute-end and onFinish run, exactly ONE assistant save carries mentionNotify', async () => {
+      sharedConversation();
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      const withNotify = assistantSaves().filter((c) => c[0]?.mentionNotify !== undefined);
+      expect(withNotify).toHaveLength(1);
+    });
+
+    it('given the execute-end save rejects, the onFinish save still carries mentionNotify (the flag only latches on success)', async () => {
+      sharedConversation();
+      let failedOnce = false;
+      mockSaveMessageToDatabase.mockImplementation(async (args: { role?: string }) => {
+        if (args.role === 'assistant' && !failedOnce) {
+          failedOnce = true;
+          throw new Error('execute-end persist down');
+        }
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      const saves = assistantSaves();
+      expect(saves).toHaveLength(2);
+      expect(saves[1][0].mentionNotify).toBeDefined();
+    });
+
+    it('given a private conversation, NO terminal write carries mentionNotify', async () => {
+      mockGetConversation.mockResolvedValueOnce({
+        id: CONV_ID, userId: 'user-1', isShared: false,
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      const withNotify = assistantSaves().filter((c) => c[0]?.mentionNotify !== undefined);
+      expect(withNotify).toHaveLength(0);
+    });
+
+    it('given the outer-catch cleanup is the only terminal write (createUIMessageStream threw), it carries mentionNotify', async () => {
+      sharedConversation();
+      const { createUIMessageStream } = await import('ai');
+      vi.mocked(createUIMessageStream).mockImplementationOnce(() => {
+        throw new Error('stream creation failed');
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+
+      const saves = assistantSaves();
+      expect(saves.length).toBeGreaterThan(0);
+      expect(saves[0][0]).toMatchObject({ status: 'interrupted' });
+      expect(saves[0][0].mentionNotify).toEqual({
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-1',
+        mentionerName: 'Test Page',
+      });
+    });
+
+    it('given the outer-catch cleanup fires for a private conversation, it does NOT carry mentionNotify', async () => {
+      mockGetConversation.mockResolvedValueOnce({
+        id: CONV_ID, userId: 'user-1', isShared: false,
+      });
+      const { createUIMessageStream } = await import('ai');
+      vi.mocked(createUIMessageStream).mockImplementationOnce(() => {
+        throw new Error('stream creation failed');
+      });
+
+      await POST(makeRequest({ conversationId: CONV_ID }));
+
+      const saves = assistantSaves();
+      expect(saves.length).toBeGreaterThan(0);
+      expect(saves[0][0].mentionNotify).toBeUndefined();
+    });
+  });
+
   describe('chunk forwarding', () => {
     it('given a text-delta chunk, should forward a text part to lifecycle.pushPart', async () => {
       await POST(makeRequest());

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -179,6 +179,15 @@ export async function POST(request: Request) {
   // the three steps wrong (e.g. latching before the save resolves, which would eat the mention
   // when the save then fails). Callers keep their own try/catch and assistantMessagePersisted
   // handling — this owns only the exactly-once mention contract.
+  //
+  // Best-effort exactly-once, named honestly: the latch flips only AFTER the save resolves
+  // (deliberately — latching before it would lose the mention when the save fails), so two
+  // terminal writers overlapping in flight (the outer-catch cleanup racing a still-running
+  // execute-end) can each pass the gate before either latches, and a stalled-but-alive stream
+  // reaped by another instance's materializer can be re-notified by this process's own later
+  // save. Both windows resolve to a DUPLICATE ping, never a lost one — the epic's chosen
+  // direction. The durable fix (idempotent createMentionNotification per user+message) is a
+  // filed epic D task.
   const saveTerminalAssistantMessage = async (
     args: Omit<Parameters<typeof saveMessageToDatabase>[0], 'mentionNotify'>,
   ): Promise<void> => {
@@ -1555,7 +1564,12 @@ export async function POST(request: Request) {
             const payload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedParts);
             // This write may be the sole record of the message (see the docblock above) — it
             // must carry the mention gate, or an @mention in a reply whose onFinish never runs
-            // is silently never notified (Codex P2, PR #2097).
+            // is silently never notified (Codex P2, PR #2097). Notification content is the
+            // buffered snapshot THIS save persists; if onFinish's refined responseMessage ever
+            // contained mention text the buffer missed (which would indicate an onChunk
+            // text-forwarding gap, not expected), that delta is not re-notified — filed as an
+            // epic D task rather than re-checking on refine, which would duplicate-notify on
+            // every normal run.
             try {
               await saveTerminalAssistantMessage({
                 messageId: serverAssistantMessageId,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -152,6 +152,29 @@ export async function POST(request: Request) {
   // createUIMessageStream even finishes constructing) must not leave the placeholder stuck at
   // 'streaming' forever (excluded from reads, 409s on edit/delete).
   let assistantMessagePersisted = false;
+  // Mention-notification context + once-flag shared by the THREE writes that can flip the
+  // assistant placeholder out of 'streaming' (execute-end, onFinish, the outer-catch cleanup).
+  // Whichever terminal write lands FIRST carries `mentionNotify` into saveMessageToDatabase;
+  // the flag (latched only after a SUCCESSFUL save, so a failed execute-end persist still lets
+  // onFinish notify) suppresses the later writes — one request never notifies the same
+  // @mention twice. Hoisted out of the try (unlike `page`) because the outer-catch cleanup
+  // needs it too. materialize-interrupted-stream.ts's CAS-gated notify RELIES on this contract:
+  // it only notifies rows it flips out of 'streaming' itself, on the premise that any row the
+  // route flipped was already notified by the route (Codex P2, PR #2097).
+  let mentionPage: { driveId: string; title: string } | undefined;
+  let mentionNotified = false;
+  const mentionNotifyFor = (
+    content: string,
+  ): { driveId: string; triggeredByUserId: string; mentionerName: string } | undefined => {
+    // Mirrors the gate the onFinish save historically applied (page.driveId present, a
+    // triggering user, conversation explicitly shared) plus saveMessageToDatabase's own
+    // content.trim() firing condition — so the flag can only latch when a notification
+    // would actually have been dispatched.
+    if (mentionNotified || !mentionPage || !userId || !isConversationShared || !content.trim()) {
+      return undefined;
+    }
+    return { driveId: mentionPage.driveId, triggeredByUserId: userId, mentionerName: mentionPage.title };
+  };
   // Captured by the inner catch (createUIMessageStream construction failure) BEFORE it calls
   // lifecycle.finish() — finish() deletes the multicast registry entry getBufferedParts() reads
   // from, so by the time the outer catch below runs, a fresh getBufferedParts() call would
@@ -354,6 +377,7 @@ export async function POST(request: Request) {
       loggers.ai.warn('AI Chat API: Page not found', { chatId });
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
+    mentionPage = page.driveId ? { driveId: page.driveId, title: page.title } : undefined;
 
     // Vision capability gate — reject images sent to non-vision models
     if (messageHasImages) {
@@ -1516,6 +1540,10 @@ export async function POST(request: Request) {
             const bufferedParts = lifecycle!.getBufferedParts();
             const aborted = isRunAborted({ agentRun, abortSignal });
             const payload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedParts);
+            // This write may be the sole record of the message (see the docblock above) — it
+            // must carry the mention gate, or an @mention in a reply whose onFinish never runs
+            // is silently never notified (Codex P2, PR #2097).
+            const mentionNotify = mentionNotifyFor(payload.content);
             try {
               await saveMessageToDatabase({
                 messageId: serverAssistantMessageId,
@@ -1525,8 +1553,10 @@ export async function POST(request: Request) {
                 role: 'assistant',
                 ...payload,
                 status: aborted ? 'interrupted' : 'complete',
+                ...(mentionNotify && { mentionNotify }),
               });
               assistantMessagePersisted = true;
+              if (mentionNotify) mentionNotified = true;
             } catch (e) {
               loggers.ai.error('AI Chat API: execute-end persist failed', e as Error);
             }
@@ -1603,6 +1633,10 @@ export async function POST(request: Request) {
                 toolResults: extractedToolResults.length
               });
 
+              // Usually a no-op for mentions: the execute-end save above already carried the
+              // gate and latched the once-flag. Attaches only when that save failed or never
+              // ran, so this refinement write is the request's first (and only) notifier.
+              const mentionNotify = mentionNotifyFor(messageContent);
               await saveMessageToDatabase({
                 messageId,
                 pageId: chatId,
@@ -1614,15 +1648,10 @@ export async function POST(request: Request) {
                 toolResults,
                 uiMessage,
                 status: aborted ? 'interrupted' : 'complete',
-                ...(page?.driveId && userId && isConversationShared && {
-                  mentionNotify: {
-                    driveId: page.driveId,
-                    triggeredByUserId: userId,
-                    mentionerName: page.title ?? undefined,
-                  },
-                }),
+                ...(mentionNotify && { mentionNotify }),
               });
               assistantMessagePersisted = true;
+              if (mentionNotify) mentionNotified = true;
 
               loggers.ai.debug('AI Chat API: AI response message saved to database with tools');
             } catch (error) {
@@ -1792,15 +1821,24 @@ export async function POST(request: Request) {
     // 'interrupted' row for a request that never started generating.
     if (!assistantMessagePersisted && serverAssistantMessageId && chatId && conversationId && lifecycle && !lifecycle.preAborted) {
       try {
+        const cleanupPayload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedPartsAtError);
+        // Same exactly-once contract as execute-end/onFinish: this is a terminal write that
+        // flips the placeholder out of 'streaming', so if it is the request's FIRST successful
+        // terminal write (it only runs when the other two never landed), it carries the
+        // mention gate — otherwise a buffered @mention in the salvaged partial reply would be
+        // notified by no one (the materializer skips rows the route already flipped).
+        const mentionNotify = mentionNotifyFor(cleanupPayload.content);
         await saveMessageToDatabase({
           messageId: serverAssistantMessageId,
           pageId: chatId,
           conversationId,
           userId: null,
           role: 'assistant',
-          ...buildAssistantPersistencePayload(serverAssistantMessageId, bufferedPartsAtError),
+          ...cleanupPayload,
           status: 'interrupted',
+          ...(mentionNotify && { mentionNotify }),
         });
+        if (mentionNotify) mentionNotified = true;
       } catch (cleanupError) {
         loggers.ai.error('AI Chat API: failed to terminalize placeholder row after error', cleanupError as Error);
       }

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -175,6 +175,17 @@ export async function POST(request: Request) {
     }
     return { driveId: mentionPage.driveId, triggeredByUserId: userId, mentionerName: mentionPage.title };
   };
+  // The gate + attach + latch protocol in ONE place, so a terminal-write site can't get one of
+  // the three steps wrong (e.g. latching before the save resolves, which would eat the mention
+  // when the save then fails). Callers keep their own try/catch and assistantMessagePersisted
+  // handling — this owns only the exactly-once mention contract.
+  const saveTerminalAssistantMessage = async (
+    args: Omit<Parameters<typeof saveMessageToDatabase>[0], 'mentionNotify'>,
+  ): Promise<void> => {
+    const mentionNotify = mentionNotifyFor(args.content);
+    await saveMessageToDatabase({ ...args, ...(mentionNotify && { mentionNotify }) });
+    if (mentionNotify) mentionNotified = true;
+  };
   // Captured by the inner catch (createUIMessageStream construction failure) BEFORE it calls
   // lifecycle.finish() — finish() deletes the multicast registry entry getBufferedParts() reads
   // from, so by the time the outer catch below runs, a fresh getBufferedParts() call would
@@ -377,7 +388,9 @@ export async function POST(request: Request) {
       loggers.ai.warn('AI Chat API: Page not found', { chatId });
       return NextResponse.json({ error: 'Page not found' }, { status: 404 });
     }
-    mentionPage = page.driveId ? { driveId: page.driveId, title: page.title } : undefined;
+    // pages.driveId is NOT NULL in the schema, so this is unconditional; mentionNotifyFor's
+    // !mentionPage guard covers only the outer-catch running before this line executes.
+    mentionPage = { driveId: page.driveId, title: page.title };
 
     // Vision capability gate — reject images sent to non-vision models
     if (messageHasImages) {
@@ -1543,9 +1556,8 @@ export async function POST(request: Request) {
             // This write may be the sole record of the message (see the docblock above) — it
             // must carry the mention gate, or an @mention in a reply whose onFinish never runs
             // is silently never notified (Codex P2, PR #2097).
-            const mentionNotify = mentionNotifyFor(payload.content);
             try {
-              await saveMessageToDatabase({
+              await saveTerminalAssistantMessage({
                 messageId: serverAssistantMessageId,
                 pageId: chatId,
                 conversationId: conversationId!,
@@ -1553,10 +1565,8 @@ export async function POST(request: Request) {
                 role: 'assistant',
                 ...payload,
                 status: aborted ? 'interrupted' : 'complete',
-                ...(mentionNotify && { mentionNotify }),
               });
               assistantMessagePersisted = true;
-              if (mentionNotify) mentionNotified = true;
             } catch (e) {
               loggers.ai.error('AI Chat API: execute-end persist failed', e as Error);
             }
@@ -1636,8 +1646,7 @@ export async function POST(request: Request) {
               // Usually a no-op for mentions: the execute-end save above already carried the
               // gate and latched the once-flag. Attaches only when that save failed or never
               // ran, so this refinement write is the request's first (and only) notifier.
-              const mentionNotify = mentionNotifyFor(messageContent);
-              await saveMessageToDatabase({
+              await saveTerminalAssistantMessage({
                 messageId,
                 pageId: chatId,
                 conversationId: conversationId!,
@@ -1648,10 +1657,8 @@ export async function POST(request: Request) {
                 toolResults,
                 uiMessage,
                 status: aborted ? 'interrupted' : 'complete',
-                ...(mentionNotify && { mentionNotify }),
               });
               assistantMessagePersisted = true;
-              if (mentionNotify) mentionNotified = true;
 
               loggers.ai.debug('AI Chat API: AI response message saved to database with tools');
             } catch (error) {
@@ -1821,24 +1828,20 @@ export async function POST(request: Request) {
     // 'interrupted' row for a request that never started generating.
     if (!assistantMessagePersisted && serverAssistantMessageId && chatId && conversationId && lifecycle && !lifecycle.preAborted) {
       try {
-        const cleanupPayload = buildAssistantPersistencePayload(serverAssistantMessageId, bufferedPartsAtError);
         // Same exactly-once contract as execute-end/onFinish: this is a terminal write that
         // flips the placeholder out of 'streaming', so if it is the request's FIRST successful
         // terminal write (it only runs when the other two never landed), it carries the
         // mention gate — otherwise a buffered @mention in the salvaged partial reply would be
         // notified by no one (the materializer skips rows the route already flipped).
-        const mentionNotify = mentionNotifyFor(cleanupPayload.content);
-        await saveMessageToDatabase({
+        await saveTerminalAssistantMessage({
           messageId: serverAssistantMessageId,
           pageId: chatId,
           conversationId,
           userId: null,
           role: 'assistant',
-          ...cleanupPayload,
+          ...buildAssistantPersistencePayload(serverAssistantMessageId, bufferedPartsAtError),
           status: 'interrupted',
-          ...(mentionNotify && { mentionNotify }),
         });
-        if (mentionNotify) mentionNotified = true;
       } catch (cleanupError) {
         loggers.ai.error('AI Chat API: failed to terminalize placeholder row after error', cleanupError as Error);
       }

--- a/apps/web/src/lib/ai/core/__tests__/checkpoint-serialize.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/checkpoint-serialize.test.ts
@@ -176,6 +176,22 @@ describe('capPartsToByteBudget', () => {
       expect(result.parts).toEqual([c]);
       expect(result.survivingFromRawIndex).toBe(12);
     });
+
+    // `parts` and `originRawIndex` are documented as parallel arrays, but the function cannot
+    // enforce that at the type level — a caller passing a truncated/mismatched origins array
+    // must land in the SAFE direction. 0 means "skip nothing": the rejoining client re-replays
+    // frames whose effect is already seeded (a self-correcting duplicate, the direction this
+    // module's docs call harmless) instead of over-skipping and permanently losing content.
+    it('given an originRawIndex that does not cover the drop point (mismatched parallel arrays), should fall back to 0 — under-skip, never over-skip', () => {
+      const oldest = text('a'.repeat(50));
+      const newest = text('b'.repeat(50));
+      const result = capPartsToByteBudget([oldest, newest], [], 60);
+
+      expect(result.wasCapped).toBe(true);
+      expect(result.prefixDropped).toBe(true);
+      expect(result.parts).toEqual([newest]);
+      expect(result.survivingFromRawIndex).toBe(0);
+    });
   });
 });
 

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -8,9 +8,8 @@ const {
   mockReturning,
   mockUpdateSet,
   mockUpdateWhere,
-  mockSelect,
-  mockSelectFrom,
-  mockSelectWhere,
+  mockFindPageById,
+  mockGetConversation,
   mockBroadcastAiStreamComplete,
   mockNotifyMentionedUsers,
   mockLoggerWarn,
@@ -21,9 +20,8 @@ const {
   mockReturning: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
-  mockSelect: vi.fn(),
-  mockSelectFrom: vi.fn(),
-  mockSelectWhere: vi.fn(),
+  mockFindPageById: vi.fn(),
+  mockGetConversation: vi.fn(),
   mockBroadcastAiStreamComplete: vi.fn(),
   mockNotifyMentionedUsers: vi.fn(),
   mockLoggerWarn: vi.fn(),
@@ -33,7 +31,6 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     insert: mockInsert,
     update: vi.fn(() => ({ set: mockUpdateSet })),
-    select: mockSelect,
   },
 }));
 
@@ -56,21 +53,12 @@ vi.mock('@pagespace/db/schema/core', () => ({
     id: 'chat_messages.id',
     status: 'chat_messages.status',
   },
-  pages: {
-    id: 'pages.id',
-    driveId: 'pages.driveId',
-    title: 'pages.title',
-  },
 }));
 
 vi.mock('@pagespace/db/schema/conversations', () => ({
   messages: {
     id: 'messages.id',
     status: 'messages.status',
-  },
-  conversations: {
-    id: 'conversations.id',
-    isShared: 'conversations.isShared',
   },
 }));
 
@@ -84,6 +72,15 @@ vi.mock('@/lib/websocket', () => ({
 
 vi.mock('@/lib/channels/notify-mentioned-users', () => ({
   notifyMentionedUsers: mockNotifyMentionedUsers,
+}));
+
+// The mention gate reads through the SAME repositories the live paths use (reuse rail) —
+// mocked at the module boundary, not as raw db.select chains.
+vi.mock('@pagespace/lib/repositories/page-repository', () => ({
+  pageRepository: { findById: mockFindPageById },
+}));
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: { getConversation: mockGetConversation },
 }));
 
 import { materializeInterruptedStream, type MaterializableStreamRow } from '../materialize-interrupted-stream';
@@ -131,11 +128,10 @@ beforeEach(() => {
   // gate needs it); the global chain awaits the upsert directly and ignores this shape.
   mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
   mockReturning.mockResolvedValue([{ id: 'msg-1' }]);
-  mockSelect.mockReturnValue({ from: mockSelectFrom });
-  mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
   // Default the mention-gate lookups to "page gone" so tests not about notifications never
   // trip the notify path.
-  mockSelectWhere.mockResolvedValue([]);
+  mockFindPageById.mockResolvedValue(null);
+  mockGetConversation.mockResolvedValue(null);
   mockNotifyMentionedUsers.mockResolvedValue(undefined);
   mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
   // Defaults to "one row actually settled" (rowCount: 1) — the common case. Tests exercising the
@@ -473,29 +469,18 @@ describe('materializeInterruptedStream — never throws', () => {
 describe('materializeInterruptedStream — mention notifications (best-effort, mirrors the finalize path)', () => {
   const MENTION_CONTENT = 'Hey @[Alice](alice-id:user), here is what I found so far';
 
-  // The mention-notify path needs the page-chat upsert chain to report whether it actually
-  // wrote (`.returning`), plus the page/conversation lookups the route-level gate reads.
-  beforeEach(() => {
-    mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
-    mockReturning.mockResolvedValue([{ id: 'msg-1' }]);
-    mockSelect.mockReturnValue({ from: mockSelectFrom });
-    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
-    mockSelectWhere.mockResolvedValue([]);
-    mockNotifyMentionedUsers.mockResolvedValue(undefined);
-  });
-
-  // Stands in for the two gate lookups, in the order the implementation runs them: the page
-  // (driveId + title, mirroring `page?.driveId` and `mentionerName: page.title`) and then the
-  // conversation (`isShared`, mirroring `isConversationShared`).
+  // Stands in for the two gate lookups the implementation runs: pageRepository.findById
+  // (driveId + title; null = missing OR trashed) and conversationRepository.getConversation
+  // (`isShared`, the route's own source of isConversationShared).
   const gateLookups = ({
-    page = [{ driveId: 'drive-1', title: 'Research Agent' }],
-    conversation = [{ isShared: true }],
+    page = { driveId: 'drive-1', title: 'Research Agent' },
+    conversation = { isShared: true },
   }: {
-    page?: Array<{ driveId: string; title: string }>;
-    conversation?: Array<{ isShared: boolean }>;
+    page?: { driveId: string; title: string } | null;
+    conversation?: { isShared: boolean } | null;
   } = {}) => {
-    mockSelectWhere.mockReset();
-    mockSelectWhere.mockResolvedValueOnce(page).mockResolvedValueOnce(conversation);
+    mockFindPageById.mockResolvedValue(page);
+    mockGetConversation.mockResolvedValue(conversation);
   };
 
   // The notification is fire-and-forget (like the finalize path's own `void notifyMentionedUsers`)
@@ -528,7 +513,7 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
     await flushNotify();
 
     expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
-    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockFindPageById).not.toHaveBeenCalled();
   });
 
   it('given the compare-and-swap upsert wrote nothing (the row already left streaming via its own onFinish, which already notified), does not notify again', async () => {
@@ -558,11 +543,11 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
     await flushNotify();
 
     expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
-    expect(mockSelect).not.toHaveBeenCalled();
+    expect(mockFindPageById).not.toHaveBeenCalled();
   });
 
-  it('given the page row is gone (deleted between death and reap), does not notify — mirrors the route\'s page?.driveId gate', async () => {
-    gateLookups({ page: [] });
+  it('given the page row is gone or trashed (findById filters both), does not notify', async () => {
+    gateLookups({ page: null });
 
     await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
     await flushNotify();
@@ -571,7 +556,7 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
   });
 
   it('given the conversation row is missing, fails closed and does not notify — same as the route treating a missing row as private', async () => {
-    gateLookups({ conversation: [] });
+    gateLookups({ conversation: null });
 
     await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
     await flushNotify();
@@ -580,7 +565,7 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
   });
 
   it('given the conversation is not shared, does not notify — a private conversation\'s reply must not page other drive members', async () => {
-    gateLookups({ conversation: [{ isShared: false }] });
+    gateLookups({ conversation: { isShared: false } });
 
     await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
     await flushNotify();
@@ -589,8 +574,7 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
   });
 
   it('given the gate lookup rejects, warns (best-effort, operator-visible) and the materialization result is unaffected', async () => {
-    mockSelectWhere.mockReset();
-    mockSelectWhere.mockRejectedValue(new Error('lookup down'));
+    mockFindPageById.mockRejectedValue(new Error('lookup down'));
 
     await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(true);
     await flushNotify();
@@ -603,8 +587,7 @@ describe('materializeInterruptedStream — mention notifications (best-effort, m
   });
 
   it('given the gate lookup rejects with a non-Error value, still warns without throwing', async () => {
-    mockSelectWhere.mockReset();
-    mockSelectWhere.mockRejectedValue('a rejected string, not an Error instance');
+    mockFindPageById.mockRejectedValue('a rejected string, not an Error instance');
 
     await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(true);
     await flushNotify();

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -5,17 +5,27 @@ const {
   mockInsert,
   mockInsertValues,
   mockOnConflictDoUpdate,
+  mockReturning,
   mockUpdateSet,
   mockUpdateWhere,
+  mockSelect,
+  mockSelectFrom,
+  mockSelectWhere,
   mockBroadcastAiStreamComplete,
+  mockNotifyMentionedUsers,
   mockLoggerWarn,
 } = vi.hoisted(() => ({
   mockInsert: vi.fn(),
   mockInsertValues: vi.fn(),
   mockOnConflictDoUpdate: vi.fn(),
+  mockReturning: vi.fn(),
   mockUpdateSet: vi.fn(),
   mockUpdateWhere: vi.fn(),
+  mockSelect: vi.fn(),
+  mockSelectFrom: vi.fn(),
+  mockSelectWhere: vi.fn(),
   mockBroadcastAiStreamComplete: vi.fn(),
+  mockNotifyMentionedUsers: vi.fn(),
   mockLoggerWarn: vi.fn(),
 }));
 
@@ -23,6 +33,7 @@ vi.mock('@pagespace/db/db', () => ({
   db: {
     insert: mockInsert,
     update: vi.fn(() => ({ set: mockUpdateSet })),
+    select: mockSelect,
   },
 }));
 
@@ -45,12 +56,21 @@ vi.mock('@pagespace/db/schema/core', () => ({
     id: 'chat_messages.id',
     status: 'chat_messages.status',
   },
+  pages: {
+    id: 'pages.id',
+    driveId: 'pages.driveId',
+    title: 'pages.title',
+  },
 }));
 
 vi.mock('@pagespace/db/schema/conversations', () => ({
   messages: {
     id: 'messages.id',
     status: 'messages.status',
+  },
+  conversations: {
+    id: 'conversations.id',
+    isShared: 'conversations.isShared',
   },
 }));
 
@@ -60,6 +80,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 vi.mock('@/lib/websocket', () => ({
   broadcastAiStreamComplete: mockBroadcastAiStreamComplete,
+}));
+
+vi.mock('@/lib/channels/notify-mentioned-users', () => ({
+  notifyMentionedUsers: mockNotifyMentionedUsers,
 }));
 
 import { materializeInterruptedStream, type MaterializableStreamRow } from '../materialize-interrupted-stream';
@@ -429,5 +453,170 @@ describe('materializeInterruptedStream — never throws', () => {
     mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
 
     await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
+  });
+});
+
+// D task st3pyh9q4zwnmae00j195o97: an interrupted reply that @mentions a user must produce the
+// same mention notification the normal finalize path produces (message-utils.ts's
+// saveMessageToDatabase fires notifyMentionedUsers for assistant saves when the route's gate —
+// page.driveId present, a triggering user, conversation explicitly shared — passes). Before this
+// fix, a reply that died mid-stream and was materialized here never notified anyone, so an
+// @mention in a recovered reply silently vanished.
+describe('materializeInterruptedStream — mention notifications (best-effort, mirrors the finalize path)', () => {
+  const MENTION_CONTENT = 'Hey @[Alice](alice-id:user), here is what I found so far';
+
+  // The mention-notify path needs the page-chat upsert chain to report whether it actually
+  // wrote (`.returning`), plus the page/conversation lookups the route-level gate reads.
+  beforeEach(() => {
+    mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+    mockReturning.mockResolvedValue([{ id: 'msg-1' }]);
+    mockSelect.mockReturnValue({ from: mockSelectFrom });
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+    mockSelectWhere.mockResolvedValue([]);
+    mockNotifyMentionedUsers.mockResolvedValue(undefined);
+  });
+
+  // Stands in for the two gate lookups, in the order the implementation runs them: the page
+  // (driveId + title, mirroring `page?.driveId` and `mentionerName: page.title`) and then the
+  // conversation (`isShared`, mirroring `isConversationShared`).
+  const gateLookups = ({
+    page = [{ driveId: 'drive-1', title: 'Research Agent' }],
+    conversation = [{ isShared: true }],
+  }: {
+    page?: Array<{ driveId: string; title: string }>;
+    conversation?: Array<{ isShared: boolean }>;
+  } = {}) => {
+    mockSelectWhere.mockReset();
+    mockSelectWhere.mockResolvedValueOnce(page).mockResolvedValueOnce(conversation);
+  };
+
+  // The notification is fire-and-forget (like the finalize path's own `void notifyMentionedUsers`)
+  // — drain the microtask/timer queue before asserting on it.
+  const flushNotify = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  it('given a materialized page-chat reply in a shared conversation, fires notifyMentionedUsers exactly once with the finalize path\'s own argument shape', async () => {
+    gateLookups();
+
+    await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).toHaveBeenCalledTimes(1);
+    assert({
+      given: 'an interrupted materialization whose reply @mentions a user',
+      should: 'notify with the same shape the normal finalize path sends (content, pageId, driveId, stream owner as triggeredBy, page title as mentioner)',
+      actual: mockNotifyMentionedUsers.mock.calls[0][0],
+      expected: {
+        content: MENTION_CONTENT,
+        pageId: 'page-abc123',
+        driveId: 'drive-1',
+        triggeredByUserId: 'user-a',
+        mentionerNameOverride: 'Research Agent',
+      },
+    });
+  });
+
+  it('given a global-assistant row, never notifies and never even runs the page/conversation lookups (global conversations have no page mention surface)', async () => {
+    await materializeInterruptedStream(globalRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('given the compare-and-swap upsert wrote nothing (the row already left streaming via its own onFinish, which already notified), does not notify again', async () => {
+    gateLookups();
+    mockReturning.mockResolvedValue([]);
+
+    await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('given the message write itself failed, does not notify (nothing was materialized)', async () => {
+    gateLookups();
+    mockReturning.mockRejectedValue(new Error('db down'));
+
+    await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(false);
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('given an empty recovered reply (no parts survived), does not notify — mirrors the finalize path\'s content.trim() gate', async () => {
+    gateLookups();
+
+    await materializeInterruptedStream(pageRow({ parts: [] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+    expect(mockSelect).not.toHaveBeenCalled();
+  });
+
+  it('given the page row is gone (deleted between death and reap), does not notify — mirrors the route\'s page?.driveId gate', async () => {
+    gateLookups({ page: [] });
+
+    await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('given the conversation row is missing, fails closed and does not notify — same as the route treating a missing row as private', async () => {
+    gateLookups({ conversation: [] });
+
+    await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('given the conversation is not shared, does not notify — a private conversation\'s reply must not page other drive members', async () => {
+    gateLookups({ conversation: [{ isShared: false }] });
+
+    await materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }));
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+  });
+
+  it('given the gate lookup rejects, warns (best-effort, operator-visible) and the materialization result is unaffected', async () => {
+    mockSelectWhere.mockReset();
+    mockSelectWhere.mockRejectedValue(new Error('lookup down'));
+
+    await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(true);
+    await flushNotify();
+
+    expect(mockNotifyMentionedUsers).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('mention notification failed'),
+      expect.objectContaining({ error: 'lookup down' }),
+    );
+  });
+
+  it('given the gate lookup rejects with a non-Error value, still warns without throwing', async () => {
+    mockSelectWhere.mockReset();
+    mockSelectWhere.mockRejectedValue('a rejected string, not an Error instance');
+
+    await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(true);
+    await flushNotify();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('mention notification failed'),
+      expect.objectContaining({ error: 'unknown' }),
+    );
+  });
+
+  it('given notifyMentionedUsers itself rejects, warns and the materialization result is unaffected', async () => {
+    gateLookups();
+    mockNotifyMentionedUsers.mockRejectedValue(new Error('notify boom'));
+
+    await expect(materializeInterruptedStream(pageRow({ parts: [textPart(MENTION_CONTENT)] }))).resolves.toBe(true);
+    await flushNotify();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('mention notification failed'),
+      expect.objectContaining({ error: 'notify boom' }),
+    );
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/materialize-interrupted-stream.test.ts
@@ -127,7 +127,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockInsert.mockReturnValue({ values: mockInsertValues });
   mockInsertValues.mockReturnValue({ onConflictDoUpdate: mockOnConflictDoUpdate });
-  mockOnConflictDoUpdate.mockResolvedValue(undefined);
+  // The page-chat chain ends `.returning(...)` (reports whether the CAS wrote — the mention
+  // gate needs it); the global chain awaits the upsert directly and ignores this shape.
+  mockOnConflictDoUpdate.mockReturnValue({ returning: mockReturning });
+  mockReturning.mockResolvedValue([{ id: 'msg-1' }]);
+  mockSelect.mockReturnValue({ from: mockSelectFrom });
+  mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+  // Default the mention-gate lookups to "page gone" so tests not about notifications never
+  // trip the notify path.
+  mockSelectWhere.mockResolvedValue([]);
+  mockNotifyMentionedUsers.mockResolvedValue(undefined);
   mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
   // Defaults to "one row actually settled" (rowCount: 1) — the common case. Tests exercising the
   // zero-row race (a concurrent reap already settled this row) override this per-case.
@@ -364,7 +373,7 @@ describe('materializeInterruptedStream — settling the session row', () => {
   });
 
   it('does not settle the session row when the message write fails', async () => {
-    mockOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
+    mockReturning.mockRejectedValue(new Error('db down'));
 
     await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
 
@@ -385,7 +394,7 @@ describe('materializeInterruptedStream — settling the session row', () => {
   });
 
   it('logs a non-Error message-write rejection without throwing, and reports false', async () => {
-    mockOnConflictDoUpdate.mockRejectedValue('a rejected string, not an Error instance');
+    mockReturning.mockRejectedValue('a rejected string, not an Error instance');
 
     await expect(materializeInterruptedStream(pageRow())).resolves.toBe(false);
     expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -418,7 +427,7 @@ describe('materializeInterruptedStream — broadcast', () => {
   });
 
   it('does not broadcast when the message write failed (nothing was actually materialized)', async () => {
-    mockOnConflictDoUpdate.mockRejectedValue(new Error('db down'));
+    mockReturning.mockRejectedValue(new Error('db down'));
 
     await materializeInterruptedStream(pageRow());
 
@@ -448,7 +457,6 @@ describe('materializeInterruptedStream — broadcast', () => {
 
 describe('materializeInterruptedStream — never throws', () => {
   it('resolves (with false, since the session row never settled) even when every DB call rejects', async () => {
-    mockOnConflictDoUpdate.mockResolvedValue(undefined);
     mockUpdateWhere.mockRejectedValue(new Error('db down'));
     mockBroadcastAiStreamComplete.mockRejectedValue(new Error('socket down'));
 

--- a/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/start-generation-exclusive.test.ts
@@ -296,16 +296,16 @@ describe('startGenerationExclusive', () => {
       expect(client.release).toHaveBeenCalledTimes(1);
     });
 
-    it('given run() SUCCEEDS but withAdvisoryLock\'s post-run lock release then throws, should propagate that error and NOT invoke run a second time unlocked', async () => {
-      // Codex review finding on PR #2080: withAdvisoryLock's `finally` releases the Postgres
-      // session AFTER fn() resolves (packages/db/src/advisory-lock.ts:76-103). If the unlock
-      // query rejects AND the destroy-on-release fallback (`client.release(err)`) also throws,
-      // that exception is uncaught and escapes the finally block, overriding the successful
-      // return value — so `withAdvisoryLock`'s overall promise rejects despite `run` having
-      // already completed successfully. A `runThrew`-only flag (set only inside guardedRun's
-      // catch) would stay false here and this would be misclassified as `lock_error`,
-      // triggering degradeToUnlocked and a second, unlocked invocation of an already-succeeded
-      // `run`. `runSettled` (set on BOTH the success and failure paths) closes this.
+    it('given run() SUCCEEDS but withAdvisoryLock\'s post-run unlock AND destroy both throw, should still resolve locked with run\'s result and NOT invoke run a second time unlocked', async () => {
+      // Codex review finding on PR #2080, contract updated by PR #2097: withAdvisoryLock's
+      // release machinery (`unlockAndRelease`/`releaseQuietly` in
+      // packages/db/src/advisory-lock.ts) now NEVER throws — a failed unlock destroys the
+      // connection, and a destroy that itself throws is swallowed and logged. So even this
+      // double failure (unlock query rejects, then `client.release(err)` throws too) can no
+      // longer escape the finally and override `run`'s already-successful return. The
+      // property this test has always guarded is unchanged: `run` executes exactly once and
+      // is never re-invoked unlocked — but now the caller also keeps the successful result
+      // instead of losing an already-started generation to lock-cleanup noise.
       const releaseError = new Error('release also failed');
       const client: AdvisoryLockClient = {
         query: vi
@@ -320,9 +320,14 @@ describe('startGenerationExclusive', () => {
       const run = vi.fn(async () => 'lifecycle-handle');
       const sleep = vi.fn(async () => {});
 
-      await expect(startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep })).rejects.toThrow(releaseError);
+      const result = await startGenerationExclusive({ conversationId: 'conv-1', run, pool, sleep });
 
+      expect(result).toEqual({ outcome: 'locked', result: 'lifecycle-handle' });
       expect(run).toHaveBeenCalledTimes(1);
+      // The destroy WAS attempted (release(err)) — the failure is contained, not skipped.
+      expect(client.release).toHaveBeenCalledWith(expect.any(Error));
+      // Not a lock_error: no degrade telemetry for a post-run cleanup failure.
+      expect(mockLogPerformance).not.toHaveBeenCalled();
     });
 
     it('given a prior call on the SAME conversation had run() throw, a later call that hits a genuine lock-machinery failure should still degrade normally', async () => {

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
@@ -177,6 +177,132 @@ describe('startStreamJoinPollFallback', () => {
     expect(mockFetchWithAuth).not.toHaveBeenCalled();
   });
 
+  // The abort can land at ANY await point inside an in-flight tick, not just between ticks.
+  // Each suspension point re-checks the signal so a snapshot from a tick that outlived its
+  // caller (e.g. stream_complete arrived and the DB-reload path already took over) can never
+  // clobber the authoritative final content.
+  describe('signal aborts mid-tick (at each suspension point)', () => {
+    it('given the signal aborts while the fetch is in flight, should discard the resolved response without calling onSnapshot', async () => {
+      const controller = new AbortController();
+      mockFetchWithAuth.mockImplementation(async () => {
+        controller.abort();
+        return okResponse([{ messageId: 'msg-1', parts: [{ type: 'text', text: 'stale' }] }]);
+      });
+      const onSnapshot = vi.fn();
+      const onNotFound = vi.fn();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, onSnapshot, onNotFound);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onSnapshot).not.toHaveBeenCalled();
+      expect(onNotFound).not.toHaveBeenCalled();
+    });
+
+    it('given the signal aborts while the body json is being read, should discard the parsed payload without calling onSnapshot or onNotFound', async () => {
+      const controller = new AbortController();
+      mockFetchWithAuth.mockResolvedValue({
+        ok: true,
+        json: async () => {
+          controller.abort();
+          // A payload with NO matching row — if the post-json abort check were missing, this
+          // would wrongly fire onNotFound after the caller already moved on.
+          return { streams: [] };
+        },
+      });
+      const onSnapshot = vi.fn();
+      const onNotFound = vi.fn();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, onSnapshot, onNotFound);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(onSnapshot).not.toHaveBeenCalled();
+      expect(onNotFound).not.toHaveBeenCalled();
+    });
+
+    it('given the abort lands before the clearInterval listener is even registered, a later interval tick should return at the entry guard without fetching', async () => {
+      const controller = new AbortController();
+      // Aborting synchronously INSIDE the first fetch call happens before
+      // startStreamJoinPollFallback reaches its own addEventListener('abort') line, so the
+      // interval is never cleared by the listener — the per-tick entry guard is the only thing
+      // standing between that orphaned interval and a fetch against an aborted signal.
+      mockFetchWithAuth.mockImplementation(async () => {
+        controller.abort();
+        return okResponse([{ messageId: 'msg-1', parts: [] }]);
+      });
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 3);
+
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given the fetch rejects because the abort landed mid-flight, should stay silent (no retry warning for an intentional stop)', async () => {
+      const controller = new AbortController();
+      mockFetchWithAuth.mockImplementation(async () => {
+        controller.abort();
+        throw new Error('socket closed');
+      });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  // fetch rejects DOMException-style AbortErrors from cancellation paths that don't flip THIS
+  // signal (e.g. the auth wrapper's own internal timeout/retry cancellation). Not a failure
+  // worth warning about — but also not a reason to stop: the interval keeps polling.
+  it('given a tick rejects with an AbortError while the signal is NOT aborted, should stay silent and keep polling on the next interval', async () => {
+    mockFetchWithAuth
+      .mockRejectedValueOnce(Object.assign(new Error('The operation was aborted'), { name: 'AbortError' }))
+      .mockResolvedValueOnce(okResponse([{ messageId: 'msg-1', parts: [{ type: 'text', text: 'recovered' }] }]));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new AbortController();
+    const onSnapshot = vi.fn();
+
+    startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, onSnapshot, vi.fn());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS);
+    expect(onSnapshot).toHaveBeenCalledWith([{ type: 'text', text: 'recovered' }]);
+    warnSpy.mockRestore();
+  });
+
+  it('given a tick rejects with a non-Error value, should warn and keep polling (not an abort, just a broken tick)', async () => {
+    mockFetchWithAuth
+      .mockRejectedValueOnce('a rejected string, not an Error instance')
+      .mockResolvedValueOnce(okResponse([{ messageId: 'msg-1', parts: [] }]));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new AbortController();
+
+    startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS);
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(2);
+    warnSpy.mockRestore();
+  });
+
+  it('given a response body with no streams field at all, should treat it as row-gone (terminal) rather than crashing', async () => {
+    mockFetchWithAuth.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const controller = new AbortController();
+    const onNotFound = vi.fn();
+
+    startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), onNotFound);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onNotFound).toHaveBeenCalledTimes(1);
+  });
+
   it('given a poll tick returns a non-ok response, should not call onSnapshot but should still tick again', async () => {
     mockFetchWithAuth
       .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -1,14 +1,16 @@
 import { db } from '@pagespace/db/db';
 import { and, eq } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
-import { chatMessages, pages } from '@pagespace/db/schema/core';
-import { conversations, messages } from '@pagespace/db/schema/conversations';
+import { chatMessages } from '@pagespace/db/schema/core';
+import { messages } from '@pagespace/db/schema/conversations';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { broadcastAiStreamComplete } from '@/lib/websocket';
 import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistantParts';
 import { extractStructuredContentFromParts } from '@/lib/ai/core/message-utils';
 import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
 
 /**
@@ -99,16 +101,14 @@ export interface MaterializableStreamRow {
  */
 const notifyMentionsBestEffort = async (row: MaterializableStreamRow, content: string): Promise<void> => {
   try {
-    const [page] = await db
-      .select({ driveId: pages.driveId, title: pages.title })
-      .from(pages)
-      .where(eq(pages.id, row.channelId));
-    if (!page?.driveId) return;
+    // The same readers the live paths use (never re-derived selects, per the reuse rail):
+    // pageRepository.findById excludes trashed pages by default, so a page trashed between
+    // stream death and this reap can't page drive members about content they can no longer
+    // open; getConversation is the route's own source of isConversationShared.
+    const page = await pageRepository.findById(row.channelId);
+    if (!page) return;
 
-    const [conversation] = await db
-      .select({ isShared: conversations.isShared })
-      .from(conversations)
-      .where(eq(conversations.id, row.conversationId));
+    const conversation = await conversationRepository.getConversation(row.conversationId);
     if (conversation?.isShared !== true) return;
 
     await notifyMentionedUsers({

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -1,13 +1,14 @@
 import { db } from '@pagespace/db/db';
 import { and, eq } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
-import { chatMessages } from '@pagespace/db/schema/core';
-import { messages } from '@pagespace/db/schema/conversations';
+import { chatMessages, pages } from '@pagespace/db/schema/core';
+import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { broadcastAiStreamComplete } from '@/lib/websocket';
 import { buildAssistantPersistencePayload } from '@/lib/ai/core/persistAssistantParts';
 import { extractStructuredContentFromParts } from '@/lib/ai/core/message-utils';
+import { notifyMentionedUsers } from '@/lib/channels/notify-mentioned-users';
 import type { UIMessagePart } from '@/lib/ai/core/stream-multicast-registry';
 
 /**
@@ -80,6 +81,51 @@ export interface MaterializableStreamRow {
  * misreporting bug (a log that attests to nothing) this module's sibling functions already
  * guard against.
  */
+/**
+ * Best-effort mirror of the finalize path's mention notifications for a page-chat reply this
+ * sweep just materialized. The normal path (saveMessageToDatabase, message-utils.ts) fires
+ * `notifyMentionedUsers` for an assistant save when the route's gate passes — the page has a
+ * driveId, a user triggered the generation, and the conversation is explicitly shared. A dead
+ * stream's materialization is the same terminal assistant write arriving by a different door,
+ * so it re-derives that exact gate here (the route's in-memory `page` / `isConversationShared`
+ * are gone with the dead process): page lookup for driveId + title (title doubles as the
+ * mentioner name, same as the route's `mentionerName: page.title`), conversation lookup for
+ * `isShared` — a missing row fails closed as private, matching the route's own comment.
+ *
+ * Best-effort by design: a failure here (lookup or notify) is warned, never propagated — the
+ * reply itself was already durably materialized, and a notification must never un-succeed that.
+ * Global-assistant rows never reach this (a global conversation has no page mention surface,
+ * and the global save path has no mentionNotify seam either).
+ */
+const notifyMentionsBestEffort = async (row: MaterializableStreamRow, content: string): Promise<void> => {
+  try {
+    const [page] = await db
+      .select({ driveId: pages.driveId, title: pages.title })
+      .from(pages)
+      .where(eq(pages.id, row.channelId));
+    if (!page?.driveId) return;
+
+    const [conversation] = await db
+      .select({ isShared: conversations.isShared })
+      .from(conversations)
+      .where(eq(conversations.id, row.conversationId));
+    if (conversation?.isShared !== true) return;
+
+    await notifyMentionedUsers({
+      content,
+      pageId: row.channelId,
+      driveId: page.driveId,
+      triggeredByUserId: row.userId,
+      mentionerNameOverride: page.title,
+    });
+  } catch (error) {
+    loggers.ai.warn('materializeInterruptedStream: mention notification failed (best-effort)', {
+      messageId: row.messageId,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+  }
+};
+
 export const materializeInterruptedStream = async (row: MaterializableStreamRow): Promise<boolean> => {
   const now = new Date();
 
@@ -129,7 +175,7 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           setWhere: eq(messages.status, 'streaming'),
         });
     } else {
-      await db
+      const written = await db
         .insert(chatMessages)
         .values({
           id: row.messageId,
@@ -158,7 +204,20 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
             status: 'interrupted',
           },
           setWhere: eq(chatMessages.status, 'streaming'),
-        });
+        })
+        // `.returning` reports whether the CAS actually landed. When it returns nothing, the
+        // row already left 'streaming' via its own onFinish — which already fired this exact
+        // notification behind the same gate — so notifying again here would double-page the
+        // mentioned user for one reply.
+        .returning({ id: chatMessages.id });
+
+      // Same gate order as saveMessageToDatabase: assistant role is implicit here, and the
+      // content.trim() check keeps an empty recovered reply (no parts survived) from paying for
+      // two gate lookups that can never produce a mention. Fire-and-forget, like the finalize
+      // path's own `void notifyMentionedUsers` — the helper never rejects (it catches and warns).
+      if (written.length > 0 && payload.content.trim()) {
+        void notifyMentionsBestEffort(row, payload.content);
+      }
     }
   } catch (error) {
     loggers.ai.warn('materializeInterruptedStream: message upsert failed', {

--- a/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
+++ b/apps/web/src/lib/ai/core/materialize-interrupted-stream.ts
@@ -206,9 +206,11 @@ export const materializeInterruptedStream = async (row: MaterializableStreamRow)
           setWhere: eq(chatMessages.status, 'streaming'),
         })
         // `.returning` reports whether the CAS actually landed. When it returns nothing, the
-        // row already left 'streaming' via its own onFinish — which already fired this exact
-        // notification behind the same gate — so notifying again here would double-page the
-        // mentioned user for one reply.
+        // row already left 'streaming' via one of the route's own terminal writes (execute-end,
+        // onFinish, or its outer-catch cleanup) — and the route guarantees whichever of those
+        // lands first carries this exact notification behind the same gate (`mentionNotifyFor`
+        // + its once-flag, route.ts; Codex P2 on PR #2097) — so notifying again here would
+        // double-page the mentioned user for one reply.
         .returning({ id: chatMessages.id });
 
       // Same gate order as saveMessageToDatabase: assistant role is implicit here, and the

--- a/apps/web/src/lib/ai/core/start-generation-exclusive.ts
+++ b/apps/web/src/lib/ai/core/start-generation-exclusive.ts
@@ -29,14 +29,15 @@ import { loggers, logPerformance } from '@pagespace/lib/logging/logger-config';
  * once per call, either inside the lock or, on degrade, once unlocked. It never runs twice for
  * one `startGenerationExclusive` call — enforced structurally, not by classifying a catch: the
  * loop below awaits `withAdvisoryLock(pool, lockKey, run)` unwrapped and only branches on its
- * RESOLVED outcome (`connection_error` | `lock_busy` | `acquired`). Any rejection — `run`
- * itself throwing, or `withAdvisoryLock`'s post-run lock-release throwing and overriding an
- * already-successful return (`finally` can still do that; see advisory-lock.ts) — is never
- * caught here, so there is no reclassification step that could mistake "run already ran" for
- * "the lock never engaged" and re-invoke `run` unlocked. `withAdvisoryLock` itself never calls
- * `fn` more than once per call, so a rejection propagating straight through this function is
- * always safe. Every operation inside `run` is ALSO expected to catch and log its own errors
- * (each call site's own try/catch) — this function's job is only to never double-invoke it.
+ * RESOLVED outcome (`connection_error` | `lock_busy` | `acquired`). The only rejection that can
+ * come out of that await is `run`'s own — `withAdvisoryLock`'s release machinery never throws
+ * (a failed unlock destroys the connection; a failed destroy is swallowed and logged; see
+ * advisory-lock.ts), so a successful `run` always surfaces as `acquired` with its result. `run`'s
+ * rejection is never caught here, so there is no reclassification step that could mistake "run
+ * already ran" for "the lock never engaged" and re-invoke `run` unlocked. `withAdvisoryLock`
+ * itself never calls `fn` more than once per call. Every operation inside `run` is ALSO expected
+ * to catch and log its own errors (each call site's own try/catch) — this function's job is only
+ * to never double-invoke it.
  */
 
 export const MAX_LOCK_BUSY_RETRIES = 3;
@@ -136,14 +137,12 @@ export async function startGenerationExclusive<T>(
     // failures, so a catch site had to disambiguate "run threw" from "the lock connection
     // itself broke" before deciding whether re-invoking `run` unlocked was safe. This
     // version never introduces that catch site at all: `withAdvisoryLock` is awaited
-    // unwrapped, so ANY rejection (`run` throwing, or the post-run lock-release throwing
-    // and overriding a successful return — `withAdvisoryLock`'s `finally` can still do
-    // that, see advisory-lock.ts:105-131) propagates straight out of this function without
-    // ever being caught and reinterpreted. `run` runs at most once per call either way —
-    // `withAdvisoryLock` itself never invokes it twice — so there is no reclassification
-    // step left for `runSettled` to guard. Verified directly: every test in
-    // start-generation-exclusive.test.ts, including the "post-run lock release throws"
-    // case PR #2080 added, passes unchanged against this simpler shape.
+    // unwrapped, and since its release machinery never throws (unlockAndRelease /
+    // releaseQuietly in advisory-lock.ts — a failed unlock destroys the connection, a
+    // failed destroy is swallowed and logged), the ONLY rejection that can propagate out
+    // of this function is `run`'s own, never caught and reinterpreted here. `run` runs at
+    // most once per call either way — `withAdvisoryLock` itself never invokes it twice —
+    // so there is no reclassification step left for `runSettled` to guard.
     const attempt = await withAdvisoryLock(pool, lockKey, run);
 
     if (attempt.outcome === 'connection_error') {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -67,6 +67,11 @@ export default defineConfig({
         // #2022 never-overwrite-complete guard — gated at 100% branch per the epic's own
         // constraints.
         'src/lib/ai/core/materialize-interrupted-stream.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        // Server Stream Durability PR 5 (R.4 remediation): checkpoint shaping and the
+        // join-404 poll fallback are pure/leaf decision modules gated at 100% branch,
+        // same as materialize-interrupted-stream above.
+        'src/lib/ai/core/checkpoint-serialize.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        'src/lib/ai/core/stream-join-poll-fallback.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/useConversationMessagesStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/usePendingStreamsStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/conversationMessages/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -61,6 +61,27 @@ describe('withAdvisoryLock', () => {
     expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 
+  // Lock keys can be derived from request-supplied ids, so the failure log must treat the key
+  // as data: constant format string (%s), newlines stripped — a crafted key must not be able to
+  // forge log lines or smuggle %-directives (CodeQL js/log-injection / js/tainted-format-string).
+  it('given a lock key containing newlines, should log it newline-stripped as a format argument, never interpolated into the format string', async () => {
+    const client = makeClient({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockRejectedValueOnce(new Error('unlock failed')),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await withAdvisoryLock(pool, 'evil\nkey\r%s', async () => 'ok');
+
+    const [format, keyArg] = errorSpy.mock.calls[0];
+    expect(format).not.toContain('evil');
+    expect(keyArg).toBe('evil key %s');
+    errorSpy.mockRestore();
+  });
+
   // pg's release(err) only destroys the connection when handed an actual Error — a raw driver
   // rejection value (drivers CAN reject with strings/objects) passed through unwrapped would be
   // truthy enough to look intentional but is not guaranteed to trip pg's destroy path. The
@@ -84,8 +105,11 @@ describe('withAdvisoryLock', () => {
     expect(releasedWith).toBeInstanceOf(Error);
     expect((releasedWith as Error).message).toContain('unlock rejected as a plain string');
     // The recurring-failure signal must stay operator-visible even for non-Error rejections.
+    // Constant format string + args (never the key interpolated into the format position) —
+    // see the CodeQL note at the console.error call.
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Advisory unlock failed'),
+      'my-lock',
       'unlock rejected as a plain string',
     );
     errorSpy.mockRestore();

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -83,8 +83,8 @@ describe('withAdvisoryLock', () => {
 
     expect(client.release).toHaveBeenCalledTimes(2);
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Destroy-release also failed'),
-      'my-lock',
+      expect.stringContaining('release() itself failed'),
+      JSON.stringify('my-lock'),
       'Release called on a client which has already been released',
     );
     errorSpy.mockRestore();
@@ -107,8 +107,8 @@ describe('withAdvisoryLock', () => {
     });
 
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Destroy-release also failed'),
-      'my-lock',
+      expect.stringContaining('release() itself failed'),
+      JSON.stringify('my-lock'),
       'released twice',
     );
     errorSpy.mockRestore();
@@ -117,7 +117,7 @@ describe('withAdvisoryLock', () => {
   // Lock keys can be derived from request-supplied ids, so the failure log must treat the key
   // as data: constant format string (%s), newlines stripped — a crafted key must not be able to
   // forge log lines or smuggle %-directives (CodeQL js/log-injection / js/tainted-format-string).
-  it('given a lock key containing newlines, should log it newline-stripped as a format argument, never interpolated into the format string', async () => {
+  it('given a lock key containing newlines, should log it JSON-escaped as a format argument, never interpolated into the format string', async () => {
     const client = makeClient({
       query: vi
         .fn()
@@ -131,7 +131,9 @@ describe('withAdvisoryLock', () => {
 
     const [format, keyArg] = errorSpy.mock.calls[0];
     expect(format).not.toContain('evil');
-    expect(keyArg).toBe('evil key %s');
+    // JSON.stringify escapes the newlines to literal \n/\r — a crafted key cannot start a new
+    // log line, and the constant format string means %s in the key is inert data.
+    expect(keyArg).toBe(JSON.stringify('evil\nkey\r%s'));
     errorSpy.mockRestore();
   });
 
@@ -162,7 +164,7 @@ describe('withAdvisoryLock', () => {
     // see the CodeQL note at the console.error call.
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Advisory unlock failed'),
-      'my-lock',
+      JSON.stringify('my-lock'),
       'unlock rejected as a plain string',
     );
     errorSpy.mockRestore();
@@ -195,6 +197,46 @@ describe('withAdvisoryLock', () => {
 
     expect(result).toEqual({ outcome: 'connection_error', error: connectError });
     expect(fn).not.toHaveBeenCalled();
+  });
+
+  // CodeRabbit (PR #2097): every exit must keep its promised RESOLVED outcome even when
+  // release() itself throws — not just the post-acquisition paths the earlier tests covered.
+  it('given release() throws on the lock-busy path, should still resolve lock_busy', async () => {
+    const client = makeClient({
+      query: vi.fn().mockResolvedValueOnce({ rows: [{ acquired: false }] }),
+      release: vi.fn(() => { throw new Error('pool gone'); }),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(withAdvisoryLock(pool, 'my-lock', async () => 'unreachable')).resolves.toEqual({
+      outcome: 'lock_busy',
+    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('release() itself failed'),
+      JSON.stringify('my-lock'),
+      'pool gone',
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('given release() throws on the try-lock-failure path, should still resolve connection_error', async () => {
+    const client = makeClient({
+      query: vi.fn().mockRejectedValueOnce(new Error('connection reset')),
+      release: vi.fn(() => { throw new Error('pool gone'); }),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await withAdvisoryLock(pool, 'my-lock', async () => 'unreachable');
+
+    expect(result).toMatchObject({ outcome: 'connection_error', error: expect.any(Error) });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('release() itself failed'),
+      JSON.stringify('my-lock'),
+      'pool gone',
+    );
+    errorSpy.mockRestore();
   });
 
   it('given fn itself throws after acquiring, should still unlock cleanly (fn error does not poison the lock connection) and rethrow', async () => {

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -61,6 +61,59 @@ describe('withAdvisoryLock', () => {
     expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 
+  // The never-throws contract must hold even when release() itself throws: without the guard,
+  // the success-path release throwing would route into the catch, whose destroy-release then
+  // throws a synchronous double-release error that escapes — replacing a successful fn() result
+  // with a rejection inside withAdvisoryLock's finally.
+  it('given release() itself throws after a successful unlock, should swallow the double-release error and still resolve acquired', async () => {
+    const client = makeClient({
+      query: vi.fn().mockResolvedValueOnce({ rows: [{ acquired: true }] }).mockResolvedValueOnce({ rows: [] }),
+      release: vi
+        .fn()
+        .mockImplementationOnce(() => { throw new Error('release hook failed'); })
+        .mockImplementationOnce(() => { throw new Error('Release called on a client which has already been released'); }),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(withAdvisoryLock(pool, 'my-lock', async () => 'ok')).resolves.toEqual({
+      outcome: 'acquired',
+      result: 'ok',
+    });
+
+    expect(client.release).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Destroy-release also failed'),
+      'my-lock',
+      'Release called on a client which has already been released',
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('given release() throws a non-Error value, should stringify it in the destroy-release log and still resolve', async () => {
+    const client = makeClient({
+      query: vi.fn().mockResolvedValueOnce({ rows: [{ acquired: true }] }).mockResolvedValueOnce({ rows: [] }),
+      release: vi
+        .fn()
+        .mockImplementationOnce(() => { throw new Error('release hook failed'); })
+        .mockImplementationOnce(() => { throw 'released twice'; }),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(withAdvisoryLock(pool, 'my-lock', async () => 'ok')).resolves.toEqual({
+      outcome: 'acquired',
+      result: 'ok',
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Destroy-release also failed'),
+      'my-lock',
+      'released twice',
+    );
+    errorSpy.mockRestore();
+  });
+
   // Lock keys can be derived from request-supplied ids, so the failure log must treat the key
   // as data: constant format string (%s), newlines stripped — a crafted key must not be able to
   // forge log lines or smuggle %-directives (CodeQL js/log-injection / js/tainted-format-string).

--- a/packages/db/src/advisory-lock.test.ts
+++ b/packages/db/src/advisory-lock.test.ts
@@ -61,6 +61,36 @@ describe('withAdvisoryLock', () => {
     expect(client.release.mock.calls[0][0]).toBeInstanceOf(Error);
   });
 
+  // pg's release(err) only destroys the connection when handed an actual Error — a raw driver
+  // rejection value (drivers CAN reject with strings/objects) passed through unwrapped would be
+  // truthy enough to look intentional but is not guaranteed to trip pg's destroy path. The
+  // helper must wrap it so the destroy-instead-of-pool decision (and the operator-visible log)
+  // hold regardless of what the driver rejected with.
+  it('given the unlock query rejects with a non-Error value, should wrap it in an Error (preserving the original text) and still destroy the connection', async () => {
+    const client = makeClient({
+      query: vi
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ acquired: true }] })
+        .mockRejectedValueOnce('unlock rejected as a plain string'),
+    });
+    const pool: AdvisoryLockPool = { connect: vi.fn(async () => client) };
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await withAdvisoryLock(pool, 'my-lock', async () => 'ok');
+
+    expect(result).toEqual({ outcome: 'acquired', result: 'ok' });
+    expect(client.release).toHaveBeenCalledTimes(1);
+    const releasedWith = client.release.mock.calls[0][0];
+    expect(releasedWith).toBeInstanceOf(Error);
+    expect((releasedWith as Error).message).toContain('unlock rejected as a plain string');
+    // The recurring-failure signal must stay operator-visible even for non-Error rejections.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Advisory unlock failed'),
+      'unlock rejected as a plain string',
+    );
+    errorSpy.mockRestore();
+  });
+
   // Leaf 5.6/5.7 (triaged D fix, fmfmzw4g4gh6u6q9cjt7ylne): the lock connection's own failure
   // must be a STRUCTURALLY distinct, resolved outcome — never a thrown/rejected promise — so a
   // caller can tell "the lock machinery is broken" apart from "fn threw" without guessing. Before

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -61,6 +61,29 @@ export type WithAdvisoryLockResult<T> =
       error: unknown;
     };
 
+/**
+ * Unlock and return the connection to the pool — or, when the unlock query itself fails,
+ * destroy the connection instead. A session that failed to unlock may still hold the
+ * session-level advisory lock; returned to the pool alive it would leak the lock permanently
+ * (every future try-lock sees lock_busy forever). Postgres releases session advisory locks
+ * when the backend dies, so destroying is the safe exit. Logged plainly (not via
+ * @pagespace/lib's logger — packages/db must not depend on packages/lib) so a recurring
+ * failure is operator-visible before the dedicated pool is starved. Never throws.
+ */
+async function unlockAndRelease(client: AdvisoryLockClient, lockKey: string): Promise<void> {
+  try {
+    await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey]);
+    client.release();
+  } catch (unlockError) {
+    const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
+    console.error(
+      `[withAdvisoryLock:${lockKey}] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool:`,
+      err.message,
+    );
+    client.release(err);
+  }
+}
+
 export async function withAdvisoryLock<T>(
   pool: AdvisoryLockPool,
   lockKey: string,
@@ -73,61 +96,35 @@ export async function withAdvisoryLock<T>(
     return { outcome: 'connection_error', error };
   }
 
-  let lockAcquired = false;
-  // Set only when a query ON THIS CLIENT (try-lock or unlock) itself threw —
-  // NOT when `fn()` throws, since `fn` runs against its own I/O and leaves
-  // this lock connection's protocol state untouched.
-  let clientPoisoned = false;
-
+  // The try-lock query gets its own catch, separate from `fn`'s errors below: a query that
+  // threw ON THIS CLIENT leaves the connection's protocol state indeterminate, so it is
+  // destroyed on release rather than pooled as if healthy — and the failure is lock machinery,
+  // reported as a resolved `connection_error` outcome, never a rejection.
+  let lockResult: { rows: Record<string, unknown>[] };
   try {
-    let lockResult: { rows: Record<string, unknown>[] };
-    try {
-      lockResult = await client.query('SELECT pg_try_advisory_lock(hashtext($1)) AS acquired', [lockKey]);
-    } catch (tryLockError) {
-      clientPoisoned = true;
-      throw tryLockError;
-    }
-    lockAcquired = Boolean(lockResult.rows[0]?.acquired);
-    if (!lockAcquired) {
-      return { outcome: 'lock_busy' };
-    }
-
-    const result = await fn();
-    return { outcome: 'acquired', result };
+    lockResult = await client.query('SELECT pg_try_advisory_lock(hashtext($1)) AS acquired', [lockKey]);
   } catch (error) {
-    // Only the try-lock query poisons the client — `fn`'s own errors leave this lock
-    // connection's protocol state untouched, so they are NOT lock machinery and must
-    // keep propagating as a rejection (the caller's own error, unwrapped).
-    if (clientPoisoned) {
-      return { outcome: 'connection_error', error };
-    }
-    throw error;
-  } finally {
-    if (lockAcquired) {
-      try {
-        await client.query('SELECT pg_advisory_unlock(hashtext($1))', [lockKey]);
-        client.release();
-      } catch (unlockError) {
-        const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
-        // A session that failed to unlock may still hold the session-level
-        // advisory lock; returned to the pool alive it would leak the lock
-        // permanently (every future try-lock sees lock_busy forever). Destroy
-        // it instead — Postgres releases session advisory locks when the
-        // backend dies. Logged plainly (not via @pagespace/lib's logger —
-        // packages/db must not depend on packages/lib) so a recurring failure
-        // is operator-visible before the dedicated pool is starved.
-        console.error(
-          `[withAdvisoryLock:${lockKey}] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool:`,
-          err.message,
-        );
-        client.release(err);
-      }
-    } else {
-      client.release(
-        clientPoisoned
-          ? new Error(`withAdvisoryLock(${lockKey}): try-lock query failed, connection left in an indeterminate state`)
-          : undefined,
-      );
-    }
+    client.release(
+      new Error(`withAdvisoryLock(${lockKey}): try-lock query failed, connection left in an indeterminate state`),
+    );
+    return { outcome: 'connection_error', error };
   }
+
+  if (!lockResult.rows[0]?.acquired) {
+    client.release();
+    return { outcome: 'lock_busy' };
+  }
+
+  // `fn`'s own errors run against its own I/O and leave this lock connection's protocol state
+  // untouched — they are NOT lock machinery and keep propagating as a rejection (the caller's
+  // own error, unwrapped), after the lock is released either way.
+  let result: T;
+  try {
+    result = await fn();
+  } catch (fnError) {
+    await unlockAndRelease(client, lockKey);
+    throw fnError;
+  }
+  await unlockAndRelease(client, lockKey);
+  return { outcome: 'acquired', result };
 }

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -76,8 +76,13 @@ async function unlockAndRelease(client: AdvisoryLockClient, lockKey: string): Pr
     client.release();
   } catch (unlockError) {
     const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
+    // Constant format string with the key passed as a %s argument, newlines stripped: lock keys
+    // can be derived from request-supplied ids (e.g. a per-conversation lock), so interpolating
+    // one into the format-string position would let a crafted key smuggle %-directives or forge
+    // log lines (CodeQL js/tainted-format-string, js/log-injection — PR #2097).
     console.error(
-      `[withAdvisoryLock:${lockKey}] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool:`,
+      '[withAdvisoryLock:%s] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool: %s',
+      lockKey.replace(/[\r\n]/g, ' '),
       err.message,
     );
     client.release(err);
@@ -117,14 +122,12 @@ export async function withAdvisoryLock<T>(
 
   // `fn`'s own errors run against its own I/O and leave this lock connection's protocol state
   // untouched — they are NOT lock machinery and keep propagating as a rejection (the caller's
-  // own error, unwrapped), after the lock is released either way.
-  let result: T;
+  // own error, unwrapped), after the lock is released either way. unlockAndRelease never
+  // throws, so the finally cannot mask fn's rejection.
   try {
-    result = await fn();
-  } catch (fnError) {
+    const result = await fn();
+    return { outcome: 'acquired', result };
+  } finally {
     await unlockAndRelease(client, lockKey);
-    throw fnError;
   }
-  await unlockAndRelease(client, lockKey);
-  return { outcome: 'acquired', result };
 }

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -85,7 +85,20 @@ async function unlockAndRelease(client: AdvisoryLockClient, lockKey: string): Pr
       lockKey.replace(/[\r\n]/g, ' '),
       err.message,
     );
-    client.release(err);
+    // This catch is also reached when the SUCCESS-path release() itself threw (e.g. a
+    // double-release from a hook, or a pool already shut down) — in that case this second
+    // release(err) throws synchronously too, and without the guard it would escape the catch
+    // and break the never-throws contract the caller's finally relies on (it would replace a
+    // successful fn() result with a rejection).
+    try {
+      client.release(err);
+    } catch (releaseError) {
+      console.error(
+        '[withAdvisoryLock:%s] Destroy-release also failed — connection already released or pool gone: %s',
+        lockKey.replace(/[\r\n]/g, ' '),
+        releaseError instanceof Error ? releaseError.message : String(releaseError),
+      );
+    }
   }
 }
 

--- a/packages/db/src/advisory-lock.ts
+++ b/packages/db/src/advisory-lock.ts
@@ -62,13 +62,35 @@ export type WithAdvisoryLockResult<T> =
     };
 
 /**
+ * Release the connection — destroying it when handed an error — swallowing any synchronous
+ * release failure (a double-release from a hook, a pool already shut down). Every exit of
+ * withAdvisoryLock funnels through this: a throwing release() must never replace the promised
+ * resolved outcome (acquired/lock_busy/connection_error) with a rejection. Logged plainly (not
+ * via @pagespace/lib's logger — packages/db must not depend on packages/lib). Never throws.
+ *
+ * The key is logged via JSON.stringify as a %s argument to a CONSTANT format string: lock keys
+ * can be derived from request-supplied ids (e.g. a per-conversation lock), so a raw key in the
+ * format position could smuggle %-directives, and unescaped newlines could forge log lines
+ * (CodeQL js/tainted-format-string, js/log-injection — PR #2097).
+ */
+function releaseQuietly(client: AdvisoryLockClient, lockKey: string, destroyWithError?: Error): void {
+  try {
+    client.release(destroyWithError);
+  } catch (releaseError) {
+    console.error(
+      '[withAdvisoryLock:%s] release() itself failed — connection already released or pool gone: %s',
+      JSON.stringify(lockKey),
+      releaseError instanceof Error ? releaseError.message : String(releaseError),
+    );
+  }
+}
+
+/**
  * Unlock and return the connection to the pool — or, when the unlock query itself fails,
  * destroy the connection instead. A session that failed to unlock may still hold the
  * session-level advisory lock; returned to the pool alive it would leak the lock permanently
  * (every future try-lock sees lock_busy forever). Postgres releases session advisory locks
- * when the backend dies, so destroying is the safe exit. Logged plainly (not via
- * @pagespace/lib's logger — packages/db must not depend on packages/lib) so a recurring
- * failure is operator-visible before the dedicated pool is starved. Never throws.
+ * when the backend dies, so destroying is the safe exit. Never throws.
  */
 async function unlockAndRelease(client: AdvisoryLockClient, lockKey: string): Promise<void> {
   try {
@@ -76,29 +98,15 @@ async function unlockAndRelease(client: AdvisoryLockClient, lockKey: string): Pr
     client.release();
   } catch (unlockError) {
     const err = unlockError instanceof Error ? unlockError : new Error(String(unlockError));
-    // Constant format string with the key passed as a %s argument, newlines stripped: lock keys
-    // can be derived from request-supplied ids (e.g. a per-conversation lock), so interpolating
-    // one into the format-string position would let a crafted key smuggle %-directives or forge
-    // log lines (CodeQL js/tainted-format-string, js/log-injection — PR #2097).
     console.error(
       '[withAdvisoryLock:%s] Advisory unlock failed — destroying the connection so the session lock cannot leak into the pool: %s',
-      lockKey.replace(/[\r\n]/g, ' '),
+      JSON.stringify(lockKey),
       err.message,
     );
-    // This catch is also reached when the SUCCESS-path release() itself threw (e.g. a
-    // double-release from a hook, or a pool already shut down) — in that case this second
-    // release(err) throws synchronously too, and without the guard it would escape the catch
-    // and break the never-throws contract the caller's finally relies on (it would replace a
-    // successful fn() result with a rejection).
-    try {
-      client.release(err);
-    } catch (releaseError) {
-      console.error(
-        '[withAdvisoryLock:%s] Destroy-release also failed — connection already released or pool gone: %s',
-        lockKey.replace(/[\r\n]/g, ' '),
-        releaseError instanceof Error ? releaseError.message : String(releaseError),
-      );
-    }
+    // Also reached when the SUCCESS-path release() above threw — releaseQuietly keeps the
+    // second (destroy) release from escaping and breaking the never-throws contract the
+    // caller's finally relies on.
+    releaseQuietly(client, lockKey, err);
   }
 }
 
@@ -122,14 +130,16 @@ export async function withAdvisoryLock<T>(
   try {
     lockResult = await client.query('SELECT pg_try_advisory_lock(hashtext($1)) AS acquired', [lockKey]);
   } catch (error) {
-    client.release(
-      new Error(`withAdvisoryLock(${lockKey}): try-lock query failed, connection left in an indeterminate state`),
+    releaseQuietly(
+      client,
+      lockKey,
+      new Error(`withAdvisoryLock(${JSON.stringify(lockKey)}): try-lock query failed, connection left in an indeterminate state`),
     );
     return { outcome: 'connection_error', error };
   }
 
   if (!lockResult.rows[0]?.acquired) {
-    client.release();
+    releaseQuietly(client, lockKey);
     return { outcome: 'lock_busy' };
   }
 

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -34,10 +34,20 @@ export default defineConfig({
         '**/node_modules/**',
       ],
       thresholds: {
+        // The /* ratchet:start */.../* ratchet:end */ markers are load-bearing:
+        // ../../scripts/coverage-ratchet.mjs rewrites only the four scalars between
+        // them. Without the markers its plain-regex fallback would stop at the
+        // per-glob sub-object's first `}` below and corrupt this block. Do not
+        // remove/move the markers, and do not add new scalar thresholds inside them.
+        /* ratchet:start */
         lines: 77,
         branches: 94,
         functions: 0,
         statements: 77,
+        /* ratchet:end */
+        // Advisory-lock primitive (Server Stream Durability epic, R.4 remediation):
+        // the lock/unlock/destroy decision paths are gated at 100% branch.
+        'src/advisory-lock.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
       },
     },
   },


### PR DESCRIPTION
Closes the reviewer-filed coverage findings from #2078 (E2 PR5 R.4 audit) plus one real server gap the same audit surfaced. Board: D.1/D.2/D.3 on the PR5 page + the epic-level mention-notification D task.

## 1. Mention notifications for materialized interrupted replies (the real bug)

`materializeInterruptedStream` never fired `notifyMentionedUsers`, so a reply that died mid-stream and @mentioned a user vanished without notifying anyone — the normal finalize path (`saveMessageToDatabase`) notifies behind the route's gate (page has a driveId, conversation explicitly shared, non-empty content).

RED first (commit 1), then GREEN mirroring that exact gate:

- Best-effort helper (`notifyMentionsBestEffort`) re-derives the route's gate from the DB (the route's in-memory `page`/`isConversationShared` died with the process): page lookup for `driveId` + `title` (mentioner name), conversation lookup for `isShared`, missing rows fail closed as private.
- **Exactly once**: the page-chat upsert now ends `.returning(...)`; the notification only fires when the compare-and-swap actually wrote. A row that already left `'streaming'` via its own onFinish (which already notified behind the same gate) can never double-page the mentioned user.
- Fire-and-forget and warned-not-thrown on failure — a notification failure never un-succeeds a durable materialization. Global-assistant rows never notify (no page mention surface; the global save path has no mentionNotify seam either).
- `materialize-interrupted-stream.ts` stays at 100% branch (36/36, up from 23 branches) with 11 new behavioral tests.

### Review follow-up (Codex P2): the gate travels with whichever terminal write lands first

Codex correctly flagged that the route's execute-end save (whose docblock says "when onFinish never runs, this write stands as the sole record") carried no `mentionNotify` — so in that gap the mention was lost and the materializer's CAS guard could never recover it. The root fix (RED `ff7957e0d`, GREEN `b64737ce6`): a route-scoped `mentionNotifyFor` helper + once-flag shared by **all three** writes that can flip the placeholder out of `'streaming'` (execute-end, onFinish, outer-catch cleanup). Whichever lands first carries the gate, exactly once per request; the flag latches only on a successful save so a failed execute-end persist still lets onFinish notify. Six new route tests pin the contract (execute-end alone, exactly-one-of-both, failed-execute-end fallback, private-conversation negative on every path, cleanup positive + negative).

## 2. Coverage gaps closed + thresholds ENFORCED in config

| Module | Branch before | Branch after | Per-glob 100% gate |
|---|---|---|---|
| `packages/db/src/advisory-lock.ts` | 90% (uncovered: non-Error unlock rejection) | **100%** | added (`packages/db/vitest.config.ts`) |
| `apps/web .../checkpoint-serialize.ts` | 93.33% (uncovered: `originRawIndex[droppedCount] ?? 0`) | **100%** | added (`apps/web/vitest.config.ts`) |
| `apps/web .../stream-join-poll-fallback.ts` | 78.94% (uncovered: aborted-mid-tick ×3, AbortError-name, non-Error tick rejection, missing `streams` field) | **100%** | added (`apps/web/vitest.config.ts`) |

All new tests assert behavior, not lines:

- **advisory-lock**: a non-Error unlock rejection must still be wrapped in an Error (pg's `release(err)` destroy contract), still destroy the connection, and stay operator-visible in the log.
- **checkpoint-serialize**: a mismatched/truncated `originRawIndex` falls back to `survivingFromRawIndex: 0` — the under-skip (self-correcting duplicate) direction, never the over-skip (permanent content loss) direction.
- **poll-fallback**: an abort landing at each await point inside an in-flight tick discards the stale snapshot (and never fires a bogus `onNotFound`); an abort that lands before the clearInterval listener is registered is caught by the per-tick entry guard; an `AbortError`-named rejection with a live signal stays silent but keeps polling; a `{}` body is terminal, not a crash.

## 3. Ratchet-script safety (why packages/db got sentinel markers)

`scripts/coverage-ratchet.mjs` covers `packages/db/vitest.config.ts`, and its plain-regex fallback (`thresholds:\s*\{[^}]+\}`) would truncate at the per-glob sub-object's first `}` and corrupt the block. The config now carries the same `/* ratchet:start */ … /* ratchet:end */` whole-line sentinel #2081 introduced for apps/web; `node scripts/coverage-ratchet.mjs --dry-run` verified both configs rewrite cleanly with the per-glob keys preserved.

## 4. advisory-lock flatten (why the source changed for a coverage task)

The last uncovered "branch" (line 105) was a v8 artifact: the catch→finally junction of a catch block that exits abruptly on every path — unreachable by any input, so no test could ever cover it. Per the epic's own rail ("threshold too hard = a branch you didn't design; fix the design") the function was flattened: the try-lock query gets its own catch, the `clientPoisoned` mutable flag is deleted, and the unlock/destroy logic moved to a named `unlockAndRelease` helper. All 7 pre-existing behavior tests pass unchanged — the contract (connection_error/lock_busy/acquired outcomes, destroy-on-poison, destroy-on-unlock-failure, fn errors propagate unwrapped) is untouched.

### Review follow-up 2 (CodeQL + self-review pass, `857f88dd6`)

- **CodeQL (js/tainted-format-string high, js/log-injection medium)**: the unlock-failure `console.error` interpolated `lockKey` into the format-string position; lock keys can derive from request-supplied ids. Now a constant format string with the key newline-stripped as a `%s` argument, pinned by a test (`evil\nkey\r%s` → logged as `evil key %s`, never in the format).
- **Cleanups from an 8-angle self-review pass** (behavior pinned by existing tests): advisory-lock's duplicated unlock collapsed to one `try/finally`; the route's gate+attach+latch trio centralized in `saveTerminalAssistantMessage` so a future terminal write can't break the exactly-once contract; dead `page.driveId` ternary removed (schema NOT NULL); the materializer's inline gate selects replaced with `pageRepository.findById` (also fixes: a page trashed between stream death and reap no longer triggers mention notifications) and `conversationRepository.getConversation` (the route's own `isConversationShared` source — the two gates can't drift). Cross-route mention-gate extraction (v1 completions) filed as an epic-level D task rather than done as a drive-by.

**Known limits (named honestly, filed as epic D tasks; confirmed independently by three self-review finder agents):** the exactly-once contract is best-effort. (a) Cross-process: an owner whose heartbeat *writes* fail 2+ minutes while the process stays alive can be reaped + notified by another instance, then re-notify via its own recovered terminal save (no status CAS on the route's upsert; once-flag is in-memory). (b) Intra-process: the latch flips only after the save resolves (deliberately — latching earlier would lose the mention on save failure), so the outer-catch cleanup racing a still-in-flight execute-end can double-attach. Both windows produce a **duplicate** ping, never a lost one — the epic's chosen direction; the durable fix (idempotent `createMentionNotification` per user+message) is filed. (c) Notification content is the buffered snapshot the first terminal save persists; refined-content-only mention text (would imply an onChunk forwarding gap) is not re-notified — also filed.

### Review follow-up 3 (CI regression from the never-throws hardening, `e0c0cdd25`)

The `518876d12` hardening (releaseQuietly on every advisory-lock exit, per CodeRabbit) changed one observable contract: the #2080 double-failure scenario (unlock query rejects **and** the destroy `release(err)` throws) no longer escapes `withAdvisoryLock`'s finally — it resolves `acquired` with `fn`'s result instead of rejecting an already-successful run. CI caught the one consumer test pinning the old shape (`start-generation-exclusive.test.ts`). Re-pinned to the new contract: the guarded property is unchanged (`run` executes exactly once, never re-invoked unlocked) and the caller now keeps the successful locked result instead of losing an already-started generation to lock-cleanup noise; destroy still attempted; no `lock_error` degrade telemetry. Stale docblock references to the old finally-can-throw behavior refreshed. Audited every other real-`withAdvisoryLock` consumer: `machine-storage-billing` branches on the resolved `connection_error` outcome (passes); the processor workers use their own pre-helper raw-pg copies (out of scope, unchanged).

## Verification

- `bun run typecheck`: 16/16 Turbo tasks green across the monorepo
- `packages/db` full `vitest run --coverage`: 421 passed, **zero threshold violations** (new per-glob gate enforced and passing). 8 failures are pre-existing environmental (`database "jono" does not exist` — the DB-backed compliance test that CI runs via `test-with-db`).
- `apps/web` full `vitest run --coverage`: 14,585 passed, **zero threshold violations** with both new per-glob gates enforced. 16 failures across 3 pre-existing environmental files (`role "test" does not exist` in activity-tools + admin-role-version — DB-backed; one timezone-dependent midnight test in messages/grouping) — none import any module this PR touches.
- `node scripts/coverage-ratchet.mjs --dry-run` clean on both touched configs (sentinel matched, per-glob keys preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
