### PR TITLE
feat(machines): editable file pane with save (epic task 14)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 
@@ -7,8 +7,18 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+/** Stable across calls (unlike a fresh `vi.fn()` per `getState()`) so tests can
+ * assert on startEditing/endEditing pairs across renders. */
+const editingStore = { startEditing: vi.fn(), endEditing: vi.fn() };
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: { getState: () => editingStore },
+}));
+
 /**
- * Every (language, value) pair Monaco has been handed, across ALL renders.
+ * Every (language, value, readOnly) triple Monaco has been handed, across ALL
+ * renders.
  *
  * The final DOM is not enough to police "never show one file's content under
  * another file's name": React flushes the pane's effect before paint, so a bad
@@ -17,22 +27,47 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
  * real setValue against its model. Recording renders is what makes that window
  * observable.
  */
-const monacoRenders: { language: string | undefined; value: string }[] = [];
+const monacoRenders: { language: string | undefined; value: string; readOnly: boolean | undefined }[] = [];
 
 // Monaco is next/dynamic(ssr:false); stub it so the pane's fetch/state logic and
-// the props it hands the editor (value, language, readOnly) are what's asserted.
+// the props it hands the editor (value, language, readOnly, onChange) are what's
+// asserted. The stub renders a textarea wired to onChange so tests can simulate
+// a user editing the buffer without needing the real Monaco bundle.
 vi.mock('@/components/editors/MonacoEditor', () => ({
-  default: ({ value, language, readOnly }: { value: string; language?: string; readOnly?: boolean }) => {
-    monacoRenders.push({ language, value });
+  default: ({
+    value,
+    language,
+    readOnly,
+    onChange,
+  }: {
+    value: string;
+    language?: string;
+    readOnly?: boolean;
+    onChange?: (value: string | undefined) => void;
+  }) => {
+    monacoRenders.push({ language, value, readOnly });
+    // Read-only renders `value` as plain text; editable renders a textarea bound
+    // to `onChange` instead of ALSO showing the text, so `monaco.textContent`
+    // reflects the buffer exactly once either way (a textarea's value is its
+    // own text-node child in the DOM, so rendering both would double it).
     return (
       <div data-testid="monaco" data-language={language} data-readonly={String(readOnly)}>
-        {value}
+        {readOnly ? (
+          value
+        ) : (
+          <textarea
+            aria-label="editor-content"
+            value={value}
+            onChange={(e) => onChange?.(e.target.value)}
+          />
+        )}
       </div>
     );
   },
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
 import FilesFilePane from './FilesFilePane';
 import type { FilesScope } from './files-scope';
 
@@ -62,21 +97,21 @@ describe('FilesFilePane', () => {
     monacoRenders.length = 0;
   });
 
-  test('reads the selected file and shows it read-only with a detected language', async () => {
+  test('reads the selected file and shows it editable with a detected language', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'export const x = 1;', encoding: 'utf8', truncated: false }));
     renderPane('src/index.ts');
 
     const monaco = await waitFor(() => screen.getByTestId('monaco'));
 
     assert({
-      given: 'a .ts file whose read succeeds',
-      should: 'render its content read-only in Monaco with typescript highlighting',
+      given: 'a .ts file whose read succeeds cleanly (not truncated)',
+      should: 'mount it editable in Monaco with typescript highlighting',
       actual: {
         value: monaco.textContent,
         language: monaco.getAttribute('data-language'),
         readOnly: monaco.getAttribute('data-readonly'),
       },
-      expected: { value: 'export const x = 1;', language: 'typescript', readOnly: 'true' },
+      expected: { value: 'export const x = 1;', language: 'typescript', readOnly: 'false' },
     });
   });
 
@@ -106,6 +141,27 @@ describe('FilesFilePane', () => {
       should: 'surface a Truncated banner alongside the content',
       actual: screen.queryByText('Truncated') !== null,
       expected: true,
+    });
+  });
+
+  test('a truncated read stays read-only with no Save affordance', async () => {
+    // Saving a truncated view would silently drop the file's tail on disk — the
+    // route caps a single read at 2 MiB, so a truncated buffer never has the
+    // whole file to begin with.
+    vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'partial', encoding: 'utf8', truncated: true }));
+    renderPane();
+
+    const monaco = await waitFor(() => screen.getByTestId('monaco'));
+
+    assert({
+      given: 'a truncated read',
+      should: 'stay read-only in Monaco (no editable buffer mounted) and never offer a Save button',
+      actual: {
+        readOnly: monaco.getAttribute('data-readonly'),
+        editorTextarea: screen.queryByLabelText('editor-content'),
+        saveButton: screen.queryByTitle('Save file (Cmd/Ctrl-S)'),
+      },
+      expected: { readOnly: 'true', editorTextarea: null, saveButton: null },
     });
   });
 
@@ -412,6 +468,283 @@ describe('FilesFilePane', () => {
       should: 'use the root-scope copy, not the branch-scope "checkout" phrasing',
       actual: message.textContent,
       expected: 'This file is no longer on the machine.',
+    });
+  });
+
+  describe('editing and save', () => {
+    const editContent = async (text: string) => {
+      const editor = screen.getByLabelText('editor-content');
+      await userEvent.clear(editor);
+      await userEvent.type(editor, text);
+      return editor;
+    };
+
+    test('editing a clean file marks it dirty and shows the Save affordance', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'export const x = 1;', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts');
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('export const x = 2;');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      assert({
+        given: 'a clean text file edited in the editor',
+        should: 'show the dirty dot and a Save button',
+        actual: {
+          dirtyDot: screen.queryByTitle('Unsaved changes') !== null,
+          saveButton: screen.queryByTitle('Save file (Cmd/Ctrl-S)') !== null,
+        },
+        expected: { dirtyDot: true, saveButton: true },
+      });
+    });
+
+    test('Save POSTs the edited content with scope fields and cleans the dirty state', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      const call = vi.mocked(fetchWithAuth).mock.calls[1];
+      const options = call[1] as RequestInit;
+
+      assert({
+        given: 'a dirty branch-scope file, saved via the Save button',
+        should: "POST kind:'file' utf8 content plus scope fields to the files route, then clean the dirty state",
+        actual: {
+          url: call[0],
+          method: options.method,
+          body: JSON.parse(String(options.body)),
+          dirtyAfter: screen.queryByTitle('Unsaved changes'),
+          saveButtonAfter: screen.queryByTitle('Save file (Cmd/Ctrl-S)'),
+        },
+        expected: {
+          url: '/api/machines/files',
+          method: 'POST',
+          body: {
+            machineId: 'machine-1',
+            projectName: 'repo',
+            branchName: 'main',
+            path: 'src/index.ts',
+            kind: 'file',
+            encoding: 'utf8',
+            content: 'after',
+          },
+          dirtyAfter: null,
+          saveButtonAfter: null,
+        },
+      });
+    });
+
+    test('root scope saves omit projectName/branchName from the POST body', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('README.md', { kind: 'root' });
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      const body = JSON.parse(String((vi.mocked(fetchWithAuth).mock.calls[1][1] as RequestInit).body));
+
+      assert({
+        given: 'a dirty root-scope file, saved',
+        should: 'POST without projectName/branchName, matching the root-scope read',
+        actual: { projectName: body.projectName, branchName: body.branchName },
+        expected: { projectName: undefined, branchName: undefined },
+      });
+    });
+
+    test('Cmd/Ctrl-S saves the dirty draft', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 's', ctrlKey: true });
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      assert({
+        given: 'a dirty draft and a Ctrl-S keypress',
+        should: 'trigger the same save POST as clicking Save, and prevent the browser default',
+        actual: {
+          fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+          method: (vi.mocked(fetchWithAuth).mock.calls[1][1] as RequestInit).method,
+        },
+        expected: { fetches: 2, method: 'POST' },
+      });
+    });
+
+    test('a 403 save failure toasts the edit-access copy and leaves the draft dirty', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: "You don't have edit access to this machine", reason: 'forbidden' }, 403));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected with 403',
+        should: 'toast the edit-access copy and leave the draft dirty',
+        actual: {
+          toastMessage: vi.mocked(toast.error).mock.calls[0]?.[0],
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { toastMessage: "You don't have edit access to this machine", stillDirty: true },
+      });
+    });
+
+    test('a 413 save failure toasts the too-large copy', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'File is too large to upload', reason: 'too_large' }, 413));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected with 413',
+        should: 'toast the too-large copy',
+        actual: vi.mocked(toast.error).mock.calls[0]?.[0],
+        expected: 'File is too large to upload',
+      });
+    });
+
+    test("a save failure for any other reason toasts the route's own error text", async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'Failed to complete the operation on the machine', reason: 'exec_failed' }, 502));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected for a reason other than 403/413',
+        should: "toast the route's own error text unmodified",
+        actual: vi.mocked(toast.error).mock.calls[0]?.[0],
+        expected: 'Failed to complete the operation on the machine',
+      });
+    });
+
+    test('registers with useEditingStore while dirty and releases the same session id after save', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => {
+        if (editingStore.startEditing.mock.calls.length === 0) throw new Error('not registered yet');
+      });
+      const sessionId = editingStore.startEditing.mock.calls[0][0];
+
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (!editingStore.endEditing.mock.calls.some((c) => c[0] === sessionId)) throw new Error('not released yet');
+      });
+
+      assert({
+        given: "a draft that went dirty (useEditingStore registration, repo rule) then was saved",
+        should: 'register a session while dirty and release that SAME session id once the save cleans the draft',
+        actual: {
+          registeredWhileDirty: editingStore.startEditing.mock.calls.some((c) => c[0] === sessionId && c[1] === 'document'),
+          releasedAfterSave: editingStore.endEditing.mock.calls.some((c) => c[0] === sessionId),
+        },
+        expected: { registeredWhileDirty: true, releasedAfterSave: true },
+      });
+    });
+
+    test('the reload button confirms before discarding a dirty draft, and declining keeps it', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await userEvent.click(screen.getByTitle('Reload file'));
+
+      assert({
+        given: 'a dirty draft, Reload clicked, but the discard confirm declined',
+        should: 'ask for confirmation and skip the re-fetch, leaving the dirty draft intact',
+        actual: {
+          confirmed: confirmSpy.mock.calls.length,
+          fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { confirmed: 1, fetches: 1, stillDirty: true },
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    test('a confirmed reload discards the dirty draft and re-fetches', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ content: 'reloaded from disk', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      await userEvent.click(screen.getByTitle('Reload file'));
+      await waitFor(() => screen.getByText('reloaded from disk'));
+
+      assert({
+        given: 'a dirty draft, Reload clicked, discard confirmed',
+        should: 're-fetch the file and clear the dirty state',
+        actual: {
+          confirmed: confirmSpy.mock.calls.length,
+          value: screen.getByTestId('monaco').textContent,
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { confirmed: 1, value: 'reloaded from disk', stillDirty: false },
+      });
+
+      confirmSpy.mockRestore();
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -2,21 +2,28 @@
 
 /**
  * FilesFilePane — the Files tab's main pane: fetches ONE selected file's content
- * from the machine files route (`mode=read`) and shows it in a read-only Monaco.
- * Scoped by `FilesScope` (Machine Files Manager epic, Part A) — either the
- * Machine's own root Sprite (`/workspace`) or a project/branch checkout within
- * it — like its sibling {@link MachineFileTree}.
+ * from the machine files route (`mode=read`) and shows it in Monaco, editable
+ * when it loaded cleanly as (non-truncated) text. Scoped by `FilesScope`
+ * (Machine Files Manager epic, Part A) — either the Machine's own root Sprite
+ * (`/workspace`) or a project/branch checkout within it — like its sibling
+ * {@link MachineFileTree}.
  *
- * Read-only by design — this tab views a live filesystem, it does not edit it,
- * so Monaco is mounted with `readOnly` and there is no onChange/save path.
- * Content is fetched lazily: the pane only mounts once a file is actually
- * clicked (the tab renders a placeholder until then), and every settled state
- * carries the path it settled for, so the pane can never paint one file's
- * content under another's name. The route caps a single read at 2 MiB and
- * reports `truncated` when it clips a larger file; that surfaces as a banner so
- * a partial view is never mistaken for the whole file. The working tree is LIVE
- * (an agent terminal can rewrite the open file), and re-clicking the same row
- * in the tree is a no-op, so the header carries a reload.
+ * EDITING + SAVE. A clean text read (`loaded`, not `truncated`, not binary) is
+ * editable; Cmd/Ctrl-S or the header's Save button POSTs `kind: 'file'` with the
+ * editor's current value back to the same route (overwrite IS save — see the
+ * route header). The editor's draft is tracked separately from the last-loaded
+ * content so a failed save never loses the edit, and the header's dot + "Save"
+ * affordance only appear once the draft actually diverges from what's on disk.
+ * `truncated` reads stay READ-ONLY, full stop — the route caps a single read at
+ * 2 MiB, so a truncated buffer is missing the file's tail, and saving it would
+ * silently truncate the real file on disk.
+ *
+ * Saving registers with `useEditingStore` for as long as the draft is dirty
+ * (repo rule, CLAUDE.md) — this is what stops an SWR revalidation or an auth
+ * refresh from clobbering an edit the user hasn't saved yet. The reload button
+ * (needed because the working tree is LIVE — see below) confirms before
+ * discarding a dirty draft, since it's the only path that would otherwise
+ * silently blow away unsaved work.
  *
  * BINARIES. A real filesystem is full of them — images, fonts, archives,
  * `.node` addons, `__pycache__` — and the route decodes whatever it reads as
@@ -38,12 +45,14 @@
  * we can tell the reader which of the two actually happened instead of guessing.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { AlertTriangle, FileQuestion, RefreshCw } from 'lucide-react';
+import { AlertTriangle, FileQuestion, RefreshCw, Save } from 'lucide-react';
+import { toast } from 'sonner';
 import { detectLanguageFromFilename, isBinaryFile } from '@pagespace/lib/utils/language-detection';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Button } from '@/components/ui/button';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { PaneLoading, PaneNotice } from './tab-states';
 import { FILES_ABSENT_COPY, asAbsentReason, readErrorBody, type FilesAbsentReason } from './checkout-states';
 import { type FilesScope, filesScopeSearchParams } from './files-scope';
@@ -108,24 +117,39 @@ const looksBinary = (content: string): boolean => {
   return replacements >= MIN_REPLACEMENTS && replacements / sample.length > MAX_REPLACEMENT_RATIO;
 };
 
+/** The POST body's scope fields — a pair, present only for branch scope (mirrors `filesScopeSearchParams`). */
+const filesScopeBodyFields = (scope: FilesScope): Record<string, string> =>
+  scope.kind === 'branch' ? { projectName: scope.projectName, branchName: scope.branchName } : {};
+
 export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneProps) {
   const [state, setState] = useState<FileState>({ status: 'loading' });
-  // Bumped by Retry to re-run the read without changing the selected file.
+  // Bumped by Retry/Reload to re-run the read without changing the selected file.
   const [attempt, setAttempt] = useState(0);
+  // Non-null once the user edits a clean text file — the draft buffer the
+  // editor shows, distinct from `state`'s content (the last-loaded/last-saved
+  // value) so a failed save never loses the edit and Save has something to
+  // diff against.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const fileName = basename(path);
 
   useEffect(() => {
     // Nothing useful to render for a known binary, so don't spend a read on one.
     if (isBinaryFile(fileName)) {
       setState({ status: 'binary', path });
+      setDraft(null);
       return;
     }
 
-    // A new file, a Retry, or a Refresh makes an in-flight read stale — this
+    // A new file, a Retry, or a Reload makes an in-flight read stale — this
     // flag, flipped by the cleanup, keeps a late resolver from landing on the
     // state that replaced it.
     let cancelled = false;
     setState({ status: 'loading' });
+    // A new load (new path, Retry, or a confirmed Reload) always starts clean —
+    // the draft it would replace has already been either discarded (Reload's
+    // confirm) or was never valid for this path to begin with.
+    setDraft(null);
 
     const load = async () => {
       try {
@@ -188,7 +212,97 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
   // The state of a DIFFERENT file is not this file's state — until the effect
   // catches up, we have nothing to show but the spinner. (See FileState.)
   const current: FileState = state.status === 'loading' || state.path === path ? state : { status: 'loading' };
-  const reload = () => setAttempt((a) => a + 1);
+  // Truncated content is a partial read (the route caps at 2 MiB) — editing and
+  // saving it would silently drop the file's tail on disk, so it stays
+  // read-only no matter what the banner already says.
+  const editable = current.status === 'loaded' && !current.truncated;
+  const dirty = editable && draft !== null;
+
+  // Registers for as long as the draft is dirty — repo rule (CLAUDE.md): this
+  // is what stops an SWR revalidation or an auth-refresh interrupt from
+  // clobbering an edit the user hasn't saved yet. Mirrors CodePageView's
+  // registration for the same store.
+  useEffect(() => {
+    const sessionId = `machine-files-pane-${machineId}`;
+    if (dirty) {
+      useEditingStore.getState().startEditing(sessionId, 'document', { componentName: 'FilesFilePane' });
+    } else {
+      useEditingStore.getState().endEditing(sessionId);
+    }
+    return () => {
+      useEditingStore.getState().endEditing(sessionId);
+    };
+  }, [dirty, machineId]);
+
+  const save = async () => {
+    if (!dirty || current.status !== 'loaded' || draft === null) return;
+    const content = draft;
+    setSaving(true);
+    try {
+      const res = await fetchWithAuth('/api/machines/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          machineId,
+          ...filesScopeBodyFields(scope),
+          path,
+          kind: 'file',
+          encoding: 'utf8',
+          content,
+        }),
+      });
+      if (!res.ok) {
+        const { error } = readErrorBody(await res.json().catch(() => null));
+        const message =
+          res.status === 403
+            ? "You don't have edit access to this machine"
+            : res.status === 413
+              ? 'File is too large to upload'
+              : (error ?? `Failed to save file (${res.status})`);
+        toast.error(message);
+        return;
+      }
+      setState({ status: 'loaded', path, content, truncated: false });
+      setDraft(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save file');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Kept fresh every render (a plain assignment, not an effect — `save` is a
+  // new closure every render, so an effect for this would just run every
+  // render anyway) so the mount-once keydown listener below always calls the
+  // current save (current draft, current path) — mirrors CodePageView's
+  // forceSaveRef.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        void saveRef.current();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  const reload = () => {
+    // The only place `attempt` bumps — a confirmed discard here is what keeps a
+    // Reload from silently blowing away an unsaved edit.
+    if (dirty && !window.confirm('Discard unsaved changes to this file?')) return;
+    setAttempt((a) => a + 1);
+  };
+
+  const handleChange = (value: string | undefined) => {
+    if (value === undefined) return;
+    setDraft(value);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -196,12 +310,30 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
         <span className="min-w-0 truncate text-xs text-muted-foreground" title={path}>
           {path}
         </span>
-        <div className="ml-auto flex shrink-0 items-center gap-1">
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {dirty && (
+            // Matches TabItem's dirty-tab dot exactly (amber dot + this title).
+            <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Unsaved changes" />
+          )}
           {current.status === 'loaded' && current.truncated && (
             <span className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
               <AlertTriangle className="size-3" />
               Truncated
             </span>
+          )}
+          {dirty && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-5 gap-1 px-1.5 text-[10px]"
+              title="Save file (Cmd/Ctrl-S)"
+              onClick={() => void save()}
+              disabled={saving}
+            >
+              <Save className="size-3" />
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
           )}
           {/* The working tree is LIVE — an agent terminal can rewrite this file
               while it's open — and re-clicking the same row in the tree is a
@@ -246,8 +378,9 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
         )}
         {current.status === 'loaded' && (
           <MonacoEditor
-            value={current.content}
-            readOnly
+            value={draft ?? current.content}
+            onChange={editable ? handleChange : undefined}
+            readOnly={!editable}
             language={detectLanguageFromFilename(fileName)}
             className="h-full"
           />


### PR DESCRIPTION
## Summary

Turns `FilesFilePane`'s read-only Monaco viewer into an editor with save, per epic task 14 (Machine Files Manager). Scope: `FilesFilePane.tsx` + `FilesFilePane.test.tsx` only.

- A file that loads cleanly as text (`loaded`, not `truncated`, not binary) mounts Monaco **editable** — reuses `MonacoEditor`'s editable mode the way `CodePageView` does. `truncated` reads stay **read-only**, enforced and commented: saving a partial 2 MiB-capped read would silently drop the file's tail on disk.
- **Dirty tracking**: a `draft` buffer distinct from the last-loaded/saved content, so a failed save never loses the edit. Header shows an amber dot + `"Unsaved changes"` title (matches `TabItem`'s dirty-tab convention exactly) and a Save button once dirty. Cmd/Ctrl-S saves too, via a document-level keydown handler that calls `preventDefault()`.
- **Save**: POSTs `{ machineId, projectName?, branchName?, path, kind: 'file', encoding: 'utf8', content }` to the same `/api/machines/files` route (overwrite IS save — see the route's header contract). Success cleans the draft and updates the loaded content to the saved value. Failure toasts (403 → edit-access copy, 413 → too-large copy, else the route's own `error`) and leaves the draft dirty.
- **`useEditingStore` registration** (repo rule, CLAUDE.md): registers a `'document'`-type session for as long as the draft is dirty, releases on clean or unmount — mirrors `CodePageView`'s registration for the same store, so SWR revalidation / auth-refresh can't clobber an unsaved edit.
- **Reload**: confirms via `window.confirm` before discarding a dirty draft. `attempt` (the state Reload bumps to re-run the read) is bumped in exactly one place, so this single guard covers both the button and the "would replace a dirty state" case from the task brief.
- Binary/absent/error states: unchanged.

**Explicit non-goal (per task brief)**: intercepting a `path` prop change (a different file selected in the tree) while the current file is dirty — that flow lives in `FilesTab`'s Selection state, which this task doesn't touch. Flagging as a follow-up rather than expanding scope. In practice this can't corrupt state: the moment `path` changes, `current` no longer matches the previous file's loaded state, so `dirty` (which requires `current.status === 'loaded'`) drops to `false` automatically — the stale draft is just discarded, never silently saved to the wrong file.

## Test plan

- [x] `FilesFilePane.test.tsx` — 30/30 passing, including new coverage: editable mount for clean text, truncated stays read-only (no Save affordance), Save posts the exact body (branch + root scope) and cleans state, Cmd/Ctrl-S saves, 403/413/other save failures toast the right copy and stay dirty, `useEditingStore` register/release pairing (same session id), reload confirm accepted/declined.
- [x] `bun run typecheck` — clean.
- [x] `eslint` on both changed files — clean.
- [x] `git diff --stat` — touches only `FilesFilePane.tsx` and `FilesFilePane.test.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQUhNQGGpBA93iKmygFzz