### PR TITLE
feat(machines): files route mutations — create/upload, move/copy, delete, download (epic tasks 8-10)

### DIFF
--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -3,25 +3,34 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 /**
  * /api/machines/files contract + path-confinement tests.
  *
- * The security-critical property under test: the untrusted `path` query param
- * is RELATIVE to the branch checkout root and is confined under it BEFORE the
- * machine filesystem is touched. A `..` escape or an absolute path must be
- * rejected (400) without ever calling listMachineDirectory/readMachineFile, so
- * a viewer cannot read `/etc/passwd` or step outside `/workspace/repo`.
+ * The security-critical property under test: every untrusted path field
+ * (`path`, `fromPath`, `toPath`) is RELATIVE to the scope root and is confined
+ * under it BEFORE the machine filesystem is touched. A `..` escape or an
+ * absolute path must be rejected (400) without ever calling a machine-fs
+ * primitive, so a caller cannot read/write `/etc/passwd` or step outside the
+ * scope root.
  *
  * `resolvePathWithinSync` (the real confinement helper) is intentionally NOT
- * mocked — it is the code under test. Everything else (auth, access check,
- * handle resolution, the fs primitives) is mocked so the test isolates the
- * route's own request handling.
+ * mocked — it is the code under test. Everything else (auth, access checks,
+ * handle resolution, the fs primitives, audit) is mocked so the tests isolate
+ * the route's own request handling.
  */
 
 // Inlined (not a top-level const) because vi.mock factories are hoisted above
 // any module-scope variable and cannot close over one.
 vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({ BRANCH_REPO_PATH: '/workspace/repo' }));
 
+type AuthResult = { userId: string } | { error: Response };
+const authenticateRequestWithOptions = vi.fn(async (): Promise<AuthResult> => ({ userId: 'user-1' }));
+const isAuthError = vi.fn((result: AuthResult) => 'error' in result);
 vi.mock('@/lib/auth', () => ({
-  authenticateRequestWithOptions: vi.fn(async () => ({ userId: 'user-1' })),
-  isAuthError: vi.fn(() => false),
+  authenticateRequestWithOptions: (...args: unknown[]) => authenticateRequestWithOptions(...(args as [])),
+  isAuthError: (...args: unknown[]) => isAuthError(...(args as [AuthResult])),
+}));
+
+const auditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => auditRequest(...(args as [])),
 }));
 
 type HandleResult =
@@ -29,11 +38,13 @@ type HandleResult =
   | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
 
 const canViewMachine = vi.fn(async () => true);
+const canEditMachine = vi.fn(async () => true);
 const resolveMachineFilesHandle = vi.fn(
   async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
 );
 vi.mock('@/lib/machines/machine-files-runtime', () => ({
   canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
+  canEditMachine: (...args: unknown[]) => canEditMachine(...(args as [])),
   resolveMachineFilesHandle: (...args: unknown[]) => resolveMachineFilesHandle(...(args as [])),
 }));
 
@@ -44,27 +55,69 @@ type ListResult =
   | { ok: true; entries: { name: string; type: 'file' | 'directory' }[] }
   | { ok: false; reason: 'not_found' | 'exec_failed'; detail?: string };
 type ReadResult = { ok: true; content: Buffer } | { ok: false; reason: 'not_found' };
+type MutateResult = { ok: true } | { ok: false; reason: 'not_found' | 'already_exists' | 'exec_failed'; detail?: string };
 
 const listMachineDirectory = vi.fn(async (): Promise<ListResult> => ({ ok: true, entries: [] }));
 const readMachineFile = vi.fn(async (): Promise<ReadResult> => ({ ok: true, content: Buffer.from('hi', 'utf8') }));
+const createMachineDirectory = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const writeMachineFile = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const moveMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const copyMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const deleteMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
 vi.mock('@pagespace/lib/services/sandbox/machine-fs', () => ({
   listMachineDirectory: (...args: unknown[]) => listMachineDirectory(...(args as [])),
   readMachineFile: (...args: unknown[]) => readMachineFile(...(args as [])),
+  createMachineDirectory: (...args: unknown[]) => createMachineDirectory(...(args as [])),
+  writeMachineFile: (...args: unknown[]) => writeMachineFile(...(args as [])),
+  moveMachinePath: (...args: unknown[]) => moveMachinePath(...(args as [])),
+  copyMachinePath: (...args: unknown[]) => copyMachinePath(...(args as [])),
+  deleteMachinePath: (...args: unknown[]) => deleteMachinePath(...(args as [])),
 }));
 
-import { GET } from '../route';
+import { GET, POST, PATCH, DELETE } from '../route';
 
 function get(query: Record<string, string>): Request {
   const params = new URLSearchParams({ machineId: 't1', projectName: 'p1', branchName: 'b1', ...query });
   return new Request(`http://localhost/api/machines/files?${params.toString()}`);
 }
 
+function jsonRequest(method: string, body: unknown): Request {
+  return new Request('http://localhost/api/machines/files', {
+    method,
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function rawRequest(method: string, rawBody: string): Request {
+  return new Request('http://localhost/api/machines/files', {
+    method,
+    body: rawBody,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const post = (body: unknown) => jsonRequest('POST', body);
+const patch = (body: unknown) => jsonRequest('PATCH', body);
+const del = (body: unknown) => jsonRequest('DELETE', body);
+
+const BRANCH_BODY = { machineId: 't1', projectName: 'p1', branchName: 'b1' };
+const ROOT_BODY = { machineId: 't1' };
+
 beforeEach(() => {
   vi.clearAllMocks();
+  authenticateRequestWithOptions.mockResolvedValue({ userId: 'user-1' });
+  isAuthError.mockImplementation((result: AuthResult) => 'error' in result);
   canViewMachine.mockResolvedValue(true);
+  canEditMachine.mockResolvedValue(true);
   resolveMachineFilesHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
   listMachineDirectory.mockResolvedValue({ ok: true, entries: [] });
   readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('hi', 'utf8') });
+  createMachineDirectory.mockResolvedValue({ ok: true });
+  writeMachineFile.mockResolvedValue({ ok: true });
+  moveMachinePath.mockResolvedValue({ ok: true });
+  copyMachinePath.mockResolvedValue({ ok: true });
+  deleteMachinePath.mockResolvedValue({ ok: true });
 });
 
 describe('/api/machines/files path confinement', () => {
@@ -310,5 +363,444 @@ describe('/api/machines/files root scope', () => {
     const body = await (await GET(getRoot())).json();
     expect(body.reason).toBe('dir_not_found');
     expect(body.error).toBe('This folder is no longer on the machine');
+  });
+});
+
+describe('/api/machines/files GET mode=download', () => {
+  it('requires a path', async () => {
+    const res = await GET(get({ mode: 'download' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('is a read — view access is enough, no CSRF requirement', async () => {
+    await GET(get({ mode: 'download', path: 'src/index.ts' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requireCSRF: false }),
+    );
+    expect(canViewMachine).toHaveBeenCalled();
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('confines the path under the scope root before touching the filesystem', async () => {
+    const res = await GET(get({ mode: 'download', path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 file_not_found when the file is missing', async () => {
+    readMachineFile.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await GET(get({ mode: 'download', path: 'gone.bin' }));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'File not found', reason: 'file_not_found' });
+  });
+
+  it('returns 413 when the file exceeds the 50 MiB download cap', async () => {
+    readMachineFile.mockResolvedValue({ ok: true, content: Buffer.alloc(50 * 1024 * 1024 + 1) });
+    const res = await GET(get({ mode: 'download', path: 'huge.bin' }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'File is too large to download', reason: 'too_large' });
+  });
+
+  it('returns byte-faithful binary content with octet-stream headers', async () => {
+    const bytes = Buffer.from([0, 1, 2, 255, 254, 253]);
+    readMachineFile.mockResolvedValue({ ok: true, content: bytes });
+    const res = await GET(get({ mode: 'download', path: 'src/blob.bin' }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/octet-stream');
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.equals(bytes)).toBe(true);
+  });
+
+  it('sanitizes the filename to a basename, stripping directories and quotes', async () => {
+    const res = await GET(get({ mode: 'download', path: 'a/b"c.txt' }));
+    expect(res.status).toBe(200);
+    const disposition = res.headers.get('content-disposition') ?? '';
+    expect(disposition).toMatch(/^attachment; filename="[^"/\\]*"; filename\*=UTF-8''/);
+    expect(disposition).not.toMatch(/a\/b/);
+    expect(disposition).not.toContain('"c.txt"; filename'); // no stray embedded quote from the raw name
+  });
+});
+
+describe('/api/machines/files POST (create/upload)', () => {
+  it('returns the auth error when unauthenticated', async () => {
+    const authError = { error: new Response(null, { status: 401 }) };
+    authenticateRequestWithOptions.mockResolvedValueOnce(authError);
+    isAuthError.mockReturnValueOnce(true);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400, not a crash', async () => {
+    const res = await POST(rawRequest('POST', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON with 400', async () => {
+    const res = await POST(rawRequest('POST', '{not json'));
+    expect(res.status).toBe(400);
+  });
+
+  it('403s when canEditMachine is false, even though canViewMachine is true (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'You do not have edit access to this machine' });
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('403s before validating field shape (unauthorized caller cannot distinguish well-formed from malformed)', async () => {
+    canEditMachine.mockResolvedValue(false);
+    const res = await POST(post({ machineId: 't1', kind: 'not-a-real-kind' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await POST(post({ machineId: 't1', projectName: 'p1', path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when path is the scope root (empty string)', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: '', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when path escapes the scope root', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: '../../etc', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid kind', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'symlink' }));
+    expect(res.status).toBe(400);
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('creates a directory (branch scope) with the confined absolute path and audits the write', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(createMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/newdir' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', userId: 'user-1', resourceId: 't1' }),
+    );
+  });
+
+  it('creates a directory (root scope) with the confined absolute path under SANDBOX_ROOT', async () => {
+    const res = await POST(post({ ...ROOT_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(200);
+    expect(createMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/newdir' }),
+    );
+  });
+
+  it('409s when the directory already exists', async () => {
+    createMachineDirectory.mockResolvedValue({ ok: false, reason: 'already_exists' });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Something already has that name', reason: 'already_exists' });
+  });
+
+  it('404s when the parent folder is missing', async () => {
+    createMachineDirectory.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'gone/newdir', kind: 'directory' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('writes a file with default utf8 encoding and empty content, and overwrite is allowed (save)', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file' }));
+    expect(res.status).toBe(200);
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/a.txt', content: Buffer.from('', 'utf8') }),
+    );
+  });
+
+  it('writes utf8 content verbatim', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'hello world', encoding: 'utf8' }));
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ content: Buffer.from('hello world', 'utf8') }),
+    );
+  });
+
+  it('decodes base64 content', async () => {
+    const b64 = Buffer.from('binary payload', 'utf8').toString('base64');
+    await POST(post({ ...BRANCH_BODY, path: 'a.bin', kind: 'file', content: b64, encoding: 'base64' }));
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ content: Buffer.from('binary payload', 'utf8') }),
+    );
+  });
+
+  it('400s on malformed base64 content without calling writeMachineFile', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.bin', kind: 'file', content: 'not-valid-base64!!', encoding: 'base64' }));
+    expect(res.status).toBe(400);
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid encoding', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'x', encoding: 'latin1' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('413s when decoded content exceeds the 10 MiB upload cap, without calling writeMachineFile', async () => {
+    const big = 'x'.repeat(10 * 1024 * 1024 + 1);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'big.txt', kind: 'file', content: big, encoding: 'utf8' }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'File is too large to upload', reason: 'too_large' });
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('audits the file write with the op and relative path (never the absolute sprite path)', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'hi' }));
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ op: 'write_file', path: 'a.txt' }) }),
+    );
+  });
+});
+
+describe('/api/machines/files PATCH (move/copy)', () => {
+  const BASE = { ...BRANCH_BODY, fromPath: 'a.txt', toPath: 'b.txt' };
+
+  it('returns the auth error when unauthenticated', async () => {
+    authenticateRequestWithOptions.mockResolvedValueOnce({ error: new Response(null, { status: 401 }) });
+    isAuthError.mockReturnValueOnce(true);
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400', async () => {
+    const res = await PATCH(rawRequest('PATCH', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('403s when canEditMachine is false (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(403);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await PATCH(patch({ machineId: 't1', projectName: 'p1', fromPath: 'a', toPath: 'b', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid op', async () => {
+    const res = await PATCH(patch({ ...BASE, op: 'rename' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400s when fromPath is the scope root (empty string)', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: '', toPath: 'b.txt', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when toPath is the scope root (empty string)', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: 'a.txt', toPath: '', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when fromPath escapes the scope root', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: '../../etc/passwd', toPath: 'b.txt', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when toPath escapes the scope root', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: 'a.txt', toPath: '/etc/passwd', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('moves a path (branch scope) with confined absolute from/to paths and audits the write', async () => {
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(moveMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ fromPath: '/workspace/repo/a.txt', toPath: '/workspace/repo/b.txt' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'data.write',
+        details: expect.objectContaining({ op: 'move', fromPath: 'a.txt', toPath: 'b.txt' }),
+      }),
+    );
+  });
+
+  it('copies a path (root scope) with confined absolute paths under SANDBOX_ROOT', async () => {
+    const res = await PATCH(patch({ machineId: 't1', fromPath: 'a.txt', toPath: 'b.txt', op: 'copy' }));
+    expect(res.status).toBe(200);
+    expect(copyMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ fromPath: '/workspace/a.txt', toPath: '/workspace/b.txt' }),
+    );
+  });
+
+  it('409s when the destination already exists', async () => {
+    moveMachinePath.mockResolvedValue({ ok: false, reason: 'already_exists' });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Something already has that name', reason: 'already_exists' });
+  });
+
+  it('404s when the source is missing', async () => {
+    moveMachinePath.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('502s with detail (not error) when the exec fails', async () => {
+    copyMachinePath.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'cp: Permission denied on /workspace/repo/a.txt' });
+    const res = await PATCH(patch({ ...BASE, op: 'copy' }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toMatch(/workspace/);
+    expect(body.detail).toMatch(/Permission denied/);
+  });
+});
+
+describe('/api/machines/files DELETE', () => {
+  it('returns the auth error when unauthenticated', async () => {
+    authenticateRequestWithOptions.mockResolvedValueOnce({ error: new Response(null, { status: 401 }) });
+    isAuthError.mockReturnValueOnce(true);
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400', async () => {
+    const res = await DELETE(rawRequest('DELETE', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('403s when canEditMachine is false (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(403);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await DELETE(del({ machineId: 't1', branchName: 'b1', path: 'a.txt' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when path is the scope root (empty string), never calling the primitive', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: '' }));
+    expect(res.status).toBe(400);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when path escapes the scope root', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('deletes a path (branch scope) with the confined absolute path and audits the write', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deleteMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/a.txt' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'data.write',
+        details: expect.objectContaining({ op: 'delete', path: 'a.txt' }),
+      }),
+    );
+  });
+
+  it('deletes a path (root scope) with the confined absolute path under SANDBOX_ROOT', async () => {
+    const res = await DELETE(del({ machineId: 't1', path: 'a.txt' }));
+    expect(res.status).toBe(200);
+    expect(deleteMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/a.txt' }),
+    );
+  });
+
+  it('deleting an already-missing path is idempotent success (rm -rf semantics)', async () => {
+    deleteMachinePath.mockResolvedValue({ ok: true });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'already-gone.txt' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('502s with detail (not error) when the exec fails', async () => {
+    deleteMachinePath.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'rm: Permission denied on /workspace/repo/a.txt' });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toMatch(/workspace/);
+    expect(body.detail).toMatch(/Permission denied/);
   });
 });

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -2,60 +2,103 @@
  * Machine Files API — the Machine page's surface onto a WORKING TREE: either a
  * branch checkout, or (when `projectName`/`branchName` are absent) the root
  * Machine's own persistent Sprite (Machine page rebuild, Phase 1 — file
- * browsing; root scope added for the Machine Files Manager epic).
+ * browsing; root scope added for the Machine Files Manager epic; Phase 2 adds
+ * mutating verbs — create/upload, move/copy, delete, download).
  *
- * GET ?machineId=[&projectName=&branchName=][&path=][&mode=list|read]
+ * GET    ?machineId=[&projectName=&branchName=][&path=][&mode=list|read|download]
  *   projectName/branchName BOTH present → branch scope (a branch checkout)
  *   projectName/branchName BOTH absent  → root scope (the Machine's own tree)
  *   exactly one present                 → 400 (they are a pair)
  *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
  *   mode=read           → { content, encoding, truncated } for the file `path`
+ *   mode=download       → raw bytes, `Content-Disposition: attachment`, for the file `path`
+ *
+ * POST   { machineId, projectName?, branchName?, path, kind: 'directory' }
+ *        { machineId, projectName?, branchName?, path, kind: 'file', content?, encoding? }
+ *   Creates a directory, or creates/overwrites a file (overwrite IS allowed —
+ *   this is also how "save" works). `path` may not be `''` (the scope root).
+ *
+ * PATCH  { machineId, projectName?, branchName?, op: 'move' | 'copy', fromPath, toPath }
+ *   Moves or copies a path within the same scope. Neither `fromPath` nor
+ *   `toPath` may be `''` (the scope root is never itself the operand).
+ *
+ * DELETE { machineId, projectName?, branchName?, path }
+ *   Removes a path, recursively and idempotently (a missing target is
+ *   success). `path` may not be `''` (the scope root is never deleted).
+ *
+ * Every mutating verb requires edit access (`canEditMachine`), CSRF, and is
+ * audited on success (`auditRequest` with `eventType: 'data.write'`). GET
+ * (including `mode=download`) requires only view access — it is a read.
  *
  * FAILURES are `{ error, reason, detail? }`. `reason` is the machine-readable
  * fact and is what clients switch on; `error` is a sentence fit to show a human,
  * NEVER an internal token and never our own stderr (which names absolute paths
  * inside the Sprite) — that goes in `detail`, for logs and developers. The
  * reasons are disjoint on purpose:
- *   not_found      (404) — no checkout (branch: no row, or never cloned)
+ *   not_found      (404) — no checkout (branch: no row, or never cloned), or
+ *                          (mutations) the item being moved/copied/created-under is gone
  *   not_started    (404) — root scope only: the Machine has no live session
  *   vanished       (503) — the resolved Sprite is gone
  *   dir_not_found  (404) — the tree is there; that one directory is not
  *   file_not_found (404) — the tree is there; that one file is not
+ *   already_exists (409) — the mutation's destination already has something there
+ *   too_large      (413) — uploaded/downloaded content exceeds the size cap
  *   exec_failed    (502) — the exec itself failed; see `detail`
  * "no checkout", "no such directory" and "no such file" are different facts. A
  * client that conflates them tells the reader a file vanished when in truth
  * the whole branch did — so each gets its own token.
  *
- * `path` is RELATIVE to the scope's root — the branch checkout root
- * (`/workspace/repo`) for branch scope, `/workspace` (`SANDBOX_ROOT`) for root
- * scope — and is confined under it before the machine filesystem is touched —
- * an absolute path or a `..` escape is rejected (400), so a viewer cannot read
- * `/etc/passwd` or step out of the tree. Root scope confines via
- * `resolvePathWithinSync(SANDBOX_ROOT, …)` directly rather than
- * `resolveSandboxPath` — the latter's `/workspace`-prefix-stripping leniency is
- * an agent-tool affordance that has no place here and would break symmetry
- * with the branch arm. `path` defaults to the scope root for a listing and is
- * REQUIRED for a read. Reads the live filesystem only — no git ref (that is a
- * separate git-object service). Session-only (no MCP/agent tokens) — this is a
+ * `path`/`fromPath`/`toPath` are RELATIVE to the scope's root — the branch
+ * checkout root (`/workspace/repo`) for branch scope, `/workspace`
+ * (`SANDBOX_ROOT`) for root scope — and each is individually confined under it
+ * before the machine filesystem is touched — an absolute path or a `..` escape
+ * is rejected (400), so a caller cannot read/write `/etc/passwd` or step out of
+ * the tree. Root scope confines via `resolvePathWithinSync(SANDBOX_ROOT, …)`
+ * directly rather than `resolveSandboxPath` — the latter's
+ * `/workspace`-prefix-stripping leniency is an agent-tool affordance that has
+ * no place here and would break symmetry with the branch arm. `path` defaults
+ * to the scope root for a listing and is REQUIRED for a read/download/mutation.
+ * Confined absolute paths are what reach the `machine-fs` primitives — NEVER
+ * re-derived from the raw input once confined (PR #2039 TOCTOU lesson).
+ *
+ * Operates on the live filesystem only — no git ref (that is a separate
+ * git-object service). Session-only (no MCP/agent tokens) — this is a
  * human/UI surface, so it does NOT route through the AI agent tool
- * orchestration; every request re-checks view access for the Machine page,
- * same as the Branches/Agent-Terminals APIs.
+ * orchestration; every request re-checks access for the Machine page, same as
+ * the Branches/Agent-Terminals APIs.
  */
 
+import { basename } from 'node:path';
 import { StringDecoder } from 'string_decoder';
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
+import {
+  listMachineDirectory,
+  readMachineFile,
+  createMachineDirectory,
+  writeMachineFile,
+  moveMachinePath,
+  copyMachinePath,
+  deleteMachinePath,
+  type MutateMachinePathResult,
+} from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
-import { canViewMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
+import { canViewMachine, canEditMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
 import type { MachineFilesScope } from '@/lib/machines/machine-files-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
-/** A single file read is capped so a large blob can't flood the response. */
+const RESOURCE_TYPE = 'machine';
+
+/** A single file read/download is capped so a large blob can't flood the response. */
 const MAX_FILE_READ_BYTES = 2 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024;
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
 function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
   if (typeof value !== 'string' || value.length === 0) {
@@ -64,16 +107,164 @@ function requireString(value: unknown, field: string): { ok: true; value: string
   return { ok: true, value };
 }
 
-const LIST_DENIAL_STATUS: Record<string, number> = {
-  not_found: 404,
-  exec_failed: 502,
-};
+function requireEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+): { ok: true; value: T } | { ok: false; error: NextResponse } {
+  if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) {
+    return { ok: true, value: value as T };
+  }
+  return {
+    ok: false,
+    error: NextResponse.json(
+      { error: `${field} must be ${allowed.map((a) => `'${a}'`).join(' or ')}` },
+      { status: 400 },
+    ),
+  };
+}
+
+/** `request.json()` resolves (not throws) for a body like `null` or `42` — guard so that's a 400, not a 500. */
+async function parseJsonBody(request: Request): Promise<{ ok: true; value: Record<string, unknown> } | { ok: false; error: NextResponse }> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return { ok: false, error: NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) };
+  }
+  if (body === null || typeof body !== 'object') {
+    return { ok: false, error: NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) };
+  }
+  return { ok: true, value: body as Record<string, unknown> };
+}
+
+/** `null`/`''`/non-string all normalize to absent — mirrors the search-param handling below. */
+function normalizeScopePart(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * projectName/branchName are a pair: both present → branch scope, both absent
+ * → root scope. Shared by every verb so query-param (GET) and JSON-body
+ * (POST/PATCH/DELETE) callers get identical pairing semantics.
+ */
+function buildScope(
+  machineId: string,
+  rawProjectName: unknown,
+  rawBranchName: unknown,
+): { ok: true; scope: MachineFilesScope } | { ok: false; error: NextResponse } {
+  const projectName = normalizeScopePart(rawProjectName);
+  const branchName = normalizeScopePart(rawBranchName);
+  if ((projectName === null) !== (branchName === null)) {
+    return {
+      ok: false,
+      error: NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 }),
+    };
+  }
+  const scope: MachineFilesScope =
+    projectName !== null && branchName !== null
+      ? { scope: 'branch', machineId, projectName, branchName }
+      : { scope: 'root', machineId };
+  return { ok: true, scope };
+}
+
+function scopeRoot(scope: MachineFilesScope): string {
+  return scope.scope === 'branch' ? BRANCH_REPO_PATH : SANDBOX_ROOT;
+}
+
+/** Confines one relative path field under the scope root. Returns the confined absolute path, or a 400 response naming `field`. */
+function confineScopedPath(
+  scope: MachineFilesScope,
+  relativePath: string,
+  field: string,
+): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  const confined = resolvePathWithinSync(scopeRoot(scope), relativePath);
+  if (confined === null) {
+    return { ok: false, error: NextResponse.json({ error: `${field} escapes the machine filesystem root` }, { status: 400 }) };
+  }
+  return { ok: true, value: confined };
+}
 
 const RESOLVE_DENIAL_STATUS: Record<'not_found' | 'vanished' | 'not_started', number> = {
   not_found: 404,
   vanished: 503,
   not_started: 404,
 };
+
+/**
+ * `error` is user-facing: clients switch on `reason`, and at least one (the
+ * Code tab's file tree) renders `error` straight into the UI — so it must
+ * never be the internal token. "Branch machine vanished" is a sentence about
+ * our internals, not about anything the reader did or can act on.
+ */
+function resolveDenialResponse(reason: 'not_found' | 'vanished' | 'not_started'): NextResponse {
+  const error = reason === 'not_started' ? "This machine hasn't been started yet" : 'This branch checkout is unavailable';
+  return NextResponse.json({ error, reason }, { status: RESOLVE_DENIAL_STATUS[reason] });
+}
+
+/**
+ * Maps a `MutateMachinePathResult` failure to a response. `notFoundMessage` is
+ * op-specific ("the parent folder" vs "the item to move") because a bare
+ * `not_found` here can mean either "the destination's parent is missing" or
+ * "the source doesn't exist" depending on the verb.
+ */
+function mutateFailureResponse(result: Extract<MutateMachinePathResult, { ok: false }>, notFoundMessage: string): NextResponse {
+  if (result.reason === 'already_exists') {
+    return NextResponse.json({ error: 'Something already has that name', reason: 'already_exists' }, { status: 409 });
+  }
+  if (result.reason === 'not_found') {
+    return NextResponse.json({ error: notFoundMessage, reason: 'not_found' }, { status: 404 });
+  }
+  // The exec's stderr has real diagnostic value, but it is OUR stderr: it names
+  // absolute paths inside the Sprite. It belongs in `detail`, for logs and
+  // developers — never in `error`, which clients render straight at a person.
+  return NextResponse.json(
+    { error: 'Failed to complete the operation on the machine', reason: 'exec_failed', detail: result.detail },
+    { status: 502 },
+  );
+}
+
+function auditWrite(request: Request, userId: string, machineId: string, details: Record<string, unknown>): void {
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId,
+    details,
+  });
+}
+
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/**
+ * Node's `Buffer.from(str, 'base64')` is lenient — it silently drops invalid
+ * characters rather than throwing, so a malformed upload must be rejected
+ * before decoding, not caught after.
+ */
+function isValidBase64(value: string): boolean {
+  return value.length % 4 === 0 && BASE64_RE.test(value);
+}
+
+function decodeFileContent(
+  rawContent: unknown,
+  rawEncoding: unknown,
+): { ok: true; content: Buffer } | { ok: false; error: NextResponse } {
+  if (rawContent !== undefined && typeof rawContent !== 'string') {
+    return { ok: false, error: NextResponse.json({ error: 'content must be a string' }, { status: 400 }) };
+  }
+  if (rawEncoding !== undefined && rawEncoding !== 'utf8' && rawEncoding !== 'base64') {
+    return { ok: false, error: NextResponse.json({ error: "encoding must be 'utf8' or 'base64'" }, { status: 400 }) };
+  }
+  const content = rawContent ?? '';
+  const encoding = rawEncoding ?? 'utf8';
+  if (encoding === 'base64') {
+    if (!isValidBase64(content)) {
+      return { ok: false, error: NextResponse.json({ error: 'content is not valid base64' }, { status: 400 }) };
+    }
+    return { ok: true, content: Buffer.from(content, 'base64') };
+  }
+  return { ok: true, content: Buffer.from(content, 'utf8') };
+}
 
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
@@ -89,30 +280,18 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
 
-  // projectName/branchName are a pair: both present → branch scope, both
-  // absent → root scope. Treat `null` and `''` identically as absent — `''`
-  // already 400ed before this change, so no existing client observes new
-  // behavior for it.
-  const rawProjectName = url.searchParams.get('projectName');
-  const rawBranchName = url.searchParams.get('branchName');
-  const projectName = rawProjectName === null || rawProjectName.length === 0 ? null : rawProjectName;
-  const branchName = rawBranchName === null || rawBranchName.length === 0 ? null : rawBranchName;
-  if ((projectName === null) !== (branchName === null)) {
-    return NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 });
-  }
-  const scope: MachineFilesScope =
-    projectName !== null && branchName !== null
-      ? { scope: 'branch', machineId: machineId.value, projectName, branchName }
-      : { scope: 'root', machineId: machineId.value };
+  const scopeResult = buildScope(machineId.value, url.searchParams.get('projectName'), url.searchParams.get('branchName'));
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
 
   const mode = url.searchParams.get('mode') ?? 'list';
-  if (mode !== 'list' && mode !== 'read') {
-    return NextResponse.json({ error: "mode must be 'list' or 'read'" }, { status: 400 });
+  if (mode !== 'list' && mode !== 'read' && mode !== 'download') {
+    return NextResponse.json({ error: "mode must be 'list', 'read', or 'download'" }, { status: 400 });
   }
 
   const rawPath = url.searchParams.get('path');
-  if (mode === 'read' && (rawPath === null || rawPath.length === 0)) {
-    return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
+  if ((mode === 'read' || mode === 'download') && (rawPath === null || rawPath.length === 0)) {
+    return NextResponse.json({ error: `path is required when mode=${mode}` }, { status: 400 });
   }
 
   // `path` is untrusted and RELATIVE to the scope's root; confine it before any
@@ -120,29 +299,12 @@ export async function GET(request: Request) {
   // a `..` escape resolves to null → 400. Absolute path passed to the
   // filesystem is the confined result, never the raw input.
   const relativePath = rawPath !== null && rawPath.length > 0 ? rawPath : '';
-  const path =
-    scope.scope === 'branch'
-      ? resolvePathWithinSync(BRANCH_REPO_PATH, relativePath)
-      : resolvePathWithinSync(SANDBOX_ROOT, relativePath);
-  if (path === null) {
-    return NextResponse.json({ error: 'path escapes the machine filesystem root' }, { status: 400 });
-  }
+  const confined = confineScopedPath(scope, relativePath, 'path');
+  if (!confined.ok) return confined.error;
+  const path = confined.value;
 
   const resolved = await resolveMachineFilesHandle(scope);
-  if (!resolved.ok) {
-    // `error` is user-facing: clients switch on `reason`, and at least one (the
-    // Code tab's file tree) renders `error` straight into the UI — so it must
-    // never be the internal token. "Branch machine vanished" is a sentence about
-    // our internals, not about anything the reader did or can act on.
-    const error =
-      resolved.reason === 'not_started'
-        ? "This machine hasn't been started yet"
-        : 'This branch checkout is unavailable';
-    return NextResponse.json(
-      { error, reason: resolved.reason },
-      { status: RESOLVE_DENIAL_STATUS[resolved.reason] },
-    );
-  }
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
 
   if (mode === 'read') {
     const result = await readMachineFile({ handle: resolved.handle, path });
@@ -160,6 +322,30 @@ export async function GET(request: Request) {
     // (not the whole buffer) also bounds the work for a large file.
     const content = new StringDecoder('utf8').write(bytes);
     return NextResponse.json({ content, encoding: 'utf8', truncated });
+  }
+
+  if (mode === 'download') {
+    const result = await readMachineFile({ handle: resolved.handle, path });
+    if (!result.ok) {
+      return NextResponse.json({ error: 'File not found', reason: 'file_not_found' }, { status: 404 });
+    }
+    if (result.content.length > MAX_DOWNLOAD_BYTES) {
+      return NextResponse.json({ error: 'File is too large to download', reason: 'too_large' }, { status: 413 });
+    }
+    // Basename only (strip directories), then strip quotes/control chars via the
+    // shared header sanitizer; the ASCII fallback feeds `filename=`, the
+    // sanitized-but-unicode-preserved name feeds RFC 5987 `filename*`.
+    const safeName = sanitizeFilenameForHeader(basename(path));
+    const asciiName = safeName.replace(/[^\x20-\x7E]/g, '_');
+    const disposition = `attachment; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(safeName)}`;
+    return new NextResponse(new Uint8Array(result.content), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': disposition,
+        'Content-Length': String(result.content.length),
+      },
+    });
   }
 
   const result = await listMachineDirectory({ handle: resolved.handle, path });
@@ -187,8 +373,148 @@ export async function GET(request: Request) {
     // clients render straight at a person.
     return NextResponse.json(
       { error: 'Failed to list the checkout directory', reason: result.reason, detail: result.detail },
-      { status: LIST_DENIAL_STATUS[result.reason] ?? 500 },
+      { status: result.reason === 'exec_failed' ? 502 : 500 },
     );
   }
   return NextResponse.json({ entries: result.entries });
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  // Authorize BEFORE validating field shapes so an unauthorized caller can't
+  // distinguish a well-formed request (would-be success) from a malformed one
+  // (400) — same invariant as the settings route.
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  // Empty rejected by `requireString` too — the scope root can never itself be
+  // the thing being created.
+  const rawPath = requireString(body.path, 'path');
+  if (!rawPath.ok) return rawPath.error;
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  if (!confinedPath.ok) return confinedPath.error;
+  const path = confinedPath.value;
+
+  const kind = requireEnum(body.kind, ['directory', 'file'] as const, 'kind');
+  if (!kind.ok) return kind.error;
+
+  if (kind.value === 'directory') {
+    const resolved = await resolveMachineFilesHandle(scope);
+    if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+    const result = await createMachineDirectory({ handle: resolved.handle, path });
+    if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
+    auditWrite(request, auth.userId, machineId.value, { op: 'create_directory', path: rawPath.value });
+    return NextResponse.json({ ok: true });
+  }
+
+  const decoded = decodeFileContent(body.content, body.encoding);
+  if (!decoded.ok) return decoded.error;
+  if (decoded.content.length > MAX_UPLOAD_BYTES) {
+    return NextResponse.json({ error: 'File is too large to upload', reason: 'too_large' }, { status: 413 });
+  }
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+  const result = await writeMachineFile({ handle: resolved.handle, path, content: decoded.content });
+  if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
+  auditWrite(request, auth.userId, machineId.value, { op: 'write_file', path: rawPath.value });
+  return NextResponse.json({ ok: true });
+}
+
+export async function PATCH(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  const op = requireEnum(body.op, ['move', 'copy'] as const, 'op');
+  if (!op.ok) return op.error;
+
+  // Empty rejected by `requireString` too — the scope root can never itself be
+  // an operand of move/copy.
+  const rawFromPath = requireString(body.fromPath, 'fromPath');
+  if (!rawFromPath.ok) return rawFromPath.error;
+  const rawToPath = requireString(body.toPath, 'toPath');
+  if (!rawToPath.ok) return rawToPath.error;
+
+  const fromPath = confineScopedPath(scope, rawFromPath.value, 'fromPath');
+  if (!fromPath.ok) return fromPath.error;
+  const toPath = confineScopedPath(scope, rawToPath.value, 'toPath');
+  if (!toPath.ok) return toPath.error;
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+
+  const notFoundMessage = `The item to ${op.value} could not be found`;
+  const result =
+    op.value === 'move'
+      ? await moveMachinePath({ handle: resolved.handle, fromPath: fromPath.value, toPath: toPath.value })
+      : await copyMachinePath({ handle: resolved.handle, fromPath: fromPath.value, toPath: toPath.value });
+  if (!result.ok) return mutateFailureResponse(result, notFoundMessage);
+
+  auditWrite(request, auth.userId, machineId.value, { op: op.value, fromPath: rawFromPath.value, toPath: rawToPath.value });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  // Empty rejected by `requireString` too — the scope root is never deleted.
+  const rawPath = requireString(body.path, 'path');
+  if (!rawPath.ok) return rawPath.error;
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  if (!confinedPath.ok) return confinedPath.error;
+  const path = confinedPath.value;
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+
+  const result = await deleteMachinePath({ handle: resolved.handle, path });
+  if (!result.ok) return mutateFailureResponse(result, 'The item to delete could not be found');
+
+  auditWrite(request, auth.userId, machineId.value, { op: 'delete', path: rawPath.value });
+  return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- Adds mutating verbs (POST create/upload, PATCH move/copy, DELETE) and a third GET mode (`mode=download`) to `apps/web/src/app/api/machines/files/route.ts`, on top of the root-scope GET dispatcher (#2102) and the `machine-fs` write primitives (#2101).
- Every mutating verb: `authenticateRequestWithOptions({allow:['session'], requireCSRF:true})` → JSON body null/primitive guard → `requireString(machineId)` → `canEditMachine` 403 **before** any field-shape validation (settings-route invariant) → scope pairing (same optional-but-paired projectName/branchName as GET) → every path field (`path`/`fromPath`/`toPath`) individually confined via `resolvePathWithinSync` under the scope root → `resolveMachineFilesHandle` with GET's exact denial mapping → primitive call → `auditRequest({eventType:'data.write', ...})` with relative paths only (never absolute sprite paths).
- POST: `kind:'directory'` → `createMachineDirectory` (409 on `already_exists`, 404 on parent `not_found`); `kind:'file'` → decode utf8/base64 content (manual base64 validation — Node's decoder is lenient and won't throw on garbage), 10 MiB decoded cap → 413, `writeMachineFile` (overwrite allowed — this is also "save").
- PATCH: `op:'move'|'copy'` → `moveMachinePath`/`copyMachinePath`, `fromPath`/`toPath` of `''` rejected (scope root can't be an operand), 409/404/502 mapping.
- DELETE: `deleteMachinePath`, idempotent (missing target = success), `path===''` rejected.
- GET `mode=download`: same auth/scope/confinement as list/read (view access only, no CSRF), 50 MiB cap → 413, sanitized `Content-Disposition` (basename-only, RFC 5987 `filename*` for non-ASCII), byte-faithful `NextResponse` body.
- Module doc rewritten with the full verb table and the extended reasons table (`already_exists` 409, `too_large` 413).

## Test plan
- [x] `bunx vitest run src/app/api/machines/files/__tests__/route.test.ts` from `apps/web` — 91 tests passing (all existing GET tests unchanged + new POST/PATCH/DELETE/download coverage: auth/CSRF, 403-before-field-validation ordering, scope pairing, path-escape rejection with no primitive call, scope-root refusals, resolver denial mapping, 409/413/502 mapping, root+branch confined-absolute-path assertions, audit assertions, download header/byte fidelity).
- [x] `bun run typecheck` — clean across the monorepo.
- [x] `git diff --stat` against base — touches only `route.ts` and its test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)