### PR TITLE
chore(machines): epic convergence — verification evidence + changelog (epic task 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   OS user can read, credential store included — no CLI feature changes that. The actual isolation
   boundary is a dedicated OS user, container, or VM that receives only a scoped token via
   `PAGESPACE_TOKEN`.
+- **Machine page Files tab** — browse, open, and edit files directly on a Machine's own root
+  filesystem or any branch checkout, with a PageTree-matched file tree (lazy-loaded directories,
+  sorted directories-first) and an editable pane with Monaco language detection, binary-file
+  detection, and Cmd/Ctrl-S save. Right-click or the "+" palette to create files/folders, rename,
+  move, copy, delete, upload (10 MiB cap), or download (50 MiB cap) — every mutation requires edit
+  access and is audited. A machine that hasn't been started yet shows an explicit "not started"
+  state instead of an empty tree.
 
 ### Changed
 


### PR DESCRIPTION
## Summary

Convergence pass for the **Machine Files Manager** epic (all 14 implementation leaves merged into
`pu/machine-files-tab-fix` via PRs #2099–#2106, #2108, #2109). This PR proves the assembled whole
is coherent, adds the missing changelog entry, and leaves the branch ready for the epic PR to
`master` (assembled by the orchestrator, not this PR).

**No functional code changes.** Only `CHANGELOG.md` was touched — every verification step below
passed with no seam breakage found.

## Verification

| Step | Result |
|---|---|
| `bun install` | ✅ 4359 packages |
| `packages/db` build (`tsc -p tsconfig.build.json`) | ✅ clean |
| `packages/lib` build (`tsc -p tsconfig.build.json`) | ✅ clean |
| `bun run typecheck` (monorepo, `turbo typecheck`) | ✅ exit 0, zero `error TS` matches |
| `packages/lib` test suite (`vitest run`) | ✅ **366 passed, 4 skipped** (370 files) / **8467 tests passed, 11 skipped** |
| `apps/web` machine-scoped suites (listed below) | ✅ **32 files, 570 tests, 100% passed** |
| `apps/web` full unit suite (`bun run test`, 972 files) | ⚠️ 968 passed / 3 pre-existing failures (unrelated — see below) |
| `bun run lint` (apps/web + admin via turbo) | ✅ exit 0 — only pre-existing warnings in untouched files (`useCommandSuggestion.ts`, `useGlobalDriveSocket.ts`, `useOwnStreamMirror.ts`, `useVoiceMode.ts`) |
| `bun run changelog:generate` | ❌ broken independent of this epic (see below) |

### apps/web machine-scoped suites (all green)
```
src/app/api/machines/__tests__/route.test.ts                              10 tests
src/app/api/machines/agent-terminals/__tests__/route.test.ts              27 tests
src/app/api/machines/branches/__tests__/route.test.ts                     33 tests
src/app/api/machines/diff/__tests__/route.test.ts                        23 tests
src/app/api/machines/files/__tests__/route.test.ts                        91 tests
src/app/api/machines/git-blob/__tests__/route.test.ts                      9 tests
src/app/api/machines/projects/__tests__/route.test.ts                    28 tests
src/app/api/machines/settings/__tests__/route.test.ts                    21 tests
src/app/api/machines/workspaces/__tests__/route.test.ts                  17 tests
src/app/api/machines/workspaces/bootstrap/__tests__/route.test.ts         7 tests
src/lib/machines/__tests__/machine-files-runtime.test.ts                  6 tests
src/lib/machines/__tests__/machine-orphan-reconcile-runtime.integration.test.ts  13 tests
src/lib/machines/__tests__/machine-orphan-reconcile-runtime.killmap.test.ts       4 tests
src/lib/machines/__tests__/machine-settings-runtime.test.ts              19 tests
+ 18 component test files under
  src/components/layout/middle-content/page-views/machine/**            262 tests
```
Total: 32 files, 570 tests, all passing.

### The 3 pre-existing full-suite failures (not this epic)
All three files are **untouched** by the epic diff (`git diff master...HEAD --name-only` confirms
none of them appear), and none touch shared config:

- `src/lib/auth/__tests__/admin-role-version.test.ts` (12 tests) and
  `src/lib/ai/tools/__tests__/activity-tools.test.ts` (1 test) — fail with
  `role "test" does not exist`. These need the Postgres role provisioned by the root-level
  `bun run test` → `./scripts/test-with-db.sh` (docker + migrations); this sandbox has no docker
  daemon, so running `apps/web`'s own `vitest run` directly (as instructed) skips that setup. Not a
  code regression — a DB-provisioning-environment gap.
- `src/lib/messages/__tests__/grouping.test.ts` — 1 test ("breaks the group when messages cross
  midnight") is timezone-dependent: it hardcodes `2026-05-04T23:59:30Z` / `2026-05-05T00:00:30Z`
  and `isFirstInGroup` compares via `Date.prototype.toDateString()` (local time). This machine's
  local TZ is `America/Chicago` (UTC-5 in May), so both UTC timestamps land on the *same* local
  calendar day — the midnight crossing the test asserts never happens locally. Pre-existing TZ bug
  in the test, unrelated to Machine Files.

### `bun run changelog:generate` — broken independent of this epic
`scripts/changelog/index.ts` does not exist — not on this branch, and not on `master` either
(confirmed via `git show master:scripts/changelog/index.ts`). It looks like #1044 ("chore: remove
stale docs/, prune cross-references") removed the script directory without updating the
`package.json` reference. This is pre-existing repo debt, out of scope to fix here. `CHANGELOG.md`
already carries a hand-maintained `[Unreleased]` section (matching Keep a Changelog format) with no
generator involved in practice, so I added the epic's user-facing entry by hand under `### Added`,
matching the file's existing style.

## Invariant audit

1. **Diff/git-blob files untouched** —
   `git diff master...HEAD --stat -- apps/web/src/app/api/machines/diff apps/web/src/app/api/machines/git-blob apps/web/src/lib/machines/machine-diff-runtime.ts apps/web/src/lib/machines/machine-git-blob-runtime.ts`
   → **empty output**. Confirmed no epic PR touched these frozen files.

2. **`resolveBranchMachineHandle` signature/body unchanged** — the function's full body
   (`apps/web/src/lib/machines/machine-files-runtime.ts`, lines 34–51 on `master` vs lines 38–55 on
   `HEAD`) diffs to **zero lines**:
   `diff <(git show master:...machine-files-runtime.ts | sed -n '34,51p') <(sed -n '38,55p' ...)`
   → exit 0, no output. Every change to this file is the module doc-comment (extended to describe
   the new root-scope dispatcher) and new imports/exports/functions appended after the unchanged
   function. `machine-files-runtime.test.ts` also directly asserts this at the dispatcher level:
   *"produces the exact same result as calling resolveBranchMachineHandle directly."*

3. **Forbidden-pattern grep across the epic diff** (10 non-test files changed, full list in the
   diff):
   - **No `any` introduced** — grepped every added line in each non-test changed file for
     `any`-shaped annotations; zero matches.
   - **No shell-interpolated exec paths** — the only new `exec()` call sites are in
     `packages/lib/src/services/sandbox/machine-fs.ts` (the 5 new mutation primitives); every one
     passes `path`/`fromPath`/`toPath` as a **discrete argv array element**, never a template string
     built into a single arg.
   - **`--` before path args in new machine-fs exec calls**:
     - `mkdir`: `['--', path]` ✅
     - `mv`: `['-T', '--', fromPath, toPath]` ✅
     - `cp`: `['-a', '--', fromPath, toPath]` ✅
     - `rm`: `['-rf', '--', path]` ✅
     - `test -e … -o -L …` (no-clobber guard): **no `--`**, but this is intentional and documented
       inline — POSIX `test` doesn't support a `--` end-of-options marker, and `path` is still a
       discrete argv element (no shell parsing), so there's no injection surface.

## Acceptance matrix — automated evidence

| Epic criterion | Covering test(s) |
|---|---|
| Root default listing | `route.test.ts`: *"resolves root scope when projectName/branchName are absent"*, *"confines a relative path under /workspace (SANDBOX_ROOT), not the branch checkout root"* |
| `not_started` distinct state | `route.test.ts`: *"maps a null root handle to 404 not_started with no internal token in error"*; `FilesTab.test.tsx`: *"a never-started machine shows the not-started empty state, not the file tree"*, *"'Check again' mounts the root tree once a never-started machine has been started"*; `FilesFilePane.test.tsx`: *"a not_started machine renders its own absent copy"* |
| Branch regression byte-for-byte | `machine-files-runtime.test.ts`: *"produces the exact same result as calling resolveBranchMachineHandle directly"* (+ invariant-audit item 2 above, diff-empty proof) |
| `SANDBOX_ROOT` vs `BRANCH_REPO_PATH` confinement | `route.test.ts`: *"confines a relative path under /workspace (SANDBOX_ROOT), not the branch checkout root"*, *"rejects a `..` traversal in root scope…"*, *"rejects an absolute path in root scope…"*, *"confines a valid relative path under the checkout root before listing"* (branch arm) |
| Both-or-neither 400 | `route.test.ts` (GET): *"400s when only projectName is present…"*, *"…only branchName is present…"* (+ empty-string variants); repeated per-verb in POST/PATCH/DELETE describe blocks: *"400s when only one of projectName/branchName is present"* |
| Create round-trip | `route.test.ts`: *"creates a directory (branch scope) with the confined absolute path and audits the write"*, *"creates a directory (root scope)…"*; `machine-fs.test.ts`: `createMachineDirectory` describe block |
| Rename round-trip | `MachineFileTree.test.tsx`: *"Rename posts a same-parent PATCH move and drops the renamed directory's stale descendant cache"* |
| Move round-trip | `route.test.ts` PATCH describe block + `MachineFileTree.test.tsx`: *"Move posts a PATCH with the entered destination, re-lists both parents, and drops the moved directory's own stale cache"*; `machine-fs.test.ts`: `moveMachinePath` describe block |
| Copy round-trip | `MachineFileTree.test.tsx`: *"Copy posts a PATCH with the entered destination, re-lists both parents, and never touches the open-file selection"*; `machine-fs.test.ts`: `copyMachinePath` describe block |
| Delete round-trip | `route.test.ts` DELETE describe block (incl. idempotent-missing-target); `MachineFileTree.test.tsx`: *"Delete confirm fires DELETE and re-lists the parent"*; `machine-fs.test.ts`: `deleteMachinePath` describe block |
| Upload round-trip | `MachineFileTree.test.tsx`: *"Upload files… posts each selected file sequentially as base64 and re-lists the target directory exactly once"* |
| Download round-trip | `MachineFileTree.test.tsx`: *"Download fetches mode=download for the full path, then clicks an object-URL anchor named by the file's own basename"*; `route.test.ts` GET mode=download describe block |
| Edit+save with `useEditingStore` | `FilesFilePane.test.tsx` "editing and save" describe block: *"registers with useEditingStore while dirty and releases the same session id after save"*, *"Save POSTs the edited content…"*, *"Cmd/Ctrl-S saves the dirty draft"* |
| Truncated read-only | `FilesFilePane.test.tsx`: *"flags a truncated read so a partial view is not mistaken for the whole file"*, *"a truncated read stays read-only with no Save affordance"* |
| Caps 413 | `route.test.ts`: *"returns 413 when the file exceeds the 50 MiB download cap"*, *"413s when decoded content exceeds the 10 MiB upload cap, without calling writeMachineFile"*; `MachineFileTree.test.tsx`: *"a file over the 10 MiB client cap is skipped with a toast and never POSTed, without blocking the rest of the batch"* |
| CSRF + `canEditMachine` ordering | `route.test.ts` per-verb: *"requires session auth with CSRF enforced"* (CSRF gate, inside `authenticateRequestWithOptions`) then *"403s when canEditMachine is false, even though canViewMachine is true (view-only is not enough)"*, and *"403s before validating field shape (unauthorized caller cannot distinguish well-formed from malformed)"* — confirmed in `route.ts` source: CSRF is enforced by `AUTH_OPTIONS_WRITE` inside `authenticateRequestWithOptions` (called first in every mutating verb), `canEditMachine` is checked immediately after and before any body-shape validation |
| Audit on writes | `route.test.ts`: *"audits the file write with the op and relative path (never the absolute sprite path)"* (POST), plus explicit *"…and audits the write"* assertions in the create-directory, move, and delete tests |

**Nothing in this matrix is unproven** — every criterion has at least one direct automated test
cited above.

## Files changed
- `CHANGELOG.md` — hand-added `[Unreleased] > Added` entry for the Machine Files tab (generator is
  broken independent of this epic, see above).

No other files were modified. `diff`/`git-blob` files were never touched, per the epic's frozen-file
constraint.
