### PR TITLE
feat(machines): file tree context menus — create, rename, delete (epic task 11)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -55,18 +55,25 @@ vi.mock('../workspace/MachineFileTree', () => ({
   default: function MachineFileTreeStub({
     scope,
     onSelectFile,
+    onPathRemoved,
   }: {
     scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
     onSelectFile?: (path: string) => void;
+    onPathRemoved?: (path: string) => void;
   }) {
     const scopeName = scope.kind === 'branch' ? scope.branchName : 'root';
     useEffect(() => {
       treeListings.push(scopeName);
     }, [scopeName]);
     return (
-      <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
-        tree:{scopeName}
-      </button>
+      <div>
+        <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
+          tree:{scopeName}
+        </button>
+        <button type="button" data-testid="delete-open-file" onClick={() => onPathRemoved?.('src/index.ts')}>
+          delete-open-file
+        </button>
+      </div>
     );
   },
 }));
@@ -423,6 +430,31 @@ describe('FilesTab', () => {
       should: 'render the file pane scoped to that branch and path',
       actual: pane.textContent,
       expected: 'pane:main:src/index.ts',
+    });
+  });
+
+  test('deleting the open file clears the pane', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
+
+    await userEvent.click(screen.getByText('pick-main'));
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByTestId('delete-open-file'));
+
+    assert({
+      given: 'the currently open file deleted from the tree',
+      should: 'clear the open file and fall back to the pick-a-file prompt',
+      actual: {
+        pane: screen.queryByTestId('file-pane'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
+      },
+      expected: { pane: null, filePrompt: true },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -34,6 +34,12 @@
  * is the initial scope, so the Machine's own files render immediately with no
  * pick required; picking a branch is additive, unchanged browsing on top of
  * that default.
+ *
+ * `MachineFileTree`'s own create/rename/delete operations (task 11) can hit
+ * the open file — deleting it, deleting an ancestor directory, or renaming
+ * either — so `onPathRemoved`/`onPathRenamed` below clear or retarget `path`
+ * to keep the pane honest. Everything else about those mutations (dialogs,
+ * cache invalidation, request bodies) lives entirely inside the tree.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -98,6 +104,26 @@ export default function FilesTab({ machineId }: FilesTabProps) {
     setSelection((current) => ({ ...current, path: next }));
   }, []);
 
+  // A delete/rename in the tree only matters to the open file if it hit the
+  // open path itself OR one of its ancestor directories — anything else
+  // leaves the pane alone.
+  const onPathRemoved = useCallback((removed: string) => {
+    setSelection((current) =>
+      current.path !== null && (current.path === removed || current.path.startsWith(`${removed}/`))
+        ? { ...current, path: null }
+        : current,
+    );
+  }, []);
+
+  const onPathRenamed = useCallback((from: string, to: string) => {
+    setSelection((current) => {
+      if (current.path === null) return current;
+      if (current.path === from) return { ...current, path: to };
+      if (current.path.startsWith(`${from}/`)) return { ...current, path: `${to}${current.path.slice(from.length)}` };
+      return current;
+    });
+  }, []);
+
   return (
     <TabSidebar
       title="Files"
@@ -152,6 +178,8 @@ export default function FilesTab({ machineId }: FilesTabProps) {
                 close();
               }}
               selectedPath={path}
+              onPathRemoved={onPathRemoved}
+              onPathRenamed={onPathRenamed}
             />
           </div>
         </>
@@ -191,11 +219,15 @@ function ScopeFiles({
   scope,
   onSelectFile,
   selectedPath,
+  onPathRemoved,
+  onPathRenamed,
 }: {
   machineId: string;
   scope: FilesScope;
   onSelectFile: (path: string) => void;
   selectedPath: string | null;
+  onPathRemoved: (path: string) => void;
+  onPathRenamed: (from: string, to: string) => void;
 }) {
   const [state, setState] = useState<ScopeState>({ status: 'loading' });
   // Bumped by Retry — re-runs the probe without changing the scope identity.
@@ -273,5 +305,14 @@ function ScopeFiles({
     );
   }
 
-  return <MachineFileTree machineId={machineId} scope={scope} onSelectFile={onSelectFile} selectedPath={selectedPath} />;
+  return (
+    <MachineFileTree
+      machineId={machineId}
+      scope={scope}
+      onSelectFile={onSelectFile}
+      selectedPath={selectedPath}
+      onPathRemoved={onPathRemoved}
+      onPathRenamed={onPathRenamed}
+    />
+  );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/FileNameDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/FileNameDialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * FileNameDialog — the single name-input dialog `MachineFileTree` uses for New
+ * File, New Folder, and Rename (Machine Files Manager epic, task 11). The
+ * app's `RenameDialog`/`MovePageDialog` are page-entity-specific (drive pages,
+ * not machine filesystem paths) — this is a small local equivalent rather than
+ * a reuse of those.
+ *
+ * Validation is client-side and minimal: a path segment can't be empty or
+ * contain `/` (the route treats `path`/`toPath` as a single segment appended
+ * to a parent directory, not a nested path). Deeper failures — a name that
+ * already exists, a vanished parent — come back from the mutation itself and
+ * are surfaced as a toast by the caller, not from here.
+ */
+
+import { useEffect, useState, type FormEvent } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface FileNameDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  /** Pre-filled for Rename; empty for New File / New Folder. */
+  initialName?: string;
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string) => void;
+}
+
+function validateName(name: string): string | null {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return 'Name is required';
+  if (trimmed.includes('/')) return "Name cannot contain '/'";
+  return null;
+}
+
+export default function FileNameDialog({
+  open,
+  title,
+  description,
+  initialName = '',
+  submitting = false,
+  onCancel,
+  onSubmit,
+}: FileNameDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed from `initialName` every time the dialog opens — the same instance
+  // is reused across New File / New Folder / Rename by the caller.
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setError(null);
+    }
+  }, [open, initialName]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validationError = validateName(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onSubmit(name.trim());
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description ?? 'A name cannot be empty or contain \'/\'.'}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="file-name-dialog-input">Name</Label>
+            <Input
+              id="file-name-dialog-input"
+              autoFocus
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              disabled={submitting}
+            />
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -1,10 +1,15 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
+}));
+
+const toastMocks = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: toastMocks,
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -56,10 +61,46 @@ const cannedFetch = (overrides: Record<string, () => Promise<Response>> = {}) =>
     return jsonResponse({ entries });
   });
 
+// Excludes mutation calls: a POST/PATCH/DELETE to `/api/machines/files` has no
+// `path` query param at all, so it would otherwise be miscounted as a listing
+// of the root ('').
 const listCallsFor = (path: string): number =>
-  vi.mocked(fetchWithAuth).mock.calls.filter((call) => requestedPath(String(call[0])) === path).length;
+  vi.mocked(fetchWithAuth).mock.calls.filter((call) => {
+    const init = (call[1] ?? {}) as RequestInit | undefined;
+    const method = typeof init?.method === 'string' ? init.method : 'GET';
+    return method === 'GET' && requestedPath(String(call[0])) === path;
+  }).length;
 
 const BRANCH_SCOPE: FilesScope = { kind: 'branch', projectName: 'my-repo', branchName: 'main' };
+
+/** One recorded mutation (POST/PATCH/DELETE) call, with its body already parsed. */
+interface MutationCall {
+  method: string | undefined;
+  body: unknown;
+}
+
+/**
+ * Serves listings from FAKE_FS same as `cannedFetch`, but routes any
+ * non-GET call to `mutationResponse` and records it — used by the
+ * context-menu/mutation tests below, which need to inspect the request the
+ * tree issued rather than only what it rendered afterwards.
+ */
+const cannedFetchWithMutation = (
+  mutationCalls: MutationCall[],
+  mutationResponse: () => Response | Promise<Response>,
+) =>
+  vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+    const init = (args[1] ?? {}) as RequestInit;
+    const method = typeof init.method === 'string' ? init.method : undefined;
+    if (method && method !== 'GET') {
+      mutationCalls.push({ method, body: init.body ? JSON.parse(String(init.body)) : undefined });
+      return mutationResponse();
+    }
+    const path = requestedPath(String(args[0]));
+    const entries = FAKE_FS[path];
+    if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+    return jsonResponse({ entries });
+  });
 
 const renderTree = (props: Partial<Parameters<typeof MachineFileTree>[0]> = {}) =>
   render(<MachineFileTree machineId="machine-1" scope={BRANCH_SCOPE} {...props} />);
@@ -78,6 +119,8 @@ const rowLabels = (): (string | null)[] =>
 describe('MachineFileTree', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    toastMocks.error.mockClear();
+    toastMocks.success.mockClear();
     cannedFetch();
   });
 
@@ -364,6 +407,189 @@ describe('MachineFileTree', () => {
       should: 'render an explicit empty row instead of nothing',
       actual: empty.textContent,
       expected: 'Empty folder',
+    });
+  });
+
+  describe('context menu operations', () => {
+    test('New Folder via a directory context menu POSTs a scoped, confined path and re-lists the parent once', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+
+      fireEvent.contextMenu(screen.getByText('src'));
+      await userEvent.click(await waitFor(() => screen.getByText('New Folder')));
+      await userEvent.type(screen.getByLabelText('Name'), 'newdir');
+      await userEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "New Folder chosen from the 'src' directory's context menu, named 'newdir'",
+        should: "POST the confined child path with the branch scope fields, then re-list 'src' exactly once",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'POST',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              path: 'src/newdir',
+              kind: 'directory',
+            },
+          },
+          srcRelistCount: 1,
+        },
+      });
+    });
+
+    test('Rename posts a same-parent PATCH move and drops the renamed directory\'s stale descendant cache', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await expandFolder('components');
+      await waitFor(() => screen.getByText('Button.tsx'));
+      const componentsFetchesBefore = listCallsFor('src/components');
+
+      fireEvent.contextMenu(screen.getByText('components'));
+      await userEvent.click(await waitFor(() => screen.getByText('Rename')));
+      const input = await waitFor(() => screen.getByLabelText('Name')) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'ui');
+      await userEvent.click(screen.getByText('Save'));
+
+      // 'components' stays expanded across the rename, so dropping its cache
+      // entry alone (without a manual toggle) is what proves the descendant
+      // cache was actually invalidated, not just the parent.
+      await waitFor(() => {
+        if (listCallsFor('src/components') <= componentsFetchesBefore) {
+          throw new Error('renamed directory\'s stale cache not dropped yet');
+        }
+      });
+
+      assert({
+        given: "Rename chosen from the 'components' directory's context menu, renamed to 'ui'",
+        should: 'PATCH a move with fromPath/toPath in the same parent, and refetch the old path once (stale cache dropped)',
+        actual: {
+          mutation: calls[0],
+          staleCacheDropped: listCallsFor('src/components') - componentsFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'move',
+              fromPath: 'src/components',
+              toPath: 'src/ui',
+            },
+          },
+          staleCacheDropped: 1,
+        },
+      });
+    });
+
+    test('Delete confirm fires DELETE and re-lists the parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Delete')));
+      await waitFor(() => screen.getByText('Delete "src/index.ts"?', { exact: false }));
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "Delete confirmed from 'src/index.ts'’s context menu",
+        should: 'DELETE the scoped path and re-list its parent once',
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'DELETE',
+            body: { machineId: 'machine-1', projectName: 'my-repo', branchName: 'main', path: 'src/index.ts' },
+          },
+          srcRelistCount: 1,
+        },
+      });
+    });
+
+    test('a 409 from a mutation toasts a friendly message and never re-lists or renders a row error', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'already_exists' }, 409));
+      renderTree();
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      await userEvent.click(screen.getByTitle('New file'));
+      await userEvent.type(screen.getByLabelText('Name'), 'zeta.md');
+      await userEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a create-file mutation that comes back 409',
+        should: 'toast a friendly "already has that name" message, issue no re-list, and never render a red tree row',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          rowError: screen.queryByTestId('file-tree-error'),
+        },
+        expected: {
+          toastMessage: 'Something already has that name',
+          rootRelistCount: 0,
+          rowError: null,
+        },
+      });
+    });
+
+    test('deleting the currently open file reports it via onPathRemoved', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRemoved = vi.fn();
+      renderTree({ scope: { kind: 'root' }, selectedPath: 'README.md', onPathRemoved });
+
+      await waitFor(() => screen.getByText('README.md'));
+
+      fireEvent.contextMenu(screen.getByText('README.md'));
+      await userEvent.click(await waitFor(() => screen.getByText('Delete')));
+      await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'Delete' })));
+
+      await waitFor(() => {
+        if (onPathRemoved.mock.calls.length === 0) throw new Error('onPathRemoved not called yet');
+      });
+
+      assert({
+        given: 'the currently open file (selectedPath) deleted via its context menu',
+        should: 'report the deleted path through onPathRemoved so the parent can clear it',
+        actual: onPathRemoved.mock.calls[0]?.[0],
+        expected: 'README.md',
+      });
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -3,7 +3,8 @@
 /**
  * MachineFileTree — the Files tab's file explorer over a Machine's filesystem:
  * either its own root Sprite (`/workspace`) or one project/branch checkout
- * within it, per `FilesScope` (Machine Files Manager epic, Part A).
+ * within it, per `FilesScope` (Machine Files Manager epic, Part A), plus
+ * create/rename/delete management operations over it (Part B, task 11).
  *
  * Sibling of MachineTree.tsx and follows its plain border-border inner-sidebar
  * row conventions (this is NOT one of the app's liquid-glass sidebars). Reads
@@ -31,23 +32,65 @@
  * Presentation-only about selection: file rows report their scope-relative
  * path through `onSelectFile`; the Files tab owns what selection does (e.g.
  * driving the file pane).
+ *
+ * MANAGEMENT OPERATIONS (task 11): directory rows get a right-click menu with
+ * New File / New Folder / Rename / Delete; file rows get Rename / Delete; the
+ * header gets New File / New Folder targeting the scope root. Move / Copy /
+ * Upload menu entries are deliberately NOT here yet — the `ContextMenuSeparator`
+ * before Rename is where tasks 12/13 slot them in, and Download slots into the
+ * file row's menu above Rename. One shared `FileNameDialog` (a local
+ * name-input dialog — the app's page-entity `RenameDialog` doesn't apply to
+ * filesystem paths) serves both create and rename; delete uses a local
+ * `AlertDialog` confirm naming the scope-relative path. All three mutations POST/
+ * PATCH/DELETE `/api/machines/files` with the scope fields in the JSON body
+ * (mirroring `filesScopeSearchParams`'s pairing rule, but this file doesn't
+ * import that helper — `files-scope.ts` is out of scope for this task). On
+ * success, the affected path(s) are dropped from `cacheRef` (see `invalidate`)
+ * so the existing fetch-on-render effect re-lists whatever's visible, and a
+ * delete/rename of the currently-open file bubbles up via `onPathRemoved` /
+ * `onPathRenamed` so `FilesTab` can clear or retarget the pane. Failures never
+ * become a red tree row for a mutation (rows are for LISTING errors only) — a
+ * mutation failure is always a `sonner` toast.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MachineDirectoryEntry } from '@pagespace/lib/services/sandbox/machine-fs';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   ChevronRight,
   File as FileIcon,
+  FilePlus,
   Folder,
   FolderOpen,
+  FolderPlus,
+  Pencil,
   RefreshCw,
+  Trash2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { SidebarLoading, SidebarNotice } from '../tabs/tab-states';
 import { readErrorBody } from '../tabs/checkout-states';
 import { type FilesScope, filesScopeKey, filesScopeSearchParams } from '../tabs/files-scope';
+import FileNameDialog from './FileNameDialog';
 
 export interface MachineFileTreeProps {
   machineId: string;
@@ -56,6 +99,10 @@ export interface MachineFileTreeProps {
   onSelectFile?: (path: string) => void;
   /** Scope-relative path of the file the parent currently shows, for the selected-row highlight. */
   selectedPath?: string | null;
+  /** A path was deleted (or, for a directory, everything under it) — parent should clear it if it was (or was an ancestor of) the open file. */
+  onPathRemoved?: (path: string) => void;
+  /** A path was renamed/moved from `from` to `to` — parent should retarget the open file if `from` was (or was an ancestor of) it. */
+  onPathRenamed?: (from: string, to: string) => void;
 }
 
 type DirectoryState =
@@ -63,7 +110,20 @@ type DirectoryState =
   | { status: 'loaded'; entries: MachineDirectoryEntry[] }
   | { status: 'error'; message: string };
 
-/** Everything the recursive nodes need, threaded as one object so recursion doesn't re-plumb six props per level. */
+type EntryKind = 'file' | 'directory';
+
+/**
+ * One dialog slot shared by New File / New Folder / Rename / Delete — only
+ * ever one of these is open at a time, so a single piece of state (rather than
+ * one boolean per op) is enough and can't get two dialogs open together.
+ */
+type PendingDialog =
+  | { kind: 'create'; parentPath: string; entryKind: EntryKind }
+  | { kind: 'rename'; path: string; parentPath: string; currentName: string; entryKind: EntryKind }
+  | { kind: 'delete'; path: string; entryKind: EntryKind }
+  | null;
+
+/** Everything the recursive nodes need, threaded as one object so recursion doesn't re-plumb props per level. */
 interface TreeContext {
   directories: ReadonlyMap<string, DirectoryState>;
   expandedPaths: ReadonlySet<string>;
@@ -71,6 +131,9 @@ interface TreeContext {
   toggleExpanded: (path: string) => void;
   onSelectFile?: (path: string) => void;
   selectedPath: string | null;
+  openCreateDialog: (parentPath: string, entryKind: EntryKind) => void;
+  openRenameDialog: (path: string, entryKind: EntryKind) => void;
+  openDeleteDialog: (path: string, entryKind: EntryKind) => void;
 }
 
 /** Directories first, then files, each alphabetical — the universal file-explorer ordering. */
@@ -86,18 +149,69 @@ const sortEntries = (entries: MachineDirectoryEntry[]): MachineDirectoryEntry[] 
  */
 const readErrorMessage = (body: unknown): string | null => readErrorBody(body).error;
 
+/** The path's final segment — used for a rename dialog's starting value and the delete confirm's label. */
+const basenameOf = (path: string): string => (path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path);
+
+/** The path's parent, scope-relative (`''` for a root-level entry). */
+const parentOf = (path: string): string => {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '' : path.slice(0, i);
+};
+
+const joinPath = (parentPath: string, name: string): string => (parentPath.length > 0 ? `${parentPath}/${name}` : name);
+
+/**
+ * JSON-body scope fields for a mutation. Mirrors `filesScopeSearchParams`'s
+ * pairing rule (branch scope sends `projectName`/`branchName`, root scope
+ * sends neither) but is local to this file — `files-scope.ts` is out of scope
+ * for task 11.
+ */
+const scopeBodyFields = (machineId: string, scope: FilesScope): Record<string, string> =>
+  scope.kind === 'branch'
+    ? { machineId, projectName: scope.projectName, branchName: scope.branchName }
+    : { machineId };
+
+/**
+ * POSTs/PATCHes/DELETEs a mutation and turns any failure into the app's toast
+ * convention — 403 and 409 get fixed, friendly copy; anything else falls back
+ * to the route's own human-readable `error`. Returns whether it succeeded so
+ * the caller can decide what to do next (invalidate cache, close a dialog);
+ * never throws.
+ */
+async function runMutation(init: RequestInit): Promise<boolean> {
+  try {
+    const res = await fetchWithAuth('/api/machines/files', {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...init.headers },
+    });
+    if (res.ok) return true;
+    const body: unknown = await res.json().catch(() => null);
+    if (res.status === 403) {
+      toast.error("You don't have edit access to this machine");
+    } else if (res.status === 409) {
+      toast.error('Something already has that name');
+    } else {
+      toast.error(readErrorMessage(body) ?? `Request failed (${res.status})`);
+    }
+    return false;
+  } catch (err) {
+    toast.error(err instanceof Error ? err.message : 'Request failed');
+    return false;
+  }
+}
+
 export default function MachineFileTree(props: MachineFileTreeProps) {
   // Remount on identity change so the per-path cache and all expansion state
   // reset together — a different machine or scope is a different tree.
   return (
     <FileTreeRoot
-      key={`${props.machineId}\u0000${filesScopeKey(props.scope)}`}
+      key={`${props.machineId} ${filesScopeKey(props.scope)}`}
       {...props}
     />
   );
 }
 
-function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineFileTreeProps) {
+function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemoved, onPathRenamed }: MachineFileTreeProps) {
   // The ref is the canonical cache — synchronously readable, so two renders
   // racing the same path (e.g. a collapse/re-expand while the listing is still
   // in flight) can never issue a duplicate fetch. The state map is a snapshot
@@ -105,6 +219,8 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
   const cacheRef = useRef<Map<string, DirectoryState>>(new Map());
   const [directories, setDirectories] = useState<ReadonlyMap<string, DirectoryState>>(new Map());
   const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(new Set());
+  const [pendingDialog, setPendingDialog] = useState<PendingDialog>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   const setDirectoryState = useCallback((path: string, state: DirectoryState) => {
     cacheRef.current.set(path, state);
@@ -162,6 +278,93 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
     setDirectories(new Map());
   }, []);
 
+  /**
+   * Drops every cache entry equal to (or nested under) any of `paths` — the
+   * surgical, per-path sibling of `refresh()`. A directory dropped this way
+   * that's currently mounted (visible) re-lists itself via its own
+   * fetch-on-render effect; one that's collapsed just refetches lazily next
+   * time it's expanded.
+   */
+  const invalidate = useCallback((paths: string[]) => {
+    const next = new Map(cacheRef.current);
+    let changed = false;
+    for (const key of next.keys()) {
+      if (paths.some((p) => key === p || key.startsWith(`${p}/`))) {
+        next.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) {
+      cacheRef.current = next;
+      setDirectories(new Map(next));
+    }
+  }, []);
+
+  const openCreateDialog = useCallback((parentPath: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'create', parentPath, entryKind });
+  }, []);
+
+  const openRenameDialog = useCallback((path: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'rename', path, parentPath: parentOf(path), currentName: basenameOf(path), entryKind });
+  }, []);
+
+  const openDeleteDialog = useCallback((path: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'delete', path, entryKind });
+  }, []);
+
+  const closeDialog = useCallback(() => setPendingDialog(null), []);
+
+  const handleCreateOrRenameSubmit = useCallback(
+    async (name: string) => {
+      if (pendingDialog === null || pendingDialog.kind === 'delete') return;
+      setSubmitting(true);
+      try {
+        if (pendingDialog.kind === 'create') {
+          const { parentPath, entryKind } = pendingDialog;
+          const path = joinPath(parentPath, name);
+          const ok = await runMutation({
+            method: 'POST',
+            body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: entryKind }),
+          });
+          if (!ok) return;
+          invalidate([parentPath]);
+        } else {
+          const { path: fromPath, parentPath } = pendingDialog;
+          const toPath = joinPath(parentPath, name);
+          const ok = await runMutation({
+            method: 'PATCH',
+            body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op: 'move', fromPath, toPath }),
+          });
+          if (!ok) return;
+          invalidate([parentPath, fromPath]);
+          onPathRenamed?.(fromPath, toPath);
+        }
+        setPendingDialog(null);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [pendingDialog, machineId, scope, invalidate, onPathRenamed],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (pendingDialog === null || pendingDialog.kind !== 'delete') return;
+    const { path } = pendingDialog;
+    setSubmitting(true);
+    try {
+      const ok = await runMutation({
+        method: 'DELETE',
+        body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path }),
+      });
+      if (!ok) return;
+      invalidate([parentOf(path), path]);
+      onPathRemoved?.(path);
+      setPendingDialog(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [pendingDialog, machineId, scope, invalidate, onPathRemoved]);
+
   const ctx: TreeContext = {
     directories,
     expandedPaths,
@@ -169,24 +372,89 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
     toggleExpanded,
     onSelectFile,
     selectedPath: selectedPath ?? null,
+    openCreateDialog,
+    openRenameDialog,
+    openDeleteDialog,
   };
 
   return (
     <div className="p-1 text-sm" data-testid="machine-file-tree">
       <div className="flex items-center justify-between py-0.5 pr-1">
         <span className="text-xs text-muted-foreground">Files</span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-5"
-          title="Refresh files"
-          onClick={refresh}
-        >
-          <RefreshCw className="size-3" />
-        </Button>
+        <div className="flex items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="New file"
+            onClick={() => openCreateDialog('', 'file')}
+          >
+            <FilePlus className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="New folder"
+            onClick={() => openCreateDialog('', 'directory')}
+          >
+            <FolderPlus className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="Refresh files"
+            onClick={refresh}
+          >
+            <RefreshCw className="size-3" />
+          </Button>
+        </div>
       </div>
       <DirectoryChildren path="" depth={0} ctx={ctx} />
+
+      <FileNameDialog
+        open={pendingDialog?.kind === 'create' || pendingDialog?.kind === 'rename'}
+        title={
+          pendingDialog?.kind === 'create'
+            ? pendingDialog.entryKind === 'directory'
+              ? 'New Folder'
+              : 'New File'
+            : 'Rename'
+        }
+        initialName={pendingDialog?.kind === 'rename' ? pendingDialog.currentName : ''}
+        submitting={submitting}
+        onCancel={closeDialog}
+        onSubmit={handleCreateOrRenameSubmit}
+      />
+      <AlertDialog open={pendingDialog?.kind === 'delete'} onOpenChange={(next) => { if (!next) closeDialog(); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete &quot;{pendingDialog?.kind === 'delete' ? pendingDialog.path : ''}&quot;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes it from the machine. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleDeleteConfirm();
+              }}
+              disabled={submitting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {submitting ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -255,29 +523,56 @@ function DirectoryNode({
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => ctx.toggleExpanded(path)}
-        aria-expanded={expanded}
-        data-testid="file-tree-dir-toggle"
-        className="relative flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all hover:bg-gray-200 dark:hover:bg-gray-700"
-        style={{ paddingLeft: `${depth * 8 + 16}px` }}
-      >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn(
-            'absolute h-3 w-3 shrink-0 text-gray-500 transition-transform duration-200',
-            expanded && 'rotate-90',
-          )}
-          style={{ left: `${depth * 8}px` }}
-        />
-        {expanded ? (
-          <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
-        ) : (
-          <Folder className="h-4 w-4 shrink-0 text-primary" />
-        )}
-        <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
-      </button>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={() => ctx.toggleExpanded(path)}
+            aria-expanded={expanded}
+            data-testid="file-tree-dir-toggle"
+            className="relative flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all hover:bg-gray-200 dark:hover:bg-gray-700"
+            style={{ paddingLeft: `${depth * 8 + 16}px` }}
+          >
+            <ChevronRight
+              aria-hidden="true"
+              className={cn(
+                'absolute h-3 w-3 shrink-0 text-gray-500 transition-transform duration-200',
+                expanded && 'rotate-90',
+              )}
+              style={{ left: `${depth * 8}px` }}
+            />
+            {expanded ? (
+              <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
+            ) : (
+              <Folder className="h-4 w-4 shrink-0 text-primary" />
+            )}
+            <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-48">
+          <ContextMenuItem onSelect={() => ctx.openCreateDialog(path, 'file')}>
+            <FilePlus className="mr-2 h-4 w-4" />
+            <span>New File</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openCreateDialog(path, 'directory')}>
+            <FolderPlus className="mr-2 h-4 w-4" />
+            <span>New Folder</span>
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          {/* Move to... / Copy to... / Upload here land here — tasks 12/13. */}
+          <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'directory')}>
+            <Pencil className="mr-2 h-4 w-4" />
+            <span>Rename</span>
+          </ContextMenuItem>
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() => ctx.openDeleteDialog(path, 'directory')}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            <span>Delete</span>
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       {expanded && <DirectoryChildren path={path} depth={depth + 1} ctx={ctx} />}
     </div>
   );
@@ -296,21 +591,36 @@ function FileNode({
 }) {
   const selected = ctx.selectedPath === path;
   return (
-    <button
-      type="button"
-      onClick={() => ctx.onSelectFile?.(path)}
-      disabled={ctx.onSelectFile === undefined}
-      aria-current={selected ? 'true' : undefined}
-      data-testid="file-tree-file"
-      style={{ paddingLeft: `${depth * 8 + 16}px` }}
-      className={cn(
-        'flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all',
-        selected ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
-        ctx.onSelectFile === undefined && 'cursor-default',
-      )}
-    >
-      <FileIcon className="h-4 w-4 shrink-0 text-gray-500" />
-      <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
-    </button>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          onClick={() => ctx.onSelectFile?.(path)}
+          disabled={ctx.onSelectFile === undefined}
+          aria-current={selected ? 'true' : undefined}
+          data-testid="file-tree-file"
+          style={{ paddingLeft: `${depth * 8 + 16}px` }}
+          className={cn(
+            'flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all',
+            selected ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
+            ctx.onSelectFile === undefined && 'cursor-default',
+          )}
+        >
+          <FileIcon className="h-4 w-4 shrink-0 text-gray-500" />
+          <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        {/* Download lands here — task 13. */}
+        <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'file')}>
+          <Pencil className="mr-2 h-4 w-4" />
+          <span>Rename</span>
+        </ContextMenuItem>
+        <ContextMenuItem variant="destructive" onSelect={() => ctx.openDeleteDialog(path, 'file')}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          <span>Delete</span>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }


### PR DESCRIPTION
## Summary
- `MachineFileTree`: right-click context menus — directory rows get New File, New Folder, Rename, Delete; file rows get Rename, Delete; the tree header gets New File/New Folder targeting the scope root (alongside Refresh).
- New `FileNameDialog` (shadcn `Dialog` + `Input`): shared by New File / New Folder / Rename, with client-side validation (non-empty, no `/`).
- Delete confirm via `AlertDialog`, destructive copy naming the scope-relative path.
- Cache invalidation is surgical: on success, the affected parent path (and, for rename, the old path's cache — including any cached descendants) is dropped from `cacheRef` so the existing fetch-on-render effect re-lists exactly what's visible, rather than a full `refresh()`.
- Mutation failures are always a `sonner` toast, never a red tree row: 403 → "You don't have edit access to this machine", 409 → "Something already has that name", other errors → the route's own `error` string.
- `MachineFileTree` gains optional `onPathRemoved`/`onPathRenamed` props; `FilesTab` wires them to clear the open file (delete of it or an ancestor directory) or retarget it (rename of it or an ancestor directory).
- Move/Copy/Upload menu entries and Download are deliberately NOT added yet — a `ContextMenuSeparator` in each row's menu marks where tasks 12/13 slot them in.

Builds on the merged files route mutations (PR #2105) and the scope-aware tree (PR #2103/#2104). Touches only `MachineFileTree.tsx` (+test), the new `FileNameDialog.tsx`, and a minimal `FilesTab.tsx` touch (+test) for open-file coordination — no route/machine-fs/FilesFilePane/files-scope/checkout-states/MachineTree changes.

## Test plan
- [x] `MachineFileTree.test.tsx` — new `context menu operations` describe block: New Folder happy path (POST body + scope, parent re-listed exactly once), Rename (PATCH move, same-parent `toPath`, stale descendant cache dropped), Delete confirm (DELETE + re-list), 409 → toast with no re-list/no row error, delete-of-open-file reports via `onPathRemoved`. All 22 tests in the file green.
- [x] `FilesTab.test.tsx` — new case: deleting the open file clears the pane. All 16 tests green.
- [x] Full `apps/web/src/components/layout/middle-content/page-views/machine` suite: 243/243 passing.
- [x] `bun run typecheck` clean.
- [x] `bunx eslint` clean on all touched files.
- [x] `git diff --stat` against base touches only the files named in the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)