### PR TITLE
fix(db): statement_timeout/lock_timeout on the main pool — Phase 7 of task board crash-prevention epic

### DIFF
--- a/packages/db/src/__tests__/db-pool-timeouts.test.ts
+++ b/packages/db/src/__tests__/db-pool-timeouts.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { buildAppPoolOptions, pool, getAdvisoryLockPool } from '../db';
+
+describe('buildAppPoolOptions (Phase 7 — statement_timeout/lock_timeout on the main pool)', () => {
+  it('should set statement_timeout to 15000ms', () => {
+    expect(buildAppPoolOptions()).toContain('statement_timeout=15000');
+  });
+
+  it('should set lock_timeout to 5000ms', () => {
+    expect(buildAppPoolOptions()).toContain('lock_timeout=5000');
+  });
+
+  it('should be a single "-c key=value -c key=value" PGOPTIONS-style string', () => {
+    expect(buildAppPoolOptions()).toBe('-c statement_timeout=15000 -c lock_timeout=5000');
+  });
+
+  it('given the main pool (db), should carry the statement_timeout/lock_timeout options string', () => {
+    expect(pool.options.options).toBe(buildAppPoolOptions());
+  });
+
+  it('given the advisory-lock pool, should NOT carry lock_timeout (it holds/waits on session-level locks for the span of a background job)', () => {
+    const advisoryPool = getAdvisoryLockPool();
+    expect(advisoryPool.options.options ?? '').not.toContain('lock_timeout');
+  });
+
+  it('given the advisory-lock pool, should also not inherit statement_timeout from the main pool options', () => {
+    const advisoryPool = getAdvisoryLockPool();
+    expect(advisoryPool.options.options ?? '').not.toContain('statement_timeout');
+  });
+});

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -18,11 +18,26 @@ function basePoolConfig() {
   };
 }
 
+// statement_timeout/lock_timeout for the main pool ONLY — every application
+// query goes through `db`, so a runaway query or a lock-wait pileup fails
+// fast instead of holding a connection (and locks) indefinitely. Deliberately
+// NOT part of basePoolConfig(): the advisory-lock pool below must never get
+// lock_timeout (see its doc comment). A call site that legitimately needs
+// longer than statement_timeout can still opt out per-transaction via
+// `set_config('statement_timeout', ..., true)` — see drive-search-service.ts.
+const APP_STATEMENT_TIMEOUT_MS = 15000;
+const APP_LOCK_TIMEOUT_MS = 5000;
+
+export function buildAppPoolOptions(): string {
+  return `-c statement_timeout=${APP_STATEMENT_TIMEOUT_MS} -c lock_timeout=${APP_LOCK_TIMEOUT_MS}`;
+}
+
 // Exported for the adminDb break-glass path (admin-db.ts), which binds an
 // admin-schema client over this same pool — no second connection pool.
 export const pool = new Pool({
   ...basePoolConfig(),
   max: process.env.DB_POOL_MAX ? parseInt(process.env.DB_POOL_MAX, 10) : 10,
+  options: buildAppPoolOptions(),
 });
 
 // Prevent uncaughtException spam when Fly's network drops idle connections


### PR DESCRIPTION
## Summary

Phase 7 of an 8-phase epic (PageSpace page `j44e35jwzlhr54fbmruk3k4i`, "Task Board Query & Reorder Safety"). The other phases fix specific application-level bugs (an unbounded query, an unordered multi-row write); this phase is deliberately independent — a defense-in-depth guardrail at the database connection boundary so a *future* bug of this shape fails fast instead of taking prod down.

- Applies `statement_timeout=15000` (15s) and `lock_timeout=5000` (5s) to every connection on the main `pool` (exported as `db`, the pool every application route query runs through), via the pool's `options` connection param (`-c statement_timeout=... -c lock_timeout=...`), extracted into a pure `buildAppPoolOptions()` for direct unit testing.
- **The advisory-lock pool (`getAdvisoryLockPool()`) is deliberately excluded.** It holds/waits on session-level advisory locks for the whole span of a background job (e.g. the machine-storage reconcile lock) — a `lock_timeout` there would silently turn that intentional blocking wait into a spurious failure. The new options are applied only where the main `pool` is constructed, **not** added to the shared `basePoolConfig()`, so the advisory-lock pool's config is untouched.
- **The migration/backfill pool (`getMigrationPool()`) is also excluded**, added after review feedback (see below) — `migrate.ts`'s DDL runner and `migrate-pending-invites.ts`'s bulk backfill both previously ran on the app-throttled `db`, so an index build/table rewrite past 15s, or DDL queued behind an app transaction's lock for more than 5s, would abort a migration mid-run and block deployment. They now build their own drizzle client from a dedicated pool (mirroring `getAdvisoryLockPool()`'s pattern: `basePoolConfig()` only, no timeout options). `migrate-admin.ts` already used its own separate pool and was never affected.

## Verification

- Unit tests (TDD, RED→GREEN) assert `buildAppPoolOptions()` returns the expected string, that the main `pool.options.options` carries it, that `getAdvisoryLockPool()` and `getMigrationPool()` each carry neither `lock_timeout` nor `statement_timeout`, and that the migration pool is a distinct singleton from the other two pools.
- `bun run typecheck` — green across the monorepo (confirmed twice; one run hit a stale/incomplete `.next/types` build-artifact failure unrelated to this diff, which cleared on rebuild).
- `bun run test:unit` — green, aside from 3 pre-existing failures (`admin-role-version.test.ts`, `activity-tools.test.ts`, `grouping.test.ts`) that are unrelated to this change — confirmed by stashing this diff and re-running `admin-role-version.test.ts` against the unmodified baseline, which fails identically with `role "test" does not exist` (a local Postgres role never provisioned in this environment).
- **Live-verified against a local Postgres test container** (not just unit tests):
  - A deliberately slow query (`pg_sleep(20)`) on the main pool was killed at ~15.1s with `canceling statement due to statement timeout`; a normal query on the same pool was unaffected.
  - A lock-contended `UPDATE` on the main pool was killed at ~5.0s with `canceling statement due to lock timeout`.
  - The same lock-contended `UPDATE`, issued through a pool built like the advisory-lock pool (no `lock_timeout`), blocked correctly past the 5s and 7s marks and succeeded once the lock holder released — proving the exclusion holds at the connection level, not just in config.
  - Confirmed the existing escape hatch still works: a transaction-scoped `set_config('statement_timeout', ..., true)` (the pattern already used in `drive-search-service.ts`'s `REGEX_QUERY_TIMEOUT_MS`) overrides the connection-level default, so call sites that legitimately need more than 15s (report-style aggregates) are unaffected.
- `migrate.test.ts` initially broke because its mocks targeted the old `db` export migrate.ts no longer imports — updated its mocks for the new `getMigrationPool()`/`drizzle()` call shape and added a test asserting the migration pool is used and ended before exit. Full `packages/db` and root `test:unit` suites re-confirmed green (same pre-existing failures only, no new regressions) after this fix.

## Scope

`packages/db/src/db.ts` + its test, plus `migrate.ts`/`migrate-pending-invites.ts` (updated after review feedback to use the new migration pool) + `migrate.test.ts`. No other phase of this epic touches these files, so there's no merge-conflict risk with the rest of the epic.

## Review feedback addressed

- **Codex (P1)**: main-pool timeouts would abort `migrate.ts`'s DDL and `migrate-pending-invites.ts`'s bulk backfill mid-run on a populated database. Fixed via a dedicated `getMigrationPool()` — see Summary/Verification above. [Reply](https://github.com/2witstudios/PageSpace/pull/2126#discussion_r3609728008).

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:unit`
- [x] `bun run test` (packages/db) — all new/updated test files green, no regressions
- [x] Live sanity check against local Postgres: slow query killed ~15s, lock-contended query killed ~5s, advisory-lock-style pool unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UYq2XfZfwAovm1PJhBoad
