### PR TITLE
feat(machines): Files tab — full file manager over the sandbox filesystem, root-scope by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
   OS user can read, credential store included — no CLI feature changes that. The actual isolation
   boundary is a dedicated OS user, container, or VM that receives only a scoped token via
   `PAGESPACE_TOKEN`.
+- **Machine page Files tab** — browse, open, and edit files directly on a Machine's own root
+  filesystem or any branch checkout, with a PageTree-matched file tree (lazy-loaded directories,
+  sorted directories-first) and an editable pane with Monaco language detection, binary-file
+  detection, and Cmd/Ctrl-S save. Right-click or the "+" palette to create files/folders, rename,
+  move, copy, delete, upload (10 MiB cap), or download (50 MiB cap) — every mutation requires edit
+  access and is audited. A machine that hasn't been started yet shows an explicit "not started"
+  state instead of an empty tree.
 
 ### Changed
 

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -56,6 +56,10 @@ type ListResult =
   | { ok: false; reason: 'not_found' | 'exec_failed'; detail?: string };
 type ReadResult = { ok: true; content: Buffer } | { ok: false; reason: 'not_found' };
 type MutateResult = { ok: true } | { ok: false; reason: 'not_found' | 'already_exists' | 'exec_failed'; detail?: string };
+type ScopeCheckResult =
+  | { ok: true }
+  | { ok: false; reason: 'escapes'; index: number }
+  | { ok: false; reason: 'exec_failed'; detail?: string };
 
 const listMachineDirectory = vi.fn(async (): Promise<ListResult> => ({ ok: true, entries: [] }));
 const readMachineFile = vi.fn(async (): Promise<ReadResult> => ({ ok: true, content: Buffer.from('hi', 'utf8') }));
@@ -64,6 +68,7 @@ const writeMachineFile = vi.fn(async (): Promise<MutateResult> => ({ ok: true })
 const moveMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
 const copyMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
 const deleteMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const verifyMachinePathsWithinScope = vi.fn(async (): Promise<ScopeCheckResult> => ({ ok: true }));
 vi.mock('@pagespace/lib/services/sandbox/machine-fs', () => ({
   listMachineDirectory: (...args: unknown[]) => listMachineDirectory(...(args as [])),
   readMachineFile: (...args: unknown[]) => readMachineFile(...(args as [])),
@@ -72,6 +77,7 @@ vi.mock('@pagespace/lib/services/sandbox/machine-fs', () => ({
   moveMachinePath: (...args: unknown[]) => moveMachinePath(...(args as [])),
   copyMachinePath: (...args: unknown[]) => copyMachinePath(...(args as [])),
   deleteMachinePath: (...args: unknown[]) => deleteMachinePath(...(args as [])),
+  verifyMachinePathsWithinScope: (...args: unknown[]) => verifyMachinePathsWithinScope(...(args as [])),
 }));
 
 import { GET, POST, PATCH, DELETE } from '../route';
@@ -118,6 +124,93 @@ beforeEach(() => {
   moveMachinePath.mockResolvedValue({ ok: true });
   copyMachinePath.mockResolvedValue({ ok: true });
   deleteMachinePath.mockResolvedValue({ ok: true });
+  verifyMachinePathsWithinScope.mockResolvedValue({ ok: true });
+});
+
+describe('/api/machines/files machine-side symlink confinement', () => {
+  it('re-verifies the read path ON the machine and 400s an escape without reading', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'escapes', index: 0 });
+
+    const res = await GET(get({ mode: 'read', path: 'link/etc-passwd' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'path escapes the machine filesystem root' });
+    expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
+      handle: { machineId: 'sbx-1' },
+      scopeRoot: '/workspace/repo',
+      paths: ['/workspace/repo/link/etc-passwd'],
+    });
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('skips the extra exec for a bare scope-root listing — no intermediate component to hijack', async () => {
+    const res = await GET(get({}));
+
+    expect(res.status).toBe(200);
+    expect(verifyMachinePathsWithinScope).not.toHaveBeenCalled();
+    expect(listMachineDirectory).toHaveBeenCalled();
+  });
+
+  it('verifies BOTH move operands in one call and names the escaping field', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'escapes', index: 1 });
+
+    const res = await PATCH(patch({ ...BRANCH_BODY, op: 'move', fromPath: 'a.txt', toPath: 'link/b.txt' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'toPath escapes the machine filesystem root' });
+    expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
+      handle: { machineId: 'sbx-1' },
+      scopeRoot: '/workspace/repo',
+      paths: ['/workspace/repo/a.txt', '/workspace/repo/link/b.txt'],
+    });
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('blocks a root-scope write through an escaping symlink without writing', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'escapes', index: 0 });
+
+    const res = await POST(post({ ...ROOT_BODY, path: 'link/x.txt', kind: 'file', content: 'x' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'path escapes the machine filesystem root' });
+    expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
+      handle: { machineId: 'sbx-1' },
+      scopeRoot: '/workspace',
+      paths: ['/workspace/link/x.txt'],
+    });
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('blocks delete through an escaping symlink without deleting', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'escapes', index: 0 });
+
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'link' }));
+
+    expect(res.status).toBe(400);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('fails CLOSED as 502 when the machine-side check itself cannot run', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'realpath: not found' });
+
+    const res = await GET(get({ mode: 'read', path: 'a.txt' }));
+
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.reason).toBe('exec_failed');
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/machines/files write parent-preflight contract', () => {
+  it('maps writeMachineFile not_found (parent deleted on the live machine) to the documented 404', async () => {
+    writeMachineFile.mockResolvedValue({ ok: false, reason: 'not_found' });
+
+    const res = await POST(post({ ...BRANCH_BODY, path: 'gone/x.txt', kind: 'file', content: 'x' }));
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'The parent folder could not be found', reason: 'not_found' });
+  });
 });
 
 describe('/api/machines/files path confinement', () => {

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -202,6 +202,37 @@ describe('/api/machines/files machine-side symlink confinement', () => {
   });
 });
 
+describe('/api/machines/files request-body size ceiling', () => {
+  it('413s an over-ceiling declared Content-Length before parsing the body', async () => {
+    const req = new Request('http://localhost/api/machines/files', {
+      method: 'POST',
+      body: '{}',
+      headers: { 'content-type': 'application/json', 'content-length': String(20 * 1024 * 1024) },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(413);
+    expect((await res.json()).reason).toBe('too_large');
+    // Rejected on the declared size alone — nothing downstream ever ran.
+    expect(canEditMachine).not.toHaveBeenCalled();
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('accepts a normal-sized declared body (the ceiling is above the base64-inflated content cap)', async () => {
+    const body = JSON.stringify({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'x' });
+    const req = new Request('http://localhost/api/machines/files', {
+      method: 'POST',
+      body,
+      headers: { 'content-type': 'application/json', 'content-length': String(body.length) },
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+  });
+});
+
 describe('/api/machines/files write parent-preflight contract', () => {
   it('maps writeMachineFile not_found (parent deleted on the live machine) to the documented 404', async () => {
     writeMachineFile.mockResolvedValue({ ok: false, reason: 'not_found' });

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -26,15 +26,15 @@ vi.mock('@/lib/auth', () => ({
 
 type HandleResult =
   | { ok: true; handle: { machineId: string } }
-  | { ok: false; reason: 'not_found' | 'vanished' };
+  | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
 
 const canViewMachine = vi.fn(async () => true);
-const resolveBranchMachineHandle = vi.fn(
+const resolveMachineFilesHandle = vi.fn(
   async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
 );
 vi.mock('@/lib/machines/machine-files-runtime', () => ({
   canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
-  resolveBranchMachineHandle: (...args: unknown[]) => resolveBranchMachineHandle(...(args as [])),
+  resolveMachineFilesHandle: (...args: unknown[]) => resolveMachineFilesHandle(...(args as [])),
 }));
 
 // Mirrors the real machine-fs result unions, so a test can drive the FAILURE
@@ -62,7 +62,7 @@ function get(query: Record<string, string>): Request {
 beforeEach(() => {
   vi.clearAllMocks();
   canViewMachine.mockResolvedValue(true);
-  resolveBranchMachineHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
+  resolveMachineFilesHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
   listMachineDirectory.mockResolvedValue({ ok: true, entries: [] });
   readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('hi', 'utf8') });
 });
@@ -142,18 +142,18 @@ describe('/api/machines/files request contract', () => {
     canViewMachine.mockResolvedValue(false);
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(403);
-    expect(resolveBranchMachineHandle).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
     expect(listMachineDirectory).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the branch machine has no tracking row', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(404);
   });
 
   it('returns 503 when the branch Sprite has vanished', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
     const res = await GET(get({ path: 'src' }));
     expect(res.status).toBe(503);
   });
@@ -162,7 +162,7 @@ describe('/api/machines/files request contract', () => {
   // tab's file tree), so it must read as a sentence to a person — never as the
   // internal token, and never as a bare `exec_failed`.
   it('never puts an internal token in the user-facing `error`', async () => {
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'vanished' });
     const body = await (await GET(get({ path: 'src' }))).json();
     expect(body.reason).toBe('vanished'); // machine-readable fact: unchanged
     expect(body.error).toBe('This branch checkout is unavailable');
@@ -214,8 +214,101 @@ describe('/api/machines/files request contract', () => {
     const fileMiss = await (await GET(get({ path: 'src/gone.ts', mode: 'read' }))).json();
     expect(fileMiss.reason).toBe('file_not_found');
 
-    resolveBranchMachineHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_found' });
     const checkoutMiss = await (await GET(get({ path: 'src/gone.ts', mode: 'read' }))).json();
     expect(checkoutMiss.reason).toBe('not_found');
+  });
+
+  it('resolves branch scope with the right dispatcher shape', async () => {
+    const res = await GET(get({ path: 'src' }));
+    expect(res.status).toBe(200);
+    expect(resolveMachineFilesHandle).toHaveBeenCalledWith({
+      scope: 'branch',
+      machineId: 't1',
+      projectName: 'p1',
+      branchName: 'b1',
+    });
+  });
+});
+
+// Root scope omits projectName/branchName entirely — `get` (above) always
+// supplies both, so these tests build the query directly.
+function getRoot(query: Record<string, string> = {}): Request {
+  const params = new URLSearchParams({ machineId: 't1', ...query });
+  return new Request(`http://localhost/api/machines/files?${params.toString()}`);
+}
+
+describe('/api/machines/files root scope', () => {
+  it('resolves root scope when projectName/branchName are absent', async () => {
+    const res = await GET(getRoot());
+    expect(res.status).toBe(200);
+    expect(resolveMachineFilesHandle).toHaveBeenCalledWith({ scope: 'root', machineId: 't1' });
+    expect(listMachineDirectory).toHaveBeenCalledWith(expect.objectContaining({ path: '/workspace' }));
+  });
+
+  it('confines a relative path under /workspace (SANDBOX_ROOT), not the branch checkout root', async () => {
+    const res = await GET(getRoot({ path: 'repo/src' }));
+    expect(res.status).toBe(200);
+    expect(listMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/src' }),
+    );
+  });
+
+  it('rejects a `..` traversal in root scope without touching the filesystem', async () => {
+    const res = await GET(getRoot({ path: '../etc' }));
+    expect(res.status).toBe(400);
+    expect(listMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('rejects an absolute path in root scope without touching the filesystem', async () => {
+    const res = await GET(getRoot({ mode: 'read', path: '/etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('maps a null root handle to 404 not_started with no internal token in `error`', async () => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason: 'not_started' });
+    const res = await GET(getRoot());
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.reason).toBe('not_started');
+    expect(body.error).toBe("This machine hasn't been started yet");
+    expect(body.error).not.toMatch(/not_started/);
+  });
+
+  it('400s when only projectName is present (root/branch pair broken)', async () => {
+    const res = await GET(getRoot({ projectName: 'p1' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'projectName and branchName must be provided together' });
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only branchName is present (root/branch pair broken)', async () => {
+    const res = await GET(getRoot({ branchName: 'b1' }));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'projectName and branchName must be provided together' });
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only projectName is present as an empty string', async () => {
+    const res = await GET(getRoot({ projectName: '', branchName: 'b1' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when only branchName is present as an empty string', async () => {
+    const res = await GET(getRoot({ projectName: 'p1', branchName: '' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  // The branch arm's "empty relativePath => not_found" remap encodes "never
+  // cloned" — a BRANCH-only fact. A live root Sprite's /workspace always
+  // exists, so root scope must never emit that remap, even at the root path.
+  it("does not leak the branch arm's root-missing remap into root scope", async () => {
+    listMachineDirectory.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const body = await (await GET(getRoot())).json();
+    expect(body.reason).toBe('dir_not_found');
+    expect(body.error).toBe('This folder is no longer on the machine');
   });
 });

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -3,25 +3,34 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 /**
  * /api/machines/files contract + path-confinement tests.
  *
- * The security-critical property under test: the untrusted `path` query param
- * is RELATIVE to the branch checkout root and is confined under it BEFORE the
- * machine filesystem is touched. A `..` escape or an absolute path must be
- * rejected (400) without ever calling listMachineDirectory/readMachineFile, so
- * a viewer cannot read `/etc/passwd` or step outside `/workspace/repo`.
+ * The security-critical property under test: every untrusted path field
+ * (`path`, `fromPath`, `toPath`) is RELATIVE to the scope root and is confined
+ * under it BEFORE the machine filesystem is touched. A `..` escape or an
+ * absolute path must be rejected (400) without ever calling a machine-fs
+ * primitive, so a caller cannot read/write `/etc/passwd` or step outside the
+ * scope root.
  *
  * `resolvePathWithinSync` (the real confinement helper) is intentionally NOT
- * mocked — it is the code under test. Everything else (auth, access check,
- * handle resolution, the fs primitives) is mocked so the test isolates the
- * route's own request handling.
+ * mocked — it is the code under test. Everything else (auth, access checks,
+ * handle resolution, the fs primitives, audit) is mocked so the tests isolate
+ * the route's own request handling.
  */
 
 // Inlined (not a top-level const) because vi.mock factories are hoisted above
 // any module-scope variable and cannot close over one.
 vi.mock('@pagespace/lib/services/machines/machine-branches', () => ({ BRANCH_REPO_PATH: '/workspace/repo' }));
 
+type AuthResult = { userId: string } | { error: Response };
+const authenticateRequestWithOptions = vi.fn(async (): Promise<AuthResult> => ({ userId: 'user-1' }));
+const isAuthError = vi.fn((result: AuthResult) => 'error' in result);
 vi.mock('@/lib/auth', () => ({
-  authenticateRequestWithOptions: vi.fn(async () => ({ userId: 'user-1' })),
-  isAuthError: vi.fn(() => false),
+  authenticateRequestWithOptions: (...args: unknown[]) => authenticateRequestWithOptions(...(args as [])),
+  isAuthError: (...args: unknown[]) => isAuthError(...(args as [AuthResult])),
+}));
+
+const auditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => auditRequest(...(args as [])),
 }));
 
 type HandleResult =
@@ -29,11 +38,13 @@ type HandleResult =
   | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
 
 const canViewMachine = vi.fn(async () => true);
+const canEditMachine = vi.fn(async () => true);
 const resolveMachineFilesHandle = vi.fn(
   async (): Promise<HandleResult> => ({ ok: true, handle: { machineId: 'sbx-1' } }),
 );
 vi.mock('@/lib/machines/machine-files-runtime', () => ({
   canViewMachine: (...args: unknown[]) => canViewMachine(...(args as [])),
+  canEditMachine: (...args: unknown[]) => canEditMachine(...(args as [])),
   resolveMachineFilesHandle: (...args: unknown[]) => resolveMachineFilesHandle(...(args as [])),
 }));
 
@@ -44,27 +55,69 @@ type ListResult =
   | { ok: true; entries: { name: string; type: 'file' | 'directory' }[] }
   | { ok: false; reason: 'not_found' | 'exec_failed'; detail?: string };
 type ReadResult = { ok: true; content: Buffer } | { ok: false; reason: 'not_found' };
+type MutateResult = { ok: true } | { ok: false; reason: 'not_found' | 'already_exists' | 'exec_failed'; detail?: string };
 
 const listMachineDirectory = vi.fn(async (): Promise<ListResult> => ({ ok: true, entries: [] }));
 const readMachineFile = vi.fn(async (): Promise<ReadResult> => ({ ok: true, content: Buffer.from('hi', 'utf8') }));
+const createMachineDirectory = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const writeMachineFile = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const moveMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const copyMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
+const deleteMachinePath = vi.fn(async (): Promise<MutateResult> => ({ ok: true }));
 vi.mock('@pagespace/lib/services/sandbox/machine-fs', () => ({
   listMachineDirectory: (...args: unknown[]) => listMachineDirectory(...(args as [])),
   readMachineFile: (...args: unknown[]) => readMachineFile(...(args as [])),
+  createMachineDirectory: (...args: unknown[]) => createMachineDirectory(...(args as [])),
+  writeMachineFile: (...args: unknown[]) => writeMachineFile(...(args as [])),
+  moveMachinePath: (...args: unknown[]) => moveMachinePath(...(args as [])),
+  copyMachinePath: (...args: unknown[]) => copyMachinePath(...(args as [])),
+  deleteMachinePath: (...args: unknown[]) => deleteMachinePath(...(args as [])),
 }));
 
-import { GET } from '../route';
+import { GET, POST, PATCH, DELETE } from '../route';
 
 function get(query: Record<string, string>): Request {
   const params = new URLSearchParams({ machineId: 't1', projectName: 'p1', branchName: 'b1', ...query });
   return new Request(`http://localhost/api/machines/files?${params.toString()}`);
 }
 
+function jsonRequest(method: string, body: unknown): Request {
+  return new Request('http://localhost/api/machines/files', {
+    method,
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function rawRequest(method: string, rawBody: string): Request {
+  return new Request('http://localhost/api/machines/files', {
+    method,
+    body: rawBody,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const post = (body: unknown) => jsonRequest('POST', body);
+const patch = (body: unknown) => jsonRequest('PATCH', body);
+const del = (body: unknown) => jsonRequest('DELETE', body);
+
+const BRANCH_BODY = { machineId: 't1', projectName: 'p1', branchName: 'b1' };
+const ROOT_BODY = { machineId: 't1' };
+
 beforeEach(() => {
   vi.clearAllMocks();
+  authenticateRequestWithOptions.mockResolvedValue({ userId: 'user-1' });
+  isAuthError.mockImplementation((result: AuthResult) => 'error' in result);
   canViewMachine.mockResolvedValue(true);
+  canEditMachine.mockResolvedValue(true);
   resolveMachineFilesHandle.mockResolvedValue({ ok: true, handle: { machineId: 'sbx-1' } });
   listMachineDirectory.mockResolvedValue({ ok: true, entries: [] });
   readMachineFile.mockResolvedValue({ ok: true, content: Buffer.from('hi', 'utf8') });
+  createMachineDirectory.mockResolvedValue({ ok: true });
+  writeMachineFile.mockResolvedValue({ ok: true });
+  moveMachinePath.mockResolvedValue({ ok: true });
+  copyMachinePath.mockResolvedValue({ ok: true });
+  deleteMachinePath.mockResolvedValue({ ok: true });
 });
 
 describe('/api/machines/files path confinement', () => {
@@ -310,5 +363,444 @@ describe('/api/machines/files root scope', () => {
     const body = await (await GET(getRoot())).json();
     expect(body.reason).toBe('dir_not_found');
     expect(body.error).toBe('This folder is no longer on the machine');
+  });
+});
+
+describe('/api/machines/files GET mode=download', () => {
+  it('requires a path', async () => {
+    const res = await GET(get({ mode: 'download' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('is a read — view access is enough, no CSRF requirement', async () => {
+    await GET(get({ mode: 'download', path: 'src/index.ts' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ requireCSRF: false }),
+    );
+    expect(canViewMachine).toHaveBeenCalled();
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('confines the path under the scope root before touching the filesystem', async () => {
+    const res = await GET(get({ mode: 'download', path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 file_not_found when the file is missing', async () => {
+    readMachineFile.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await GET(get({ mode: 'download', path: 'gone.bin' }));
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: 'File not found', reason: 'file_not_found' });
+  });
+
+  it('returns 413 when the file exceeds the 50 MiB download cap', async () => {
+    readMachineFile.mockResolvedValue({ ok: true, content: Buffer.alloc(50 * 1024 * 1024 + 1) });
+    const res = await GET(get({ mode: 'download', path: 'huge.bin' }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'File is too large to download', reason: 'too_large' });
+  });
+
+  it('returns byte-faithful binary content with octet-stream headers', async () => {
+    const bytes = Buffer.from([0, 1, 2, 255, 254, 253]);
+    readMachineFile.mockResolvedValue({ ok: true, content: bytes });
+    const res = await GET(get({ mode: 'download', path: 'src/blob.bin' }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/octet-stream');
+    const buf = Buffer.from(await res.arrayBuffer());
+    expect(buf.equals(bytes)).toBe(true);
+  });
+
+  it('sanitizes the filename to a basename, stripping directories and quotes', async () => {
+    const res = await GET(get({ mode: 'download', path: 'a/b"c.txt' }));
+    expect(res.status).toBe(200);
+    const disposition = res.headers.get('content-disposition') ?? '';
+    expect(disposition).toMatch(/^attachment; filename="[^"/\\]*"; filename\*=UTF-8''/);
+    expect(disposition).not.toMatch(/a\/b/);
+    expect(disposition).not.toContain('"c.txt"; filename'); // no stray embedded quote from the raw name
+  });
+});
+
+describe('/api/machines/files POST (create/upload)', () => {
+  it('returns the auth error when unauthenticated', async () => {
+    const authError = { error: new Response(null, { status: 401 }) };
+    authenticateRequestWithOptions.mockResolvedValueOnce(authError);
+    isAuthError.mockReturnValueOnce(true);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400, not a crash', async () => {
+    const res = await POST(rawRequest('POST', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid JSON with 400', async () => {
+    const res = await POST(rawRequest('POST', '{not json'));
+    expect(res.status).toBe(400);
+  });
+
+  it('403s when canEditMachine is false, even though canViewMachine is true (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'You do not have edit access to this machine' });
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('403s before validating field shape (unauthorized caller cannot distinguish well-formed from malformed)', async () => {
+    canEditMachine.mockResolvedValue(false);
+    const res = await POST(post({ machineId: 't1', kind: 'not-a-real-kind' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await POST(post({ machineId: 't1', projectName: 'p1', path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when path is the scope root (empty string)', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: '', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when path escapes the scope root', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: '../../etc', kind: 'directory' }));
+    expect(res.status).toBe(400);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid kind', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'symlink' }));
+    expect(res.status).toBe(400);
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a', kind: 'directory' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('creates a directory (branch scope) with the confined absolute path and audits the write', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(createMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/newdir' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', userId: 'user-1', resourceId: 't1' }),
+    );
+  });
+
+  it('creates a directory (root scope) with the confined absolute path under SANDBOX_ROOT', async () => {
+    const res = await POST(post({ ...ROOT_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(200);
+    expect(createMachineDirectory).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/newdir' }),
+    );
+  });
+
+  it('409s when the directory already exists', async () => {
+    createMachineDirectory.mockResolvedValue({ ok: false, reason: 'already_exists' });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'newdir', kind: 'directory' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Something already has that name', reason: 'already_exists' });
+  });
+
+  it('404s when the parent folder is missing', async () => {
+    createMachineDirectory.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await POST(post({ ...BRANCH_BODY, path: 'gone/newdir', kind: 'directory' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('writes a file with default utf8 encoding and empty content, and overwrite is allowed (save)', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file' }));
+    expect(res.status).toBe(200);
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/a.txt', content: Buffer.from('', 'utf8') }),
+    );
+  });
+
+  it('writes utf8 content verbatim', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'hello world', encoding: 'utf8' }));
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ content: Buffer.from('hello world', 'utf8') }),
+    );
+  });
+
+  it('decodes base64 content', async () => {
+    const b64 = Buffer.from('binary payload', 'utf8').toString('base64');
+    await POST(post({ ...BRANCH_BODY, path: 'a.bin', kind: 'file', content: b64, encoding: 'base64' }));
+    expect(writeMachineFile).toHaveBeenCalledWith(
+      expect.objectContaining({ content: Buffer.from('binary payload', 'utf8') }),
+    );
+  });
+
+  it('400s on malformed base64 content without calling writeMachineFile', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.bin', kind: 'file', content: 'not-valid-base64!!', encoding: 'base64' }));
+    expect(res.status).toBe(400);
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid encoding', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'x', encoding: 'latin1' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('413s when decoded content exceeds the 10 MiB upload cap, without calling writeMachineFile', async () => {
+    const big = 'x'.repeat(10 * 1024 * 1024 + 1);
+    const res = await POST(post({ ...BRANCH_BODY, path: 'big.txt', kind: 'file', content: big, encoding: 'utf8' }));
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({ error: 'File is too large to upload', reason: 'too_large' });
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+
+  it('audits the file write with the op and relative path (never the absolute sprite path)', async () => {
+    await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', content: 'hi' }));
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ details: expect.objectContaining({ op: 'write_file', path: 'a.txt' }) }),
+    );
+  });
+});
+
+describe('/api/machines/files PATCH (move/copy)', () => {
+  const BASE = { ...BRANCH_BODY, fromPath: 'a.txt', toPath: 'b.txt' };
+
+  it('returns the auth error when unauthenticated', async () => {
+    authenticateRequestWithOptions.mockResolvedValueOnce({ error: new Response(null, { status: 401 }) });
+    isAuthError.mockReturnValueOnce(true);
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400', async () => {
+    const res = await PATCH(rawRequest('PATCH', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('403s when canEditMachine is false (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(403);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await PATCH(patch({ machineId: 't1', projectName: 'p1', fromPath: 'a', toPath: 'b', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s on an invalid op', async () => {
+    const res = await PATCH(patch({ ...BASE, op: 'rename' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('400s when fromPath is the scope root (empty string)', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: '', toPath: 'b.txt', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when toPath is the scope root (empty string)', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: 'a.txt', toPath: '', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when fromPath escapes the scope root', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: '../../etc/passwd', toPath: 'b.txt', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when toPath escapes the scope root', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, fromPath: 'a.txt', toPath: '/etc/passwd', op: 'move' }));
+    expect(res.status).toBe(400);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('moves a path (branch scope) with confined absolute from/to paths and audits the write', async () => {
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(moveMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ fromPath: '/workspace/repo/a.txt', toPath: '/workspace/repo/b.txt' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'data.write',
+        details: expect.objectContaining({ op: 'move', fromPath: 'a.txt', toPath: 'b.txt' }),
+      }),
+    );
+  });
+
+  it('copies a path (root scope) with confined absolute paths under SANDBOX_ROOT', async () => {
+    const res = await PATCH(patch({ machineId: 't1', fromPath: 'a.txt', toPath: 'b.txt', op: 'copy' }));
+    expect(res.status).toBe(200);
+    expect(copyMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ fromPath: '/workspace/a.txt', toPath: '/workspace/b.txt' }),
+    );
+  });
+
+  it('409s when the destination already exists', async () => {
+    moveMachinePath.mockResolvedValue({ ok: false, reason: 'already_exists' });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Something already has that name', reason: 'already_exists' });
+  });
+
+  it('404s when the source is missing', async () => {
+    moveMachinePath.mockResolvedValue({ ok: false, reason: 'not_found' });
+    const res = await PATCH(patch({ ...BASE, op: 'move' }));
+    expect(res.status).toBe(404);
+  });
+
+  it('502s with detail (not error) when the exec fails', async () => {
+    copyMachinePath.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'cp: Permission denied on /workspace/repo/a.txt' });
+    const res = await PATCH(patch({ ...BASE, op: 'copy' }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toMatch(/workspace/);
+    expect(body.detail).toMatch(/Permission denied/);
+  });
+});
+
+describe('/api/machines/files DELETE', () => {
+  it('returns the auth error when unauthenticated', async () => {
+    authenticateRequestWithOptions.mockResolvedValueOnce({ error: new Response(null, { status: 401 }) });
+    isAuthError.mockReturnValueOnce(true);
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(401);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('requires session auth with CSRF enforced', async () => {
+    await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(authenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.anything(),
+      { allow: ['session'], requireCSRF: true },
+    );
+  });
+
+  it('rejects a null JSON body with 400', async () => {
+    const res = await DELETE(rawRequest('DELETE', 'null'));
+    expect(res.status).toBe(400);
+    expect(canEditMachine).not.toHaveBeenCalled();
+  });
+
+  it('403s when canEditMachine is false (view-only is not enough)', async () => {
+    canViewMachine.mockResolvedValue(true);
+    canEditMachine.mockResolvedValue(false);
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(403);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s when only one of projectName/branchName is present', async () => {
+    const res = await DELETE(del({ machineId: 't1', branchName: 'b1', path: 'a.txt' }));
+    expect(res.status).toBe(400);
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it('400s when path is the scope root (empty string), never calling the primitive', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: '' }));
+    expect(res.status).toBe(400);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('400s and never calls the primitive when path escapes the scope root', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: '../../etc/passwd' }));
+    expect(res.status).toBe(400);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+    expect(resolveMachineFilesHandle).not.toHaveBeenCalled();
+  });
+
+  it.each(['not_found', 'vanished', 'not_started'] as const)('maps resolver denial %s to the GET-equivalent status', async (reason) => {
+    resolveMachineFilesHandle.mockResolvedValue({ ok: false, reason });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(reason === 'vanished' ? 503 : 404);
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('deletes a path (branch scope) with the confined absolute path and audits the write', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(deleteMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo/a.txt' }),
+    );
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'data.write',
+        details: expect.objectContaining({ op: 'delete', path: 'a.txt' }),
+      }),
+    );
+  });
+
+  it('deletes a path (root scope) with the confined absolute path under SANDBOX_ROOT', async () => {
+    const res = await DELETE(del({ machineId: 't1', path: 'a.txt' }));
+    expect(res.status).toBe(200);
+    expect(deleteMachinePath).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/a.txt' }),
+    );
+  });
+
+  it('deleting an already-missing path is idempotent success (rm -rf semantics)', async () => {
+    deleteMachinePath.mockResolvedValue({ ok: true });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'already-gone.txt' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it('502s with detail (not error) when the exec fails', async () => {
+    deleteMachinePath.mockResolvedValue({ ok: false, reason: 'exec_failed', detail: 'rm: Permission denied on /workspace/repo/a.txt' });
+    const res = await DELETE(del({ ...BRANCH_BODY, path: 'a.txt' }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).not.toMatch(/workspace/);
+    expect(body.detail).toMatch(/Permission denied/);
   });
 });

--- a/apps/web/src/app/api/machines/files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/files/__tests__/route.test.ts
@@ -137,6 +137,7 @@ describe('/api/machines/files machine-side symlink confinement', () => {
     expect(await res.json()).toEqual({ error: 'path escapes the machine filesystem root' });
     expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
       handle: { machineId: 'sbx-1' },
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace/repo',
       paths: ['/workspace/repo/link/etc-passwd'],
     });
@@ -160,6 +161,7 @@ describe('/api/machines/files machine-side symlink confinement', () => {
     expect(await res.json()).toEqual({ error: 'toPath escapes the machine filesystem root' });
     expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
       handle: { machineId: 'sbx-1' },
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace/repo',
       paths: ['/workspace/repo/a.txt', '/workspace/repo/link/b.txt'],
     });
@@ -175,6 +177,7 @@ describe('/api/machines/files machine-side symlink confinement', () => {
     expect(await res.json()).toEqual({ error: 'path escapes the machine filesystem root' });
     expect(verifyMachinePathsWithinScope).toHaveBeenCalledWith({
       handle: { machineId: 'sbx-1' },
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace',
       paths: ['/workspace/link/x.txt'],
     });
@@ -198,6 +201,72 @@ describe('/api/machines/files machine-side symlink confinement', () => {
     expect(res.status).toBe(502);
     const body = await res.json();
     expect(body.reason).toBe('exec_failed');
+    expect(readMachineFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/machines/files confined-root refusal (NUL-only paths)', () => {
+  // `resolvePathWithinSync` strips NUL bytes, so `" "` is non-empty on
+  // the wire yet confines to the scope root — the raw non-empty check alone
+  // would let DELETE reach `rm -rf` on /workspace itself.
+  it('DELETE with a NUL-only path 400s instead of deleting the scope root', async () => {
+    const res = await DELETE(del({ ...BRANCH_BODY, path: ' ' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'path must not be the scope root' });
+    expect(deleteMachinePath).not.toHaveBeenCalled();
+  });
+
+  it('POST with a NUL-only path 400s instead of creating over the scope root', async () => {
+    const res = await POST(post({ ...ROOT_BODY, path: ' ', kind: 'directory' }));
+
+    expect(res.status).toBe(400);
+    expect(createMachineDirectory).not.toHaveBeenCalled();
+  });
+
+  it('PATCH with a NUL-only fromPath 400s naming the field', async () => {
+    const res = await PATCH(patch({ ...BRANCH_BODY, op: 'move', fromPath: ' ', toPath: 'b.txt' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'fromPath must not be the scope root' });
+    expect(moveMachinePath).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/machines/files create-vs-save overwrite semantics', () => {
+  it('overwrite:false reaches writeMachineFile as noClobber and an existing file 409s', async () => {
+    writeMachineFile.mockResolvedValue({ ok: false, reason: 'already_exists' });
+
+    const res = await POST(post({ ...BRANCH_BODY, path: 'exists.txt', kind: 'file', overwrite: false }));
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'Something already has that name', reason: 'already_exists' });
+    expect(writeMachineFile).toHaveBeenCalledWith(expect.objectContaining({ noClobber: true }));
+  });
+
+  it('absent overwrite keeps save semantics (noClobber false)', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'save.txt', kind: 'file', content: 'x' }));
+
+    expect(res.status).toBe(200);
+    expect(writeMachineFile).toHaveBeenCalledWith(expect.objectContaining({ noClobber: false }));
+  });
+
+  it('400s a non-boolean overwrite', async () => {
+    const res = await POST(post({ ...BRANCH_BODY, path: 'a.txt', kind: 'file', overwrite: 'nope' }));
+
+    expect(res.status).toBe(400);
+    expect(writeMachineFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('/api/machines/files symlinked scope-root boundary', () => {
+  it('a scope root resolving outside the boundary (index -1) 400s without touching the filesystem', async () => {
+    verifyMachinePathsWithinScope.mockResolvedValue({ ok: false, reason: 'escapes', index: -1 });
+
+    const res = await GET(get({ mode: 'read', path: 'passwd' }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'path escapes the machine filesystem root' });
     expect(readMachineFile).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -61,6 +61,12 @@
  * Confined absolute paths are what reach the `machine-fs` primitives — NEVER
  * re-derived from the raw input once confined (PR #2039 TOCTOU lesson).
  *
+ * Confinement is TWO passes because string confinement alone cannot see the
+ * Sprite's symlinks: after the handle resolves, every non-root path is
+ * re-resolved ON the machine (`verifyMachinePathsWithinScope`, `realpath -m`)
+ * and rejected (400) if following links lands it outside the scope root — an
+ * in-scope symlink pointing at `/etc` cannot be used to read or write there.
+ *
  * Operates on the live filesystem only — no git ref (that is a separate
  * git-object service). Session-only (no MCP/agent tokens) — this is a
  * human/UI surface, so it does NOT route through the AI agent tool
@@ -82,11 +88,13 @@ import {
   moveMachinePath,
   copyMachinePath,
   deleteMachinePath,
+  verifyMachinePathsWithinScope,
   type MutateMachinePathResult,
 } from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
+import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
 import { canViewMachine, canEditMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
 import type { MachineFilesScope } from '@/lib/machines/machine-files-runtime';
 
@@ -183,6 +191,43 @@ function confineScopedPath(
     return { ok: false, error: NextResponse.json({ error: `${field} escapes the machine filesystem root` }, { status: 400 }) };
   }
   return { ok: true, value: confined };
+}
+
+/**
+ * Second confinement pass, ON the machine: string confinement above cannot see
+ * the Sprite's symlinks, so `/workspace/link/x` with `link → /etc` passes it
+ * and every later fs op on the machine would follow the link out of scope.
+ * `verifyMachinePathsWithinScope` re-resolves each path with the machine's own
+ * `realpath` and rejects any that escape once links are followed. Returns null
+ * when every path is in scope, else the response to send. `checks` pairs each
+ * confined absolute path with the request field it came from so the 400 names
+ * the offending field, same as the string-confinement 400s.
+ */
+async function requireMachinePathsWithinScope(
+  handle: MachineHandle,
+  scope: MachineFilesScope,
+  checks: ReadonlyArray<{ field: string; path: string }>,
+): Promise<NextResponse | null> {
+  // The scope root itself has no intermediate components to traverse — nothing
+  // a symlink could hijack — so a bare root listing skips the extra exec.
+  const toCheck = checks.filter((c) => c.path !== scopeRoot(scope));
+  if (toCheck.length === 0) return null;
+  const result = await verifyMachinePathsWithinScope({
+    handle,
+    scopeRoot: scopeRoot(scope),
+    paths: toCheck.map((c) => c.path),
+  });
+  if (result.ok) return null;
+  if (result.reason === 'escapes') {
+    return NextResponse.json(
+      { error: `${toCheck[result.index].field} escapes the machine filesystem root` },
+      { status: 400 },
+    );
+  }
+  return NextResponse.json(
+    { error: 'Failed to complete the operation on the machine', reason: 'exec_failed', detail: result.detail },
+    { status: 502 },
+  );
 }
 
 const RESOLVE_DENIAL_STATUS: Record<'not_found' | 'vanished' | 'not_started', number> = {
@@ -306,6 +351,9 @@ export async function GET(request: Request) {
   const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) return resolveDenialResponse(resolved.reason);
 
+  const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [{ field: 'path', path }]);
+  if (escape) return escape;
+
   if (mode === 'read') {
     const result = await readMachineFile({ handle: resolved.handle, path });
     if (!result.ok) {
@@ -415,6 +463,8 @@ export async function POST(request: Request) {
   if (kind.value === 'directory') {
     const resolved = await resolveMachineFilesHandle(scope);
     if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+    const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [{ field: 'path', path }]);
+    if (escape) return escape;
     const result = await createMachineDirectory({ handle: resolved.handle, path });
     if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
     auditWrite(request, auth.userId, machineId.value, { op: 'create_directory', path: rawPath.value });
@@ -429,6 +479,8 @@ export async function POST(request: Request) {
 
   const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+  const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [{ field: 'path', path }]);
+  if (escape) return escape;
   const result = await writeMachineFile({ handle: resolved.handle, path, content: decoded.content });
   if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
   auditWrite(request, auth.userId, machineId.value, { op: 'write_file', path: rawPath.value });
@@ -472,6 +524,12 @@ export async function PATCH(request: Request) {
   const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) return resolveDenialResponse(resolved.reason);
 
+  const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [
+    { field: 'fromPath', path: fromPath.value },
+    { field: 'toPath', path: toPath.value },
+  ]);
+  if (escape) return escape;
+
   const notFoundMessage = `The item to ${op.value} could not be found`;
   const result =
     op.value === 'move'
@@ -511,6 +569,9 @@ export async function DELETE(request: Request) {
 
   const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+
+  const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [{ field: 'path', path }]);
+  if (escape) return escape;
 
   const result = await deleteMachinePath({ handle: resolved.handle, path });
   if (!result.ok) return mutateFailureResponse(result, 'The item to delete could not be found');

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -14,9 +14,12 @@
  *   mode=download       → raw bytes, `Content-Disposition: attachment`, for the file `path`
  *
  * POST   { machineId, projectName?, branchName?, path, kind: 'directory' }
- *        { machineId, projectName?, branchName?, path, kind: 'file', content?, encoding? }
- *   Creates a directory, or creates/overwrites a file (overwrite IS allowed —
- *   this is also how "save" works). `path` may not be `''` (the scope root).
+ *        { machineId, projectName?, branchName?, path, kind: 'file', content?, encoding?, overwrite? }
+ *   Creates a directory, or creates/overwrites a file (overwrite IS allowed by
+ *   default — this is also how "save" works). `overwrite: false` switches the
+ *   file arm to CREATE semantics: an existing entry at `path` is a 409, never
+ *   a silent truncation (the "New File" flow). `path` may not resolve to the
+ *   scope root.
  *
  * PATCH  { machineId, projectName?, branchName?, op: 'move' | 'copy', fromPath, toPath }
  *   Moves or copies a path within the same scope. Neither `fromPath` nor
@@ -199,15 +202,29 @@ function scopeRoot(scope: MachineFilesScope): string {
   return scope.scope === 'branch' ? BRANCH_REPO_PATH : SANDBOX_ROOT;
 }
 
-/** Confines one relative path field under the scope root. Returns the confined absolute path, or a 400 response naming `field`. */
+/**
+ * Confines one relative path field under the scope root. Returns the confined
+ * absolute path, or a 400 response naming `field`.
+ *
+ * `forbidRoot` (every mutating verb): reject when the CONFINED result is the
+ * scope root itself. The raw-input non-empty check alone cannot guarantee this
+ * — `resolvePathWithinSync` strips NUL bytes, so a NUL-only `path` (or
+ * anything else that sanitizes to empty) is non-empty on the wire yet resolves
+ * to the scope root, which would let a DELETE reach `rm -rf` on `/workspace`
+ * itself. The refusal must live at the confined level, not the raw level.
+ */
 function confineScopedPath(
   scope: MachineFilesScope,
   relativePath: string,
   field: string,
+  options?: { forbidRoot?: boolean },
 ): { ok: true; value: string } | { ok: false; error: NextResponse } {
   const confined = resolvePathWithinSync(scopeRoot(scope), relativePath);
   if (confined === null) {
     return { ok: false, error: NextResponse.json({ error: `${field} escapes the machine filesystem root` }, { status: 400 }) };
+  }
+  if (options?.forbidRoot && confined === scopeRoot(scope)) {
+    return { ok: false, error: NextResponse.json({ error: `${field} must not be the scope root` }, { status: 400 }) };
   }
   return { ok: true, value: confined };
 }
@@ -233,13 +250,20 @@ async function requireMachinePathsWithinScope(
   if (toCheck.length === 0) return null;
   const result = await verifyMachinePathsWithinScope({
     handle,
+    // SANDBOX_ROOT is the outermost trust boundary regardless of scope: a
+    // branch checkout root replaced by a symlink out of /workspace must reject
+    // as a whole, not re-anchor containment at the link's target.
+    boundaryRoot: SANDBOX_ROOT,
     scopeRoot: scopeRoot(scope),
     paths: toCheck.map((c) => c.path),
   });
   if (result.ok) return null;
   if (result.reason === 'escapes') {
+    // index -1 = the scope root itself escaped the boundary; there is no single
+    // offending field to name.
+    const label = result.index === -1 ? 'path' : toCheck[result.index].field;
     return NextResponse.json(
-      { error: `${toCheck[result.index].field} escapes the machine filesystem root` },
+      { error: `${label} escapes the machine filesystem root` },
       { status: 400 },
     );
   }
@@ -471,11 +495,12 @@ export async function POST(request: Request) {
   if (!scopeResult.ok) return scopeResult.error;
   const scope = scopeResult.scope;
 
-  // Empty rejected by `requireString` too — the scope root can never itself be
-  // the thing being created.
+  // `forbidRoot`, not just `requireString`: a NUL-only (or otherwise
+  // sanitized-to-empty) path is non-empty on the wire yet confines to the
+  // scope root — the root can never itself be the thing being created.
   const rawPath = requireString(body.path, 'path');
   if (!rawPath.ok) return rawPath.error;
-  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path', { forbidRoot: true });
   if (!confinedPath.ok) return confinedPath.error;
   const path = confinedPath.value;
 
@@ -499,11 +524,23 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'File is too large to upload', reason: 'too_large' }, { status: 413 });
   }
 
+  // `overwrite: false` = CREATE semantics (the "New File" flow): an existing
+  // entry is a 409, never a silent truncation. Absent/`true` keeps
+  // overwrite-is-save semantics for editor saves and uploads.
+  if (body.overwrite !== undefined && typeof body.overwrite !== 'boolean') {
+    return NextResponse.json({ error: 'overwrite must be a boolean' }, { status: 400 });
+  }
+
   const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) return resolveDenialResponse(resolved.reason);
   const escape = await requireMachinePathsWithinScope(resolved.handle, scope, [{ field: 'path', path }]);
   if (escape) return escape;
-  const result = await writeMachineFile({ handle: resolved.handle, path, content: decoded.content });
+  const result = await writeMachineFile({
+    handle: resolved.handle,
+    path,
+    content: decoded.content,
+    noClobber: body.overwrite === false,
+  });
   if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
   auditWrite(request, auth.userId, machineId.value, { op: 'write_file', path: rawPath.value });
   return NextResponse.json({ ok: true });
@@ -541,9 +578,9 @@ export async function PATCH(request: Request) {
   const rawToPath = requireString(body.toPath, 'toPath');
   if (!rawToPath.ok) return rawToPath.error;
 
-  const fromPath = confineScopedPath(scope, rawFromPath.value, 'fromPath');
+  const fromPath = confineScopedPath(scope, rawFromPath.value, 'fromPath', { forbidRoot: true });
   if (!fromPath.ok) return fromPath.error;
-  const toPath = confineScopedPath(scope, rawToPath.value, 'toPath');
+  const toPath = confineScopedPath(scope, rawToPath.value, 'toPath', { forbidRoot: true });
   if (!toPath.ok) return toPath.error;
 
   const resolved = await resolveMachineFilesHandle(scope);
@@ -588,10 +625,11 @@ export async function DELETE(request: Request) {
   if (!scopeResult.ok) return scopeResult.error;
   const scope = scopeResult.scope;
 
-  // Empty rejected by `requireString` too — the scope root is never deleted.
+  // `forbidRoot`, not just `requireString`: a NUL-only path is non-empty on
+  // the wire yet confines to the scope root — the scope root is never deleted.
   const rawPath = requireString(body.path, 'path');
   if (!rawPath.ok) return rawPath.error;
-  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path', { forbidRoot: true });
   if (!confinedPath.ok) return confinedPath.error;
   const path = confinedPath.value;
 

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -1,8 +1,13 @@
 /**
- * Machine Files API — the Machine page's surface onto a branch checkout's
- * WORKING TREE (Machine page rebuild, Phase 1 — file browsing).
+ * Machine Files API — the Machine page's surface onto a WORKING TREE: either a
+ * branch checkout, or (when `projectName`/`branchName` are absent) the root
+ * Machine's own persistent Sprite (Machine page rebuild, Phase 1 — file
+ * browsing; root scope added for the Machine Files Manager epic).
  *
- * GET ?machineId=&projectName=&branchName=[&path=][&mode=list|read]
+ * GET ?machineId=[&projectName=&branchName=][&path=][&mode=list|read]
+ *   projectName/branchName BOTH present → branch scope (a branch checkout)
+ *   projectName/branchName BOTH absent  → root scope (the Machine's own tree)
+ *   exactly one present                 → 400 (they are a pair)
  *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
  *   mode=read           → { content, encoding, truncated } for the file `path`
  *
@@ -11,22 +16,28 @@
  * NEVER an internal token and never our own stderr (which names absolute paths
  * inside the Sprite) — that goes in `detail`, for logs and developers. The
  * reasons are disjoint on purpose:
- *   not_found      (404) — this branch has no checkout (no row, or never cloned)
- *   vanished       (503) — the branch's Sprite is gone
- *   dir_not_found  (404) — the checkout is there; that one directory is not
- *   file_not_found (404) — the checkout is there; that one file is not
+ *   not_found      (404) — no checkout (branch: no row, or never cloned)
+ *   not_started    (404) — root scope only: the Machine has no live session
+ *   vanished       (503) — the resolved Sprite is gone
+ *   dir_not_found  (404) — the tree is there; that one directory is not
+ *   file_not_found (404) — the tree is there; that one file is not
  *   exec_failed    (502) — the exec itself failed; see `detail`
- * "no checkout", "no such directory" and "no such file" are THREE different
- * facts. A client that conflates them tells the reader a file vanished when in
- * truth the whole branch did — so each gets its own token.
+ * "no checkout", "no such directory" and "no such file" are different facts. A
+ * client that conflates them tells the reader a file vanished when in truth
+ * the whole branch did — so each gets its own token.
  *
- * `path` is RELATIVE to the branch checkout root (`/workspace/repo`) and is
- * confined under it before the machine filesystem is touched — an absolute path
- * or a `..` escape is rejected (400), so a viewer cannot read `/etc/passwd` or
- * step out of the checkout. It defaults to the checkout root for a listing and
- * is REQUIRED for a read. Reads the live filesystem only — no git ref (that is
- * a separate git-object service). Session-only (no MCP/agent tokens) — this is
- * a human/UI surface, so it does NOT route through the AI agent tool
+ * `path` is RELATIVE to the scope's root — the branch checkout root
+ * (`/workspace/repo`) for branch scope, `/workspace` (`SANDBOX_ROOT`) for root
+ * scope — and is confined under it before the machine filesystem is touched —
+ * an absolute path or a `..` escape is rejected (400), so a viewer cannot read
+ * `/etc/passwd` or step out of the tree. Root scope confines via
+ * `resolvePathWithinSync(SANDBOX_ROOT, …)` directly rather than
+ * `resolveSandboxPath` — the latter's `/workspace`-prefix-stripping leniency is
+ * an agent-tool affordance that has no place here and would break symmetry
+ * with the branch arm. `path` defaults to the scope root for a listing and is
+ * REQUIRED for a read. Reads the live filesystem only — no git ref (that is a
+ * separate git-object service). Session-only (no MCP/agent tokens) — this is a
+ * human/UI surface, so it does NOT route through the AI agent tool
  * orchestration; every request re-checks view access for the Machine page,
  * same as the Branches/Agent-Terminals APIs.
  */
@@ -36,8 +47,10 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
+import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
-import { canViewMachine, resolveBranchMachineHandle } from '@/lib/machines/machine-files-runtime';
+import { canViewMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
+import type { MachineFilesScope } from '@/lib/machines/machine-files-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 
@@ -56,6 +69,12 @@ const LIST_DENIAL_STATUS: Record<string, number> = {
   exec_failed: 502,
 };
 
+const RESOLVE_DENIAL_STATUS: Record<'not_found' | 'vanished' | 'not_started', number> = {
+  not_found: 404,
+  vanished: 503,
+  not_started: 404,
+};
+
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
   if (isAuthError(auth)) return auth.error;
@@ -63,16 +82,28 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const machineId = requireString(url.searchParams.get('machineId'), 'machineId');
   if (!machineId.ok) return machineId.error;
-  const projectName = requireString(url.searchParams.get('projectName'), 'projectName');
-  if (!projectName.ok) return projectName.error;
-  const branchName = requireString(url.searchParams.get('branchName'), 'branchName');
-  if (!branchName.ok) return branchName.error;
 
   // Authorize BEFORE parsing optional params, so a user without view access gets
-  // a uniform 403 and can never probe path/mode handling.
+  // a uniform 403 and can never probe path/mode/scope handling.
   if (!(await canViewMachine(auth.userId, machineId.value))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
+
+  // projectName/branchName are a pair: both present → branch scope, both
+  // absent → root scope. Treat `null` and `''` identically as absent — `''`
+  // already 400ed before this change, so no existing client observes new
+  // behavior for it.
+  const rawProjectName = url.searchParams.get('projectName');
+  const rawBranchName = url.searchParams.get('branchName');
+  const projectName = rawProjectName === null || rawProjectName.length === 0 ? null : rawProjectName;
+  const branchName = rawBranchName === null || rawBranchName.length === 0 ? null : rawBranchName;
+  if ((projectName === null) !== (branchName === null)) {
+    return NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 });
+  }
+  const scope: MachineFilesScope =
+    projectName !== null && branchName !== null
+      ? { scope: 'branch', machineId: machineId.value, projectName, branchName }
+      : { scope: 'root', machineId: machineId.value };
 
   const mode = url.searchParams.get('mode') ?? 'list';
   if (mode !== 'list' && mode !== 'read') {
@@ -84,29 +115,32 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
   }
 
-  // `path` is untrusted and RELATIVE to the checkout root; confine it under
-  // BRANCH_REPO_PATH before any filesystem access. An empty path lists the root
-  // itself; an absolute path or a `..` escape resolves to null → 400. Absolute
-  // path passed to the filesystem is the confined result, never the raw input.
+  // `path` is untrusted and RELATIVE to the scope's root; confine it before any
+  // filesystem access. An empty path lists the root itself; an absolute path or
+  // a `..` escape resolves to null → 400. Absolute path passed to the
+  // filesystem is the confined result, never the raw input.
   const relativePath = rawPath !== null && rawPath.length > 0 ? rawPath : '';
-  const path = resolvePathWithinSync(BRANCH_REPO_PATH, relativePath);
+  const path =
+    scope.scope === 'branch'
+      ? resolvePathWithinSync(BRANCH_REPO_PATH, relativePath)
+      : resolvePathWithinSync(SANDBOX_ROOT, relativePath);
   if (path === null) {
-    return NextResponse.json({ error: 'path escapes the branch checkout root' }, { status: 400 });
+    return NextResponse.json({ error: 'path escapes the machine filesystem root' }, { status: 400 });
   }
 
-  const resolved = await resolveBranchMachineHandle({
-    machineId: machineId.value,
-    projectName: projectName.value,
-    branchName: branchName.value,
-  });
+  const resolved = await resolveMachineFilesHandle(scope);
   if (!resolved.ok) {
     // `error` is user-facing: clients switch on `reason`, and at least one (the
     // Code tab's file tree) renders `error` straight into the UI — so it must
     // never be the internal token. "Branch machine vanished" is a sentence about
     // our internals, not about anything the reader did or can act on.
+    const error =
+      resolved.reason === 'not_started'
+        ? "This machine hasn't been started yet"
+        : 'This branch checkout is unavailable';
     return NextResponse.json(
-      { error: 'This branch checkout is unavailable', reason: resolved.reason },
-      { status: resolved.reason === 'not_found' ? 404 : 503 },
+      { error, reason: resolved.reason },
+      { status: RESOLVE_DENIAL_STATUS[resolved.reason] },
     );
   }
 
@@ -136,14 +170,16 @@ export async function GET(request: Request) {
     //   a subdirectory is missing    → the checkout is fine; that folder is gone
     //                                  (an agent terminal deleted it a moment ago)
     // The root keeps `not_found`, so it reads as "not checked out yet" alongside
-    // the resolve failure above; a subdirectory gets its own token.
+    // the resolve failure above; a subdirectory gets its own token. This split is
+    // a BRANCH fact only — a live Sprite's `/workspace` is driver-guaranteed, so
+    // in root scope every missing directory (root path included) is just a gone
+    // folder, never "never checked out".
     if (result.reason === 'not_found') {
-      return NextResponse.json(
-        relativePath === ''
-          ? { error: 'This branch checkout is unavailable', reason: 'not_found' }
-          : { error: 'This folder is no longer in the checkout', reason: 'dir_not_found' },
-        { status: 404 },
-      );
+      if (scope.scope === 'branch' && relativePath === '') {
+        return NextResponse.json({ error: 'This branch checkout is unavailable', reason: 'not_found' }, { status: 404 });
+      }
+      const error = scope.scope === 'root' ? 'This folder is no longer on the machine' : 'This folder is no longer in the checkout';
+      return NextResponse.json({ error, reason: 'dir_not_found' }, { status: 404 });
     }
     // The exec's stderr has real diagnostic value, but it is OUR stderr: it names
     // absolute paths inside the Sprite ("ls: cannot access '/workspace/repo/…'").

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -2,60 +2,103 @@
  * Machine Files API — the Machine page's surface onto a WORKING TREE: either a
  * branch checkout, or (when `projectName`/`branchName` are absent) the root
  * Machine's own persistent Sprite (Machine page rebuild, Phase 1 — file
- * browsing; root scope added for the Machine Files Manager epic).
+ * browsing; root scope added for the Machine Files Manager epic; Phase 2 adds
+ * mutating verbs — create/upload, move/copy, delete, download).
  *
- * GET ?machineId=[&projectName=&branchName=][&path=][&mode=list|read]
+ * GET    ?machineId=[&projectName=&branchName=][&path=][&mode=list|read|download]
  *   projectName/branchName BOTH present → branch scope (a branch checkout)
  *   projectName/branchName BOTH absent  → root scope (the Machine's own tree)
  *   exactly one present                 → 400 (they are a pair)
  *   mode=list (default) → { entries: [{ name, type }] } for the directory `path`
  *   mode=read           → { content, encoding, truncated } for the file `path`
+ *   mode=download       → raw bytes, `Content-Disposition: attachment`, for the file `path`
+ *
+ * POST   { machineId, projectName?, branchName?, path, kind: 'directory' }
+ *        { machineId, projectName?, branchName?, path, kind: 'file', content?, encoding? }
+ *   Creates a directory, or creates/overwrites a file (overwrite IS allowed —
+ *   this is also how "save" works). `path` may not be `''` (the scope root).
+ *
+ * PATCH  { machineId, projectName?, branchName?, op: 'move' | 'copy', fromPath, toPath }
+ *   Moves or copies a path within the same scope. Neither `fromPath` nor
+ *   `toPath` may be `''` (the scope root is never itself the operand).
+ *
+ * DELETE { machineId, projectName?, branchName?, path }
+ *   Removes a path, recursively and idempotently (a missing target is
+ *   success). `path` may not be `''` (the scope root is never deleted).
+ *
+ * Every mutating verb requires edit access (`canEditMachine`), CSRF, and is
+ * audited on success (`auditRequest` with `eventType: 'data.write'`). GET
+ * (including `mode=download`) requires only view access — it is a read.
  *
  * FAILURES are `{ error, reason, detail? }`. `reason` is the machine-readable
  * fact and is what clients switch on; `error` is a sentence fit to show a human,
  * NEVER an internal token and never our own stderr (which names absolute paths
  * inside the Sprite) — that goes in `detail`, for logs and developers. The
  * reasons are disjoint on purpose:
- *   not_found      (404) — no checkout (branch: no row, or never cloned)
+ *   not_found      (404) — no checkout (branch: no row, or never cloned), or
+ *                          (mutations) the item being moved/copied/created-under is gone
  *   not_started    (404) — root scope only: the Machine has no live session
  *   vanished       (503) — the resolved Sprite is gone
  *   dir_not_found  (404) — the tree is there; that one directory is not
  *   file_not_found (404) — the tree is there; that one file is not
+ *   already_exists (409) — the mutation's destination already has something there
+ *   too_large      (413) — uploaded/downloaded content exceeds the size cap
  *   exec_failed    (502) — the exec itself failed; see `detail`
  * "no checkout", "no such directory" and "no such file" are different facts. A
  * client that conflates them tells the reader a file vanished when in truth
  * the whole branch did — so each gets its own token.
  *
- * `path` is RELATIVE to the scope's root — the branch checkout root
- * (`/workspace/repo`) for branch scope, `/workspace` (`SANDBOX_ROOT`) for root
- * scope — and is confined under it before the machine filesystem is touched —
- * an absolute path or a `..` escape is rejected (400), so a viewer cannot read
- * `/etc/passwd` or step out of the tree. Root scope confines via
- * `resolvePathWithinSync(SANDBOX_ROOT, …)` directly rather than
- * `resolveSandboxPath` — the latter's `/workspace`-prefix-stripping leniency is
- * an agent-tool affordance that has no place here and would break symmetry
- * with the branch arm. `path` defaults to the scope root for a listing and is
- * REQUIRED for a read. Reads the live filesystem only — no git ref (that is a
- * separate git-object service). Session-only (no MCP/agent tokens) — this is a
+ * `path`/`fromPath`/`toPath` are RELATIVE to the scope's root — the branch
+ * checkout root (`/workspace/repo`) for branch scope, `/workspace`
+ * (`SANDBOX_ROOT`) for root scope — and each is individually confined under it
+ * before the machine filesystem is touched — an absolute path or a `..` escape
+ * is rejected (400), so a caller cannot read/write `/etc/passwd` or step out of
+ * the tree. Root scope confines via `resolvePathWithinSync(SANDBOX_ROOT, …)`
+ * directly rather than `resolveSandboxPath` — the latter's
+ * `/workspace`-prefix-stripping leniency is an agent-tool affordance that has
+ * no place here and would break symmetry with the branch arm. `path` defaults
+ * to the scope root for a listing and is REQUIRED for a read/download/mutation.
+ * Confined absolute paths are what reach the `machine-fs` primitives — NEVER
+ * re-derived from the raw input once confined (PR #2039 TOCTOU lesson).
+ *
+ * Operates on the live filesystem only — no git ref (that is a separate
+ * git-object service). Session-only (no MCP/agent tokens) — this is a
  * human/UI surface, so it does NOT route through the AI agent tool
- * orchestration; every request re-checks view access for the Machine page,
- * same as the Branches/Agent-Terminals APIs.
+ * orchestration; every request re-checks access for the Machine page, same as
+ * the Branches/Agent-Terminals APIs.
  */
 
+import { basename } from 'node:path';
 import { StringDecoder } from 'string_decoder';
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { listMachineDirectory, readMachineFile } from '@pagespace/lib/services/sandbox/machine-fs';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
+import {
+  listMachineDirectory,
+  readMachineFile,
+  createMachineDirectory,
+  writeMachineFile,
+  moveMachinePath,
+  copyMachinePath,
+  deleteMachinePath,
+  type MutateMachinePathResult,
+} from '@pagespace/lib/services/sandbox/machine-fs';
 import { BRANCH_REPO_PATH } from '@pagespace/lib/services/machines/machine-branches';
 import { SANDBOX_ROOT } from '@pagespace/lib/services/sandbox/sandbox-paths';
 import { resolvePathWithinSync } from '@pagespace/lib/security/path-validator';
-import { canViewMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
+import { canViewMachine, canEditMachine, resolveMachineFilesHandle } from '@/lib/machines/machine-files-runtime';
 import type { MachineFilesScope } from '@/lib/machines/machine-files-runtime';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
-/** A single file read is capped so a large blob can't flood the response. */
+const RESOURCE_TYPE = 'machine';
+
+/** A single file read/download is capped so a large blob can't flood the response. */
 const MAX_FILE_READ_BYTES = 2 * 1024 * 1024;
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024;
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
 function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
   if (typeof value !== 'string' || value.length === 0) {
@@ -64,16 +107,164 @@ function requireString(value: unknown, field: string): { ok: true; value: string
   return { ok: true, value };
 }
 
-const LIST_DENIAL_STATUS: Record<string, number> = {
-  not_found: 404,
-  exec_failed: 502,
-};
+function requireEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  field: string,
+): { ok: true; value: T } | { ok: false; error: NextResponse } {
+  if (typeof value === 'string' && (allowed as readonly string[]).includes(value)) {
+    return { ok: true, value: value as T };
+  }
+  return {
+    ok: false,
+    error: NextResponse.json(
+      { error: `${field} must be ${allowed.map((a) => `'${a}'`).join(' or ')}` },
+      { status: 400 },
+    ),
+  };
+}
+
+/** `request.json()` resolves (not throws) for a body like `null` or `42` — guard so that's a 400, not a 500. */
+async function parseJsonBody(request: Request): Promise<{ ok: true; value: Record<string, unknown> } | { ok: false; error: NextResponse }> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return { ok: false, error: NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) };
+  }
+  if (body === null || typeof body !== 'object') {
+    return { ok: false, error: NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 }) };
+  }
+  return { ok: true, value: body as Record<string, unknown> };
+}
+
+/** `null`/`''`/non-string all normalize to absent — mirrors the search-param handling below. */
+function normalizeScopePart(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/**
+ * projectName/branchName are a pair: both present → branch scope, both absent
+ * → root scope. Shared by every verb so query-param (GET) and JSON-body
+ * (POST/PATCH/DELETE) callers get identical pairing semantics.
+ */
+function buildScope(
+  machineId: string,
+  rawProjectName: unknown,
+  rawBranchName: unknown,
+): { ok: true; scope: MachineFilesScope } | { ok: false; error: NextResponse } {
+  const projectName = normalizeScopePart(rawProjectName);
+  const branchName = normalizeScopePart(rawBranchName);
+  if ((projectName === null) !== (branchName === null)) {
+    return {
+      ok: false,
+      error: NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 }),
+    };
+  }
+  const scope: MachineFilesScope =
+    projectName !== null && branchName !== null
+      ? { scope: 'branch', machineId, projectName, branchName }
+      : { scope: 'root', machineId };
+  return { ok: true, scope };
+}
+
+function scopeRoot(scope: MachineFilesScope): string {
+  return scope.scope === 'branch' ? BRANCH_REPO_PATH : SANDBOX_ROOT;
+}
+
+/** Confines one relative path field under the scope root. Returns the confined absolute path, or a 400 response naming `field`. */
+function confineScopedPath(
+  scope: MachineFilesScope,
+  relativePath: string,
+  field: string,
+): { ok: true; value: string } | { ok: false; error: NextResponse } {
+  const confined = resolvePathWithinSync(scopeRoot(scope), relativePath);
+  if (confined === null) {
+    return { ok: false, error: NextResponse.json({ error: `${field} escapes the machine filesystem root` }, { status: 400 }) };
+  }
+  return { ok: true, value: confined };
+}
 
 const RESOLVE_DENIAL_STATUS: Record<'not_found' | 'vanished' | 'not_started', number> = {
   not_found: 404,
   vanished: 503,
   not_started: 404,
 };
+
+/**
+ * `error` is user-facing: clients switch on `reason`, and at least one (the
+ * Code tab's file tree) renders `error` straight into the UI — so it must
+ * never be the internal token. "Branch machine vanished" is a sentence about
+ * our internals, not about anything the reader did or can act on.
+ */
+function resolveDenialResponse(reason: 'not_found' | 'vanished' | 'not_started'): NextResponse {
+  const error = reason === 'not_started' ? "This machine hasn't been started yet" : 'This branch checkout is unavailable';
+  return NextResponse.json({ error, reason }, { status: RESOLVE_DENIAL_STATUS[reason] });
+}
+
+/**
+ * Maps a `MutateMachinePathResult` failure to a response. `notFoundMessage` is
+ * op-specific ("the parent folder" vs "the item to move") because a bare
+ * `not_found` here can mean either "the destination's parent is missing" or
+ * "the source doesn't exist" depending on the verb.
+ */
+function mutateFailureResponse(result: Extract<MutateMachinePathResult, { ok: false }>, notFoundMessage: string): NextResponse {
+  if (result.reason === 'already_exists') {
+    return NextResponse.json({ error: 'Something already has that name', reason: 'already_exists' }, { status: 409 });
+  }
+  if (result.reason === 'not_found') {
+    return NextResponse.json({ error: notFoundMessage, reason: 'not_found' }, { status: 404 });
+  }
+  // The exec's stderr has real diagnostic value, but it is OUR stderr: it names
+  // absolute paths inside the Sprite. It belongs in `detail`, for logs and
+  // developers — never in `error`, which clients render straight at a person.
+  return NextResponse.json(
+    { error: 'Failed to complete the operation on the machine', reason: 'exec_failed', detail: result.detail },
+    { status: 502 },
+  );
+}
+
+function auditWrite(request: Request, userId: string, machineId: string, details: Record<string, unknown>): void {
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: RESOURCE_TYPE,
+    resourceId: machineId,
+    details,
+  });
+}
+
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/**
+ * Node's `Buffer.from(str, 'base64')` is lenient — it silently drops invalid
+ * characters rather than throwing, so a malformed upload must be rejected
+ * before decoding, not caught after.
+ */
+function isValidBase64(value: string): boolean {
+  return value.length % 4 === 0 && BASE64_RE.test(value);
+}
+
+function decodeFileContent(
+  rawContent: unknown,
+  rawEncoding: unknown,
+): { ok: true; content: Buffer } | { ok: false; error: NextResponse } {
+  if (rawContent !== undefined && typeof rawContent !== 'string') {
+    return { ok: false, error: NextResponse.json({ error: 'content must be a string' }, { status: 400 }) };
+  }
+  if (rawEncoding !== undefined && rawEncoding !== 'utf8' && rawEncoding !== 'base64') {
+    return { ok: false, error: NextResponse.json({ error: "encoding must be 'utf8' or 'base64'" }, { status: 400 }) };
+  }
+  const content = rawContent ?? '';
+  const encoding = rawEncoding ?? 'utf8';
+  if (encoding === 'base64') {
+    if (!isValidBase64(content)) {
+      return { ok: false, error: NextResponse.json({ error: 'content is not valid base64' }, { status: 400 }) };
+    }
+    return { ok: true, content: Buffer.from(content, 'base64') };
+  }
+  return { ok: true, content: Buffer.from(content, 'utf8') };
+}
 
 export async function GET(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
@@ -89,30 +280,18 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
 
-  // projectName/branchName are a pair: both present → branch scope, both
-  // absent → root scope. Treat `null` and `''` identically as absent — `''`
-  // already 400ed before this change, so no existing client observes new
-  // behavior for it.
-  const rawProjectName = url.searchParams.get('projectName');
-  const rawBranchName = url.searchParams.get('branchName');
-  const projectName = rawProjectName === null || rawProjectName.length === 0 ? null : rawProjectName;
-  const branchName = rawBranchName === null || rawBranchName.length === 0 ? null : rawBranchName;
-  if ((projectName === null) !== (branchName === null)) {
-    return NextResponse.json({ error: 'projectName and branchName must be provided together' }, { status: 400 });
-  }
-  const scope: MachineFilesScope =
-    projectName !== null && branchName !== null
-      ? { scope: 'branch', machineId: machineId.value, projectName, branchName }
-      : { scope: 'root', machineId: machineId.value };
+  const scopeResult = buildScope(machineId.value, url.searchParams.get('projectName'), url.searchParams.get('branchName'));
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
 
   const mode = url.searchParams.get('mode') ?? 'list';
-  if (mode !== 'list' && mode !== 'read') {
-    return NextResponse.json({ error: "mode must be 'list' or 'read'" }, { status: 400 });
+  if (mode !== 'list' && mode !== 'read' && mode !== 'download') {
+    return NextResponse.json({ error: "mode must be 'list', 'read', or 'download'" }, { status: 400 });
   }
 
   const rawPath = url.searchParams.get('path');
-  if (mode === 'read' && (rawPath === null || rawPath.length === 0)) {
-    return NextResponse.json({ error: 'path is required when mode=read' }, { status: 400 });
+  if ((mode === 'read' || mode === 'download') && (rawPath === null || rawPath.length === 0)) {
+    return NextResponse.json({ error: `path is required when mode=${mode}` }, { status: 400 });
   }
 
   // `path` is untrusted and RELATIVE to the scope's root; confine it before any
@@ -120,29 +299,12 @@ export async function GET(request: Request) {
   // a `..` escape resolves to null → 400. Absolute path passed to the
   // filesystem is the confined result, never the raw input.
   const relativePath = rawPath !== null && rawPath.length > 0 ? rawPath : '';
-  const path =
-    scope.scope === 'branch'
-      ? resolvePathWithinSync(BRANCH_REPO_PATH, relativePath)
-      : resolvePathWithinSync(SANDBOX_ROOT, relativePath);
-  if (path === null) {
-    return NextResponse.json({ error: 'path escapes the machine filesystem root' }, { status: 400 });
-  }
+  const confined = confineScopedPath(scope, relativePath, 'path');
+  if (!confined.ok) return confined.error;
+  const path = confined.value;
 
   const resolved = await resolveMachineFilesHandle(scope);
-  if (!resolved.ok) {
-    // `error` is user-facing: clients switch on `reason`, and at least one (the
-    // Code tab's file tree) renders `error` straight into the UI — so it must
-    // never be the internal token. "Branch machine vanished" is a sentence about
-    // our internals, not about anything the reader did or can act on.
-    const error =
-      resolved.reason === 'not_started'
-        ? "This machine hasn't been started yet"
-        : 'This branch checkout is unavailable';
-    return NextResponse.json(
-      { error, reason: resolved.reason },
-      { status: RESOLVE_DENIAL_STATUS[resolved.reason] },
-    );
-  }
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
 
   if (mode === 'read') {
     const result = await readMachineFile({ handle: resolved.handle, path });
@@ -160,6 +322,30 @@ export async function GET(request: Request) {
     // (not the whole buffer) also bounds the work for a large file.
     const content = new StringDecoder('utf8').write(bytes);
     return NextResponse.json({ content, encoding: 'utf8', truncated });
+  }
+
+  if (mode === 'download') {
+    const result = await readMachineFile({ handle: resolved.handle, path });
+    if (!result.ok) {
+      return NextResponse.json({ error: 'File not found', reason: 'file_not_found' }, { status: 404 });
+    }
+    if (result.content.length > MAX_DOWNLOAD_BYTES) {
+      return NextResponse.json({ error: 'File is too large to download', reason: 'too_large' }, { status: 413 });
+    }
+    // Basename only (strip directories), then strip quotes/control chars via the
+    // shared header sanitizer; the ASCII fallback feeds `filename=`, the
+    // sanitized-but-unicode-preserved name feeds RFC 5987 `filename*`.
+    const safeName = sanitizeFilenameForHeader(basename(path));
+    const asciiName = safeName.replace(/[^\x20-\x7E]/g, '_');
+    const disposition = `attachment; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(safeName)}`;
+    return new NextResponse(new Uint8Array(result.content), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': disposition,
+        'Content-Length': String(result.content.length),
+      },
+    });
   }
 
   const result = await listMachineDirectory({ handle: resolved.handle, path });
@@ -187,8 +373,148 @@ export async function GET(request: Request) {
     // clients render straight at a person.
     return NextResponse.json(
       { error: 'Failed to list the checkout directory', reason: result.reason, detail: result.detail },
-      { status: LIST_DENIAL_STATUS[result.reason] ?? 500 },
+      { status: result.reason === 'exec_failed' ? 502 : 500 },
     );
   }
   return NextResponse.json({ entries: result.entries });
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  // Authorize BEFORE validating field shapes so an unauthorized caller can't
+  // distinguish a well-formed request (would-be success) from a malformed one
+  // (400) — same invariant as the settings route.
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  // Empty rejected by `requireString` too — the scope root can never itself be
+  // the thing being created.
+  const rawPath = requireString(body.path, 'path');
+  if (!rawPath.ok) return rawPath.error;
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  if (!confinedPath.ok) return confinedPath.error;
+  const path = confinedPath.value;
+
+  const kind = requireEnum(body.kind, ['directory', 'file'] as const, 'kind');
+  if (!kind.ok) return kind.error;
+
+  if (kind.value === 'directory') {
+    const resolved = await resolveMachineFilesHandle(scope);
+    if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+    const result = await createMachineDirectory({ handle: resolved.handle, path });
+    if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
+    auditWrite(request, auth.userId, machineId.value, { op: 'create_directory', path: rawPath.value });
+    return NextResponse.json({ ok: true });
+  }
+
+  const decoded = decodeFileContent(body.content, body.encoding);
+  if (!decoded.ok) return decoded.error;
+  if (decoded.content.length > MAX_UPLOAD_BYTES) {
+    return NextResponse.json({ error: 'File is too large to upload', reason: 'too_large' }, { status: 413 });
+  }
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+  const result = await writeMachineFile({ handle: resolved.handle, path, content: decoded.content });
+  if (!result.ok) return mutateFailureResponse(result, 'The parent folder could not be found');
+  auditWrite(request, auth.userId, machineId.value, { op: 'write_file', path: rawPath.value });
+  return NextResponse.json({ ok: true });
+}
+
+export async function PATCH(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  const op = requireEnum(body.op, ['move', 'copy'] as const, 'op');
+  if (!op.ok) return op.error;
+
+  // Empty rejected by `requireString` too — the scope root can never itself be
+  // an operand of move/copy.
+  const rawFromPath = requireString(body.fromPath, 'fromPath');
+  if (!rawFromPath.ok) return rawFromPath.error;
+  const rawToPath = requireString(body.toPath, 'toPath');
+  if (!rawToPath.ok) return rawToPath.error;
+
+  const fromPath = confineScopedPath(scope, rawFromPath.value, 'fromPath');
+  if (!fromPath.ok) return fromPath.error;
+  const toPath = confineScopedPath(scope, rawToPath.value, 'toPath');
+  if (!toPath.ok) return toPath.error;
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+
+  const notFoundMessage = `The item to ${op.value} could not be found`;
+  const result =
+    op.value === 'move'
+      ? await moveMachinePath({ handle: resolved.handle, fromPath: fromPath.value, toPath: toPath.value })
+      : await copyMachinePath({ handle: resolved.handle, fromPath: fromPath.value, toPath: toPath.value });
+  if (!result.ok) return mutateFailureResponse(result, notFoundMessage);
+
+  auditWrite(request, auth.userId, machineId.value, { op: op.value, fromPath: rawFromPath.value, toPath: rawToPath.value });
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const parsedBody = await parseJsonBody(request);
+  if (!parsedBody.ok) return parsedBody.error;
+  const body = parsedBody.value;
+
+  const machineId = requireString(body.machineId, 'machineId');
+  if (!machineId.ok) return machineId.error;
+
+  if (!(await canEditMachine(auth.userId, machineId.value))) {
+    return NextResponse.json({ error: 'You do not have edit access to this machine' }, { status: 403 });
+  }
+
+  const scopeResult = buildScope(machineId.value, body.projectName, body.branchName);
+  if (!scopeResult.ok) return scopeResult.error;
+  const scope = scopeResult.scope;
+
+  // Empty rejected by `requireString` too — the scope root is never deleted.
+  const rawPath = requireString(body.path, 'path');
+  if (!rawPath.ok) return rawPath.error;
+  const confinedPath = confineScopedPath(scope, rawPath.value, 'path');
+  if (!confinedPath.ok) return confinedPath.error;
+  const path = confinedPath.value;
+
+  const resolved = await resolveMachineFilesHandle(scope);
+  if (!resolved.ok) return resolveDenialResponse(resolved.reason);
+
+  const result = await deleteMachinePath({ handle: resolved.handle, path });
+  if (!result.ok) return mutateFailureResponse(result, 'The item to delete could not be found');
+
+  auditWrite(request, auth.userId, machineId.value, { op: 'delete', path: rawPath.value });
+  return NextResponse.json({ ok: true });
 }

--- a/apps/web/src/app/api/machines/files/route.ts
+++ b/apps/web/src/app/api/machines/files/route.ts
@@ -107,6 +107,25 @@ const RESOURCE_TYPE = 'machine';
 const MAX_FILE_READ_BYTES = 2 * 1024 * 1024;
 const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024;
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+/**
+ * Request-body ceiling for the mutating verbs, checked against Content-Length
+ * BEFORE `request.json()` buffers anything: base64 inflates the 10 MiB content
+ * cap by 4/3, plus slack for the JSON envelope. An oversized declared body is
+ * rejected without ever being read, so it cannot spike memory just to be
+ * turned away by the post-decode cap. (A chunked request without
+ * Content-Length still falls through to the post-decode cap — the declared-
+ * length check is a fast-path bound, not the only line.)
+ */
+const MAX_MUTATION_REQUEST_BYTES = Math.ceil((MAX_UPLOAD_BYTES * 4) / 3) + 64 * 1024;
+
+/** 413 for a declared body size over the ceiling, before any buffering. */
+function rejectOversizedBody(request: Request): NextResponse | null {
+  const declared = Number(request.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_MUTATION_REQUEST_BYTES) {
+    return NextResponse.json({ error: 'File is too large to upload', reason: 'too_large' }, { status: 413 });
+  }
+  return null;
+}
 
 function requireString(value: unknown, field: string): { ok: true; value: string } | { ok: false; error: NextResponse } {
   if (typeof value !== 'string' || value.length === 0) {
@@ -431,6 +450,9 @@ export async function POST(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
 
+  const oversized = rejectOversizedBody(request);
+  if (oversized) return oversized;
+
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.error;
   const body = parsedBody.value;
@@ -491,6 +513,9 @@ export async function PATCH(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
 
+  const oversized = rejectOversizedBody(request);
+  if (oversized) return oversized;
+
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.error;
   const body = parsedBody.value;
@@ -544,6 +569,9 @@ export async function PATCH(request: Request) {
 export async function DELETE(request: Request) {
   const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
   if (isAuthError(auth)) return auth.error;
+
+  const oversized = rejectOversizedBody(request);
+  if (oversized) return oversized;
 
   const parsedBody = await parseJsonBody(request);
   if (!parsedBody.ok) return parsedBody.error;

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 
@@ -7,8 +7,18 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+/** Stable across calls (unlike a fresh `vi.fn()` per `getState()`) so tests can
+ * assert on startEditing/endEditing pairs across renders. */
+const editingStore = { startEditing: vi.fn(), endEditing: vi.fn() };
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: { getState: () => editingStore },
+}));
+
 /**
- * Every (language, value) pair Monaco has been handed, across ALL renders.
+ * Every (language, value, readOnly) triple Monaco has been handed, across ALL
+ * renders.
  *
  * The final DOM is not enough to police "never show one file's content under
  * another file's name": React flushes the pane's effect before paint, so a bad
@@ -17,22 +27,47 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
  * real setValue against its model. Recording renders is what makes that window
  * observable.
  */
-const monacoRenders: { language: string | undefined; value: string }[] = [];
+const monacoRenders: { language: string | undefined; value: string; readOnly: boolean | undefined }[] = [];
 
 // Monaco is next/dynamic(ssr:false); stub it so the pane's fetch/state logic and
-// the props it hands the editor (value, language, readOnly) are what's asserted.
+// the props it hands the editor (value, language, readOnly, onChange) are what's
+// asserted. The stub renders a textarea wired to onChange so tests can simulate
+// a user editing the buffer without needing the real Monaco bundle.
 vi.mock('@/components/editors/MonacoEditor', () => ({
-  default: ({ value, language, readOnly }: { value: string; language?: string; readOnly?: boolean }) => {
-    monacoRenders.push({ language, value });
+  default: ({
+    value,
+    language,
+    readOnly,
+    onChange,
+  }: {
+    value: string;
+    language?: string;
+    readOnly?: boolean;
+    onChange?: (value: string | undefined) => void;
+  }) => {
+    monacoRenders.push({ language, value, readOnly });
+    // Read-only renders `value` as plain text; editable renders a textarea bound
+    // to `onChange` instead of ALSO showing the text, so `monaco.textContent`
+    // reflects the buffer exactly once either way (a textarea's value is its
+    // own text-node child in the DOM, so rendering both would double it).
     return (
       <div data-testid="monaco" data-language={language} data-readonly={String(readOnly)}>
-        {value}
+        {readOnly ? (
+          value
+        ) : (
+          <textarea
+            aria-label="editor-content"
+            value={value}
+            onChange={(e) => onChange?.(e.target.value)}
+          />
+        )}
       </div>
     );
   },
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
 import FilesFilePane from './FilesFilePane';
 import type { FilesScope } from './files-scope';
 
@@ -62,21 +97,21 @@ describe('FilesFilePane', () => {
     monacoRenders.length = 0;
   });
 
-  test('reads the selected file and shows it read-only with a detected language', async () => {
+  test('reads the selected file and shows it editable with a detected language', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'export const x = 1;', encoding: 'utf8', truncated: false }));
     renderPane('src/index.ts');
 
     const monaco = await waitFor(() => screen.getByTestId('monaco'));
 
     assert({
-      given: 'a .ts file whose read succeeds',
-      should: 'render its content read-only in Monaco with typescript highlighting',
+      given: 'a .ts file whose read succeeds cleanly (not truncated)',
+      should: 'mount it editable in Monaco with typescript highlighting',
       actual: {
         value: monaco.textContent,
         language: monaco.getAttribute('data-language'),
         readOnly: monaco.getAttribute('data-readonly'),
       },
-      expected: { value: 'export const x = 1;', language: 'typescript', readOnly: 'true' },
+      expected: { value: 'export const x = 1;', language: 'typescript', readOnly: 'false' },
     });
   });
 
@@ -106,6 +141,27 @@ describe('FilesFilePane', () => {
       should: 'surface a Truncated banner alongside the content',
       actual: screen.queryByText('Truncated') !== null,
       expected: true,
+    });
+  });
+
+  test('a truncated read stays read-only with no Save affordance', async () => {
+    // Saving a truncated view would silently drop the file's tail on disk — the
+    // route caps a single read at 2 MiB, so a truncated buffer never has the
+    // whole file to begin with.
+    vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'partial', encoding: 'utf8', truncated: true }));
+    renderPane();
+
+    const monaco = await waitFor(() => screen.getByTestId('monaco'));
+
+    assert({
+      given: 'a truncated read',
+      should: 'stay read-only in Monaco (no editable buffer mounted) and never offer a Save button',
+      actual: {
+        readOnly: monaco.getAttribute('data-readonly'),
+        editorTextarea: screen.queryByLabelText('editor-content'),
+        saveButton: screen.queryByTitle('Save file (Cmd/Ctrl-S)'),
+      },
+      expected: { readOnly: 'true', editorTextarea: null, saveButton: null },
     });
   });
 
@@ -412,6 +468,283 @@ describe('FilesFilePane', () => {
       should: 'use the root-scope copy, not the branch-scope "checkout" phrasing',
       actual: message.textContent,
       expected: 'This file is no longer on the machine.',
+    });
+  });
+
+  describe('editing and save', () => {
+    const editContent = async (text: string) => {
+      const editor = screen.getByLabelText('editor-content');
+      await userEvent.clear(editor);
+      await userEvent.type(editor, text);
+      return editor;
+    };
+
+    test('editing a clean file marks it dirty and shows the Save affordance', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'export const x = 1;', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts');
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('export const x = 2;');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      assert({
+        given: 'a clean text file edited in the editor',
+        should: 'show the dirty dot and a Save button',
+        actual: {
+          dirtyDot: screen.queryByTitle('Unsaved changes') !== null,
+          saveButton: screen.queryByTitle('Save file (Cmd/Ctrl-S)') !== null,
+        },
+        expected: { dirtyDot: true, saveButton: true },
+      });
+    });
+
+    test('Save POSTs the edited content with scope fields and cleans the dirty state', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      const call = vi.mocked(fetchWithAuth).mock.calls[1];
+      const options = call[1] as RequestInit;
+
+      assert({
+        given: 'a dirty branch-scope file, saved via the Save button',
+        should: "POST kind:'file' utf8 content plus scope fields to the files route, then clean the dirty state",
+        actual: {
+          url: call[0],
+          method: options.method,
+          body: JSON.parse(String(options.body)),
+          dirtyAfter: screen.queryByTitle('Unsaved changes'),
+          saveButtonAfter: screen.queryByTitle('Save file (Cmd/Ctrl-S)'),
+        },
+        expected: {
+          url: '/api/machines/files',
+          method: 'POST',
+          body: {
+            machineId: 'machine-1',
+            projectName: 'repo',
+            branchName: 'main',
+            path: 'src/index.ts',
+            kind: 'file',
+            encoding: 'utf8',
+            content: 'after',
+          },
+          dirtyAfter: null,
+          saveButtonAfter: null,
+        },
+      });
+    });
+
+    test('root scope saves omit projectName/branchName from the POST body', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('README.md', { kind: 'root' });
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      const body = JSON.parse(String((vi.mocked(fetchWithAuth).mock.calls[1][1] as RequestInit).body));
+
+      assert({
+        given: 'a dirty root-scope file, saved',
+        should: 'POST without projectName/branchName, matching the root-scope read',
+        actual: { projectName: body.projectName, branchName: body.branchName },
+        expected: { projectName: undefined, branchName: undefined },
+      });
+    });
+
+    test('Cmd/Ctrl-S saves the dirty draft', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+
+      await act(async () => {
+        fireEvent.keyDown(document, { key: 's', ctrlKey: true });
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        if (vi.mocked(fetchWithAuth).mock.calls.length < 2) throw new Error('not saved yet');
+      });
+
+      assert({
+        given: 'a dirty draft and a Ctrl-S keypress',
+        should: 'trigger the same save POST as clicking Save, and prevent the browser default',
+        actual: {
+          fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+          method: (vi.mocked(fetchWithAuth).mock.calls[1][1] as RequestInit).method,
+        },
+        expected: { fetches: 2, method: 'POST' },
+      });
+    });
+
+    test('a 403 save failure toasts the edit-access copy and leaves the draft dirty', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: "You don't have edit access to this machine", reason: 'forbidden' }, 403));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected with 403',
+        should: 'toast the edit-access copy and leave the draft dirty',
+        actual: {
+          toastMessage: vi.mocked(toast.error).mock.calls[0]?.[0],
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { toastMessage: "You don't have edit access to this machine", stillDirty: true },
+      });
+    });
+
+    test('a 413 save failure toasts the too-large copy', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'File is too large to upload', reason: 'too_large' }, 413));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected with 413',
+        should: 'toast the too-large copy',
+        actual: vi.mocked(toast.error).mock.calls[0]?.[0],
+        expected: 'File is too large to upload',
+      });
+    });
+
+    test("a save failure for any other reason toasts the route's own error text", async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ error: 'Failed to complete the operation on the machine', reason: 'exec_failed' }, 502));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('not toasted yet');
+      });
+
+      assert({
+        given: 'a save rejected for a reason other than 403/413',
+        should: "toast the route's own error text unmodified",
+        actual: vi.mocked(toast.error).mock.calls[0]?.[0],
+        expected: 'Failed to complete the operation on the machine',
+      });
+    });
+
+    test('registers with useEditingStore while dirty and releases the same session id after save', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => {
+        if (editingStore.startEditing.mock.calls.length === 0) throw new Error('not registered yet');
+      });
+      const sessionId = editingStore.startEditing.mock.calls[0][0];
+
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (!editingStore.endEditing.mock.calls.some((c) => c[0] === sessionId)) throw new Error('not released yet');
+      });
+
+      assert({
+        given: "a draft that went dirty (useEditingStore registration, repo rule) then was saved",
+        should: 'register a session while dirty and release that SAME session id once the save cleans the draft',
+        actual: {
+          registeredWhileDirty: editingStore.startEditing.mock.calls.some((c) => c[0] === sessionId && c[1] === 'document'),
+          releasedAfterSave: editingStore.endEditing.mock.calls.some((c) => c[0] === sessionId),
+        },
+        expected: { registeredWhileDirty: true, releasedAfterSave: true },
+      });
+    });
+
+    test('the reload button confirms before discarding a dirty draft, and declining keeps it', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await userEvent.click(screen.getByTitle('Reload file'));
+
+      assert({
+        given: 'a dirty draft, Reload clicked, but the discard confirm declined',
+        should: 'ask for confirmation and skip the re-fetch, leaving the dirty draft intact',
+        actual: {
+          confirmed: confirmSpy.mock.calls.length,
+          fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { confirmed: 1, fetches: 1, stillDirty: true },
+      });
+
+      confirmSpy.mockRestore();
+    });
+
+    test('a confirmed reload discards the dirty draft and re-fetches', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ content: 'reloaded from disk', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts', BRANCH_SCOPE);
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      await userEvent.click(screen.getByTitle('Reload file'));
+      await waitFor(() => screen.getByText('reloaded from disk'));
+
+      assert({
+        given: 'a dirty draft, Reload clicked, discard confirmed',
+        should: 're-fetch the file and clear the dirty state',
+        actual: {
+          confirmed: confirmSpy.mock.calls.length,
+          value: screen.getByTestId('monaco').textContent,
+          stillDirty: screen.queryByTitle('Unsaved changes') !== null,
+        },
+        expected: { confirmed: 1, value: 'reloaded from disk', stillDirty: false },
+      });
+
+      confirmSpy.mockRestore();
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -34,12 +34,15 @@ vi.mock('@/components/editors/MonacoEditor', () => ({
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import FilesFilePane from './FilesFilePane';
+import type { FilesScope } from './files-scope';
 
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 
-const renderPane = (path = 'src/index.ts') =>
-  render(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path={path} />);
+const BRANCH_SCOPE: FilesScope = { kind: 'branch', projectName: 'repo', branchName: 'main' };
+
+const renderPane = (path = 'src/index.ts', scope: FilesScope = BRANCH_SCOPE) =>
+  render(<FilesFilePane machineId="machine-1" scope={scope} path={path} />);
 
 const requested = (call: unknown[], param: string): string | null =>
   new URL(String(call[0]), 'http://test').searchParams.get(param);
@@ -182,7 +185,7 @@ describe('FilesFilePane', () => {
     const { rerender } = renderPane('a.ts');
     await waitFor(() => screen.getByTestId('monaco'));
 
-    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" scope={BRANCH_SCOPE} path="b.ts" />);
     await waitFor(() => {
       const lastPath = requested(vi.mocked(fetchWithAuth).mock.calls.at(-1) ?? [], 'path');
       if (lastPath !== 'b.ts') throw new Error('new path not fetched yet');
@@ -209,7 +212,7 @@ describe('FilesFilePane', () => {
       .mockResolvedValueOnce(jsonResponse({ content: 'the file I clicked second', encoding: 'utf8', truncated: false }));
 
     const { rerender } = renderPane('slow.ts');
-    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="quick.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" scope={BRANCH_SCOPE} path="quick.ts" />);
     await waitFor(() => screen.getByTestId('monaco'));
 
     // Only NOW does the abandoned first read resolve. Flush inside act() so any
@@ -252,7 +255,7 @@ describe('FilesFilePane', () => {
     const { rerender } = renderPane('assets/logo.png');
     await waitFor(() => screen.getByTestId('binary-file'));
 
-    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="src/a.ts" />);
+    rerender(<FilesFilePane machineId="machine-1" scope={BRANCH_SCOPE} path="src/a.ts" />);
     const monaco = await waitFor(() => screen.getByTestId('monaco'));
 
     assert({
@@ -340,7 +343,7 @@ describe('FilesFilePane', () => {
     const { rerender } = renderPane('a.ts');
     await waitFor(() => screen.getByText('contents of a.ts'));
 
-    rerender(<FilesFilePane machineId="machine-1" projectName="repo" branchName="main" path="b.py" />);
+    rerender(<FilesFilePane machineId="machine-1" scope={BRANCH_SCOPE} path="b.py" />);
     await waitFor(() => screen.getByText('Loading file…'));
 
     assert({
@@ -362,6 +365,53 @@ describe('FilesFilePane', () => {
       should: 'render a meaningful error instead of throwing',
       actual: error.textContent,
       expected: 'Malformed file read response',
+    });
+  });
+
+  test('root scope reads without projectName/branchName params', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'x', encoding: 'utf8', truncated: false }));
+    renderPane('README.md', { kind: 'root' });
+
+    await waitFor(() => screen.getByTestId('monaco'));
+    const call = vi.mocked(fetchWithAuth).mock.calls[0];
+
+    assert({
+      given: 'a pane mounted with root scope',
+      should: 'read with no projectName/branchName params',
+      actual: { projectName: requested(call, 'projectName'), branchName: requested(call, 'branchName') },
+      expected: { projectName: null, branchName: null },
+    });
+  });
+
+  test('a not_started machine renders its own absent copy', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      jsonResponse({ error: "This machine hasn't been started yet", reason: 'not_started' }, 404),
+    );
+    renderPane('README.md', { kind: 'root' });
+
+    const message = await waitFor(() => screen.getByText("This machine hasn't been started yet"));
+
+    assert({
+      given: 'a root scope whose machine has never been started',
+      should: 'render the not_started absent copy, distinct from not_found/vanished',
+      actual: message.textContent,
+      expected: "This machine hasn't been started yet",
+    });
+  });
+
+  test('a missing file in root scope reads as "no longer on the machine"', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      jsonResponse({ error: 'File not found', reason: 'file_not_found' }, 404),
+    );
+    renderPane('deleted.txt', { kind: 'root' });
+
+    const message = await waitFor(() => screen.getByText('This file is no longer on the machine.'));
+
+    assert({
+      given: 'a file deleted from the machine root between listing and reading it',
+      should: 'use the root-scope copy, not the branch-scope "checkout" phrasing',
+      actual: message.textContent,
+      expected: 'This file is no longer on the machine.',
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -498,6 +498,61 @@ describe('FilesFilePane', () => {
       });
     });
 
+    test('a draft edited back to the loaded content is clean again', async () => {
+      vi.mocked(fetchWithAuth).mockResolvedValue(jsonResponse({ content: 'original', encoding: 'utf8', truncated: false }));
+      renderPane('src/index.ts');
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('changed');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+      await editContent('original');
+
+      await waitFor(() => {
+        if (screen.queryByTitle('Unsaved changes') !== null) throw new Error('still dirty');
+      });
+      assert({
+        given: 'an edit fully reverted to the loaded content',
+        should: 'drop the dirty dot and Save affordance — there is no edit left to save',
+        actual: {
+          dirtyDot: screen.queryByTitle('Unsaved changes'),
+          saveButton: screen.queryByTitle('Save file (Cmd/Ctrl-S)'),
+        },
+        expected: { dirtyDot: null, saveButton: null },
+      });
+    });
+
+    test("a save completing after further edits does not discard the newer draft", async () => {
+      let releaseSave: (() => void) | undefined;
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'v1', encoding: 'utf8', truncated: false }))
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseSave = () => resolve(jsonResponse({ ok: true }));
+            }),
+        );
+      renderPane('src/index.ts');
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('v2');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      // Keep typing while the POST is still in flight…
+      await editContent('v3');
+      // …then let the v2 save land.
+      releaseSave?.();
+
+      await waitFor(() => {
+        if (screen.queryByTitle('Unsaved changes') === null) throw new Error('newer draft was discarded');
+      });
+      assert({
+        given: 'a save of v2 that completes after the user typed v3',
+        should: 'keep v3 as an unsaved draft instead of letting the stale completion clear it',
+        actual: screen.queryByTitle('Unsaved changes') !== null,
+        expected: true,
+      });
+    });
+
     test('reports dirty transitions up through onDirtyChange, ending false on unmount', async () => {
       vi.mocked(fetchWithAuth)
         .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.test.tsx
@@ -498,6 +498,40 @@ describe('FilesFilePane', () => {
       });
     });
 
+    test('reports dirty transitions up through onDirtyChange, ending false on unmount', async () => {
+      vi.mocked(fetchWithAuth)
+        .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))
+        .mockResolvedValueOnce(jsonResponse({ ok: true }));
+      const reports: boolean[] = [];
+      const { unmount } = render(
+        <FilesFilePane
+          machineId="machine-1"
+          scope={BRANCH_SCOPE}
+          path="src/index.ts"
+          onDirtyChange={(dirty) => reports.push(dirty)}
+        />,
+      );
+
+      await waitFor(() => screen.getByTestId('monaco'));
+      await editContent('after');
+      await waitFor(() => screen.getByTitle('Unsaved changes'));
+      await userEvent.click(screen.getByTitle('Save file (Cmd/Ctrl-S)'));
+      await waitFor(() => {
+        if (screen.queryByTitle('Unsaved changes') !== null) throw new Error('still dirty');
+      });
+      unmount();
+
+      assert({
+        given: 'an edit, a successful save, then an unmount',
+        should: 'report dirty=true on the edit, dirty=false after the save, and false again on unmount — the parent is never left thinking a gone pane holds an edit',
+        actual: {
+          sawDirty: reports.includes(true),
+          settledClean: reports[reports.length - 1],
+        },
+        expected: { sawDirty: true, settledClean: false },
+      });
+    });
+
     test('Save POSTs the edited content with scope fields and cleans the dirty state', async () => {
       vi.mocked(fetchWithAuth)
         .mockResolvedValueOnce(jsonResponse({ content: 'before', encoding: 'utf8', truncated: false }))

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -2,21 +2,28 @@
 
 /**
  * FilesFilePane — the Files tab's main pane: fetches ONE selected file's content
- * from the machine files route (`mode=read`) and shows it in a read-only Monaco.
- * Scoped by `FilesScope` (Machine Files Manager epic, Part A) — either the
- * Machine's own root Sprite (`/workspace`) or a project/branch checkout within
- * it — like its sibling {@link MachineFileTree}.
+ * from the machine files route (`mode=read`) and shows it in Monaco, editable
+ * when it loaded cleanly as (non-truncated) text. Scoped by `FilesScope`
+ * (Machine Files Manager epic, Part A) — either the Machine's own root Sprite
+ * (`/workspace`) or a project/branch checkout within it — like its sibling
+ * {@link MachineFileTree}.
  *
- * Read-only by design — this tab views a live filesystem, it does not edit it,
- * so Monaco is mounted with `readOnly` and there is no onChange/save path.
- * Content is fetched lazily: the pane only mounts once a file is actually
- * clicked (the tab renders a placeholder until then), and every settled state
- * carries the path it settled for, so the pane can never paint one file's
- * content under another's name. The route caps a single read at 2 MiB and
- * reports `truncated` when it clips a larger file; that surfaces as a banner so
- * a partial view is never mistaken for the whole file. The working tree is LIVE
- * (an agent terminal can rewrite the open file), and re-clicking the same row
- * in the tree is a no-op, so the header carries a reload.
+ * EDITING + SAVE. A clean text read (`loaded`, not `truncated`, not binary) is
+ * editable; Cmd/Ctrl-S or the header's Save button POSTs `kind: 'file'` with the
+ * editor's current value back to the same route (overwrite IS save — see the
+ * route header). The editor's draft is tracked separately from the last-loaded
+ * content so a failed save never loses the edit, and the header's dot + "Save"
+ * affordance only appear once the draft actually diverges from what's on disk.
+ * `truncated` reads stay READ-ONLY, full stop — the route caps a single read at
+ * 2 MiB, so a truncated buffer is missing the file's tail, and saving it would
+ * silently truncate the real file on disk.
+ *
+ * Saving registers with `useEditingStore` for as long as the draft is dirty
+ * (repo rule, CLAUDE.md) — this is what stops an SWR revalidation or an auth
+ * refresh from clobbering an edit the user hasn't saved yet. The reload button
+ * (needed because the working tree is LIVE — see below) confirms before
+ * discarding a dirty draft, since it's the only path that would otherwise
+ * silently blow away unsaved work.
  *
  * BINARIES. A real filesystem is full of them — images, fonts, archives,
  * `.node` addons, `__pycache__` — and the route decodes whatever it reads as
@@ -38,12 +45,14 @@
  * we can tell the reader which of the two actually happened instead of guessing.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { AlertTriangle, FileQuestion, RefreshCw } from 'lucide-react';
+import { AlertTriangle, FileQuestion, RefreshCw, Save } from 'lucide-react';
+import { toast } from 'sonner';
 import { detectLanguageFromFilename, isBinaryFile } from '@pagespace/lib/utils/language-detection';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Button } from '@/components/ui/button';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { PaneLoading, PaneNotice } from './tab-states';
 import { FILES_ABSENT_COPY, asAbsentReason, readErrorBody, type FilesAbsentReason } from './checkout-states';
 import { type FilesScope, filesScopeSearchParams } from './files-scope';
@@ -108,24 +117,39 @@ const looksBinary = (content: string): boolean => {
   return replacements >= MIN_REPLACEMENTS && replacements / sample.length > MAX_REPLACEMENT_RATIO;
 };
 
+/** The POST body's scope fields — a pair, present only for branch scope (mirrors `filesScopeSearchParams`). */
+const filesScopeBodyFields = (scope: FilesScope): Record<string, string> =>
+  scope.kind === 'branch' ? { projectName: scope.projectName, branchName: scope.branchName } : {};
+
 export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneProps) {
   const [state, setState] = useState<FileState>({ status: 'loading' });
-  // Bumped by Retry to re-run the read without changing the selected file.
+  // Bumped by Retry/Reload to re-run the read without changing the selected file.
   const [attempt, setAttempt] = useState(0);
+  // Non-null once the user edits a clean text file — the draft buffer the
+  // editor shows, distinct from `state`'s content (the last-loaded/last-saved
+  // value) so a failed save never loses the edit and Save has something to
+  // diff against.
+  const [draft, setDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
   const fileName = basename(path);
 
   useEffect(() => {
     // Nothing useful to render for a known binary, so don't spend a read on one.
     if (isBinaryFile(fileName)) {
       setState({ status: 'binary', path });
+      setDraft(null);
       return;
     }
 
-    // A new file, a Retry, or a Refresh makes an in-flight read stale — this
+    // A new file, a Retry, or a Reload makes an in-flight read stale — this
     // flag, flipped by the cleanup, keeps a late resolver from landing on the
     // state that replaced it.
     let cancelled = false;
     setState({ status: 'loading' });
+    // A new load (new path, Retry, or a confirmed Reload) always starts clean —
+    // the draft it would replace has already been either discarded (Reload's
+    // confirm) or was never valid for this path to begin with.
+    setDraft(null);
 
     const load = async () => {
       try {
@@ -188,7 +212,97 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
   // The state of a DIFFERENT file is not this file's state — until the effect
   // catches up, we have nothing to show but the spinner. (See FileState.)
   const current: FileState = state.status === 'loading' || state.path === path ? state : { status: 'loading' };
-  const reload = () => setAttempt((a) => a + 1);
+  // Truncated content is a partial read (the route caps at 2 MiB) — editing and
+  // saving it would silently drop the file's tail on disk, so it stays
+  // read-only no matter what the banner already says.
+  const editable = current.status === 'loaded' && !current.truncated;
+  const dirty = editable && draft !== null;
+
+  // Registers for as long as the draft is dirty — repo rule (CLAUDE.md): this
+  // is what stops an SWR revalidation or an auth-refresh interrupt from
+  // clobbering an edit the user hasn't saved yet. Mirrors CodePageView's
+  // registration for the same store.
+  useEffect(() => {
+    const sessionId = `machine-files-pane-${machineId}`;
+    if (dirty) {
+      useEditingStore.getState().startEditing(sessionId, 'document', { componentName: 'FilesFilePane' });
+    } else {
+      useEditingStore.getState().endEditing(sessionId);
+    }
+    return () => {
+      useEditingStore.getState().endEditing(sessionId);
+    };
+  }, [dirty, machineId]);
+
+  const save = async () => {
+    if (!dirty || current.status !== 'loaded' || draft === null) return;
+    const content = draft;
+    setSaving(true);
+    try {
+      const res = await fetchWithAuth('/api/machines/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          machineId,
+          ...filesScopeBodyFields(scope),
+          path,
+          kind: 'file',
+          encoding: 'utf8',
+          content,
+        }),
+      });
+      if (!res.ok) {
+        const { error } = readErrorBody(await res.json().catch(() => null));
+        const message =
+          res.status === 403
+            ? "You don't have edit access to this machine"
+            : res.status === 413
+              ? 'File is too large to upload'
+              : (error ?? `Failed to save file (${res.status})`);
+        toast.error(message);
+        return;
+      }
+      setState({ status: 'loaded', path, content, truncated: false });
+      setDraft(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to save file');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Kept fresh every render (a plain assignment, not an effect — `save` is a
+  // new closure every render, so an effect for this would just run every
+  // render anyway) so the mount-once keydown listener below always calls the
+  // current save (current draft, current path) — mirrors CodePageView's
+  // forceSaveRef.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        void saveRef.current();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
+  const reload = () => {
+    // The only place `attempt` bumps — a confirmed discard here is what keeps a
+    // Reload from silently blowing away an unsaved edit.
+    if (dirty && !window.confirm('Discard unsaved changes to this file?')) return;
+    setAttempt((a) => a + 1);
+  };
+
+  const handleChange = (value: string | undefined) => {
+    if (value === undefined) return;
+    setDraft(value);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -196,12 +310,30 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
         <span className="min-w-0 truncate text-xs text-muted-foreground" title={path}>
           {path}
         </span>
-        <div className="ml-auto flex shrink-0 items-center gap-1">
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
+          {dirty && (
+            // Matches TabItem's dirty-tab dot exactly (amber dot + this title).
+            <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Unsaved changes" />
+          )}
           {current.status === 'loaded' && current.truncated && (
             <span className="flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
               <AlertTriangle className="size-3" />
               Truncated
             </span>
+          )}
+          {dirty && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-5 gap-1 px-1.5 text-[10px]"
+              title="Save file (Cmd/Ctrl-S)"
+              onClick={() => void save()}
+              disabled={saving}
+            >
+              <Save className="size-3" />
+              {saving ? 'Saving…' : 'Save'}
+            </Button>
           )}
           {/* The working tree is LIVE — an agent terminal can rewrite this file
               while it's open — and re-clicking the same row in the tree is a
@@ -246,8 +378,9 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
         )}
         {current.status === 'loaded' && (
           <MonacoEditor
-            value={current.content}
-            readOnly
+            value={draft ?? current.content}
+            onChange={editable ? handleChange : undefined}
+            readOnly={!editable}
             language={detectLanguageFromFilename(fileName)}
             className="h-full"
           />

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -224,7 +224,10 @@ export default function FilesFilePane({ machineId, scope, path, onDirtyChange }:
   // saving it would silently drop the file's tail on disk, so it stays
   // read-only no matter what the banner already says.
   const editable = current.status === 'loaded' && !current.truncated;
-  const dirty = editable && draft !== null;
+  // A draft that has been edited BACK to the loaded content is clean — no Save
+  // affordance, no navigation guard, no editing-store session for an edit that
+  // no longer exists.
+  const dirty = editable && draft !== null && draft !== current.content;
 
   // Mirror the dirty flag up to the parent so ITS navigation (file clicks,
   // scope switches) can confirm before discarding — see the prop doc. The
@@ -253,9 +256,18 @@ export default function FilesFilePane({ machineId, scope, path, onDirtyChange }:
     };
   }, [dirty, machineId]);
 
+  // Kept current by plain assignment so an async save completion can ask
+  // "is the pane still showing the file I saved?" without a stale closure.
+  const latestPathRef = useRef(path);
+  latestPathRef.current = path;
+
   const save = async () => {
-    if (!dirty || current.status !== 'loaded' || draft === null) return;
+    // `saving` also gates re-entrancy: the Cmd/Ctrl-S listener bypasses the
+    // disabled Save button, so without it a held keystroke would fire
+    // overlapping POSTs whose completions race each other's setDraft.
+    if (!dirty || current.status !== 'loaded' || draft === null || saving) return;
     const content = draft;
+    const savedPath = path;
     setSaving(true);
     try {
       const res = await fetchWithAuth('/api/machines/files', {
@@ -264,7 +276,7 @@ export default function FilesFilePane({ machineId, scope, path, onDirtyChange }:
         body: JSON.stringify({
           machineId,
           ...filesScopeBodyFields(scope),
-          path,
+          path: savedPath,
           kind: 'file',
           encoding: 'utf8',
           content,
@@ -281,8 +293,15 @@ export default function FilesFilePane({ machineId, scope, path, onDirtyChange }:
         toast.error(message);
         return;
       }
-      setState({ status: 'loaded', path, content, truncated: false });
-      setDraft(null);
+      // The user may have kept typing while the POST was in flight, or
+      // navigated to another file. Only adopt the saved content as the loaded
+      // state if the pane still shows the saved file, and only clear the draft
+      // if it is still EXACTLY what was submitted — a newer draft is unsaved
+      // work and must survive the older save's completion.
+      if (latestPathRef.current === savedPath) {
+        setState({ status: 'loaded', path: savedPath, content, truncated: false });
+      }
+      setDraft((d) => (d === content ? null : d));
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to save file');
     } finally {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -66,6 +66,14 @@ interface FilesFilePaneProps {
   scope: FilesScope;
   /** Path of the file to show, relative to the scope root, e.g. `src/index.ts`. */
   path: string;
+  /**
+   * Reports whether the pane currently holds an unsaved draft. The parent uses
+   * this to guard its own navigation (file clicks, scope switches) behind the
+   * same discard-confirm the Reload button applies — without it, ordinary
+   * navigation would be the one path that silently drops an edit. Reported
+   * `false` again on unmount.
+   */
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 /**
@@ -121,7 +129,7 @@ const looksBinary = (content: string): boolean => {
 const filesScopeBodyFields = (scope: FilesScope): Record<string, string> =>
   scope.kind === 'branch' ? { projectName: scope.projectName, branchName: scope.branchName } : {};
 
-export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneProps) {
+export default function FilesFilePane({ machineId, scope, path, onDirtyChange }: FilesFilePaneProps) {
   const [state, setState] = useState<FileState>({ status: 'loading' });
   // Bumped by Retry/Reload to re-run the read without changing the selected file.
   const [attempt, setAttempt] = useState(0);
@@ -217,6 +225,17 @@ export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneP
   // read-only no matter what the banner already says.
   const editable = current.status === 'loaded' && !current.truncated;
   const dirty = editable && draft !== null;
+
+  // Mirror the dirty flag up to the parent so ITS navigation (file clicks,
+  // scope switches) can confirm before discarding — see the prop doc. The
+  // cleanup reports `false` so an unmount never strands the parent thinking a
+  // gone pane still holds an edit.
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+    return () => {
+      onDirtyChange?.(false);
+    };
+  }, [dirty, onDirtyChange]);
 
   // Registers for as long as the draft is dirty — repo rule (CLAUDE.md): this
   // is what stops an SWR revalidation or an auth-refresh interrupt from

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -28,12 +28,12 @@
  *      binary. A flood of U+FFFD (bytes the server's decoder couldn't map) is
  *      the same conclusion by a different route.
  *
- * A checkout that has gone away is NOT an error here: the route's `reason` is
- * mapped through the shared {@link CHECKOUT_ABSENT_COPY}, so the pane says the
+ * A scope that has gone away is NOT an error here: the route's `reason` is
+ * mapped through the shared {@link FILES_ABSENT_COPY}, so the pane says the
  * same words the sidebar says, at the same moment, about the same fact. The
- * route keeps `not_found`/`vanished` (this branch has no checkout) distinct from
- * `file_not_found` (the checkout is fine; that one file is gone), so we can tell
- * the reader which of the two actually happened instead of guessing.
+ * route keeps `not_found`/`vanished`/`not_started` (this scope isn't reachable)
+ * distinct from `file_not_found` (the scope is fine; that one file is gone), so
+ * we can tell the reader which of the two actually happened instead of guessing.
  */
 
 import { useEffect, useState } from 'react';
@@ -43,7 +43,7 @@ import { detectLanguageFromFilename, isBinaryFile } from '@pagespace/lib/utils/l
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Button } from '@/components/ui/button';
 import { PaneLoading, PaneNotice } from './tab-states';
-import { CHECKOUT_ABSENT_COPY, asAbsentReason, readErrorBody, type CheckoutAbsentReason } from './checkout-states';
+import { FILES_ABSENT_COPY, asAbsentReason, readErrorBody, type FilesAbsentReason } from './checkout-states';
 
 // Monaco pulls the editor bundle + `window`, so it must never SSR — matches
 // every other MonacoEditor mount in the app (CodePageView, DocumentView, …).
@@ -69,7 +69,7 @@ type FileState =
   | { status: 'loading' }
   | { status: 'loaded'; path: string; content: string; truncated: boolean }
   | { status: 'binary'; path: string }
-  | { status: 'absent'; path: string; reason: CheckoutAbsentReason }
+  | { status: 'absent'; path: string; reason: FilesAbsentReason }
   | { status: 'error'; path: string; message: string };
 
 const NUL_CHAR_CODE = 0;
@@ -219,8 +219,8 @@ export default function FilesFilePane({ machineId, projectName, branchName, path
         {current.status === 'absent' && (
           <PaneNotice
             testId="checkout-absent-pane"
-            title={CHECKOUT_ABSENT_COPY[current.reason].title}
-            description={CHECKOUT_ABSENT_COPY[current.reason].description}
+            title={FILES_ABSENT_COPY[current.reason].title}
+            description={FILES_ABSENT_COPY[current.reason].description}
           />
         )}
         {current.status === 'error' && (

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesFilePane.tsx
@@ -2,21 +2,23 @@
 
 /**
  * FilesFilePane — the Files tab's main pane: fetches ONE selected file's content
- * from the machine files route (`mode=read`) and shows it in a read-only Monaco
- * (Machine page rebuild, Phase 3).
+ * from the machine files route (`mode=read`) and shows it in a read-only Monaco.
+ * Scoped by `FilesScope` (Machine Files Manager epic, Part A) — either the
+ * Machine's own root Sprite (`/workspace`) or a project/branch checkout within
+ * it — like its sibling {@link MachineFileTree}.
  *
- * Read-only by design — this tab views a live checkout, it does not edit it, so
- * Monaco is mounted with `readOnly` and there is no onChange/save path. Content
- * is fetched lazily: the pane only mounts once a file is actually clicked (the
- * tab renders a placeholder until then), and every settled state carries the
- * path it settled for, so the pane can never paint one file's content under
- * another's name. The route caps a single read at 2 MiB and reports `truncated`
- * when it clips a larger file; that surfaces as a banner so a partial view is
- * never mistaken for the whole file. The working tree is LIVE (an agent terminal
- * can rewrite the open file), and re-clicking the same row in the tree is a
- * no-op, so the header carries a reload.
+ * Read-only by design — this tab views a live filesystem, it does not edit it,
+ * so Monaco is mounted with `readOnly` and there is no onChange/save path.
+ * Content is fetched lazily: the pane only mounts once a file is actually
+ * clicked (the tab renders a placeholder until then), and every settled state
+ * carries the path it settled for, so the pane can never paint one file's
+ * content under another's name. The route caps a single read at 2 MiB and
+ * reports `truncated` when it clips a larger file; that surfaces as a banner so
+ * a partial view is never mistaken for the whole file. The working tree is LIVE
+ * (an agent terminal can rewrite the open file), and re-clicking the same row
+ * in the tree is a no-op, so the header carries a reload.
  *
- * BINARIES. A real working tree is full of them — images, fonts, archives,
+ * BINARIES. A real filesystem is full of them — images, fonts, archives,
  * `.node` addons, `__pycache__` — and the route decodes whatever it reads as
  * UTF-8, so a binary would land in Monaco as mojibake. Two guards, because
  * neither alone is enough:
@@ -44,6 +46,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Button } from '@/components/ui/button';
 import { PaneLoading, PaneNotice } from './tab-states';
 import { FILES_ABSENT_COPY, asAbsentReason, readErrorBody, type FilesAbsentReason } from './checkout-states';
+import { type FilesScope, filesScopeSearchParams } from './files-scope';
 
 // Monaco pulls the editor bundle + `window`, so it must never SSR — matches
 // every other MonacoEditor mount in the app (CodePageView, DocumentView, …).
@@ -51,9 +54,8 @@ const MonacoEditor = dynamic(() => import('@/components/editors/MonacoEditor'), 
 
 interface FilesFilePaneProps {
   machineId: string;
-  projectName: string;
-  branchName: string;
-  /** Checkout-relative path of the file to show, e.g. `src/index.ts`. */
+  scope: FilesScope;
+  /** Path of the file to show, relative to the scope root, e.g. `src/index.ts`. */
   path: string;
 }
 
@@ -106,7 +108,7 @@ const looksBinary = (content: string): boolean => {
   return replacements >= MIN_REPLACEMENTS && replacements / sample.length > MAX_REPLACEMENT_RATIO;
 };
 
-export default function FilesFilePane({ machineId, projectName, branchName, path }: FilesFilePaneProps) {
+export default function FilesFilePane({ machineId, scope, path }: FilesFilePaneProps) {
   const [state, setState] = useState<FileState>({ status: 'loading' });
   // Bumped by Retry to re-run the read without changing the selected file.
   const [attempt, setAttempt] = useState(0);
@@ -127,16 +129,19 @@ export default function FilesFilePane({ machineId, projectName, branchName, path
 
     const load = async () => {
       try {
-        const search = new URLSearchParams({ machineId, projectName, branchName, path, mode: 'read' });
+        const search = filesScopeSearchParams(machineId, scope);
+        search.set('path', path);
+        search.set('mode', 'read');
         const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
         if (cancelled) return;
 
         if (!res.ok) {
           const { error, reason } = readErrorBody(await res.json().catch(() => null));
           if (cancelled) return;
-          // The route keeps "this branch has no checkout" (`not_found`/`vanished`)
-          // and "that one file is gone" (`file_not_found`) as distinct reasons, so
-          // we can tell the reader which actually happened instead of guessing.
+          // The route keeps "this scope isn't reachable" (`not_found`/`vanished`/
+          // `not_started`) and "that one file is gone" (`file_not_found`) as
+          // distinct reasons, so we can tell the reader which actually happened
+          // instead of guessing.
           const absent = asAbsentReason(reason);
           if (absent !== null) {
             setState({ status: 'absent', path, reason: absent });
@@ -144,7 +149,9 @@ export default function FilesFilePane({ machineId, projectName, branchName, path
           }
           throw new Error(
             reason === 'file_not_found'
-              ? 'This file is no longer in the checkout.'
+              ? scope.kind === 'branch'
+                ? 'This file is no longer in the checkout.'
+                : 'This file is no longer on the machine.'
               : error ?? `Failed to read file (${res.status})`,
           );
         }
@@ -171,7 +178,12 @@ export default function FilesFilePane({ machineId, projectName, branchName, path
     return () => {
       cancelled = true;
     };
-  }, [machineId, projectName, branchName, path, fileName, attempt]);
+    // `scope` is safe alongside `path` here even though it isn't part of the
+    // effect's cache-busting story: the pane only ever mounts while `path` is
+    // non-null, and FilesTab's Selection nulls `path` in the very same state
+    // update that changes `scope` — so a scope change can never fire this
+    // effect on its own; `path` becoming null unmounts the pane first.
+  }, [machineId, scope, path, fileName, attempt]);
 
   // The state of a DIFFERENT file is not this file's state — until the effect
   // catches up, we have nothing to show but the spinner. (See FileState.)

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -55,18 +55,25 @@ vi.mock('../workspace/MachineFileTree', () => ({
   default: function MachineFileTreeStub({
     scope,
     onSelectFile,
+    onPathRemoved,
   }: {
     scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
     onSelectFile?: (path: string) => void;
+    onPathRemoved?: (path: string) => void;
   }) {
     const scopeName = scope.kind === 'branch' ? scope.branchName : 'root';
     useEffect(() => {
       treeListings.push(scopeName);
     }, [scopeName]);
     return (
-      <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
-        tree:{scopeName}
-      </button>
+      <div>
+        <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
+          tree:{scopeName}
+        </button>
+        <button type="button" data-testid="delete-open-file" onClick={() => onPathRemoved?.('src/index.ts')}>
+          delete-open-file
+        </button>
+      </div>
     );
   },
 }));
@@ -423,6 +430,31 @@ describe('FilesTab', () => {
       should: 'render the file pane scoped to that branch and path',
       actual: pane.textContent,
       expected: 'pane:main:src/index.ts',
+    });
+  });
+
+  test('deleting the open file clears the pane', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
+
+    await userEvent.click(screen.getByText('pick-main'));
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByTestId('delete-open-file'));
+
+    assert({
+      given: 'the currently open file deleted from the tree',
+      should: 'clear the open file and fall back to the pick-a-file prompt',
+      actual: {
+        pane: screen.queryByTestId('file-pane'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
+      },
+      expected: { pane: null, filePrompt: true },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -46,12 +46,13 @@ const treeListings: string[] = [];
 
 vi.mock('../workspace/MachineFileTree', () => ({
   default: function MachineFileTreeStub({
-    branchName,
+    scope,
     onSelectFile,
   }: {
-    branchName: string;
+    scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
     onSelectFile?: (path: string) => void;
   }) {
+    const branchName = scope.kind === 'branch' ? scope.branchName : 'root';
     useEffect(() => {
       treeListings.push(branchName);
     }, [branchName]);
@@ -65,8 +66,16 @@ vi.mock('../workspace/MachineFileTree', () => ({
 
 // Stub the main pane so FilesTab's composition (which file, which branch) is what's asserted.
 vi.mock('./FilesFilePane', () => ({
-  default: ({ path, branchName }: { path: string; branchName: string }) => (
-    <div data-testid="file-pane">pane:{branchName}:{path}</div>
+  default: ({
+    path,
+    scope,
+  }: {
+    path: string;
+    scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
+  }) => (
+    <div data-testid="file-pane">
+      pane:{scope.kind === 'branch' ? scope.branchName : 'root'}:{path}
+    </div>
   ),
 }));
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -8,13 +8,19 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
-// Stub the branch picker: expose one button per node kind so a test can drive
+// Stub the scope picker: expose one button per node kind so a test can drive
 // exactly the selection FilesTab reacts to, without pulling MachineTree's whole
 // projects/branches hook subtree.
 vi.mock('../workspace/MachineTree', () => ({
   default: ({ onSelectNode }: { onSelectNode?: (node: unknown) => void }) => (
     <div>
       <button type="button" onClick={() => onSelectNode?.({ level: 'machine' })}>pick-machine</button>
+      <button
+        type="button"
+        onClick={() => onSelectNode?.({ level: 'project', projectName: 'repo' })}
+      >
+        pick-project
+      </button>
       <button
         type="button"
         onClick={() => onSelectNode?.({ level: 'branch', projectName: 'repo', branchName: 'main' })}
@@ -32,15 +38,16 @@ vi.mock('../workspace/MachineTree', () => ({
 }));
 
 /**
- * Every root listing the (stubbed) file tree performs, in order.
+ * Every root/branch listing the (stubbed) file tree performs, in order,
+ * identified by `'root'` or the branch name.
  *
  * The stub MUST model the one behaviour of the real MachineFileTree that this
- * tab's correctness depends on: it self-keys on `${machineId}/${projectName}/
- * ${branchName}`, so mounting it — or handing it a new branch — fetches that
- * branch's root listing. A dumb stub that never fetches would let the "no wasted
- * listing" test pass even with FilesTab's key deleted, which is exactly the hole
- * a reviewer caught: the wasted listing came from the REAL tree, so a stub that
- * doesn't list cannot witness it.
+ * tab's correctness depends on: it self-keys on the scope, so mounting it — or
+ * handing it a new scope — fetches that scope's root listing. A dumb stub that
+ * never fetches would let the "no wasted listing" test pass even with
+ * FilesTab's key deleted, which is exactly the hole a reviewer caught: the
+ * wasted listing came from the REAL tree, so a stub that doesn't list cannot
+ * witness it.
  */
 const treeListings: string[] = [];
 
@@ -52,19 +59,19 @@ vi.mock('../workspace/MachineFileTree', () => ({
     scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
     onSelectFile?: (path: string) => void;
   }) {
-    const branchName = scope.kind === 'branch' ? scope.branchName : 'root';
+    const scopeName = scope.kind === 'branch' ? scope.branchName : 'root';
     useEffect(() => {
-      treeListings.push(branchName);
-    }, [branchName]);
+      treeListings.push(scopeName);
+    }, [scopeName]);
     return (
       <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
-        tree:{branchName}
+        tree:{scopeName}
       </button>
     );
   },
 }));
 
-// Stub the main pane so FilesTab's composition (which file, which branch) is what's asserted.
+// Stub the main pane so FilesTab's composition (which file, which scope) is what's asserted.
 vi.mock('./FilesFilePane', () => ({
   default: ({
     path,
@@ -85,14 +92,23 @@ import FilesTab from './FilesTab';
 const jsonResponse = (body: unknown, status = 200) =>
   new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 
-/** Serve the checkout-root probe: `ready` for known branches, an absence reason otherwise. */
-const cannedFetch = (perBranch: Record<string, () => Promise<Response>>) =>
+/**
+ * Serve the scope-root probe, keyed by `'root'` or the branch name (a request
+ * with no `branchName` param is root scope).
+ */
+const cannedFetch = (perScope: Record<string, () => Promise<Response>>) =>
   vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
-    const branch = new URL(String(args[0]), 'http://test').searchParams.get('branchName') ?? '';
-    const handler = perBranch[branch];
+    const params = new URL(String(args[0]), 'http://test').searchParams;
+    const scopeKey = params.get('branchName') ?? 'root';
+    const handler = perScope[scopeKey];
     if (handler) return handler();
-    return jsonResponse({ error: 'unexpected branch' }, 500);
+    return jsonResponse({ error: 'unexpected scope' }, 500);
   });
+
+const scopesProbed = () =>
+  vi
+    .mocked(fetchWithAuth)
+    .mock.calls.map((call) => new URL(String(call[0]), 'http://test').searchParams.get('branchName') ?? 'root');
 
 describe('FilesTab', () => {
   beforeEach(() => {
@@ -100,85 +116,185 @@ describe('FilesTab', () => {
     treeListings.length = 0;
   });
 
-  test('shows the branch prompt before any branch is picked', () => {
-    cannedFetch({});
+  test('mounts immediately in root scope, probing it exactly once with no project/branch params', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
     render(<FilesTab machineId="machine-1" />);
+
+    const tree = await waitFor(() => screen.getByTestId('file-tree'));
+    const firstRequestParams = new URL(String(vi.mocked(fetchWithAuth).mock.calls[0][0]), 'http://test').searchParams;
 
     assert({
       given: 'a freshly mounted Files tab',
-      should: 'prompt to select a branch and probe nothing',
+      should: 'probe the root scope exactly once and mount its file tree, with no branch pick required',
       actual: {
-        prompt: screen.queryByText('Select a branch to browse its checkout.') !== null,
-        fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+        tree: tree.textContent,
+        probes: vi.mocked(fetchWithAuth).mock.calls.length,
+        hasBranchParams: firstRequestParams.has('projectName') || firstRequestParams.has('branchName'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
       },
-      expected: { prompt: true, fetches: 0 },
+      expected: { tree: 'tree:root', probes: 1, hasBranchParams: false, filePrompt: true },
     });
   });
 
-  test('selecting a machine (non-branch) node is ignored', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+  test('selecting a project (non-machine, non-branch) node is ignored', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByTestId('file-tree'));
 
-    await userEvent.click(screen.getByText('pick-machine'));
+    await userEvent.click(screen.getByText('pick-project'));
 
     assert({
-      given: 'a machine-level node selected (no checkout to browse)',
-      should: 'keep the branch prompt and issue no probe',
+      given: 'a project-level node selected (no filesystem of its own)',
+      should: 'keep the current root scope and issue no additional probe',
       actual: {
-        prompt: screen.queryByText('Select a branch to browse its checkout.') !== null,
-        fetches: vi.mocked(fetchWithAuth).mock.calls.length,
+        tree: screen.getByTestId('file-tree').textContent,
+        probes: vi.mocked(fetchWithAuth).mock.calls.length,
       },
-      expected: { prompt: true, fetches: 0 },
+      expected: { tree: 'tree:root', probes: 1 },
     });
   });
 
-  test('picking a ready branch probes its checkout ONCE and mounts the file tree', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+  test('a never-started machine shows the not-started empty state, not the file tree', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ error: "This machine hasn't been started yet", reason: 'not_started' }, 404),
+    });
     render(<FilesTab machineId="machine-1" />);
+
+    await waitFor(() => screen.getByTestId('checkout-absent'));
+
+    assert({
+      given: "a root scope probe that returns reason 'not_started'",
+      should: 'show the not-started empty state and never mount the file tree',
+      actual: {
+        empty: screen.queryByText("This machine hasn't been started yet") !== null,
+        tree: screen.queryByTestId('file-tree'),
+      },
+      expected: { empty: true, tree: null },
+    });
+  });
+
+  test('"Check again" mounts the root tree once a never-started machine has been started', async () => {
+    let started = false;
+    cannedFetch({
+      root: async () =>
+        started
+          ? jsonResponse({ entries: [] })
+          : jsonResponse({ error: "This machine hasn't been started yet", reason: 'not_started' }, 404),
+    });
+    render(<FilesTab machineId="machine-1" />);
+
+    await waitFor(() => screen.getByTestId('checkout-absent'));
+
+    started = true; // the user opened the Terminal tab and started it
+    await userEvent.click(screen.getByText('Check again'));
+    await waitFor(() => screen.getByTestId('file-tree'));
+
+    assert({
+      given: 'a never-started machine that gets started, then "Check again" clicked',
+      should: 're-probe and mount the root file tree without needing a branch pick',
+      actual: {
+        tree: screen.getByTestId('file-tree').textContent,
+        absent: screen.queryByTestId('checkout-absent'),
+      },
+      expected: { tree: 'tree:root', absent: null },
+    });
+  });
+
+  test('picking a branch switches from root scope to that branch checkout, probing it once', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     const tree = await waitFor(() => screen.getByTestId('file-tree'));
 
     assert({
-      given: 'a branch whose checkout probe returns 200',
-      should: 'render the file tree for that branch, having probed exactly once',
+      given: 'a branch picked while root scope was already ready',
+      should: 'render the file tree for that branch, having probed root once and the branch once',
       actual: {
         tree: tree.textContent,
-        probes: vi.mocked(fetchWithAuth).mock.calls.length,
+        probed: scopesProbed(),
         filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
       },
-      expected: { tree: 'tree:main', probes: 1, filePrompt: true },
+      expected: { tree: 'tree:main', probed: ['root', 'main'], filePrompt: true },
     });
   });
 
-  test('switching branches never mounts the file tree against a stale ready state', async () => {
+  test('scope switches (root -> branch -> root) never mount the file tree against a stale ready state', async () => {
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ entries: [] }),
-      dev: async () => jsonResponse({ entries: [] }),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByText('tree:main'));
-    await userEvent.click(screen.getByText('pick-dev'));
-    await waitFor(() => screen.getByText('tree:dev'));
-
-    const branchesProbed = vi
-      .mocked(fetchWithAuth)
-      .mock.calls.map((call) => new URL(String(call[0]), 'http://test').searchParams.get('branchName'));
+    await userEvent.click(screen.getByText('pick-machine'));
+    await waitFor(() => screen.getByText('tree:root'));
 
     assert({
-      given: 'a branch switch after the first branch was already ready',
+      given: 'a root -> branch -> root scope walk',
       should:
-        'list each branch root exactly once — BranchFiles is keyed by branch, so the tree is never mounted at the new branch under the old ready state (unkeyed, dev is listed twice: once thrown away)',
-      actual: { probed: branchesProbed, listed: treeListings },
-      expected: { probed: ['main', 'dev'], listed: ['main', 'dev'] },
+        'list each scope visit exactly once — ScopeFiles is keyed by scope, so the tree is never mounted at a new scope under a stale ready state',
+      actual: { probed: scopesProbed(), listed: treeListings },
+      expected: { probed: ['root', 'main', 'root'], listed: ['root', 'main', 'root'] },
+    });
+  });
+
+  test('picking the machine node returns to root scope and drops the open file', async () => {
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
+    render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
+
+    await userEvent.click(screen.getByText('pick-main'));
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByText('pick-machine'));
+    await waitFor(() => screen.getByText('tree:root'));
+
+    assert({
+      given: 'a file open on a branch, then the machine node picked',
+      should: 'clear the open file and fall back to the pick-a-file prompt',
+      actual: {
+        pane: screen.queryByTestId('file-pane'),
+        filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
+      },
+      expected: { pane: null, filePrompt: true },
+    });
+  });
+
+  test('re-picking root while already on root keeps the open file', async () => {
+    cannedFetch({ root: async () => jsonResponse({ entries: [] }) });
+    render(<FilesTab machineId="machine-1" />);
+
+    await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+    await waitFor(() => screen.getByTestId('file-pane'));
+
+    await userEvent.click(screen.getByText('pick-machine')); // already root
+
+    assert({
+      given: 'the root scope re-picked while already selected',
+      should: 'leave the open file alone (only a DIFFERENT scope invalidates the path)',
+      actual: screen.queryByTestId('file-pane')?.textContent ?? null,
+      expected: 'pane:root:src/index.ts',
     });
   });
 
   test('re-picking the branch already open keeps the open file', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -188,15 +304,19 @@ describe('FilesTab', () => {
 
     assert({
       given: 'the branch that is already selected picked a second time',
-      should: 'leave the open file alone (only a DIFFERENT branch invalidates the path)',
+      should: 'leave the open file alone (only a DIFFERENT scope invalidates the path)',
       actual: screen.queryByTestId('file-pane')?.textContent ?? null,
       expected: 'pane:main:src/index.ts',
     });
   });
 
   test('a not-yet-cloned branch shows the empty state, not the file tree', async () => {
-    cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine not_found', reason: 'not_found' }, 404) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ error: 'Branch machine not_found', reason: 'not_found' }, 404),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -213,8 +333,12 @@ describe('FilesTab', () => {
   });
 
   test("a vanished sandbox reports the checkout is gone", async () => {
-    cannedFetch({ main: async () => jsonResponse({ error: 'Branch machine vanished', reason: 'vanished' }, 503) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ error: 'Branch machine vanished', reason: 'vanished' }, 503),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     const gone = await waitFor(() => screen.getByText('This branch checkout is gone'));
@@ -231,9 +355,11 @@ describe('FilesTab', () => {
     // The invariant behind the absent/error split: "no checkout" is a state of
     // the world; a permission failure is not, and must never be shown as one.
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ error: 'You do not have access to this machine' }, 403),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-error'));
@@ -253,12 +379,14 @@ describe('FilesTab', () => {
   test('“Check again” re-probes a branch that has since been cloned', async () => {
     let cloned = false;
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () =>
         cloned
           ? jsonResponse({ entries: [] })
           : jsonResponse({ error: 'This branch checkout is unavailable', reason: 'not_found' }, 404),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await waitFor(() => screen.getByTestId('checkout-absent'));
@@ -279,8 +407,12 @@ describe('FilesTab', () => {
   });
 
   test('selecting a file in the tree opens it in the main pane', async () => {
-    cannedFetch({ main: async () => jsonResponse({ entries: [] }) });
+    cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
+      main: async () => jsonResponse({ entries: [] }),
+    });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
@@ -296,10 +428,12 @@ describe('FilesTab', () => {
 
   test('switching branches drops the previously open file', async () => {
     cannedFetch({
+      root: async () => jsonResponse({ entries: [] }),
       main: async () => jsonResponse({ entries: [] }),
       dev: async () => jsonResponse({ entries: [] }),
     });
     render(<FilesTab machineId="machine-1" />);
+    await waitFor(() => screen.getByText('tree:root'));
 
     await userEvent.click(screen.getByText('pick-main'));
     await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.test.tsx
@@ -70,6 +70,9 @@ vi.mock('../workspace/MachineFileTree', () => ({
         <button type="button" data-testid="file-tree" onClick={() => onSelectFile?.('src/index.ts')}>
           tree:{scopeName}
         </button>
+        <button type="button" data-testid="file-tree-other" onClick={() => onSelectFile?.('src/other.ts')}>
+          tree-other:{scopeName}
+        </button>
         <button type="button" data-testid="delete-open-file" onClick={() => onPathRemoved?.('src/index.ts')}>
           delete-open-file
         </button>
@@ -78,17 +81,26 @@ vi.mock('../workspace/MachineFileTree', () => ({
   },
 }));
 
-// Stub the main pane so FilesTab's composition (which file, which scope) is what's asserted.
+// Stub the main pane so FilesTab's composition (which file, which scope) is
+// what's asserted. `mark-dirty` drives the pane's onDirtyChange report the way
+// a real edit would, so the tab's discard-confirm guard can be exercised.
 vi.mock('./FilesFilePane', () => ({
   default: ({
     path,
     scope,
+    onDirtyChange,
   }: {
     path: string;
     scope: { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
+    onDirtyChange?: (dirty: boolean) => void;
   }) => (
-    <div data-testid="file-pane">
-      pane:{scope.kind === 'branch' ? scope.branchName : 'root'}:{path}
+    <div>
+      <div data-testid="file-pane">
+        pane:{scope.kind === 'branch' ? scope.branchName : 'root'}:{path}
+      </div>
+      <button type="button" data-testid="mark-dirty" onClick={() => onDirtyChange?.(true)}>
+        mark-dirty
+      </button>
     </div>
   ),
 }));
@@ -482,6 +494,108 @@ describe('FilesTab', () => {
         filePrompt: screen.queryByText('Select a file to view its contents.') !== null,
       },
       expected: { pane: null, filePrompt: true },
+    });
+  });
+
+  describe('unsaved-draft navigation guard', () => {
+    const openDirtyRootFile = async () => {
+      cannedFetch({
+        root: async () => jsonResponse({ entries: [] }),
+        main: async () => jsonResponse({ entries: [] }),
+      });
+      render(<FilesTab machineId="machine-1" />);
+      await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+      await waitFor(() => screen.getByTestId('file-pane'));
+      await userEvent.click(screen.getByTestId('mark-dirty'));
+    };
+
+    test('clicking another file with a dirty draft asks first, and a decline keeps the open file', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await openDirtyRootFile();
+
+      await userEvent.click(screen.getByTestId('file-tree-other'));
+
+      assert({
+        given: 'a dirty draft and a click on a different file, with the confirm declined',
+        should: 'ask before discarding and keep the original file open',
+        actual: {
+          asked: confirmSpy.mock.calls.length,
+          pane: screen.getByTestId('file-pane').textContent?.startsWith('pane:root:src/index.ts'),
+        },
+        expected: { asked: 1, pane: true },
+      });
+      confirmSpy.mockRestore();
+    });
+
+    test('accepting the confirm discards the draft and opens the clicked file', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      await openDirtyRootFile();
+
+      await userEvent.click(screen.getByTestId('file-tree-other'));
+
+      assert({
+        given: 'a dirty draft and a click on a different file, with the confirm accepted',
+        should: 'switch to the clicked file',
+        actual: screen.getByTestId('file-pane').textContent?.startsWith('pane:root:src/other.ts'),
+        expected: true,
+      });
+      confirmSpy.mockRestore();
+    });
+
+    test('switching scope with a dirty draft asks first, and a decline keeps scope and file', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await openDirtyRootFile();
+
+      await userEvent.click(screen.getByText('pick-main'));
+
+      assert({
+        given: 'a dirty draft and a branch pick, with the confirm declined',
+        should: 'stay on root scope with the file still open',
+        actual: {
+          asked: confirmSpy.mock.calls.length,
+          tree: screen.queryByText('tree:root') !== null,
+          pane: screen.getByTestId('file-pane').textContent?.startsWith('pane:root:src/index.ts'),
+        },
+        expected: { asked: 1, tree: true, pane: true },
+      });
+      confirmSpy.mockRestore();
+    });
+
+    test('re-clicking the already-open file never asks', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await openDirtyRootFile();
+
+      await userEvent.click(screen.getByTestId('file-tree'));
+
+      assert({
+        given: 'a dirty draft and a re-click on the same open file',
+        should: 'treat it as a no-op, not a discard',
+        actual: { asked: confirmSpy.mock.calls.length, pane: screen.queryByTestId('file-pane') !== null },
+        expected: { asked: 0, pane: true },
+      });
+      confirmSpy.mockRestore();
+    });
+
+    test('clean navigation never asks', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+      cannedFetch({
+        root: async () => jsonResponse({ entries: [] }),
+        main: async () => jsonResponse({ entries: [] }),
+      });
+      render(<FilesTab machineId="machine-1" />);
+      await userEvent.click(await waitFor(() => screen.getByTestId('file-tree')));
+      await waitFor(() => screen.getByTestId('file-pane'));
+
+      await userEvent.click(screen.getByTestId('file-tree-other'));
+      await userEvent.click(screen.getByText('pick-main'));
+
+      assert({
+        given: 'navigation with no dirty draft',
+        should: 'never show a discard confirm',
+        actual: confirmSpy.mock.calls.length,
+        expected: 0,
+      });
+      confirmSpy.mockRestore();
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -37,10 +37,10 @@ import FilesFilePane from './FilesFilePane';
 import TabSidebar from './TabSidebar';
 import { PaneNotice, SidebarLoading, SidebarNotice } from './tab-states';
 import {
-  CHECKOUT_ABSENT_COPY,
+  FILES_ABSENT_COPY,
   asAbsentReason,
   readErrorBody,
-  type CheckoutAbsentReason,
+  type FilesAbsentReason,
 } from './checkout-states';
 
 interface FilesTabProps {
@@ -153,7 +153,7 @@ export default function FilesTab({ machineId }: FilesTabProps) {
 type CheckoutState =
   | { status: 'loading' }
   | { status: 'ready' }
-  | { status: 'absent'; reason: CheckoutAbsentReason }
+  | { status: 'absent'; reason: FilesAbsentReason }
   | { status: 'error'; message: string };
 
 /**
@@ -239,7 +239,7 @@ function BranchFiles({
   const retry = () => setAttempt((a) => a + 1);
 
   if (state.status === 'absent') {
-    const copy = CHECKOUT_ABSENT_COPY[state.reason];
+    const copy = FILES_ABSENT_COPY[state.reason];
     return (
       <SidebarNotice
         testId="checkout-absent"

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -1,31 +1,39 @@
 "use client";
 
 /**
- * FilesTab — the Machine page's Files tab: a read-only viewer over a branch
- * checkout's working tree (Machine page rebuild, Phase 3).
+ * FilesTab — the Machine page's Files tab: a file-system viewer that defaults
+ * to the Machine's own root Sprite filesystem (`/workspace`), with a project's
+ * branch checkout browsable as an additional, opt-in scope (Machine Files
+ * Manager epic, Part A).
  *
  * Composes the pieces the earlier phases landed: an inner page-scoped sidebar
  * (plain border-border chrome, deliberately NOT one of the app's liquid-glass
  * sidebars — same shell as {@link TerminalTab}) holding a BARE {@link MachineTree}
- * as the branch picker, then a {@link MachineFileTree} over the picked branch's
- * checkout; and a main pane with a read-only Monaco showing the selected file.
+ * as the scope picker, then a {@link MachineFileTree} over whichever scope is
+ * selected; and a main pane with a read-only Monaco showing the selected file.
  *
- * A checkout only exists on a branch-terminal's OWN Sprite once that branch has
- * been cloned, and nothing in `machine_branches` tracks clone state (the store
- * row carries only a `sandboxId`) — so "is there a checkout?" is answered by the
- * live filesystem, not the DB. The files route already gives a clean, typed
- * signal for it: branch resolution failures come back as `reason: 'not_found'`
- * (no tracking row, or the repo dir isn't there) or `reason: 'vanished'` (the row
- * is there but its Sprite is gone). {@link BranchFiles} probes the checkout root
- * once per branch and turns both into an explicit empty state rather than letting
- * MachineFileTree render them as a raw error row. An `exec_failed` is NOT folded
- * in: a broken exec is a real error and stays one.
+ * A branch checkout only exists on a branch-terminal's OWN Sprite once that
+ * branch has been cloned, and nothing in `machine_branches` tracks clone state
+ * (the store row carries only a `sandboxId`) — so "is there a checkout?" is
+ * answered by the live filesystem, not the DB. Root scope has an absence of
+ * its own kind: a Machine whose Terminal was never opened has no Sprite at
+ * all yet. The files route gives a clean, typed signal for all three cases:
+ * branch resolution failures come back as `reason: 'not_found'` (no tracking
+ * row, or the repo dir isn't there) or `reason: 'vanished'` (the row is there
+ * but its Sprite is gone); root resolution failure is `reason: 'not_started'`
+ * (no Sprite has ever been provisioned). {@link ScopeFiles} probes the scope
+ * root once per scope and turns all three into an explicit empty state rather
+ * than letting MachineFileTree render them as a raw error row. An
+ * `exec_failed` is NOT folded in: a broken exec is a real error and stays one.
  *
- * Selection (branch + open file) is ONE piece of state, and both children are
- * keyed by it. A path only means something inside the checkout it came from, so
- * a branch switch drops the open file in the same update — and the key makes the
- * switch a remount, which is what stops a stale `ready` from flashing the file
- * tree at the new branch and firing a listing that gets thrown away.
+ * Selection (scope + open file) is ONE piece of state, and both children are
+ * keyed by it. A path only means something inside the scope it came from, so
+ * a scope switch drops the open file in the same update — and the key makes
+ * the switch a remount, which is what stops a stale `ready` from flashing the
+ * file tree at the new scope and firing a listing that gets thrown away. Root
+ * is the initial scope, so the Machine's own files render immediately with no
+ * pick required; picking a branch is additive, unchanged browsing on top of
+ * that default.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -36,6 +44,7 @@ import MachineFileTree from '../workspace/MachineFileTree';
 import FilesFilePane from './FilesFilePane';
 import TabSidebar from './TabSidebar';
 import { PaneNotice, SidebarLoading, SidebarNotice } from './tab-states';
+import { type FilesScope, filesScopeKey, filesScopeSearchParams } from './files-scope';
 import {
   FILES_ABSENT_COPY,
   asAbsentReason,
@@ -48,36 +57,40 @@ interface FilesTabProps {
   machineId: string;
 }
 
-/** The branch whose checkout the tab is browsing, and the file open from it. */
+/** The scope the tab is browsing, and the file open from it. */
 interface Selection {
-  branch: { projectName: string; branchName: string } | null;
-  /** Checkout-relative path, only ever meaningful within `branch`. */
+  scope: FilesScope;
+  /** Scope-relative path, only ever meaningful within `scope`. */
   path: string | null;
 }
 
-/**
- * Identity of a branch's checkout — also the React key that scopes per-branch
- * state. JSON-encoded rather than joined on a separator so that no project /
- * branch name pair can collide (a branch name may legally contain `/`).
- */
-const branchKey = (branch: NonNullable<Selection['branch']>): string =>
-  JSON.stringify([branch.projectName, branch.branchName]);
+const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
+
+/** The `MachineTree` node that corresponds to a scope, for the selection highlight. */
+const selectedNodeFor = (scope: FilesScope): MachineTreeNode =>
+  scope.kind === 'root'
+    ? MACHINE_NODE
+    : { level: 'branch', projectName: scope.projectName, branchName: scope.branchName };
 
 export default function FilesTab({ machineId }: FilesTabProps) {
-  // Branch and path move as ONE value: a path only means something inside the
-  // checkout it came from, so switching branches must drop the open file in the
-  // same update — never as a second, separately-scheduled setState.
-  const [{ branch, path }, setSelection] = useState<Selection>({ branch: null, path: null });
+  // Scope and path move as ONE value: a path only means something inside the
+  // scope it came from, so switching scopes must drop the open file in the
+  // same update — never as a second, separately-scheduled setState. Root is
+  // the initial scope, so files render immediately with no pick required.
+  const [{ scope, path }, setSelection] = useState<Selection>({ scope: { kind: 'root' }, path: null });
 
   const onSelectNode = useCallback((node: MachineTreeNode) => {
-    // Only a branch has a checkout to browse. Machine/Project rows stay
-    // expand-only (their chevron still works) — selecting one would have no
-    // file tree to show.
-    if (node.level !== 'branch') return;
+    // Projects are expand-only groupings with no filesystem of their own —
+    // their chevron still works, but selecting one has no scope to switch to.
+    if (node.level === 'project') return;
+    const nextScope: FilesScope =
+      node.level === 'machine'
+        ? { kind: 'root' }
+        : { kind: 'branch', projectName: node.projectName, branchName: node.branchName };
     setSelection((current) =>
-      current.branch?.projectName === node.projectName && current.branch.branchName === node.branchName
-        ? current // re-picking the open branch keeps the open file
-        : { branch: { projectName: node.projectName, branchName: node.branchName }, path: null },
+      filesScopeKey(current.scope) === filesScopeKey(nextScope)
+        ? current // re-picking the open scope keeps the open file
+        : { scope: nextScope, path: null },
     );
   }, []);
 
@@ -89,24 +102,18 @@ export default function FilesTab({ machineId }: FilesTabProps) {
     <TabSidebar
       title="Files"
       pane={
-        branch && path ? (
+        path ? (
           // Deliberately UNKEYED. Keying by path would tear down and recreate
           // Monaco on every file click; the pane doesn't need it, because it
           // refuses to render a state belonging to a different file. Keying by
-          // branch would be dead code: a branch switch clears `path` in the same
+          // scope would be dead code: a scope switch clears `path` in the same
           // update, so the pane unmounts anyway.
-          <FilesFilePane
-            machineId={machineId}
-            scope={{ kind: 'branch', projectName: branch.projectName, branchName: branch.branchName }}
-            path={path}
-          />
+          <FilesFilePane machineId={machineId} scope={scope} path={path} />
         ) : (
           <PaneNotice
             icon={<FileCode2 className="size-6 text-muted-foreground" />}
-            title={branch ? 'No file open' : 'No branch selected'}
-            description={
-              branch ? 'Select a file to view its contents.' : 'Select a branch to browse its checkout.'
-            }
+            title="No file open"
+            description="Select a file to view its contents."
           />
         )
       }
@@ -116,91 +123,95 @@ export default function FilesTab({ machineId }: FilesTabProps) {
           {/* Picking a BRANCH must not close the sheet on mobile — the file the
               user is actually after is one level further in, in the tree that
               picking the branch just revealed. Only opening a file closes it. */}
-          <MachineTree machineId={machineId} onSelectNode={onSelectNode} />
-          {branch && (
-            <div className="border-t border-border">
+          <MachineTree
+            machineId={machineId}
+            onSelectNode={onSelectNode}
+            isNodeSelectable={(n) => n.level !== 'project'}
+            selectedNode={selectedNodeFor(scope)}
+          />
+          <div className="border-t border-border">
+            {scope.kind === 'branch' && (
               <div className="flex min-w-0 items-center gap-1 px-2 pt-2 text-xs text-muted-foreground">
-                <span className="truncate" title={`${branch.projectName} / ${branch.branchName}`}>
-                  {branch.projectName} / {branch.branchName}
+                <span className="truncate" title={`${scope.projectName} / ${scope.branchName}`}>
+                  {scope.projectName} / {scope.branchName}
                 </span>
               </div>
-              {/* Keyed on the branch so a switch REMOUNTS the probe. Without it,
-                  BranchFiles would render one frame still holding the previous
-                  branch's `ready` state, mounting the file tree against the new
-                  branch — a whole root listing fetched and thrown away before
-                  the probe effect resets it. */}
-              <BranchFiles
-                key={branchKey(branch)}
-                machineId={machineId}
-                projectName={branch.projectName}
-                branchName={branch.branchName}
-                onSelectFile={(next) => {
-                  onSelectFile(next);
-                  close();
-                }}
-                selectedPath={path}
-              />
-            </div>
-          )}
+            )}
+            {/* Keyed on the scope so a switch REMOUNTS the probe. Without it,
+                ScopeFiles would render one frame still holding the previous
+                scope's `ready` state, mounting the file tree against the new
+                scope — a whole root listing fetched and thrown away before the
+                probe effect resets it. This applies to root exactly as much as
+                to a branch switch: never special-case root as unkeyed. */}
+            <ScopeFiles
+              key={filesScopeKey(scope)}
+              machineId={machineId}
+              scope={scope}
+              onSelectFile={(next) => {
+                onSelectFile(next);
+                close();
+              }}
+              selectedPath={path}
+            />
+          </div>
         </>
       )}
     </TabSidebar>
   );
 }
 
-/** Whether the branch's checkout exists on its Sprite yet — see the module doc. */
-type CheckoutState =
+/** Whether the scope's filesystem is reachable yet — see the module doc. */
+type ScopeState =
   | { status: 'loading' }
   | { status: 'ready' }
   | { status: 'absent'; reason: FilesAbsentReason }
   | { status: 'error'; message: string };
 
 /**
- * Probes the checkout root once per branch and, only once it answers `ready`,
+ * Probes the scope root once per scope and, only once it answers `ready`,
  * mounts the file tree.
  *
  * COST, stated plainly: the probe is exactly the listing MachineFileTree makes
- * for the root anyway, so a ready branch pays for two root listings — one here,
- * one in the tree. That buys the distinction the tab exists to make: "this
- * branch was never cloned" is a state of the world and belongs in the sidebar as
- * an empty state, not as a red error row buried inside a file tree. The
- * duplicate is bounded — once per branch selection, never per directory, and
- * FilesTab keys us by branch so it cannot fire on a re-render.
+ * for the root anyway, so a ready scope pays for two root listings — one
+ * here, one in the tree. That buys the distinction the tab exists to make:
+ * "this scope isn't reachable yet" is a state of the world and belongs in the
+ * sidebar as an empty state, not as a red error row buried inside a file
+ * tree. The duplicate is bounded — once per scope selection, never per
+ * directory, and FilesTab keys us by scope so it cannot fire on a re-render.
  *
- * It is not free, and it is not the only design: MachineFileTree is mounted here
- * and nowhere else, so it could instead report a root-level absence back to us
- * (an `onRootUnavailable(reason)` prop) and the probe would disappear entirely.
- * That is the better end state and a small refactor; it is deliberately not being
- * done in the same PR that changes this route's contract.
+ * It is not free, and it is not the only design: MachineFileTree is mounted
+ * here and nowhere else, so it could instead report a root-level absence back
+ * to us (an `onRootUnavailable(reason)` prop) and the probe would disappear
+ * entirely. That is the better end state and a small refactor; it is
+ * deliberately not being done in the same PR that changes this route's
+ * contract.
  */
-function BranchFiles({
+function ScopeFiles({
   machineId,
-  projectName,
-  branchName,
+  scope,
   onSelectFile,
   selectedPath,
 }: {
   machineId: string;
-  projectName: string;
-  branchName: string;
+  scope: FilesScope;
   onSelectFile: (path: string) => void;
   selectedPath: string | null;
 }) {
-  const [state, setState] = useState<CheckoutState>({ status: 'loading' });
-  // Bumped by Retry — re-runs the probe without changing the branch identity.
+  const [state, setState] = useState<ScopeState>({ status: 'loading' });
+  // Bumped by Retry — re-runs the probe without changing the scope identity.
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     // Retry makes an in-flight probe's answer stale — this flag, flipped by the
-    // cleanup, keeps it from landing on the newer one. (A branch switch can't
-    // race us at all: FilesTab keys this component by branch, so a switch is a
+    // cleanup, keeps it from landing on the newer one. (A scope switch can't
+    // race us at all: FilesTab keys this component by scope, so a switch is a
     // remount, not a re-render.)
     let cancelled = false;
     setState({ status: 'loading' });
 
     const probe = async () => {
       try {
-        const search = new URLSearchParams({ machineId, projectName, branchName });
+        const search = filesScopeSearchParams(machineId, scope);
         const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
         if (cancelled) return;
         if (res.ok) {
@@ -209,19 +220,19 @@ function BranchFiles({
         }
         const { error, reason } = readErrorBody(await res.json().catch(() => null));
         if (cancelled) return;
-        // `not_found`/`vanished` mean the checkout isn't there — a state of the
-        // world, not a failure. Anything else (403, `exec_failed`, …) IS a
-        // failure and must stay visible as one rather than be dressed up as an
-        // empty state.
+        // `not_found`/`vanished`/`not_started` mean the scope isn't reachable —
+        // a state of the world, not a failure. Anything else (403,
+        // `exec_failed`, …) IS a failure and must stay visible as one rather
+        // than be dressed up as an empty state.
         const absent = asAbsentReason(reason);
         if (absent !== null) {
           setState({ status: 'absent', reason: absent });
           return;
         }
-        setState({ status: 'error', message: error ?? `Failed to open checkout (${res.status})` });
+        setState({ status: 'error', message: error ?? `Failed to open files (${res.status})` });
       } catch (err) {
         if (cancelled) return;
-        setState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to open checkout' });
+        setState({ status: 'error', message: err instanceof Error ? err.message : 'Failed to open files' });
       }
     };
 
@@ -229,10 +240,10 @@ function BranchFiles({
     return () => {
       cancelled = true;
     };
-  }, [machineId, projectName, branchName, attempt]);
+  }, [machineId, scope, attempt]);
 
   if (state.status === 'loading') {
-    return <SidebarLoading message="Opening checkout…" />;
+    return <SidebarLoading message={scope.kind === 'branch' ? 'Opening checkout…' : 'Opening files…'} />;
   }
 
   const retry = () => setAttempt((a) => a + 1);
@@ -262,12 +273,5 @@ function BranchFiles({
     );
   }
 
-  return (
-    <MachineFileTree
-      machineId={machineId}
-      scope={{ kind: 'branch', projectName, branchName }}
-      onSelectFile={onSelectFile}
-      selectedPath={selectedPath}
-    />
-  );
+  return <MachineFileTree machineId={machineId} scope={scope} onSelectFile={onSelectFile} selectedPath={selectedPath} />;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -134,12 +134,16 @@ export default function FilesTab({ machineId }: FilesTabProps) {
     [confirmDiscardIfDirty],
   );
 
+  // Returns whether the navigation was ACCEPTED — a declined dirty-discard
+  // confirm keeps the current file, and the caller (the sheet-closing wrapper
+  // below) must not close over a click that changed nothing. A re-click on the
+  // open file counts as accepted: the file the user asked for IS showing.
   const onSelectFile = useCallback(
-    (next: string) => {
-      // Re-clicking the open file is a no-op, not a discard.
-      if (next === selectionRef.current.path) return;
-      if (!confirmDiscardIfDirty()) return;
+    (next: string): boolean => {
+      if (next === selectionRef.current.path) return true;
+      if (!confirmDiscardIfDirty()) return false;
       setSelection((current) => ({ ...current, path: next }));
+      return true;
     },
     [confirmDiscardIfDirty],
   );
@@ -214,8 +218,11 @@ export default function FilesTab({ machineId }: FilesTabProps) {
               machineId={machineId}
               scope={scope}
               onSelectFile={(next) => {
-                onSelectFile(next);
-                close();
+                // Close the mobile sheet only when navigation actually
+                // happened — a declined dirty-discard confirm keeps the
+                // current file, and yanking the sheet away on top of that
+                // would look like the click was obeyed.
+                if (onSelectFile(next)) close();
               }}
               selectedPath={path}
               onPathRemoved={onPathRemoved}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -34,6 +34,12 @@
  * is the initial scope, so the Machine's own files render immediately with no
  * pick required; picking a branch is additive, unchanged browsing on top of
  * that default.
+ *
+ * `MachineFileTree`'s own create/rename/delete operations (task 11) can hit
+ * the open file — deleting it, deleting an ancestor directory, or renaming
+ * either — so `onPathRemoved`/`onPathRenamed` below clear or retarget `path`
+ * to keep the pane honest. Everything else about those mutations (dialogs,
+ * cache invalidation, request bodies) lives entirely inside the tree.
  */
 
 import { useCallback, useEffect, useState } from 'react';
@@ -98,6 +104,26 @@ export default function FilesTab({ machineId }: FilesTabProps) {
     setSelection((current) => ({ ...current, path: next }));
   }, []);
 
+  // A delete/rename in the tree only matters to the open file if it hit the
+  // open path itself OR one of its ancestor directories — anything else
+  // leaves the pane alone.
+  const onPathRemoved = useCallback((removed: string) => {
+    setSelection((current) =>
+      current.path !== null && (current.path === removed || current.path.startsWith(`${removed}/`))
+        ? { ...current, path: null }
+        : current,
+    );
+  }, []);
+
+  const onPathRenamed = useCallback((from: string, to: string) => {
+    setSelection((current) => {
+      if (current.path === null) return current;
+      if (current.path === from) return { ...current, path: to };
+      if (current.path.startsWith(`${from}/`)) return { ...current, path: `${to}${current.path.slice(from.length)}` };
+      return current;
+    });
+  }, []);
+
   return (
     <TabSidebar
       title="Files"
@@ -152,6 +178,8 @@ export default function FilesTab({ machineId }: FilesTabProps) {
                 close();
               }}
               selectedPath={path}
+              onPathRemoved={onPathRemoved}
+              onPathRenamed={onPathRenamed}
             />
           </div>
         </>
@@ -191,11 +219,15 @@ function ScopeFiles({
   scope,
   onSelectFile,
   selectedPath,
+  onPathRemoved,
+  onPathRenamed,
 }: {
   machineId: string;
   scope: FilesScope;
   onSelectFile: (path: string) => void;
   selectedPath: string | null;
+  onPathRemoved: (path: string) => void;
+  onPathRenamed: (from: string, to: string) => void;
 }) {
   const [state, setState] = useState<ScopeState>({ status: 'loading' });
   // Bumped by Retry — re-runs the probe without changing the scope identity.
@@ -273,5 +305,14 @@ function ScopeFiles({
     );
   }
 
-  return <MachineFileTree machineId={machineId} scope={scope} onSelectFile={onSelectFile} selectedPath={selectedPath} />;
+  return (
+    <MachineFileTree
+      machineId={machineId}
+      scope={scope}
+      onSelectFile={onSelectFile}
+      selectedPath={selectedPath}
+      onPathRemoved={onPathRemoved}
+      onPathRenamed={onPathRenamed}
+    />
+  );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -97,8 +97,7 @@ export default function FilesTab({ machineId }: FilesTabProps) {
           // update, so the pane unmounts anyway.
           <FilesFilePane
             machineId={machineId}
-            projectName={branch.projectName}
-            branchName={branch.branchName}
+            scope={{ kind: 'branch', projectName: branch.projectName, branchName: branch.branchName }}
             path={path}
           />
         ) : (
@@ -266,8 +265,7 @@ function BranchFiles({
   return (
     <MachineFileTree
       machineId={machineId}
-      projectName={projectName}
-      branchName={branchName}
+      scope={{ kind: 'branch', projectName, branchName }}
       onSelectFile={onSelectFile}
       selectedPath={selectedPath}
     />

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/FilesTab.tsx
@@ -40,9 +40,17 @@
  * either — so `onPathRemoved`/`onPathRenamed` below clear or retarget `path`
  * to keep the pane honest. Everything else about those mutations (dialogs,
  * cache invalidation, request bodies) lives entirely inside the tree.
+ *
+ * UNSAVED DRAFTS: the pane reports its dirty state up (`onDirtyChange`), and
+ * the two USER-navigation paths that would drop it — clicking another file,
+ * switching scope — confirm first, with the same wording as the pane's own
+ * Reload confirm. `onPathRemoved`/`onPathRenamed` deliberately do NOT confirm:
+ * they react to a mutation the user already performed in the tree (or that an
+ * agent performed on the live filesystem), where blocking after the fact
+ * protects nothing.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileCode2 } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import MachineTree, { type MachineTreeNode } from '../workspace/MachineTree';
@@ -85,24 +93,56 @@ export default function FilesTab({ machineId }: FilesTabProps) {
   // the initial scope, so files render immediately with no pick required.
   const [{ scope, path }, setSelection] = useState<Selection>({ scope: { kind: 'root' }, path: null });
 
-  const onSelectNode = useCallback((node: MachineTreeNode) => {
-    // Projects are expand-only groupings with no filesystem of their own —
-    // their chevron still works, but selecting one has no scope to switch to.
-    if (node.level === 'project') return;
-    const nextScope: FilesScope =
-      node.level === 'machine'
-        ? { kind: 'root' }
-        : { kind: 'branch', projectName: node.projectName, branchName: node.branchName };
-    setSelection((current) =>
-      filesScopeKey(current.scope) === filesScopeKey(nextScope)
-        ? current // re-picking the open scope keeps the open file
-        : { scope: nextScope, path: null },
-    );
+  // The pane reports whether it holds an unsaved draft (see FilesFilePane's
+  // `onDirtyChange`); the selection ref keeps the guards below stable (their
+  // useCallback([]) identity feeds ScopeFiles) while still reading the CURRENT
+  // selection. Plain-assignment refs, not state — the guards are event
+  // handlers, never render inputs.
+  const dirtyRef = useRef(false);
+  const selectionRef = useRef<Selection>({ scope, path });
+  selectionRef.current = { scope, path };
+  const onDirtyChange = useCallback((dirty: boolean) => {
+    dirtyRef.current = dirty;
   }, []);
 
-  const onSelectFile = useCallback((next: string) => {
-    setSelection((current) => ({ ...current, path: next }));
+  // Navigating away from a dirty draft (another file, another scope) is the
+  // discard path a person actually takes — the pane's Reload confirm alone
+  // would leave ordinary clicks as the one silent way to lose an edit. Same
+  // wording as the pane's Reload confirm, deliberately.
+  const confirmDiscardIfDirty = useCallback((): boolean => {
+    if (!dirtyRef.current) return true;
+    const discard = window.confirm('Discard unsaved changes to this file?');
+    if (discard) dirtyRef.current = false;
+    return discard;
   }, []);
+
+  const onSelectNode = useCallback(
+    (node: MachineTreeNode) => {
+      // Projects are expand-only groupings with no filesystem of their own —
+      // their chevron still works, but selecting one has no scope to switch to.
+      if (node.level === 'project') return;
+      const nextScope: FilesScope =
+        node.level === 'machine'
+          ? { kind: 'root' }
+          : { kind: 'branch', projectName: node.projectName, branchName: node.branchName };
+      // Re-picking the open scope keeps the open file (and any draft) — only a
+      // real switch drops `path`, so only a real switch needs the confirm.
+      if (filesScopeKey(selectionRef.current.scope) === filesScopeKey(nextScope)) return;
+      if (!confirmDiscardIfDirty()) return;
+      setSelection({ scope: nextScope, path: null });
+    },
+    [confirmDiscardIfDirty],
+  );
+
+  const onSelectFile = useCallback(
+    (next: string) => {
+      // Re-clicking the open file is a no-op, not a discard.
+      if (next === selectionRef.current.path) return;
+      if (!confirmDiscardIfDirty()) return;
+      setSelection((current) => ({ ...current, path: next }));
+    },
+    [confirmDiscardIfDirty],
+  );
 
   // A delete/rename in the tree only matters to the open file if it hit the
   // open path itself OR one of its ancestor directories — anything else
@@ -134,7 +174,7 @@ export default function FilesTab({ machineId }: FilesTabProps) {
           // refuses to render a state belonging to a different file. Keying by
           // scope would be dead code: a scope switch clears `path` in the same
           // update, so the pane unmounts anyway.
-          <FilesFilePane machineId={machineId} scope={scope} path={path} />
+          <FilesFilePane machineId={machineId} scope={scope} path={path} onDirtyChange={onDirtyChange} />
         ) : (
           <PaneNotice
             icon={<FileCode2 className="size-6 text-muted-foreground" />}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/__tests__/files-scope.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/__tests__/files-scope.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { filesScopeKey, filesScopeSearchParams } from '../files-scope';
+
+describe('filesScopeKey', () => {
+  it('given root scope, should return the bare literal "root"', () => {
+    expect(filesScopeKey({ kind: 'root' })).toBe('root');
+  });
+
+  it('given branch scope, should return a JSON-encoded key distinct from "root"', () => {
+    const key = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'main' });
+    expect(key).not.toBe('root');
+    expect(key).toBe(JSON.stringify(['branch', 'proj', 'main']));
+  });
+
+  it('given a branch name containing "/", should still never collide with the root key', () => {
+    const key = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'feature/root' });
+    expect(key).not.toBe('root');
+  });
+
+  it('given two different branches, should produce different keys', () => {
+    const a = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'main' });
+    const b = filesScopeKey({ kind: 'branch', projectName: 'proj', branchName: 'dev' });
+    expect(a).not.toBe(b);
+  });
+
+  it('given the same scope twice, should return a stable, equal key', () => {
+    const scope = { kind: 'branch' as const, projectName: 'proj', branchName: 'main' };
+    expect(filesScopeKey(scope)).toBe(filesScopeKey({ ...scope }));
+  });
+});
+
+describe('filesScopeSearchParams', () => {
+  it('given root scope, should include machineId but omit projectName/branchName', () => {
+    const params = filesScopeSearchParams('machine-1', { kind: 'root' });
+    expect(params.get('machineId')).toBe('machine-1');
+    expect(params.has('projectName')).toBe(false);
+    expect(params.has('branchName')).toBe(false);
+  });
+
+  it('given branch scope, should include machineId, projectName, and branchName', () => {
+    const params = filesScopeSearchParams('machine-1', { kind: 'branch', projectName: 'proj', branchName: 'main' });
+    expect(params.get('machineId')).toBe('machine-1');
+    expect(params.get('projectName')).toBe('proj');
+    expect(params.get('branchName')).toBe('main');
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/checkout-states.ts
@@ -1,32 +1,35 @@
 /**
- * Shared vocabulary for the Files tab's "the checkout isn't there" states
- * (Machine page rebuild, Phase 3).
+ * Shared vocabulary for the Files tab's "there's nothing browsable here"
+ * states (Machine Files Manager epic).
  *
- * The files route reports why a branch checkout couldn't be reached with a typed
- * `reason` (see `machine-files-runtime.ts` / `route.ts`), and BOTH surfaces of
- * the tab have to speak about it: the sidebar (which can't list files) and the
- * main pane (which can't read the open file). They live in separate modules and
- * the tab imports the pane, so this copy lives here rather than in either one —
- * importing it back out of FilesTab would be a cycle.
+ * The files route reports why a scope (root Sprite or branch checkout)
+ * couldn't be reached with a typed `reason` (see `machine-files-runtime.ts` /
+ * `route.ts`), and BOTH surfaces of the tab have to speak about it: the
+ * sidebar (which can't list files) and the main pane (which can't read the
+ * open file). They live in separate modules and the tab imports the pane, so
+ * this copy lives here rather than in either one — importing it back out of
+ * FilesTab would be a cycle.
  *
  * The user-facing rule this encodes: NEVER render the route's internal phrasing
- * ("Branch machine vanished") at a person. A checkout that isn't there is a
+ * ("Branch machine vanished") at a person. A scope that isn't reachable is a
  * state of the world, not an error message.
  */
 
 /**
- * The route's absence reasons — a branch we cannot reach a checkout for.
+ * The route's absence reasons — a scope we cannot reach a filesystem for.
  *
- * Note what is NOT here: `file_not_found`. A missing FILE is a fact about one
- * path inside a checkout that exists; these two are facts about the checkout
- * itself. The route keeps the tokens distinct precisely so a client cannot tell
- * a reader "this file is gone" when the whole branch is.
+ * Note what is NOT here: `file_not_found`/`dir_not_found`. A missing file or
+ * folder is a fact about one path inside a scope that IS reachable; these
+ * three are facts about the scope itself (no checkout, checkout reclaimed,
+ * machine never started). The route keeps the tokens distinct precisely so a
+ * client cannot tell a reader "this path is gone" when the whole scope is.
  */
-export type CheckoutAbsentReason = 'not_found' | 'vanished';
+export type FilesAbsentReason = 'not_found' | 'vanished' | 'not_started';
 
-export const CHECKOUT_ABSENT_COPY: Record<CheckoutAbsentReason, { title: string; description: string }> = {
-  // Covers both of the route's 404 sources: no `machine_branches` row at all,
-  // and a row whose Sprite has no `/workspace/repo` yet (never cloned).
+export const FILES_ABSENT_COPY: Record<FilesAbsentReason, { title: string; description: string }> = {
+  // Covers both of the route's 404 sources for branch scope: no
+  // `machine_branches` row at all, and a row whose Sprite has no
+  // `/workspace/repo` yet (never cloned).
   not_found: {
     title: "This branch hasn't been checked out yet",
     description: 'Open a terminal on this branch to clone it, then check again.',
@@ -35,11 +38,18 @@ export const CHECKOUT_ABSENT_COPY: Record<CheckoutAbsentReason, { title: string;
     title: 'This branch checkout is gone',
     description: 'Its sandbox was reclaimed. Open a terminal on the branch to check it out again.',
   },
+  // Root scope only: no `machine_branches` row exists to distinguish "this
+  // machine's Sprite never started" from "it's gone" the way branch scope
+  // can — so this is deliberately coarser than `not_found`/`vanished`.
+  not_started: {
+    title: "This machine hasn't been started yet",
+    description: 'Open the Terminal tab to start it, then check again.',
+  },
 };
 
 /** Narrows an unknown response body's `reason` to one we have copy for. */
-export const asAbsentReason = (reason: unknown): CheckoutAbsentReason | null =>
-  reason === 'not_found' || reason === 'vanished' ? reason : null;
+export const asAbsentReason = (reason: unknown): FilesAbsentReason | null =>
+  reason === 'not_found' || reason === 'vanished' || reason === 'not_started' ? reason : null;
 
 /** `{ error, reason }` off a files-route failure body, without trusting its shape. */
 export const readErrorBody = (body: unknown): { error: string | null; reason: unknown } => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/files-scope.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared vocabulary for what the Files tab is browsing: either the Machine's
+ * own root Sprite filesystem (`/workspace`), or a project/branch checkout
+ * within it (Machine Files Manager epic, Part A).
+ *
+ * Lives in `tabs/` rather than `workspace/` because `MachineFileTree` already
+ * imports from `../tabs/checkout-states` — same precedent, no import cycle.
+ */
+
+export type FilesScope = { kind: 'root' } | { kind: 'branch'; projectName: string; branchName: string };
+
+/**
+ * Stable identity for a scope — used as a React key so switching scopes (root
+ * to branch, or between branches) remounts rather than reusing stale state.
+ *
+ * JSON-encoded rather than joined on a separator so that no project/branch
+ * name pair can collide with another (a branch name may legally contain
+ * `/`), mirroring `branchKey` in FilesTab.tsx. `'root'` is a bare literal
+ * that can never equal a `JSON.stringify([...])` result, so root and branch
+ * keys can never collide with each other either.
+ */
+export const filesScopeKey = (scope: FilesScope): string =>
+  scope.kind === 'root' ? 'root' : JSON.stringify(['branch', scope.projectName, scope.branchName]);
+
+/**
+ * The files route's query params for a given scope — `projectName`/`branchName`
+ * only appear for branch scope. The route itself doesn't accept root-scope
+ * requests yet (that's a separate epic task landing the GET root-scope
+ * support); this helper is forward-declared so FilesTab/MachineFileTree can
+ * adopt `FilesScope` in one place once both land, rather than twice.
+ */
+export const filesScopeSearchParams = (machineId: string, scope: FilesScope): URLSearchParams => {
+  const params = new URLSearchParams({ machineId });
+  if (scope.kind === 'branch') {
+    params.set('projectName', scope.projectName);
+    params.set('branchName', scope.branchName);
+  }
+  return params;
+};

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/DestinationPathDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/DestinationPathDialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * DestinationPathDialog — the single destination-path dialog `MachineFileTree`
+ * uses for Move and Copy (Machine Files Manager epic, task 12). Unlike
+ * `FileNameDialog` (a single path SEGMENT appended to a fixed parent), this
+ * dialog's input is the FULL destination path, relative to the scope root,
+ * INCLUDING the item's name — e.g. moving `src/old.ts` into a sibling folder
+ * `lib` under the same name means entering `lib/old.ts`, not just `lib`. That
+ * is the one semantic the caller commits to: `toPath` sent to the PATCH verb
+ * is exactly what's typed here, never `destinationDir + '/' + currentName`.
+ * The field is prefilled with the item's current PARENT directory as an
+ * editing starting point — the item's name is deliberately left for the user
+ * to type (or change, to rename in the same step). Submitting the prefilled
+ * value unedited lands on the parent directory's own path, which the mutation
+ * itself rejects (typically `already_exists`, since a directory of that name
+ * is already there) — an immediate, legible failure rather than a silent
+ * wrong move.
+ *
+ * Validation is client-side and minimal: the entered path can't be empty
+ * (this also blocks landing on the scope root, which the route rejects on its
+ * own). Deeper failures — the destination already existing, the source having
+ * vanished — come back from the mutation itself and are surfaced as a toast
+ * by the caller, not from here.
+ */
+
+import { useEffect, useState, type FormEvent } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface DestinationPathDialogProps {
+  open: boolean;
+  /** 'Move' or 'Copy' — also drives the submit button's label. */
+  title: 'Move' | 'Copy';
+  /** Prefilled destination path — the item's current PARENT directory, not its full path (see module doc). */
+  initialPath: string;
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (path: string) => void;
+}
+
+function validatePath(path: string): string | null {
+  if (path.trim().length === 0) return 'Destination path is required';
+  return null;
+}
+
+export default function DestinationPathDialog({
+  open,
+  title,
+  initialPath,
+  submitting = false,
+  onCancel,
+  onSubmit,
+}: DestinationPathDialogProps) {
+  const [path, setPath] = useState(initialPath);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed from `initialPath` every time the dialog opens — the same instance
+  // is reused across Move and Copy by the caller.
+  useEffect(() => {
+    if (open) {
+      setPath(initialPath);
+      setError(null);
+    }
+  }, [open, initialPath]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validationError = validatePath(path);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onSubmit(path.trim());
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            Enter the full destination path, relative to the scope root, including the name — e.g. folder/name.ext.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="destination-path-dialog-input">Destination path</Label>
+            <Input
+              id="destination-path-dialog-input"
+              autoFocus
+              value={path}
+              onChange={(e) => {
+                setPath(e.target.value);
+                setError(null);
+              }}
+              disabled={submitting}
+            />
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? (title === 'Move' ? 'Moving…' : 'Copying…') : title}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/FileNameDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/FileNameDialog.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * FileNameDialog — the single name-input dialog `MachineFileTree` uses for New
+ * File, New Folder, and Rename (Machine Files Manager epic, task 11). The
+ * app's `RenameDialog`/`MovePageDialog` are page-entity-specific (drive pages,
+ * not machine filesystem paths) — this is a small local equivalent rather than
+ * a reuse of those.
+ *
+ * Validation is client-side and minimal: a path segment can't be empty or
+ * contain `/` (the route treats `path`/`toPath` as a single segment appended
+ * to a parent directory, not a nested path). Deeper failures — a name that
+ * already exists, a vanished parent — come back from the mutation itself and
+ * are surfaced as a toast by the caller, not from here.
+ */
+
+import { useEffect, useState, type FormEvent } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface FileNameDialogProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  /** Pre-filled for Rename; empty for New File / New Folder. */
+  initialName?: string;
+  submitting?: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string) => void;
+}
+
+function validateName(name: string): string | null {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return 'Name is required';
+  if (trimmed.includes('/')) return "Name cannot contain '/'";
+  return null;
+}
+
+export default function FileNameDialog({
+  open,
+  title,
+  description,
+  initialName = '',
+  submitting = false,
+  onCancel,
+  onSubmit,
+}: FileNameDialogProps) {
+  const [name, setName] = useState(initialName);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed from `initialName` every time the dialog opens — the same instance
+  // is reused across New File / New Folder / Rename by the caller.
+  useEffect(() => {
+    if (open) {
+      setName(initialName);
+      setError(null);
+    }
+  }, [open, initialName]);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const validationError = validateName(name);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onSubmit(name.trim());
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description ?? 'A name cannot be empty or contain \'/\'.'}</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-2 py-2">
+            <Label htmlFor="file-name-dialog-input">Name</Label>
+            <Input
+              id="file-name-dialog-input"
+              autoFocus
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
+              disabled={submitting}
+            />
+            {error && (
+              <p className="text-sm text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -1,10 +1,15 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
+}));
+
+const toastMocks = vi.hoisted(() => ({ error: vi.fn(), success: vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: toastMocks,
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -56,10 +61,46 @@ const cannedFetch = (overrides: Record<string, () => Promise<Response>> = {}) =>
     return jsonResponse({ entries });
   });
 
+// Excludes mutation calls: a POST/PATCH/DELETE to `/api/machines/files` has no
+// `path` query param at all, so it would otherwise be miscounted as a listing
+// of the root ('').
 const listCallsFor = (path: string): number =>
-  vi.mocked(fetchWithAuth).mock.calls.filter((call) => requestedPath(String(call[0])) === path).length;
+  vi.mocked(fetchWithAuth).mock.calls.filter((call) => {
+    const init = (call[1] ?? {}) as RequestInit | undefined;
+    const method = typeof init?.method === 'string' ? init.method : 'GET';
+    return method === 'GET' && requestedPath(String(call[0])) === path;
+  }).length;
 
 const BRANCH_SCOPE: FilesScope = { kind: 'branch', projectName: 'my-repo', branchName: 'main' };
+
+/** One recorded mutation (POST/PATCH/DELETE) call, with its body already parsed. */
+interface MutationCall {
+  method: string | undefined;
+  body: unknown;
+}
+
+/**
+ * Serves listings from FAKE_FS same as `cannedFetch`, but routes any
+ * non-GET call to `mutationResponse` and records it — used by the
+ * context-menu/mutation tests below, which need to inspect the request the
+ * tree issued rather than only what it rendered afterwards.
+ */
+const cannedFetchWithMutation = (
+  mutationCalls: MutationCall[],
+  mutationResponse: () => Response | Promise<Response>,
+) =>
+  vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+    const init = (args[1] ?? {}) as RequestInit;
+    const method = typeof init.method === 'string' ? init.method : undefined;
+    if (method && method !== 'GET') {
+      mutationCalls.push({ method, body: init.body ? JSON.parse(String(init.body)) : undefined });
+      return mutationResponse();
+    }
+    const path = requestedPath(String(args[0]));
+    const entries = FAKE_FS[path];
+    if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+    return jsonResponse({ entries });
+  });
 
 const renderTree = (props: Partial<Parameters<typeof MachineFileTree>[0]> = {}) =>
   render(<MachineFileTree machineId="machine-1" scope={BRANCH_SCOPE} {...props} />);
@@ -78,6 +119,8 @@ const rowLabels = (): (string | null)[] =>
 describe('MachineFileTree', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    toastMocks.error.mockClear();
+    toastMocks.success.mockClear();
     cannedFetch();
   });
 
@@ -364,6 +407,189 @@ describe('MachineFileTree', () => {
       should: 'render an explicit empty row instead of nothing',
       actual: empty.textContent,
       expected: 'Empty folder',
+    });
+  });
+
+  describe('context menu operations', () => {
+    test('New Folder via a directory context menu POSTs a scoped, confined path and re-lists the parent once', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+
+      fireEvent.contextMenu(screen.getByText('src'));
+      await userEvent.click(await waitFor(() => screen.getByText('New Folder')));
+      await userEvent.type(screen.getByLabelText('Name'), 'newdir');
+      await userEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "New Folder chosen from the 'src' directory's context menu, named 'newdir'",
+        should: "POST the confined child path with the branch scope fields, then re-list 'src' exactly once",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'POST',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              path: 'src/newdir',
+              kind: 'directory',
+            },
+          },
+          srcRelistCount: 1,
+        },
+      });
+    });
+
+    test('Rename posts a same-parent PATCH move and drops the renamed directory\'s stale descendant cache', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await expandFolder('components');
+      await waitFor(() => screen.getByText('Button.tsx'));
+      const componentsFetchesBefore = listCallsFor('src/components');
+
+      fireEvent.contextMenu(screen.getByText('components'));
+      await userEvent.click(await waitFor(() => screen.getByText('Rename')));
+      const input = await waitFor(() => screen.getByLabelText('Name')) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'ui');
+      await userEvent.click(screen.getByText('Save'));
+
+      // 'components' stays expanded across the rename, so dropping its cache
+      // entry alone (without a manual toggle) is what proves the descendant
+      // cache was actually invalidated, not just the parent.
+      await waitFor(() => {
+        if (listCallsFor('src/components') <= componentsFetchesBefore) {
+          throw new Error('renamed directory\'s stale cache not dropped yet');
+        }
+      });
+
+      assert({
+        given: "Rename chosen from the 'components' directory's context menu, renamed to 'ui'",
+        should: 'PATCH a move with fromPath/toPath in the same parent, and refetch the old path once (stale cache dropped)',
+        actual: {
+          mutation: calls[0],
+          staleCacheDropped: listCallsFor('src/components') - componentsFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'move',
+              fromPath: 'src/components',
+              toPath: 'src/ui',
+            },
+          },
+          staleCacheDropped: 1,
+        },
+      });
+    });
+
+    test('Delete confirm fires DELETE and re-lists the parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Delete')));
+      await waitFor(() => screen.getByText('Delete "src/index.ts"?', { exact: false }));
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "Delete confirmed from 'src/index.ts'’s context menu",
+        should: 'DELETE the scoped path and re-list its parent once',
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+        },
+        expected: {
+          mutation: {
+            method: 'DELETE',
+            body: { machineId: 'machine-1', projectName: 'my-repo', branchName: 'main', path: 'src/index.ts' },
+          },
+          srcRelistCount: 1,
+        },
+      });
+    });
+
+    test('a 409 from a mutation toasts a friendly message and never re-lists or renders a row error', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'already_exists' }, 409));
+      renderTree();
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      await userEvent.click(screen.getByTitle('New file'));
+      await userEvent.type(screen.getByLabelText('Name'), 'zeta.md');
+      await userEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a create-file mutation that comes back 409',
+        should: 'toast a friendly "already has that name" message, issue no re-list, and never render a red tree row',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          rowError: screen.queryByTestId('file-tree-error'),
+        },
+        expected: {
+          toastMessage: 'Something already has that name',
+          rootRelistCount: 0,
+          rowError: null,
+        },
+      });
+    });
+
+    test('deleting the currently open file reports it via onPathRemoved', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRemoved = vi.fn();
+      renderTree({ scope: { kind: 'root' }, selectedPath: 'README.md', onPathRemoved });
+
+      await waitFor(() => screen.getByText('README.md'));
+
+      fireEvent.contextMenu(screen.getByText('README.md'));
+      await userEvent.click(await waitFor(() => screen.getByText('Delete')));
+      await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'Delete' })));
+
+      await waitFor(() => {
+        if (onPathRemoved.mock.calls.length === 0) throw new Error('onPathRemoved not called yet');
+      });
+
+      assert({
+        given: 'the currently open file (selectedPath) deleted via its context menu',
+        should: 'report the deleted path through onPathRemoved so the parent can clear it',
+        actual: onPathRemoved.mock.calls[0]?.[0],
+        expected: 'README.md',
+      });
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -826,6 +826,88 @@ describe('MachineFileTree', () => {
       });
     });
 
+    test('a file whose read fails is skipped with its own toast and the rest of the batch still uploads', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      // A FileReader that fails for exactly one file name, real for the rest —
+      // models a file deleted/permission-changed between pick and read.
+      const RealFileReader = window.FileReader;
+      class SelectivelyFailingFileReader extends RealFileReader {
+        override readAsDataURL(blob: Blob): void {
+          if (blob instanceof File && blob.name === 'bad.bin') {
+            setTimeout(() => this.dispatchEvent(new ProgressEvent('error')));
+            return;
+          }
+          super.readAsDataURL(blob);
+        }
+      }
+      vi.stubGlobal('FileReader', SelectivelyFailingFileReader);
+      try {
+        renderTree({ scope: { kind: 'root' } });
+        await waitFor(() => screen.getByText('README.md'));
+        const rootFetchesBefore = listCallsFor('');
+
+        const badFile = new File(['x'], 'bad.bin', { type: 'application/octet-stream' });
+        const goodFile = new File(['ok'], 'good.txt', { type: 'text/plain' });
+        const input = screen.getByTestId('file-tree-upload-input') as HTMLInputElement;
+        await userEvent.click(screen.getByTitle('Upload files'));
+        await userEvent.upload(input, [badFile, goodFile]);
+
+        await waitFor(() => {
+          if (calls.length < 1) throw new Error('surviving upload not posted yet');
+        });
+        await waitFor(() => {
+          if (listCallsFor('') <= rootFetchesBefore) throw new Error('target dir not relisted yet');
+        });
+
+        assert({
+          given: 'a batch where the first file fails to read client-side',
+          should: 'toast that file by name, still upload the rest, and re-list once',
+          actual: {
+            posted: calls.map((c) => (c.body as Record<string, unknown>).path),
+            badToasted: toastMocks.error.mock.calls.some((c) => String(c[0]).includes('bad.bin')),
+          },
+          expected: { posted: ['good.txt'], badToasted: true },
+        });
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    test('a listing already in flight when the cache is invalidated can never resurrect stale entries', async () => {
+      // Root listing: first call held by the test (it will resolve LATE with
+      // the pre-refresh entries); every later call answers fresh entries.
+      const stale = deferredResponse();
+      let rootCalls = 0;
+      vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+        const init = (args[1] ?? {}) as RequestInit;
+        if (typeof init.method === 'string' && init.method !== 'GET') return jsonResponse({ ok: true });
+        if (requestedPath(String(args[0])) === '') {
+          rootCalls += 1;
+          if (rootCalls === 1) return stale.promise;
+          return jsonResponse({ entries: [{ name: 'fresh.txt', type: 'file' }] });
+        }
+        return jsonResponse({ entries: [] });
+      });
+      renderTree({ scope: { kind: 'root' } });
+
+      // First listing is pending; refresh evicts its marker and starts call 2.
+      await userEvent.click(screen.getByTitle('Refresh files'));
+      await waitFor(() => screen.getByText('fresh.txt'));
+
+      // NOW the pre-refresh listing lands, carrying the stale world.
+      stale.resolve(jsonResponse({ entries: [{ name: 'stale.txt', type: 'file' }] }));
+      // Give the stale resolution every chance to (wrongly) commit.
+      await new Promise((r) => setTimeout(r, 25));
+
+      assert({
+        given: 'a refresh while the first listing was still in flight, with the old listing resolving after the fresh one rendered',
+        should: 'keep the fresh entries — the evicted marker means the stale resolution is discarded, not committed',
+        actual: { fresh: screen.queryByText('fresh.txt') !== null, stale: screen.queryByText('stale.txt') },
+        expected: { fresh: true, stale: null },
+      });
+    });
+
     test('a file over the 10 MiB client cap is skipped with a toast and never POSTed, without blocking the rest of the batch', async () => {
       const calls: MutationCall[] = [];
       cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -592,4 +592,375 @@ describe('MachineFileTree', () => {
       });
     });
   });
+
+  describe('move / copy / upload / download operations', () => {
+    test('Move posts a PATCH with the entered destination, re-lists both parents, and drops the moved directory\'s own stale cache', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRenamed = vi.fn();
+      renderTree({ onPathRenamed });
+
+      await expandFolder('src');
+      await expandFolder('components');
+      await waitFor(() => screen.getByText('Button.tsx'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+      const componentsFetchesBefore = listCallsFor('src/components');
+
+      fireEvent.contextMenu(screen.getByText('components'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'components');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (onPathRenamed.mock.calls.length === 0) throw new Error('onPathRenamed not called yet');
+      });
+
+      assert({
+        given: "Move chosen from the 'src/components' directory's context menu, destination entered as 'components' (root)",
+        should:
+          "PATCH op:'move' with the exact entered toPath, re-list both the source and destination parent once, drop the moved directory's own stale cache (same mechanism as rename), and report the move via onPathRenamed",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          componentsStaleCacheDropped: listCallsFor('src/components') - componentsFetchesBefore,
+          renamedArgs: onPathRenamed.mock.calls[0],
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'move',
+              fromPath: 'src/components',
+              toPath: 'components',
+            },
+          },
+          srcRelistCount: 1,
+          rootRelistCount: 1,
+          componentsStaleCacheDropped: 1,
+          renamedArgs: ['src/components', 'components'],
+        },
+      });
+    });
+
+    test('Copy posts a PATCH with the entered destination, re-lists both parents, and never touches the open-file selection', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      const onPathRenamed = vi.fn();
+      renderTree({ onPathRenamed });
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Copy…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'index-copy.ts');
+      await userEvent.click(screen.getByRole('button', { name: 'Copy' }));
+
+      await waitFor(() => {
+        if (listCallsFor('') <= rootFetchesBefore) throw new Error('destination parent not relisted yet');
+      });
+
+      // 'src/index.ts' is a FILE — it never had a cache entry of its own (only
+      // directory listings are cached), so "no source cache drop of the old
+      // path" is provable simply by there being nothing at that key to begin
+      // with, unlike Move's directory case above.
+      assert({
+        given: "Copy chosen from 'src/index.ts'’s context menu, destination entered as 'index-copy.ts' (root)",
+        should:
+          "PATCH op:'copy' with the exact entered toPath, re-list both the source and destination parent once, and never call onPathRenamed (copy doesn't touch the open file)",
+        actual: {
+          mutation: calls[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+          renamedCalls: onPathRenamed.mock.calls.length,
+        },
+        expected: {
+          mutation: {
+            method: 'PATCH',
+            body: {
+              machineId: 'machine-1',
+              projectName: 'my-repo',
+              branchName: 'main',
+              op: 'copy',
+              fromPath: 'src/index.ts',
+              toPath: 'index-copy.ts',
+            },
+          },
+          srcRelistCount: 1,
+          rootRelistCount: 1,
+          renamedCalls: 0,
+        },
+      });
+    });
+
+    test('a 409 from a move toasts a friendly message and issues no re-list of either parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'already_exists' }, 409));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'zeta.md');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a move whose destination already has something there (409)',
+        should: 'toast the friendly "already has that name" message and issue no re-list of either parent',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'Something already has that name',
+          srcRelistCount: 0,
+          rootRelistCount: 0,
+        },
+      });
+    });
+
+    test('a 404 from a move (source vanished) toasts the route\'s own error and re-lists only the now-stale source parent', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ error: 'The item to move could not be found', reason: 'not_found' }, 404));
+      renderTree();
+
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+      const srcFetchesBefore = listCallsFor('src');
+      const rootFetchesBefore = listCallsFor('');
+
+      fireEvent.contextMenu(screen.getByText('index.ts'));
+      await userEvent.click(await waitFor(() => screen.getByText('Move…')));
+      const input = (await waitFor(() => screen.getByLabelText('Destination path'))) as HTMLInputElement;
+      await userEvent.clear(input);
+      await userEvent.type(input, 'moved.ts');
+      await userEvent.click(screen.getByRole('button', { name: 'Move' }));
+
+      await waitFor(() => {
+        if (listCallsFor('src') <= srcFetchesBefore) throw new Error('src not relisted yet');
+      });
+
+      assert({
+        given: "a move whose source has vanished out from under it (404 'not_found')",
+        should: "toast the route's own error and re-list only the stale source parent, never the destination parent",
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          srcRelistCount: listCallsFor('src') - srcFetchesBefore,
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'The item to move could not be found',
+          srcRelistCount: 1,
+          rootRelistCount: 0,
+        },
+      });
+    });
+
+    test('Upload files… posts each selected file sequentially as base64 and re-lists the target directory exactly once', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree({ scope: { kind: 'root' } });
+
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      const fileA = new File(['hello'], 'a.txt', { type: 'text/plain' });
+      const fileB = new File(['world'], 'b.txt', { type: 'text/plain' });
+      const input = screen.getByTestId('file-tree-upload-input') as HTMLInputElement;
+
+      await userEvent.click(screen.getByTitle('Upload files'));
+      await userEvent.upload(input, [fileA, fileB]);
+
+      await waitFor(() => {
+        if (calls.length < 2) throw new Error('both uploads not posted yet');
+      });
+      await waitFor(() => {
+        if (listCallsFor('') <= rootFetchesBefore) throw new Error('target dir not relisted yet');
+      });
+
+      assert({
+        given: 'two files selected via "Upload files…" at the scope root',
+        should: 'POST each sequentially as base64-encoded content at the root, then re-list the root exactly once for the whole batch',
+        actual: {
+          uploads: calls.map((c) => {
+            const body = c.body as Record<string, unknown>;
+            return {
+              method: c.method,
+              path: body.path,
+              kind: body.kind,
+              encoding: body.encoding,
+              content: Buffer.from(body.content as string, 'base64').toString('utf8'),
+            };
+          }),
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          uploads: [
+            { method: 'POST', path: 'a.txt', kind: 'file', encoding: 'base64', content: 'hello' },
+            { method: 'POST', path: 'b.txt', kind: 'file', encoding: 'base64', content: 'world' },
+          ],
+          rootRelistCount: 1,
+        },
+      });
+    });
+
+    test('a file over the 10 MiB client cap is skipped with a toast and never POSTed, without blocking the rest of the batch', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree({ scope: { kind: 'root' } });
+
+      await waitFor(() => screen.getByText('README.md'));
+      const rootFetchesBefore = listCallsFor('');
+
+      const bigFile = new File([new Uint8Array(10 * 1024 * 1024 + 1)], 'big.bin', { type: 'application/octet-stream' });
+      const okFile = new File(['ok'], 'ok.txt', { type: 'text/plain' });
+      const input = screen.getByTestId('file-tree-upload-input') as HTMLInputElement;
+
+      await userEvent.click(screen.getByTitle('Upload files'));
+      await userEvent.upload(input, [bigFile, okFile]);
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+      await waitFor(() => {
+        if (calls.length === 0) throw new Error('ok.txt not posted yet');
+      });
+
+      assert({
+        given: 'a batch with one file over the 10 MiB client cap and one comfortably under it',
+        should: 'toast the oversized file by name, skip POSTing it entirely, but still upload the other file and re-list once',
+        actual: {
+          toastMessage: toastMocks.error.mock.calls[0]?.[0],
+          postedPaths: calls.map((c) => (c.body as Record<string, unknown>).path),
+          rootRelistCount: listCallsFor('') - rootFetchesBefore,
+        },
+        expected: {
+          toastMessage: 'big.bin: File is too large to upload',
+          postedPaths: ['ok.txt'],
+          rootRelistCount: 1,
+        },
+      });
+    });
+
+    test('Download fetches mode=download for the full path, then clicks an object-URL anchor named by the file\'s own basename', async () => {
+      const downloadRequests: string[] = [];
+      vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+        const url = String(args[0]);
+        const init = (args[1] ?? {}) as RequestInit;
+        const method = typeof init.method === 'string' ? init.method : 'GET';
+        const parsed = new URL(url, 'http://test');
+        if (method === 'GET' && parsed.searchParams.get('mode') === 'download') {
+          downloadRequests.push(parsed.searchParams.get('path') ?? '');
+          return new Response(new Blob(['contents']), { status: 200 });
+        }
+        const path = requestedPath(url);
+        const entries = FAKE_FS[path];
+        if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+        return jsonResponse({ entries });
+      });
+
+      // jsdom doesn't implement the Blob-URL/anchor-click machinery at all —
+      // stub it in so the component's real download path (blob → object URL →
+      // programmatic anchor click) is exercised and observable.
+      if (typeof URL.createObjectURL !== 'function') {
+        (URL as unknown as { createObjectURL: () => void }).createObjectURL = () => undefined;
+      }
+      if (typeof URL.revokeObjectURL !== 'function') {
+        (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = () => undefined;
+      }
+      const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:mock-url');
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => undefined);
+      const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => undefined);
+
+      try {
+        renderTree();
+        await expandFolder('src');
+        await expandFolder('components');
+        await waitFor(() => screen.getByText('Button.tsx'));
+
+        fireEvent.contextMenu(screen.getByText('Button.tsx'));
+        await userEvent.click(await waitFor(() => screen.getByText('Download')));
+
+        await waitFor(() => {
+          if (clickSpy.mock.calls.length === 0) throw new Error('anchor not clicked yet');
+        });
+
+        const anchor = clickSpy.mock.instances[0] as unknown as HTMLAnchorElement;
+
+        assert({
+          given: "Download chosen from 'Button.tsx'’s context menu, nested under src/components",
+          should:
+            "fetch mode=download for the full checkout-relative path, then click a same-tab object-URL anchor named by the file's own basename (not the full path)",
+          actual: {
+            downloadRequests,
+            objectUrlCreated: createObjectURLSpy.mock.calls.length,
+            objectUrlRevoked: revokeObjectURLSpy.mock.calls.length,
+            anchorDownloadName: anchor.download,
+          },
+          expected: {
+            downloadRequests: ['src/components/Button.tsx'],
+            objectUrlCreated: 1,
+            objectUrlRevoked: 1,
+            anchorDownloadName: 'Button.tsx',
+          },
+        });
+      } finally {
+        createObjectURLSpy.mockRestore();
+        revokeObjectURLSpy.mockRestore();
+        clickSpy.mockRestore();
+      }
+    });
+
+    test('a failed download toasts the route\'s own error', async () => {
+      vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+        const url = String(args[0]);
+        const parsed = new URL(url, 'http://test');
+        if (parsed.searchParams.get('mode') === 'download') {
+          return jsonResponse({ error: 'File is too large to download', reason: 'too_large' }, 413);
+        }
+        const path = requestedPath(url);
+        const entries = FAKE_FS[path];
+        if (!entries) return jsonResponse({ error: 'not_found' }, 404);
+        return jsonResponse({ entries });
+      });
+      renderTree();
+
+      await waitFor(() => screen.getByText('README.md'));
+      fireEvent.contextMenu(screen.getByText('README.md'));
+      await userEvent.click(await waitFor(() => screen.getByText('Download')));
+
+      await waitFor(() => {
+        if (toastMocks.error.mock.calls.length === 0) throw new Error('toast not fired yet');
+      });
+
+      assert({
+        given: 'a download request that comes back 413 too_large',
+        should: "toast the route's own error message",
+        actual: toastMocks.error.mock.calls[0]?.[0],
+        expected: 'File is too large to download',
+      });
+    });
+  });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -826,6 +826,29 @@ describe('MachineFileTree', () => {
       });
     });
 
+    test('New File sends overwrite:false so an existing name 409s instead of truncating the file', async () => {
+      const calls: MutationCall[] = [];
+      cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));
+      renderTree({ scope: { kind: 'root' } });
+      await expandFolder('src');
+      await waitFor(() => screen.getByText('index.ts'));
+
+      fireEvent.contextMenu(screen.getByText('src'));
+      await userEvent.click(await waitFor(() => screen.getByText('New File')));
+      await userEvent.type(screen.getByLabelText('Name'), 'notes.txt');
+      await userEvent.click(screen.getByText('Save'));
+
+      await waitFor(() => {
+        if (calls.length < 1) throw new Error('create not posted yet');
+      });
+      assert({
+        given: 'a file created through the New File dialog',
+        should: 'POST with overwrite:false — create semantics, never silent truncation of an existing file',
+        actual: (calls[0].body as Record<string, unknown>).overwrite,
+        expected: false,
+      });
+    });
+
     test('a file whose read fails is skipped with its own toast and the rest of the batch still uploads', async () => {
       const calls: MutationCall[] = [];
       cannedFetchWithMutation(calls, () => jsonResponse({ ok: true }));

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import MachineFileTree from './MachineFileTree';
+import type { FilesScope } from '../tabs/files-scope';
 
 /**
  * Fake checkout served by the mocked /api/machines/files. Root order is
@@ -58,10 +59,10 @@ const cannedFetch = (overrides: Record<string, () => Promise<Response>> = {}) =>
 const listCallsFor = (path: string): number =>
   vi.mocked(fetchWithAuth).mock.calls.filter((call) => requestedPath(String(call[0])) === path).length;
 
+const BRANCH_SCOPE: FilesScope = { kind: 'branch', projectName: 'my-repo', branchName: 'main' };
+
 const renderTree = (props: Partial<Parameters<typeof MachineFileTree>[0]> = {}) =>
-  render(
-    <MachineFileTree machineId="machine-1" projectName="my-repo" branchName="main" {...props} />,
-  );
+  render(<MachineFileTree machineId="machine-1" scope={BRANCH_SCOPE} {...props} />);
 
 const expandFolder = async (name: string) => {
   const label = await waitFor(() => screen.getByText(name));
@@ -90,6 +91,21 @@ describe('MachineFileTree', () => {
       should: 'show the root directory entries returned by the files API',
       actual: [screen.getByText('src').textContent, screen.getByText('README.md').textContent],
       expected: ['src', 'README.md'],
+    });
+  });
+
+  test('root scope lists without projectName/branchName params', async () => {
+    renderTree({ scope: { kind: 'root' } });
+
+    await waitFor(() => screen.getByText('README.md'));
+    const call = vi.mocked(fetchWithAuth).mock.calls[0];
+    const url = new URL(String(call[0]), 'http://test');
+
+    assert({
+      given: 'a tree mounted with root scope',
+      should: "list the files route with no projectName/branchName — just machineId",
+      actual: { projectName: url.searchParams.get('projectName'), branchName: url.searchParams.get('branchName') },
+      expected: { projectName: null, branchName: null },
     });
   });
 
@@ -197,7 +213,10 @@ describe('MachineFileTree', () => {
     await waitFor(() => screen.getByText('index.ts'));
 
     rerender(
-      <MachineFileTree machineId="machine-1" projectName="my-repo" branchName="dev" />,
+      <MachineFileTree
+        machineId="machine-1"
+        scope={{ kind: 'branch', projectName: 'my-repo', branchName: 'dev' }}
+      />,
     );
     await waitFor(() => {
       if (listCallsFor('') < 2) throw new Error('new branch root listing not fetched yet');

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -1,33 +1,42 @@
 "use client";
 
 /**
- * MachineFileTree — the Code tab's inner-sidebar file explorer over one branch
- * checkout's working tree (Machine page rebuild, Phase 2).
+ * MachineFileTree — the Files tab's file explorer over a Machine's filesystem:
+ * either its own root Sprite (`/workspace`) or one project/branch checkout
+ * within it, per `FilesScope` (Machine Files Manager epic, Part A).
  *
  * Sibling of MachineTree.tsx and follows its plain border-border inner-sidebar
  * row conventions (this is NOT one of the app's liquid-glass sidebars). Reads
  * `/api/machines/files` (mode=list). Each directory fetches its immediate
- * children only when its listing first becomes visible — a real checkout can be
- * large, so there is deliberately no eager whole-tree walk on mount — and
+ * children only when its listing first becomes visible — a real filesystem can
+ * be large, so there is deliberately no eager whole-tree walk on mount — and
  * listings are cached per path, so collapsing and re-expanding a folder never
  * refetches. Expansion state lives in one root-level set keyed by path (not in
  * per-node component state), so collapsing a parent does not discard which of
- * its descendants were expanded. The working tree is LIVE (agent terminals
- * write and delete files), so the header offers a manual refresh that drops the
- * whole cache while keeping expansion — every visible directory then reloads.
- * Cache and expansion also reset when the terminal/project/branch identity
- * changes, via a React key remount.
+ * its descendants were expanded. The filesystem is LIVE (agent terminals write
+ * and delete files), so the header offers a manual refresh that drops the whole
+ * cache while keeping expansion — every visible directory then reloads. Cache
+ * and expansion also reset when the machine or scope identity changes, via a
+ * React key remount keyed on `filesScopeKey`.
  *
- * Presentation-only about selection: file rows report their checkout-relative
- * path through `onSelectFile`; the Code tab owns what selection does (e.g.
- * driving the Monaco read-only viewer).
+ * Every path handled here — cache keys, `onSelectFile`, `selectedPath` — is
+ * relative to the scope root: `/workspace` for root scope, the checkout root
+ * for branch scope.
+ *
+ * Row visuals match the drive sidebar's `PageTreeItem` (the canonical
+ * PageSpace filesystem look) — depth-indented rows, a single rotating chevron
+ * in the indent gutter, `text-primary` folder icons — without importing it
+ * (it's welded to dnd-kit/context-menus/multi-select).
+ *
+ * Presentation-only about selection: file rows report their scope-relative
+ * path through `onSelectFile`; the Files tab owns what selection does (e.g.
+ * driving the file pane).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MachineDirectoryEntry } from '@pagespace/lib/services/sandbox/machine-fs';
 import { cn } from '@/lib/utils';
 import {
-  ChevronDown,
   ChevronRight,
   File as FileIcon,
   Folder,
@@ -38,14 +47,14 @@ import { Button } from '@/components/ui/button';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { SidebarLoading, SidebarNotice } from '../tabs/tab-states';
 import { readErrorBody } from '../tabs/checkout-states';
+import { type FilesScope, filesScopeKey, filesScopeSearchParams } from '../tabs/files-scope';
 
 export interface MachineFileTreeProps {
   machineId: string;
-  projectName: string;
-  branchName: string;
-  /** Called with the clicked file's path RELATIVE to the branch checkout root (e.g. `src/index.ts`). Omit to render files as non-interactive rows. */
+  scope: FilesScope;
+  /** Called with the clicked file's path RELATIVE to the scope root (e.g. `src/index.ts`). Omit to render files as non-interactive rows. */
   onSelectFile?: (path: string) => void;
-  /** Checkout-relative path of the file the parent currently shows, for the selected-row highlight. */
+  /** Scope-relative path of the file the parent currently shows, for the selected-row highlight. */
   selectedPath?: string | null;
 }
 
@@ -79,16 +88,16 @@ const readErrorMessage = (body: unknown): string | null => readErrorBody(body).e
 
 export default function MachineFileTree(props: MachineFileTreeProps) {
   // Remount on identity change so the per-path cache and all expansion state
-  // reset together — a different branch is a different tree.
+  // reset together — a different machine or scope is a different tree.
   return (
     <FileTreeRoot
-      key={`${props.machineId}\u0000${props.projectName}\u0000${props.branchName}`}
+      key={`${props.machineId}\u0000${filesScopeKey(props.scope)}`}
       {...props}
     />
   );
 }
 
-function FileTreeRoot({ machineId, projectName, branchName, onSelectFile, selectedPath }: MachineFileTreeProps) {
+function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineFileTreeProps) {
   // The ref is the canonical cache — synchronously readable, so two renders
   // racing the same path (e.g. a collapse/re-expand while the listing is still
   // in flight) can never issue a duplicate fetch. The state map is a snapshot
@@ -109,7 +118,7 @@ function FileTreeRoot({ machineId, projectName, branchName, onSelectFile, select
       if (existing !== undefined && existing.status !== 'error') return;
       setDirectoryState(path, { status: 'loading' });
       try {
-        const search = new URLSearchParams({ machineId, projectName, branchName });
+        const search = filesScopeSearchParams(machineId, scope);
         if (path.length > 0) search.set('path', path);
         const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
         if (!res.ok) {
@@ -129,7 +138,13 @@ function FileTreeRoot({ machineId, projectName, branchName, onSelectFile, select
         });
       }
     },
-    [machineId, projectName, branchName, setDirectoryState],
+    // Safe without an inline-constructed scope: `scope` is FilesTab state with
+    // stable identity across re-renders, AND the key on the exported component
+    // remounts this whole tree whenever the scope changes — so this callback
+    // never needs to notice a scope change mid-life, only mount fresh with the
+    // new one. A scope built fresh on every render here would defeat that and
+    // cause a refetch loop.
+    [machineId, scope, setDirectoryState],
   );
 
   const toggleExpanded = useCallback((path: string) => {
@@ -171,7 +186,7 @@ function FileTreeRoot({ machineId, projectName, branchName, onSelectFile, select
           <RefreshCw className="size-3" />
         </Button>
       </div>
-      <DirectoryChildren path="" ctx={ctx} />
+      <DirectoryChildren path="" depth={0} ctx={ctx} />
     </div>
   );
 }
@@ -181,8 +196,11 @@ function FileTreeRoot({ machineId, projectName, branchName, onSelectFile, select
  * and every expanded folder. Fetch-on-render: becoming visible with no cache
  * entry is what triggers the (lazy) load, which also makes refresh trivial —
  * clearing the cache reloads exactly the directories currently on screen.
+ * `depth` is the indent level of the ENTRIES rendered here (one deeper than
+ * the directory whose children these are), threaded down instead of nested
+ * `pl-*` wrapper divs, matching PageTreeItem's flat-indent convention.
  */
-function DirectoryChildren({ path, ctx }: { path: string; ctx: TreeContext }) {
+function DirectoryChildren({ path, depth, ctx }: { path: string; depth: number; ctx: TreeContext }) {
   const { loadDirectory } = ctx;
   const state = ctx.directories.get(path);
   const needsLoad = state === undefined;
@@ -213,16 +231,26 @@ function DirectoryChildren({ path, ctx }: { path: string; ctx: TreeContext }) {
       {state.entries.map((entry) => {
         const entryPath = path.length > 0 ? `${path}/${entry.name}` : entry.name;
         return entry.type === 'directory' ? (
-          <DirectoryNode key={entry.name} name={entry.name} path={entryPath} ctx={ctx} />
+          <DirectoryNode key={entry.name} name={entry.name} path={entryPath} depth={depth} ctx={ctx} />
         ) : (
-          <FileNode key={entry.name} name={entry.name} path={entryPath} ctx={ctx} />
+          <FileNode key={entry.name} name={entry.name} path={entryPath} depth={depth} ctx={ctx} />
         );
       })}
     </>
   );
 }
 
-function DirectoryNode({ name, path, ctx }: { name: string; path: string; ctx: TreeContext }) {
+function DirectoryNode({
+  name,
+  path,
+  depth,
+  ctx,
+}: {
+  name: string;
+  path: string;
+  depth: number;
+  ctx: TreeContext;
+}) {
   const expanded = ctx.expandedPaths.has(path);
 
   return (
@@ -232,30 +260,40 @@ function DirectoryNode({ name, path, ctx }: { name: string; path: string; ctx: T
         onClick={() => ctx.toggleExpanded(path)}
         aria-expanded={expanded}
         data-testid="file-tree-dir-toggle"
-        className="flex w-full min-w-0 items-center gap-1 rounded-sm py-1 pr-1 text-left hover:bg-accent/50"
+        className="relative flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all hover:bg-gray-200 dark:hover:bg-gray-700"
+        style={{ paddingLeft: `${depth * 8 + 16}px` }}
       >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            'absolute h-3 w-3 shrink-0 text-gray-500 transition-transform duration-200',
+            expanded && 'rotate-90',
+          )}
+          style={{ left: `${depth * 8}px` }}
+        />
         {expanded ? (
-          <ChevronDown className="size-3.5 shrink-0" />
+          <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
         ) : (
-          <ChevronRight className="size-3.5 shrink-0" />
+          <Folder className="h-4 w-4 shrink-0 text-primary" />
         )}
-        {expanded ? (
-          <FolderOpen className="size-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          <Folder className="size-3.5 shrink-0 text-muted-foreground" />
-        )}
-        <span className="truncate">{name}</span>
+        <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
       </button>
-      {expanded && (
-        <div className="pl-4">
-          <DirectoryChildren path={path} ctx={ctx} />
-        </div>
-      )}
+      {expanded && <DirectoryChildren path={path} depth={depth + 1} ctx={ctx} />}
     </div>
   );
 }
 
-function FileNode({ name, path, ctx }: { name: string; path: string; ctx: TreeContext }) {
+function FileNode({
+  name,
+  path,
+  depth,
+  ctx,
+}: {
+  name: string;
+  path: string;
+  depth: number;
+  ctx: TreeContext;
+}) {
   const selected = ctx.selectedPath === path;
   return (
     <button
@@ -264,16 +302,15 @@ function FileNode({ name, path, ctx }: { name: string; path: string; ctx: TreeCo
       disabled={ctx.onSelectFile === undefined}
       aria-current={selected ? 'true' : undefined}
       data-testid="file-tree-file"
+      style={{ paddingLeft: `${depth * 8 + 16}px` }}
       className={cn(
-        'flex w-full min-w-0 items-center gap-1 rounded-sm py-1 pr-1 text-left hover:bg-accent/50',
-        selected && 'bg-accent',
+        'flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all',
+        selected ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
         ctx.onSelectFile === undefined && 'cursor-default',
       )}
     >
-      {/* Spacer keeps file labels aligned with sibling folder labels (which spend this slot on a chevron). */}
-      <span className="size-3.5 shrink-0" aria-hidden="true" />
-      <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
-      <span className="truncate">{name}</span>
+      <FileIcon className="h-4 w-4 shrink-0 text-gray-500" />
+      <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
     </button>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -411,9 +411,17 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
         if (pendingDialog.kind === 'create') {
           const { parentPath, entryKind } = pendingDialog;
           const path = joinPath(parentPath, name);
+          // `overwrite: false`: New File is CREATE, not save — a name that
+          // already exists must 409 like folders do, never silently truncate
+          // the existing file to the empty content this request carries.
           const result = await runMutation({
             method: 'POST',
-            body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: entryKind }),
+            body: JSON.stringify({
+              ...scopeBodyFields(machineId, scope),
+              path,
+              kind: entryKind,
+              ...(entryKind === 'file' ? { overwrite: false } : {}),
+            }),
           });
           if (!result.ok) return;
           invalidate([parentPath]);

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -35,38 +35,70 @@
  *
  * MANAGEMENT OPERATIONS (task 11): directory rows get a right-click menu with
  * New File / New Folder / Rename / Delete; file rows get Rename / Delete; the
- * header gets New File / New Folder targeting the scope root. Move / Copy /
- * Upload menu entries are deliberately NOT here yet — the `ContextMenuSeparator`
- * before Rename is where tasks 12/13 slot them in, and Download slots into the
- * file row's menu above Rename. One shared `FileNameDialog` (a local
- * name-input dialog — the app's page-entity `RenameDialog` doesn't apply to
- * filesystem paths) serves both create and rename; delete uses a local
- * `AlertDialog` confirm naming the scope-relative path. All three mutations POST/
- * PATCH/DELETE `/api/machines/files` with the scope fields in the JSON body
- * (mirroring `filesScopeSearchParams`'s pairing rule, but this file doesn't
- * import that helper — `files-scope.ts` is out of scope for this task). On
- * success, the affected path(s) are dropped from `cacheRef` (see `invalidate`)
- * so the existing fetch-on-render effect re-lists whatever's visible, and a
- * delete/rename of the currently-open file bubbles up via `onPathRemoved` /
- * `onPathRenamed` so `FilesTab` can clear or retarget the pane. Failures never
- * become a red tree row for a mutation (rows are for LISTING errors only) — a
- * mutation failure is always a `sonner` toast.
+ * header gets New File / New Folder targeting the scope root. One shared
+ * `FileNameDialog` (a local name-input dialog — the app's page-entity
+ * `RenameDialog` doesn't apply to filesystem paths) serves both create and
+ * rename; delete uses a local `AlertDialog` confirm naming the scope-relative
+ * path.
+ *
+ * MOVE / COPY (task 12): directory AND file rows also get Move… / Copy…,
+ * sharing one `DestinationPathDialog` (`open` picks Move vs Copy by which was
+ * clicked). Both PATCH `op: 'move' | 'copy'` with `fromPath`/`toPath`, where
+ * `toPath` is exactly what the dialog's input holds — see its module doc for
+ * the full-path-including-name semantic. Both invalidate the source AND
+ * destination parent directories; move additionally invalidates `fromPath`
+ * itself (dropping any cached descendant listings, same as rename) and calls
+ * `onPathRenamed` — copy touches nothing at the source, so it calls neither.
+ * A 404 (`not_found`, source vanished) additionally re-lists the source
+ * parent on its own, since that parent's cached listing is now stale even
+ * though the mutation failed.
+ *
+ * UPLOAD / DOWNLOAD (task 13): a hidden `<input type="file" multiple>`
+ * (`fileInputRef`) is triggered from the header (targeting the scope root) or
+ * a directory's "Upload here" menu item (targeting that directory);
+ * `uploadTargetRef` carries which, since one shared input serves every
+ * trigger. Each selected file is read client-side via `FileReader` into
+ * base64 and POSTed `kind: 'file', encoding: 'base64'` SEQUENTIALLY (awaited
+ * one at a time, not `Promise.all` — concurrent writes into the same
+ * directory would race the eventual single re-list); a file over the
+ * server's 10 MiB cap is skipped client-side with its own toast rather than
+ * making a doomed request. One re-list of the target directory happens after
+ * the whole batch, not per file. Download (file rows only) fetches
+ * `mode=download` and turns the response into a blob → object-URL →
+ * programmatic anchor click, because a bare `<a href>` cannot carry the
+ * `fetchWithAuth` auth header.
+ *
+ * All mutations POST/PATCH/DELETE `/api/machines/files` with the scope fields
+ * in the JSON body (mirroring `filesScopeSearchParams`'s pairing rule, but
+ * this file doesn't import that helper — `files-scope.ts` is out of scope for
+ * this file's tasks). On success, the affected path(s) are dropped from
+ * `cacheRef` (see `invalidate`) so the existing fetch-on-render effect
+ * re-lists whatever's visible, and a delete/rename/move of the currently-open
+ * file bubbles up via `onPathRemoved` / `onPathRenamed` so `FilesTab` can
+ * clear or retarget the pane. Failures never become a red tree row for a
+ * mutation (rows are for LISTING errors only) — a mutation failure is always
+ * a `sonner` toast, optionally prefixed with a file name (see `runMutation`'s
+ * `toastPrefix`) so a per-file upload failure names which file it was.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from 'react';
 import type { MachineDirectoryEntry } from '@pagespace/lib/services/sandbox/machine-fs';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   ChevronRight,
+  Copy,
+  Download,
   File as FileIcon,
   FilePlus,
   Folder,
   FolderOpen,
   FolderPlus,
+  Move,
   Pencil,
   RefreshCw,
   Trash2,
+  Upload,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
@@ -91,6 +123,7 @@ import { SidebarLoading, SidebarNotice } from '../tabs/tab-states';
 import { readErrorBody } from '../tabs/checkout-states';
 import { type FilesScope, filesScopeKey, filesScopeSearchParams } from '../tabs/files-scope';
 import FileNameDialog from './FileNameDialog';
+import DestinationPathDialog from './DestinationPathDialog';
 
 export interface MachineFileTreeProps {
   machineId: string;
@@ -113,13 +146,16 @@ type DirectoryState =
 type EntryKind = 'file' | 'directory';
 
 /**
- * One dialog slot shared by New File / New Folder / Rename / Delete — only
- * ever one of these is open at a time, so a single piece of state (rather than
- * one boolean per op) is enough and can't get two dialogs open together.
+ * One dialog slot shared by New File / New Folder / Rename / Move / Copy /
+ * Delete — only ever one of these is open at a time, so a single piece of
+ * state (rather than one boolean per op) is enough and can't get two dialogs
+ * open together.
  */
 type PendingDialog =
   | { kind: 'create'; parentPath: string; entryKind: EntryKind }
   | { kind: 'rename'; path: string; parentPath: string; currentName: string; entryKind: EntryKind }
+  | { kind: 'move'; path: string; entryKind: EntryKind }
+  | { kind: 'copy'; path: string; entryKind: EntryKind }
   | { kind: 'delete'; path: string; entryKind: EntryKind }
   | null;
 
@@ -133,7 +169,10 @@ interface TreeContext {
   selectedPath: string | null;
   openCreateDialog: (parentPath: string, entryKind: EntryKind) => void;
   openRenameDialog: (path: string, entryKind: EntryKind) => void;
+  openMoveCopyDialog: (path: string, entryKind: EntryKind, op: 'move' | 'copy') => void;
   openDeleteDialog: (path: string, entryKind: EntryKind) => void;
+  triggerUpload: (targetPath: string) => void;
+  downloadFile: (path: string) => void;
 }
 
 /** Directories first, then files, each alphabetical — the universal file-explorer ordering. */
@@ -172,31 +211,67 @@ const scopeBodyFields = (machineId: string, scope: FilesScope): Record<string, s
     : { machineId };
 
 /**
+ * Mirrors the route's own upload cap (`MAX_UPLOAD_BYTES` in
+ * `api/machines/files/route.ts`) so an oversized file is rejected here,
+ * before a doomed request and its base64 encoding work happen at all. The
+ * server enforces its own cap independently — this is a UX shortcut, not the
+ * source of truth.
+ */
+const MAX_CLIENT_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** Reads a File client-side into base64 (no data-URL prefix) for the route's `encoding: 'base64'` upload body. */
+function readFileAsBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read file'));
+        return;
+      }
+      // `readAsDataURL` yields `data:<mime>;base64,<data>` — only the part
+      // after the comma is the base64 payload the route expects.
+      const commaIndex = result.indexOf(',');
+      resolve(commaIndex === -1 ? result : result.slice(commaIndex + 1));
+    };
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsDataURL(file);
+  });
+}
+
+type MutationOutcome = { ok: true } | { ok: false; status: number };
+
+/**
  * POSTs/PATCHes/DELETEs a mutation and turns any failure into the app's toast
  * convention — 403 and 409 get fixed, friendly copy; anything else falls back
- * to the route's own human-readable `error`. Returns whether it succeeded so
- * the caller can decide what to do next (invalidate cache, close a dialog);
- * never throws.
+ * to the route's own human-readable `error`. `toastPrefix` (used by upload,
+ * which fires many of these in one batch) names which file/item a toast is
+ * about — e.g. `"report.pdf: File is too large to upload"` — so a failure
+ * deep in a multi-file batch is still traceable to its cause. Returns the
+ * outcome, including the HTTP status on failure, so a caller can react to a
+ * SPECIFIC failure (e.g. move/copy re-listing the source parent only on a 404)
+ * without re-deriving it from the toast text; never throws.
  */
-async function runMutation(init: RequestInit): Promise<boolean> {
+async function runMutation(init: RequestInit, options?: { toastPrefix?: string }): Promise<MutationOutcome> {
+  const prefix = options?.toastPrefix ? `${options.toastPrefix}: ` : '';
   try {
     const res = await fetchWithAuth('/api/machines/files', {
       ...init,
       headers: { 'Content-Type': 'application/json', ...init.headers },
     });
-    if (res.ok) return true;
+    if (res.ok) return { ok: true };
     const body: unknown = await res.json().catch(() => null);
     if (res.status === 403) {
-      toast.error("You don't have edit access to this machine");
+      toast.error(`${prefix}You don't have edit access to this machine`);
     } else if (res.status === 409) {
-      toast.error('Something already has that name');
+      toast.error(`${prefix}Something already has that name`);
     } else {
-      toast.error(readErrorMessage(body) ?? `Request failed (${res.status})`);
+      toast.error(`${prefix}${readErrorMessage(body) ?? `Request failed (${res.status})`}`);
     }
-    return false;
+    return { ok: false, status: res.status };
   } catch (err) {
-    toast.error(err instanceof Error ? err.message : 'Request failed');
-    return false;
+    toast.error(`${prefix}${err instanceof Error ? err.message : 'Request failed'}`);
+    return { ok: false, status: 0 };
   }
 }
 
@@ -308,6 +383,10 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     setPendingDialog({ kind: 'rename', path, parentPath: parentOf(path), currentName: basenameOf(path), entryKind });
   }, []);
 
+  const openMoveCopyDialog = useCallback((path: string, entryKind: EntryKind, op: 'move' | 'copy') => {
+    setPendingDialog(op === 'move' ? { kind: 'move', path, entryKind } : { kind: 'copy', path, entryKind });
+  }, []);
+
   const openDeleteDialog = useCallback((path: string, entryKind: EntryKind) => {
     setPendingDialog({ kind: 'delete', path, entryKind });
   }, []);
@@ -316,29 +395,63 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
 
   const handleCreateOrRenameSubmit = useCallback(
     async (name: string) => {
-      if (pendingDialog === null || pendingDialog.kind === 'delete') return;
+      if (pendingDialog === null || pendingDialog.kind === 'delete' || pendingDialog.kind === 'move' || pendingDialog.kind === 'copy') return;
       setSubmitting(true);
       try {
         if (pendingDialog.kind === 'create') {
           const { parentPath, entryKind } = pendingDialog;
           const path = joinPath(parentPath, name);
-          const ok = await runMutation({
+          const result = await runMutation({
             method: 'POST',
             body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: entryKind }),
           });
-          if (!ok) return;
+          if (!result.ok) return;
           invalidate([parentPath]);
         } else {
           const { path: fromPath, parentPath } = pendingDialog;
           const toPath = joinPath(parentPath, name);
-          const ok = await runMutation({
+          const result = await runMutation({
             method: 'PATCH',
             body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op: 'move', fromPath, toPath }),
           });
-          if (!ok) return;
+          if (!result.ok) return;
           invalidate([parentPath, fromPath]);
           onPathRenamed?.(fromPath, toPath);
         }
+        setPendingDialog(null);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [pendingDialog, machineId, scope, invalidate, onPathRenamed],
+  );
+
+  const handleMoveCopySubmit = useCallback(
+    async (toPathRaw: string) => {
+      if (pendingDialog === null || (pendingDialog.kind !== 'move' && pendingDialog.kind !== 'copy')) return;
+      const op = pendingDialog.kind;
+      const fromPath = pendingDialog.path;
+      const toPath = toPathRaw;
+      setSubmitting(true);
+      try {
+        const result = await runMutation({
+          method: 'PATCH',
+          body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op, fromPath, toPath }),
+        });
+        if (!result.ok) {
+          // The source's parent listing is now stale if the source itself
+          // vanished out from under us — re-list it even though the mutation
+          // failed, same as the route contract's `error` toast (already fired
+          // by `runMutation`) documents.
+          if (result.status === 404) invalidate([parentOf(fromPath)]);
+          return;
+        }
+        // Both ops touch the destination's parent; only a MOVE also empties the
+        // source's parent of this entry and invalidates any cached descendant
+        // listings under the old path (mirrors rename's cache-drop). Copy
+        // leaves the source untouched, so it drops neither.
+        invalidate(op === 'move' ? [parentOf(fromPath), parentOf(toPath), fromPath] : [parentOf(fromPath), parentOf(toPath)]);
+        if (op === 'move') onPathRenamed?.(fromPath, toPath);
         setPendingDialog(null);
       } finally {
         setSubmitting(false);
@@ -352,11 +465,11 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     const { path } = pendingDialog;
     setSubmitting(true);
     try {
-      const ok = await runMutation({
+      const result = await runMutation({
         method: 'DELETE',
         body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path }),
       });
-      if (!ok) return;
+      if (!result.ok) return;
       invalidate([parentOf(path), path]);
       onPathRemoved?.(path);
       setPendingDialog(null);
@@ -364,6 +477,88 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
       setSubmitting(false);
     }
   }, [pendingDialog, machineId, scope, invalidate, onPathRemoved]);
+
+  // One shared hidden input serves every upload trigger (header + every
+  // directory's "Upload here"); `uploadTargetRef` carries which directory the
+  // NEXT file selection targets, set synchronously right before the input is
+  // clicked (a ref, not state — no render needs to observe it).
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const uploadTargetRef = useRef<string>('');
+  const [uploading, setUploading] = useState(false);
+
+  const triggerUpload = useCallback((targetPath: string) => {
+    uploadTargetRef.current = targetPath;
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleUploadInputChange = useCallback(
+    async (e: ChangeEvent<HTMLInputElement>) => {
+      const fileList = e.target.files;
+      const targetPath = uploadTargetRef.current;
+      // Reset immediately so selecting the exact same file(s) again still
+      // fires a change event.
+      e.target.value = '';
+      if (fileList === null || fileList.length === 0) return;
+      setUploading(true);
+      try {
+        // Sequential, not concurrent — these all write into the same
+        // directory and share one re-list at the end; racing the writes would
+        // buy nothing and could reorder failures confusingly.
+        for (const file of Array.from(fileList)) {
+          if (file.size > MAX_CLIENT_UPLOAD_BYTES) {
+            toast.error(`${file.name}: File is too large to upload`);
+            continue;
+          }
+          const content = await readFileAsBase64(file);
+          const path = joinPath(targetPath, file.name);
+          await runMutation(
+            {
+              method: 'POST',
+              body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: 'file', encoding: 'base64', content }),
+            },
+            { toastPrefix: file.name },
+          );
+        }
+        invalidate([targetPath]);
+      } finally {
+        setUploading(false);
+      }
+    },
+    [machineId, scope, invalidate],
+  );
+
+  const downloadFile = useCallback(
+    (path: string) => {
+      void (async () => {
+        try {
+          const search = filesScopeSearchParams(machineId, scope);
+          search.set('path', path);
+          search.set('mode', 'download');
+          const res = await fetchWithAuth(`/api/machines/files?${search.toString()}`);
+          if (!res.ok) {
+            const body: unknown = await res.json().catch(() => null);
+            toast.error(readErrorMessage(body) ?? `Failed to download file (${res.status})`);
+            return;
+          }
+          const blob = await res.blob();
+          const url = URL.createObjectURL(blob);
+          // A bare `<a href>` cannot carry the `fetchWithAuth` auth header —
+          // the blob + object-URL round-trip is what makes an authed download
+          // possible from a click the browser treats as same-origin-anonymous.
+          const anchor = document.createElement('a');
+          anchor.href = url;
+          anchor.download = basenameOf(path);
+          document.body.appendChild(anchor);
+          anchor.click();
+          anchor.remove();
+          URL.revokeObjectURL(url);
+        } catch (err) {
+          toast.error(err instanceof Error ? err.message : 'Failed to download file');
+        }
+      })();
+    },
+    [machineId, scope],
+  );
 
   const ctx: TreeContext = {
     directories,
@@ -374,7 +569,10 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
     selectedPath: selectedPath ?? null,
     openCreateDialog,
     openRenameDialog,
+    openMoveCopyDialog,
     openDeleteDialog,
+    triggerUpload,
+    downloadFile,
   };
 
   return (
@@ -407,6 +605,17 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
             variant="ghost"
             size="icon"
             className="size-5"
+            title="Upload files"
+            disabled={uploading}
+            onClick={() => triggerUpload('')}
+          >
+            <Upload className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
             title="Refresh files"
             onClick={refresh}
           >
@@ -414,6 +623,18 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
           </Button>
         </div>
       </div>
+      {/* Shared by every upload trigger (header + each directory's "Upload
+          here"); `uploadTargetRef` carries which directory a given click
+          targets. Hidden rather than `sr-only` — it must stay out of layout
+          and never receive focus/tab order of its own. */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        data-testid="file-tree-upload-input"
+        onChange={(e) => void handleUploadInputChange(e)}
+      />
       <DirectoryChildren path="" depth={0} ctx={ctx} />
 
       <FileNameDialog
@@ -429,6 +650,16 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
         submitting={submitting}
         onCancel={closeDialog}
         onSubmit={handleCreateOrRenameSubmit}
+      />
+      <DestinationPathDialog
+        open={pendingDialog?.kind === 'move' || pendingDialog?.kind === 'copy'}
+        title={pendingDialog?.kind === 'copy' ? 'Copy' : 'Move'}
+        initialPath={
+          pendingDialog?.kind === 'move' || pendingDialog?.kind === 'copy' ? parentOf(pendingDialog.path) : ''
+        }
+        submitting={submitting}
+        onCancel={closeDialog}
+        onSubmit={handleMoveCopySubmit}
       />
       <AlertDialog open={pendingDialog?.kind === 'delete'} onOpenChange={(next) => { if (!next) closeDialog(); }}>
         <AlertDialogContent>
@@ -559,7 +790,19 @@ function DirectoryNode({
             <span>New Folder</span>
           </ContextMenuItem>
           <ContextMenuSeparator />
-          {/* Move to... / Copy to... / Upload here land here — tasks 12/13. */}
+          <ContextMenuItem onSelect={() => ctx.triggerUpload(path)}>
+            <Upload className="mr-2 h-4 w-4" />
+            <span>Upload here</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'directory', 'move')}>
+            <Move className="mr-2 h-4 w-4" />
+            <span>Move…</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'directory', 'copy')}>
+            <Copy className="mr-2 h-4 w-4" />
+            <span>Copy…</span>
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'directory')}>
             <Pencil className="mr-2 h-4 w-4" />
             <span>Rename</span>
@@ -611,7 +854,19 @@ function FileNode({
         </button>
       </ContextMenuTrigger>
       <ContextMenuContent className="w-48">
-        {/* Download lands here — task 13. */}
+        <ContextMenuItem onSelect={() => ctx.downloadFile(path)}>
+          <Download className="mr-2 h-4 w-4" />
+          <span>Download</span>
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'file', 'move')}>
+          <Move className="mr-2 h-4 w-4" />
+          <span>Move…</span>
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => ctx.openMoveCopyDialog(path, 'file', 'copy')}>
+          <Copy className="mr-2 h-4 w-4" />
+          <span>Copy…</span>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
         <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'file')}>
           <Pencil className="mr-2 h-4 w-4" />
           <span>Rename</span>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -3,7 +3,8 @@
 /**
  * MachineFileTree — the Files tab's file explorer over a Machine's filesystem:
  * either its own root Sprite (`/workspace`) or one project/branch checkout
- * within it, per `FilesScope` (Machine Files Manager epic, Part A).
+ * within it, per `FilesScope` (Machine Files Manager epic, Part A), plus
+ * create/rename/delete management operations over it (Part B, task 11).
  *
  * Sibling of MachineTree.tsx and follows its plain border-border inner-sidebar
  * row conventions (this is NOT one of the app's liquid-glass sidebars). Reads
@@ -31,23 +32,65 @@
  * Presentation-only about selection: file rows report their scope-relative
  * path through `onSelectFile`; the Files tab owns what selection does (e.g.
  * driving the file pane).
+ *
+ * MANAGEMENT OPERATIONS (task 11): directory rows get a right-click menu with
+ * New File / New Folder / Rename / Delete; file rows get Rename / Delete; the
+ * header gets New File / New Folder targeting the scope root. Move / Copy /
+ * Upload menu entries are deliberately NOT here yet — the `ContextMenuSeparator`
+ * before Rename is where tasks 12/13 slot them in, and Download slots into the
+ * file row's menu above Rename. One shared `FileNameDialog` (a local
+ * name-input dialog — the app's page-entity `RenameDialog` doesn't apply to
+ * filesystem paths) serves both create and rename; delete uses a local
+ * `AlertDialog` confirm naming the scope-relative path. All three mutations POST/
+ * PATCH/DELETE `/api/machines/files` with the scope fields in the JSON body
+ * (mirroring `filesScopeSearchParams`'s pairing rule, but this file doesn't
+ * import that helper — `files-scope.ts` is out of scope for this task). On
+ * success, the affected path(s) are dropped from `cacheRef` (see `invalidate`)
+ * so the existing fetch-on-render effect re-lists whatever's visible, and a
+ * delete/rename of the currently-open file bubbles up via `onPathRemoved` /
+ * `onPathRenamed` so `FilesTab` can clear or retarget the pane. Failures never
+ * become a red tree row for a mutation (rows are for LISTING errors only) — a
+ * mutation failure is always a `sonner` toast.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MachineDirectoryEntry } from '@pagespace/lib/services/sandbox/machine-fs';
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import {
   ChevronRight,
   File as FileIcon,
+  FilePlus,
   Folder,
   FolderOpen,
+  FolderPlus,
+  Pencil,
   RefreshCw,
+  Trash2,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { SidebarLoading, SidebarNotice } from '../tabs/tab-states';
 import { readErrorBody } from '../tabs/checkout-states';
 import { type FilesScope, filesScopeKey, filesScopeSearchParams } from '../tabs/files-scope';
+import FileNameDialog from './FileNameDialog';
 
 export interface MachineFileTreeProps {
   machineId: string;
@@ -56,6 +99,10 @@ export interface MachineFileTreeProps {
   onSelectFile?: (path: string) => void;
   /** Scope-relative path of the file the parent currently shows, for the selected-row highlight. */
   selectedPath?: string | null;
+  /** A path was deleted (or, for a directory, everything under it) — parent should clear it if it was (or was an ancestor of) the open file. */
+  onPathRemoved?: (path: string) => void;
+  /** A path was renamed/moved from `from` to `to` — parent should retarget the open file if `from` was (or was an ancestor of) it. */
+  onPathRenamed?: (from: string, to: string) => void;
 }
 
 type DirectoryState =
@@ -63,7 +110,20 @@ type DirectoryState =
   | { status: 'loaded'; entries: MachineDirectoryEntry[] }
   | { status: 'error'; message: string };
 
-/** Everything the recursive nodes need, threaded as one object so recursion doesn't re-plumb six props per level. */
+type EntryKind = 'file' | 'directory';
+
+/**
+ * One dialog slot shared by New File / New Folder / Rename / Delete — only
+ * ever one of these is open at a time, so a single piece of state (rather than
+ * one boolean per op) is enough and can't get two dialogs open together.
+ */
+type PendingDialog =
+  | { kind: 'create'; parentPath: string; entryKind: EntryKind }
+  | { kind: 'rename'; path: string; parentPath: string; currentName: string; entryKind: EntryKind }
+  | { kind: 'delete'; path: string; entryKind: EntryKind }
+  | null;
+
+/** Everything the recursive nodes need, threaded as one object so recursion doesn't re-plumb props per level. */
 interface TreeContext {
   directories: ReadonlyMap<string, DirectoryState>;
   expandedPaths: ReadonlySet<string>;
@@ -71,6 +131,9 @@ interface TreeContext {
   toggleExpanded: (path: string) => void;
   onSelectFile?: (path: string) => void;
   selectedPath: string | null;
+  openCreateDialog: (parentPath: string, entryKind: EntryKind) => void;
+  openRenameDialog: (path: string, entryKind: EntryKind) => void;
+  openDeleteDialog: (path: string, entryKind: EntryKind) => void;
 }
 
 /** Directories first, then files, each alphabetical — the universal file-explorer ordering. */
@@ -86,18 +149,69 @@ const sortEntries = (entries: MachineDirectoryEntry[]): MachineDirectoryEntry[] 
  */
 const readErrorMessage = (body: unknown): string | null => readErrorBody(body).error;
 
+/** The path's final segment — used for a rename dialog's starting value and the delete confirm's label. */
+const basenameOf = (path: string): string => (path.includes('/') ? path.slice(path.lastIndexOf('/') + 1) : path);
+
+/** The path's parent, scope-relative (`''` for a root-level entry). */
+const parentOf = (path: string): string => {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? '' : path.slice(0, i);
+};
+
+const joinPath = (parentPath: string, name: string): string => (parentPath.length > 0 ? `${parentPath}/${name}` : name);
+
+/**
+ * JSON-body scope fields for a mutation. Mirrors `filesScopeSearchParams`'s
+ * pairing rule (branch scope sends `projectName`/`branchName`, root scope
+ * sends neither) but is local to this file — `files-scope.ts` is out of scope
+ * for task 11.
+ */
+const scopeBodyFields = (machineId: string, scope: FilesScope): Record<string, string> =>
+  scope.kind === 'branch'
+    ? { machineId, projectName: scope.projectName, branchName: scope.branchName }
+    : { machineId };
+
+/**
+ * POSTs/PATCHes/DELETEs a mutation and turns any failure into the app's toast
+ * convention — 403 and 409 get fixed, friendly copy; anything else falls back
+ * to the route's own human-readable `error`. Returns whether it succeeded so
+ * the caller can decide what to do next (invalidate cache, close a dialog);
+ * never throws.
+ */
+async function runMutation(init: RequestInit): Promise<boolean> {
+  try {
+    const res = await fetchWithAuth('/api/machines/files', {
+      ...init,
+      headers: { 'Content-Type': 'application/json', ...init.headers },
+    });
+    if (res.ok) return true;
+    const body: unknown = await res.json().catch(() => null);
+    if (res.status === 403) {
+      toast.error("You don't have edit access to this machine");
+    } else if (res.status === 409) {
+      toast.error('Something already has that name');
+    } else {
+      toast.error(readErrorMessage(body) ?? `Request failed (${res.status})`);
+    }
+    return false;
+  } catch (err) {
+    toast.error(err instanceof Error ? err.message : 'Request failed');
+    return false;
+  }
+}
+
 export default function MachineFileTree(props: MachineFileTreeProps) {
   // Remount on identity change so the per-path cache and all expansion state
   // reset together — a different machine or scope is a different tree.
   return (
     <FileTreeRoot
-      key={`${props.machineId}\u0000${filesScopeKey(props.scope)}`}
+      key={`${props.machineId} ${filesScopeKey(props.scope)}`}
       {...props}
     />
   );
 }
 
-function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineFileTreeProps) {
+function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemoved, onPathRenamed }: MachineFileTreeProps) {
   // The ref is the canonical cache — synchronously readable, so two renders
   // racing the same path (e.g. a collapse/re-expand while the listing is still
   // in flight) can never issue a duplicate fetch. The state map is a snapshot
@@ -105,6 +219,8 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
   const cacheRef = useRef<Map<string, DirectoryState>>(new Map());
   const [directories, setDirectories] = useState<ReadonlyMap<string, DirectoryState>>(new Map());
   const [expandedPaths, setExpandedPaths] = useState<ReadonlySet<string>>(new Set());
+  const [pendingDialog, setPendingDialog] = useState<PendingDialog>(null);
+  const [submitting, setSubmitting] = useState(false);
 
   const setDirectoryState = useCallback((path: string, state: DirectoryState) => {
     cacheRef.current.set(path, state);
@@ -162,6 +278,93 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
     setDirectories(new Map());
   }, []);
 
+  /**
+   * Drops every cache entry equal to (or nested under) any of `paths` — the
+   * surgical, per-path sibling of `refresh()`. A directory dropped this way
+   * that's currently mounted (visible) re-lists itself via its own
+   * fetch-on-render effect; one that's collapsed just refetches lazily next
+   * time it's expanded.
+   */
+  const invalidate = useCallback((paths: string[]) => {
+    const next = new Map(cacheRef.current);
+    let changed = false;
+    for (const key of next.keys()) {
+      if (paths.some((p) => key === p || key.startsWith(`${p}/`))) {
+        next.delete(key);
+        changed = true;
+      }
+    }
+    if (changed) {
+      cacheRef.current = next;
+      setDirectories(new Map(next));
+    }
+  }, []);
+
+  const openCreateDialog = useCallback((parentPath: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'create', parentPath, entryKind });
+  }, []);
+
+  const openRenameDialog = useCallback((path: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'rename', path, parentPath: parentOf(path), currentName: basenameOf(path), entryKind });
+  }, []);
+
+  const openDeleteDialog = useCallback((path: string, entryKind: EntryKind) => {
+    setPendingDialog({ kind: 'delete', path, entryKind });
+  }, []);
+
+  const closeDialog = useCallback(() => setPendingDialog(null), []);
+
+  const handleCreateOrRenameSubmit = useCallback(
+    async (name: string) => {
+      if (pendingDialog === null || pendingDialog.kind === 'delete') return;
+      setSubmitting(true);
+      try {
+        if (pendingDialog.kind === 'create') {
+          const { parentPath, entryKind } = pendingDialog;
+          const path = joinPath(parentPath, name);
+          const ok = await runMutation({
+            method: 'POST',
+            body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path, kind: entryKind }),
+          });
+          if (!ok) return;
+          invalidate([parentPath]);
+        } else {
+          const { path: fromPath, parentPath } = pendingDialog;
+          const toPath = joinPath(parentPath, name);
+          const ok = await runMutation({
+            method: 'PATCH',
+            body: JSON.stringify({ ...scopeBodyFields(machineId, scope), op: 'move', fromPath, toPath }),
+          });
+          if (!ok) return;
+          invalidate([parentPath, fromPath]);
+          onPathRenamed?.(fromPath, toPath);
+        }
+        setPendingDialog(null);
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [pendingDialog, machineId, scope, invalidate, onPathRenamed],
+  );
+
+  const handleDeleteConfirm = useCallback(async () => {
+    if (pendingDialog === null || pendingDialog.kind !== 'delete') return;
+    const { path } = pendingDialog;
+    setSubmitting(true);
+    try {
+      const ok = await runMutation({
+        method: 'DELETE',
+        body: JSON.stringify({ ...scopeBodyFields(machineId, scope), path }),
+      });
+      if (!ok) return;
+      invalidate([parentOf(path), path]);
+      onPathRemoved?.(path);
+      setPendingDialog(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [pendingDialog, machineId, scope, invalidate, onPathRemoved]);
+
   const ctx: TreeContext = {
     directories,
     expandedPaths,
@@ -169,24 +372,89 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath }: MachineF
     toggleExpanded,
     onSelectFile,
     selectedPath: selectedPath ?? null,
+    openCreateDialog,
+    openRenameDialog,
+    openDeleteDialog,
   };
 
   return (
     <div className="p-1 text-sm" data-testid="machine-file-tree">
       <div className="flex items-center justify-between py-0.5 pr-1">
         <span className="text-xs text-muted-foreground">Files</span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="size-5"
-          title="Refresh files"
-          onClick={refresh}
-        >
-          <RefreshCw className="size-3" />
-        </Button>
+        <div className="flex items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="New file"
+            onClick={() => openCreateDialog('', 'file')}
+          >
+            <FilePlus className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="New folder"
+            onClick={() => openCreateDialog('', 'directory')}
+          >
+            <FolderPlus className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-5"
+            title="Refresh files"
+            onClick={refresh}
+          >
+            <RefreshCw className="size-3" />
+          </Button>
+        </div>
       </div>
       <DirectoryChildren path="" depth={0} ctx={ctx} />
+
+      <FileNameDialog
+        open={pendingDialog?.kind === 'create' || pendingDialog?.kind === 'rename'}
+        title={
+          pendingDialog?.kind === 'create'
+            ? pendingDialog.entryKind === 'directory'
+              ? 'New Folder'
+              : 'New File'
+            : 'Rename'
+        }
+        initialName={pendingDialog?.kind === 'rename' ? pendingDialog.currentName : ''}
+        submitting={submitting}
+        onCancel={closeDialog}
+        onSubmit={handleCreateOrRenameSubmit}
+      />
+      <AlertDialog open={pendingDialog?.kind === 'delete'} onOpenChange={(next) => { if (!next) closeDialog(); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Delete &quot;{pendingDialog?.kind === 'delete' ? pendingDialog.path : ''}&quot;?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This permanently removes it from the machine. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={submitting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleDeleteConfirm();
+              }}
+              disabled={submitting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {submitting ? 'Deleting…' : 'Delete'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }
@@ -255,29 +523,56 @@ function DirectoryNode({
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => ctx.toggleExpanded(path)}
-        aria-expanded={expanded}
-        data-testid="file-tree-dir-toggle"
-        className="relative flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all hover:bg-gray-200 dark:hover:bg-gray-700"
-        style={{ paddingLeft: `${depth * 8 + 16}px` }}
-      >
-        <ChevronRight
-          aria-hidden="true"
-          className={cn(
-            'absolute h-3 w-3 shrink-0 text-gray-500 transition-transform duration-200',
-            expanded && 'rotate-90',
-          )}
-          style={{ left: `${depth * 8}px` }}
-        />
-        {expanded ? (
-          <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
-        ) : (
-          <Folder className="h-4 w-4 shrink-0 text-primary" />
-        )}
-        <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
-      </button>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={() => ctx.toggleExpanded(path)}
+            aria-expanded={expanded}
+            data-testid="file-tree-dir-toggle"
+            className="relative flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all hover:bg-gray-200 dark:hover:bg-gray-700"
+            style={{ paddingLeft: `${depth * 8 + 16}px` }}
+          >
+            <ChevronRight
+              aria-hidden="true"
+              className={cn(
+                'absolute h-3 w-3 shrink-0 text-gray-500 transition-transform duration-200',
+                expanded && 'rotate-90',
+              )}
+              style={{ left: `${depth * 8}px` }}
+            />
+            {expanded ? (
+              <FolderOpen className="h-4 w-4 shrink-0 text-primary" />
+            ) : (
+              <Folder className="h-4 w-4 shrink-0 text-primary" />
+            )}
+            <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-48">
+          <ContextMenuItem onSelect={() => ctx.openCreateDialog(path, 'file')}>
+            <FilePlus className="mr-2 h-4 w-4" />
+            <span>New File</span>
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => ctx.openCreateDialog(path, 'directory')}>
+            <FolderPlus className="mr-2 h-4 w-4" />
+            <span>New Folder</span>
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          {/* Move to... / Copy to... / Upload here land here — tasks 12/13. */}
+          <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'directory')}>
+            <Pencil className="mr-2 h-4 w-4" />
+            <span>Rename</span>
+          </ContextMenuItem>
+          <ContextMenuItem
+            variant="destructive"
+            onSelect={() => ctx.openDeleteDialog(path, 'directory')}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            <span>Delete</span>
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       {expanded && <DirectoryChildren path={path} depth={depth + 1} ctx={ctx} />}
     </div>
   );
@@ -296,21 +591,36 @@ function FileNode({
 }) {
   const selected = ctx.selectedPath === path;
   return (
-    <button
-      type="button"
-      onClick={() => ctx.onSelectFile?.(path)}
-      disabled={ctx.onSelectFile === undefined}
-      aria-current={selected ? 'true' : undefined}
-      data-testid="file-tree-file"
-      style={{ paddingLeft: `${depth * 8 + 16}px` }}
-      className={cn(
-        'flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all',
-        selected ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
-        ctx.onSelectFile === undefined && 'cursor-default',
-      )}
-    >
-      <FileIcon className="h-4 w-4 shrink-0 text-gray-500" />
-      <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
-    </button>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <button
+          type="button"
+          onClick={() => ctx.onSelectFile?.(path)}
+          disabled={ctx.onSelectFile === undefined}
+          aria-current={selected ? 'true' : undefined}
+          data-testid="file-tree-file"
+          style={{ paddingLeft: `${depth * 8 + 16}px` }}
+          className={cn(
+            'flex w-full min-w-0 items-center rounded-lg py-1.5 pr-1 text-left transition-all',
+            selected ? 'bg-gray-200 dark:bg-gray-700' : 'hover:bg-gray-200 dark:hover:bg-gray-700',
+            ctx.onSelectFile === undefined && 'cursor-default',
+          )}
+        >
+          <FileIcon className="h-4 w-4 shrink-0 text-gray-500" />
+          <span className="ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100">{name}</span>
+        </button>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-48">
+        {/* Download lands here — task 13. */}
+        <ContextMenuItem onSelect={() => ctx.openRenameDialog(path, 'file')}>
+          <Pencil className="mr-2 h-4 w-4" />
+          <span>Rename</span>
+        </ContextMenuItem>
+        <ContextMenuItem variant="destructive" onSelect={() => ctx.openDeleteDialog(path, 'file')}>
+          <Trash2 className="mr-2 h-4 w-4" />
+          <span>Delete</span>
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineFileTree.tsx
@@ -307,7 +307,15 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
       const existing = cacheRef.current.get(path);
       // Loaded or in flight → cache hit, no refetch. Only an error is retryable.
       if (existing !== undefined && existing.status !== 'error') return;
-      setDirectoryState(path, { status: 'loading' });
+      // The loading marker doubles as this load's claim ticket: `invalidate`/
+      // `refresh` evict it, and a fresh load for the same path installs its OWN
+      // marker — so committing only while OUR marker is still the cache entry
+      // (reference equality) means a listing that raced a mutation's
+      // invalidation can never resolve late and resurrect pre-mutation
+      // entries, while a newer load's result is never clobbered either.
+      const marker: DirectoryState = { status: 'loading' };
+      const stillOurs = () => cacheRef.current.get(path) === marker;
+      setDirectoryState(path, marker);
       try {
         const search = filesScopeSearchParams(machineId, scope);
         if (path.length > 0) search.set('path', path);
@@ -318,11 +326,13 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
         }
         const body = (await res.json()) as { entries?: unknown };
         if (!Array.isArray(body.entries)) throw new Error('Malformed file listing response');
+        if (!stillOurs()) return;
         setDirectoryState(path, {
           status: 'loaded',
           entries: sortEntries(body.entries as MachineDirectoryEntry[]),
         });
       } catch (err) {
+        if (!stillOurs()) return;
         setDirectoryState(path, {
           status: 'error',
           message: err instanceof Error ? err.message : 'Failed to list directory',
@@ -509,7 +519,17 @@ function FileTreeRoot({ machineId, scope, onSelectFile, selectedPath, onPathRemo
             toast.error(`${file.name}: File is too large to upload`);
             continue;
           }
-          const content = await readFileAsBase64(file);
+          // Per-file, not batch-level: a FileReader rejection (file deleted or
+          // permission-changed between pick and read) must skip THIS file with
+          // its own toast and keep the rest of the batch going — an aborted
+          // loop would silently drop every later file.
+          let content: string;
+          try {
+            content = await readFileAsBase64(file);
+          } catch {
+            toast.error(`${file.name}: Could not read the file`);
+            continue;
+          }
           const path = joinPath(targetPath, file.name);
           await runMutation(
             {

--- a/apps/web/src/lib/machines/__tests__/machine-files-runtime.test.ts
+++ b/apps/web/src/lib/machines/__tests__/machine-files-runtime.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the root-or-branch dispatcher `resolveMachineFilesHandle`.
+ *
+ * Branch scope must delegate to `resolveBranchMachineHandle` with identical
+ * behavior (unchanged `not_found`/`vanished` reasons); root scope resolves
+ * through `resolveRootMachineHandle` and collapses a `null` handle (no live
+ * session — no tracking row exists to say why) into the coarser `not_started`
+ * reason.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockResolveRootMachineHandle, mockGetMachineHostForBranches, mockFindByName, mockAttach } = vi.hoisted(
+  () => ({
+    mockResolveRootMachineHandle: vi.fn(),
+    mockGetMachineHostForBranches: vi.fn(),
+    mockFindByName: vi.fn(),
+    mockAttach: vi.fn(),
+  }),
+);
+
+vi.mock('../machine-branches-runtime', () => ({
+  resolveRootMachineHandle: (...args: unknown[]) => mockResolveRootMachineHandle(...args),
+  getMachineHostForBranches: (...args: unknown[]) => mockGetMachineHostForBranches(...args),
+}));
+vi.mock('../machine-access-runtime', () => ({
+  canViewMachine: vi.fn(),
+  canEditMachine: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/machines/machine-branches-store', () => ({
+  createDbMachineBranchStore: vi.fn(async () => ({
+    findByName: (...args: unknown[]) => mockFindByName(...args),
+  })),
+}));
+
+import { resolveMachineFilesHandle, resolveBranchMachineHandle } from '../machine-files-runtime';
+
+const MACHINE = 'machine-1';
+const HANDLE = { machineId: 'sbx-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetMachineHostForBranches.mockResolvedValue({ attach: (...args: unknown[]) => mockAttach(...args) });
+});
+
+describe('resolveMachineFilesHandle — root scope', () => {
+  it('resolves ok with the live handle when the root Machine has a session', async () => {
+    mockResolveRootMachineHandle.mockResolvedValue(HANDLE);
+
+    const result = await resolveMachineFilesHandle({ scope: 'root', machineId: MACHINE });
+
+    expect(mockResolveRootMachineHandle).toHaveBeenCalledWith(MACHINE);
+    expect(result).toEqual({ ok: true, handle: HANDLE });
+  });
+
+  it('maps a null handle to not_started (no tracking row to say never-started vs gone)', async () => {
+    mockResolveRootMachineHandle.mockResolvedValue(null);
+
+    const result = await resolveMachineFilesHandle({ scope: 'root', machineId: MACHINE });
+
+    expect(result).toEqual({ ok: false, reason: 'not_started' });
+  });
+});
+
+describe('resolveMachineFilesHandle — branch scope', () => {
+  const scope = { scope: 'branch' as const, machineId: MACHINE, projectName: 'p1', branchName: 'b1' };
+
+  it('delegates to resolveBranchMachineHandle and returns not_found when no tracking row exists', async () => {
+    mockFindByName.mockResolvedValue(undefined);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(mockFindByName).toHaveBeenCalledWith(MACHINE, 'p1', 'b1');
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    expect(mockResolveRootMachineHandle).not.toHaveBeenCalled();
+  });
+
+  it('delegates and returns vanished when the tracking row exists but the Sprite is gone', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(null);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(mockAttach).toHaveBeenCalledWith({ machineId: 'sbx-2' });
+    expect(result).toEqual({ ok: false, reason: 'vanished' });
+  });
+
+  it('delegates and returns ok with the reconnected handle when the row and Sprite both exist', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(HANDLE);
+
+    const result = await resolveMachineFilesHandle(scope);
+
+    expect(result).toEqual({ ok: true, handle: HANDLE });
+  });
+
+  it('produces the exact same result as calling resolveBranchMachineHandle directly', async () => {
+    mockFindByName.mockResolvedValue({ sandboxId: 'sbx-2' });
+    mockAttach.mockResolvedValue(HANDLE);
+
+    const dispatched = await resolveMachineFilesHandle(scope);
+    const direct = await resolveBranchMachineHandle(scope);
+
+    expect(dispatched).toEqual(direct);
+  });
+});

--- a/apps/web/src/lib/machines/machine-files-runtime.ts
+++ b/apps/web/src/lib/machines/machine-files-runtime.ts
@@ -2,25 +2,29 @@
  * Production wiring for the Machine Files browse API (Machine page rebuild,
  * Phase 1 — working-tree file browsing).
  *
- * Resolves a branch-terminal's LIVE `MachineHandle` (its own Sprite) so the
- * route can drive the provider-neutral `listMachineDirectory`/`readMachineFile`
- * primitives against it. Reuses the branch store + the `MachineHost` seam and
- * the shared view-access check from the canonical `machine-access-runtime` — no
- * bespoke authz and no direct Sprites-SDK import.
+ * Resolves a branch-terminal's or the root Machine's LIVE `MachineHandle` so
+ * the route can drive the provider-neutral `listMachineDirectory`/
+ * `readMachineFile` primitives against it. Reuses the branch store + the
+ * `MachineHost` seam and the shared view/edit-access checks from the
+ * canonical `machine-access-runtime` — no bespoke authz and no direct
+ * Sprites-SDK import.
  *
- * Branch scope only: a branch-terminal holds its own Sprite addressed by a
- * stored `sandboxId`, so `host.attach` reconnects to exactly the machine whose
- * checkout the user is browsing. Machine/project-scope browse would resolve
- * through the shared persistent-session acquire path instead and is a separate
- * follow-up.
+ * `resolveMachineFilesHandle` is the dispatcher every Files-tab caller should
+ * use: branch scope delegates to `resolveBranchMachineHandle` below
+ * (unchanged); root scope resolves through `resolveRootMachineHandle`
+ * (`./machine-branches-runtime`) — the shared persistent-session read path,
+ * never provisioning. Root scope has no tracking row to distinguish "never
+ * started" from "gone", so a `null` handle collapses to the single coarser
+ * `not_started` reason rather than reusing branch scope's `not_found`/
+ * `vanished` split.
  */
 
 import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
 import type { MachineHandle } from '@pagespace/lib/services/sandbox/machine-host';
-import { getMachineHostForBranches } from './machine-branches-runtime';
-import { canViewMachine } from './machine-access-runtime';
+import { getMachineHostForBranches, resolveRootMachineHandle } from './machine-branches-runtime';
+import { canViewMachine, canEditMachine } from './machine-access-runtime';
 
-export { canViewMachine };
+export { canViewMachine, canEditMachine };
 
 export type ResolveBranchMachineHandleResult =
   | { ok: true; handle: MachineHandle }
@@ -48,4 +52,27 @@ export async function resolveBranchMachineHandle({
   const handle = await host.attach({ machineId: existing.sandboxId });
   if (!handle) return { ok: false, reason: 'vanished' };
   return { ok: true, handle };
+}
+
+export type MachineFilesScope =
+  | { scope: 'root'; machineId: string }
+  | { scope: 'branch'; machineId: string; projectName: string; branchName: string };
+
+export type ResolveMachineFilesHandleResult =
+  | { ok: true; handle: MachineHandle }
+  | { ok: false; reason: 'not_found' | 'vanished' | 'not_started' };
+
+/**
+ * Root-or-branch dispatcher for the Files tab. Branch scope is a pure
+ * delegation to `resolveBranchMachineHandle` (byte-for-byte identical
+ * behavior); root scope resolves the Machine's own persistent Sprite via
+ * `resolveRootMachineHandle`, mapping a `null` (no live session) to
+ * `not_started`.
+ */
+export async function resolveMachineFilesHandle(
+  scope: MachineFilesScope,
+): Promise<ResolveMachineFilesHandleResult> {
+  if (scope.scope === 'branch') return resolveBranchMachineHandle(scope);
+  const handle = await resolveRootMachineHandle(scope.machineId);
+  return handle ? { ok: true, handle } : { ok: false, reason: 'not_started' };
 }

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -279,25 +279,65 @@ describe('writeMachineFile', () => {
     expect(result).toEqual({ ok: false, reason: 'not_found' });
     expect(wrote).toBe(false);
   });
+
+  it('noClobber: returns already_exists WITHOUT writing when something already sits at the path', async () => {
+    let wrote = false;
+    const { handle } = makeExecRecorder((args) =>
+      // The `test -e -o -L` existence guard answers "present"; `test -d` for
+      // the parent would too, but the guard runs first and short-circuits.
+      args.cmd === 'test' ? { exitCode: 0, stdout: '', stderr: '' } : { exitCode: 0, stdout: '', stderr: '' },
+    );
+    const writingHandle = makeHandle({
+      exec: handle.exec,
+      writeFiles: async () => {
+        wrote = true;
+      },
+    });
+
+    const result = await writeMachineFile({ handle: writingHandle, path: '/workspace/exists.txt', content: '', noClobber: true });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(wrote).toBe(false);
+  });
+
+  it('noClobber: proceeds to write when the path is free', async () => {
+    let wrote = false;
+    const { handle, calls } = makeExecRecorder((args) =>
+      args.args?.[0] === '-e' ? { exitCode: 1, stdout: '', stderr: '' } : { exitCode: 0, stdout: '', stderr: '' },
+    );
+    const writingHandle = makeHandle({
+      exec: handle.exec,
+      writeFiles: async () => {
+        wrote = true;
+      },
+    });
+
+    const result = await writeMachineFile({ handle: writingHandle, path: '/workspace/new.txt', content: 'x', noClobber: true });
+
+    expect(result).toEqual({ ok: true });
+    expect(wrote).toBe(true);
+    expect(calls[0]).toEqual({ cmd: 'test', args: ['-e', '/workspace/new.txt', '-o', '-L', '/workspace/new.txt'] });
+  });
 });
 
 describe('verifyMachinePathsWithinScope', () => {
-  it('resolves the scope root and every path in ONE `realpath -m --` exec, in order', async () => {
+  it('resolves boundary, scope root, and every path in ONE `realpath -m --` exec, in order', async () => {
     const { handle, calls } = makeExecRecorder(() => ({
       exitCode: 0,
-      stdout: '/workspace\n/workspace/a\n/workspace/b/c\n',
+      stdout: '/workspace\n/workspace/repo\n/workspace/repo/a\n/workspace/repo/b/c\n',
       stderr: '',
     }));
 
     const result = await verifyMachinePathsWithinScope({
       handle,
-      scopeRoot: '/workspace',
-      paths: ['/workspace/a', '/workspace/b/c'],
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace/repo',
+      paths: ['/workspace/repo/a', '/workspace/repo/b/c'],
     });
 
     expect(result).toEqual({ ok: true });
     expect(calls).toEqual([
-      { cmd: 'realpath', args: ['-m', '--', '/workspace', '/workspace/a', '/workspace/b/c'] },
+      { cmd: 'realpath', args: ['-m', '--', '/workspace', '/workspace/repo', '/workspace/repo/a', '/workspace/repo/b/c'] },
     ]);
   });
 
@@ -305,13 +345,14 @@ describe('verifyMachinePathsWithinScope', () => {
     const handle = makeHandle({
       exec: async () => ({
         exitCode: 0,
-        stdout: '/workspace\n/workspace/ok\n/etc/passwd\n',
+        stdout: '/workspace\n/workspace\n/workspace/ok\n/etc/passwd\n',
         stderr: '',
       }),
     });
 
     const result = await verifyMachinePathsWithinScope({
       handle,
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace',
       paths: ['/workspace/ok', '/workspace/link/passwd'],
     });
@@ -319,13 +360,54 @@ describe('verifyMachinePathsWithinScope', () => {
     expect(result).toEqual({ ok: false, reason: 'escapes', index: 1 });
   });
 
-  it('does NOT treat a sibling with the root as a prefix (`/workspace-evil`) as in scope', async () => {
+  it('rejects the whole request (index -1) when the SCOPE ROOT itself resolves outside the boundary', async () => {
+    // /workspace/repo has been replaced with a symlink to /etc: every path
+    // "contains" perfectly under the resolved root — in the wrong filesystem.
     const handle = makeHandle({
-      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace-evil/x\n', stderr: '' }),
+      exec: async () => ({
+        exitCode: 0,
+        stdout: '/workspace\n/etc\n/etc/passwd\n',
+        stderr: '',
+      }),
     });
 
     const result = await verifyMachinePathsWithinScope({
       handle,
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace/repo',
+      paths: ['/workspace/repo/passwd'],
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'escapes', index: -1 });
+  });
+
+  it('accepts a scope root that resolves to a symlinked location still INSIDE the boundary', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 0,
+        stdout: '/workspace\n/workspace/actual-repo\n/workspace/actual-repo/x\n',
+        stderr: '',
+      }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace/repo',
+      paths: ['/workspace/repo/x'],
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('does NOT treat a sibling with the root as a prefix (`/workspace-evil`) as in scope', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace\n/workspace-evil/x\n', stderr: '' }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace',
       paths: ['/workspace/link/x'],
     });
@@ -335,31 +417,14 @@ describe('verifyMachinePathsWithinScope', () => {
 
   it('accepts a path that resolves to exactly the scope root', async () => {
     const handle = makeHandle({
-      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace\n', stderr: '' }),
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace\n/workspace\n', stderr: '' }),
     });
 
     const result = await verifyMachinePathsWithinScope({
       handle,
+      boundaryRoot: '/workspace',
       scopeRoot: '/workspace',
       paths: ['/workspace/link-to-root'],
-    });
-
-    expect(result).toEqual({ ok: true });
-  });
-
-  it('compares against the RESOLVED root, so a symlinked scope root cannot skew containment', async () => {
-    const handle = makeHandle({
-      exec: async () => ({
-        exitCode: 0,
-        stdout: '/mnt/real-workspace\n/mnt/real-workspace/repo/x\n',
-        stderr: '',
-      }),
-    });
-
-    const result = await verifyMachinePathsWithinScope({
-      handle,
-      scopeRoot: '/workspace',
-      paths: ['/workspace/repo/x'],
     });
 
     expect(result).toEqual({ ok: true });
@@ -370,17 +435,27 @@ describe('verifyMachinePathsWithinScope', () => {
       exec: async () => ({ exitCode: 1, stdout: '', stderr: 'realpath: not found' }),
     });
 
-    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: ['/workspace/a'] });
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace',
+      paths: ['/workspace/a'],
+    });
 
     expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'realpath: not found' });
   });
 
   it('fails CLOSED as exec_failed when the output line count does not match (e.g. a newline in a path)', async () => {
     const handle = makeHandle({
-      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace/a\n/workspace/b\n', stderr: '' }),
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace\n/workspace/a\n/workspace/b\n', stderr: '' }),
     });
 
-    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: ['/workspace/a'] });
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace',
+      paths: ['/workspace/a'],
+    });
 
     expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'unexpected realpath output shape' });
   });
@@ -388,7 +463,12 @@ describe('verifyMachinePathsWithinScope', () => {
   it('short-circuits ok with zero execs for an empty path list', async () => {
     const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
 
-    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: [] });
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      boundaryRoot: '/workspace',
+      scopeRoot: '/workspace',
+      paths: [],
+    });
 
     expect(result).toEqual({ ok: true });
     expect(calls).toEqual([]);

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -7,6 +7,7 @@ import {
   moveMachinePath,
   copyMachinePath,
   deleteMachinePath,
+  verifyMachinePathsWithinScope,
 } from '../machine-fs';
 import type { MachineHandle } from '../machine-host';
 import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
@@ -242,6 +243,155 @@ describe('writeMachineFile', () => {
     const result = await writeMachineFile({ handle, path: '/workspace/repo/x', content: 'y' });
 
     expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'disk full' });
+  });
+
+  it('preflights the parent with `test -d` BEFORE writing', async () => {
+    const order: string[] = [];
+    const { handle, calls } = makeExecRecorder(() => {
+      order.push('exec');
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+    const writingHandle = makeHandle({
+      exec: handle.exec,
+      writeFiles: async () => {
+        order.push('write');
+      },
+    });
+
+    const result = await writeMachineFile({ handle: writingHandle, path: '/workspace/repo/src/x.ts', content: 'y' });
+
+    expect(result).toEqual({ ok: true });
+    expect(order).toEqual(['exec', 'write']);
+    expect(calls).toEqual([{ cmd: 'test', args: ['-d', '/workspace/repo/src'] }]);
+  });
+
+  it('returns not_found WITHOUT writing when the parent directory is missing — writeFiles would silently mkdir -p it back', async () => {
+    let wrote = false;
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: '' }),
+      writeFiles: async () => {
+        wrote = true;
+      },
+    });
+
+    const result = await writeMachineFile({ handle, path: '/workspace/gone/x.ts', content: 'y' });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+    expect(wrote).toBe(false);
+  });
+});
+
+describe('verifyMachinePathsWithinScope', () => {
+  it('resolves the scope root and every path in ONE `realpath -m --` exec, in order', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({
+      exitCode: 0,
+      stdout: '/workspace\n/workspace/a\n/workspace/b/c\n',
+      stderr: '',
+    }));
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      scopeRoot: '/workspace',
+      paths: ['/workspace/a', '/workspace/b/c'],
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([
+      { cmd: 'realpath', args: ['-m', '--', '/workspace', '/workspace/a', '/workspace/b/c'] },
+    ]);
+  });
+
+  it('rejects a path whose symlink resolution lands outside the scope, naming its index', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 0,
+        stdout: '/workspace\n/workspace/ok\n/etc/passwd\n',
+        stderr: '',
+      }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      scopeRoot: '/workspace',
+      paths: ['/workspace/ok', '/workspace/link/passwd'],
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'escapes', index: 1 });
+  });
+
+  it('does NOT treat a sibling with the root as a prefix (`/workspace-evil`) as in scope', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace-evil/x\n', stderr: '' }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      scopeRoot: '/workspace',
+      paths: ['/workspace/link/x'],
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'escapes', index: 0 });
+  });
+
+  it('accepts a path that resolves to exactly the scope root', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace\n', stderr: '' }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      scopeRoot: '/workspace',
+      paths: ['/workspace/link-to-root'],
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('compares against the RESOLVED root, so a symlinked scope root cannot skew containment', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 0,
+        stdout: '/mnt/real-workspace\n/mnt/real-workspace/repo/x\n',
+        stderr: '',
+      }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({
+      handle,
+      scopeRoot: '/workspace',
+      paths: ['/workspace/repo/x'],
+    });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('fails CLOSED as exec_failed on a nonzero exit', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'realpath: not found' }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: ['/workspace/a'] });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'realpath: not found' });
+  });
+
+  it('fails CLOSED as exec_failed when the output line count does not match (e.g. a newline in a path)', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '/workspace\n/workspace/a\n/workspace/b\n', stderr: '' }),
+    });
+
+    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: ['/workspace/a'] });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'unexpected realpath output shape' });
+  });
+
+  it('short-circuits ok with zero execs for an empty path list', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await verifyMachinePathsWithinScope({ handle, scopeRoot: '/workspace', paths: [] });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([]);
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-fs.test.ts
@@ -1,7 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import { listMachineDirectory, readMachineFile } from '../machine-fs';
+import {
+  listMachineDirectory,
+  readMachineFile,
+  createMachineDirectory,
+  writeMachineFile,
+  moveMachinePath,
+  copyMachinePath,
+  deleteMachinePath,
+} from '../machine-fs';
 import type { MachineHandle } from '../machine-host';
 import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
+import type { WriteFileEntry } from '../sandbox-client/types';
 
 /**
  * The primitives take a `MachineHandle` as an injected dependency, so a fake
@@ -11,13 +20,14 @@ import type { RunCommandArgs, SandboxRunResult } from '../sandbox-client/types';
 function makeHandle(overrides: {
   exec?: (args: RunCommandArgs) => Promise<SandboxRunResult>;
   readFile?: (args: { path: string }) => Promise<Buffer | null>;
+  writeFiles?: (files: WriteFileEntry[]) => Promise<void>;
 }): MachineHandle {
   return {
     machineId: 'sbx-test',
     spriteInstanceId: null,
     exec: overrides.exec ?? (async () => ({ exitCode: 0, stdout: '', stderr: '' })),
     readFile: overrides.readFile ?? (async () => null),
-    writeFiles: async () => {},
+    writeFiles: overrides.writeFiles ?? (async () => {}),
     createCheckpoint: async () => {},
     stream: async () => {
       throw new Error('stream() is not used by the fs primitives');
@@ -25,6 +35,20 @@ function makeHandle(overrides: {
     listStreams: async () => [],
     killSession: async () => {},
   };
+}
+
+/** Records every `exec` call's argv for assertions on argv shape/ordering. */
+function makeExecRecorder(
+  responder: (args: RunCommandArgs) => SandboxRunResult,
+): { handle: MachineHandle; calls: RunCommandArgs[] } {
+  const calls: RunCommandArgs[] = [];
+  const handle = makeHandle({
+    exec: async (args) => {
+      calls.push(args);
+      return responder(args);
+    },
+  });
+  return { handle, calls };
 }
 
 describe('listMachineDirectory', () => {
@@ -121,5 +145,303 @@ describe('readMachineFile', () => {
     const handle = makeHandle({ readFile: async () => null });
     const result = await readMachineFile({ handle, path: '/workspace/repo/missing' });
     expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('createMachineDirectory', () => {
+  it('invokes `mkdir -- <path>` and reports success on exit 0', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await createMachineDirectory({ handle, path: '/workspace/repo/new-dir' });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([{ cmd: 'mkdir', args: ['--', '/workspace/repo/new-dir'] }]);
+  });
+
+  it('a leading-dash path is passed after `--`, never read as a flag', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    await createMachineDirectory({ handle, path: '-weird-dir' });
+
+    expect(calls).toEqual([{ cmd: 'mkdir', args: ['--', '-weird-dir'] }]);
+  });
+
+  it('maps "File exists" stderr to already_exists', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: "mkdir: cannot create directory '/workspace/repo/x': File exists\n",
+      }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/workspace/repo/x' });
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+  });
+
+  it('maps a missing parent ("No such file or directory") to not_found', async () => {
+    const handle = makeHandle({
+      exec: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: "mkdir: cannot create directory '/workspace/missing/x': No such file or directory\n",
+      }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/workspace/missing/x' });
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('maps any other nonzero exit to exec_failed with trimmed stderr detail', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'mkdir: permission denied\n' }),
+    });
+    const result = await createMachineDirectory({ handle, path: '/root/x' });
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'mkdir: permission denied' });
+  });
+});
+
+describe('writeMachineFile', () => {
+  it('calls handle.writeFiles with the path and content, and reports success', async () => {
+    let seen: WriteFileEntry[] | undefined;
+    const handle = makeHandle({
+      writeFiles: async (files) => {
+        seen = files;
+      },
+    });
+
+    const result = await writeMachineFile({
+      handle,
+      path: '/workspace/repo/README.md',
+      content: 'hello',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(seen).toEqual([{ path: '/workspace/repo/README.md', content: 'hello' }]);
+  });
+
+  it('accepts Uint8Array content and passes it through unchanged', async () => {
+    let seen: WriteFileEntry[] | undefined;
+    const bytes = new Uint8Array([1, 2, 3]);
+    const handle = makeHandle({
+      writeFiles: async (files) => {
+        seen = files;
+      },
+    });
+
+    await writeMachineFile({ handle, path: '/workspace/repo/bin.dat', content: bytes });
+
+    expect(seen).toEqual([{ path: '/workspace/repo/bin.dat', content: bytes }]);
+  });
+
+  it('folds a driver throw into exec_failed with the error message as detail', async () => {
+    const handle = makeHandle({
+      writeFiles: async () => {
+        throw new Error('disk full');
+      },
+    });
+
+    const result = await writeMachineFile({ handle, path: '/workspace/repo/x', content: 'y' });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'disk full' });
+  });
+});
+
+describe('moveMachinePath', () => {
+  it('runs the `test -e -o -L` guard then `mv -T -- <from> <to>` when the destination is free', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt', '-o', '-L', '/workspace/repo/b.txt'] },
+      { cmd: 'mv', args: ['-T', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
+    ]);
+  });
+
+  it('returns already_exists without calling mv when the guard finds the destination present', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/existing.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/existing.txt', '-o', '-L', '/workspace/repo/existing.txt'] },
+    ]);
+    expect(calls.some((c) => c.cmd === 'mv')).toBe(false);
+  });
+
+  it('returns already_exists (not a clobber) when the destination is a dangling symlink', async () => {
+    // `test -e` alone follows symlinks and would report `false` for a symlink
+    // whose target is missing; only `-L` also matches it. Simulate a driver
+    // that faithfully implements that distinction: `-e` fails, `-e -o -L` (as
+    // this guard sends it) succeeds.
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') {
+        const isDanglingSymlinkAware = args.args?.includes('-L');
+        return { exitCode: isDanglingSymlinkAware ? 0 : 1, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/dangling-link',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls.some((c) => c.cmd === 'mv')).toBe(false);
+  });
+
+  it('maps a missing source to not_found', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: "mv: cannot stat '/workspace/repo/gone.txt': No such file or directory\n",
+      };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/gone.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+
+  it('maps any other mv failure to exec_failed', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 1, stdout: '', stderr: 'mv: permission denied\n' };
+    });
+
+    const result = await moveMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'mv: permission denied' });
+  });
+});
+
+describe('copyMachinePath', () => {
+  it('runs the `test -e -o -L` guard then `cp -a -- <from> <to>` when the destination is free', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/b.txt', '-o', '-L', '/workspace/repo/b.txt'] },
+      { cmd: 'cp', args: ['-a', '--', '/workspace/repo/a.txt', '/workspace/repo/b.txt'] },
+    ]);
+  });
+
+  it('returns already_exists without calling cp when the guard finds the destination present', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/existing.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls).toEqual([
+      { cmd: 'test', args: ['-e', '/workspace/repo/existing.txt', '-o', '-L', '/workspace/repo/existing.txt'] },
+    ]);
+    expect(calls.some((c) => c.cmd === 'cp')).toBe(false);
+  });
+
+  it('returns already_exists (not a clobber) when the destination is a dangling symlink', async () => {
+    const { handle, calls } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') {
+        const isDanglingSymlinkAware = args.args?.includes('-L');
+        return { exitCode: isDanglingSymlinkAware ? 0 : 1, stdout: '', stderr: '' };
+      }
+      return { exitCode: 0, stdout: '', stderr: '' };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/a.txt',
+      toPath: '/workspace/repo/dangling-link',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'already_exists' });
+    expect(calls.some((c) => c.cmd === 'cp')).toBe(false);
+  });
+
+  it('maps a missing source to not_found', async () => {
+    const { handle } = makeExecRecorder((args) => {
+      if (args.cmd === 'test') return { exitCode: 1, stdout: '', stderr: '' };
+      return {
+        exitCode: 1,
+        stdout: '',
+        stderr: "cp: cannot stat '/workspace/repo/gone.txt': No such file or directory\n",
+      };
+    });
+
+    const result = await copyMachinePath({
+      handle,
+      fromPath: '/workspace/repo/gone.txt',
+      toPath: '/workspace/repo/b.txt',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_found' });
+  });
+});
+
+describe('deleteMachinePath', () => {
+  it('invokes `rm -rf -- <path>` and reports success', async () => {
+    const { handle, calls } = makeExecRecorder(() => ({ exitCode: 0, stdout: '', stderr: '' }));
+
+    const result = await deleteMachinePath({ handle, path: '/workspace/repo/tmp' });
+
+    expect(result).toEqual({ ok: true });
+    expect(calls).toEqual([{ cmd: 'rm', args: ['-rf', '--', '/workspace/repo/tmp'] }]);
+  });
+
+  it('is idempotent: deleting an already-missing path still reports ok: true', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+    });
+
+    const result = await deleteMachinePath({ handle, path: '/workspace/repo/already-gone' });
+
+    expect(result).toEqual({ ok: true });
+    expect(result.ok).toBe(true);
+  });
+
+  it('maps a nonzero exit to exec_failed with stderr detail', async () => {
+    const handle = makeHandle({
+      exec: async () => ({ exitCode: 1, stdout: '', stderr: 'rm: permission denied\n' }),
+    });
+
+    const result = await deleteMachinePath({ handle, path: '/root/protected' });
+
+    expect(result).toEqual({ ok: false, reason: 'exec_failed', detail: 'rm: permission denied' });
   });
 });

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -140,9 +140,30 @@ export async function createMachineDirectory({
 }
 
 /**
- * Create or overwrite one file's bytes on a Machine's working tree. A thin
- * wrapper over `MachineHandle.writeFiles`, which has no stderr channel — it
- * either resolves or throws — so a throw is folded into `exec_failed`.
+ * `test -d <path>` (no `--`: `test` doesn't support it; `path` is a discrete
+ * argv element, never shell-interpolated — same documented exception as
+ * `machinePathExists` below).
+ */
+async function machineDirectoryExists(handle: MachineHandle, path: string): Promise<boolean> {
+  const run = await handle.exec({ cmd: 'test', args: ['-d', path] });
+  return run.exitCode === 0;
+}
+
+/**
+ * Create or overwrite one file's bytes on a Machine's working tree.
+ *
+ * The parent directory is preflighted (`test -d`) and a missing parent is
+ * `not_found`, NEVER silently created: `MachineHandle.writeFiles` is not a
+ * plain write — the Sprite implementation retries a failed write after
+ * `mkdir -p`-ing the file's parent, so without this guard a save against a
+ * path whose folder a live terminal just deleted would quietly resurrect the
+ * folder with only that file in it, instead of surfacing the route's
+ * documented 404. (Benign TOCTOU, same class as `machinePathExists`: the
+ * user's own sandbox can delete the parent between check and write, in which
+ * case the driver's self-heal wins — there is no cross-tenant boundary here.)
+ *
+ * `writeFiles` has no stderr channel — it either resolves or throws — so a
+ * throw is folded into `exec_failed`.
  */
 export async function writeMachineFile({
   handle,
@@ -153,6 +174,11 @@ export async function writeMachineFile({
   path: string;
   content: string | Uint8Array;
 }): Promise<MutateMachinePathResult> {
+  const lastSlash = path.lastIndexOf('/');
+  const parent = lastSlash > 0 ? path.slice(0, lastSlash) : '/';
+  if (!(await machineDirectoryExists(handle, parent))) {
+    return { ok: false, reason: 'not_found' };
+  }
   try {
     await handle.writeFiles([{ path, content }]);
     return { ok: true };
@@ -225,6 +251,57 @@ export async function copyMachinePath({
   if (run.exitCode !== 0) {
     return mapMutateExecFailure(run.stderr);
   }
+  return { ok: true };
+}
+
+export type MachineScopeCheckResult =
+  | { ok: true }
+  | { ok: false; reason: 'escapes'; /** Index into `paths` of the first escaping path. */ index: number }
+  | { ok: false; reason: 'exec_failed'; detail?: string };
+
+/**
+ * Verify — ON the machine — that each of `paths` still resolves inside
+ * `scopeRoot` once symlinks are followed.
+ *
+ * String confinement (`resolvePathWithinSync`) happens host-side and cannot
+ * see the Sprite's filesystem: `/workspace/link/x` passes it even when `link`
+ * is a symlink to `/etc`, and every later `readFile`/`mkdir`/`mv`/`cp` on the
+ * machine FOLLOWS that link. This closes the gap by resolving with the
+ * machine's own `realpath -m` (`-m` so a not-yet-existing final component —
+ * a file about to be created, a move destination — still resolves through its
+ * existing prefix) and re-checking containment against the RESOLVED scope
+ * root, which is resolved in the same exec so a symlinked root cannot skew
+ * the comparison.
+ *
+ * Fails CLOSED: any exec failure or unparseable output (e.g. a path containing
+ * a newline splits the line-per-path output) rejects rather than allows.
+ * Benign TOCTOU, same class as `machinePathExists`: the user's own sandbox can
+ * swap a symlink in after this check — no cross-tenant boundary exists inside
+ * one Sprite.
+ */
+export async function verifyMachinePathsWithinScope({
+  handle,
+  scopeRoot,
+  paths,
+}: {
+  handle: MachineHandle;
+  scopeRoot: string;
+  paths: string[];
+}): Promise<MachineScopeCheckResult> {
+  if (paths.length === 0) return { ok: true };
+  const run = await handle.exec({ cmd: 'realpath', args: ['-m', '--', scopeRoot, ...paths] });
+  if (run.exitCode !== 0) {
+    return { ok: false, reason: 'exec_failed', detail: run.stderr.trim() || undefined };
+  }
+  const lines = run.stdout.split('\n').filter((line) => line.length > 0);
+  if (lines.length !== paths.length + 1) {
+    return { ok: false, reason: 'exec_failed', detail: 'unexpected realpath output shape' };
+  }
+  const [resolvedRoot, ...resolved] = lines;
+  const index = resolved.findIndex(
+    (p) => p !== resolvedRoot && !p.startsWith(`${resolvedRoot}/`),
+  );
+  if (index !== -1) return { ok: false, reason: 'escapes', index };
   return { ok: true };
 }
 

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -169,11 +169,22 @@ export async function writeMachineFile({
   handle,
   path,
   content,
+  noClobber = false,
 }: {
   handle: MachineHandle;
   path: string;
   content: string | Uint8Array;
+  /**
+   * `true` = CREATE semantics: an existing entry at `path` is `already_exists`,
+   * never silently overwritten (the "New File" flow). Default `false` =
+   * overwrite-is-save semantics (editor save, upload). Same `machinePathExists`
+   * guard — and the same benign same-tenant TOCTOU — as move/copy's no-clobber.
+   */
+  noClobber?: boolean;
 }): Promise<MutateMachinePathResult> {
+  if (noClobber && (await machinePathExists(handle, path))) {
+    return { ok: false, reason: 'already_exists' };
+  }
   const lastSlash = path.lastIndexOf('/');
   const parent = lastSlash > 0 ? path.slice(0, lastSlash) : '/';
   if (!(await machineDirectoryExists(handle, parent))) {
@@ -256,12 +267,18 @@ export async function copyMachinePath({
 
 export type MachineScopeCheckResult =
   | { ok: true }
-  | { ok: false; reason: 'escapes'; /** Index into `paths` of the first escaping path. */ index: number }
+  | {
+      ok: false;
+      reason: 'escapes';
+      /** Index into `paths` of the first escaping path, or -1 when the SCOPE ROOT itself resolves outside the boundary. */
+      index: number;
+    }
   | { ok: false; reason: 'exec_failed'; detail?: string };
 
 /**
  * Verify — ON the machine — that each of `paths` still resolves inside
- * `scopeRoot` once symlinks are followed.
+ * `scopeRoot`, AND that the scope root itself still resolves inside
+ * `boundaryRoot`, once symlinks are followed.
  *
  * String confinement (`resolvePathWithinSync`) happens host-side and cannot
  * see the Sprite's filesystem: `/workspace/link/x` passes it even when `link`
@@ -269,9 +286,18 @@ export type MachineScopeCheckResult =
  * machine FOLLOWS that link. This closes the gap by resolving with the
  * machine's own `realpath -m` (`-m` so a not-yet-existing final component —
  * a file about to be created, a move destination — still resolves through its
- * existing prefix) and re-checking containment against the RESOLVED scope
- * root, which is resolved in the same exec so a symlinked root cannot skew
- * the comparison.
+ * existing prefix) and re-checking containment against the RESOLVED roots.
+ *
+ * `boundaryRoot` is the OUTERMOST trust boundary and is what keeps a
+ * symlinked scope root from moving the goalposts: comparing paths against the
+ * resolved scope root alone would bless `/workspace/repo/passwd` when
+ * `/workspace/repo` itself has been replaced by a symlink to `/etc` — the
+ * paths "contain" perfectly, just in the wrong filesystem. Requiring the
+ * resolved scope root to sit inside the resolved boundary (`/workspace`, which
+ * the driver provisions as a real directory) closes that: a scope root that
+ * resolves outside the boundary rejects as an escape (`index: -1`, no single
+ * offending path). When `boundaryRoot === scopeRoot` (root scope) the extra
+ * check is trivially true.
  *
  * Fails CLOSED: any exec failure or unparseable output (e.g. a path containing
  * a newline splits the line-per-path output) rejects rather than allows.
@@ -281,26 +307,30 @@ export type MachineScopeCheckResult =
  */
 export async function verifyMachinePathsWithinScope({
   handle,
+  boundaryRoot,
   scopeRoot,
   paths,
 }: {
   handle: MachineHandle;
+  boundaryRoot: string;
   scopeRoot: string;
   paths: string[];
 }): Promise<MachineScopeCheckResult> {
   if (paths.length === 0) return { ok: true };
-  const run = await handle.exec({ cmd: 'realpath', args: ['-m', '--', scopeRoot, ...paths] });
+  const run = await handle.exec({ cmd: 'realpath', args: ['-m', '--', boundaryRoot, scopeRoot, ...paths] });
   if (run.exitCode !== 0) {
     return { ok: false, reason: 'exec_failed', detail: run.stderr.trim() || undefined };
   }
   const lines = run.stdout.split('\n').filter((line) => line.length > 0);
-  if (lines.length !== paths.length + 1) {
+  if (lines.length !== paths.length + 2) {
     return { ok: false, reason: 'exec_failed', detail: 'unexpected realpath output shape' };
   }
-  const [resolvedRoot, ...resolved] = lines;
-  const index = resolved.findIndex(
-    (p) => p !== resolvedRoot && !p.startsWith(`${resolvedRoot}/`),
-  );
+  const [resolvedBoundary, resolvedRoot, ...resolved] = lines;
+  const within = (child: string, parent: string) => child === parent || child.startsWith(`${parent}/`);
+  if (!within(resolvedRoot, resolvedBoundary)) {
+    return { ok: false, reason: 'escapes', index: -1 };
+  }
+  const index = resolved.findIndex((p) => !within(p, resolvedRoot));
   if (index !== -1) return { ok: false, reason: 'escapes', index };
   return { ok: true };
 }

--- a/packages/lib/src/services/sandbox/machine-fs.ts
+++ b/packages/lib/src/services/sandbox/machine-fs.ts
@@ -1,28 +1,39 @@
 /**
- * Machine filesystem browsing primitives (pure, DI'd).
+ * Machine filesystem browse + mutate primitives (pure, DI'd).
  *
- * Two functions the human-facing Machine page uses to browse a Machine's
+ * The human-facing Machine page's Files tab drives these against a Machine's
  * WORKING TREE — the live files on a Sprite's persistent filesystem, e.g. a
  * branch-terminal's checkout at `/workspace/repo`:
  *
  *   listMachineDirectory — one directory's immediate children ({ name, type }).
  *   readMachineFile      — one file's bytes.
+ *   createMachineDirectory — mkdir a new directory.
+ *   writeMachineFile     — create or overwrite a file's bytes.
+ *   moveMachinePath      — rename/move a path (no-clobber).
+ *   copyMachinePath      — copy a path (no-clobber).
+ *   deleteMachinePath    — remove a path, recursively, idempotently.
  *
- * Both take a `MachineHandle` (./machine-host.ts) as an INJECTED dependency
- * rather than constructing a Sprite host themselves, mirroring the DI shape of
- * `runGitInSandbox` (./git-tool-runners.ts). That keeps them unit-testable
- * against a fake handle with zero real Sprite calls, per the repo's
- * pure-functions-plus-DI build mandate.
+ * All seven take a `MachineHandle` (./machine-host.ts) as an INJECTED
+ * dependency rather than constructing a Sprite host themselves, mirroring the
+ * DI shape of `runGitInSandbox` (./git-tool-runners.ts). That keeps them
+ * unit-testable against a fake handle with zero real Sprite calls, per the
+ * repo's pure-functions-plus-DI build mandate.
  *
- * SCOPE BOUNDARY: this reads the working tree ONLY — it is filesystem-level and
- * takes no git ref. A diff tab's "before" content needs git-object reads, a
- * separate git-ref-aware service that depends on this one; do NOT add a ref
- * parameter here.
+ * PATH CONTRACT: every `path`/`fromPath`/`toPath` argument here MUST already be
+ * an absolute, pre-confined path — confinement (resolving `..`/symlink escapes
+ * against the caller's scope root) is the calling ROUTE's job, done EXACTLY
+ * ONCE before it reaches this module (PR #2039 TOCTOU lesson: never re-derive
+ * or re-validate a path down here from a name/fragment).
  *
- * This runs commands through `MachineHandle.exec`/`readFile`, deliberately NOT
- * through the AI-agent tool-runner orchestration (billing holds, injection
- * screening, LLM-facing denial vocabulary) — that layer is shaped for an agent,
- * not a browsing UI.
+ * SCOPE BOUNDARY: this operates on the working tree ONLY — it is
+ * filesystem-level and takes no git ref. A diff tab's "before" content needs
+ * git-object reads, a separate git-ref-aware service that depends on this one;
+ * do NOT add a ref parameter here.
+ *
+ * This runs commands through `MachineHandle.exec`/`readFile`/`writeFiles`,
+ * deliberately NOT through the AI-agent tool-runner orchestration (billing
+ * holds, injection screening, LLM-facing denial vocabulary) — that layer is
+ * shaped for an agent, not a browsing UI.
  */
 
 import type { MachineHandle } from './machine-host';
@@ -40,6 +51,10 @@ export type ListMachineDirectoryResult =
 export type ReadMachineFileResult =
   | { ok: true; content: Buffer }
   | { ok: false; reason: 'not_found' };
+
+export type MutateMachinePathResult =
+  | { ok: true }
+  | { ok: false; reason: 'not_found' | 'already_exists' | 'exec_failed'; detail?: string };
 
 /**
  * List a directory's immediate children on a Machine.
@@ -88,4 +103,146 @@ export async function readMachineFile({
   const content = await handle.readFile({ path });
   if (content === null) return { ok: false, reason: 'not_found' };
   return { ok: true, content };
+}
+
+/** Maps a failed exec's stderr to a `MutateMachinePathResult`, optionally treating a caller-supplied pattern as `already_exists` first. */
+function mapMutateExecFailure(
+  stderr: string,
+  alreadyExistsPattern?: RegExp,
+): MutateMachinePathResult {
+  if (alreadyExistsPattern?.test(stderr)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  if (/no such file or directory/i.test(stderr)) {
+    return { ok: false, reason: 'not_found' };
+  }
+  return { ok: false, reason: 'exec_failed', detail: stderr.trim() || undefined };
+}
+
+/**
+ * Create one directory on a Machine.
+ *
+ * `path` is an argv element, never shell-parsed; `--` stops a path that begins
+ * with `-` being read as a flag (mirrors `listMachineDirectory`'s `ls` call).
+ */
+export async function createMachineDirectory({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<MutateMachinePathResult> {
+  const run = await handle.exec({ cmd: 'mkdir', args: ['--', path] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr, /file exists/i);
+  }
+  return { ok: true };
+}
+
+/**
+ * Create or overwrite one file's bytes on a Machine's working tree. A thin
+ * wrapper over `MachineHandle.writeFiles`, which has no stderr channel — it
+ * either resolves or throws — so a throw is folded into `exec_failed`.
+ */
+export async function writeMachineFile({
+  handle,
+  path,
+  content,
+}: {
+  handle: MachineHandle;
+  path: string;
+  content: string | Uint8Array;
+}): Promise<MutateMachinePathResult> {
+  try {
+    await handle.writeFiles([{ path, content }]);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'exec_failed',
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * `test -e <path> -o -L <path>` (no `--`: `test` doesn't support it, and there
+ * is no injection surface here — `path` is still a discrete argv element,
+ * never shell-interpolated). Used by move/copy as a no-clobber guard on the
+ * destination before the real op runs.
+ *
+ * `-L` is required alongside `-e`: every `test` file operator except `-h`/`-L`
+ * follows symlinks, so `-e` alone reports `false` for a DANGLING symlink (one
+ * whose target is missing) even though the symlink itself is a real directory
+ * entry sitting at `path`. Without `-L`, the guard would miss that entry and
+ * let `mv`/`cp` silently clobber it.
+ *
+ * This is a benign TOCTOU: two execs, not one atomic op. Worst case, the
+ * user's own sandbox process creates something at `toPath` in the gap between
+ * this check and the following `mv`/`cp`, which then clobbers it — there is no
+ * cross-tenant boundary to violate here, and path confinement already happened
+ * once, upstream in the route.
+ */
+async function machinePathExists(handle: MachineHandle, path: string): Promise<boolean> {
+  const run = await handle.exec({ cmd: 'test', args: ['-e', path, '-o', '-L', path] });
+  return run.exitCode === 0;
+}
+
+/** Move (rename) `fromPath` to `toPath`, refusing to clobber an existing `toPath`. */
+export async function moveMachinePath({
+  handle,
+  fromPath,
+  toPath,
+}: {
+  handle: MachineHandle;
+  fromPath: string;
+  toPath: string;
+}): Promise<MutateMachinePathResult> {
+  if (await machinePathExists(handle, toPath)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  const run = await handle.exec({ cmd: 'mv', args: ['-T', '--', fromPath, toPath] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
+}
+
+/** Copy `fromPath` to `toPath` (recursively, preserving attributes), refusing to clobber an existing `toPath`. */
+export async function copyMachinePath({
+  handle,
+  fromPath,
+  toPath,
+}: {
+  handle: MachineHandle;
+  fromPath: string;
+  toPath: string;
+}): Promise<MutateMachinePathResult> {
+  if (await machinePathExists(handle, toPath)) {
+    return { ok: false, reason: 'already_exists' };
+  }
+  const run = await handle.exec({ cmd: 'cp', args: ['-a', '--', fromPath, toPath] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
+}
+
+/**
+ * Delete a path, recursively. `rm -rf` is idempotent by design — deleting an
+ * already-missing path is a success, not a `not_found`; confirming with the
+ * user before deleting is UI policy, not this lib's.
+ */
+export async function deleteMachinePath({
+  handle,
+  path,
+}: {
+  handle: MachineHandle;
+  path: string;
+}): Promise<MutateMachinePathResult> {
+  const run = await handle.exec({ cmd: 'rm', args: ['-rf', '--', path] });
+  if (run.exitCode !== 0) {
+    return mapMutateExecFailure(run.stderr);
+  }
+  return { ok: true };
 }


### PR DESCRIPTION
## Summary

The Machine page's **Files tab is now a full file manager over the sandbox filesystem** — and it no longer demands a project/branch pick before showing anything.

- **Root scope by default**: opening the tab immediately lists the Machine's own root Sprite filesystem (`/workspace`). Picking a branch in the tree still browses that branch's checkout exactly as before (regression-proven, not assumed).
- **Honest absence states**: a Machine whose Terminal was never opened gets its own `not_started` state ("This machine hasn't been started yet") — distinct from the branch-scoped `not_found` (never cloned) and `vanished` (Sprite reclaimed).
- **Finder/Explorer operations**: create file/folder, rename, move, copy, delete (with confirm), upload (10 MiB cap), download (50 MiB cap) via context menus matching the drive page tree's visuals; plus an editable Monaco pane with dirty tracking, Cmd/Ctrl-S save, and `useEditingStore` registration. Truncated reads stay read-only so a partial view can never destroy a file's tail.

## Security posture

- Every mutation: session auth with **CSRF enforced**, **`canEditMachine`** checked *before* field-shape validation (unauthorized callers can't probe), and an audit `data.write` with relative paths only.
- Every path (`path`, `fromPath`, `toPath`) is confined exactly once via `resolvePathWithinSync` under the scope root (`/workspace` for root scope, `/workspace/repo` for branch scope) and passed to the Sprite as a discrete `--`-terminated argv element — never re-derived, never shell-interpolated.
- Scope-root operations (`''`) are refused; upload/download size caps return 413.

## What did NOT change

- `resolveBranchMachineHandle` — body byte-identical to master (proven by diff in #2110); the Diff and git-blob routes and their runtimes have an **empty diff** against master.

## Constituent PRs (each reviewed + test-verified before merging into this branch)

| PR | Scope |
|---|---|
| #2099 | Root-or-branch dispatcher `resolveMachineFilesHandle` (+ `not_started`) |
| #2100 | `FilesScope` client vocabulary + absence-state generalization |
| #2101 | machine-fs write primitives (mkdir/write/move/copy/delete) |
| #2102 | Files route GET: root scope, both-or-neither params, `SANDBOX_ROOT` confinement |
| #2103 | Scope-aware file tree + file pane, PageTree-matched visuals |
| #2104 | Files tab defaults to the machine's root filesystem |
| #2105 | Route mutations: POST create/upload, PATCH move/copy, DELETE, GET download |
| #2106 | Tree context menus: create, rename, delete + cache invalidation |
| #2108 | Editable file pane with save + `useEditingStore` |
| #2109 | Move/copy dialogs, upload, download UI |
| #2110 | Convergence: verification evidence + changelog |

## Verification (full detail in #2110's description)

- Monorepo `typecheck` clean; `packages/lib` suite 8467 tests green; all 32 machine-scoped web suites green (570 tests, including 91 for the files route alone).
- Full `apps/web` unit suite: 968/972 files green; the 3 failures are pre-existing and triaged in #2110 (2 need the docker-provisioned test DB role; 1 is a timezone-dependent pre-existing test bug) — all in files this epic never touched.
- Acceptance matrix in #2110 maps **every** epic criterion to named covering tests; nothing unproven.
- ⚠️ Known repo debt surfaced (not fixed here): `bun run changelog:generate` references `scripts/changelog/index.ts`, which no longer exists on master — the changelog entry was hand-written in the file's existing style.

Epic board: PageSpace → Features → *Machine Files Manager Epic* (15/15 tasks completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review-fix addendum (b04dbacce)

Three findings from the Codex review, all fixed on this branch (threads left open for reviewer verification):

1. **Symlink-escape confinement (P2, security)** — confinement is now two passes: string confinement host-side, then `verifyMachinePathsWithinScope` re-resolves every non-root path ON the machine (`realpath -m`, one exec) and 400s any path that escapes the resolved scope root once links are followed. Applies to all verbs including reads; fails closed on exec failure or unparseable output.
2. **Write parent resurrection (P2)** — `writeMachineFile` preflights the parent (`test -d`) so a save into a deleted folder returns the documented 404 instead of the Sprite driver's `mkdir -p` retry silently recreating it.
3. **Dirty-draft navigation guard (P1)** — the pane reports dirty state up (`onDirtyChange`); FilesTab confirms before a file click or scope switch discards an unsaved draft (same wording as the Reload confirm). Tree-driven removals/renames deliberately don't prompt — the mutation already happened.

+17 route/machine-fs tests, +6 component tests. Machine-scoped suites: 583 web + 38 lib, all green; monorepo typecheck clean.

## Review-fix addendum 2 (1de01f4e0)

CodeRabbit's pass produced 7 findings; 6 fixed (it verified and resolved those threads), 1 acknowledged with reasoning:

- **Fixed**: pre-buffer 413 on declared Content-Length for all mutating verbs; revert-to-loaded-content counts as clean; stale save completions can't discard newer drafts (+ Cmd/Ctrl-S re-entrancy gate); mobile sheet closes only on accepted navigation; in-flight listings can't resurrect pre-mutation entries after invalidate/refresh (marker-identity commits); per-file FileReader failure handling in uploads.
- **Acknowledged, not changed**: fully-atomic write/move/copy preflights — needs driver-seam primitives (no-parent-create write mode, detectable atomic no-clobber move); residual race is same-tenant-benign and documented inline. Streaming GET reads likewise need a ranged `MachineHandle.readFile` — driver-seam follow-up.

+6 tests. Machine suites: 589 web + 38 lib green; typecheck clean.

## Review-fix addendum 3 (d51c61bf6)

Codex re-review produced 3 findings, all fixed:

- **NUL-path root refusal (P1)** — mutating verbs' path fields use `forbidRoot` confinement: a NUL-only path (non-empty on the wire, sanitized to empty, resolved to the scope root) now 400s instead of letting DELETE reach `rm -rf` on the scope root itself.
- **Symlinked scope-root boundary (P2)** — `verifyMachinePathsWithinScope` gains a `boundaryRoot` (`SANDBOX_ROOT`): a branch checkout root replaced by a symlink out of `/workspace` rejects as a whole instead of re-anchoring containment at the link's target.
- **No-clobber New File (P2)** — `overwrite: false` on POST `kind:'file'` gives CREATE semantics (409 on existing); the New File dialog sends it, so a name collision fails like folders do instead of silently truncating.

+13 tests. Machine suites: 597 web + 41 lib green; typecheck clean.
