### PR TITLE
feat(machines): file tree move/copy, upload, download (epic tasks 12+13)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/DestinationPathDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/DestinationPathDialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * DestinationPathDialog — the single destination-path dialog `MachineFileTree`
+ * uses for Move and Copy (Machine Files Manager epic, task 12). Unlike
+ * `FileNameDialog` (a single path SEGMENT appended to a fixed parent), this
+ * dialog's input is the FULL destination path, relative to the scope root,
+ * INCLUDING the item's name — e.g. moving `src/old.ts` into a sibling folder
+ * `lib` under the same name means entering `lib/old.ts`, not just `lib`. That
+ * is the one semantic the caller commits to: `toPath` sent to the PATCH verb
+ * is exactly what's typed here, never `destinationDir + '/' + currentName`.
+ * The field is prefilled with the item's current PARENT directory as an
+ * editing starting point — the item's name is deliberately left for the user
+ * to type (or change, to rename in the same step). Submitting the prefilled
+ * value unedited lands on the parent directory's own path, which the mutation
+ * itself rejects (typically `already_exists`, since a directory of that name
+ * is already there) — an immediate, legible failure rather than a silent
+ * wrong move.
+ *
+ * Validation is client-side and minimal: the entered path can't be empty
+ * (this also blocks landing on the scope root, which the route rejects on its
+ * own). Deeper failures — the destination already existing, the source having
+ * vanished — come back from the mutation itself and are surfaced as a toast
+ * by the caller, not from here.
+ */
+
+import { useEffect, useState, type FormEvent } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface DestinationPathDialogProps {
+  open: boolean;
+  /** 'Move' or 'Copy' — also drives the submit button's label. */
+  title: 'Move' | 'Copy';
+  /** Prefilled destination path — the item's current PARENT directory, not its full path (see module doc). */
+  initialPath: string;
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (path: string) => void;
+}
+
+function validatePath(path: string): string | null {
+  if (path.trim().length === 0) return 'Destination path is required';
+  return null;
+}
+
+export default function DestinationPathDialog({
+  open,
+  title,
+  initialPath,
+  submitting = false,
+  onCancel,
+  onSubmit,
+}: DestinationPathDialogProps) {
+  const [path, setPath] = useState(initialPath);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed from `initialPath` every time the dialog opens — the same instance
+  // is reused across Move and Copy by the caller.
+  useEffect(() => {
+    if (open) {
+      setPath(initialPath);
+      setError(null);
+    }
+  }, [open, initialPath]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validationError = validatePath(path);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onSubmit(path.trim());
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Enter the full destination path, relative to the scope root, including the name — e.g. folder/name.ext.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="destination-path-dialog-input">Destination path</Label>
+            <Input
+              id="destination-path-dialog-input"
+              autoFocus
+              value={path}
+              onChange={(e) => {
+                setPath(e.target.value);
+                setError(null);
+              }}
+              disabled={submitting}
+            />
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (title === 'Move' ? 'Moving…' : 'Copying…') : title}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -592,4 +592,375 @@ describe('MachineFileTree', () => {
       });
     });
   });
+
+  describe('move / copy / upload / download operations', () => {
+    test('Move posts a PATCH with the entered destination, re-lists both parents, and drops the moved directory\'s own stale cache', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRenamed = vi.fn();
+      renderTree({ onPathRenamed });
+
+      await expandFolder('src');
+      await expandFolder('components');
+      await waitFor(() => screen.getByText('Button.tsx'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+      const componentsFetchesBefore = listCallsFor('src/components');
+
+      fireEvent.contextMenu(screen.getByText('components'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'components');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (onPathRenamed.mock.calls.length === 0) throw new Error('onPathRenamed not called yet');
+      });
+
+      assert({
+        given: "Move chosen from the 'src/components' directory's context menu, destination entered as 'components' (root)",
+        should:
+          "PATCH op:'move' with the exact entered toPath, re-list both the source and destination parent once, drop the moved directory's own stale cache (same mechanism as rename), and report the move via onPathRenamed",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          componentsStaleCacheDropped: listCallsFor('src/components') - componentsFetchesBefore,
+          renamedArgs: onPathRenamed.mock.calls[0],
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'move',
+              fromPath: 'src/components',
+              toPath: 'components',
+            },
+          },
+          srcRelistCount: 1,
+          rootRelistCount: 1,
+          componentsStaleCacheDropped: 1,
+          renamedArgs: ['src/components', 'components'],
+        },
+      });
+    });
+
+    test('Copy posts a PATCH with the entered destination, re-lists both parents, and never touches the open-file selection', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRenamed = vi.fn();
+      renderTree({ onPathRenamed });
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Copy…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'index-copy.ts');
+      await userEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+      await waitFor(() => {
+        if (listCallsFor('') <= rootFetchesBefore) throw new Error('destination parent not relisted yet');
+      });
+
+      // 'src/index.ts' is a FILE — it never had a cache entry of its own (only
+      // directory listings are cached), so "no source cache drop of the old
+      // path" is provable simply by there being nothing at that key to begin
+      // with, unlike Move's directory case above.
+      assert({
+        given: "Copy chosen from 'src/index.ts'’s context menu, destination entered as 'index-copy.ts' (root)",
+        should:
+          "PATCH op:'copy' with the exact entered toPath, re-list both the source and destination parent once, and never call onPathRenamed (copy doesn't touch the open file)",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          renamedCalls: onPathRenamed.mock.calls.length,
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'copy',
+              fromPath: 'src/index.ts',
+              toPath: 'index-copy.ts',
+            },
+          },
+          srcRelistCount: 1,
+          rootRelistCount: 1,
+          renamedCalls: 0,
+        },
+      });
+    });
+
+    test('a 409 from a move toasts a friendly message and issues no re-list of either parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'already_exists' }, 409));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'zeta.md');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a move whose destination already has something there (409)',
+        should: 'toast the friendly "already has that name" message and issue no re-list of either parent',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'Something already has that name',
+          srcRelistCount: 0,
+          rootRelistCount: 0,
+        },
+      });
+    });
+
+    test('a 404 from a move (source vanished) toasts the route\'s own error and re-lists only the now-stale source parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'The item to move could not be found', reason: 'not_found' }, 404));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'moved.ts');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "a move whose source has vanished out from under it (404 'not_found')",
+        should: "toast the route's own error and re-list only the stale source parent, never the destination parent",
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'The item to move could not be found',
+          srcRelistCount: 1,
+          rootRelistCount: 0,
+        },
+      });
+    });
+
+    test('Upload files… posts each selected file sequentially as base64 and re-lists the target directory exactly once', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree({ scope: { kind: 'root' } });
+
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      const fileA = new File(['hello'], 'a.txt', { type: 'text/plain' });
+      const fileB = new File(['world'], 'b.txt', { type: 'text/plain' });
+      const input = screen.getByTestId('file-tree-upload-input') as HTMLInputElement;
+
+      await userEvent.click(screen.getByTitle('Upload files'));
+      await userEvent.upload(input, [fileA, fileB]);
+
+      await waitFor(() => {
+        if (calls.length < 2) throw new Error('both uploads not posted yet');
+      });
+      await waitFor(() => {
+        if (listCallsFor('') <= rootFetchesBefore) throw new Error('target dir not relisted yet');
+      });
+
+      assert({
+        given: 'two files selected via "Upload files…" at the scope root',
+        should: 'POST each sequentially as base64-encoded content at the root, then re-list the root exactly once for the whole batch',
+        actual: {
+          uploads: calls.map((c) => {
+            const body = c.body as Record<string, unknown>;
+            return {
+              method: c.method,
+              path: body.path,
+              kind: body.kind,
+              encoding: body.encoding,
+              content: Buffer.from(body.content as string, 'base64').toString('utf8'),
+            };
+          }),
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          uploads: [
+            { method: 'POST', path: 'a.txt', kind: 'file', encoding: 'base64', content: 'hello' },
+            { method: 'POST', path: 'b.txt', kind: 'file', encoding: 'base64', content: 'world' },
+          ],
+          rootRelistCount: 1,
+        },
+      });
+    });
+
+    test('a file over the 10 MiB client cap is skipped with a toast and never POSTed, without blocking the rest of the batch', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree({ scope: { kind: 'root' } });
+
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      const bigFile = new File([new Uint8Array(10 * 1024 * 1024 + 1)], 'big.bin', { type: 'application/octet-stream' });
+      const okFile = new File(['ok'], 'ok.txt', { type: 'text/plain' });
+      const input = screen.getByTestId('file-tree-upload-input') as HTMLInputElement;
+
+      await userEvent.click(screen.getByTitle('Upload files'));
+      await userEvent.upload(input, [bigFile, okFile]);
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+      await waitFor(() => {
+        if (calls.length === 0) throw new Error('ok.txt not posted yet');
+      });
+
+      assert({
+        given: 'a batch with one file over the 10 MiB client cap and one comfortably under it',
+        should: 'toast the oversized file by name, skip POSTing it entirely, but still upload the other file and re-list once',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          postedPaths: calls.map((c) => (c.body as Record<string, unknown>).path),
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'big.bin: File is too large to upload',
+          postedPaths: ['ok.txt'],
+          rootRelistCount: 1,
+        },
+      });
+    });
+
+    test('Download fetches mode=download for the full path, then clicks an object-URL anchor named by the file\'s own basename', async () => {
+      const downloadRequests: string[] = [];
+      vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+        const url = String(args[0]);
+        const init = (args[1] ?? {}) as RequestInit;
+        const method = typeof init.method === 'string' ? init.method : 'GET';
+        const parsed = new URL(url, 'http://test');
+        if (method === 'GET' && parsed.searchParams.get('mode') === 'download') {
+          downloadRequests.push(parsed.searchParams.get('path') ?? '');
+          return new Response(new Blob(['contents']), { status: 200 });
+        }
+        const path = requestedPath(url);
+        const entries = FAKE_FS[path];
+        if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+        return jsonResponse({ entries });
+      });
+
+      // jsdom doesn't implement the Blob-URL/anchor-click machinery at all —
+      // stub it in so the component's real download path (blob → object URL →
+      // programmatic anchor click) is exercised and observable.
+      if (typeof URL.createObjectURL !== 'function') {
+        (URL as unknown as { createObjectURL: () => void }).createObjectURL = () => undefined;
+      }
+      if (typeof URL.revokeObjectURL !== 'function') {
+        (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = () => undefined;
+      }
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+      try {
+        renderTree();
+        await expandFolder('src');
+        await expandFolder('components');
+        await waitFor(() => screen.getByText('Button.tsx'));
+
+        fireEvent.contextMenu(screen.getByText('Button.tsx'));
+        await userEvent.click(await waitFor(() => screen.getByText('Download')));
+
+        await waitFor(() => {
+          if (clickSpy.mock.calls.length === 0) throw new Error('anchor not clicked yet');
+        });
+
+        const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement;
+
+        assert({
+          given: "Download chosen from 'Button.tsx'’s context menu, nested under src/components",
+          should:
+            "fetch mode=download for the full checkout-relative path, then click a same-tab object-URL anchor named by the file's own basename (not the full path)",
+          actual: {
+            downloadRequests,
+            objectUrlCreated: createObjectURLSpy.mock.calls.length,
+            objectUrlRevoked: revokeObjectURLSpy.mock.calls.length,
+            anchorDownloadName: anchor.download,
+          },
+          expected: {
+            downloadRequests: ['src/components/Button.tsx'],
+            objectUrlCreated: 1,
+            objectUrlRevoked: 1,
+            anchorDownloadName: 'Button.tsx',
+          },
+        });
+      } finally {
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+        clickSpy.mockRestore();
+      }
+    });
+
+    test('a failed download toasts the route\'s own error', async () => {
+      vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+        const url = String(args[0]);
+        const parsed = new URL(url, 'http://test');
+        if (parsed.searchParams.get('mode') === 'download') {
+          return jsonResponse({ error: 'File is too large to download', reason: 'too_large' }, 413);
+        }
+        const path = requestedPath(url);
+        const entries = FAKE_FS[path];
+        if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+        return jsonResponse({ entries });
+      });
+      renderTree();
+
+      await waitFor(() => screen.getByText('README.md'));
+      fireEvent.contextMenu(screen.getByText('README.md'));
+      await userEvent.click(await waitFor(() => screen.getByText('Download')));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a download request that comes back 413 too_large',
+        should: "toast the route's own error message",
+        actual: toastMocks.error.mock.calls[0]?.[0],
+        expected: 'File is too large to download',
+      });
+    });
+  });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -35,38 +35,70 @@
  *
  * MANAGEMENT OPERATIONS (task 11): directory rows get a right-click menu with
  * New File / New Folder / Rename / Delete; file rows get Rename / Delete; the
- * header gets New File / New Folder targeting the scope root. Move / Copy /
- * Upload menu entries are deliberately NOT here yet — the `ContextMenuSeparator`
- * before Rename is where tasks 12/13 slot them in, and Download slots into the
- * file row's menu above Rename. One shared `FileNameDialog` (a local
- * name-input dialog — the app's page-entity `RenameDialog` doesn't apply to
- * filesystem paths) serves both create and rename; delete uses a local
- * `AlertDialog` confirm naming the scope-relative path. All three mutations POST/
- * PATCH/DELETE `/api/machines/files` with the scope fields in the JSON body
- * (mirroring `filesScopeSearchParams`'s pairing rule, but this file doesn't
- * import that helper — `files-scope.ts` is out of scope for this task). On
- * success, the affected path(s) are dropped from `cacheRef` (see `invalidate`)
- * so the existing fetch-on-render effect re-lists whatever's visible, and a
- * delete/rename of the currently-open file bubbles up via `onPathRemoved` /
- * `onPathRenamed` so `FilesTab` can clear or retarget the pane. Failures never
- * become a red tree row for a mutation (rows are for LISTING errors only) — a
- * mutation failure is always a `sonner` toast.
+ * header gets New File / New Folder targeting the scope root. One shared
+ * `FileNameDialog` (a local name-input dialog — the app's page-entity
+ * `RenameDialog` doesn't apply to filesystem paths) serves both create and
+ * rename; delete uses a local `AlertDialog` confirm naming the scope-relative
+ * path.
+ *
+ * MOVE / COPY (task 12): directory AND file rows also get Move… / Copy…,
+ * sharing one `DestinationPathDialog` (`open` picks Move vs Copy by which was
+ * clicked). Both PATCH `op: 'move' | 'copy'` with `fromPath`/`toPath`, where
+ * `toPath` is exactly what the dialog's input holds — see its module doc for
+ * the full-path-including-name semantic. Both invalidate the source AND
+ * destination parent directories; move additionally invalidates `fromPath`
+ * itself (dropping any cached descendant listings, same as rename) and calls
+ * `onPathRenamed` — copy touches nothing at the source, so it calls neither.
+ * A 404 (`not_found`, source vanished) additionally re-lists the source
+ * parent on its own, since that parent's cached listing is now stale even
+ * though the mutation failed.
+ *
+ * UPLOAD / DOWNLOAD (task 13): a hidden `<input type="file" multiple>`
+ * (`fileInputRef`) is triggered from the header (targeting the scope root) or
+ * a directory's "Upload here" menu item (targeting that directory);
+ * `uploadTargetRef` carries which, since one shared input serves every
+ * trigger. Each selected file is read client-side via `FileReader` into
+ * base64 and POSTed `kind: 'file', encoding: 'base64'` SEQUENTIALLY (awaited
+ * one at a time, not `Promise.all` — concurrent writes into the same
+ * directory would race the eventual single re-list); a file over the
+ * server's 10 MiB cap is skipped client-side with its own toast rather than
+ * making a doomed request. One re-list of the target directory happens after
+ * the whole batch, not per file. Download (file rows only) fetches
+ * `mode=download` and turns the response into a blob → object-URL →
+ * programmatic anchor click, because a bare `<a href>` cannot carry the
+ * `fetchWithAuth` auth header.
+ *
+ * All mutations POST/PATCH/DELETE `/api/machines/files` with the scope fields
+ * in the JSON body (mirroring `filesScopeSearchParams`'s pairing rule, but
+ * this file doesn't import that helper — `files-scope.ts` is out of scope for
+ * this file's tasks). On success, the affected path(s) are dropped from
+ * `cacheRef` (see `invalidate`) so the existing fetch-on-render effect
+ * re-lists whatever's visible, and a delete/rename/move of the currently-open
+ * file bubbles up via `onPathRemoved` / `onPathRenamed` so `FilesTab` can
+ * clear or retarget the pane. Failures never become a red tree row for a
+ * mutation (rows are for LISTING errors only) — a mutation failure is always
+ * a `sonner` toast, optionally prefixed with a file name (see `runMutation`'s
+ * `toastPrefix`) so a per-file upload failure names which file it was.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 import type { MachineDirectoryEntry } from '@pagespace/lib/services/sandbox/machine-fs';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   ChevronRight,
+  Copy,
+  Download,
   File as FileIcon,
   FilePlus,
   Folder,
   FolderOpen,
   FolderPlus,
+  Move,
   Pencil,
   RefreshCw,
   Trash2,
+  Upload,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -91,6 +123,7 @@ import { SidebarLoading, SidebarNotice } from '../tabs/tab-states';
 import { readErrorBody } from '../tabs/checkout-states';
 import { type FilesScope, filesScopeKey, filesScopeSearchParams } from '../tabs/files-scope';
 import FileNameDialog from './FileNameDialog';
+import DestinationPathDialog from './DestinationPathDialog';
 
 export interface MachineFileTreeProps {
   machineId: string;
@@ -113,13 +146,16 @@ type DirectoryState =
 type EntryKind = 'file' | 'directory';
 
 /**
- * One dialog slot shared by New File / New Folder / Rename / Delete — only
- * ever one of these is open at a time, so a single piece of state (rather than
- * one boolean per op) is enough and can't get two dialogs open together.
+ * One dialog slot shared by New File / New Folder / Rename / Move / Copy /
+ * Delete — only ever one of these is open at a time, so a single piece of
+ * state (rather than one boolean per op) is enough and can't get two dialogs
+ * open together.
  */
 type PendingDialog =
   | { kind: 'create'; parentPath: string; entryKind: EntryKind }
   | { kind: 'rename'; path: string; parentPath: string; currentName: string; entryKind: EntryKind }
+  | { kind: 'move'; path: string; entryKind: EntryKind }
+  | { kind: 'copy'; path: string; entryKind: EntryKind }
   | { kind: 'delete'; path: string; entryKind: EntryKind }
   | null;
 
@@ -133,7 +169,10 @@ interface TreeContext {
   selectedPath: string | null;
   openCreateDialog: (parentPath: string, entryKind: EntryKind) => void;
   openRenameDialog: (path: string, entryKind: EntryKind) => void;
+  openMoveCopyDialog: (path: string, entryKind: EntryKind, op: 'move' | 'copy') => void;
   openDeleteDialog: (path: string, entryKind: EntryKind) => void;
+  triggerUpload: (targetPath: string) => void;
+  downloadFile: (path: string) => void;
 }
 
 /** Directories first, then files, each alphabetical — the universal file-explorer ordering. */
@@ -172,31 +211,67 @@ const scopeBodyFields = (machineId: string, scope: FilesScope): Record<string, s
     : { machineId };
 
 /**
+ * Mirrors the route's own upload cap (`MAX_UPLOAD_BYTES` in
+ * `api/machines/files/route.ts`) so an oversized file is rejected here,
+ * before a doomed request and its base64 encoding work happen at all. The
+ * server enforces its own cap independently — this is a UX shortcut, not the
+ * source of truth.
+ */
+const MAX_CLIENT_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Reads a File client-side into base64 (no data-URL prefix) for the route's `encoding: 'base64'` upload body. */
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read file'));
+        return;
+      }
+      // `readAsDataURL` yields `data:<mime>;base64,<data>` — only the part
+      // after the comma is the base64 payload the route expects.
+      const commaIndex = result.indexOf(',');
+      resolve(commaIndex === -1 ? result : result.slice(commaIndex + 1));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+type MutationOutcome = { ok: true } | { ok: false; status: number };
+
+/**
  * POSTs/PATCHes/DELETEs a mutation and turns any failure into the app's toast
  * convention — 403 and 409 get fixed, friendly copy; anything else falls back
- * to the route's own human-readable `error`. Returns whether it succeeded so
- * the caller can decide what to do next (invalidate cache, close a dialog);
- * never throws.
+ * to the route's own human-readable `error`. `toastPrefix` (used by upload,
+ * which fires many of these in one batch) names which file/item a toast is
+ * about — e.g. `"report.pdf: File is too large to upload"` — so a failure
+ * deep in a multi-file batch is still traceable to its cause. Returns the
+ * outcome, including the HTTP status on failure, so a caller can react to a
+ * SPECIFIC failure (e.g. move/copy re-listing the source parent only on a 404)
+ * without re-deriving it from the toast text; never throws.
  */
-async function runMutation(init: RequestInit): Promise<boolean> {
+async function runMutation(init: RequestInit, options?: { toastPrefix?: string }): Promise<MutationOutcome> {
+  const prefix = options?.toastPrefix ? `${options.toastPrefix}: ` : '';
   try {
     const res = await fetchWithAuth('/api/machines/files', {
       ...init,
       headers: { 'Content-Type': 'application/json', ...init.headers },
     });
-    if (res.ok) return true;
+    if (res.ok) return { ok: true };
     const body: unknown = await res.json().catch(() => null);
     if (res.status === 403) {
-      toast.error("You don't have edit access to this machine");
+      toast.error(`${prefix}You don't have edit access to this machine`);
     } else if (res.status === 409) {
-      toast.error('Something already has that name');
+      toast.error(`${prefix}Something already has that name`);
     } else {
-      toast.error(readErrorMessage(body) ?? `Request failed (${res.status})`);
+      toast.error(`${prefix}${readErrorMessage(body) ?? `Request failed (${res.status})`}`);
     }
-    return false;
+    return { ok: false, status: res.status };
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Request failed');
-    return false;
+    toast.error(`${prefix}${err instanceof Error ? err.message : 'Request failed'}`);
+    return { ok: false, status: 0 };
   }
 }
 
@@ -308,6 +383,10 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     setPendingDialog({ kind: 'rename', path, parentPath: parentOf(path), currentName: basenameOf(path), entryKind });
   }, []);
 
+  const openMoveCopyDialog = useCallback((path: string, entryKind: EntryKind, op: 'move' | 'copy') => {
+    setPendingDialog(op === 'move' ? { kind: 'move', path, entryKind } : { kind: 'copy', path, entryKind });
+  }, []);
+
   const openDeleteDialog = useCallback((path: string, entryKind: EntryKind) => {
     setPendingDialog({ kind: 'delete', path, entryKind });
   }, []);
@@ -316,29 +395,63 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
 
   const handleCreateOrRenameSubmit = useCallback(
     async (name: string) => {
-      if (pendingDialog === null || pendingDialog.kind === 'delete') return;
+      if (pendingDialog === null || pendingDialog.kind === 'delete' || pendingDialog.kind === 'move' || pendingDialog.kind === 'copy') return;
       setSubmitting(true);
       try {
         if (pendingDialog.kind === 'create') {
           const { parentPath, entryKind } = pendingDialog;
           const path = joinPath(parentPath, name);
-          const ok = await runMutation({
+          const result = await runMutation({
             method: 'POST',
             body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: entryKind }),
           });
-          if (!ok) return;
+          if (!result.ok) return;
           invalidate([parentPath]);
         } else {
           const { path: fromPath, parentPath } = pendingDialog;
           const toPath = joinPath(parentPath, name);
-          const ok = await runMutation({
+          const result = await runMutation({
             method: 'PATCH',
             body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op: 'move', fromPath, toPath }),
           });
-          if (!ok) return;
+          if (!result.ok) return;
           invalidate([parentPath, fromPath]);
           onPathRenamed?.(fromPath, toPath);
         }
+        setPendingDialog(null);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [pendingDialog, machineId, scope, invalidate, onPathRenamed],
+  );
+
+  const handleMoveCopySubmit = useCallback(
+    async (toPathRaw: string) => {
+      if (pendingDialog === null || (pendingDialog.kind !== 'move' && pendingDialog.kind !== 'copy')) return;
+      const op = pendingDialog.kind;
+      const fromPath = pendingDialog.path;
+      const toPath = toPathRaw;
+      setSubmitting(true);
+      try {
+        const result = await runMutation({
+          method: 'PATCH',
+          body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op, fromPath, toPath }),
+        });
+        if (!result.ok) {
+          // The source's parent listing is now stale if the source itself
+          // vanished out from under us — re-list it even though the mutation
+          // failed, same as the route contract's `error` toast (already fired
+          // by `runMutation`) documents.
+          if (result.status === 404) invalidate([parentOf(fromPath)]);
+          return;
+        }
+        // Both ops touch the destination's parent; only a MOVE also empties the
+        // source's parent of this entry and invalidates any cached descendant
+        // listings under the old path (mirrors rename's cache-drop). Copy
+        // leaves the source untouched, so it drops neither.
+        invalidate(op === 'move' ? [parentOf(fromPath), parentOf(toPath), fromPath] : [parentOf(fromPath), parentOf(toPath)]);
+        if (op === 'move') onPathRenamed?.(fromPath, toPath);
         setPendingDialog(null);
       } finally {
         setSubmitting(false);
@@ -352,11 +465,11 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     const { path } = pendingDialog;
     setSubmitting(true);
     try {
-      const ok = await runMutation({
+      const result = await runMutation({
         method: 'DELETE',
         body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path }),
       });
-      if (!ok) return;
+      if (!result.ok) return;
       invalidate([parentOf(path), path]);
       onPathRemoved?.(path);
       setPendingDialog(null);
@@ -364,6 +477,88 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
       setSubmitting(false);
     }
   }, [pendingDialog, machineId, scope, invalidate, onPathRemoved]);
+
+  // One shared hidden input serves every upload trigger (header + every
+  // directory's "Upload here"); `uploadTargetRef` carries which directory the
+  // NEXT file selection targets, set synchronously right before the input is
+  // clicked (a ref, not state — no render needs to observe it).
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadTargetRef = useRef<string>('');
+  const [uploading, setUploading] = useState(false);
+
+  const triggerUpload = useCallback((targetPath: string) => {
+    uploadTargetRef.current = targetPath;
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleUploadInputChange = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const fileList = e.target.files;
+      const targetPath = uploadTargetRef.current;
+      // Reset immediately so selecting the exact same file(s) again still
+      // fires a change event.
+      e.target.value = '';
+      if (fileList === null || fileList.length === 0) return;
+      setUploading(true);
+      try {
+        // Sequential, not concurrent — these all write into the same
+        // directory and share one re-list at the end; racing the writes would
+        // buy nothing and could reorder failures confusingly.
+        for (const file of Array.from(fileList)) {
+          if (file.size > MAX_CLIENT_UPLOAD_BYTES) {
+            toast.error(`${file.name}: File is too large to upload`);
+            continue;
+          }
+          const content = await readFileAsBase64(file);
+          const path = joinPath(targetPath, file.name);
+          await runMutation(
+            {
+              method: 'POST',
+              body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: 'file', encoding: 'base64', content }),
+            },
+            { toastPrefix: file.name },
+          );
+        }
+        invalidate([targetPath]);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [machineId, scope, invalidate],
+  );
+
+  const downloadFile = useCallback(
+    (path: string) => {
+      void (async () => {
+        try {
+          const search = filesScopeSearchParams(machineId, scope);
+          search.set('path', path);
+          search.set('mode', 'download');
+          const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
+          if (!res.ok) {
+            const body: unknown = await res.json().catch(() => null);
+            toast.error(readErrorMessage(body) ?? `Failed to download file (${res.status})`);
+            return;
+          }
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          // A bare `<a href>` cannot carry the `fetchWithAuth` auth header —
+          // the blob + object-URL round-trip is what makes an authed download
+          // possible from a click the browser treats as same-origin-anonymous.
+          const anchor = document.createElement('a');
+          anchor.href = url;
+          anchor.download = basenameOf(path);
+          document.body.appendChild(anchor);
+          anchor.click();
+          anchor.remove();
+          URL.revokeObjectURL(url);
+        } catch (err) {
+          toast.error(err instanceof Error ? err.message : 'Failed to download file');
+        }
+      })();
+    },
+    [machineId, scope],
+  );
 
   const ctx: TreeContext = {
     directories,
@@ -374,7 +569,10 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     selectedPath: selectedPath ?? null,
     openCreateDialog,
     openRenameDialog,
+    openMoveCopyDialog,
     openDeleteDialog,
+    triggerUpload,
+    downloadFile,
   };
 
   return (
@@ -407,6 +605,17 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
             variant="ghost"
             size="icon"
             className="size-5"
+            title="Upload files"
+            disabled={uploading}
+            onClick={() => triggerUpload('')}
+          >
+            <Upload className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
             title="Refresh files"
             onClick={refresh}
           >
@@ -414,6 +623,18 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
           </Button>
         </div>
       </div>
+      {/* Shared by every upload trigger (header + each directory's "Upload
+          here"); `uploadTargetRef` carries which directory a given click
+          targets. Hidden rather than `sr-only` — it must stay out of layout
+          and never receive focus/tab order of its own. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        data-testid="file-tree-upload-input"
+        onChange={(e) => void handleUploadInputChange(e)}
+      />
       <DirectoryChildren path="" depth={0} ctx={ctx} />
 
       <FileNameDialog
@@ -429,6 +650,16 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
         submitting={submitting}
         onCancel={closeDialog}
         onSubmit={handleCreateOrRenameSubmit}
+      />
+      <DestinationPathDialog
+        open={pendingDialog?.kind === 'move' || pendingDialog?.kind === 'copy'}
+        title={pendingDialog?.kind === 'copy' ? 'Copy' : 'Move'}
+        initialPath={
+          pendingDialog?.kind === 'move' || pendingDialog?.kind === 'copy' ? parentOf(pendingDialog.path) : ''
+        }
+        submitting={submitting}
+        onCancel={closeDialog}
+        onSubmit={handleMoveCopySubmit}
       />
       <AlertDialog open={pendingDialog?.kind === 'delete'} onOpenChange={(next) => { if (!next) closeDialog(); }}>
         <AlertDialogContent>
@@ -559,7 +790,19 @@ function DirectoryNode({
             <span>New Folder</span>
           </ContextMenuItem>
           <ContextMenuSeparator />
-          {/* Move to... / Copy to... / Upload here land here — tasks 12/13. */}
+          <ContextMenuItem onSelect={() => ctx.triggerUpload(path)}>
+            <Upload className="mr-2 h-4 w-4" />
+            <span>Upload here</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'directory', 'move')}>
+            <Move className="mr-2 h-4 w-4" />
+            <span>Move…</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'directory', 'copy')}>
+            <Copy className="mr-2 h-4 w-4" />
+            <span>Copy…</span>
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'directory')}>
             <Pencil className="mr-2 h-4 w-4" />
             <span>Rename</span>
@@ -611,7 +854,19 @@ function FileNode({
         </button>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">
-        {/* Download lands here — task 13. */}
+        <ContextMenuItem onSelect={() => ctx.downloadFile(path)}>
+          <Download className="mr-2 h-4 w-4" />
+          <span>Download</span>
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'file', 'move')}>
+          <Move className="mr-2 h-4 w-4" />
+          <span>Move…</span>
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'file', 'copy')}>
+          <Copy className="mr-2 h-4 w-4" />
+          <span>Copy…</span>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'file')}>
           <Pencil className="mr-2 h-4 w-4" />
           <span>Rename</span>


### PR DESCRIPTION
## Summary
- **Task 12 — move/copy**: new `DestinationPathDialog` (destination path relative to the scope root, including the name, prefilled with the item's current parent dir) wired into `MachineFileTree`'s directory/file context menus as Move…/Copy…. Both PATCH `op:'move'|'copy'` and invalidate both the source and destination parent listings; move additionally drops the moved path's own stale cache (same mechanism as task 11's rename) and reuses `onPathRenamed` for open-file retargeting — copy touches neither. A 404 (source vanished) re-lists the now-stale source parent on top of the route's own toast; a 409 issues no re-list.
- **Task 13 — upload/download**: a hidden multi-file input, shared by the header's "Upload files…" (scope root) and each directory's "Upload here", reads files client-side via `FileReader` into base64 and POSTs them sequentially (each toast-prefixed by filename on failure); files over the 10 MiB client cap are skipped with their own toast before any request; one re-list of the target directory happens after the whole batch. Download (file rows) fetches `mode=download`, turns the response into a blob → object URL → programmatic anchor click, since a bare `<a href>` can't carry the `fetchWithAuth` auth header.
- Tests extend `MachineFileTree.test.tsx` following task 11's patterns.

Epic: Machine Files Manager (PageSpace epic `gqpesv6uk1m3etdtx8z4zybj`). Builds on task 11 (#2106, merged into this branch) and the route contract from tasks 8-10 (#2105).

## Test plan
- [x] `bunx vitest run src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx` — 30/30 passing
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings (pre-existing warnings only, unrelated files)
- [x] `git diff --stat` against base — touches only `MachineFileTree.tsx`, `MachineFileTree.test.tsx`, and the new `DestinationPathDialog.tsx`
- [ ] Manual round-trip against a live machine (move/copy/upload/download) — not yet performed

Not merging — base is the integration branch `pu/machine-files-tab-fix`, not `master`.