### PR TITLE
feat(machines): root-or-branch dispatcher resolveMachineFilesHandle (epic task 1)

### DIFF
--- a/apps/web/src/lib/machines/__tests__/machine-files-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-files-runtime.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the root-or-branch dispatcher `resolveMachineFilesHandle`.
+ *
+ * Branch scope must delegate to `resolveBranchMachineHandle` with identical
+ * behavior (unchanged `not_found`/`vanished` reasons); root scope resolves
+ * through `resolveRootMachineHandle` and collapses a `null` handle (no live
+ * session — no tracking row exists to say why) into the coarser `not_started`
+ * reason.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockResolveRootMachineHandle, mockGetMachineHostForBranches, mockFindByName, mockAttach } = vi.hoisted(
+  () => ({
+    mockResolveRootMachineHandle: vi.fn(),
+    mockGetMachineHostForBranches: vi.fn(),
+    mockFindByName: vi.fn(),
+    mockAttach: vi.fn(),
+  }),
+);
+
+vi.mock('../machine-branches-runtime', () => ({
+  resolveRootMachineHandle: (...args: unknown[]) => mockResolveRootMachineHandle(...args),
+  getMachineHostForBranches: (...args: unknown[]) => mockGetMachineHostForBranches(...args),
+}));
+vi.mock('../machine-access-runtime', () => ({
+  canViewMachine: vi.fn(),
+  canEditMachine: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/machines/machine-branches-store', () => ({
+  createDbMachineBranchStore: vi.fn(async () => ({
+    findByName: (...args: unknown[]) => mockFindByName(...args),
+  })),
+}));
+
+import { resolveMachineFilesHandle, resolveBranchMachineHandle } from '../machine-files-runtime';
+
+const MACHINE = 'machine-1';
+const HANDLE = { machineId: 'sbx-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMachineHostForBranches.mockResolvedValue({ attach: (...args: unknown[]) => mockAttach(...args) });
+});
+
+describe('resolveMachineFilesHandle — root scope', () => {
+  it('resolves ok with the live handle when the root Machine has a session', async () => {
+    mockResolveRootMachineHandle.mockResolvedValue(HANDLE);
+
+    const result = await resolveMachineFilesHandle({ scope: 'root', machineId: MACHINE });
+
+    expect(mockResolveRootMachineHandle).toHaveBeenCalledWith(MACHINE);
+    expect(result).toEqual({ ok: true, handle: HANDLE });
+  });
+
+  it('maps a null handle to not_started (no tracking row to say never-started vs gone)', async () => {
+    mockResolveRootMachineHandle.mockResolvedValue(null);
+
+    const result = await resolveMachineFilesHandle({ scope: 'root', machineId: MACHINE });
+
+    expect(result).toEqual({ ok: false, reason: 'not_started' });
+  });
+});
+
+describe('resolveMachineFilesHandle — branch scope', () => {
+  const scope = { scope: 'branch' as const, machineId: MACHINE, projectName: 'p1', branchName: 'b1' };
+
+  it('delegates to resolveBranchMachineHandle and returns not_found when no tracking row exists', async () => {
+    mockFindByName.mockResolvedValue(undefined);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(mockFindByName).toHaveBeenCalledWith(MACHINE, 'p1', 'b1');
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    expect(mockResolveRootMachineHandle).not.toHaveBeenCalled();
+  });
+
+  it('delegates and returns vanished when the tracking row exists but the Sprite is gone', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(null);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(mockAttach).toHaveBeenCalledWith({ machineId: 'sbx-2' });
+    expect(result).toEqual({ ok: false, reason: 'vanished' });
+  });
+
+  it('delegates and returns ok with the reconnected handle when the row and Sprite both exist', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(HANDLE);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(result).toEqual({ ok: true, handle: HANDLE });
+  });
+
+  it('produces the exact same result as calling resolveBranchMachineHandle directly', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(HANDLE);
+
+    const dispatched = await resolveMachineFilesHandle(scope);
+    const direct = await resolveBranchMachineHandle(scope);
+
+    expect(dispatched).toEqual(direct);
+  });
+});

--- a/apps/web/src/lib/machines/machine-files-runtime.ts
+++ b/apps/web/src/lib/machines/machine-files-runtime.ts
@@ -2,25 +2,29 @@
  * Production wiring for the Machine Files browse API (Machine page rebuild,
  * Phase 1 — working-tree file browsing).
  *
- * Resolves a branch-terminal's LIVE `MachineHandle` (its own Sprite) so the
- * route can drive the provider-neutral `listMachineDirectory`/`readMachineFile`
- * primitives against it. Reuses the branch store + the `MachineHost` seam and
- * the shared view-access check from the canonical `machine-access-runtime` — no
- * bespoke authz and no direct Sprites-SDK import.
+ * Resolves a branch-terminal's or the root Machine's LIVE `MachineHandle` so
+ * the route can drive the provider-neutral `listMachineDirectory`/
+ * `readMachineFile` primitives against it. Reuses the branch store + the
+ * `MachineHost` seam and the shared view/edit-access checks from the
+ * canonical `machine-access-runtime` — no bespoke authz and no direct
+ * Sprites-SDK import.
  *
- * Branch scope only: a branch-terminal holds its own Sprite addressed by a
- * stored `sandboxId`, so `host.attach` reconnects to exactly the machine whose
- * checkout the user is browsing. Machine/project-scope browse would resolve
- * through the shared persistent-session acquire path instead and is a separate
- * follow-up.
+ * `resolveMachineFilesHandle` is the dispatcher every Files-tab caller should
+ * use: branch scope delegates to `resolveBranchMachineHandle` below
+ * (unchanged); root scope resolves through `resolveRootMachineHandle`
+ * (`./machine-branches-runtime`) — the shared persistent-session read path,
+ * never provisioning. Root scope has no tracking row to distinguish "never
+ * started" from "gone", so a `null` handle collapses to the single coarser
+ * `not_started` reason rather than reusing branch scope's `not_found`/
+ * `vanished` split.
  */
 
 import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
 import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
-import { getMachineHostForBranches } from './machine-branches-runtime';
-import { canViewMachine } from './machine-access-runtime';
+import { getMachineHostForBranches, resolveRootMachineHandle } from './machine-branches-runtime';
+import { canViewMachine, canEditMachine } from './machine-access-runtime';
 
-export { canViewMachine };
+export { canViewMachine, canEditMachine };
 
 export type ResolveBranchMachineHandleResult =
   | { ok: true; handle: MachineHandle }
@@ -48,4 +52,27 @@ export async function resolveBranchMachineHandle({
   const handle = await host.attach({ machineId: existing.sandboxId });
   if (!handle) return { ok: false, reason: 'vanished' };
   return { ok: true, handle };
+}
+
+export type MachineFilesScope =
+  | { scope: 'root'; machineId: string }
+  | { scope: 'branch'; machineId: string; projectName: string; branchName: string };
+
+export type ResolveMachineFilesHandleResult =
+  | { ok: true; handle: MachineHandle }
+  | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
+
+/**
+ * Root-or-branch dispatcher for the Files tab. Branch scope is a pure
+ * delegation to `resolveBranchMachineHandle` (byte-for-byte identical
+ * behavior); root scope resolves the Machine's own persistent Sprite via
+ * `resolveRootMachineHandle`, mapping a `null` (no live session) to
+ * `not_started`.
+ */
+export async function resolveMachineFilesHandle(
+  scope: MachineFilesScope,
+): Promise<ResolveMachineFilesHandleResult> {
+  if (scope.scope === 'branch') return resolveBranchMachineHandle(scope);
+  const handle = await resolveRootMachineHandle(scope.machineId);
+  return handle ? { ok: true, handle } : { ok: false, reason: 'not_started' };
 }


### PR DESCRIPTION
## Summary
- Adds `resolveMachineFilesHandle` — the root-or-branch dispatcher every Files-tab caller (route GET, and later mutation tasks) will use.
- Branch scope: pure delegation to `resolveBranchMachineHandle`, byte-for-byte unchanged behavior.
- Root scope: resolves via `resolveRootMachineHandle` (`./machine-branches-runtime`, read-only, never provisions); a `null` handle maps to the coarser `not_started` reason (no tracking row exists to distinguish "never started" from "gone").
- Re-exports `canEditMachine` from `./machine-access-runtime` alongside the existing `canViewMachine` re-export, for later mutation tasks.
- Updates the module doc: root/machine-scope browse is no longer a "separate follow-up" — this task is that follow-up.

Part of the **Machine Files Manager** epic (Phase 1, task 1). Blocks task 2 (route GET root scope).

Design doc: `~/.claude/plans/refactored-finding-biscuit.md`, Step 1.

## Test plan
- [x] New test `apps/web/src/lib/machines/__tests__/machine-files-runtime.test.ts` — root+handle→ok, root+null→`not_started`, branch delegation (not_found / vanished / ok), dispatcher output matches calling `resolveBranchMachineHandle` directly.
- [x] `bun run typecheck` (full monorepo build) green — 16/16 tasks successful.
- [x] `resolveBranchMachineHandle`/`ResolveBranchMachineHandleResult` byte-for-byte unchanged; diff/git-blob routes + tests untouched and green (`git diff --stat` touches only `machine-files-runtime.ts` + new test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnk5ZDqJCMMxyzwoWmaJor