### PR TITLE
feat(machines): Files tab defaults to the machine's root filesystem (epic task 4)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -8,13 +8,19 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-// Stub the branch picker: expose one button per node kind so a test can drive
+// Stub the scope picker: expose one button per node kind so a test can drive
 // exactly the selection FilesTab reacts to, without pulling MachineTree's whole
 // projects/branches hook subtree.
 vi.mock('../workspace/MachineTree', () => ({
   default: ({ onSelectNode }: { onSelectNode?: (node: unknown) => void }) => (
     <div>
       <button type="button" onClick={() => onSelectNode?.({ level: 'machine' })}>pick-machine</button>
+      <button
+        type="button"
+        onClick={() => onSelectNode?.({ level: 'project', projectName: 'repo' })}
+      >
+        pick-project
+      </button>
       <button
         type="button"
         onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'main' })}
@@ -32,15 +38,16 @@ vi.mock('../workspace/MachineTree', () => ({
 }));
 
 /**
- * Every root listing the (stubbed) file tree performs, in order.
+ * Every root/branch listing the (stubbed) file tree performs, in order,
+ * identified by `'root'` or the branch name.
  *
  * The stub MUST model the one behaviour of the real MachineFileTree that this
- * tab's correctness depends on: it self-keys on `${machineId}/${projectName}/
- * ${branchName}`, so mounting it — or handing it a new branch — fetches that
- * branch's root listing. A dumb stub that never fetches would let the "no wasted
- * listing" test pass even with FilesTab's key deleted, which is exactly the hole
- * a reviewer caught: the wasted listing came from the REAL tree, so a stub that
- * doesn't list cannot witness it.
+ * tab's correctness depends on: it self-keys on the scope, so mounting it — or
+ * handing it a new scope — fetches that scope's root listing. A dumb stub that
+ * never fetches would let the "no wasted listing" test pass even with
+ * FilesTab's key deleted, which is exactly the hole a reviewer caught: the
+ * wasted listing came from the REAL tree, so a stub that doesn't list cannot
+ * witness it.
  */
 const treeListings: string[] = [];
 
@@ -52,19 +59,19 @@ vi.mock('../workspace/MachineFileTree', () => ({
     scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
     onSelectFile?: (path: string) => void;
   }) {
-    const branchName = scope.kind === 'branch' ? scope.branchName : 'root';
+    const scopeName = scope.kind === 'branch' ? scope.branchName : 'root';
     useEffect(() => {
-      treeListings.push(branchName);
-    }, [branchName]);
+      treeListings.push(scopeName);
+    }, [scopeName]);
     return (
       <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
-        tree:{branchName}
+        tree:{scopeName}
       </button>
     );
   },
 }));
 
-// Stub the main pane so FilesTab's composition (which file, which branch) is what's asserted.
+// Stub the main pane so FilesTab's composition (which file, which scope) is what's asserted.
 vi.mock('./FilesFilePane', () => ({
   default: ({
     path,
@@ -85,14 +92,23 @@ import FilesTab from './FilesTab';
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 
-/** Serve the checkout-root probe: `ready` for known branches, an absence reason otherwise. */
-const cannedFetch = (perBranch: Record<string, () => Promise<Response>>) =>
+/**
+ * Serve the scope-root probe, keyed by `'root'` or the branch name (a request
+ * with no `branchName` param is root scope).
+ */
+const cannedFetch = (perScope: Record<string, () => Promise<Response>>) =>
   vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
-    const branch = new URL(String(args[0]), 'http://test').searchParams.get('branchName') ?? '';
-    const handler = perBranch[branch];
+    const params = new URL(String(args[0]), 'http://test').searchParams;
+    const scopeKey = params.get('branchName') ?? 'root';
+    const handler = perScope[scopeKey];
     if (handler) return handler();
-    return jsonResponse({ error: 'unexpected branch' }, 500);
+    return jsonResponse({ error: 'unexpected scope' }, 500);
   });
+
+const scopesProbed = () =>
+  vi
+    .mocked(fetchWithAuth)
+    .mock.calls.map((call) => new URL(String(call[0]), 'http://test').searchParams.get('branchName') ?? 'root');
 
 describe('FilesTab', () => {
   beforeEach(() => {
@@ -100,85 +116,185 @@ describe('FilesTab', () => {
     treeListings.length = 0;
   });
 
-  test('shows the branch prompt before any branch is picked', () => {
-    cannedFetch({});
+  test('mounts immediately in root scope, probing it exactly once with no project/branch params', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
     render(<FilesTab machineId="machine-1" />);
+
+    const tree = await waitFor(() => screen.getByTestId('file-tree'));
+    const firstRequestParams = new URL(String(vi.mocked(fetchWithAuth).mock.calls[0][0]), 'http://test').searchParams;
 
     assert({
       given: 'a freshly mounted Files tab',
-      should: 'prompt to select a branch and probe nothing',
+      should: 'probe the root scope exactly once and mount its file tree, with no branch pick required',
       actual: {
-        prompt: screen.queryByText('Select a branch to browse its checkout.') !== null,
-        fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+        tree: tree.textContent,
+        probes: vi.mocked(fetchWithAuth).mock.calls.length,
+        hasBranchParams: firstRequestParams.has('projectName') || firstRequestParams.has('branchName'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
       },
-      expected: { prompt: true, fetches: 0 },
+      expected: { tree: 'tree:root', probes: 1, hasBranchParams: false, filePrompt: true },
     });
   });
 
-  test('selecting a machine (non-branch) node is ignored', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+  test('selecting a project (non-machine, non-branch) node is ignored', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByTestId('file-tree'));
 
-    await userEvent.click(screen.getByText('pick-machine'));
+    await userEvent.click(screen.getByText('pick-project'));
 
     assert({
-      given: 'a machine-level node selected (no checkout to browse)',
-      should: 'keep the branch prompt and issue no probe',
+      given: 'a project-level node selected (no filesystem of its own)',
+      should: 'keep the current root scope and issue no additional probe',
       actual: {
-        prompt: screen.queryByText('Select a branch to browse its checkout.') !== null,
-        fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+        tree: screen.getByTestId('file-tree').textContent,
+        probes: vi.mocked(fetchWithAuth).mock.calls.length,
       },
-      expected: { prompt: true, fetches: 0 },
+      expected: { tree: 'tree:root', probes: 1 },
     });
   });
 
-  test('picking a ready branch probes its checkout ONCE and mounts the file tree', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+  test('a never-started machine shows the not-started empty state, not the file tree', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ error: "This machine hasn't been started yet", reason: 'not_started' }, 404),
+    });
     render(<FilesTab machineId="machine-1" />);
+
+    await waitFor(() => screen.getByTestId('checkout-absent'));
+
+    assert({
+      given: "a root scope probe that returns reason 'not_started'",
+      should: 'show the not-started empty state and never mount the file tree',
+      actual: {
+        empty: screen.queryByText("This machine hasn't been started yet") !== null,
+        tree: screen.queryByTestId('file-tree'),
+      },
+      expected: { empty: true, tree: null },
+    });
+  });
+
+  test('"Check again" mounts the root tree once a never-started machine has been started', async () => {
+    let started = false;
+    cannedFetch({
+      root: async () =>
+        started
+          ? jsonResponse({ entries: [] })
+          : jsonResponse({ error: "This machine hasn't been started yet", reason: 'not_started' }, 404),
+    });
+    render(<FilesTab machineId="machine-1" />);
+
+    await waitFor(() => screen.getByTestId('checkout-absent'));
+
+    started = true; // the user opened the Terminal tab and started it
+    await userEvent.click(screen.getByText('Check again'));
+    await waitFor(() => screen.getByTestId('file-tree'));
+
+    assert({
+      given: 'a never-started machine that gets started, then "Check again" clicked',
+      should: 're-probe and mount the root file tree without needing a branch pick',
+      actual: {
+        tree: screen.getByTestId('file-tree').textContent,
+        absent: screen.queryByTestId('checkout-absent'),
+      },
+      expected: { tree: 'tree:root', absent: null },
+    });
+  });
+
+  test('picking a branch switches from root scope to that branch checkout, probing it once', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     const tree = await waitFor(() => screen.getByTestId('file-tree'));
 
     assert({
-      given: 'a branch whose checkout probe returns 200',
-      should: 'render the file tree for that branch, having probed exactly once',
+      given: 'a branch picked while root scope was already ready',
+      should: 'render the file tree for that branch, having probed root once and the branch once',
       actual: {
         tree: tree.textContent,
-        probes: vi.mocked(fetchWithAuth).mock.calls.length,
+        probed: scopesProbed(),
         filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
       },
-      expected: { tree: 'tree:main', probes: 1, filePrompt: true },
+      expected: { tree: 'tree:main', probed: ['root', 'main'], filePrompt: true },
     });
   });
 
-  test('switching branches never mounts the file tree against a stale ready state', async () => {
+  test('scope switches (root -> branch -> root) never mount the file tree against a stale ready state', async () => {
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ entries: [] }),
-      dev: async () => jsonResponse({ entries: [] }),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByText('tree:main'));
-    await userEvent.click(screen.getByText('pick-dev'));
-    await waitFor(() => screen.getByText('tree:dev'));
-
-    const branchesProbed = vi
-      .mocked(fetchWithAuth)
-      .mock.calls.map((call) => new URL(String(call[0]), 'http://test').searchParams.get('branchName'));
+    await userEvent.click(screen.getByText('pick-machine'));
+    await waitFor(() => screen.getByText('tree:root'));
 
     assert({
-      given: 'a branch switch after the first branch was already ready',
+      given: 'a root -> branch -> root scope walk',
       should:
-        'list each branch root exactly once — BranchFiles is keyed by branch, so the tree is never mounted at the new branch under the old ready state (unkeyed, dev is listed twice: once thrown away)',
-      actual: { probed: branchesProbed, listed: treeListings },
-      expected: { probed: ['main', 'dev'], listed: ['main', 'dev'] },
+        'list each scope visit exactly once — ScopeFiles is keyed by scope, so the tree is never mounted at a new scope under a stale ready state',
+      actual: { probed: scopesProbed(), listed: treeListings },
+      expected: { probed: ['root', 'main', 'root'], listed: ['root', 'main', 'root'] },
+    });
+  });
+
+  test('picking the machine node returns to root scope and drops the open file', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
+
+    await userEvent.click(screen.getByText('pick-main'));
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByText('pick-machine'));
+    await waitFor(() => screen.getByText('tree:root'));
+
+    assert({
+      given: 'a file open on a branch, then the machine node picked',
+      should: 'clear the open file and fall back to the pick-a-file prompt',
+      actual: {
+        pane: screen.queryByTestId('file-pane'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
+      },
+      expected: { pane: null, filePrompt: true },
+    });
+  });
+
+  test('re-picking root while already on root keeps the open file', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
+    render(<FilesTab machineId="machine-1" />);
+
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByText('pick-machine')); // already root
+
+    assert({
+      given: 'the root scope re-picked while already selected',
+      should: 'leave the open file alone (only a DIFFERENT scope invalidates the path)',
+      actual: screen.queryByTestId('file-pane')?.textContent ?? null,
+      expected: 'pane:root:src/index.ts',
     });
   });
 
   test('re-picking the branch already open keeps the open file', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -188,15 +304,19 @@ describe('FilesTab', () => {
 
     assert({
       given: 'the branch that is already selected picked a second time',
-      should: 'leave the open file alone (only a DIFFERENT branch invalidates the path)',
+      should: 'leave the open file alone (only a DIFFERENT scope invalidates the path)',
       actual: screen.queryByTestId('file-pane')?.textContent ?? null,
       expected: 'pane:main:src/index.ts',
     });
   });
 
   test('a not-yet-cloned branch shows the empty state, not the file tree', async () => {
-    cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine not_found', reason: 'not_found' }, 404) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ error: 'Branch machine not_found', reason: 'not_found' }, 404),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -213,8 +333,12 @@ describe('FilesTab', () => {
   });
 
   test("a vanished sandbox reports the checkout is gone", async () => {
-    cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine vanished', reason: 'vanished' }, 503) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ error: 'Branch machine vanished', reason: 'vanished' }, 503),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     const gone = await waitFor(() => screen.getByText('This branch checkout is gone'));
@@ -231,9 +355,11 @@ describe('FilesTab', () => {
     // The invariant behind the absent/error split: "no checkout" is a state of
     // the world; a permission failure is not, and must never be shown as one.
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ error: 'You do not have access to this machine' }, 403),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-error'));
@@ -253,12 +379,14 @@ describe('FilesTab', () => {
   test('“Check again” re-probes a branch that has since been cloned', async () => {
     let cloned = false;
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () =>
         cloned
           ? jsonResponse({ entries: [] })
           : jsonResponse({ error: 'This branch checkout is unavailable', reason: 'not_found' }, 404),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -279,8 +407,12 @@ describe('FilesTab', () => {
   });
 
   test('selecting a file in the tree opens it in the main pane', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -296,10 +428,12 @@ describe('FilesTab', () => {
 
   test('switching branches drops the previously open file', async () => {
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ entries: [] }),
       dev: async () => jsonResponse({ entries: [] }),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -1,31 +1,39 @@
 "use client";
 
 /**
- * FilesTab — the Machine page's Files tab: a read-only viewer over a branch
- * checkout's working tree (Machine page rebuild, Phase 3).
+ * FilesTab — the Machine page's Files tab: a file-system viewer that defaults
+ * to the Machine's own root Sprite filesystem (`/workspace`), with a project's
+ * branch checkout browsable as an additional, opt-in scope (Machine Files
+ * Manager epic, Part A).
  *
  * Composes the pieces the earlier phases landed: an inner page-scoped sidebar
  * (plain border-border chrome, deliberately NOT one of the app's liquid-glass
  * sidebars — same shell as {@link TerminalTab}) holding a BARE {@link MachineTree}
- * as the branch picker, then a {@link MachineFileTree} over the picked branch's
- * checkout; and a main pane with a read-only Monaco showing the selected file.
+ * as the scope picker, then a {@link MachineFileTree} over whichever scope is
+ * selected; and a main pane with a read-only Monaco showing the selected file.
  *
- * A checkout only exists on a branch-terminal's OWN Sprite once that branch has
- * been cloned, and nothing in `machine_branches` tracks clone state (the store
- * row carries only a `sandboxId`) — so "is there a checkout?" is answered by the
- * live filesystem, not the DB. The files route already gives a clean, typed
- * signal for it: branch resolution failures come back as `reason: 'not_found'`
- * (no tracking row, or the repo dir isn't there) or `reason: 'vanished'` (the row
- * is there but its Sprite is gone). {@link BranchFiles} probes the checkout root
- * once per branch and turns both into an explicit empty state rather than letting
- * MachineFileTree render them as a raw error row. An `exec_failed` is NOT folded
- * in: a broken exec is a real error and stays one.
+ * A branch checkout only exists on a branch-terminal's OWN Sprite once that
+ * branch has been cloned, and nothing in `machine_branches` tracks clone state
+ * (the store row carries only a `sandboxId`) — so "is there a checkout?" is
+ * answered by the live filesystem, not the DB. Root scope has an absence of
+ * its own kind: a Machine whose Terminal was never opened has no Sprite at
+ * all yet. The files route gives a clean, typed signal for all three cases:
+ * branch resolution failures come back as `reason: 'not_found'` (no tracking
+ * row, or the repo dir isn't there) or `reason: 'vanished'` (the row is there
+ * but its Sprite is gone); root resolution failure is `reason: 'not_started'`
+ * (no Sprite has ever been provisioned). {@link ScopeFiles} probes the scope
+ * root once per scope and turns all three into an explicit empty state rather
+ * than letting MachineFileTree render them as a raw error row. An
+ * `exec_failed` is NOT folded in: a broken exec is a real error and stays one.
  *
- * Selection (branch + open file) is ONE piece of state, and both children are
- * keyed by it. A path only means something inside the checkout it came from, so
- * a branch switch drops the open file in the same update — and the key makes the
- * switch a remount, which is what stops a stale `ready` from flashing the file
- * tree at the new branch and firing a listing that gets thrown away.
+ * Selection (scope + open file) is ONE piece of state, and both children are
+ * keyed by it. A path only means something inside the scope it came from, so
+ * a scope switch drops the open file in the same update — and the key makes
+ * the switch a remount, which is what stops a stale `ready` from flashing the
+ * file tree at the new scope and firing a listing that gets thrown away. Root
+ * is the initial scope, so the Machine's own files render immediately with no
+ * pick required; picking a branch is additive, unchanged browsing on top of
+ * that default.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -36,6 +44,7 @@ import MachineFileTree from '../workspace/MachineFileTree';
 import FilesFilePane from './FilesFilePane';
 import TabSidebar from './TabSidebar';
 import { PaneNotice, SidebarLoading, SidebarNotice } from './tab-states';
+import { type FilesScope, filesScopeKey, filesScopeSearchParams } from './files-scope';
 import {
   FILES_ABSENT_COPY,
   asAbsentReason,
@@ -48,36 +57,40 @@ interface FilesTabProps {
   machineId: string;
 }
 
-/** The branch whose checkout the tab is browsing, and the file open from it. */
+/** The scope the tab is browsing, and the file open from it. */
 interface Selection {
-  branch: { projectName: string; branchName: string } | null;
-  /** Checkout-relative path, only ever meaningful within `branch`. */
+  scope: FilesScope;
+  /** Scope-relative path, only ever meaningful within `scope`. */
   path: string | null;
 }
 
-/**
- * Identity of a branch's checkout — also the React key that scopes per-branch
- * state. JSON-encoded rather than joined on a separator so that no project /
- * branch name pair can collide (a branch name may legally contain `/`).
- */
-const branchKey = (branch: NonNullable<Selection['branch']>): string =>
-  JSON.stringify([branch.projectName, branch.branchName]);
+const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
+
+/** The `MachineTree` node that corresponds to a scope, for the selection highlight. */
+const selectedNodeFor = (scope: FilesScope): MachineTreeNode =>
+  scope.kind === 'root'
+    ? MACHINE_NODE
+    : { level: 'branch', projectName: scope.projectName, branchName: scope.branchName };
 
 export default function FilesTab({ machineId }: FilesTabProps) {
-  // Branch and path move as ONE value: a path only means something inside the
-  // checkout it came from, so switching branches must drop the open file in the
-  // same update — never as a second, separately-scheduled setState.
-  const [{ branch, path }, setSelection] = useState<Selection>({ branch: null, path: null });
+  // Scope and path move as ONE value: a path only means something inside the
+  // scope it came from, so switching scopes must drop the open file in the
+  // same update — never as a second, separately-scheduled setState. Root is
+  // the initial scope, so files render immediately with no pick required.
+  const [{ scope, path }, setSelection] = useState<Selection>({ scope: { kind: 'root' }, path: null });
 
   const onSelectNode = useCallback((node: MachineTreeNode) => {
-    // Only a branch has a checkout to browse. Machine/Project rows stay
-    // expand-only (their chevron still works) — selecting one would have no
-    // file tree to show.
-    if (node.level !== 'branch') return;
+    // Projects are expand-only groupings with no filesystem of their own —
+    // their chevron still works, but selecting one has no scope to switch to.
+    if (node.level === 'project') return;
+    const nextScope: FilesScope =
+      node.level === 'machine'
+        ? { kind: 'root' }
+        : { kind: 'branch', projectName: node.projectName, branchName: node.branchName };
     setSelection((current) =>
-      current.branch?.projectName === node.projectName && current.branch.branchName === node.branchName
-        ? current // re-picking the open branch keeps the open file
-        : { branch: { projectName: node.projectName, branchName: node.branchName }, path: null },
+      filesScopeKey(current.scope) === filesScopeKey(nextScope)
+        ? current // re-picking the open scope keeps the open file
+        : { scope: nextScope, path: null },
     );
   }, []);
 
@@ -89,24 +102,18 @@ export default function FilesTab({ machineId }: FilesTabProps) {
     <TabSidebar
       title="Files"
       pane={
-        branch && path ? (
+        path ? (
           // Deliberately UNKEYED. Keying by path would tear down and recreate
           // Monaco on every file click; the pane doesn't need it, because it
           // refuses to render a state belonging to a different file. Keying by
-          // branch would be dead code: a branch switch clears `path` in the same
+          // scope would be dead code: a scope switch clears `path` in the same
           // update, so the pane unmounts anyway.
-          <FilesFilePane
-            machineId={machineId}
-            scope={{ kind: 'branch', projectName: branch.projectName, branchName: branch.branchName }}
-            path={path}
-          />
+          <FilesFilePane machineId={machineId} scope={scope} path={path} />
         ) : (
           <PaneNotice
             icon={<FileCode2 className="size-6 text-muted-foreground" />}
-            title={branch ? 'No file open' : 'No branch selected'}
-            description={
-              branch ? 'Select a file to view its contents.' : 'Select a branch to browse its checkout.'
-            }
+            title="No file open"
+            description="Select a file to view its contents."
           />
         )
       }
@@ -116,91 +123,95 @@ export default function FilesTab({ machineId }: FilesTabProps) {
           {/* Picking a BRANCH must not close the sheet on mobile — the file the
               user is actually after is one level further in, in the tree that
               picking the branch just revealed. Only opening a file closes it. */}
-          <MachineTree machineId={machineId} onSelectNode={onSelectNode} />
-          {branch && (
-            <div className="border-t border-border">
+          <MachineTree
+            machineId={machineId}
+            onSelectNode={onSelectNode}
+            isNodeSelectable={(n) => n.level !== 'project'}
+            selectedNode={selectedNodeFor(scope)}
+          />
+          <div className="border-t border-border">
+            {scope.kind === 'branch' && (
               <div className="flex min-w-0 items-center gap-1 px-2 pt-2 text-xs text-muted-foreground">
-                <span className="truncate" title={`${branch.projectName} / ${branch.branchName}`}>
-                  {branch.projectName} / {branch.branchName}
+                <span className="truncate" title={`${scope.projectName} / ${scope.branchName}`}>
+                  {scope.projectName} / {scope.branchName}
                 </span>
               </div>
-              {/* Keyed on the branch so a switch REMOUNTS the probe. Without it,
-                  BranchFiles would render one frame still holding the previous
-                  branch's `ready` state, mounting the file tree against the new
-                  branch — a whole root listing fetched and thrown away before
-                  the probe effect resets it. */}
-              <BranchFiles
-                key={branchKey(branch)}
-                machineId={machineId}
-                projectName={branch.projectName}
-                branchName={branch.branchName}
-                onSelectFile={(next) => {
-                  onSelectFile(next);
-                  close();
-                }}
-                selectedPath={path}
-              />
-            </div>
-          )}
+            )}
+            {/* Keyed on the scope so a switch REMOUNTS the probe. Without it,
+                ScopeFiles would render one frame still holding the previous
+                scope's `ready` state, mounting the file tree against the new
+                scope — a whole root listing fetched and thrown away before the
+                probe effect resets it. This applies to root exactly as much as
+                to a branch switch: never special-case root as unkeyed. */}
+            <ScopeFiles
+              key={filesScopeKey(scope)}
+              machineId={machineId}
+              scope={scope}
+              onSelectFile={(next) => {
+                onSelectFile(next);
+                close();
+              }}
+              selectedPath={path}
+            />
+          </div>
         </>
       )}
     </TabSidebar>
   );
 }
 
-/** Whether the branch's checkout exists on its Sprite yet — see the module doc. */
-type CheckoutState =
+/** Whether the scope's filesystem is reachable yet — see the module doc. */
+type ScopeState =
   | { status: 'loading' }
   | { status: 'ready' }
   | { status: 'absent'; reason: FilesAbsentReason }
   | { status: 'error'; message: string };
 
 /**
- * Probes the checkout root once per branch and, only once it answers `ready`,
+ * Probes the scope root once per scope and, only once it answers `ready`,
  * mounts the file tree.
  *
  * COST, stated plainly: the probe is exactly the listing MachineFileTree makes
- * for the root anyway, so a ready branch pays for two root listings — one here,
- * one in the tree. That buys the distinction the tab exists to make: "this
- * branch was never cloned" is a state of the world and belongs in the sidebar as
- * an empty state, not as a red error row buried inside a file tree. The
- * duplicate is bounded — once per branch selection, never per directory, and
- * FilesTab keys us by branch so it cannot fire on a re-render.
+ * for the root anyway, so a ready scope pays for two root listings — one
+ * here, one in the tree. That buys the distinction the tab exists to make:
+ * "this scope isn't reachable yet" is a state of the world and belongs in the
+ * sidebar as an empty state, not as a red error row buried inside a file
+ * tree. The duplicate is bounded — once per scope selection, never per
+ * directory, and FilesTab keys us by scope so it cannot fire on a re-render.
  *
- * It is not free, and it is not the only design: MachineFileTree is mounted here
- * and nowhere else, so it could instead report a root-level absence back to us
- * (an `onRootUnavailable(reason)` prop) and the probe would disappear entirely.
- * That is the better end state and a small refactor; it is deliberately not being
- * done in the same PR that changes this route's contract.
+ * It is not free, and it is not the only design: MachineFileTree is mounted
+ * here and nowhere else, so it could instead report a root-level absence back
+ * to us (an `onRootUnavailable(reason)` prop) and the probe would disappear
+ * entirely. That is the better end state and a small refactor; it is
+ * deliberately not being done in the same PR that changes this route's
+ * contract.
  */
-function BranchFiles({
+function ScopeFiles({
   machineId,
-  projectName,
-  branchName,
+  scope,
   onSelectFile,
   selectedPath,
 }: {
   machineId: string;
-  projectName: string;
-  branchName: string;
+  scope: FilesScope;
   onSelectFile: (path: string) => void;
   selectedPath: string | null;
 }) {
-  const [state, setState] = useState<CheckoutState>({ status: 'loading' });
-  // Bumped by Retry — re-runs the probe without changing the branch identity.
+  const [state, setState] = useState<ScopeState>({ status: 'loading' });
+  // Bumped by Retry — re-runs the probe without changing the scope identity.
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     // Retry makes an in-flight probe's answer stale — this flag, flipped by the
-    // cleanup, keeps it from landing on the newer one. (A branch switch can't
-    // race us at all: FilesTab keys this component by branch, so a switch is a
+    // cleanup, keeps it from landing on the newer one. (A scope switch can't
+    // race us at all: FilesTab keys this component by scope, so a switch is a
     // remount, not a re-render.)
     let cancelled = false;
     setState({ status: 'loading' });
 
     const probe = async () => {
       try {
-        const search = new URLSearchParams({ machineId, projectName, branchName });
+        const search = filesScopeSearchParams(machineId, scope);
         const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
         if (cancelled) return;
         if (res.ok) {
@@ -209,19 +220,19 @@ function BranchFiles({
         }
         const { error, reason } = readErrorBody(await res.json().catch(() => null));
         if (cancelled) return;
-        // `not_found`/`vanished` mean the checkout isn't there — a state of the
-        // world, not a failure. Anything else (403, `exec_failed`, …) IS a
-        // failure and must stay visible as one rather than be dressed up as an
-        // empty state.
+        // `not_found`/`vanished`/`not_started` mean the scope isn't reachable —
+        // a state of the world, not a failure. Anything else (403,
+        // `exec_failed`, …) IS a failure and must stay visible as one rather
+        // than be dressed up as an empty state.
         const absent = asAbsentReason(reason);
         if (absent !== null) {
           setState({ status: 'absent', reason: absent });
           return;
         }
-        setState({ status: 'error', message: error ?? `Failed to open checkout (${res.status})` });
+        setState({ status: 'error', message: error ?? `Failed to open files (${res.status})` });
       } catch (err) {
         if (cancelled) return;
-        setState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to open checkout' });
+        setState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to open files' });
       }
     };
 
@@ -229,10 +240,10 @@ function BranchFiles({
     return () => {
       cancelled = true;
     };
-  }, [machineId, projectName, branchName, attempt]);
+  }, [machineId, scope, attempt]);
 
   if (state.status === 'loading') {
-    return <SidebarLoading message="Opening checkout…" />;
+    return <SidebarLoading message={scope.kind === 'branch' ? 'Opening checkout…' : 'Opening files…'} />;
   }
 
   const retry = () => setAttempt((a) => a + 1);
@@ -262,12 +273,5 @@ function BranchFiles({
     );
   }
 
-  return (
-    <MachineFileTree
-      machineId={machineId}
-      scope={{ kind: 'branch', projectName, branchName }}
-      onSelectFile={onSelectFile}
-      selectedPath={selectedPath}
-    />
-  );
+  return <MachineFileTree machineId={machineId} scope={scope} onSelectFile={onSelectFile} selectedPath={selectedPath} />;
 }


### PR DESCRIPTION
## Summary
- FilesTab now opens directly onto the Machine's own root Sprite filesystem (`/workspace`) with no branch pick required — root is the initial `Selection.scope`, replacing the old "select a branch first" prompt.
- Branch checkout browsing is preserved unchanged as an additive, opt-in scope: picking a branch node switches to `{ kind: 'branch', ... }`, picking the machine node returns to root (dropping the open file, mirroring the existing same-scope re-pick guard), project nodes stay non-selectable via `isNodeSelectable`.
- `BranchFiles` renamed to `ScopeFiles` and now **always** renders (no more `branch &&` gate), keyed by `filesScopeKey(scope)` so root↔branch switches get the same keyed-remount discipline that prevented wasted listings across branch↔branch switches. Loading copy is scope-aware (`'Opening files…'` vs `'Opening checkout…'`); absent copy comes from the (already-extended) `FILES_ABSENT_COPY`, which now includes `not_started`.
- Sidebar caption (`projectName / branchName`) only renders for branch scope; the file pane placeholder drops its "No branch selected" arm.

Only `FilesTab.tsx` + `FilesTab.test.tsx` touched — `git diff --stat` against base confirms this. No changes to `MachineFileTree.tsx`, `FilesFilePane.tsx`, `files-scope.ts`, `checkout-states.ts`, `MachineTree.tsx`, or the route (all consumed as-is from earlier merged tasks).

## Test plan
- [x] `FilesTab.test.tsx` — 15/15 passing, incl.: fresh mount probes root exactly once (no `projectName`/`branchName` params) and mounts the root tree; a `not_started` root probe shows the new empty state with no tree, and "Check again" mounts the tree once the machine has started; picking a branch switches scope (regression, unchanged behavior); picking the machine node returns to root scope and drops the open file; root→branch→root scope walk probes/lists exactly once per visit (no wasted listings); all pre-existing branch-scope tests green with the +1 initial root probe accounted for.
- [x] `MachineFileTree.test.tsx` (17/17) and `FilesFilePane.test.tsx` (19/19) — untouched, still green.
- [x] `bun run typecheck` — clean across the monorepo.
- [x] `git diff --stat` — touches only `FilesTab.tsx` and `FilesTab.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfakEEcHCBpP5f9fy5n1Gi