### PR TITLE
feat(sandbox): machine-fs write primitives — mkdir/write/move/copy/delete (epic task 7)

### DIFF
--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -246,7 +246,7 @@ describe('writeMachineFile', () => {
 });
 
 describe('moveMachinePath', () => {
-  it('runs the `test -e` guard then `mv -T -- <from> <to>` when the destination is free', async () => {
+  it('runs the `test -e -o -L` guard then `mv -T -- <from> <to>` when the destination is free', async () => {
     const { handle, calls } = makeExecRecorder((args) => {
       if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
       return { exitCode: 0, stdout: '', stderr: '' };
@@ -260,7 +260,7 @@ describe('moveMachinePath', () => {
 
     expect(result).toEqual({ ok: true });
     expect(calls).toEqual([
-      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt'] },
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt', '-o', '-L', '/workspace/repo/b.txt'] },
       { cmd: 'mv', args: ['-T', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
     ]);
   });
@@ -275,7 +275,32 @@ describe('moveMachinePath', () => {
     });
 
     expect(result).toEqual({ ok: false, reason: 'already_exists' });
-    expect(calls).toEqual([{ cmd: 'test', args: ['-e', '/workspace/repo/existing.txt'] }]);
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/existing.txt', '-o', '-L', '/workspace/repo/existing.txt'] },
+    ]);
+    expect(calls.some((c) => c.cmd === 'mv')).toBe(false);
+  });
+
+  it('returns already_exists (not a clobber) when the destination is a dangling symlink', async () => {
+    // `test -e` alone follows symlinks and would report `false` for a symlink
+    // whose target is missing; only `-L` also matches it. Simulate a driver
+    // that faithfully implements that distinction: `-e` fails, `-e -o -L` (as
+    // this guard sends it) succeeds.
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') {
+        const isDanglingSymlinkAware = args.args?.includes('-L');
+        return { exitCode: isDanglingSymlinkAware ? 0 : 1, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/dangling-link',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
     expect(calls.some((c) => c.cmd === 'mv')).toBe(false);
   });
 
@@ -315,7 +340,7 @@ describe('moveMachinePath', () => {
 });
 
 describe('copyMachinePath', () => {
-  it('runs the `test -e` guard then `cp -a -- <from> <to>` when the destination is free', async () => {
+  it('runs the `test -e -o -L` guard then `cp -a -- <from> <to>` when the destination is free', async () => {
     const { handle, calls } = makeExecRecorder((args) => {
       if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
       return { exitCode: 0, stdout: '', stderr: '' };
@@ -329,7 +354,7 @@ describe('copyMachinePath', () => {
 
     expect(result).toEqual({ ok: true });
     expect(calls).toEqual([
-      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt'] },
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt', '-o', '-L', '/workspace/repo/b.txt'] },
       { cmd: 'cp', args: ['-a', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
     ]);
   });
@@ -344,7 +369,28 @@ describe('copyMachinePath', () => {
     });
 
     expect(result).toEqual({ ok: false, reason: 'already_exists' });
-    expect(calls).toEqual([{ cmd: 'test', args: ['-e', '/workspace/repo/existing.txt'] }]);
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/existing.txt', '-o', '-L', '/workspace/repo/existing.txt'] },
+    ]);
+    expect(calls.some((c) => c.cmd === 'cp')).toBe(false);
+  });
+
+  it('returns already_exists (not a clobber) when the destination is a dangling symlink', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') {
+        const isDanglingSymlinkAware = args.args?.includes('-L');
+        return { exitCode: isDanglingSymlinkAware ? 0 : 1, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/dangling-link',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
     expect(calls.some((c) => c.cmd === 'cp')).toBe(false);
   });
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { listMachineDirectory, readMachineFile } from '../machine-fs';
+import {
+  listMachineDirectory,
+  readMachineFile,
+  createMachineDirectory,
+  writeMachineFile,
+  moveMachinePath,
+  copyMachinePath,
+  deleteMachinePath,
+} from '../machine-fs';
 import type { MachineHandle } from '../machine-host';
 import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+import type { WriteFileEntry } from '../sandbox-client/types';
 
 /**
  * The primitives take a `MachineHandle` as an injected dependency, so a fake
@@ -11,13 +20,14 @@ import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
 function makeHandle(overrides: {
   exec?: (args: RunCommandArgs) => Promise<SandboxRunResult>;
   readFile?: (args: { path: string }) => Promise<Buffer | null>;
+  writeFiles?: (files: WriteFileEntry[]) => Promise<void>;
 }): MachineHandle {
   return {
     machineId: 'sbx-test',
     spriteInstanceId: null,
     exec: overrides.exec ?? (async () => ({ exitCode: 0, stdout: '', stderr: '' })),
     readFile: overrides.readFile ?? (async () => null),
-    writeFiles: async () => {},
+    writeFiles: overrides.writeFiles ?? (async () => {}),
     createCheckpoint: async () => {},
     stream: async () => {
       throw new Error('stream() is not used by the fs primitives');
@@ -25,6 +35,20 @@ function makeHandle(overrides: {
     listStreams: async () => [],
     killSession: async () => {},
   };
+}
+
+/** Records every `exec` call's argv for assertions on argv shape/ordering. */
+function makeExecRecorder(
+  responder: (args: RunCommandArgs) => SandboxRunResult,
+): { handle: MachineHandle; calls: RunCommandArgs[] } {
+  const calls: RunCommandArgs[] = [];
+  const handle = makeHandle({
+    exec: async (args) => {
+      calls.push(args);
+      return responder(args);
+    },
+  });
+  return { handle, calls };
 }
 
 describe('listMachineDirectory', () => {
@@ -121,5 +145,257 @@ describe('readMachineFile', () => {
     const handle = makeHandle({ readFile: async () => null });
     const result = await readMachineFile({ handle, path: '/workspace/repo/missing' });
     expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('createMachineDirectory', () => {
+  it('invokes `mkdir -- <path>` and reports success on exit 0', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await createMachineDirectory({ handle, path: '/workspace/repo/new-dir' });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([{ cmd: 'mkdir', args: ['--', '/workspace/repo/new-dir'] }]);
+  });
+
+  it('a leading-dash path is passed after `--`, never read as a flag', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    await createMachineDirectory({ handle, path: '-weird-dir' });
+
+    expect(calls).toEqual([{ cmd: 'mkdir', args: ['--', '-weird-dir'] }]);
+  });
+
+  it('maps "File exists" stderr to already_exists', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: "mkdir: cannot create directory '/workspace/repo/x': File exists\n",
+      }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/workspace/repo/x' });
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+  });
+
+  it('maps a missing parent ("No such file or directory") to not_found', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: "mkdir: cannot create directory '/workspace/missing/x': No such file or directory\n",
+      }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/workspace/missing/x' });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('maps any other nonzero exit to exec_failed with trimmed stderr detail', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'mkdir: permission denied\n' }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/root/x' });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'mkdir: permission denied' });
+  });
+});
+
+describe('writeMachineFile', () => {
+  it('calls handle.writeFiles with the path and content, and reports success', async () => {
+    let seen: WriteFileEntry[] | undefined;
+    const handle = makeHandle({
+      writeFiles: async (files) => {
+        seen = files;
+      },
+    });
+
+    const result = await writeMachineFile({
+      handle,
+      path: '/workspace/repo/README.md',
+      content: 'hello',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(seen).toEqual([{ path: '/workspace/repo/README.md', content: 'hello' }]);
+  });
+
+  it('accepts Uint8Array content and passes it through unchanged', async () => {
+    let seen: WriteFileEntry[] | undefined;
+    const bytes = new Uint8Array([1, 2, 3]);
+    const handle = makeHandle({
+      writeFiles: async (files) => {
+        seen = files;
+      },
+    });
+
+    await writeMachineFile({ handle, path: '/workspace/repo/bin.dat', content: bytes });
+
+    expect(seen).toEqual([{ path: '/workspace/repo/bin.dat', content: bytes }]);
+  });
+
+  it('folds a driver throw into exec_failed with the error message as detail', async () => {
+    const handle = makeHandle({
+      writeFiles: async () => {
+        throw new Error('disk full');
+      },
+    });
+
+    const result = await writeMachineFile({ handle, path: '/workspace/repo/x', content: 'y' });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'disk full' });
+  });
+});
+
+describe('moveMachinePath', () => {
+  it('runs the `test -e` guard then `mv -T -- <from> <to>` when the destination is free', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt'] },
+      { cmd: 'mv', args: ['-T', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
+    ]);
+  });
+
+  it('returns already_exists without calling mv when the guard finds the destination present', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/existing.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls).toEqual([{ cmd: 'test', args: ['-e', '/workspace/repo/existing.txt'] }]);
+    expect(calls.some((c) => c.cmd === 'mv')).toBe(false);
+  });
+
+  it('maps a missing source to not_found', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: "mv: cannot stat '/workspace/repo/gone.txt': No such file or directory\n",
+      };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/gone.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('maps any other mv failure to exec_failed', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 1, stdout: '', stderr: 'mv: permission denied\n' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'mv: permission denied' });
+  });
+});
+
+describe('copyMachinePath', () => {
+  it('runs the `test -e` guard then `cp -a -- <from> <to>` when the destination is free', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt'] },
+      { cmd: 'cp', args: ['-a', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
+    ]);
+  });
+
+  it('returns already_exists without calling cp when the guard finds the destination present', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/existing.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls).toEqual([{ cmd: 'test', args: ['-e', '/workspace/repo/existing.txt'] }]);
+    expect(calls.some((c) => c.cmd === 'cp')).toBe(false);
+  });
+
+  it('maps a missing source to not_found', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: "cp: cannot stat '/workspace/repo/gone.txt': No such file or directory\n",
+      };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/gone.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('deleteMachinePath', () => {
+  it('invokes `rm -rf -- <path>` and reports success', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await deleteMachinePath({ handle, path: '/workspace/repo/tmp' });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([{ cmd: 'rm', args: ['-rf', '--', '/workspace/repo/tmp'] }]);
+  });
+
+  it('is idempotent: deleting an already-missing path still reports ok: true', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    });
+
+    const result = await deleteMachinePath({ handle, path: '/workspace/repo/already-gone' });
+
+    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it('maps a nonzero exit to exec_failed with stderr detail', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'rm: permission denied\n' }),
+    });
+
+    const result = await deleteMachinePath({ handle, path: '/root/protected' });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'rm: permission denied' });
   });
 });

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -1,28 +1,39 @@
 /**
- * Machine filesystem browsing primitives (pure, DI'd).
+ * Machine filesystem browse + mutate primitives (pure, DI'd).
  *
- * Two functions the human-facing Machine page uses to browse a Machine's
+ * The human-facing Machine page's Files tab drives these against a Machine's
  * WORKING TREE — the live files on a Sprite's persistent filesystem, e.g. a
  * branch-terminal's checkout at `/workspace/repo`:
  *
  *   listMachineDirectory — one directory's immediate children ({ name, type }).
  *   readMachineFile      — one file's bytes.
+ *   createMachineDirectory — mkdir a new directory.
+ *   writeMachineFile     — create or overwrite a file's bytes.
+ *   moveMachinePath      — rename/move a path (no-clobber).
+ *   copyMachinePath      — copy a path (no-clobber).
+ *   deleteMachinePath    — remove a path, recursively, idempotently.
  *
- * Both take a `MachineHandle` (./machine-host.ts) as an INJECTED dependency
- * rather than constructing a Sprite host themselves, mirroring the DI shape of
- * `runGitInSandbox` (./git-tool-runners.ts). That keeps them unit-testable
- * against a fake handle with zero real Sprite calls, per the repo's
- * pure-functions-plus-DI build mandate.
+ * All seven take a `MachineHandle` (./machine-host.ts) as an INJECTED
+ * dependency rather than constructing a Sprite host themselves, mirroring the
+ * DI shape of `runGitInSandbox` (./git-tool-runners.ts). That keeps them
+ * unit-testable against a fake handle with zero real Sprite calls, per the
+ * repo's pure-functions-plus-DI build mandate.
  *
- * SCOPE BOUNDARY: this reads the working tree ONLY — it is filesystem-level and
- * takes no git ref. A diff tab's "before" content needs git-object reads, a
- * separate git-ref-aware service that depends on this one; do NOT add a ref
- * parameter here.
+ * PATH CONTRACT: every `path`/`fromPath`/`toPath` argument here MUST already be
+ * an absolute, pre-confined path — confinement (resolving `..`/symlink escapes
+ * against the caller's scope root) is the calling ROUTE's job, done EXACTLY
+ * ONCE before it reaches this module (PR #2039 TOCTOU lesson: never re-derive
+ * or re-validate a path down here from a name/fragment).
  *
- * This runs commands through `MachineHandle.exec`/`readFile`, deliberately NOT
- * through the AI-agent tool-runner orchestration (billing holds, injection
- * screening, LLM-facing denial vocabulary) — that layer is shaped for an agent,
- * not a browsing UI.
+ * SCOPE BOUNDARY: this operates on the working tree ONLY — it is
+ * filesystem-level and takes no git ref. A diff tab's "before" content needs
+ * git-object reads, a separate git-ref-aware service that depends on this one;
+ * do NOT add a ref parameter here.
+ *
+ * This runs commands through `MachineHandle.exec`/`readFile`/`writeFiles`,
+ * deliberately NOT through the AI-agent tool-runner orchestration (billing
+ * holds, injection screening, LLM-facing denial vocabulary) — that layer is
+ * shaped for an agent, not a browsing UI.
  */
 
 import type { MachineHandle } from './machine-host';
@@ -40,6 +51,10 @@ export type ListMachineDirectoryResult =
 export type ReadMachineFileResult =
   | { ok: true; content: Buffer }
   | { ok: false; reason: 'not_found' };
+
+export type MutateMachinePathResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'already_exists' | 'exec_failed'; detail?: string };
 
 /**
  * List a directory's immediate children on a Machine.
@@ -88,4 +103,140 @@ export async function readMachineFile({
   const content = await handle.readFile({ path });
   if (content === null) return { ok: false, reason: 'not_found' };
   return { ok: true, content };
+}
+
+/** Maps a failed exec's stderr to a `MutateMachinePathResult`, optionally treating a caller-supplied pattern as `already_exists` first. */
+function mapMutateExecFailure(
+  stderr: string,
+  alreadyExistsPattern?: RegExp,
+): MutateMachinePathResult {
+  if (alreadyExistsPattern?.test(stderr)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  if (/no such file or directory/i.test(stderr)) {
+    return { ok: false, reason: 'not_found' };
+  }
+  return { ok: false, reason: 'exec_failed', detail: stderr.trim() || undefined };
+}
+
+/**
+ * Create one directory on a Machine.
+ *
+ * `path` is an argv element, never shell-parsed; `--` stops a path that begins
+ * with `-` being read as a flag (mirrors `listMachineDirectory`'s `ls` call).
+ */
+export async function createMachineDirectory({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<MutateMachinePathResult> {
+  const run = await handle.exec({ cmd: 'mkdir', args: ['--', path] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr, /file exists/i);
+  }
+  return { ok: true };
+}
+
+/**
+ * Create or overwrite one file's bytes on a Machine's working tree. A thin
+ * wrapper over `MachineHandle.writeFiles`, which has no stderr channel — it
+ * either resolves or throws — so a throw is folded into `exec_failed`.
+ */
+export async function writeMachineFile({
+  handle,
+  path,
+  content,
+}: {
+  handle: MachineHandle;
+  path: string;
+  content: string | Uint8Array;
+}): Promise<MutateMachinePathResult> {
+  try {
+    await handle.writeFiles([{ path, content }]);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'exec_failed',
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * `test -e <path>` (no `--`: `test` doesn't support it, and there is no
+ * injection surface here — `path` is still a discrete argv element, never
+ * shell-interpolated). Used by move/copy as a no-clobber guard on the
+ * destination before the real op runs.
+ *
+ * This is a benign TOCTOU: two execs, not one atomic op. Worst case, the
+ * user's own sandbox process creates something at `toPath` in the gap between
+ * this check and the following `mv`/`cp`, which then clobbers it — there is no
+ * cross-tenant boundary to violate here, and path confinement already happened
+ * once, upstream in the route.
+ */
+async function machinePathExists(handle: MachineHandle, path: string): Promise<boolean> {
+  const run = await handle.exec({ cmd: 'test', args: ['-e', path] });
+  return run.exitCode === 0;
+}
+
+/** Move (rename) `fromPath` to `toPath`, refusing to clobber an existing `toPath`. */
+export async function moveMachinePath({
+  handle,
+  fromPath,
+  toPath,
+}: {
+  handle: MachineHandle;
+  fromPath: string;
+  toPath: string;
+}): Promise<MutateMachinePathResult> {
+  if (await machinePathExists(handle, toPath)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  const run = await handle.exec({ cmd: 'mv', args: ['-T', '--', fromPath, toPath] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
+}
+
+/** Copy `fromPath` to `toPath` (recursively, preserving attributes), refusing to clobber an existing `toPath`. */
+export async function copyMachinePath({
+  handle,
+  fromPath,
+  toPath,
+}: {
+  handle: MachineHandle;
+  fromPath: string;
+  toPath: string;
+}): Promise<MutateMachinePathResult> {
+  if (await machinePathExists(handle, toPath)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  const run = await handle.exec({ cmd: 'cp', args: ['-a', '--', fromPath, toPath] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
+}
+
+/**
+ * Delete a path, recursively. `rm -rf` is idempotent by design — deleting an
+ * already-missing path is a success, not a `not_found`; confirming with the
+ * user before deleting is UI policy, not this lib's.
+ */
+export async function deleteMachinePath({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<MutateMachinePathResult> {
+  const run = await handle.exec({ cmd: 'rm', args: ['-rf', '--', path] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
 }

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -166,10 +166,16 @@ export async function writeMachineFile({
 }
 
 /**
- * `test -e <path>` (no `--`: `test` doesn't support it, and there is no
- * injection surface here — `path` is still a discrete argv element, never
- * shell-interpolated). Used by move/copy as a no-clobber guard on the
+ * `test -e <path> -o -L <path>` (no `--`: `test` doesn't support it, and there
+ * is no injection surface here — `path` is still a discrete argv element,
+ * never shell-interpolated). Used by move/copy as a no-clobber guard on the
  * destination before the real op runs.
+ *
+ * `-L` is required alongside `-e`: every `test` file operator except `-h`/`-L`
+ * follows symlinks, so `-e` alone reports `false` for a DANGLING symlink (one
+ * whose target is missing) even though the symlink itself is a real directory
+ * entry sitting at `path`. Without `-L`, the guard would miss that entry and
+ * let `mv`/`cp` silently clobber it.
  *
  * This is a benign TOCTOU: two execs, not one atomic op. Worst case, the
  * user's own sandbox process creates something at `toPath` in the gap between
@@ -178,7 +184,7 @@ export async function writeMachineFile({
  * once, upstream in the route.
  */
 async function machinePathExists(handle: MachineHandle, path: string): Promise<boolean> {
-  const run = await handle.exec({ cmd: 'test', args: ['-e', path] });
+  const run = await handle.exec({ cmd: 'test', args: ['-e', path, '-o', '-L', path] });
   return run.exitCode === 0;
 }
 


### PR DESCRIPTION
## Summary
- Adds five write primitives to `packages/lib/src/services/sandbox/machine-fs.ts`: `createMachineDirectory`, `writeMachineFile`, `moveMachinePath`, `copyMachinePath`, `deleteMachinePath` — the ones the Machine Files Manager epic's mutating API routes (tasks 8-9) will call.
- Matches the existing `listMachineDirectory`/`readMachineFile` DI shape exactly: `MachineHandle` in, typed `MutateMachinePathResult` union out.
- All paths passed as `--`-terminated argv elements via `handle.exec` — never shell-interpolated (there is no shell).
- Move/copy guard the destination with `test -e <path> -o -L <path>` before running (no silent clobber); the `-o -L` also matches a dangling symlink, which `-e` alone would miss since it follows symlinks (see fixup below). Documented as a benign two-exec TOCTOU (no cross-tenant boundary — confinement already happened once, upstream in the route).
- `deleteMachinePath` is idempotent: a missing path is `{ ok: true }` (UI owns delete confirmations, not this lib).
- `writeMachineFile` wraps `MachineHandle.writeFiles`'s throw (no stderr channel) into `exec_failed`.
- Updated the module doc: no longer browse-only; states the pre-confined-absolute-path contract.

## Review fixups
- **Dangling-symlink no-clobber gap** (flagged by Codex): `test -e` alone reports `false` for a symlink whose target is missing, so `moveMachinePath`/`copyMachinePath` would proceed past a real directory entry instead of returning `already_exists`. Fixed in `6d6f24d89` by adding `-o -L` to the guard's `test` invocation; added regression tests for both primitives.

## Test plan
- [x] `bunx vitest run src/services/sandbox/__tests__/machine-fs.test.ts` from `packages/lib` — 28/28 passing (argv shapes incl. `--` placement, stderr→reason mapping per primitive, `test -e -o -L` no-clobber guard sequencing incl. dangling-symlink case, delete idempotence, `writeFiles` throw → `exec_failed`).
- [x] `bun run typecheck` (full monorepo via Turbo) — 16/16 tasks green.
- [x] `git diff --stat` against base touches only `machine-fs.ts` + its test file.

Design doc: `~/.claude/plans/refactored-finding-biscuit.md` — "Step 7". Does not touch `listMachineDirectory`/`readMachineFile`, `machine-host.ts`, or `apps/web` (tasks 8-9, blocked on this PR). Not merging — staying available.

https://claude.ai/code/session_01EcAmF71ZPAi6zmmPrbs5fH
