### PR TITLE
feat(broadcast): admin console UI — compose, preview, live-send, progress

### DIFF
--- a/apps/admin/src/app/(admin)/broadcasts/[id]/page.tsx
+++ b/apps/admin/src/app/(admin)/broadcasts/[id]/page.tsx
@@ -1,0 +1,13 @@
+import { PageHeader } from "@/components/admin/kit";
+import { BroadcastProgress } from "@/components/admin/broadcasts/broadcast-progress";
+
+export default async function BroadcastDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Broadcast" description="Live status, counts, and step log for this broadcast." />
+      <BroadcastProgress broadcastId={id} />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/broadcasts/new/page.tsx
+++ b/apps/admin/src/app/(admin)/broadcasts/new/page.tsx
@@ -1,0 +1,14 @@
+import { PageHeader } from "@/components/admin/kit";
+import { BroadcastComposer } from "@/components/admin/broadcasts/broadcast-composer";
+
+export default function NewBroadcastPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="New broadcast"
+        description="Compose or pick a template, target an audience, preview, then send."
+      />
+      <BroadcastComposer />
+    </div>
+  );
+}

--- a/apps/admin/src/app/(admin)/broadcasts/page.tsx
+++ b/apps/admin/src/app/(admin)/broadcasts/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Plus, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { PageHeader, DataState } from "@/components/admin/kit";
+import { StatusBadge } from "@/components/admin/broadcasts/status-badge";
+import { useAdminQuery } from "@/hooks/use-admin-query";
+import { num } from "@/lib/format";
+import type { BroadcastsListResponse } from "@/components/admin/broadcasts/types";
+
+function BroadcastsSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Skeleton key={i} className="h-12 w-full" />
+      ))}
+    </div>
+  );
+}
+
+export default function BroadcastsPage() {
+  const router = useRouter();
+  const { data, isLoading, isFetching, error, refetch } = useAdminQuery<BroadcastsListResponse>(
+    "/api/admin/broadcasts",
+    { refreshInterval: 15000 },
+  );
+
+  const broadcasts = data?.broadcasts ?? [];
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Broadcasts"
+        description="Compose, target, and send email broadcasts to your users."
+        actions={
+          <>
+            <Button variant="outline" size="sm" onClick={refetch} disabled={isFetching}>
+              <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
+              Refresh
+            </Button>
+            <Button size="sm" onClick={() => router.push("/broadcasts/new")}>
+              <Plus className="mr-1.5 h-4 w-4" />
+              New broadcast
+            </Button>
+          </>
+        }
+      />
+
+      <DataState
+        isLoading={isLoading}
+        error={error}
+        isEmpty={!!data && broadcasts.length === 0}
+        emptyMessage="No broadcasts yet. Start with a dry run to preview an audience and email."
+        onRetry={refetch}
+        skeleton={<BroadcastsSkeleton />}
+        hasData={!!data}
+      >
+        <div className="overflow-x-auto rounded-lg border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Subject</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Engine</TableHead>
+                <TableHead className="text-right">Sent</TableHead>
+                <TableHead className="text-right">Skipped</TableHead>
+                <TableHead className="text-right">Failed</TableHead>
+                <TableHead className="text-right">Targeted</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {broadcasts.map((broadcast) => (
+                <TableRow
+                  key={broadcast.id}
+                  className="cursor-pointer"
+                  onClick={() => router.push(`/broadcasts/${broadcast.id}`)}
+                >
+                  <TableCell className="max-w-[320px] truncate font-medium">
+                    <Link href={`/broadcasts/${broadcast.id}`} className="hover:underline" onClick={(e) => e.stopPropagation()}>
+                      {broadcast.subject || "(untitled)"}
+                    </Link>
+                    {broadcast.dryRun && (
+                      <Badge variant="outline" className="ml-2 align-middle">
+                        Dry run
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <StatusBadge status={broadcast.status} />
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {broadcast.engine === "transactional" ? "Transactional" : "Marketing (Resend)"}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">{num(broadcast.sentCount)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{num(broadcast.skippedCount)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{num(broadcast.failedCount)}</TableCell>
+                  <TableCell className="text-right tabular-nums">{num(broadcast.totalTargeted)}</TableCell>
+                  <TableCell className="whitespace-nowrap text-muted-foreground">
+                    {new Date(broadcast.createdAt).toLocaleString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      </DataState>
+    </div>
+  );
+}

--- a/apps/admin/src/components/admin/broadcasts/__tests__/composer-form.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/composer-form.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EMPTY_AUDIENCE,
+  EMPTY_COMPOSER_FORM,
+  buildAudienceDefinition,
+  buildCreatePayload,
+  formSnapshot,
+  isPreviewStale,
+  type ComposerFormState,
+} from '../composer-form';
+
+describe('buildAudienceDefinition', () => {
+  it('drops every untouched field so an empty builder targets everyone', () => {
+    expect(buildAudienceDefinition(EMPTY_AUDIENCE)).toEqual({});
+  });
+
+  it('includes only the fields the admin actually set', () => {
+    const def = buildAudienceDefinition({
+      includeUnverified: true,
+      planTiers: ['pro', 'founder'],
+      signupAfter: '2026-01-01',
+      signupBefore: '',
+      userIds: ['u1'],
+    });
+    expect(def.includeUnverified).toBe(true);
+    expect(def.planTiers).toEqual(['pro', 'founder']);
+    expect(def.signupAfter).toBe('2026-01-01T00:00:00.000Z');
+    expect(def.signupBefore).toBeUndefined();
+    expect(def.userIds).toEqual(['u1']);
+  });
+
+  it('bounds signupBefore to end-of-day so the inclusive date reads as intended', () => {
+    const def = buildAudienceDefinition({ ...EMPTY_AUDIENCE, signupBefore: '2026-01-31' });
+    expect(def.signupBefore).toBe('2026-01-31T23:59:59.999Z');
+  });
+});
+
+describe('buildCreatePayload', () => {
+  const composeForm: ComposerFormState = {
+    ...EMPTY_COMPOSER_FORM,
+    contentMode: 'compose',
+    subject: 'Hello',
+    bodyMarkdown: 'World',
+    templateId: 'stale-template-id',
+  };
+
+  it('drops the cross-mode templateId when composing', () => {
+    const payload = buildCreatePayload(composeForm, true);
+    expect(payload.contentMode).toBe('compose');
+    expect(payload.bodyMarkdown).toBe('World');
+    expect(payload.templateId).toBeUndefined();
+  });
+
+  it('drops the cross-mode bodyMarkdown when using a template', () => {
+    const templateForm: ComposerFormState = {
+      ...EMPTY_COMPOSER_FORM,
+      contentMode: 'template',
+      bodyMarkdown: 'stale draft text',
+      templateId: 'tpl_1',
+    };
+    const payload = buildCreatePayload(templateForm, true);
+    expect(payload.contentMode).toBe('template');
+    expect(payload.templateId).toBe('tpl_1');
+    expect(payload.bodyMarkdown).toBeUndefined();
+  });
+
+  it('always sets dryRun explicitly, never defaults it', () => {
+    expect(buildCreatePayload(composeForm, true).dryRun).toBe(true);
+    expect(buildCreatePayload(composeForm, false).dryRun).toBe(false);
+  });
+
+  it('carries sendLimit/delayMs/allowDuplicate only for a live send', () => {
+    const payload = buildCreatePayload(composeForm, false, { sendLimit: 5, delayMs: 250, allowDuplicate: true });
+    expect(payload.sendLimit).toBe(5);
+    expect(payload.delayMs).toBe(250);
+    expect(payload.allowDuplicate).toBe(true);
+  });
+
+  it('trims the subject', () => {
+    const payload = buildCreatePayload({ ...composeForm, subject: '  Hello  ' }, true);
+    expect(payload.subject).toBe('Hello');
+  });
+});
+
+describe('isPreviewStale', () => {
+  const form: ComposerFormState = { ...EMPTY_COMPOSER_FORM, subject: 'A', bodyMarkdown: 'B' };
+
+  it('is never stale before a preview has been taken', () => {
+    expect(isPreviewStale(null, form)).toBe(false);
+  });
+
+  it('is not stale immediately after taking a preview of the current form', () => {
+    const snapshot = formSnapshot(form);
+    expect(isPreviewStale(snapshot, form)).toBe(false);
+  });
+
+  it('goes stale the moment any previewed field changes', () => {
+    const snapshot = formSnapshot(form);
+    const edited: ComposerFormState = { ...form, subject: 'A (edited)' };
+    expect(isPreviewStale(snapshot, edited)).toBe(true);
+  });
+
+  it('goes stale on an audience-only edit', () => {
+    const snapshot = formSnapshot(form);
+    const edited: ComposerFormState = { ...form, audience: { ...form.audience, includeUnverified: true } };
+    expect(isPreviewStale(snapshot, edited)).toBe(true);
+  });
+
+  it('goes stale on an engine change', () => {
+    const snapshot = formSnapshot(form);
+    const edited: ComposerFormState = { ...form, engine: 'resend_broadcast' };
+    expect(isPreviewStale(snapshot, edited)).toBe(true);
+  });
+});

--- a/apps/admin/src/components/admin/broadcasts/__tests__/composer-form.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/composer-form.test.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_COMPOSER_FORM,
   buildAudienceDefinition,
   buildCreatePayload,
+  formatServerFailureMessage,
   formSnapshot,
   isPreviewStale,
   type ComposerFormState,
@@ -110,5 +111,29 @@ describe('isPreviewStale', () => {
     const snapshot = formSnapshot(form);
     const edited: ComposerFormState = { ...form, engine: 'resend_broadcast' };
     expect(isPreviewStale(snapshot, edited)).toBe(true);
+  });
+});
+
+describe('formatServerFailureMessage', () => {
+  it('includes the broadcastId + "retrying is safe" only when the server actually returned one', () => {
+    const msg = formatServerFailureMessage({ error: 'Failed to enqueue broadcast job', broadcastId: 'b_1' }, 500);
+    expect(msg).toBe('Failed to enqueue broadcast job — broadcast b_1 was marked failed; retrying is safe.');
+  });
+
+  it('does not claim a row was marked failed when the outer catch returned no broadcastId', () => {
+    // The route's outer catch (e.g. broadcastRepository.create itself throwing,
+    // before any row exists) returns just { error } — no broadcastId.
+    const msg = formatServerFailureMessage({ error: 'Failed to create broadcast' }, 500);
+    expect(msg).toBe('Failed to create broadcast');
+    expect(msg).not.toContain('undefined');
+    expect(msg).not.toContain('retrying is safe');
+  });
+
+  it('falls back to a generic message when the body is unparseable', () => {
+    expect(formatServerFailureMessage(null, 500)).toBe('Send failed (500)');
+  });
+
+  it('falls back to a generic message when the body has no error field', () => {
+    expect(formatServerFailureMessage({ broadcastId: 'b_1' }, 500)).toBe('Send failed (500)');
   });
 });

--- a/apps/admin/src/components/admin/broadcasts/__tests__/status-badge.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/status-badge.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { statusBadgeLabel, statusBadgeVariant } from '../status-badge';
+import type { BroadcastStatus } from '../types';
+
+const STATUSES: BroadcastStatus[] = [
+  'draft', 'pending', 'queued', 'in_progress', 'paused', 'completed', 'failed', 'cancelled',
+];
+
+describe('statusBadgeVariant / statusBadgeLabel', () => {
+  it('has a mapping for every broadcast status', () => {
+    for (const status of STATUSES) {
+      expect(statusBadgeVariant(status)).toBeTruthy();
+      expect(statusBadgeLabel(status)).toBeTruthy();
+    }
+  });
+
+  it('marks failed as destructive', () => {
+    expect(statusBadgeVariant('failed')).toBe('destructive');
+  });
+
+  it('marks completed and in_progress as the default (positive) variant', () => {
+    expect(statusBadgeVariant('completed')).toBe('default');
+    expect(statusBadgeVariant('in_progress')).toBe('default');
+  });
+
+  it('gives each status a distinct, human-readable label', () => {
+    const labels = STATUSES.map(statusBadgeLabel);
+    expect(new Set(labels).size).toBe(STATUSES.length);
+    expect(statusBadgeLabel('in_progress')).toBe('In progress');
+  });
+});

--- a/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { isTerminalStatus } from '../types';
+
+describe('isTerminalStatus', () => {
+  it('treats completed, failed, and cancelled as terminal — polling stops here', () => {
+    expect(isTerminalStatus('completed')).toBe(true);
+    expect(isTerminalStatus('failed')).toBe(true);
+    expect(isTerminalStatus('cancelled')).toBe(true);
+  });
+
+  it('treats every in-flight status as non-terminal', () => {
+    expect(isTerminalStatus('draft')).toBe(false);
+    expect(isTerminalStatus('pending')).toBe(false);
+    expect(isTerminalStatus('queued')).toBe(false);
+    expect(isTerminalStatus('in_progress')).toBe(false);
+    expect(isTerminalStatus('paused')).toBe(false);
+  });
+});

--- a/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { isTerminalStatus } from '../types';
+import { isPollingSettled, isTerminalStatus } from '../types';
 
 describe('isTerminalStatus', () => {
-  it('treats completed and cancelled as terminal — polling stops here', () => {
+  it('treats completed and cancelled as terminal — the API always refuses further intervention here', () => {
     expect(isTerminalStatus('completed')).toBe(true);
     expect(isTerminalStatus('cancelled')).toBe(true);
   });
@@ -15,7 +15,30 @@ describe('isTerminalStatus', () => {
     expect(isTerminalStatus('paused')).toBe(false);
   });
 
-  it('treats failed as NON-terminal — the worker rethrows on a retryable failure so pg-boss can resume the row, which can later reach in_progress or completed', () => {
+  it('treats failed as NON-terminal — the API always accepts a cancel on a failed row (it may be mid pg-boss-retry, or a dead row an admin wants to close out)', () => {
     expect(isTerminalStatus('failed')).toBe(false);
+  });
+});
+
+describe('isPollingSettled', () => {
+  it('is settled for completed and cancelled regardless of blockedReason', () => {
+    expect(isPollingSettled('completed', null)).toBe(true);
+    expect(isPollingSettled('cancelled', null)).toBe(true);
+  });
+
+  it('is NOT settled for every in-flight status', () => {
+    expect(isPollingSettled('draft', null)).toBe(false);
+    expect(isPollingSettled('pending', null)).toBe(false);
+    expect(isPollingSettled('queued', null)).toBe(false);
+    expect(isPollingSettled('in_progress', null)).toBe(false);
+    expect(isPollingSettled('paused', null)).toBe(false);
+  });
+
+  it('is settled for a failed row with a blockedReason — refuse() RETURNS without rethrowing, so pg-boss will never retry it', () => {
+    expect(isPollingSettled('failed', 'on-prem: transactional email is a no-op')).toBe(true);
+  });
+
+  it('is NOT settled for a failed row with no blockedReason — a retryable per-recipient/ledger failure rethrows, so pg-boss WILL retry it', () => {
+    expect(isPollingSettled('failed', null)).toBe(false);
   });
 });

--- a/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
+++ b/apps/admin/src/components/admin/broadcasts/__tests__/types.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { isTerminalStatus } from '../types';
 
 describe('isTerminalStatus', () => {
-  it('treats completed, failed, and cancelled as terminal — polling stops here', () => {
+  it('treats completed and cancelled as terminal — polling stops here', () => {
     expect(isTerminalStatus('completed')).toBe(true);
-    expect(isTerminalStatus('failed')).toBe(true);
     expect(isTerminalStatus('cancelled')).toBe(true);
   });
 
@@ -14,5 +13,9 @@ describe('isTerminalStatus', () => {
     expect(isTerminalStatus('queued')).toBe(false);
     expect(isTerminalStatus('in_progress')).toBe(false);
     expect(isTerminalStatus('paused')).toBe(false);
+  });
+
+  it('treats failed as NON-terminal — the worker rethrows on a retryable failure so pg-boss can resume the row, which can later reach in_progress or completed', () => {
+    expect(isTerminalStatus('failed')).toBe(false);
   });
 });

--- a/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
@@ -1,0 +1,626 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2, Mail, Search, Send, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { StatCard } from "@/components/admin/kit";
+import { ConfirmActionDialog, type ConfirmActionValues } from "@/components/admin/users/confirm-action-dialog";
+import { fetchWithAuth, post } from "@/lib/auth/auth-fetch";
+import { useAdminQuery } from "@/hooks/use-admin-query";
+import { isOnPrem } from "@/lib/deployment-mode";
+import { num } from "@/lib/format";
+import { broadcastCreateSchema, templateCreateSchema } from "@/lib/broadcasts/schema";
+import {
+  EMPTY_COMPOSER_FORM,
+  PLAN_TIERS,
+  buildCreatePayload,
+  formSnapshot,
+  isPreviewStale,
+  type ComposerFormState,
+} from "@/components/admin/broadcasts/composer-form";
+import type {
+  BroadcastCreateAcceptedResponse,
+  BroadcastCreateConflictResponse,
+  BroadcastCreateFailedResponse,
+  BroadcastDryRunResponse,
+  BroadcastTemplatesResponse,
+  BroadcastValidationErrorResponse,
+} from "@/components/admin/broadcasts/types";
+import type { AdminUser, UsersListResponse } from "@/components/admin/users/types";
+
+function parseOptionalInt(value: string): number | undefined {
+  if (!value.trim()) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.trunc(n) : undefined;
+}
+
+function firstFieldError(details?: Record<string, string[] | undefined>): string | null {
+  if (!details) return null;
+  const first = Object.values(details).flat().find(Boolean);
+  return first ?? null;
+}
+
+async function postBroadcast(
+  body: unknown,
+): Promise<{ status: number; json: unknown }> {
+  const res = await fetchWithAuth("/api/admin/broadcasts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json().catch(() => null);
+  return { status: res.status, json };
+}
+
+export function BroadcastComposer() {
+  const router = useRouter();
+  const onPrem = isOnPrem();
+
+  const [form, setForm] = useState<ComposerFormState>(EMPTY_COMPOSER_FORM);
+  const [pickedUsers, setPickedUsers] = useState<AdminUser[]>([]);
+
+  const [dryRunResult, setDryRunResult] = useState<BroadcastDryRunResponse | null>(null);
+  const [previewSnapshot, setPreviewSnapshot] = useState<string | null>(null);
+  const [dryRunPending, setDryRunPending] = useState(false);
+  const [dryRunError, setDryRunError] = useState<string | null>(null);
+
+  const [sendLimitInput, setSendLimitInput] = useState("");
+  const [delayMsInput, setDelayMsInput] = useState("");
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [sendPending, setSendPending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const [duplicateOf, setDuplicateOf] = useState<string | null>(null);
+  const [allowDuplicate, setAllowDuplicate] = useState(false);
+
+  const [templateSaveName, setTemplateSaveName] = useState("");
+  const [templateSaving, setTemplateSaving] = useState(false);
+  const [templateSaveStatus, setTemplateSaveStatus] = useState<string | null>(null);
+
+  const [userQuery, setUserQuery] = useState("");
+  const [userQueryDebounced, setUserQueryDebounced] = useState("");
+  const [userResults, setUserResults] = useState<AdminUser[]>([]);
+  const [userSearching, setUserSearching] = useState(false);
+
+  const templatesQuery = useAdminQuery<BroadcastTemplatesResponse>("/api/admin/broadcasts/templates");
+  const templates = useMemo(() => templatesQuery.data?.templates ?? [], [templatesQuery.data]);
+
+  const stale = isPreviewStale(previewSnapshot, form);
+  const preview = dryRunResult && !stale ? dryRunResult : null;
+
+  /** Every form edit invalidates the stale count/preview and clears any duplicate-send state — the admin must re-run the dry run before sending again. */
+  function updateForm(updater: (prev: ComposerFormState) => ComposerFormState) {
+    setForm(updater);
+    setSendError(null);
+    setDuplicateOf(null);
+    setAllowDuplicate(false);
+  }
+
+  function updateAudience(updater: (prev: ComposerFormState["audience"]) => ComposerFormState["audience"]) {
+    updateForm((prev) => ({ ...prev, audience: updater(prev.audience) }));
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => setUserQueryDebounced(userQuery.trim()), 300);
+    return () => clearTimeout(t);
+  }, [userQuery]);
+
+  useEffect(() => {
+    if (!userQueryDebounced) {
+      setUserResults([]);
+      return;
+    }
+    let cancelled = false;
+    setUserSearching(true);
+    fetchWithAuth(`/api/admin/users?limit=8&q=${encodeURIComponent(userQueryDebounced)}`)
+      .then((res) => (res.ok ? (res.json() as Promise<UsersListResponse>) : Promise.reject(new Error("Search failed"))))
+      .then((json) => {
+        if (!cancelled) setUserResults(json.users);
+      })
+      .catch(() => {
+        if (!cancelled) setUserResults([]);
+      })
+      .finally(() => {
+        if (!cancelled) setUserSearching(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [userQueryDebounced]);
+
+  function addUser(user: AdminUser) {
+    if (form.audience.userIds.includes(user.id)) return;
+    setPickedUsers((prev) => [...prev, user]);
+    updateAudience((prev) => ({ ...prev, userIds: [...prev.userIds, user.id] }));
+    setUserQuery("");
+    setUserResults([]);
+  }
+
+  function removeUser(userId: string) {
+    setPickedUsers((prev) => prev.filter((u) => u.id !== userId));
+    updateAudience((prev) => ({ ...prev, userIds: prev.userIds.filter((id) => id !== userId) }));
+  }
+
+  function togglePlanTier(tier: string) {
+    updateAudience((prev) => ({
+      ...prev,
+      planTiers: prev.planTiers.includes(tier)
+        ? prev.planTiers.filter((t) => t !== tier)
+        : [...prev.planTiers, tier],
+    }));
+  }
+
+  async function handleDryRun() {
+    setDryRunError(null);
+    const payload = buildCreatePayload(form, true);
+    const parsed = broadcastCreateSchema.safeParse(payload);
+    if (!parsed.success) {
+      setDryRunError(firstFieldError(parsed.error.flatten().fieldErrors) ?? "This broadcast is not valid yet.");
+      return;
+    }
+    setDryRunPending(true);
+    try {
+      const { status, json } = await postBroadcast(parsed.data);
+      if (status === 200) {
+        const result = json as BroadcastDryRunResponse;
+        setDryRunResult(result);
+        setPreviewSnapshot(formSnapshot(form));
+      } else {
+        const err = json as BroadcastValidationErrorResponse | null;
+        setDryRunError(err?.error ?? `Preview failed (${status})`);
+      }
+    } catch (error) {
+      setDryRunError(error instanceof Error ? error.message : "Preview failed");
+    } finally {
+      setDryRunPending(false);
+    }
+  }
+
+  async function handleSend(_values: ConfirmActionValues) {
+    setSendPending(true);
+    setSendError(null);
+    const payload = buildCreatePayload(form, false, {
+      sendLimit: parseOptionalInt(sendLimitInput),
+      delayMs: parseOptionalInt(delayMsInput),
+      allowDuplicate,
+    });
+    const parsed = broadcastCreateSchema.safeParse(payload);
+    if (!parsed.success) {
+      setSendError(firstFieldError(parsed.error.flatten().fieldErrors) ?? "This broadcast is not valid yet.");
+      setSendPending(false);
+      return;
+    }
+    try {
+      const { status, json } = await postBroadcast(parsed.data);
+      if (status === 202) {
+        const accepted = json as BroadcastCreateAcceptedResponse;
+        router.push(`/broadcasts/${accepted.broadcastId}`);
+        return;
+      }
+      if (status === 409) {
+        const conflict = json as BroadcastCreateConflictResponse;
+        setDuplicateOf(conflict.duplicateOf);
+        setSendError(conflict.error);
+      } else if (status === 500) {
+        const failed = json as BroadcastCreateFailedResponse;
+        setSendError(`${failed.error} — broadcast ${failed.broadcastId} was marked failed; retrying is safe.`);
+      } else {
+        const err = json as BroadcastValidationErrorResponse | null;
+        setSendError(err?.error ?? `Send failed (${status})`);
+      }
+    } catch (error) {
+      setSendError(error instanceof Error ? error.message : "Send failed");
+    } finally {
+      setSendPending(false);
+      setConfirmOpen(false);
+    }
+  }
+
+  async function handleSaveTemplate() {
+    const payload = {
+      name: templateSaveName.trim(),
+      subject: form.subject,
+      bodyMarkdown: form.bodyMarkdown,
+      isActive: true,
+    };
+    const parsed = templateCreateSchema.safeParse(payload);
+    if (!parsed.success) {
+      setTemplateSaveStatus(firstFieldError(parsed.error.flatten().fieldErrors) ?? "Template needs a name, subject, and body.");
+      return;
+    }
+    setTemplateSaving(true);
+    setTemplateSaveStatus(null);
+    try {
+      await post("/api/admin/broadcasts/templates", parsed.data);
+      setTemplateSaveStatus("Template saved.");
+      setTemplateSaveName("");
+      templatesQuery.refetch();
+    } catch (error) {
+      setTemplateSaveStatus(error instanceof Error ? error.message : "Failed to save template");
+    } finally {
+      setTemplateSaving(false);
+    }
+  }
+
+  const selectedTemplate = useMemo(
+    () => templates.find((t) => t.id === form.templateId) ?? null,
+    [templates, form.templateId],
+  );
+
+  const canSendLive = !!preview && form.engine === "transactional" && !onPrem;
+
+  return (
+    <div className="space-y-6">
+      {onPrem && (
+        <Alert variant="warning">
+          <AlertTitle>Live send disabled on-prem</AlertTitle>
+          <AlertDescription>
+            Transactional email is a no-op on this deployment. You can still run dry runs to preview
+            content and audience size.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Mail className="h-4 w-4" />
+            Content
+          </CardTitle>
+          <CardDescription>Compose fresh markdown or reuse a saved template.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Tabs
+            value={form.contentMode}
+            onValueChange={(v) => updateForm((prev) => ({ ...prev, contentMode: v as "compose" | "template" }))}
+          >
+            <TabsList>
+              <TabsTrigger value="compose">Compose</TabsTrigger>
+              <TabsTrigger value="template">Template</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="compose" className="space-y-4 pt-2">
+              <div className="space-y-2">
+                <Label htmlFor="broadcast-subject">Subject</Label>
+                <Input
+                  id="broadcast-subject"
+                  value={form.subject}
+                  onChange={(e) => updateForm((prev) => ({ ...prev, subject: e.target.value }))}
+                  placeholder="What's new in PageSpace"
+                  maxLength={200}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="broadcast-body">Body (markdown)</Label>
+                <textarea
+                  id="broadcast-body"
+                  value={form.bodyMarkdown}
+                  onChange={(e) => updateForm((prev) => ({ ...prev, bodyMarkdown: e.target.value }))}
+                  placeholder="## Hey there&#10;&#10;Write your update in markdown..."
+                  rows={12}
+                  className="w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:border-ring font-mono"
+                />
+              </div>
+              <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+                <Input
+                  value={templateSaveName}
+                  onChange={(e) => setTemplateSaveName(e.target.value)}
+                  placeholder="Template name"
+                  className="max-w-xs"
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={templateSaving || !templateSaveName.trim() || !form.subject.trim() || !form.bodyMarkdown.trim()}
+                  onClick={() => void handleSaveTemplate()}
+                >
+                  {templateSaving && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
+                  Save current as template
+                </Button>
+                {templateSaveStatus && (
+                  <span className="text-xs text-muted-foreground" role="status">{templateSaveStatus}</span>
+                )}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="template" className="space-y-4 pt-2">
+              <div className="space-y-2">
+                <Label>Template</Label>
+                <Select
+                  value={form.templateId ?? undefined}
+                  onValueChange={(v) => updateForm((prev) => ({ ...prev, templateId: v }))}
+                >
+                  <SelectTrigger className="w-full sm:w-[320px]">
+                    <SelectValue placeholder={templatesQuery.isLoading ? "Loading templates…" : "Choose a template"} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {templates.map((t) => (
+                      <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {templates.length === 0 && !templatesQuery.isLoading && (
+                  <p className="text-xs text-muted-foreground">
+                    No templates yet — compose one and save it, or switch to Compose.
+                  </p>
+                )}
+              </div>
+              {selectedTemplate && (
+                <div className="rounded-md border bg-muted/30 p-3 text-sm">
+                  <p className="font-medium">{selectedTemplate.subject}</p>
+                  <p className="mt-1 whitespace-pre-wrap text-muted-foreground line-clamp-6">
+                    {selectedTemplate.bodyMarkdown}
+                  </p>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+
+          <div className="space-y-2 border-t pt-4">
+            <Label>Engine</Label>
+            <Select
+              value={form.engine}
+              onValueChange={(v) => updateForm((prev) => ({ ...prev, engine: v as ComposerFormState["engine"] }))}
+            >
+              <SelectTrigger className="w-full sm:w-[280px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="transactional">Transactional (live)</SelectItem>
+                <SelectItem value="resend_broadcast" disabled>
+                  Marketing (Resend) — coming soon
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Audience</CardTitle>
+          <CardDescription>Every send respects the standard exclusions below, plus any filters you add.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Alert>
+            <AlertTitle>Always excluded</AlertTitle>
+            <AlertDescription>
+              Opted-out recipients, GDPR-restricted accounts, and suspended users are never targeted —
+              this can&apos;t be overridden. Unverified emails are excluded unless you opt in below.
+              Opt-outs and GDPR skips are re-checked and subtracted at send time.
+            </AlertDescription>
+          </Alert>
+
+          <label className="flex items-start gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.audience.includeUnverified}
+              onChange={(e) => updateAudience((prev) => ({ ...prev, includeUnverified: e.target.checked }))}
+              className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+            />
+            Include unverified email addresses
+          </label>
+
+          <div className="space-y-2">
+            <Label>Plan tiers</Label>
+            <div className="flex flex-wrap gap-2">
+              {PLAN_TIERS.map((tier) => (
+                <Button
+                  key={tier}
+                  type="button"
+                  size="sm"
+                  variant={form.audience.planTiers.includes(tier) ? "default" : "outline"}
+                  onClick={() => togglePlanTier(tier)}
+                >
+                  {tier}
+                </Button>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">No tiers selected = every tier.</p>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="signup-after">Signed up after</Label>
+              <Input
+                id="signup-after"
+                type="date"
+                value={form.audience.signupAfter}
+                onChange={(e) => updateAudience((prev) => ({ ...prev, signupAfter: e.target.value }))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="signup-before">Signed up before</Label>
+              <Input
+                id="signup-before"
+                type="date"
+                value={form.audience.signupBefore}
+                onChange={(e) => updateAudience((prev) => ({ ...prev, signupBefore: e.target.value }))}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="user-typeahead">Hand-pick recipients</Label>
+            <div className="relative max-w-md">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="user-typeahead"
+                value={userQuery}
+                onChange={(e) => setUserQuery(e.target.value)}
+                placeholder="Search by name or email…"
+                className="pl-10"
+              />
+              {userQueryDebounced && (userResults.length > 0 || userSearching) && (
+                <div className="absolute z-10 mt-1 w-full rounded-md border bg-popover shadow-md">
+                  {userSearching && (
+                    <p className="p-2 text-xs text-muted-foreground">Searching…</p>
+                  )}
+                  {!userSearching && userResults.map((u) => (
+                    <button
+                      key={u.id}
+                      type="button"
+                      onClick={() => addUser(u)}
+                      className="flex w-full flex-col items-start px-3 py-2 text-left text-sm hover:bg-accent"
+                    >
+                      <span className="font-medium">{u.name || u.email}</span>
+                      <span className="text-xs text-muted-foreground">{u.email}</span>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+            {pickedUsers.length > 0 && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                {pickedUsers.map((u) => (
+                  <Badge key={u.id} variant="secondary" className="gap-1 pr-1">
+                    {u.email}
+                    <button type="button" onClick={() => removeUser(u.id)} aria-label={`Remove ${u.email}`}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button onClick={() => void handleDryRun()} disabled={dryRunPending}>
+          {dryRunPending && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+          Preview &amp; count
+        </Button>
+        {stale && dryRunResult && (
+          <span className="text-xs text-muted-foreground">
+            The form changed — preview and count are stale. Run it again.
+          </span>
+        )}
+      </div>
+
+      {dryRunError && (
+        <p className="text-sm text-destructive" role="alert">{dryRunError}</p>
+      )}
+
+      {preview && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Preview</CardTitle>
+            <CardDescription>{preview.subject}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <StatCard label="Audience" value={num(preview.audienceCount)} hint="Opt-outs & GDPR skips are subtracted at send time." />
+            <iframe
+              sandbox=""
+              srcDoc={preview.previewHtml}
+              title="Email preview"
+              className="h-[480px] w-full rounded-md border bg-white"
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {preview && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Send</CardTitle>
+            <CardDescription>Live send uses the transactional engine, one email per recipient.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="send-limit">Send limit (canary cap, optional)</Label>
+                <Input
+                  id="send-limit"
+                  type="number"
+                  min={1}
+                  value={sendLimitInput}
+                  onChange={(e) => setSendLimitInput(e.target.value)}
+                  placeholder="No limit"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="delay-ms">Delay between sends (ms, optional)</Label>
+                <Input
+                  id="delay-ms"
+                  type="number"
+                  min={0}
+                  max={60000}
+                  value={delayMsInput}
+                  onChange={(e) => setDelayMsInput(e.target.value)}
+                  placeholder="Worker default"
+                />
+              </div>
+            </div>
+
+            {duplicateOf && (
+              <Alert variant="warning">
+                <AlertTitle>Already sending</AlertTitle>
+                <AlertDescription className="space-y-2">
+                  <p>
+                    A broadcast with this subject is already in flight.{" "}
+                    <Link href={`/broadcasts/${duplicateOf}`} className="underline">View it</Link>.
+                  </p>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={allowDuplicate}
+                      onChange={(e) => setAllowDuplicate(e.target.checked)}
+                      className="h-4 w-4 accent-primary"
+                    />
+                    Send anyway
+                  </label>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {sendError && !duplicateOf && (
+              <p className="text-sm text-destructive" role="alert">{sendError}</p>
+            )}
+
+            <Button
+              variant="destructive"
+              disabled={!canSendLive || (!!duplicateOf && !allowDuplicate)}
+              onClick={() => setConfirmOpen(true)}
+            >
+              <Send className="mr-1.5 h-4 w-4" />
+              Send live…
+            </Button>
+            {!canSendLive && form.engine !== "transactional" && (
+              <p className="text-xs text-muted-foreground">The marketing engine is not live-sendable yet.</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      <ConfirmActionDialog
+        open={confirmOpen && !!preview}
+        onOpenChange={(open) => !sendPending && setConfirmOpen(open)}
+        title="Send this broadcast live?"
+        description={
+          <span>
+            This sends a real email to <strong>{num(preview?.audienceCount ?? 0)} recipients</strong>.
+            This cannot be undone once sends begin.
+          </span>
+        }
+        confirmLabel="Send now"
+        reasonLabel="Confirmation note — why are you sending this now?"
+        typedConfirmation={{
+          expected: String(preview?.audienceCount ?? 0),
+          label: `Type the recipient count (${preview?.audienceCount ?? 0}) to confirm`,
+        }}
+        pending={sendPending}
+        error={sendError}
+        onConfirm={(values) => void handleSend(values)}
+      />
+    </div>
+  );
+}

--- a/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
@@ -23,6 +23,7 @@ import {
   EMPTY_COMPOSER_FORM,
   PLAN_TIERS,
   buildCreatePayload,
+  formatServerFailureMessage,
   formSnapshot,
   isPreviewStale,
   type ComposerFormState,
@@ -30,7 +31,6 @@ import {
 import type {
   BroadcastCreateAcceptedResponse,
   BroadcastCreateConflictResponse,
-  BroadcastCreateFailedResponse,
   BroadcastDryRunResponse,
   BroadcastTemplatesResponse,
   BroadcastValidationErrorResponse,
@@ -210,8 +210,7 @@ export function BroadcastComposer() {
         setDuplicateOf(conflict.duplicateOf);
         setSendError(conflict.error);
       } else if (status === 500) {
-        const failed = json as BroadcastCreateFailedResponse;
-        setSendError(`${failed.error} — broadcast ${failed.broadcastId} was marked failed; retrying is safe.`);
+        setSendError(formatServerFailureMessage(json as { error?: string; broadcastId?: string } | null, status));
       } else {
         const err = json as BroadcastValidationErrorResponse | null;
         setSendError(err?.error ?? `Send failed (${status})`);

--- a/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-composer.tsx
@@ -565,7 +565,7 @@ export function BroadcastComposer() {
                 <AlertTitle>Already sending</AlertTitle>
                 <AlertDescription className="space-y-2">
                   <p>
-                    A broadcast with this subject is already in flight.{" "}
+                    {sendError ?? "A broadcast with this subject is already in flight."}{" "}
                     <Link href={`/broadcasts/${duplicateOf}`} className="underline">View it</Link>.
                   </p>
                   <label className="flex items-center gap-2">
@@ -611,7 +611,7 @@ export function BroadcastComposer() {
           </span>
         }
         confirmLabel="Send now"
-        reasonLabel="Confirmation note — why are you sending this now?"
+        requireReason={false}
         typedConfirmation={{
           expected: String(preview?.audienceCount ?? 0),
           label: `Type the recipient count (${preview?.audienceCount ?? 0}) to confirm`,

--- a/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, CheckCircle2, CircleDashed, RefreshCw, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { StatCard, DataState } from "@/components/admin/kit";
+import { StatusBadge } from "@/components/admin/broadcasts/status-badge";
+import { ConfirmActionDialog, type ConfirmActionValues } from "@/components/admin/users/confirm-action-dialog";
+import { useAdminQuery } from "@/hooks/use-admin-query";
+import { post } from "@/lib/auth/auth-fetch";
+import { num } from "@/lib/format";
+import { isTerminalStatus, type BroadcastDetail } from "@/components/admin/broadcasts/types";
+
+const ACTIVE_STATUSES = ["pending", "queued", "in_progress", "paused"];
+
+const STEP_ICON = {
+  ok: CheckCircle2,
+  failed: XCircle,
+  skipped: CircleDashed,
+} as const;
+
+export function BroadcastProgress({ broadcastId }: { broadcastId: string }) {
+  const [cancelOpen, setCancelOpen] = useState(false);
+  const [cancelPending, setCancelPending] = useState(false);
+  const [cancelError, setCancelError] = useState<string | null>(null);
+
+  // Polls every 2s until the row reaches a terminal status, then the effect
+  // below drops the interval to 0 and useAdminQuery stops fetching.
+  const [refreshInterval, setRefreshInterval] = useState(2000);
+
+  const { data, isLoading, isFetching, error, refetch } = useAdminQuery<BroadcastDetail>(
+    `/api/admin/broadcasts/${broadcastId}`,
+    { refreshInterval },
+  );
+
+  useEffect(() => {
+    if (data && isTerminalStatus(data.status) && refreshInterval !== 0) {
+      setRefreshInterval(0);
+    }
+  }, [data, refreshInterval]);
+
+  async function handleCancel({ reason }: ConfirmActionValues) {
+    setCancelPending(true);
+    setCancelError(null);
+    try {
+      await post(`/api/admin/broadcasts/${broadcastId}`, { action: "cancel", reason });
+      setCancelOpen(false);
+      refetch();
+    } catch (err) {
+      setCancelError(err instanceof Error ? err.message : "Failed to cancel");
+    } finally {
+      setCancelPending(false);
+    }
+  }
+
+  const canCancel = !!data && ACTIVE_STATUSES.includes(data.status);
+
+  return (
+    <div className="space-y-6">
+      <DataState
+        isLoading={isLoading}
+        error={error}
+        onRetry={refetch}
+        hasData={!!data}
+      >
+        {data && (
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <StatusBadge status={data.status} />
+                <h2 className="text-lg font-semibold">{data.subject || "(untitled)"}</h2>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={refetch} disabled={isFetching}>
+                  <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${isFetching ? "animate-spin" : ""}`} />
+                  Refresh
+                </Button>
+                {canCancel && (
+                  <Button variant="destructive" size="sm" onClick={() => setCancelOpen(true)}>
+                    Cancel
+                  </Button>
+                )}
+              </div>
+            </div>
+
+            {data.dryRun && (
+              <Alert>
+                <AlertTitle>Dry run</AlertTitle>
+                <AlertDescription>This broadcast was never enqueued — no email was sent.</AlertDescription>
+              </Alert>
+            )}
+
+            {data.blockedReason && (
+              <Alert variant="warning">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Blocked</AlertTitle>
+                <AlertDescription>{data.blockedReason}</AlertDescription>
+              </Alert>
+            )}
+
+            {data.lastError && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Last error</AlertTitle>
+                <AlertDescription>{data.lastError}</AlertDescription>
+              </Alert>
+            )}
+
+            <div className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
+              <StatCard label="Targeted" value={num(data.totalTargeted)} />
+              <StatCard label="Sent" value={num(data.sentCount)} tone="positive" />
+              <StatCard label="Skipped" value={num(data.skippedCount)} tone="warning" />
+              <StatCard label="Failed" value={num(data.failedCount)} tone={data.failedCount > 0 ? "negative" : "default"} />
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Details</CardTitle>
+              </CardHeader>
+              <CardContent className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-3">
+                <Detail label="Engine" value={data.engine === "transactional" ? "Transactional" : "Marketing (Resend)"} />
+                <Detail label="Content" value={data.contentMode === "compose" ? "Composed" : "Template"} />
+                <Detail label="Attempts" value={String(data.attempts)} />
+                <Detail label="Send limit" value={data.sendLimit != null ? num(data.sendLimit) : "None"} />
+                <Detail label="Delay" value={data.delayMs != null ? `${data.delayMs}ms` : "Default"} />
+                <Detail label="Created" value={new Date(data.createdAt).toLocaleString()} />
+                <Detail label="Started" value={data.startedAt ? new Date(data.startedAt).toLocaleString() : "—"} />
+                <Detail label="Completed" value={data.completedAt ? new Date(data.completedAt).toLocaleString() : "—"} />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Step log</CardTitle>
+                <CardDescription>Progress recorded by the worker as it processes this broadcast.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                {data.stepResults.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No steps recorded yet.</p>
+                ) : (
+                  <ul className="space-y-2">
+                    {data.stepResults.map((step, i) => {
+                      const Icon = STEP_ICON[step.status];
+                      return (
+                        <li key={i} className="flex items-start gap-2 text-sm">
+                          <Icon
+                            className={`mt-0.5 h-4 w-4 shrink-0 ${
+                              step.status === "ok" ? "text-success" : step.status === "failed" ? "text-destructive" : "text-muted-foreground"
+                            }`}
+                          />
+                          <div className="min-w-0">
+                            <span className="font-medium">{step.step}</span>
+                            {step.detail && <span className="text-muted-foreground"> — {step.detail}</span>}
+                            <span className="ml-2 text-xs text-muted-foreground">
+                              {new Date(step.at).toLocaleTimeString()}
+                            </span>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </DataState>
+
+      <ConfirmActionDialog
+        open={cancelOpen}
+        onOpenChange={(open) => !cancelPending && setCancelOpen(open)}
+        title="Cancel this broadcast?"
+        description="The worker checks this status between batches and stops sending. Recipients already sent to are not affected."
+        confirmLabel="Cancel broadcast"
+        requireReason
+        reasonPlaceholder="Why is this broadcast being cancelled?"
+        pending={cancelPending}
+        error={cancelError}
+        onConfirm={(values) => void handleCancel(values)}
+      />
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="font-medium">{value}</p>
+    </div>
+  );
+}

--- a/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
@@ -11,12 +11,7 @@ import { ConfirmActionDialog, type ConfirmActionValues } from "@/components/admi
 import { useAdminQuery } from "@/hooks/use-admin-query";
 import { post } from "@/lib/auth/auth-fetch";
 import { num } from "@/lib/format";
-import { isTerminalStatus, type BroadcastDetail } from "@/components/admin/broadcasts/types";
-
-// 'failed' is active, not settled — the worker rethrows on a retryable
-// failure so pg-boss can resume the same row, and the API's cancel guard
-// (INTERVENTION_BLOCKED_STATES) never blocks cancelling it for that reason.
-const ACTIVE_STATUSES = ["pending", "queued", "in_progress", "paused", "failed"];
+import { isPollingSettled, isTerminalStatus, type BroadcastDetail } from "@/components/admin/broadcasts/types";
 
 const STEP_ICON = {
   ok: CheckCircle2,
@@ -39,7 +34,7 @@ export function BroadcastProgress({ broadcastId }: { broadcastId: string }) {
   );
 
   useEffect(() => {
-    if (data && isTerminalStatus(data.status) && refreshInterval !== 0) {
+    if (data && isPollingSettled(data.status, data.blockedReason) && refreshInterval !== 0) {
       setRefreshInterval(0);
     }
   }, [data, refreshInterval]);
@@ -58,7 +53,7 @@ export function BroadcastProgress({ broadcastId }: { broadcastId: string }) {
     }
   }
 
-  const canCancel = !!data && ACTIVE_STATUSES.includes(data.status);
+  const canCancel = !!data && !isTerminalStatus(data.status);
 
   return (
     <div className="space-y-6">

--- a/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
+++ b/apps/admin/src/components/admin/broadcasts/broadcast-progress.tsx
@@ -13,7 +13,10 @@ import { post } from "@/lib/auth/auth-fetch";
 import { num } from "@/lib/format";
 import { isTerminalStatus, type BroadcastDetail } from "@/components/admin/broadcasts/types";
 
-const ACTIVE_STATUSES = ["pending", "queued", "in_progress", "paused"];
+// 'failed' is active, not settled — the worker rethrows on a retryable
+// failure so pg-boss can resume the same row, and the API's cancel guard
+// (INTERVENTION_BLOCKED_STATES) never blocks cancelling it for that reason.
+const ACTIVE_STATUSES = ["pending", "queued", "in_progress", "paused", "failed"];
 
 const STEP_ICON = {
   ok: CheckCircle2,

--- a/apps/admin/src/components/admin/broadcasts/composer-form.ts
+++ b/apps/admin/src/components/admin/broadcasts/composer-form.ts
@@ -1,0 +1,94 @@
+import type { AudienceDefinitionInput, BroadcastCreateInput } from "@/lib/broadcasts/schema";
+
+export const PLAN_TIERS = ["free", "pro", "founder", "business"] as const;
+export type PlanTier = (typeof PLAN_TIERS)[number];
+
+export interface AudienceFormState {
+  includeUnverified: boolean;
+  planTiers: string[];
+  /** `YYYY-MM-DD` from a native date input, or '' when unset. */
+  signupAfter: string;
+  signupBefore: string;
+  userIds: string[];
+}
+
+export const EMPTY_AUDIENCE: AudienceFormState = {
+  includeUnverified: false,
+  planTiers: [],
+  signupAfter: "",
+  signupBefore: "",
+  userIds: [],
+};
+
+export interface ComposerFormState {
+  contentMode: "compose" | "template";
+  subject: string;
+  bodyMarkdown: string;
+  templateId: string | null;
+  engine: "transactional" | "resend_broadcast";
+  audience: AudienceFormState;
+}
+
+export const EMPTY_COMPOSER_FORM: ComposerFormState = {
+  contentMode: "compose",
+  subject: "",
+  bodyMarkdown: "",
+  templateId: null,
+  engine: "transactional",
+  audience: EMPTY_AUDIENCE,
+};
+
+/** Drops empty/default fields so an untouched audience builder sends `{}` — every user, no filters. */
+export function buildAudienceDefinition(audience: AudienceFormState): AudienceDefinitionInput {
+  const def: AudienceDefinitionInput = {};
+  if (audience.includeUnverified) def.includeUnverified = true;
+  if (audience.planTiers.length > 0) def.planTiers = audience.planTiers;
+  if (audience.signupAfter) def.signupAfter = new Date(`${audience.signupAfter}T00:00:00.000Z`).toISOString();
+  if (audience.signupBefore) def.signupBefore = new Date(`${audience.signupBefore}T23:59:59.999Z`).toISOString();
+  if (audience.userIds.length > 0) def.userIds = audience.userIds;
+  return def;
+}
+
+export interface LiveSendSettings {
+  sendLimit?: number;
+  delayMs?: number;
+  allowDuplicate?: boolean;
+}
+
+/** Builds the exact request body for POST /api/admin/broadcasts — parsed client-side with the SAME schema the server uses before it's sent. */
+export function buildCreatePayload(
+  form: ComposerFormState,
+  dryRun: boolean,
+  settings: LiveSendSettings = {},
+): BroadcastCreateInput {
+  return {
+    subject: form.subject.trim(),
+    engine: form.engine,
+    contentMode: form.contentMode,
+    templateId: form.contentMode === "template" ? (form.templateId ?? undefined) : undefined,
+    bodyMarkdown: form.contentMode === "compose" ? form.bodyMarkdown : undefined,
+    audienceDefinition: buildAudienceDefinition(form.audience),
+    dryRun,
+    sendLimit: settings.sendLimit,
+    delayMs: settings.delayMs,
+    allowDuplicate: settings.allowDuplicate ?? false,
+  };
+}
+
+/** A stable fingerprint of the fields that determine what a dry-run would show. Two forms with the same fingerprint would produce the same preview. */
+export function formSnapshot(form: ComposerFormState): string {
+  return JSON.stringify({
+    contentMode: form.contentMode,
+    subject: form.subject,
+    bodyMarkdown: form.bodyMarkdown,
+    templateId: form.templateId,
+    engine: form.engine,
+    audience: form.audience,
+  });
+}
+
+/** A previously-taken preview is stale once the form no longer matches the snapshot it was taken from. `null` means "no preview taken yet" — never stale, just absent. */
+export function isPreviewStale(previewSnapshot: string | null, currentForm: ComposerFormState): boolean {
+  if (previewSnapshot === null) return false;
+  return previewSnapshot !== formSnapshot(currentForm);
+}

--- a/apps/admin/src/components/admin/broadcasts/composer-form.ts
+++ b/apps/admin/src/components/admin/broadcasts/composer-form.ts
@@ -92,3 +92,21 @@ export function isPreviewStale(previewSnapshot: string | null, currentForm: Comp
   if (previewSnapshot === null) return false;
   return previewSnapshot !== formSnapshot(currentForm);
 }
+
+/**
+ * A 500 from POST /api/admin/broadcasts is not guaranteed to carry a
+ * `broadcastId` — the route's outer catch (a failure before any row exists,
+ * e.g. `broadcastRepository.create` itself throwing) returns just
+ * `{ error }`. Only the enqueue-specific catch, after the row is written and
+ * marked failed, includes `broadcastId`. Claiming a row was "marked failed;
+ * retrying is safe" when no row exists would be both wrong and misleading
+ * about whether anything durable happened.
+ */
+export function formatServerFailureMessage(
+  json: { error?: string; broadcastId?: string } | null,
+  status: number,
+): string {
+  if (!json?.error) return `Send failed (${status})`;
+  if (json.broadcastId) return `${json.error} — broadcast ${json.broadcastId} was marked failed; retrying is safe.`;
+  return json.error;
+}

--- a/apps/admin/src/components/admin/broadcasts/status-badge.tsx
+++ b/apps/admin/src/components/admin/broadcasts/status-badge.tsx
@@ -1,0 +1,40 @@
+import { Badge, type badgeVariants } from '@/components/ui/badge';
+import type { VariantProps } from 'class-variance-authority';
+import type { BroadcastStatus } from './types';
+
+type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+
+const STATUS_LABELS: Record<BroadcastStatus, string> = {
+  draft: 'Draft',
+  pending: 'Pending',
+  queued: 'Queued',
+  in_progress: 'In progress',
+  paused: 'Paused',
+  completed: 'Completed',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+};
+
+const STATUS_VARIANTS: Record<BroadcastStatus, BadgeVariant> = {
+  draft: 'outline',
+  pending: 'secondary',
+  queued: 'secondary',
+  in_progress: 'default',
+  paused: 'outline',
+  completed: 'default',
+  failed: 'destructive',
+  cancelled: 'outline',
+};
+
+/** Pure so status→badge mapping is unit-testable without rendering. */
+export function statusBadgeVariant(status: BroadcastStatus): BadgeVariant {
+  return STATUS_VARIANTS[status];
+}
+
+export function statusBadgeLabel(status: BroadcastStatus): string {
+  return STATUS_LABELS[status];
+}
+
+export function StatusBadge({ status }: { status: BroadcastStatus }) {
+  return <Badge variant={statusBadgeVariant(status)}>{statusBadgeLabel(status)}</Badge>;
+}

--- a/apps/admin/src/components/admin/broadcasts/types.ts
+++ b/apps/admin/src/components/admin/broadcasts/types.ts
@@ -11,19 +11,43 @@ export type BroadcastStatus =
   | 'cancelled';
 
 /**
- * True once a broadcast has reached a settled state — polling stops here.
- *
- * `failed` is deliberately EXCLUDED: the worker writes `failed` and rethrows
- * on a retryable per-recipient/provider failure so pg-boss retries the job,
- * meaning a `failed` row can resume sending and later reach `in_progress` or
- * `completed`. Mirrors `INTERVENTION_BLOCKED_STATES` in
- * `app/api/admin/broadcasts/[id]/route.ts`, which likewise never blocks a
- * cancel on `failed` for the same reason.
+ * True once a broadcast is in a state the admin API will always refuse to
+ * intervene on further — mirrors `INTERVENTION_BLOCKED_STATES` in
+ * `app/api/admin/broadcasts/[id]/route.ts` exactly. `failed` is deliberately
+ * EXCLUDED: cancelling a `failed` row is always accepted server-side (it may
+ * be mid pg-boss-retry backoff, or a dead row an admin just wants to close
+ * out), so Cancel must stay offered for every status except these two.
  */
 export const TERMINAL_STATUSES: readonly BroadcastStatus[] = ['completed', 'cancelled'];
 
 export function isTerminalStatus(status: BroadcastStatus): boolean {
   return (TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+/**
+ * True once NOTHING will ever change this row again, for the purpose of
+ * deciding whether the progress page should keep polling.
+ *
+ * This is a strictly narrower and separate question from `isTerminalStatus`
+ * (which governs cancellability): `completed`/`cancelled` are always settled;
+ * a `failed` row is settled ONLY when `blockedReason` is set. That's
+ * `refuse()` in `apps/processor/src/workers/email-broadcast-worker.ts` — an
+ * on-prem live-send block, unresolvable content, or an unreachable CTA link —
+ * which RETURNS (never rethrows), so pg-boss will never retry that job.
+ *
+ * A `failed` row with `blockedReason` null is ambiguous by the row's fields
+ * alone: it's either a retryable per-recipient/ledger failure mid pg-boss
+ * backoff (WILL change), or a pre-enqueue failure (`markFailed` in
+ * `broadcast-repository.ts`, hit before any job existed) or a retry-exhausted
+ * job (WILL NOT change) — nothing in the frozen `GET .../[id]` response
+ * distinguishes those two. Polling keeps running rather than risk freezing on
+ * a row that's still actually retrying; Cancel (`isTerminalStatus`) stays
+ * available the whole time so an admin who notices a dead row can close it
+ * out explicitly, which — being `cancelled` — does stop polling.
+ */
+export function isPollingSettled(status: BroadcastStatus, blockedReason: string | null): boolean {
+  if (isTerminalStatus(status)) return true;
+  return status === 'failed' && blockedReason != null;
 }
 
 export interface BroadcastListItem {

--- a/apps/admin/src/components/admin/broadcasts/types.ts
+++ b/apps/admin/src/components/admin/broadcasts/types.ts
@@ -1,0 +1,108 @@
+import type { BroadcastActionInput, BroadcastCreateInput } from '@/lib/broadcasts/schema';
+
+export type BroadcastStatus =
+  | 'draft'
+  | 'pending'
+  | 'queued'
+  | 'in_progress'
+  | 'paused'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+/** True once a broadcast has reached a settled state — polling stops here. */
+export const TERMINAL_STATUSES: readonly BroadcastStatus[] = ['completed', 'failed', 'cancelled'];
+
+export function isTerminalStatus(status: BroadcastStatus): boolean {
+  return (TERMINAL_STATUSES as readonly string[]).includes(status);
+}
+
+export interface BroadcastListItem {
+  id: string;
+  subject: string;
+  status: BroadcastStatus;
+  engine: 'transactional' | 'resend_broadcast';
+  dryRun: boolean;
+  totalTargeted: number;
+  sentCount: number;
+  skippedCount: number;
+  failedCount: number;
+  createdAt: string;
+}
+
+export interface BroadcastsListResponse {
+  broadcasts: BroadcastListItem[];
+}
+
+export interface BroadcastStepResult {
+  step: string;
+  status: 'ok' | 'skipped' | 'failed';
+  detail?: string;
+  at: string;
+}
+
+export interface BroadcastDetail {
+  id: string;
+  subject: string;
+  status: BroadcastStatus;
+  engine: 'transactional' | 'resend_broadcast';
+  contentMode: 'compose' | 'template';
+  dryRun: boolean;
+  sendLimit: number | null;
+  delayMs: number | null;
+  totalTargeted: number;
+  sentCount: number;
+  skippedCount: number;
+  failedCount: number;
+  stepResults: BroadcastStepResult[];
+  attempts: number;
+  lastError: string | null;
+  blockedReason: string | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface BroadcastTemplate {
+  id: string;
+  name: string;
+  subject: string;
+  bodyMarkdown: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface BroadcastTemplatesResponse {
+  templates: BroadcastTemplate[];
+}
+
+export interface BroadcastDryRunResponse {
+  dryRun: true;
+  audienceCount: number;
+  previewHtml: string;
+  subject: string;
+}
+
+export interface BroadcastCreateAcceptedResponse {
+  broadcastId: string;
+  jobId: string | null;
+  enqueue: 'confirmed' | 'unconfirmed';
+}
+
+export interface BroadcastCreateConflictResponse {
+  error: string;
+  duplicateOf: string;
+}
+
+export interface BroadcastCreateFailedResponse {
+  error: string;
+  broadcastId: string;
+}
+
+export interface BroadcastValidationErrorResponse {
+  error: string;
+  details?: Record<string, string[] | undefined>;
+}
+
+export type { BroadcastActionInput, BroadcastCreateInput };

--- a/apps/admin/src/components/admin/broadcasts/types.ts
+++ b/apps/admin/src/components/admin/broadcasts/types.ts
@@ -10,8 +10,17 @@ export type BroadcastStatus =
   | 'failed'
   | 'cancelled';
 
-/** True once a broadcast has reached a settled state — polling stops here. */
-export const TERMINAL_STATUSES: readonly BroadcastStatus[] = ['completed', 'failed', 'cancelled'];
+/**
+ * True once a broadcast has reached a settled state — polling stops here.
+ *
+ * `failed` is deliberately EXCLUDED: the worker writes `failed` and rethrows
+ * on a retryable per-recipient/provider failure so pg-boss retries the job,
+ * meaning a `failed` row can resume sending and later reach `in_progress` or
+ * `completed`. Mirrors `INTERVENTION_BLOCKED_STATES` in
+ * `app/api/admin/broadcasts/[id]/route.ts`, which likewise never blocks a
+ * cancel on `failed` for the same reason.
+ */
+export const TERMINAL_STATUSES: readonly BroadcastStatus[] = ['completed', 'cancelled'];
 
 export function isTerminalStatus(status: BroadcastStatus): boolean {
   return (TERMINAL_STATUSES as readonly string[]).includes(status);

--- a/apps/admin/src/components/admin/shell/admin-shell.tsx
+++ b/apps/admin/src/components/admin/shell/admin-shell.tsx
@@ -17,6 +17,7 @@ import {
   Menu,
   MessageSquareText,
   Moon,
+  Send,
   Sun,
   TrendingUp,
   Users,
@@ -78,6 +79,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: 'People',
     items: [
       { href: '/users', label: 'Users', icon: Users },
+      { href: '/broadcasts', label: 'Broadcasts', icon: Send },
       { href: '/support', label: 'Support', icon: LifeBuoy },
       { href: '/audit-logs', label: 'Audit Logs', icon: FileClock },
     ],


### PR DESCRIPTION
## Summary

Final piece of the email-broadcast epic (task 4/4). Everything server-side is already merged: DB+lib foundation (#2090), processor worker (#2094), and the admin API routes + shared Zod schema (#2096). This PR is UI only, driving those existing routes — no server-side files touched.

- **`/broadcasts`** — history list (`broadcasts/page.tsx`): `PageHeader` + "New broadcast", `useAdminQuery` at a 15s poll, `StatusBadge`, sent/skipped/failed/targeted columns, dry-run badge, rows link to detail.
- **`/broadcasts/new`** (`broadcast-composer.tsx`) — Compose/Template tabs, engine select (marketing/`resend_broadcast` shown disabled — Phase 2), audience builder (always-on exclusions `Alert`, plan-tier toggles, signup date range, user typeahead reusing `/api/admin/users?q=` with the existing 300ms debounce, removable chips). "Preview & count" runs a dry run into a StatCard + a **sandboxed** `<iframe sandbox="" srcDoc>`. "Send live…" is gated behind a fresh dry run + transactional engine + non-onprem, confirmed via `ConfirmActionDialog` with a typed recipient-count confirmation (the real deliberate-action gate — see review fixes below for why there's no separate reason field). Handles the full response contract: 202 → navigate to the detail page, 400 → field error, 409 → "already sending" banner showing the server's actual message with a "send anyway" (`allowDuplicate`) checkbox, 500 → surfaces the failed broadcast (when the response actually names one) and that retrying is safe. Any edit to subject/body/audience/engine invalidates the stale preview and re-disables live send.
- **`/broadcasts/[id]`** (`broadcast-progress.tsx`) — status badge, Sent/Skipped/Failed/Targeted `StatCard`s, step-result log, `lastError`/`blockedReason` alerts, 2s poll that stops once nothing can change the row further (`completed`/`cancelled`, or a `failed` row the worker permanently refused), Cancel via `ConfirmActionDialog` with a required reason (available on every non-terminal status, including `failed`).
- **Nav** — `Broadcasts` entry (lucide `Send`) added to the People group in `admin-shell.tsx`.
- Every request is parsed client-side with the imported `broadcastCreateSchema` / `templateCreateSchema` before POSTing, so the form can never submit something the server would reject.

## Contract mapping

| UI element | API |
|---|---|
| List page | `GET /api/admin/broadcasts` |
| Preview & count | `POST /api/admin/broadcasts` (`dryRun:true`) → 200 `{audienceCount, previewHtml, subject}` |
| Send live | `POST /api/admin/broadcasts` (`dryRun:false`) → 202/400/409/500 |
| Template select/save | `GET`/`POST /api/admin/broadcasts/templates` |
| Progress page | `GET /api/admin/broadcasts/[id]` |
| Cancel | `POST /api/admin/broadcasts/[id]` (`{action:'cancel', reason}`) |

## Review fixes

Two rounds of automated review, all confirmed against the frozen API's / processor worker's own documented semantics before fixing.

**Round 1 (Codex, 7f5c0d6cf)** — `failed` is retryable, not always terminal: the worker writes a row to `failed` and can *rethrow* on a retryable per-recipient/provider failure so pg-boss retries the job. Fixed the progress page to keep polling on `failed` instead of freezing, and to keep Cancel available during retry backoff. Also fixed a 500-response handler that assumed a `broadcastId` is always present (the route's outer catch, hit before any row exists, returns just `{error}`).

**Round 2 (independent deep-review workflow, 4 finders + per-finding verify pass, all CONFIRMED, facc1cb18)** — caught a gap in round 1 plus two unrelated bugs:
- Round 1's fix went too far: it also stopped polling from ever settling on the worker's `refuse()` path (on-prem live-send block, unresolvable content, unreachable CTA link) — that path sets `failed` + `blockedReason` and *returns without rethrowing*, so pg-boss never retries it and the row is genuinely dead, but the progress page would have polled it every 2s forever. Split into two separate, correctly-scoped functions: `isTerminalStatus` (cancellability — completed/cancelled only, mirrors the API's `INTERVENTION_BLOCKED_STATES`) and `isPollingSettled(status, blockedReason)` (polling — also settles on a refused `failed` row). A `failed` row with no `blockedReason` stays ambiguous by design: the frozen API response can't distinguish "still retrying" from "retries exhausted" or "never enqueued," so polling conservatively continues and Cancel stays available either way.
- The 409 duplicate-subject banner hardcoded generic copy instead of the server's actual message (which names the exact status and the `allowDuplicate` escape hatch) — the real message was computed but never rendered.
- The live-send confirmation dialog required typing a "reason" that was silently discarded — `broadcastCreateSchema` has no field for it (unlike Cancel's reason, which is genuinely audited) — so it was pure friction with zero audit value. Removed; the typed recipient-count confirmation is the real deliberate-action gate.

28/28 unit tests passing; typecheck + eslint clean. See inline replies on the original review threads for full detail on round 1.

## Test plan
- [x] `bun run typecheck` clean monorepo-wide
- [x] `bunx eslint` clean on all touched files
- [x] Unit tests for pure helpers (`bunx vitest run src/components/admin/broadcasts/__tests__` — 28/28 passing): status→badge mapping, `buildCreatePayload`/`buildAudienceDefinition` request-body construction, `formatServerFailureMessage`, `isTerminalStatus`/`isPollingSettled`, and the edit-invalidates-preview staleness logic
- [ ] Manual smoke test in a running admin instance (dual-React caveat makes component render tests unreliable in this worktree — typecheck/lint/unit are the primary gates per the task spec)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01SUQV4HWbwDzuSBnLBkNtM5
