### PR TITLE
feat(db): bounded-query primitive — Phase 1 of task board crash-prevention epic

### DIFF
--- a/apps/web/src/lib/utils/query-params.ts
+++ b/apps/web/src/lib/utils/query-params.ts
@@ -1,29 +1,5 @@
-interface ParseBoundedIntParamOptions {
-  defaultValue: number;
-  min?: number;
-  max?: number;
-}
-
-/**
- * Parse a numeric query param safely with explicit bounds.
- * Falls back to the bounded default value when the input is missing or invalid.
- */
-export function parseBoundedIntParam(
-  rawValue: string | null,
-  options: ParseBoundedIntParamOptions
-): number {
-  const min = options.min ?? Number.MIN_SAFE_INTEGER;
-  const max = options.max ?? Number.MAX_SAFE_INTEGER;
-  const boundedDefault = Math.min(max, Math.max(min, options.defaultValue));
-
-  if (!rawValue) {
-    return boundedDefault;
-  }
-
-  const parsed = Number.parseInt(rawValue, 10);
-  if (!Number.isFinite(parsed)) {
-    return boundedDefault;
-  }
-
-  return Math.min(max, Math.max(min, parsed));
-}
+// Relocated to @pagespace/lib/db/bounded-query so packages/lib and apps/web
+// share one implementation (packages/lib depends on packages/db, not the
+// other way around, so this couldn't live in packages/db without an inverted
+// dependency). Re-exported here to keep the existing import path stable.
+export { parseBoundedIntParam } from '@pagespace/lib/db/bounded-query';

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/commands/command-core.js",
       "require": "./dist/commands/command-core.js"
     },
+    "./db/bounded-query": {
+      "types": "./dist/db/bounded-query.d.ts",
+      "import": "./dist/db/bounded-query.js",
+      "require": "./dist/db/bounded-query.js"
+    },
     "./ai/normalize-parts": {
       "types": "./dist/ai/normalize-parts.d.ts",
       "import": "./dist/ai/normalize-parts.js",

--- a/packages/lib/src/db/__tests__/bounded-query.test.ts
+++ b/packages/lib/src/db/__tests__/bounded-query.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { parseBoundedIntParam, resolveBoundedLimit } from '../bounded-query';
+
+describe('parseBoundedIntParam', () => {
+  it('should return the default when rawValue is null', () => {
+    expect(parseBoundedIntParam(null, { defaultValue: 10 })).toBe(10);
+  });
+
+  it('should return the default when rawValue is an empty string', () => {
+    expect(parseBoundedIntParam('', { defaultValue: 10 })).toBe(10);
+  });
+
+  it('should return the default when rawValue does not parse to a finite number', () => {
+    expect(parseBoundedIntParam('not-a-number', { defaultValue: 10 })).toBe(10);
+  });
+
+  it('should return the parsed value when it is within bounds', () => {
+    expect(parseBoundedIntParam('42', { defaultValue: 10 })).toBe(42);
+  });
+
+  it('should clamp the default itself to the supplied min when no min is given for the raw value', () => {
+    expect(parseBoundedIntParam(null, { defaultValue: -5, min: 0 })).toBe(0);
+  });
+
+  it('should clamp the default itself to the supplied max', () => {
+    expect(parseBoundedIntParam(null, { defaultValue: 500, max: 100 })).toBe(100);
+  });
+
+  it('should clamp a parsed value below the supplied min', () => {
+    expect(parseBoundedIntParam('-5', { defaultValue: 10, min: 0 })).toBe(0);
+  });
+
+  it('should clamp a parsed value above the supplied max', () => {
+    expect(parseBoundedIntParam('999', { defaultValue: 10, max: 100 })).toBe(100);
+  });
+});
+
+describe('resolveBoundedLimit', () => {
+  it('should apply the policy default when the caller omits a limit', () => {
+    expect(resolveBoundedLimit(null, { defaultValue: 25, max: 100 })).toBe(25);
+  });
+
+  it('should clamp to the policy max when the caller requests a limit above it', () => {
+    expect(resolveBoundedLimit('5000', { defaultValue: 25, max: 100 })).toBe(100);
+  });
+
+  it('should clamp to 1 when the caller requests 0', () => {
+    expect(resolveBoundedLimit('0', { defaultValue: 25, max: 100 })).toBe(1);
+  });
+
+  it('should clamp to 1 when the caller requests a negative limit', () => {
+    expect(resolveBoundedLimit('-10', { defaultValue: 25, max: 100 })).toBe(1);
+  });
+
+  it('should clamp to 1 when the caller requests a non-numeric limit and the default is 0', () => {
+    expect(resolveBoundedLimit('not-a-number', { defaultValue: 0, max: 100 })).toBe(1);
+  });
+
+  it('should pass a valid in-range limit through unchanged', () => {
+    expect(resolveBoundedLimit('50', { defaultValue: 25, max: 100 })).toBe(50);
+  });
+
+  it('should honor an explicit min above 1 when provided', () => {
+    expect(resolveBoundedLimit('3', { defaultValue: 25, max: 100, min: 5 })).toBe(5);
+  });
+});

--- a/packages/lib/src/db/bounded-query.ts
+++ b/packages/lib/src/db/bounded-query.ts
@@ -1,0 +1,63 @@
+/**
+ * Bounded query primitive — pure, no DB access.
+ *
+ * Every list query must carry a hard-bounded limit before it reaches the
+ * database: an unbounded `findMany` is what OOM-crashed Postgres when the
+ * task-board route fetched every task with five joined relations at once.
+ * `resolveBoundedLimit` requires a `bounds` policy alongside the raw query
+ * param so a caller cannot accidentally pass an unclamped limit through.
+ */
+
+export interface ParseBoundedIntParamOptions {
+  defaultValue: number;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Parse a numeric query param safely with explicit bounds.
+ * Falls back to the bounded default value when the input is missing or invalid.
+ */
+export function parseBoundedIntParam(
+  rawValue: string | null,
+  options: ParseBoundedIntParamOptions
+): number {
+  const min = options.min ?? Number.MIN_SAFE_INTEGER;
+  const max = options.max ?? Number.MAX_SAFE_INTEGER;
+  const boundedDefault = Math.min(max, Math.max(min, options.defaultValue));
+
+  if (!rawValue) {
+    return boundedDefault;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed)) {
+    return boundedDefault;
+  }
+
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export interface BoundedQueryLimitPolicy {
+  /** Applied when the caller omits a limit. */
+  defaultValue: number;
+  /** Requests above this are clamped down to it. */
+  max: number;
+  /** Requests below this are clamped up to it. Defaults to 1. */
+  min?: number;
+}
+
+/**
+ * Resolve a caller-supplied `limit` query param into a value guaranteed to
+ * sit within the given policy's bounds, for passing straight into `findMany`.
+ */
+export function resolveBoundedLimit(
+  rawLimit: string | null,
+  bounds: BoundedQueryLimitPolicy
+): number {
+  return parseBoundedIntParam(rawLimit, {
+    defaultValue: bounds.defaultValue,
+    min: bounds.min ?? 1,
+    max: bounds.max,
+  });
+}

--- a/tasks/reviews/pu-bounded-query-primitive.md
+++ b/tasks/reviews/pu-bounded-query-primitive.md
@@ -49,6 +49,33 @@ No correctness, security, or test-coverage defects found:
 - Typecheck: root `bun run typecheck` (turbo, full graph) — 16/16 tasks green.
 - No TODO/FIXME or stub logic left in scope.
 
+## /simplify pass (4 parallel angles: reuse, simplification, efficiency, altitude)
+
+- **Reuse**: no violations — no existing clamp/pagination helper duplicated. Noted
+  (not fixed, out of scope): `apps/web/src/app/api/user/recents/route.ts:54-56` and
+  `apps/web/src/app/api/channels/[pageId]/messages/route.ts:145` hand-roll the same
+  clamp pattern without going through `parseBoundedIntParam` — pre-existing debt,
+  not introduced by this PR. Filed as a follow-up in the PR description.
+- **Simplification**: the two-function split (`parseBoundedIntParam` generic,
+  `resolveBoundedLimit` policy-based with min defaulting to 1) is not redundant —
+  verified `apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts:65-69`
+  genuinely needs `min: 0` for a page index, so the generic function can't collapse
+  into the stricter one. Two sub-findings considered and both skipped as
+  non-issues: (a) `resolveBoundedLimit` currently has zero callers — expected and
+  correct for a Phase-1-only PR whose explicit deliverable is the primitive itself,
+  ahead of phases 2-8 that will call it; (b) the `'0'` and `'-10'` test cases hit
+  the same clamp branch — kept anyway because the task's acceptance criteria
+  explicitly enumerate 0/negative/non-numeric as distinct required cases, not just
+  branch coverage.
+- **Efficiency**: no issues — pure arithmetic, no loops/I/O/closures.
+- **Altitude**: correct depth for Phase 1 confirmed (a generic `findMany` wrapper
+  would need per-table policy knowledge and would be the over-engineering the task
+  explicitly warned against). One soft spot noted: the `query-params.ts` re-export
+  shim has no explicit tracked cleanup step in the epic — filed as a follow-up in
+  the PR description rather than fixed now (fixing it would mean touching ~15
+  call sites, expanding this PR beyond its stated scope).
+
 ## Verdict
 
 0 blockers / 0 majors / 0 minor / 0 nit — merge-ready pending final green CI.
+Two out-of-scope follow-ups documented in the PR description, not fixed here.

--- a/tasks/reviews/pu-bounded-query-primitive.md
+++ b/tasks/reviews/pu-bounded-query-primitive.md
@@ -1,0 +1,54 @@
+# Review: pu/bounded-query-primitive (PR #2127)
+
+feat(db): bounded-query primitive — Phase 1 of task board crash-prevention epic
+
+## Scope
+
+4 files: new `packages/lib/src/db/bounded-query.ts` (pure, no I/O) + its test
+`packages/lib/src/db/__tests__/bounded-query.test.ts`; `packages/lib/package.json`
+(new `./db/bounded-query` exports entry); `apps/web/src/lib/utils/query-params.ts`
+reduced to a re-export of the relocated `parseBoundedIntParam`. Phase 1 of 8 for
+the "Task Board Query & Reorder Safety" epic (PageSpace page `j44e35jwzlhr54fbmruk3k4i`),
+triggered by the 2026-07-18 Postgres OOM crash (unbounded `taskItems.findMany`,
+5 joined relations, no limit).
+
+## Churn
+
+New file, no prior history. `query-params.ts` had no dedicated test file before
+this change (confirmed via search) — no coverage regression from reducing it to
+a re-export.
+
+## Design validation
+
+Confirmed via grep across all ~15 existing `parseBoundedIntParam` call sites that
+keeping the original flexible `{ defaultValue, min?, max? }` signature (rather than
+hardcoding `min: 1`) is necessary, not redundant: e.g.
+`apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts` uses
+`min: 0` for a 0-indexed `page` param. `resolveBoundedLimit` layers a
+stricter, harder-to-misuse policy (`min` defaults to `1`) on top for the
+new bounded-list-query use case, rather than replacing the generic parser.
+
+## Findings
+
+No correctness, security, or test-coverage defects found:
+- OWASP: no new attack surface — pure arithmetic clamping, no I/O, no user input
+  reaches a sink directly (callers still own their own `db.query` calls).
+- Dead code: none. Relocated `ParseBoundedIntParamOptions`/`parseBoundedIntParam`
+  confirmed to have zero remaining references at the old definition site; only
+  the function (not the type) was ever imported by consumers, so no call site
+  needed updating beyond the re-export.
+- Test coverage: 100% line/branch/function on the new module (`vitest --coverage`),
+  15 tests covering every branch of both `parseBoundedIntParam` (min/max present
+  vs. defaulted, null/empty/non-numeric rawValue, in-range passthrough) and
+  `resolveBoundedLimit` (omitted limit, clamp-to-max, clamp-to-1 for 0/negative/
+  non-numeric, in-range passthrough, explicit `min` override). Full
+  `packages/lib` suite (367 files / 8497 tests) green; global coverage
+  95.05/95/88.62/95.05, above the 85/94/88/85 gate.
+- Lint: clean on both touched source files (`eslint` in `packages/lib` and
+  `apps/web`).
+- Typecheck: root `bun run typecheck` (turbo, full graph) — 16/16 tasks green.
+- No TODO/FIXME or stub logic left in scope.
+
+## Verdict
+
+0 blockers / 0 majors / 0 minor / 0 nit — merge-ready pending final green CI.


### PR DESCRIPTION
## Summary

- Adds `packages/lib/src/db/bounded-query.ts`: a pure `resolveBoundedLimit(rawLimit, bounds)` helper. Its signature requires a `bounds: { defaultValue, max, min? }` policy alongside the raw query param, so it's structurally awkward for a caller to pass an unbounded/unclamped limit into a `findMany` — omitted limits get the policy default, over-max requests clamp to max, and requests below 1 (0, negative, non-numeric) clamp to 1 (or an explicit `min` if given).
- No I/O, no DB import — pure functional core per this repo's convention.

## Design choice: `parseBoundedIntParam` location

Relocated `parseBoundedIntParam` from `apps/web/src/lib/utils/query-params.ts` into `packages/lib/src/db/bounded-query.ts`, and re-exported it from the original app path so none of its ~15 existing call sites (or their `vi.mock('@/lib/utils/query-params', ...)` test mocks) needed to change.

It couldn't live in `packages/db` itself: `packages/lib` depends on `packages/db`, not the reverse, so putting a shared helper in `packages/db` that both `packages/db` consumers and `apps/web` need would require `packages/db` to import from `packages/lib` — an inverted/circular dependency. `packages/lib/src/db/` is a shared home both directions can reach without one.

`resolveBoundedLimit` wraps `parseBoundedIntParam`, defaulting `min` to `1` (matching this phase's acceptance criteria) rather than `parseBoundedIntParam`'s generic `MIN_SAFE_INTEGER` default.

## Coverage / verification

- TDD: test file written first, confirmed RED (module didn't exist), then implementation added (GREEN).
- 100% line/branch/function coverage on the new module.
- `packages/lib`: full suite green (367 files / 8497 tests), `bun run test:coverage` thresholds pass (95.05/95/88.62/95.05, ≥ the 85/94/88/85 gate).
- `apps/web`: all tests exercising `parseBoundedIntParam` (routes + mocks) still pass after the relocation.
- Root `bun run typecheck` (turbo, full graph): 16/16 tasks green.
- Self-review (aidd-review + 4-angle /simplify pass — reuse/simplification/efficiency/altitude) found zero blockers/majors/minors; full log at `tasks/reviews/pu-bounded-query-primitive.md`.

## Known follow-ups (intentionally out of scope for this PR)

Phase 1's scope is the primitive only (`packages/lib/src/db/` + the `query-params.ts` relocation) — the review pass surfaced two pieces of pre-existing debt this PR deliberately does not touch, for a later phase or cleanup pass to pick up:

- `apps/web/src/lib/utils/query-params.ts` is now a one-line re-export shim (kept so the ~15 existing `parseBoundedIntParam` call sites/mocks didn't need touching in this PR). A later pass could migrate those call sites to import directly from `@pagespace/lib/db/bounded-query` and delete the shim.
- Two routes hand-roll the same clamp pattern this primitive formalizes, without going through `parseBoundedIntParam`/`resolveBoundedLimit`: `apps/web/src/app/api/user/recents/route.ts:54-56` and `apps/web/src/app/api/channels/[pageId]/messages/route.ts:145`. Worth migrating to the shared helper in a future consolidation pass.

## Epic

Phase 1 of 8 — [Task Board Query & Reorder Safety](j44e35jwzlhr54fbmruk3k4i), triggered by the 2026-07-18 production Postgres OOM crash (unbounded `taskItems.findMany` with 5 joined relations, no limit). This phase ships the shared bounded-query primitive later phases build on to bound the actual task-board list queries.

## Test plan

- [x] `bun run test` in `packages/lib` — 8497 passed
- [x] `bun run test:coverage` in `packages/lib` — thresholds pass
- [x] `bun run typecheck` at repo root (turbo) — 16/16 green
- [x] Targeted `apps/web` route tests covering `parseBoundedIntParam` callers — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6h5QFJgGjjFm91D1n9TEW
