### PR TITLE
Raise sandbox concurrency limits + add live concurrency view

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -87,6 +87,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['channels/[pageId]/read', 'Channel read receipt, low-risk fire-and-forget'],
   ['notifications/[id]/read', 'Notification read receipt, low-risk'],
   ['notifications/read-all', 'Bulk notification read receipt, low-risk'],
+  ['credits/concurrency', 'Polled every 5s by ConcurrencyCard for as long as the usage page stays open — auditing every poll would write ~720 rows/hour per open tab into the audit table for a non-sensitive advisory count (own in-flight credit-hold count + configured tier ceiling, no spend/balance detail)'],
 
   // --- Model discovery (no user data, no external calls) ---
   ['ai/models', 'Public model-catalog discovery, unauthenticated, no user data or resource access'],

--- a/apps/web/src/app/api/credits/concurrency/route.ts
+++ b/apps/web/src/app/api/credits/concurrency/route.ts
@@ -3,7 +3,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { getLiveMachineInFlight } from '@pagespace/lib/billing/live-concurrency-query';
+import { getLiveInFlightHolds } from '@pagespace/lib/billing/live-concurrency-query';
 import { MACHINE_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { getCodeExecutionConcurrencyLimit } from '@pagespace/lib/services/sandbox/quota';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -14,10 +14,13 @@ const isSubscriptionTier = (value: string): value is SubscriptionTier =>
   value === 'free' || value === 'pro' || value === 'founder' || value === 'business';
 
 /**
- * GET /api/credits/concurrency — the authenticated user's live agent-terminal
- * session count. `liveAgentSessions` is the literal COUNT the
- * `too_many_in_flight` gate checks against `MACHINE_MAX_INFLIGHT` (not an
- * approximation). `codeExecutionLimit` is the configured per-tier ceiling from
+ * GET /api/credits/concurrency — the authenticated user's live in-flight
+ * credit-hold count. `inFlightHolds.count` is the literal COUNT the
+ * `too_many_in_flight` gate checks against `MACHINE_MAX_INFLIGHT` on the
+ * user's next Machine run (not an approximation) — it covers ALL of the
+ * user's in-flight AI activity (chat/voice/machine alike), since
+ * `credit_holds` has no per-source column to filter machine-only sessions
+ * out. `codeExecutionLimit` is the configured per-tier ceiling from
  * quota.ts — that semaphore lives in server-process memory, so it has no
  * reliable cross-replica live count and is exposed as a static value only.
  */
@@ -36,7 +39,7 @@ export async function GET(request: NextRequest) {
     const rawTier = rows[0]?.subscriptionTier;
     const tier: SubscriptionTier = rawTier && isSubscriptionTier(rawTier) ? rawTier : 'free';
 
-    const inFlight = await getLiveMachineInFlight(userId);
+    const count = await getLiveInFlightHolds(userId);
 
     auditRequest(request, {
       eventType: 'data.read',
@@ -46,7 +49,7 @@ export async function GET(request: NextRequest) {
     });
 
     return NextResponse.json({
-      liveAgentSessions: { inFlight, limit: MACHINE_MAX_INFLIGHT },
+      inFlightHolds: { count, limit: MACHINE_MAX_INFLIGHT },
       codeExecutionLimit: getCodeExecutionConcurrencyLimit(tier),
     });
   } catch (error) {

--- a/apps/web/src/app/api/credits/concurrency/route.ts
+++ b/apps/web/src/app/api/credits/concurrency/route.ts
@@ -7,7 +7,6 @@ import { getLiveInFlightHolds } from '@pagespace/lib/billing/live-concurrency-qu
 import { MACHINE_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import { getCodeExecutionConcurrencyLimit } from '@pagespace/lib/services/sandbox/quota';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
-import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const isSubscriptionTier = (value: string): value is SubscriptionTier =>
@@ -23,6 +22,15 @@ const isSubscriptionTier = (value: string): value is SubscriptionTier =>
  * out. `codeExecutionLimit` is the configured per-tier ceiling from
  * quota.ts — that semaphore lives in server-process memory, so it has no
  * reliable cross-replica live count and is exposed as a static value only.
+ *
+ * Deliberately NOT audited (unlike its `/api/credits` and
+ * `/api/credits/breakdown` siblings): those are one-shot page-load reads of
+ * financial data, so one `data.read` audit row per view is meaningful
+ * signal. This route is polled every 5s by `ConcurrencyCard` for as long as
+ * the usage page stays open — auditing every poll would write ~720 rows/hour
+ * per open tab into the tamper-evident audit table for a non-sensitive
+ * advisory count (a user reading their own live status), drowning out
+ * genuinely security-relevant events.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -40,13 +48,6 @@ export async function GET(request: NextRequest) {
     const tier: SubscriptionTier = rawTier && isSubscriptionTier(rawTier) ? rawTier : 'free';
 
     const count = await getLiveInFlightHolds(userId);
-
-    auditRequest(request, {
-      eventType: 'data.read',
-      userId,
-      resourceType: 'credit_concurrency',
-      resourceId: 'self',
-    });
 
     return NextResponse.json({
       inFlightHolds: { count, limit: MACHINE_MAX_INFLIGHT },

--- a/apps/web/src/app/api/credits/concurrency/route.ts
+++ b/apps/web/src/app/api/credits/concurrency/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
+import { getLiveMachineInFlight } from '@pagespace/lib/billing/live-concurrency-query';
+import { MACHINE_MAX_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
+import { getCodeExecutionConcurrencyLimit } from '@pagespace/lib/services/sandbox/quota';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const isSubscriptionTier = (value: string): value is SubscriptionTier =>
+  value === 'free' || value === 'pro' || value === 'founder' || value === 'business';
+
+/**
+ * GET /api/credits/concurrency — the authenticated user's live agent-terminal
+ * session count. `liveAgentSessions` is the literal COUNT the
+ * `too_many_in_flight` gate checks against `MACHINE_MAX_INFLIGHT` (not an
+ * approximation). `codeExecutionLimit` is the configured per-tier ceiling from
+ * quota.ts — that semaphore lives in server-process memory, so it has no
+ * reliable cross-replica live count and is exposed as a static value only.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const auth = await requireAuth(request);
+    if (isAuthError(auth)) return auth;
+
+    const { userId } = auth;
+
+    const rows = await db
+      .select({ subscriptionTier: users.subscriptionTier })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+    const rawTier = rows[0]?.subscriptionTier;
+    const tier: SubscriptionTier = rawTier && isSubscriptionTier(rawTier) ? rawTier : 'free';
+
+    const inFlight = await getLiveMachineInFlight(userId);
+
+    auditRequest(request, {
+      eventType: 'data.read',
+      userId,
+      resourceType: 'credit_concurrency',
+      resourceId: 'self',
+    });
+
+    return NextResponse.json({
+      liveAgentSessions: { inFlight, limit: MACHINE_MAX_INFLIGHT },
+      codeExecutionLimit: getCodeExecutionConcurrencyLimit(tier),
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching concurrency status:', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch concurrency status' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/settings/usage/page.tsx
+++ b/apps/web/src/app/settings/usage/page.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, CheckCircle, AlertTriangle } from 'lucide-react';
 import { CreditBalanceCard } from '@/components/billing/CreditBalanceCard';
 import { UsageBreakdownCard } from '@/components/billing/UsageBreakdownCard';
 import { MachineUsageCard } from '@/components/billing/MachineUsageCard';
+import { ConcurrencyCard } from '@/components/billing/ConcurrencyCard';
 import { AutomationsCard } from '@/components/billing/AutomationsCard';
 import { StorageUsageCard } from '@/components/billing/StorageUsageCard';
 
@@ -65,6 +66,7 @@ export default function UsagePage() {
       <CreditBalanceCard />
       <UsageBreakdownCard />
       <MachineUsageCard />
+      <ConcurrencyCard />
       <AutomationsCard />
       <StorageUsageCard />
     </div>

--- a/apps/web/src/components/billing/ConcurrencyCard.tsx
+++ b/apps/web/src/components/billing/ConcurrencyCard.tsx
@@ -7,7 +7,7 @@ import { Gauge } from 'lucide-react';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface ConcurrencyResponse {
-  liveAgentSessions: { inFlight: number; limit: number };
+  inFlightHolds: { count: number; limit: number };
   codeExecutionLimit: number;
 }
 
@@ -18,10 +18,12 @@ const fetcher = async (url: string): Promise<ConcurrencyResponse> => {
 };
 
 /**
- * Live agent-terminal session count — the number the `too_many_in_flight`
- * gate checks against MACHINE_MAX_INFLIGHT, polled rather than socket-driven
- * because `credits:updated` never fires on hold creation (only
- * release/settle), so it would miss increments.
+ * Live in-flight AI-call count — the number the `too_many_in_flight` gate
+ * checks against MACHINE_MAX_INFLIGHT on your next Machine run. Covers ALL
+ * in-flight AI activity (chat/voice/machine alike), not machine sessions
+ * specifically — credit_holds has no per-source column to split them.
+ * Polled rather than socket-driven because `credits:updated` never fires on
+ * hold creation (only release/settle), so it would miss increments.
  */
 export function ConcurrencyCard() {
   const { data, error, isLoading } = useSWR<ConcurrencyResponse>(
@@ -37,7 +39,7 @@ export function ConcurrencyCard() {
           <Gauge className="h-5 w-5" />
           Concurrency
         </CardTitle>
-        <CardDescription>Live agent-terminal sessions right now</CardDescription>
+        <CardDescription>AI calls in flight right now</CardDescription>
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -49,14 +51,15 @@ export function ConcurrencyCard() {
         ) : (
           <div className="space-y-1 text-sm">
             <div className="flex items-center justify-between gap-2">
-              <span className="font-medium">Live agent sessions</span>
+              <span className="font-medium">In-flight AI calls</span>
               <span className="tabular-nums text-muted-foreground">
-                {data.liveAgentSessions.inFlight} / {data.liveAgentSessions.limit}
+                {data.inFlightHolds.count} / {data.inFlightHolds.limit}
               </span>
             </div>
             <p className="text-xs text-muted-foreground">
-              Your tier&apos;s concurrent code-execution ceiling is {data.codeExecutionLimit}
-              (enforced per server instance).
+              Includes chat, voice, and Machine runs combined — this is what a Machine run
+              checks against before starting. Your tier&apos;s separate code-execution ceiling is{' '}
+              {data.codeExecutionLimit} concurrent runs (enforced per server instance).
             </p>
           </div>
         )}

--- a/apps/web/src/components/billing/ConcurrencyCard.tsx
+++ b/apps/web/src/components/billing/ConcurrencyCard.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import useSWR from 'swr';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Gauge } from 'lucide-react';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+interface ConcurrencyResponse {
+  liveAgentSessions: { inFlight: number; limit: number };
+  codeExecutionLimit: number;
+}
+
+const fetcher = async (url: string): Promise<ConcurrencyResponse> => {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`);
+  return response.json();
+};
+
+/**
+ * Live agent-terminal session count — the number the `too_many_in_flight`
+ * gate checks against MACHINE_MAX_INFLIGHT, polled rather than socket-driven
+ * because `credits:updated` never fires on hold creation (only
+ * release/settle), so it would miss increments.
+ */
+export function ConcurrencyCard() {
+  const { data, error, isLoading } = useSWR<ConcurrencyResponse>(
+    '/api/credits/concurrency',
+    fetcher,
+    { refreshInterval: 5000, revalidateOnFocus: false },
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Gauge className="h-5 w-5" />
+          Concurrency
+        </CardTitle>
+        <CardDescription>Live agent-terminal sessions right now</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-4 w-40" />
+        ) : error || !data ? (
+          <p className="text-sm text-muted-foreground">
+            Could not load your concurrency status. Please refresh and try again.
+          </p>
+        ) : (
+          <div className="space-y-1 text-sm">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium">Live agent sessions</span>
+              <span className="tabular-nums text-muted-foreground">
+                {data.liveAgentSessions.inFlight} / {data.liveAgentSessions.limit}
+              </span>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Your tier&apos;s concurrent code-execution ceiling is {data.codeExecutionLimit}
+              (enforced per server instance).
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -192,6 +192,11 @@
       "import": "./dist/billing/machine-payer.js",
       "require": "./dist/billing/machine-payer.js"
     },
+    "./billing/live-concurrency-query": {
+      "types": "./dist/billing/live-concurrency-query.d.ts",
+      "import": "./dist/billing/live-concurrency-query.js",
+      "require": "./dist/billing/live-concurrency-query.js"
+    },
     "./logging/siem-error-hook": {
       "types": "./dist/logging/siem-error-hook.d.ts",
       "import": "./dist/logging/siem-error-hook.js",
@@ -1698,6 +1703,9 @@
       ],
       "billing/credit-funding": [
         "./dist/billing/credit-funding.d.ts"
+      ],
+      "billing/live-concurrency-query": [
+        "./dist/billing/live-concurrency-query.d.ts"
       ],
       "logging/siem-error-hook": [
         "./dist/logging/siem-error-hook.d.ts"

--- a/packages/lib/src/billing/__tests__/live-concurrency-query.test.ts
+++ b/packages/lib/src/billing/__tests__/live-concurrency-query.test.ts
@@ -1,5 +1,5 @@
 /**
- * getLiveMachineInFlight integration tests (real Postgres).
+ * getLiveInFlightHolds integration tests (real Postgres).
  *
  * Requires DATABASE_URL → a running Postgres with migrations applied
  * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable,
@@ -11,7 +11,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
 import { factories } from '@pagespace/db/test/factories';
-import { getLiveMachineInFlight } from '../live-concurrency-query';
+import { getLiveInFlightHolds } from '../live-concurrency-query';
 
 let dbAvailable = false;
 
@@ -20,7 +20,7 @@ async function cleanup(userId: string): Promise<void> {
   await db.delete(creditBalances).where(eq(creditBalances.userId, userId));
 }
 
-describe('getLiveMachineInFlight', () => {
+describe('getLiveInFlightHolds', () => {
   beforeAll(async () => {
     try {
       await db.select().from(creditBalances).limit(1);
@@ -34,7 +34,7 @@ describe('getLiveMachineInFlight', () => {
     if (!dbAvailable) return;
     const user = await factories.createUser();
     try {
-      expect(await getLiveMachineInFlight(user.id)).toBe(0);
+      expect(await getLiveInFlightHolds(user.id)).toBe(0);
     } finally {
       await cleanup(user.id);
     }
@@ -52,8 +52,8 @@ describe('getLiveMachineInFlight', () => {
         { userId: other.id, estCents: 2, expiresAt: future },
       ]);
 
-      expect(await getLiveMachineInFlight(user.id)).toBe(2);
-      expect(await getLiveMachineInFlight(other.id)).toBe(1);
+      expect(await getLiveInFlightHolds(user.id)).toBe(2);
+      expect(await getLiveInFlightHolds(other.id)).toBe(1);
     } finally {
       await cleanup(user.id);
       await cleanup(other.id);
@@ -71,7 +71,27 @@ describe('getLiveMachineInFlight', () => {
         { userId: user.id, estCents: 2, expiresAt: future },
       ]);
 
-      expect(await getLiveMachineInFlight(user.id)).toBe(1);
+      expect(await getLiveInFlightHolds(user.id)).toBe(1);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+
+  it('given holds with no distinguishing source, should count them all (credit_holds has no per-call-type column)', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser();
+    try {
+      const future = new Date(Date.now() + 60_000);
+      // aiUsageLogId is null on every hold here, same as a real chat hold and
+      // a real machine hold both look before settle — there is no field to
+      // filter on, which is exactly why this counts all in-flight AI activity
+      // for the payer, not machine-specific sessions.
+      await db.insert(creditHolds).values([
+        { userId: user.id, estCents: 2, expiresAt: future, aiUsageLogId: null },
+        { userId: user.id, estCents: 25, expiresAt: future, aiUsageLogId: null },
+      ]);
+
+      expect(await getLiveInFlightHolds(user.id)).toBe(2);
     } finally {
       await cleanup(user.id);
     }

--- a/packages/lib/src/billing/__tests__/live-concurrency-query.test.ts
+++ b/packages/lib/src/billing/__tests__/live-concurrency-query.test.ts
@@ -1,0 +1,79 @@
+/**
+ * getLiveMachineInFlight integration tests (real Postgres).
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable,
+ * mirroring credit-gate-concurrency.integration.test.ts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { creditBalances, creditHolds } from '@pagespace/db/schema/credits';
+import { factories } from '@pagespace/db/test/factories';
+import { getLiveMachineInFlight } from '../live-concurrency-query';
+
+let dbAvailable = false;
+
+async function cleanup(userId: string): Promise<void> {
+  await db.delete(creditHolds).where(eq(creditHolds.userId, userId));
+  await db.delete(creditBalances).where(eq(creditBalances.userId, userId));
+}
+
+describe('getLiveMachineInFlight', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(creditBalances).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('given no holds, should return 0', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser();
+    try {
+      expect(await getLiveMachineInFlight(user.id)).toBe(0);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+
+  it('given unexpired holds, should count only this user\'s rows', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser();
+    const other = await factories.createUser();
+    try {
+      const future = new Date(Date.now() + 60_000);
+      await db.insert(creditHolds).values([
+        { userId: user.id, estCents: 2, expiresAt: future },
+        { userId: user.id, estCents: 2, expiresAt: future },
+        { userId: other.id, estCents: 2, expiresAt: future },
+      ]);
+
+      expect(await getLiveMachineInFlight(user.id)).toBe(2);
+      expect(await getLiveMachineInFlight(other.id)).toBe(1);
+    } finally {
+      await cleanup(user.id);
+      await cleanup(other.id);
+    }
+  });
+
+  it('given an expired hold, should exclude it from the count', async () => {
+    if (!dbAvailable) return;
+    const user = await factories.createUser();
+    try {
+      const past = new Date(Date.now() - 1_000);
+      const future = new Date(Date.now() + 60_000);
+      await db.insert(creditHolds).values([
+        { userId: user.id, estCents: 2, expiresAt: past },
+        { userId: user.id, estCents: 2, expiresAt: future },
+      ]);
+
+      expect(await getLiveMachineInFlight(user.id)).toBe(1);
+    } finally {
+      await cleanup(user.id);
+    }
+  });
+});

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -185,9 +185,11 @@ export const MACHINE_HOLD_ESTIMATE_CENTS = envInt('MACHINE_HOLD_ESTIMATE_CENTS',
  * `MACHINE_MAX_INFLIGHT × the real settled cost of a single run` — a payer's
  * multiple agent tool calls and/or interactive PTY sessions can run concurrently
  * across different machines, so this is generous enough for legitimate multi-machine
- * use. Default 4.
+ * use. Set to match the top subscription tier's `quota.ts` concurrency ceiling
+ * (business, 50) so that per-tier semaphore — not this flat cap — is always the
+ * binding constraint. Default 50.
  */
-export const MACHINE_MAX_INFLIGHT = envInt('MACHINE_MAX_INFLIGHT', 4);
+export const MACHINE_MAX_INFLIGHT = envInt('MACHINE_MAX_INFLIGHT', 50);
 
 /**
  * Absolute floor for {@link MACHINE_MARKUP_BPS} — 15000bps (1.5x). The whole

--- a/packages/lib/src/billing/credit-pricing.ts
+++ b/packages/lib/src/billing/credit-pricing.ts
@@ -180,14 +180,16 @@ export function resolveImageCost(
 export const MACHINE_HOLD_ESTIMATE_CENTS = envInt('MACHINE_HOLD_ESTIMATE_CENTS', 2);
 
 /**
- * Max concurrent in-flight Machine runs per payer, applied to ALL tiers
- * (mirrors VOICE_MAX_INFLIGHT). Bounds worst-case concurrent overdraw to
- * `MACHINE_MAX_INFLIGHT × the real settled cost of a single run` — a payer's
- * multiple agent tool calls and/or interactive PTY sessions can run concurrently
- * across different machines, so this is generous enough for legitimate multi-machine
- * use. Set to match the top subscription tier's `quota.ts` concurrency ceiling
- * (business, 50) so that per-tier semaphore — not this flat cap — is always the
- * binding constraint. Default 50.
+ * FLOOR for max concurrent in-flight Machine runs per payer — mirrors
+ * VOICE_MAX_INFLIGHT, and bounds worst-case concurrent overdraw to
+ * `MACHINE_MAX_INFLIGHT × the real settled cost of a single run`. Set to
+ * match the top subscription tier's `quota.ts` concurrency ceiling (business,
+ * 50) as a sane default, but `machine-billing.ts`'s `gate()` takes
+ * `Math.max(MACHINE_MAX_INFLIGHT, that payer's own tier ceiling)` rather than
+ * using this value alone — so if a tier's `quota.ts` limit is ever raised
+ * past this default without also raising this env var, the billing gate
+ * still tracks it instead of silently rejecting runs the semaphore would
+ * allow. Default 50.
  */
 export const MACHINE_MAX_INFLIGHT = envInt('MACHINE_MAX_INFLIGHT', 50);
 

--- a/packages/lib/src/billing/live-concurrency-query.ts
+++ b/packages/lib/src/billing/live-concurrency-query.ts
@@ -1,0 +1,19 @@
+/**
+ * Live in-flight Machine-run count for a payer — the same COUNT the
+ * `too_many_in_flight` gate (`credit-gate.ts` evaluateGate) checks against
+ * `MACHINE_MAX_INFLIGHT`, exposed read-only for display. Deliberately no
+ * transaction/row-lock: this is advisory dashboard data, not a gating
+ * decision, so a benign race with a concurrent hold insert/delete is fine.
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, gt, sql } from '@pagespace/db/operators';
+import { creditHolds } from '@pagespace/db/schema/credits';
+
+export async function getLiveMachineInFlight(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ inFlight: sql<number>`count(*)` })
+    .from(creditHolds)
+    .where(and(eq(creditHolds.userId, userId), gt(creditHolds.expiresAt, new Date())));
+  return Number(row?.inFlight ?? 0);
+}

--- a/packages/lib/src/billing/live-concurrency-query.ts
+++ b/packages/lib/src/billing/live-concurrency-query.ts
@@ -1,16 +1,25 @@
 /**
- * Live in-flight Machine-run count for a payer — the same COUNT the
- * `too_many_in_flight` gate (`credit-gate.ts` evaluateGate) checks against
- * `MACHINE_MAX_INFLIGHT`, exposed read-only for display. Deliberately no
- * transaction/row-lock: this is advisory dashboard data, not a gating
- * decision, so a benign race with a concurrent hold insert/delete is fine.
+ * Live in-flight credit-hold count for a payer — the same COUNT the
+ * `too_many_in_flight` gate (`credit-gate.ts` evaluateGate) checks against a
+ * caller-supplied `maxInFlight` (e.g. `MACHINE_MAX_INFLIGHT` for Machine
+ * runs, `MAX_FREE_INFLIGHT` for free-tier chat). `credit_holds` has no
+ * per-source column — a hold's origin (chat/voice/machine) is only known
+ * once it settles into `aiUsageLogs`, which hasn't happened yet while it's
+ * still a hold — so this intentionally counts ALL of the payer's in-flight
+ * AI activity, not machine-specific sessions. That's exactly right for its
+ * purpose: it's the literal number that will trip `too_many_in_flight` on
+ * the payer's NEXT call, regardless of call type.
+ *
+ * Deliberately no transaction/row-lock: this is advisory dashboard data, not
+ * a gating decision, so a benign race with a concurrent hold insert/delete
+ * is fine.
  */
 
 import { db } from '@pagespace/db/db';
 import { and, eq, gt, sql } from '@pagespace/db/operators';
 import { creditHolds } from '@pagespace/db/schema/credits';
 
-export async function getLiveMachineInFlight(userId: string): Promise<number> {
+export async function getLiveInFlightHolds(userId: string): Promise<number> {
   const [row] = await db
     .select({ inFlight: sql<number>`count(*)` })
     .from(creditHolds)

--- a/packages/lib/src/services/sandbox/__tests__/machine-billing.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/machine-billing.test.ts
@@ -19,7 +19,8 @@ const mockTrackUsage = vi.hoisted(() => vi.fn());
 vi.mock('../../../monitoring/ai-monitoring', () => ({ AIMonitoring: { trackUsage: mockTrackUsage } }));
 
 import { defaultSandboxBillingDeps } from '../machine-billing';
-import { MACHINE_MARKUP_BPS } from '../../../billing/credit-pricing';
+import { MACHINE_MARKUP_BPS, MACHINE_MAX_INFLIGHT } from '../../../billing/credit-pricing';
+import { getCodeExecutionConcurrencyLimit } from '../quota';
 
 function mockUserRow(tier: string | null) {
   mockDb.select.mockReturnValue({
@@ -113,6 +114,42 @@ describe('defaultSandboxBillingDeps.gate', () => {
 
     const opts = mockCanConsumeAI.mock.calls[0][2];
     expect(opts.skipDailyCap).not.toBe(true);
+  });
+
+  it("passes the payer's own maxInFlight when MACHINE_MAX_INFLIGHT is left at its default", async () => {
+    mockUserRow('business');
+    mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+
+    await defaultSandboxBillingDeps.gate({ payerId: 'owner-1' });
+
+    const opts = mockCanConsumeAI.mock.calls[0][2];
+    // Never below the flat MACHINE_MAX_INFLIGHT floor, and never below the
+    // resolved tier's own quota.ts ceiling — see the comment below.
+    expect(opts.maxInFlight).toBe(Math.max(MACHINE_MAX_INFLIGHT, getCodeExecutionConcurrencyLimit('business')));
+  });
+
+  it("widens maxInFlight past MACHINE_MAX_INFLIGHT when an operator raises a tier's quota.ts ceiling above it, so the billing gate never silently undercuts a raised concurrency tier", async () => {
+    const originalEnv = process.env.CODE_EXEC_CONCURRENCY_BUSINESS;
+    try {
+      // Simulate an operator raising the business tier's semaphore ceiling
+      // well past the flat MACHINE_MAX_INFLIGHT default (50) without also
+      // updating MACHINE_MAX_INFLIGHT — the exact drift Codex flagged.
+      process.env.CODE_EXEC_CONCURRENCY_BUSINESS = String(MACHINE_MAX_INFLIGHT + 25);
+      vi.resetModules();
+      const { defaultSandboxBillingDeps: freshDeps } = await import('../machine-billing');
+
+      mockUserRow('business');
+      mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+
+      await freshDeps.gate({ payerId: 'owner-1' });
+
+      const opts = mockCanConsumeAI.mock.calls[0][2];
+      expect(opts.maxInFlight).toBe(MACHINE_MAX_INFLIGHT + 25);
+    } finally {
+      if (originalEnv === undefined) delete process.env.CODE_EXEC_CONCURRENCY_BUSINESS;
+      else process.env.CODE_EXEC_CONCURRENCY_BUSINESS = originalEnv;
+      vi.resetModules();
+    }
   });
 });
 

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   acquireCodeExecutionSlot,
   releaseCodeExecutionSlot,
@@ -31,8 +31,21 @@ describe('code execution concurrency semaphore', () => {
 
   it('should scale the concurrent-run limit by subscription tier', () => {
     expect(getCodeExecutionConcurrencyLimit('free')).toBeLessThan(
+      getCodeExecutionConcurrencyLimit('pro'),
+    );
+    expect(getCodeExecutionConcurrencyLimit('pro')).toBeLessThan(
+      getCodeExecutionConcurrencyLimit('founder'),
+    );
+    expect(getCodeExecutionConcurrencyLimit('founder')).toBeLessThan(
       getCodeExecutionConcurrencyLimit('business'),
     );
+  });
+
+  it('should default each tier to its documented ceiling', () => {
+    expect(getCodeExecutionConcurrencyLimit('free')).toBe(1);
+    expect(getCodeExecutionConcurrencyLimit('pro')).toBe(10);
+    expect(getCodeExecutionConcurrencyLimit('founder')).toBe(20);
+    expect(getCodeExecutionConcurrencyLimit('business')).toBe(50);
   });
 
   it('should deny acquiring a slot once the per-tier limit is reached', () => {
@@ -50,6 +63,43 @@ describe('code execution concurrency semaphore', () => {
   it('should track concurrency independently per user', () => {
     acquireCodeExecutionSlot({ userId: 'u1', tier: 'free' });
     expect(canAcquireCodeExecutionSlot({ userId: 'u2', tier: 'free' })).toBe(true);
+  });
+});
+
+// CONCURRENCY_LIMITS is computed at module-import time from env vars, so each
+// test re-imports the module with different env conditions (same pattern as
+// MACHINE_MARKUP_BPS in credit-pricing.test.ts).
+describe('CONCURRENCY_LIMITS env overrides', () => {
+  const ENV_KEYS = [
+    'CODE_EXEC_CONCURRENCY_FREE',
+    'CODE_EXEC_CONCURRENCY_PRO',
+    'CODE_EXEC_CONCURRENCY_FOUNDER',
+    'CODE_EXEC_CONCURRENCY_BUSINESS',
+  ] as const;
+  const original = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+  beforeEach(() => {
+    vi.resetModules();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  });
+
+  it('uses an env override when set', async () => {
+    process.env.CODE_EXEC_CONCURRENCY_BUSINESS = '75';
+    const { getCodeExecutionConcurrencyLimit: getLimit } = await import('../quota');
+    expect(getLimit('business')).toBe(75);
+  });
+
+  it('falls back to the default when the env value is invalid', async () => {
+    process.env.CODE_EXEC_CONCURRENCY_FOUNDER = 'not-a-number';
+    const { getCodeExecutionConcurrencyLimit: getLimit } = await import('../quota');
+    expect(getLimit('founder')).toBe(20);
   });
 });
 

--- a/packages/lib/src/services/sandbox/machine-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-billing.ts
@@ -21,6 +21,7 @@ import { resolveMachinePayerId, lookupPageOwnerId } from '../../billing/machine-
 import { AIMonitoring } from '../../monitoring/ai-monitoring';
 import { calculateMachineCostDollars } from '../../monitoring/machine-pricing';
 import type { SubscriptionTier } from '../subscription-utils';
+import { getCodeExecutionConcurrencyLimit } from './quota';
 import type { SandboxBillingDeps } from './tool-runners';
 
 const VALID_TIERS: ReadonlySet<string> = new Set(['free', 'pro', 'founder', 'business']);
@@ -51,9 +52,18 @@ export const defaultSandboxBillingDeps: SandboxBillingDeps = {
 
   async gate({ payerId }) {
     const tier = await resolvePayerTier(payerId);
+    // MACHINE_MAX_INFLIGHT and quota.ts's per-tier CONCURRENCY_LIMITS are two
+    // independently env-configured values that are SUPPOSED to agree (this
+    // flat cap set to the top tier's ceiling), but nothing enforces that once
+    // either is retuned independently — an operator raising a tier's
+    // semaphore without also raising this constant would have the billing
+    // gate silently reject runs the semaphore itself would allow. Take the
+    // max of both so this floor can never undercut the resolved payer's own
+    // tier ceiling, regardless of env drift.
+    const maxInFlight = Math.max(MACHINE_MAX_INFLIGHT, getCodeExecutionConcurrencyLimit(tier));
     const result = await canConsumeAI(payerId, tier, {
       estCostCents: MACHINE_HOLD_ESTIMATE_CENTS,
-      maxInFlight: MACHINE_MAX_INFLIGHT,
+      maxInFlight,
     });
     return { allowed: result.allowed, holdId: result.holdId, reason: result.allowed ? undefined : result.reason };
   },

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -20,13 +20,23 @@
 
 import type { SubscriptionTier } from '../subscription-utils';
 
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (raw === undefined || raw === '') return fallback;
+  if (!/^\d+$/.test(raw)) return fallback;
+  return Number.parseInt(raw, 10);
+}
+
 // Concurrent runs permitted per user, by subscription tier. Per-process: each
 // replica enforces this independently, matching the upload-semaphore model.
+// Free stays effectively unreachable in practice (Machine pages are currently
+// admin-role gated, see apps/web/src/app/api/pages/route.ts) rather than
+// tier-gated, so its value is left low but non-zero.
 const CONCURRENCY_LIMITS: Record<SubscriptionTier, number> = {
-  free: 1,
-  pro: 2,
-  founder: 3,
-  business: 5,
+  free: envInt('CODE_EXEC_CONCURRENCY_FREE', 1),
+  pro: envInt('CODE_EXEC_CONCURRENCY_PRO', 10),
+  founder: envInt('CODE_EXEC_CONCURRENCY_FOUNDER', 20),
+  business: envInt('CODE_EXEC_CONCURRENCY_BUSINESS', 50),
 };
 
 const activeByUser = new Map<string, number>();


### PR DESCRIPTION
## Summary

- Machine agent-terminal sessions were capped at 4-5 concurrent runs globally per user, far too low for a workflow with many parallel branch-scoped agents (mirroring local `pu` worktrees inside PageSpace's Machine branches feature). `quota.ts`'s per-tier `CONCURRENCY_LIMITS` is now env-overridable and raised: free 1 (unreachable in practice — Machine pages are currently admin-role gated), pro 10, founder 20, business 50.
- `MACHINE_MAX_INFLIGHT` (the DB-backed `credit_holds` in-flight cap, `credit-pricing.ts`) raised from 4 to 50, and `machine-billing.ts`'s `gate()` now takes `Math.max(MACHINE_MAX_INFLIGHT, that payer's own quota.ts tier ceiling)` rather than the flat constant alone — so retuning a tier's concurrency limit above 50 later can never be silently undercut by this second, independently-configured value.
- Added a live concurrency view: `getLiveInFlightHolds` query, `GET /api/credits/concurrency`, and a `ConcurrencyCard` on `/settings/usage` showing the literal in-flight `credit_holds` count the `too_many_in_flight` gate checks against (polled every 5s — the `credits:updated` socket event doesn't fire on hold creation, only release/settle). Documented and labeled as an aggregate of ALL in-flight AI activity (chat/voice/machine) rather than machine-specific sessions, since `credit_holds` has no per-source column until a hold settles.

## Review history

An automated Codex review (`chatgpt-codex-connector`) caught three real issues after the initial push, all fixed and replied to inline:
1. The `MACHINE_MAX_INFLIGHT`/tier-ceiling drift risk described above.
2. The live-count naming/copy overclaiming "agent sessions" precision it can't have (also independently caught in my own self-review pass and fixed in the same window).
3. `GET /api/credits/concurrency` was auditing every request despite being polled every 5s — removed the audit call (documented why in the route's doc comment) since its siblings audit because they're one-shot page-load reads, not polled ones.

CI's `security-audit-coverage.test.ts` then caught that removing the audit call needed a matching `AUDIT_EXEMPT_ROUTES` entry — added, consistent with the existing high-frequency/low-risk exemption pattern (read receipts, etc.).

## Test plan

- [x] `packages/lib` unit tests pass (86+ tests across quota.ts, live-concurrency-query, credit-pricing, credit-gate, machine-billing — including new tier-ordering, env-override, and MACHINE_MAX_INFLIGHT-drift regression cases)
- [x] `bun run typecheck` clean in `packages/lib` and `apps/web`
- [x] `bunx eslint` clean on all changed files
- [x] All CI checks green (Unit Tests, Lint & TypeScript, Security Test Suite, CodeQL, Static Security Analysis, Dependency Audit, Secret Scanning) — CI's Unit Tests run exercises `live-concurrency-query.test.ts`'s DB-backed assertions against a real Postgres, confirming the count logic beyond the local Docker-less skip
- [ ] Manual: open `/settings/usage`, confirm `ConcurrencyCard` renders `0 / 50`; launch several agent-terminal sessions across branches and confirm the count ticks up live (not exercised in this session — no browser available; recommended as a quick sanity check before/after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxejjXWGhHQr7AU8Wi7Gp2