### PR TITLE
feat(machines): files route GET learns root scope + not_started (epic task 2)

### DIFF
--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -26,15 +26,15 @@ vi.mock('@/lib/auth', () => ({
 
 type HandleResult =
   | { ok: true; handle: { machineId: string } }
-  | { ok: false; reason: 'not_found' | 'vanished' };
+  | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
 
 const canViewMachine = vi.fn(async () => true);
-const resolveBranchMachineHandle = vi.fn(
+const resolveMachineFilesHandle = vi.fn(
   async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
 );
 vi.mock('@/lib/machines/machine-files-runtime', () => ({
   canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
-  resolveBranchMachineHandle: (...args: unknown[]) => resolveBranchMachineHandle(...(args as [])),
+  resolveMachineFilesHandle: (...args: unknown[]) => resolveMachineFilesHandle(...(args as [])),
 }));
 
 // Mirrors the real machine-fs result unions, so a test can drive the FAILURE
@@ -62,7 +62,7 @@ function get(query: Record<string, string>): Request {
 beforeEach(() => {
   vi.clearAllMocks();
   canViewMachine.mockResolvedValue(true);
-  resolveBranchMachineHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
+  resolveMachineFilesHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
   listMachineDirectory.mockResolvedValue({ ok: true, entries: [] });
   readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('hi', 'utf8') });
 });
@@ -142,18 +142,18 @@ describe('/api/machines/files request contract', () => {
     canViewMachine.mockResolvedValue(false);
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(403);
-    expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
     expect(listMachineDirectory).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the branch machine has no tracking row', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(404);
   });
 
   it('returns 503 when the branch Sprite has vanished', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(503);
   });
@@ -162,7 +162,7 @@ describe('/api/machines/files request contract', () => {
   // tab's file tree), so it must read as a sentence to a person — never as the
   // internal token, and never as a bare `exec_failed`.
   it('never puts an internal token in the user-facing `error`', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
     const body = await (await GET(get({ path: 'src' }))).json();
     expect(body.reason).toBe('vanished'); // machine-readable fact: unchanged
     expect(body.error).toBe('This branch checkout is unavailable');
@@ -214,8 +214,101 @@ describe('/api/machines/files request contract', () => {
     const fileMiss = await (await GET(get({ path: 'src/gone.ts', mode: 'read' }))).json();
     expect(fileMiss.reason).toBe('file_not_found');
 
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
     const checkoutMiss = await (await GET(get({ path: 'src/gone.ts', mode: 'read' }))).json();
     expect(checkoutMiss.reason).toBe('not_found');
+  });
+
+  it('resolves branch scope with the right dispatcher shape', async () => {
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(200);
+    expect(resolveMachineFilesHandle).toHaveBeenCalledWith({
+      scope: 'branch',
+      machineId: 't1',
+      projectName: 'p1',
+      branchName: 'b1',
+    });
+  });
+});
+
+// Root scope omits projectName/branchName entirely — `get` (above) always
+// supplies both, so these tests build the query directly.
+function getRoot(query: Record<string, string> = {}): Request {
+  const params = new URLSearchParams({ machineId: 't1', ...query });
+  return new Request(`http://localhost/api/machines/files?${params.toString()}`);
+}
+
+describe('/api/machines/files root scope', () => {
+  it('resolves root scope when projectName/branchName are absent', async () => {
+    const res = await GET(getRoot());
+    expect(res.status).toBe(200);
+    expect(resolveMachineFilesHandle).toHaveBeenCalledWith({ scope: 'root', machineId: 't1' });
+    expect(listMachineDirectory).toHaveBeenCalledWith(expect.objectContaining({ path: '/workspace' }));
+  });
+
+  it('confines a relative path under /workspace (SANDBOX_ROOT), not the branch checkout root', async () => {
+    const res = await GET(getRoot({ path: 'repo/src' }));
+    expect(res.status).toBe(200);
+    expect(listMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/src' }),
+    );
+  });
+
+  it('rejects a `..` traversal in root scope without touching the filesystem', async () => {
+    const res = await GET(getRoot({ path: '../etc' }));
+    expect(res.status).toBe(400);
+    expect(listMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('rejects an absolute path in root scope without touching the filesystem', async () => {
+    const res = await GET(getRoot({ mode: 'read', path: '/etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('maps a null root handle to 404 not_started with no internal token in `error`', async () => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_started' });
+    const res = await GET(getRoot());
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.reason).toBe('not_started');
+    expect(body.error).toBe("This machine hasn't been started yet");
+    expect(body.error).not.toMatch(/not_started/);
+  });
+
+  it('400s when only projectName is present (root/branch pair broken)', async () => {
+    const res = await GET(getRoot({ projectName: 'p1' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'projectName and branchName must be provided together' });
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only branchName is present (root/branch pair broken)', async () => {
+    const res = await GET(getRoot({ branchName: 'b1' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'projectName and branchName must be provided together' });
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only projectName is present as an empty string', async () => {
+    const res = await GET(getRoot({ projectName: '', branchName: 'b1' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only branchName is present as an empty string', async () => {
+    const res = await GET(getRoot({ projectName: 'p1', branchName: '' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  // The branch arm's "empty relativePath => not_found" remap encodes "never
+  // cloned" — a BRANCH-only fact. A live root Sprite's /workspace always
+  // exists, so root scope must never emit that remap, even at the root path.
+  it("does not leak the branch arm's root-missing remap into root scope", async () => {
+    listMachineDirectory.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const body = await (await GET(getRoot())).json();
+    expect(body.reason).toBe('dir_not_found');
+    expect(body.error).toBe('This folder is no longer on the machine');
   });
 });

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -1,8 +1,13 @@
 /**
- * Machine Files API — the Machine page's surface onto a branch checkout's
- * WORKING TREE (Machine page rebuild, Phase 1 — file browsing).
+ * Machine Files API — the Machine page's surface onto a WORKING TREE: either a
+ * branch checkout, or (when `projectName`/`branchName` are absent) the root
+ * Machine's own persistent Sprite (Machine page rebuild, Phase 1 — file
+ * browsing; root scope added for the Machine Files Manager epic).
  *
- * GET ?machineId=&projectName=&branchName=[&path=][&mode=list|read]
+ * GET ?machineId=[&projectName=&branchName=][&path=][&mode=list|read]
+ *   projectName/branchName BOTH present → branch scope (a branch checkout)
+ *   projectName/branchName BOTH absent  → root scope (the Machine's own tree)
+ *   exactly one present                 → 400 (they are a pair)
  *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
  *   mode=read           → { content, encoding, truncated } for the file `path`
  *
@@ -11,22 +16,28 @@
  * NEVER an internal token and never our own stderr (which names absolute paths
  * inside the Sprite) — that goes in `detail`, for logs and developers. The
  * reasons are disjoint on purpose:
- *   not_found      (404) — this branch has no checkout (no row, or never cloned)
- *   vanished       (503) — the branch's Sprite is gone
- *   dir_not_found  (404) — the checkout is there; that one directory is not
- *   file_not_found (404) — the checkout is there; that one file is not
+ *   not_found      (404) — no checkout (branch: no row, or never cloned)
+ *   not_started    (404) — root scope only: the Machine has no live session
+ *   vanished       (503) — the resolved Sprite is gone
+ *   dir_not_found  (404) — the tree is there; that one directory is not
+ *   file_not_found (404) — the tree is there; that one file is not
  *   exec_failed    (502) — the exec itself failed; see `detail`
- * "no checkout", "no such directory" and "no such file" are THREE different
- * facts. A client that conflates them tells the reader a file vanished when in
- * truth the whole branch did — so each gets its own token.
+ * "no checkout", "no such directory" and "no such file" are different facts. A
+ * client that conflates them tells the reader a file vanished when in truth
+ * the whole branch did — so each gets its own token.
  *
- * `path` is RELATIVE to the branch checkout root (`/workspace/repo`) and is
- * confined under it before the machine filesystem is touched — an absolute path
- * or a `..` escape is rejected (400), so a viewer cannot read `/etc/passwd` or
- * step out of the checkout. It defaults to the checkout root for a listing and
- * is REQUIRED for a read. Reads the live filesystem only — no git ref (that is
- * a separate git-object service). Session-only (no MCP/agent tokens) — this is
- * a human/UI surface, so it does NOT route through the AI agent tool
+ * `path` is RELATIVE to the scope's root — the branch checkout root
+ * (`/workspace/repo`) for branch scope, `/workspace` (`SANDBOX_ROOT`) for root
+ * scope — and is confined under it before the machine filesystem is touched —
+ * an absolute path or a `..` escape is rejected (400), so a viewer cannot read
+ * `/etc/passwd` or step out of the tree. Root scope confines via
+ * `resolvePathWithinSync(SANDBOX_ROOT, …)` directly rather than
+ * `resolveSandboxPath` — the latter's `/workspace`-prefix-stripping leniency is
+ * an agent-tool affordance that has no place here and would break symmetry
+ * with the branch arm. `path` defaults to the scope root for a listing and is
+ * REQUIRED for a read. Reads the live filesystem only — no git ref (that is a
+ * separate git-object service). Session-only (no MCP/agent tokens) — this is a
+ * human/UI surface, so it does NOT route through the AI agent tool
  * orchestration; every request re-checks view access for the Machine page,
  * same as the Branches/Agent-Terminals APIs.
  */
@@ -36,8 +47,10 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
-import { canViewMachine, resolveBranchMachineHandle } from '@/lib/machines/machine-files-runtime';
+import { canViewMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
+import type { MachineFilesScope } from '@/lib/machines/machine-files-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 
@@ -56,6 +69,12 @@ const LIST_DENIAL_STATUS: Record<string, number> = {
   exec_failed: 502,
 };
 
+const RESOLVE_DENIAL_STATUS: Record<'not_found' | 'vanished' | 'not_started', number> = {
+  not_found: 404,
+  vanished: 503,
+  not_started: 404,
+};
+
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
   if (isAuthError(auth)) return auth.error;
@@ -63,16 +82,28 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const machineId = requireString(url.searchParams.get('machineId'), 'machineId');
   if (!machineId.ok) return machineId.error;
-  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
-  if (!projectName.ok) return projectName.error;
-  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
-  if (!branchName.ok) return branchName.error;
 
   // Authorize BEFORE parsing optional params, so a user without view access gets
-  // a uniform 403 and can never probe path/mode handling.
+  // a uniform 403 and can never probe path/mode/scope handling.
   if (!(await canViewMachine(auth.userId, machineId.value))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
+
+  // projectName/branchName are a pair: both present → branch scope, both
+  // absent → root scope. Treat `null` and `''` identically as absent — `''`
+  // already 400ed before this change, so no existing client observes new
+  // behavior for it.
+  const rawProjectName = url.searchParams.get('projectName');
+  const rawBranchName = url.searchParams.get('branchName');
+  const projectName = rawProjectName === null || rawProjectName.length === 0 ? null : rawProjectName;
+  const branchName = rawBranchName === null || rawBranchName.length === 0 ? null : rawBranchName;
+  if ((projectName === null) !== (branchName === null)) {
+    return NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 });
+  }
+  const scope: MachineFilesScope =
+    projectName !== null && branchName !== null
+      ? { scope: 'branch', machineId: machineId.value, projectName, branchName }
+      : { scope: 'root', machineId: machineId.value };
 
   const mode = url.searchParams.get('mode') ?? 'list';
   if (mode !== 'list' && mode !== 'read') {
@@ -84,29 +115,32 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
   }
 
-  // `path` is untrusted and RELATIVE to the checkout root; confine it under
-  // BRANCH_REPO_PATH before any filesystem access. An empty path lists the root
-  // itself; an absolute path or a `..` escape resolves to null → 400. Absolute
-  // path passed to the filesystem is the confined result, never the raw input.
+  // `path` is untrusted and RELATIVE to the scope's root; confine it before any
+  // filesystem access. An empty path lists the root itself; an absolute path or
+  // a `..` escape resolves to null → 400. Absolute path passed to the
+  // filesystem is the confined result, never the raw input.
   const relativePath = rawPath !== null && rawPath.length > 0 ? rawPath : '';
-  const path = resolvePathWithinSync(BRANCH_REPO_PATH, relativePath);
+  const path =
+    scope.scope === 'branch'
+      ? resolvePathWithinSync(BRANCH_REPO_PATH, relativePath)
+      : resolvePathWithinSync(SANDBOX_ROOT, relativePath);
   if (path === null) {
-    return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
+    return NextResponse.json({ error: 'path escapes the machine filesystem root' }, { status: 400 });
   }
 
-  const resolved = await resolveBranchMachineHandle({
-    machineId: machineId.value,
-    projectName: projectName.value,
-    branchName: branchName.value,
-  });
+  const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) {
     // `error` is user-facing: clients switch on `reason`, and at least one (the
     // Code tab's file tree) renders `error` straight into the UI — so it must
     // never be the internal token. "Branch machine vanished" is a sentence about
     // our internals, not about anything the reader did or can act on.
+    const error =
+      resolved.reason === 'not_started'
+        ? "This machine hasn't been started yet"
+        : 'This branch checkout is unavailable';
     return NextResponse.json(
-      { error: 'This branch checkout is unavailable', reason: resolved.reason },
-      { status: resolved.reason === 'not_found' ? 404 : 503 },
+      { error, reason: resolved.reason },
+      { status: RESOLVE_DENIAL_STATUS[resolved.reason] },
     );
   }
 
@@ -136,14 +170,16 @@ export async function GET(request: Request) {
     //   a subdirectory is missing    → the checkout is fine; that folder is gone
     //                                  (an agent terminal deleted it a moment ago)
     // The root keeps `not_found`, so it reads as "not checked out yet" alongside
-    // the resolve failure above; a subdirectory gets its own token.
+    // the resolve failure above; a subdirectory gets its own token. This split is
+    // a BRANCH fact only — a live Sprite's `/workspace` is driver-guaranteed, so
+    // in root scope every missing directory (root path included) is just a gone
+    // folder, never "never checked out".
     if (result.reason === 'not_found') {
-      return NextResponse.json(
-        relativePath === ''
-          ? { error: 'This branch checkout is unavailable', reason: 'not_found' }
-          : { error: 'This folder is no longer in the checkout', reason: 'dir_not_found' },
-        { status: 404 },
-      );
+      if (scope.scope === 'branch' && relativePath === '') {
+        return NextResponse.json({ error: 'This branch checkout is unavailable', reason: 'not_found' }, { status: 404 });
+      }
+      const error = scope.scope === 'root' ? 'This folder is no longer on the machine' : 'This folder is no longer in the checkout';
+      return NextResponse.json({ error, reason: 'dir_not_found' }, { status: 404 });
     }
     // The exec's stderr has real diagnostic value, but it is OUR stderr: it names
     // absolute paths inside the Sprite ("ls: cannot access '/workspace/repo/…'").


### PR DESCRIPTION
## Summary
- `GET /api/machines/files` now dispatches via `resolveMachineFilesHandle` (epic task 1) instead of `resolveBranchMachineHandle` directly: `projectName`/`branchName` both present → branch scope (byte-identical behavior to before), both absent → root scope against the Machine's own live Sprite. Exactly one present → 400.
- Confinement is per-scope: branch stays under `BRANCH_REPO_PATH` (unchanged); root confines under `SANDBOX_ROOT` via `resolvePathWithinSync` directly — deliberately not `resolveSandboxPath`, whose `/workspace`-prefix-stripping leniency is an agent-tool affordance that would break confinement symmetry with the branch arm.
- Denial mapping: `not_found`/`vanished` response bodies are byte-identical to today; `not_started` (root scope, no live session) is new → 404 with a human-readable error and no internal token in `error`.
- The branch-only "root path missing → `not_found`" remap (encodes "this branch was never cloned") no longer leaks into root scope — a missing directory in root scope is always `dir_not_found` with new copy `'This folder is no longer on the machine'`, since `/workspace` is driver-guaranteed on a live Sprite.
- Read mode (`file_not_found`, 2MiB cap) and `exec_failed` handling unchanged in both scopes.
- Module header doc rewritten to document root scope, `not_started`, and per-scope confinement roots.

## Test plan
- [x] `bun run vitest run src/app/api/machines/files/__tests__/route.test.ts` from `apps/web` — 28/28 passing (existing branch-scope cases renamed to the new mock; added root-scope happy path, confinement, `not_started`, one-param-only 400 (both orders + `''` variants), root `not_found`→`dir_not_found` non-leak, and a branch-scope dispatcher-shape assertion)
- [x] `bun run typecheck` — clean
- [x] `git diff --stat` — touches only `route.ts` and its test file