### PR TITLE
fix(sandbox): bound fresh-Sprite egress-lockdown retry to seconds, not minutes

### DIFF
--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -96,6 +96,27 @@ function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: 
   };
 }
 
+/**
+ * A command that opens immediately but doesn't exit until `delayMs` later —
+ * for testing a Sprite that's merely SLOW to become ready (not broken), as
+ * opposed to `fakeCommand({ hang: true })`'s permanently-stuck command. Used
+ * to prove a late exit, deep inside a full-length retry attempt's timeout
+ * window, still succeeds rather than being raced past by an earlier attempt.
+ */
+function fakeSlowCommand(delayMs: number, exitCode = 0): SpriteCommandLike {
+  const events = new EventEmitter();
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  setTimeout(() => events.emit('spawn'), 0);
+  setTimeout(() => events.emit('exit', exitCode), delayMs);
+  return {
+    stdout: { on: (event, listener) => stdout.on(event, listener) },
+    stderr: { on: (event, listener) => stderr.on(event, listener) },
+    on: (event, listener) => events.on(event, listener as (...args: unknown[]) => void),
+    kill: () => {},
+  };
+}
+
 function fakeFs(over: Partial<SpriteFsLike> = {}): SpriteFsLike {
   return {
     readFile: async () => Buffer.from('contents'),
@@ -561,9 +582,10 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
   // the "not ready yet" case, distinct from the fast pre-open drop covered
   // above) used to burn the full 30s per outer attempt, since a timeout is
   // deliberately NOT retried by the inner wake-retry (`isPreOpenWakeError`
-  // excludes it). The tiered timeout bounds this to LOCKDOWN_EXEC_TIMEOUT_MS
-  // per non-final attempt, with only the last attempt keeping the full 30s.
-  it('given a FRESH create whose mkdir HANGS (never resolves) on every attempt, should fast-fail the non-final attempts and bound total retry time well under the old per-attempt-30s worst case, then destroy', async () => {
+  // excludes it). ONLY the first attempt is capped at LOCKDOWN_EXEC_TIMEOUT_MS
+  // — every attempt after it keeps the full 30s (see applyEgressLockdown's
+  // doc for why only the first, not every-but-last, is shortened).
+  it('given a FRESH create whose mkdir HANGS (never resolves) on every attempt, should fast-fail only the first attempt and bound total retry time well under the old per-attempt-30s worst case, then destroy', async () => {
     vi.useFakeTimers();
     try {
       let destroyed: string | null = null;
@@ -590,11 +612,14 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
       const result = client.getOrCreate({ name: 'k', options });
       const assertion = expect(result).rejects.toBeInstanceOf(SandboxProvisionError);
 
-      // Worst case: 2 × LOCKDOWN_EXEC_TIMEOUT_MS (5s) + FS_OP_TIMEOUT_MS (30s)
-      // on the last attempt + linear backoff (500ms + 1000ms) ≈ 41.5s — down
-      // from the ~91.5s this loop actually produced before this fix (3 × 30s,
-      // since a hang-to-timeout never triggers the inner wake-retry).
-      await vi.advanceTimersByTimeAsync(42_000);
+      // Worst case: LOCKDOWN_EXEC_TIMEOUT_MS (5s, attempt 1 only) +
+      // 2 × FS_OP_TIMEOUT_MS (30s, attempts 2 and 3) + linear backoff
+      // (500ms + 1000ms) ≈ 66.5s — down from the ~91.5s this loop actually
+      // produced before this fix (3 × 30s, since a hang-to-timeout never
+      // triggers the inner wake-retry), while keeping TWO full 30s
+      // fresh-spawn chances (not just one) for a merely-slow boot — see the
+      // next test.
+      await vi.advanceTimersByTimeAsync(67_000);
       await assertion;
 
       expect(mkdirAttempts).toBe(3);
@@ -604,7 +629,13 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     }
   });
 
-  it('given a FRESH create whose mkdir HANGS on the first two attempts but succeeds on the third (last, full-timeout) attempt, should retain and succeed rather than destroy — the safety-net attempt is never shortchanged', async () => {
+  // Direct regression test for the P2 finding on an earlier version of this
+  // fix (PR #2113): a Sprite that's merely SLOW — not broken — must still get
+  // a full, genuine 30s window on attempts after the first, not be raced past
+  // by an undersized timeout. `fakeSlowCommand` exits 25s into attempt 2's
+  // window (deep inside its 30s budget, not near-instantly), which an
+  // undersized per-attempt timeout would have missed entirely.
+  it('given a FRESH create whose mkdir HANGS on attempt 1 but succeeds 25s into attempt 2 (deep inside its full 30s window), should retain and succeed — a merely-slow boot is never shortchanged', async () => {
     vi.useFakeTimers();
     try {
       let destroyed: string | null = null;
@@ -613,7 +644,7 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
         name: 'k',
         spawn: () => {
           mkdirAttempts += 1;
-          return mkdirAttempts < 3 ? fakeCommand({ hang: true }) : fakeCommand({ exitCode: 0 });
+          return mkdirAttempts === 1 ? fakeCommand({ hang: true }) : fakeSlowCommand(25_000);
         },
       });
       const sdk: SpritesSdk = {
@@ -628,13 +659,15 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
       const client = createSpritesSandboxClient({ sdk });
       const result = client.getOrCreate({ name: 'k', options });
 
-      // Two 5s fast-fail attempts plus backoff, well under the 30s the final
-      // attempt would still have been allowed if it too had needed it.
-      await vi.advanceTimersByTimeAsync(12_000);
+      // Attempt 1 fails at 5s + 500ms backoff; attempt 2 starts at ~5.5s and
+      // succeeds at ~30.5s (25s into ITS window) — well past the 5s an
+      // undersized non-final timeout would have allowed, but comfortably
+      // inside the full 30s FS_OP_TIMEOUT_MS this attempt actually gets.
+      await vi.advanceTimersByTimeAsync(35_000);
       const handle = await result;
 
       expect(handle.sandboxId).toBe('k');
-      expect(mkdirAttempts).toBe(3);
+      expect(mkdirAttempts).toBe(2);
       expect(destroyed).toBeNull();
     } finally {
       vi.useRealTimers();

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -64,6 +64,13 @@ interface FakeCommandSpec {
    * runs, and "never opened" for one that only errors (the cold-start drop).
    */
   opened?: boolean;
+  /**
+   * Delay (ms) between `spawn` opening and `exit` firing — for a Sprite that's
+   * merely SLOW to become ready (not broken), as opposed to `hang: true`'s
+   * permanently-stuck command. Defaults to 0 (exits on the same macrotask as
+   * `spawn`/`data`).
+   */
+  exitDelayMs?: number;
 }
 
 function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: string[] } {
@@ -82,6 +89,10 @@ function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: 
       return;
     }
     if (spec.hang) return;
+    if (spec.exitDelayMs) {
+      setTimeout(() => events.emit('exit', spec.exitCode ?? 0), spec.exitDelayMs);
+      return;
+    }
     events.emit('exit', spec.exitCode ?? 0);
   }, 0);
 
@@ -93,27 +104,6 @@ function fakeCommand(spec: FakeCommandSpec = {}): SpriteCommandLike & { killed: 
       killed.push(signal ?? 'SIGTERM');
     },
     killed,
-  };
-}
-
-/**
- * A command that opens immediately but doesn't exit until `delayMs` later —
- * for testing a Sprite that's merely SLOW to become ready (not broken), as
- * opposed to `fakeCommand({ hang: true })`'s permanently-stuck command. Used
- * to prove a late exit, deep inside a full-length retry attempt's timeout
- * window, still succeeds rather than being raced past by an earlier attempt.
- */
-function fakeSlowCommand(delayMs: number, exitCode = 0): SpriteCommandLike {
-  const events = new EventEmitter();
-  const stdout = new EventEmitter();
-  const stderr = new EventEmitter();
-  setTimeout(() => events.emit('spawn'), 0);
-  setTimeout(() => events.emit('exit', exitCode), delayMs);
-  return {
-    stdout: { on: (event, listener) => stdout.on(event, listener) },
-    stderr: { on: (event, listener) => stderr.on(event, listener) },
-    on: (event, listener) => events.on(event, listener as (...args: unknown[]) => void),
-    kill: () => {},
   };
 }
 
@@ -632,7 +622,7 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
   // Direct regression test for the P2 finding on an earlier version of this
   // fix (PR #2113): a Sprite that's merely SLOW — not broken — must still get
   // a full, genuine 30s window on attempts after the first, not be raced past
-  // by an undersized timeout. `fakeSlowCommand` exits 25s into attempt 2's
+  // by an undersized timeout. `exitDelayMs: 25_000` exits 25s into attempt 2's
   // window (deep inside its 30s budget, not near-instantly), which an
   // undersized per-attempt timeout would have missed entirely.
   it('given a FRESH create whose mkdir HANGS on attempt 1 but succeeds 25s into attempt 2 (deep inside its full 30s window), should retain and succeed — a merely-slow boot is never shortchanged', async () => {
@@ -644,7 +634,7 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
         name: 'k',
         spawn: () => {
           mkdirAttempts += 1;
-          return mkdirAttempts === 1 ? fakeCommand({ hang: true }) : fakeSlowCommand(25_000);
+          return mkdirAttempts === 1 ? fakeCommand({ hang: true }) : fakeCommand({ exitDelayMs: 25_000 });
         },
       });
       const sdk: SpritesSdk = {

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -556,6 +556,91 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     expect(destroyed).toBe('k');
   });
 
+  // Regression test for the egress-lockdown retry-compounding latency bug: a
+  // freshly-created Sprite whose mkdir exec HANGS (never emits exit/error —
+  // the "not ready yet" case, distinct from the fast pre-open drop covered
+  // above) used to burn the full 30s per outer attempt, since a timeout is
+  // deliberately NOT retried by the inner wake-retry (`isPreOpenWakeError`
+  // excludes it). The tiered timeout bounds this to LOCKDOWN_EXEC_TIMEOUT_MS
+  // per non-final attempt, with only the last attempt keeping the full 30s.
+  it('given a FRESH create whose mkdir HANGS (never resolves) on every attempt, should fast-fail the non-final attempts and bound total retry time well under the old per-attempt-30s worst case, then destroy', async () => {
+    vi.useFakeTimers();
+    try {
+      let destroyed: string | null = null;
+      let mkdirAttempts = 0;
+      const sprite = fakeSprite({
+        name: 'k',
+        spawn: () => {
+          mkdirAttempts += 1;
+          // opened (spawn fires) but never exits: a Sprite whose exec surface
+          // accepted the connection but isn't ready to run commands yet.
+          return fakeCommand({ hang: true });
+        },
+      });
+      const sdk: SpritesSdk = {
+        getSprite: async () => {
+          throw new Error('not found');
+        },
+        createSprite: async () => sprite,
+        deleteSprite: async (name) => {
+          destroyed = name;
+        },
+      };
+      const client = createSpritesSandboxClient({ sdk });
+      const result = client.getOrCreate({ name: 'k', options });
+      const assertion = expect(result).rejects.toBeInstanceOf(SandboxProvisionError);
+
+      // Worst case: 2 × LOCKDOWN_EXEC_TIMEOUT_MS (5s) + FS_OP_TIMEOUT_MS (30s)
+      // on the last attempt + linear backoff (500ms + 1000ms) ≈ 41.5s — down
+      // from the ~91.5s this loop actually produced before this fix (3 × 30s,
+      // since a hang-to-timeout never triggers the inner wake-retry).
+      await vi.advanceTimersByTimeAsync(42_000);
+      await assertion;
+
+      expect(mkdirAttempts).toBe(3);
+      expect(destroyed).toBe('k');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('given a FRESH create whose mkdir HANGS on the first two attempts but succeeds on the third (last, full-timeout) attempt, should retain and succeed rather than destroy — the safety-net attempt is never shortchanged', async () => {
+    vi.useFakeTimers();
+    try {
+      let destroyed: string | null = null;
+      let mkdirAttempts = 0;
+      const sprite = fakeSprite({
+        name: 'k',
+        spawn: () => {
+          mkdirAttempts += 1;
+          return mkdirAttempts < 3 ? fakeCommand({ hang: true }) : fakeCommand({ exitCode: 0 });
+        },
+      });
+      const sdk: SpritesSdk = {
+        getSprite: async () => {
+          throw new Error('not found');
+        },
+        createSprite: async () => sprite,
+        deleteSprite: async (name) => {
+          destroyed = name;
+        },
+      };
+      const client = createSpritesSandboxClient({ sdk });
+      const result = client.getOrCreate({ name: 'k', options });
+
+      // Two 5s fast-fail attempts plus backoff, well under the 30s the final
+      // attempt would still have been allowed if it too had needed it.
+      await vi.advanceTimersByTimeAsync(12_000);
+      const handle = await result;
+
+      expect(handle.sandboxId).toBe('k');
+      expect(mkdirAttempts).toBe(3);
+      expect(destroyed).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('given a fresh Sprite destroyed after exhausting its retry budget, the next acquire under the same name should provision a clean replacement and succeed', async () => {
     let created = 0;
     let policyCalls = 0;

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -1197,6 +1197,18 @@ export function planProvisionFailure({
 // see `applyEgressLockdown`'s call site).
 const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
 
+// Per-attempt timeout for the fresh-create lockdown's `mkdir` exec, used for
+// every attempt EXCEPT the last — see `applyEgressLockdown`'s per-attempt
+// timeout selection. Both Fly's own design (fly.io/blog/design-and-implementation:
+// pooled "empty" Sprites, a `create` is "basically just... start") and
+// docs.sprites.dev's quickstart ("running and ready to accept commands") say a
+// fresh Sprite is ready in ~1-2s, so 5s already gives 2.5-5x margin for the
+// common case. The LAST attempt still gets the full `FS_OP_TIMEOUT_MS` as a
+// safety net before `planProvisionFailure` condemns the Sprite to destroy, so a
+// genuinely-slow-but-healthy outlier boot is never misjudged as unusable — this
+// only shortens how long the EARLIER attempts wait before retrying.
+const LOCKDOWN_EXEC_TIMEOUT_MS = 5_000;
+
 /**
  * Apply the deny-by-default egress policy and ensure the sandbox root exists,
  * retrying a FAILED lockdown up to `maxAttempts` times (with backoff) before
@@ -1232,16 +1244,25 @@ const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
  *
  * Nested retry note: the `mkdir` step below goes through
  * `runSpawnedWithWakeRetry`, which has its OWN bounded wake-drop retry
- * (`MAX_EXEC_ATTEMPTS`, each capped at the 30s passed here). In the
- * vanishingly rare worst case where a Sprite hits pre-open wake-drops on every
- * inner attempt AND every outer attempt, the two bounds compound
- * (`maxAttempts` × `MAX_EXEC_ATTEMPTS` × 30s, plus backoff) — several minutes,
- * not the ~90s a glance at `maxAttempts` alone suggests. This is accepted: it
- * requires a VM that is broken in a very specific, narrow way, this driver
- * runs inside long-lived Fly services (not a hard-timeout serverless
- * function), and the alternative — a shorter per-attempt timeout — risks
- * misjudging a merely slow-to-wake but healthy cold boot as "unusable" (the
- * exact failure mode this leaf exists to fix).
+ * (`MAX_EXEC_ATTEMPTS`). That inner retry only re-runs a STRUCTURALLY
+ * pre-open failure (`isPreOpenWakeError` — a fast WebSocket-closed-before-open
+ * drop); a Sprite whose exec surface simply isn't accepting commands yet
+ * hangs instead of erroring, which is a timeout, not a pre-open drop, and the
+ * inner retry deliberately does not touch it (a timeout "may already have
+ * run" the command). So a not-yet-ready Sprite is discovered only by the
+ * OUTER loop's own per-attempt timeout expiring — see `LOCKDOWN_EXEC_TIMEOUT_MS`.
+ * Each attempt but the last is capped at `LOCKDOWN_EXEC_TIMEOUT_MS` (5s); the
+ * last attempt gets the full `FS_OP_TIMEOUT_MS` (30s) as a final safety net.
+ * Worst case for a fresh Sprite that hangs on every attempt is therefore
+ * `2 × LOCKDOWN_EXEC_TIMEOUT_MS + FS_OP_TIMEOUT_MS` plus backoff — about 41.5s
+ * — down from the ~91.5s this loop actually produced before (3 × 30s, since a
+ * hang-to-timeout never triggers the inner retry) and the ~270s theoretical
+ * figure this comment used to cite (which required the inner retry to ALSO
+ * compound on fast pre-open drops every attempt — a materially different and
+ * much rarer failure mode than a merely-not-ready-yet Sprite). Reserving the
+ * full timeout for the last attempt keeps the same "don't misjudge a
+ * slow-but-healthy cold boot as unusable" guarantee the original single 30s
+ * value was there for — see `LOCKDOWN_EXEC_TIMEOUT_MS`'s doc.
  *
  * Residual risk (accepted, out of scope): if the PROCESS itself is killed
  * mid-loop (a Fly Machine restart/OOM, not a request timeout — see above),
@@ -1281,14 +1302,16 @@ async function applyEgressLockdown({
         await sprite.updateNetworkPolicy(policy);
         policyApplied = true;
       }
-      // Use spawn + runSpawned (30 s wall-clock) to create the workspace dir
-      // instead of filesystem().mkdir(). The filesystem API uses a bare fetch()
-      // with no AbortSignal — it hangs for 52–90 s when the Sprite VM is
-      // cold-booting and Fly's proxy eventually closes the connection. spawn()
-      // connects via WebSocket, which is the designated wake-up path;
-      // runSpawned enforces the timeout and SIGKILLs if the Sprite never
-      // becomes ready.
-      await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, 30_000);
+      // Use spawn + runSpawned instead of filesystem().mkdir(). The filesystem
+      // API uses a bare fetch() with no AbortSignal — it hangs for 52–90 s when
+      // the Sprite VM is cold-booting and Fly's proxy eventually closes the
+      // connection. spawn() connects via WebSocket, which is the designated
+      // wake-up path; runSpawned enforces the timeout and SIGKILLs if the
+      // Sprite never becomes ready. Every attempt but the last is capped at
+      // LOCKDOWN_EXEC_TIMEOUT_MS (fast-fail); the last gets the full
+      // FS_OP_TIMEOUT_MS as a safety net — see this function's doc comment.
+      const mkdirTimeoutMs = attempt === maxAttempts ? FS_OP_TIMEOUT_MS : LOCKDOWN_EXEC_TIMEOUT_MS;
+      await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, mkdirTimeoutMs);
       return;
     } catch (error) {
       const plan = planProvisionFailure({ fresh, attempt, maxAttempts });

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -1197,24 +1197,43 @@ export function planProvisionFailure({
 // see `applyEgressLockdown`'s call site).
 const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
 
-// Per-attempt timeout for the fresh-create lockdown's `mkdir` exec, used ONLY
-// for the FIRST of several attempts — see `applyEgressLockdown`'s per-attempt
-// timeout selection. Both Fly's own design (fly.io/blog/design-and-implementation:
-// pooled "empty" Sprites, a `create` is "basically just... start") and
-// docs.sprites.dev's quickstart ("running and ready to accept commands") say a
-// fresh Sprite is ready in ~1-2s, so 5s already gives 2.5-5x margin for the
-// common case, and this shrinks the ALWAYS-fails worst case without touching
-// destroy timing much. EVERY attempt after the first — not just the last —
-// keeps the full `FS_OP_TIMEOUT_MS`: a P2 review finding (PR #2113) on an
-// earlier version of this fix (which shortened every attempt but the last)
-// correctly pointed out that shrinking two of three attempts meaningfully cut
-// the total patience for a genuinely-slow-but-healthy boot, since a timeout is
-// never retried mid-attempt (no fresh spawn happens once one is killed) — see
-// `applyEgressLockdown`'s doc for the corrected worst-case math. Shrinking
-// only attempt 1 keeps nearly all of that patience (only one 30s window is
-// removed, not two) while still discovering an always-broken Sprite ~25s
-// faster than before.
+// Per-attempt timeout for a FRESH Sprite's very first lockdown attempt only
+// — see `mkdirLockdownTimeoutMs`. Both Fly's own design
+// (fly.io/blog/design-and-implementation: pooled "empty" Sprites, a `create`
+// is "basically just... start") and docs.sprites.dev's quickstart ("running
+// and ready to accept commands") say a fresh Sprite is ready in ~1-2s, so 5s
+// already gives 2.5-5x margin for the common case.
+//
+// Only attempt 1 is shortened — every attempt after it keeps the full
+// `FS_OP_TIMEOUT_MS` (30s). An earlier version of this fix shortened every
+// attempt but the last; a P2 review finding on PR #2113 correctly pointed out
+// that shortening two of three attempts meaningfully cut the total patience a
+// genuinely-slow-but-healthy boot has to succeed, since a timeout is never
+// retried mid-attempt (no fresh spawn happens once one is killed) — losing a
+// whole attempt is losing a whole 30s fresh-spawn chance, not just shaving
+// time off the margin. Shortening only attempt 1 keeps two full 30s chances
+// (attempts 2 and 3) instead of one: worst case for a fresh Sprite that hangs
+// on every attempt is `LOCKDOWN_EXEC_TIMEOUT_MS + 2 × FS_OP_TIMEOUT_MS` plus
+// linear backoff — about 66.5s, down from the ~91.5s this loop actually
+// produced before this fix (3 × 30s, since a hang-to-timeout never triggers
+// the inner wake-retry) and the ~270s theoretical figure once cited here
+// (which required the inner retry to ALSO compound on fast pre-open drops
+// every attempt — a materially different and much rarer failure mode).
 const LOCKDOWN_EXEC_TIMEOUT_MS = 5_000;
+
+/**
+ * Pure: the timeout for the lockdown `mkdir` exec on this `attempt` — see
+ * `LOCKDOWN_EXEC_TIMEOUT_MS`'s doc for why only attempt 1 is shortened and
+ * the worst-case math this produces. Gated on `fresh` itself, not on
+ * `maxAttempts > 1`: the two happen to coincide at today's single call site
+ * (`maxAttempts: fresh ? PROVISION_LOCKDOWN_MAX_ATTEMPTS : 1`), but `fresh` is
+ * the actual invariant this leaf cares about, so a future caller or a changed
+ * `PROVISION_LOCKDOWN_MAX_ATTEMPTS` can't silently detune it back to the old
+ * always-30s behavior.
+ */
+export function mkdirLockdownTimeoutMs(attempt: number, fresh: boolean): number {
+  return attempt === 1 && fresh ? LOCKDOWN_EXEC_TIMEOUT_MS : FS_OP_TIMEOUT_MS;
+}
 
 /**
  * Apply the deny-by-default egress policy and ensure the sandbox root exists,
@@ -1258,29 +1277,8 @@ const LOCKDOWN_EXEC_TIMEOUT_MS = 5_000;
  * inner retry deliberately does not touch it (a timeout "may already have
  * run" the command, and no fresh spawn happens once a stuck one is killed).
  * So a not-yet-ready Sprite is discovered only by the OUTER loop's own
- * per-attempt timeout expiring, and only a FRESH spawn on the NEXT outer
- * attempt gives a Sprite that becomes ready mid-wait another chance to
- * succeed — see `LOCKDOWN_EXEC_TIMEOUT_MS`.
- *
- * ONLY the first attempt is capped at `LOCKDOWN_EXEC_TIMEOUT_MS` (5s); every
- * attempt after it — including but not limited to the last — keeps the full
- * `FS_OP_TIMEOUT_MS` (30s). (An earlier version of this fix shortened every
- * attempt but the last; a P2 review finding on PR #2113 correctly pointed out
- * that shortening two of the three attempts materially cut the total time a
- * genuinely-slow-but-healthy boot has to succeed before being destroyed,
- * since each attempt is a separate fresh-spawn chance and losing one is
- * losing a whole 30s window, not just shaving time off it.) Worst case for a
- * fresh Sprite that hangs on every attempt is now `LOCKDOWN_EXEC_TIMEOUT_MS +
- * 2 × FS_OP_TIMEOUT_MS` plus backoff — about 66.5s — down from the ~91.5s
- * this loop actually produced before this fix (3 × 30s, since a
- * hang-to-timeout never triggers the inner retry) and the ~270s theoretical
- * figure this comment used to cite (which required the inner retry to ALSO
- * compound on fast pre-open drops every attempt — a materially different and
- * much rarer failure mode than a merely-not-ready-yet Sprite). This keeps two
- * full 30s fresh-spawn chances (attempts 2 and 3) instead of collapsing to
- * one, so only a boot slower than ~66.5s (rather than ~41.5s) risks being
- * misjudged as unusable — narrower, and pushed deeper into outlier territory
- * where "genuinely broken" is the more likely explanation anyway.
+ * per-attempt timeout expiring — see `mkdirLockdownTimeoutMs` for which
+ * timeout each attempt gets and the worst-case math that produces.
  *
  * Residual risk (accepted, out of scope): if the PROCESS itself is killed
  * mid-loop (a Fly Machine restart/OOM, not a request timeout — see above),
@@ -1325,12 +1323,9 @@ async function applyEgressLockdown({
       // the Sprite VM is cold-booting and Fly's proxy eventually closes the
       // connection. spawn() connects via WebSocket, which is the designated
       // wake-up path; runSpawned enforces the timeout and SIGKILLs if the
-      // Sprite never becomes ready. ONLY the first of several attempts is
-      // capped at LOCKDOWN_EXEC_TIMEOUT_MS (fast-fail); every attempt after it
-      // keeps the full FS_OP_TIMEOUT_MS, preserving two full fresh-spawn
-      // chances for a merely-slow (not broken) boot — see this function's doc
-      // comment for why only shortening attempt 1 (not every-but-last).
-      const mkdirTimeoutMs = attempt === 1 && maxAttempts > 1 ? LOCKDOWN_EXEC_TIMEOUT_MS : FS_OP_TIMEOUT_MS;
+      // Sprite never becomes ready — see `mkdirLockdownTimeoutMs` for which
+      // timeout each attempt gets.
+      const mkdirTimeoutMs = mkdirLockdownTimeoutMs(attempt, fresh);
       await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, mkdirTimeoutMs);
       return;
     } catch (error) {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -1197,16 +1197,23 @@ export function planProvisionFailure({
 // see `applyEgressLockdown`'s call site).
 const PROVISION_LOCKDOWN_MAX_ATTEMPTS = 3;
 
-// Per-attempt timeout for the fresh-create lockdown's `mkdir` exec, used for
-// every attempt EXCEPT the last — see `applyEgressLockdown`'s per-attempt
+// Per-attempt timeout for the fresh-create lockdown's `mkdir` exec, used ONLY
+// for the FIRST of several attempts — see `applyEgressLockdown`'s per-attempt
 // timeout selection. Both Fly's own design (fly.io/blog/design-and-implementation:
 // pooled "empty" Sprites, a `create` is "basically just... start") and
 // docs.sprites.dev's quickstart ("running and ready to accept commands") say a
 // fresh Sprite is ready in ~1-2s, so 5s already gives 2.5-5x margin for the
-// common case. The LAST attempt still gets the full `FS_OP_TIMEOUT_MS` as a
-// safety net before `planProvisionFailure` condemns the Sprite to destroy, so a
-// genuinely-slow-but-healthy outlier boot is never misjudged as unusable — this
-// only shortens how long the EARLIER attempts wait before retrying.
+// common case, and this shrinks the ALWAYS-fails worst case without touching
+// destroy timing much. EVERY attempt after the first — not just the last —
+// keeps the full `FS_OP_TIMEOUT_MS`: a P2 review finding (PR #2113) on an
+// earlier version of this fix (which shortened every attempt but the last)
+// correctly pointed out that shrinking two of three attempts meaningfully cut
+// the total patience for a genuinely-slow-but-healthy boot, since a timeout is
+// never retried mid-attempt (no fresh spawn happens once one is killed) — see
+// `applyEgressLockdown`'s doc for the corrected worst-case math. Shrinking
+// only attempt 1 keeps nearly all of that patience (only one 30s window is
+// removed, not two) while still discovering an always-broken Sprite ~25s
+// faster than before.
 const LOCKDOWN_EXEC_TIMEOUT_MS = 5_000;
 
 /**
@@ -1249,20 +1256,31 @@ const LOCKDOWN_EXEC_TIMEOUT_MS = 5_000;
  * drop); a Sprite whose exec surface simply isn't accepting commands yet
  * hangs instead of erroring, which is a timeout, not a pre-open drop, and the
  * inner retry deliberately does not touch it (a timeout "may already have
- * run" the command). So a not-yet-ready Sprite is discovered only by the
- * OUTER loop's own per-attempt timeout expiring — see `LOCKDOWN_EXEC_TIMEOUT_MS`.
- * Each attempt but the last is capped at `LOCKDOWN_EXEC_TIMEOUT_MS` (5s); the
- * last attempt gets the full `FS_OP_TIMEOUT_MS` (30s) as a final safety net.
- * Worst case for a fresh Sprite that hangs on every attempt is therefore
- * `2 × LOCKDOWN_EXEC_TIMEOUT_MS + FS_OP_TIMEOUT_MS` plus backoff — about 41.5s
- * — down from the ~91.5s this loop actually produced before (3 × 30s, since a
+ * run" the command, and no fresh spawn happens once a stuck one is killed).
+ * So a not-yet-ready Sprite is discovered only by the OUTER loop's own
+ * per-attempt timeout expiring, and only a FRESH spawn on the NEXT outer
+ * attempt gives a Sprite that becomes ready mid-wait another chance to
+ * succeed — see `LOCKDOWN_EXEC_TIMEOUT_MS`.
+ *
+ * ONLY the first attempt is capped at `LOCKDOWN_EXEC_TIMEOUT_MS` (5s); every
+ * attempt after it — including but not limited to the last — keeps the full
+ * `FS_OP_TIMEOUT_MS` (30s). (An earlier version of this fix shortened every
+ * attempt but the last; a P2 review finding on PR #2113 correctly pointed out
+ * that shortening two of the three attempts materially cut the total time a
+ * genuinely-slow-but-healthy boot has to succeed before being destroyed,
+ * since each attempt is a separate fresh-spawn chance and losing one is
+ * losing a whole 30s window, not just shaving time off it.) Worst case for a
+ * fresh Sprite that hangs on every attempt is now `LOCKDOWN_EXEC_TIMEOUT_MS +
+ * 2 × FS_OP_TIMEOUT_MS` plus backoff — about 66.5s — down from the ~91.5s
+ * this loop actually produced before this fix (3 × 30s, since a
  * hang-to-timeout never triggers the inner retry) and the ~270s theoretical
  * figure this comment used to cite (which required the inner retry to ALSO
  * compound on fast pre-open drops every attempt — a materially different and
- * much rarer failure mode than a merely-not-ready-yet Sprite). Reserving the
- * full timeout for the last attempt keeps the same "don't misjudge a
- * slow-but-healthy cold boot as unusable" guarantee the original single 30s
- * value was there for — see `LOCKDOWN_EXEC_TIMEOUT_MS`'s doc.
+ * much rarer failure mode than a merely-not-ready-yet Sprite). This keeps two
+ * full 30s fresh-spawn chances (attempts 2 and 3) instead of collapsing to
+ * one, so only a boot slower than ~66.5s (rather than ~41.5s) risks being
+ * misjudged as unusable — narrower, and pushed deeper into outlier territory
+ * where "genuinely broken" is the more likely explanation anyway.
  *
  * Residual risk (accepted, out of scope): if the PROCESS itself is killed
  * mid-loop (a Fly Machine restart/OOM, not a request timeout — see above),
@@ -1307,10 +1325,12 @@ async function applyEgressLockdown({
       // the Sprite VM is cold-booting and Fly's proxy eventually closes the
       // connection. spawn() connects via WebSocket, which is the designated
       // wake-up path; runSpawned enforces the timeout and SIGKILLs if the
-      // Sprite never becomes ready. Every attempt but the last is capped at
-      // LOCKDOWN_EXEC_TIMEOUT_MS (fast-fail); the last gets the full
-      // FS_OP_TIMEOUT_MS as a safety net — see this function's doc comment.
-      const mkdirTimeoutMs = attempt === maxAttempts ? FS_OP_TIMEOUT_MS : LOCKDOWN_EXEC_TIMEOUT_MS;
+      // Sprite never becomes ready. ONLY the first of several attempts is
+      // capped at LOCKDOWN_EXEC_TIMEOUT_MS (fast-fail); every attempt after it
+      // keeps the full FS_OP_TIMEOUT_MS, preserving two full fresh-spawn
+      // chances for a merely-slow (not broken) boot — see this function's doc
+      // comment for why only shortening attempt 1 (not every-but-last).
+      const mkdirTimeoutMs = attempt === 1 && maxAttempts > 1 ? LOCKDOWN_EXEC_TIMEOUT_MS : FS_OP_TIMEOUT_MS;
       await runSpawnedWithWakeRetry(() => sprite.spawn('mkdir', ['-p', SANDBOX_ROOT]), DEFAULT_MAX_OUTPUT_BYTES, mkdirTimeoutMs);
       return;
     } catch (error) {


### PR DESCRIPTION
## Summary

- Root cause (confirmed, not assumed — see below): `applyEgressLockdown`'s `mkdir` exec, the final step of locking down a freshly-created Fly Sprite, ran through a hardcoded `30_000`ms timeout on **every** outer retry attempt (up to 3 for a fresh Sprite). A Sprite whose exec surface isn't ready yet just *hangs* rather than erroring, and a timeout is deliberately **not** retried by the existing fast inner wake-retry (`isPreOpenWakeError` explicitly excludes `SandboxCommandTimeoutError` — a timeout "may already have run" the command, and no fresh spawn happens once a stuck one is killed). So non-readiness was discovered only by burning the full 30s per attempt, with no readiness probe anywhere in the driver. Worst case: ~91.5s realistic (3 × 30s), ~270s in the theoretical case the old code comment cited.
- This was previously misattributed to a Fly platform limitation and nearly justified building a custom Sprite pool. Fly's own blog ([fly.io/blog/design-and-implementation](https://fly.io/blog/design-and-implementation/)) and docs ([docs.sprites.dev/quickstart](https://docs.sprites.dev/quickstart/)) both state Sprites are pooled empty at the platform level and are "running and ready to accept commands" in ~1-2s — so the multi-minute worst case was PageSpace's own oversized timeout, not something a pool would have fixed. Building one would have been redundant infrastructure papering over this bug.
- Fix: add `LOCKDOWN_EXEC_TIMEOUT_MS` (5s — ~2.5-5x margin over Fly's documented ~1-2s ready time), used **only for the first** lockdown attempt; every attempt after it keeps the full `FS_OP_TIMEOUT_MS` (30s). New worst case: **~66.5s**, down from ~91.5s/~270s. The retry/destroy security contract (`planProvisionFailure`) is completely unchanged — lockdown is still verified and retried before any other exec is allowed through on a fresh Sprite, and a persistently-broken fresh Sprite is still destroyed on exhaustion. Only *how long* each attempt waits before deciding to retry changes.
  - **Revised during review**: an earlier version of this fix shortened *every attempt but the last* (5s, 5s, 30s ⇒ ~41.5s worst case). A [Codex P2 finding](#discussion_r0) correctly pointed out that shortening two of three attempts collapsed two independent 30s fresh-spawn chances into one, meaningfully cutting the total patience for a Sprite that's merely slow (not broken) to become ready — since a timeout is never retried mid-attempt, losing a whole attempt's window is losing a whole chance, not just shaving time. Now only attempt 1 is shortened, preserving two full 30s fresh-spawn chances (attempts 2 and 3) — a smaller latency win (~25s/~27% vs. the ~50s/~55% cut before) but a much narrower and more extreme regression window: only a boot slower than ~66.5s (not ~41.5s) risks being misjudged as unusable, deep enough into outlier territory that "genuinely broken" is the more likely explanation anyway. A new test (`fakeSlowCommand`, resolves 25s into attempt 2's window) directly proves a merely-slow boot now succeeds deep inside a full-length attempt.
- Resumed Sprites (`maxAttempts: 1`) are unaffected: their single attempt is always the "only" attempt (never treated as a shortenable "first of several"), so they keep today's 30s behavior exactly.
- Scoped to exactly one call site (`sprites.ts`'s `applyEgressLockdown`, originally line 1291). `FS_OP_TIMEOUT_MS`'s value, the general filesystem wake-retry path (`fsWithWakeRetry`/`recoverFsViaExec`), and the existing-Sprite wake-retry path (`MAX_EXEC_ATTEMPTS`/`withWakeRetry`, lines ~480-610 — already fast/correct) are untouched.

## Verification

No live `SPRITES_API_TOKEN` is available in this dev environment (confirmed — unset in shell, not in any `.env*` file; it's a Fly secret in prod), so this is verified via the retry/timeout math above, not an empirical measurement. **Live end-to-end timing against the real Sprites API is still needed** before this is considered fully done — someone with the Fly secret should time an actual fresh branch-terminal creation post-deploy to confirm the happy path is close to Fly's documented ~1-2s (this fix doesn't change the happy path — only the failure/retry path — so that should already have been true) and that a forced-unready scenario now recovers in well under two minutes rather than potentially several.

## Test plan

- [x] Three regression tests in `sprites.test.ts`, using `vi.useFakeTimers()` (matching the existing `createCheckpoint`-timeout test pattern):
  - Hangs on every attempt → destroyed within the new ~66.5s bound (not the old ~91.5s/270s).
  - Hangs on attempt 1, resolves 25s into attempt 2's full 30s window (`fakeSlowCommand`) → retained and succeeds, proving a merely-slow boot is never shortchanged.
- [x] `bun run typecheck` from `packages/lib` — identical error count (762) before/after, same single pre-existing `@fly/sprites` module-resolution error in this worktree (env issue, unrelated to this change).
- [x] `vitest run` on `sprites.test.ts` from `packages/lib` — 96/98 passing; the 2 failures (`isSpriteGoneStatus` tests dynamically importing `@fly/sprites`) are pre-existing and identical on the unmodified branch (confirmed via `git stash`).
- [ ] Live end-to-end timing against the real Sprites API (needs `SPRITES_API_TOKEN`, not available here).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_014X9zNtJ32udx1CC6gJcgop