### PR TITLE
feat(machines): FilesScope vocabulary + not_started absence state (epic task 3)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -28,12 +28,12 @@
  *      binary. A flood of U+FFFD (bytes the server's decoder couldn't map) is
  *      the same conclusion by a different route.
  *
- * A checkout that has gone away is NOT an error here: the route's `reason` is
- * mapped through the shared {@link CHECKOUT_ABSENT_COPY}, so the pane says the
+ * A scope that has gone away is NOT an error here: the route's `reason` is
+ * mapped through the shared {@link FILES_ABSENT_COPY}, so the pane says the
  * same words the sidebar says, at the same moment, about the same fact. The
- * route keeps `not_found`/`vanished` (this branch has no checkout) distinct from
- * `file_not_found` (the checkout is fine; that one file is gone), so we can tell
- * the reader which of the two actually happened instead of guessing.
+ * route keeps `not_found`/`vanished`/`not_started` (this scope isn't reachable)
+ * distinct from `file_not_found` (the scope is fine; that one file is gone), so
+ * we can tell the reader which of the two actually happened instead of guessing.
  */
 
 import { useEffect, useState } from 'react';
@@ -43,7 +43,7 @@ import { detectLanguageFromFilename, isBinaryFile } from '@pagespace/lib/utils/l
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Button } from '@/components/ui/button';
 import { PaneLoading, PaneNotice } from './tab-states';
-import { CHECKOUT_ABSENT_COPY, asAbsentReason, readErrorBody, type CheckoutAbsentReason } from './checkout-states';
+import { FILES_ABSENT_COPY, asAbsentReason, readErrorBody, type FilesAbsentReason } from './checkout-states';
 
 // Monaco pulls the editor bundle + `window`, so it must never SSR — matches
 // every other MonacoEditor mount in the app (CodePageView, DocumentView, …).
@@ -69,7 +69,7 @@ type FileState =
   | { status: 'loading' }
   | { status: 'loaded'; path: string; content: string; truncated: boolean }
   | { status: 'binary'; path: string }
-  | { status: 'absent'; path: string; reason: CheckoutAbsentReason }
+  | { status: 'absent'; path: string; reason: FilesAbsentReason }
   | { status: 'error'; path: string; message: string };
 
 const NUL_CHAR_CODE = 0;
@@ -219,8 +219,8 @@ export default function FilesFilePane({ machineId, projectName, branchName, path
         {current.status === 'absent' && (
           <PaneNotice
             testId="checkout-absent-pane"
-            title={CHECKOUT_ABSENT_COPY[current.reason].title}
-            description={CHECKOUT_ABSENT_COPY[current.reason].description}
+            title={FILES_ABSENT_COPY[current.reason].title}
+            description={FILES_ABSENT_COPY[current.reason].description}
           />
         )}
         {current.status === 'error' && (

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -37,10 +37,10 @@ import FilesFilePane from './FilesFilePane';
 import TabSidebar from './TabSidebar';
 import { PaneNotice, SidebarLoading, SidebarNotice } from './tab-states';
 import {
-  CHECKOUT_ABSENT_COPY,
+  FILES_ABSENT_COPY,
   asAbsentReason,
   readErrorBody,
-  type CheckoutAbsentReason,
+  type FilesAbsentReason,
 } from './checkout-states';
 
 interface FilesTabProps {
@@ -153,7 +153,7 @@ export default function FilesTab({ machineId }: FilesTabProps) {
 type CheckoutState =
   | { status: 'loading' }
   | { status: 'ready' }
-  | { status: 'absent'; reason: CheckoutAbsentReason }
+  | { status: 'absent'; reason: FilesAbsentReason }
   | { status: 'error'; message: string };
 
 /**
@@ -239,7 +239,7 @@ function BranchFiles({
   const retry = () => setAttempt((a) => a + 1);
 
   if (state.status === 'absent') {
-    const copy = CHECKOUT_ABSENT_COPY[state.reason];
+    const copy = FILES_ABSENT_COPY[state.reason];
     return (
       <SidebarNotice
         testId="checkout-absent"

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/__tests__/files-scope.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/__tests__/files-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { filesScopeKey, filesScopeSearchParams } from '../files-scope';
+
+describe('filesScopeKey', () => {
+  it('given root scope, should return the bare literal "root"', () => {
+    expect(filesScopeKey({ kind: 'root' })).toBe('root');
+  });
+
+  it('given branch scope, should return a JSON-encoded key distinct from "root"', () => {
+    const key = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'main' });
+    expect(key).not.toBe('root');
+    expect(key).toBe(JSON.stringify(['branch', 'proj', 'main']));
+  });
+
+  it('given a branch name containing "/", should still never collide with the root key', () => {
+    const key = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'feature/root' });
+    expect(key).not.toBe('root');
+  });
+
+  it('given two different branches, should produce different keys', () => {
+    const a = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'main' });
+    const b = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'dev' });
+    expect(a).not.toBe(b);
+  });
+
+  it('given the same scope twice, should return a stable, equal key', () => {
+    const scope = { kind: 'branch' as const, projectName: 'proj', branchName: 'main' };
+    expect(filesScopeKey(scope)).toBe(filesScopeKey({ ...scope }));
+  });
+});
+
+describe('filesScopeSearchParams', () => {
+  it('given root scope, should include machineId but omit projectName/branchName', () => {
+    const params = filesScopeSearchParams('machine-1', { kind: 'root' });
+    expect(params.get('machineId')).toBe('machine-1');
+    expect(params.has('projectName')).toBe(false);
+    expect(params.has('branchName')).toBe(false);
+  });
+
+  it('given branch scope, should include machineId, projectName, and branchName', () => {
+    const params = filesScopeSearchParams('machine-1', { kind: 'branch', projectName: 'proj', branchName: 'main' });
+    expect(params.get('machineId')).toBe('machine-1');
+    expect(params.get('projectName')).toBe('proj');
+    expect(params.get('branchName')).toBe('main');
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
@@ -1,32 +1,35 @@
 /**
- * Shared vocabulary for the Files tab's "the checkout isn't there" states
- * (Machine page rebuild, Phase 3).
+ * Shared vocabulary for the Files tab's "there's nothing browsable here"
+ * states (Machine Files Manager epic).
  *
- * The files route reports why a branch checkout couldn't be reached with a typed
- * `reason` (see `machine-files-runtime.ts` / `route.ts`), and BOTH surfaces of
- * the tab have to speak about it: the sidebar (which can't list files) and the
- * main pane (which can't read the open file). They live in separate modules and
- * the tab imports the pane, so this copy lives here rather than in either one —
- * importing it back out of FilesTab would be a cycle.
+ * The files route reports why a scope (root Sprite or branch checkout)
+ * couldn't be reached with a typed `reason` (see `machine-files-runtime.ts` /
+ * `route.ts`), and BOTH surfaces of the tab have to speak about it: the
+ * sidebar (which can't list files) and the main pane (which can't read the
+ * open file). They live in separate modules and the tab imports the pane, so
+ * this copy lives here rather than in either one — importing it back out of
+ * FilesTab would be a cycle.
  *
  * The user-facing rule this encodes: NEVER render the route's internal phrasing
- * ("Branch machine vanished") at a person. A checkout that isn't there is a
+ * ("Branch machine vanished") at a person. A scope that isn't reachable is a
  * state of the world, not an error message.
  */
 
 /**
- * The route's absence reasons — a branch we cannot reach a checkout for.
+ * The route's absence reasons — a scope we cannot reach a filesystem for.
  *
- * Note what is NOT here: `file_not_found`. A missing FILE is a fact about one
- * path inside a checkout that exists; these two are facts about the checkout
- * itself. The route keeps the tokens distinct precisely so a client cannot tell
- * a reader "this file is gone" when the whole branch is.
+ * Note what is NOT here: `file_not_found`/`dir_not_found`. A missing file or
+ * folder is a fact about one path inside a scope that IS reachable; these
+ * three are facts about the scope itself (no checkout, checkout reclaimed,
+ * machine never started). The route keeps the tokens distinct precisely so a
+ * client cannot tell a reader "this path is gone" when the whole scope is.
  */
-export type CheckoutAbsentReason = 'not_found' | 'vanished';
+export type FilesAbsentReason = 'not_found' | 'vanished' | 'not_started';
 
-export const CHECKOUT_ABSENT_COPY: Record<CheckoutAbsentReason, { title: string; description: string }> = {
-  // Covers both of the route's 404 sources: no `machine_branches` row at all,
-  // and a row whose Sprite has no `/workspace/repo` yet (never cloned).
+export const FILES_ABSENT_COPY: Record<FilesAbsentReason, { title: string; description: string }> = {
+  // Covers both of the route's 404 sources for branch scope: no
+  // `machine_branches` row at all, and a row whose Sprite has no
+  // `/workspace/repo` yet (never cloned).
   not_found: {
     title: "This branch hasn't been checked out yet",
     description: 'Open a terminal on this branch to clone it, then check again.',
@@ -35,11 +38,18 @@ export const CHECKOUT_ABSENT_COPY: Record<CheckoutAbsentReason, { title: string;
     title: 'This branch checkout is gone',
     description: 'Its sandbox was reclaimed. Open a terminal on the branch to check it out again.',
   },
+  // Root scope only: no `machine_branches` row exists to distinguish "this
+  // machine's Sprite never started" from "it's gone" the way branch scope
+  // can — so this is deliberately coarser than `not_found`/`vanished`.
+  not_started: {
+    title: "This machine hasn't been started yet",
+    description: 'Open the Terminal tab to start it, then check again.',
+  },
 };
 
 /** Narrows an unknown response body's `reason` to one we have copy for. */
-export const asAbsentReason = (reason: unknown): CheckoutAbsentReason | null =>
-  reason === 'not_found' || reason === 'vanished' ? reason : null;
+export const asAbsentReason = (reason: unknown): FilesAbsentReason | null =>
+  reason === 'not_found' || reason === 'vanished' || reason === 'not_started' ? reason : null;
 
 /** `{ error, reason }` off a files-route failure body, without trusting its shape. */
 export const readErrorBody = (body: unknown): { error: string | null; reason: unknown } => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared vocabulary for what the Files tab is browsing: either the Machine's
+ * own root Sprite filesystem (`/workspace`), or a project/branch checkout
+ * within it (Machine Files Manager epic, Part A).
+ *
+ * Lives in `tabs/` rather than `workspace/` because `MachineFileTree` already
+ * imports from `../tabs/checkout-states` — same precedent, no import cycle.
+ */
+
+export type FilesScope = { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
+
+/**
+ * Stable identity for a scope — used as a React key so switching scopes (root
+ * to branch, or between branches) remounts rather than reusing stale state.
+ *
+ * JSON-encoded rather than joined on a separator so that no project/branch
+ * name pair can collide with another (a branch name may legally contain
+ * `/`), mirroring `branchKey` in FilesTab.tsx. `'root'` is a bare literal
+ * that can never equal a `JSON.stringify([...])` result, so root and branch
+ * keys can never collide with each other either.
+ */
+export const filesScopeKey = (scope: FilesScope): string =>
+  scope.kind === 'root' ? 'root' : JSON.stringify(['branch', scope.projectName, scope.branchName]);
+
+/** The files route's query params for a given scope — `projectName`/`branchName` only appear for branch scope. */
+export const filesScopeSearchParams = (machineId: string, scope: FilesScope): URLSearchParams => {
+  const params = new URLSearchParams({ machineId });
+  if (scope.kind === 'branch') {
+    params.set('projectName', scope.projectName);
+    params.set('branchName', scope.branchName);
+  }
+  return params;
+};

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
@@ -22,7 +22,13 @@ export type FilesScope = { kind: 'root' } | { kind: 'branch'; projectName: strin
 export const filesScopeKey = (scope: FilesScope): string =>
   scope.kind === 'root' ? 'root' : JSON.stringify(['branch', scope.projectName, scope.branchName]);
 
-/** The files route's query params for a given scope — `projectName`/`branchName` only appear for branch scope. */
+/**
+ * The files route's query params for a given scope — `projectName`/`branchName`
+ * only appear for branch scope. The route itself doesn't accept root-scope
+ * requests yet (that's a separate epic task landing the GET root-scope
+ * support); this helper is forward-declared so FilesTab/MachineFileTree can
+ * adopt `FilesScope` in one place once both land, rather than twice.
+ */
 export const filesScopeSearchParams = (machineId: string, scope: FilesScope): URLSearchParams => {
   const params = new URLSearchParams({ machineId });
   if (scope.kind === 'branch') {


### PR DESCRIPTION
## Summary
- New `files-scope.ts`: `FilesScope` union (`root` | `branch`), `filesScopeKey` (JSON-encoded so `'root'` can never collide with a JSON-encoded branch key — branch names may legally contain `/`), and `filesScopeSearchParams` (machineId always; projectName/branchName appended only for branch scope). Placed in `tabs/` since `workspace/MachineFileTree.tsx` already imports from `../tabs/checkout-states` — same precedent, no cycle.
- `checkout-states.ts`: renamed `CheckoutAbsentReason` → `FilesAbsentReason`, `CHECKOUT_ABSENT_COPY` → `FILES_ABSENT_COPY` (vocabulary now covers root scope, not just branch checkouts). Added `not_started` reason + copy ("This machine hasn't been started yet" / "Open the Terminal tab to start it, then check again."). Module doc refreshed to explain the three-reason taxonomy and why `file_not_found`/`dir_not_found` stay excluded.
- Mechanically updated importers `FilesTab.tsx` and `FilesFilePane.tsx` for the rename — zero behavior change. `readErrorBody` untouched.
- New colocated tests: `tabs/__tests__/files-scope.test.ts` covering key collision-freedom (root vs branch, branch names containing `/`) and search-param shape (root omits branch params).

This is Step 3 / task 3 of the Machine Files Manager epic — shared client vocabulary that FilesTab / MachineFileTree / FilesFilePane (tasks 4–6, currently blocked on this) will consume. Full design: `~/.claude/plans/refactored-finding-biscuit.md`.

## Test plan
- [x] `bun run typecheck` (full monorepo build via Turbo) — green, 16/16 tasks
- [x] `bunx vitest run` on `FilesTab.test.tsx`, `FilesFilePane.test.tsx`, `MachineFileTree.test.tsx`, `files-scope.test.ts` from `apps/web` — 50/50 passing, rename is invisible to existing behavior
- [ ] Manual pass deferred to downstream tasks (4–6) which own the actual UI wiring of `FilesScope`

🤖 Generated with [Claude Code](https://claude.com/claude-code)