### PR TITLE
feat(reorder): locked-batch reorder primitive — Phase 3 of task board crash-prevention epic

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -962,6 +962,11 @@
       "import": "./dist/services/invites/index.js",
       "require": "./dist/services/invites/index.js"
     },
+    "./services/reorder": {
+      "types": "./dist/services/reorder/index.d.ts",
+      "import": "./dist/services/reorder/index.js",
+      "require": "./dist/services/reorder/index.js"
+    },
     "./validators/id-validators": {
       "types": "./dist/validators/id-validators.d.ts",
       "import": "./dist/validators/id-validators.js",
@@ -2046,6 +2051,9 @@
       ],
       "services/invites": [
         "./dist/services/invites/index.d.ts"
+      ],
+      "services/reorder": [
+        "./dist/services/reorder/index.d.ts"
       ],
       "validators/id-validators": [
         "./dist/validators/id-validators.d.ts"

--- a/packages/lib/src/services/reorder/__tests__/compute-reorder-plan.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/compute-reorder-plan.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { computeReorderPlan } from '../compute-reorder-plan';
+
+describe('computeReorderPlan', () => {
+  it('returns an empty plan for an empty array', () => {
+    const plan = computeReorderPlan([]);
+
+    expect(plan.orderedIds).toEqual([]);
+    expect(plan.positionById.size).toBe(0);
+  });
+
+  it('returns a single-entry plan for a single item', () => {
+    const plan = computeReorderPlan([{ id: 'a', position: 0 }]);
+
+    expect(plan.orderedIds).toEqual(['a']);
+    expect(plan.positionById.get('a')).toBe(0);
+  });
+
+  it('sorts ids ascending when input is already sorted', () => {
+    const plan = computeReorderPlan([
+      { id: 'a', position: 0 },
+      { id: 'b', position: 1 },
+      { id: 'c', position: 2 },
+    ]);
+
+    expect(plan.orderedIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts ids ascending when input is in reverse order', () => {
+    const plan = computeReorderPlan([
+      { id: 'c', position: 0 },
+      { id: 'b', position: 1 },
+      { id: 'a', position: 2 },
+    ]);
+
+    expect(plan.orderedIds).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts ids ascending when input is in arbitrary order', () => {
+    const plan = computeReorderPlan([
+      { id: 'm', position: 0 },
+      { id: 'z', position: 1 },
+      { id: 'a', position: 2 },
+      { id: 'k', position: 3 },
+    ]);
+
+    expect(plan.orderedIds).toEqual(['a', 'k', 'm', 'z']);
+  });
+
+  it('keeps only the last occurrence of a duplicate id, and its position', () => {
+    const plan = computeReorderPlan([
+      { id: 'a', position: 0 },
+      { id: 'b', position: 1 },
+      { id: 'a', position: 5 },
+    ]);
+
+    expect(plan.orderedIds).toEqual(['a', 'b']);
+    expect(plan.positionById.get('a')).toBe(5);
+    expect(plan.positionById.get('b')).toBe(1);
+  });
+
+  it('deduplicates multiple repeats of the same id, keeping the final write', () => {
+    const plan = computeReorderPlan([
+      { id: 'x', position: 0 },
+      { id: 'x', position: 1 },
+      { id: 'x', position: 2 },
+    ]);
+
+    expect(plan.orderedIds).toEqual(['x']);
+    expect(plan.positionById.get('x')).toBe(2);
+  });
+});

--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * lockedBatchReorder concurrency integration test (real Postgres).
+ *
+ * Drives the REAL lockedBatchReorder against a real database — no fake DB, no
+ * vi.mock. This is the primitive that replaces the N-sequential-unordered-update
+ * loop that deadlocked production Postgres on 2026-07-18 (task_items.position,
+ * ~7-minute deadlock storm, 17:30-17:37 UTC). The property under test is the one
+ * a mocked test cannot prove: two concurrent reorders touching OVERLAPPING rows,
+ * each submitted in an order that does not match the other's, must never raise a
+ * Postgres deadlock error — the ascending-id `FOR UPDATE` lock order
+ * (computeReorderPlan + lockedBatchReorder) serializes them instead.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable.
+ *
+ * NOTE (manual lock proof): temporarily drop the `.orderBy(asc(idColumn))` from
+ * lockedBatchReorder's `FOR UPDATE` select (or otherwise lock rows in an order
+ * that isn't shared across callers) and the second test below has a real chance
+ * to fail with a Postgres `deadlock detected` error instead of both transactions
+ * resolving cleanly. Restore after.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { driveRoles } from '@pagespace/db/schema/members';
+import { factories } from '@pagespace/db/test/factories';
+import { computeReorderPlan } from '../compute-reorder-plan';
+import { lockedBatchReorder } from '../locked-batch-reorder';
+
+let dbAvailable = false;
+
+describe('lockedBatchReorder concurrency (Postgres row lock)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(driveRoles).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('applies every position in one pass, independent of caller-submitted order', async () => {
+    if (!dbAvailable) return;
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const roles = await db
+      .insert(driveRoles)
+      .values([
+        { driveId: drive.id, name: 'role-a', permissions: {}, position: 0 },
+        { driveId: drive.id, name: 'role-b', permissions: {}, position: 1 },
+        { driveId: drive.id, name: 'role-c', permissions: {}, position: 2 },
+      ])
+      .returning();
+
+    const plan = computeReorderPlan([
+      { id: roles[2].id, position: 10 },
+      { id: roles[0].id, position: 11 },
+      { id: roles[1].id, position: 12 },
+    ]);
+
+    await db.transaction(async (tx) => {
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan,
+      });
+    });
+
+    const updated = await db.select().from(driveRoles).where(eq(driveRoles.driveId, drive.id));
+    const positionById = new Map(updated.map((r) => [r.id, r.position]));
+    expect(positionById.get(roles[0].id)).toBe(11);
+    expect(positionById.get(roles[1].id)).toBe(12);
+    expect(positionById.get(roles[2].id)).toBe(10);
+  });
+
+  it('two concurrent reorders touching overlapping rows in different orders never deadlock', async () => {
+    if (!dbAvailable) return;
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const roles = await db
+      .insert(driveRoles)
+      .values([
+        { driveId: drive.id, name: 'role-1', permissions: {}, position: 0 },
+        { driveId: drive.id, name: 'role-2', permissions: {}, position: 1 },
+        { driveId: drive.id, name: 'role-3', permissions: {}, position: 2 },
+        { driveId: drive.id, name: 'role-4', permissions: {}, position: 3 },
+      ])
+      .returning();
+
+    // Sort by actual id so we know the true ascending lock order, independent
+    // of insertion order.
+    const sorted = [...roles].sort((x, y) => (x.id < y.id ? -1 : x.id > y.id ? 1 : 0));
+    const [a, b, c, d] = sorted;
+
+    // Overlapping-but-not-identical row sets — {a,b,c} vs {b,c,d} — each
+    // submitted in an order that does NOT match ascending-id. computeReorderPlan
+    // normalizes both to ascending order; that shared order is exactly what
+    // keeps two concurrent, overlapping writers from deadlocking.
+    const planOne = computeReorderPlan([
+      { id: c.id, position: 100 },
+      { id: a.id, position: 101 },
+      { id: b.id, position: 102 },
+    ]);
+    const planTwo = computeReorderPlan([
+      { id: d.id, position: 200 },
+      { id: b.id, position: 201 },
+      { id: c.id, position: 202 },
+    ]);
+
+    const runOne = db.transaction(async (tx) => {
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan: planOne,
+      });
+    });
+    const runTwo = db.transaction(async (tx) => {
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan: planTwo,
+      });
+    });
+
+    // The deadlock-absence proof: firing both concurrently against overlapping
+    // rows must not raise Postgres error 40P01 (deadlock detected). One
+    // transaction may block briefly behind the other's row lock — that's
+    // correct serialization, not a failure — but neither may be aborted by
+    // the deadlock detector.
+    await Promise.all([runOne, runTwo]);
+
+    const updated = await db.select().from(driveRoles).where(eq(driveRoles.driveId, drive.id));
+    const positionById = new Map(updated.map((r) => [r.id, r.position]));
+
+    // Non-overlapping rows always reflect their sole writer.
+    expect(positionById.get(a.id)).toBe(101);
+    expect(positionById.get(d.id)).toBe(200);
+
+    // Overlapping rows (b, c) were written by whichever transaction committed
+    // last — but must reflect ONE consistent transaction's pair, never a mix
+    // of the two (which would mean the batched update wasn't atomic).
+    const bPos = positionById.get(b.id);
+    const cPos = positionById.get(c.id);
+    const matchesPlanOne = bPos === 102 && cPos === 100;
+    const matchesPlanTwo = bPos === 201 && cPos === 202;
+    expect(matchesPlanOne || matchesPlanTwo).toBe(true);
+  });
+});

--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
@@ -58,8 +58,9 @@ describe('lockedBatchReorder concurrency (Postgres row lock)', () => {
       { id: roles[1].id, position: 12 },
     ]);
 
+    let lockedIds: string[] = [];
     await db.transaction(async (tx) => {
-      await lockedBatchReorder(tx, {
+      lockedIds = await lockedBatchReorder(tx, {
         table: driveRoles,
         idColumn: driveRoles.id,
         positionColumn: driveRoles.position,
@@ -68,11 +69,53 @@ describe('lockedBatchReorder concurrency (Postgres row lock)', () => {
       });
     });
 
+    expect([...lockedIds].sort()).toEqual([...plan.orderedIds].sort());
+
     const updated = await db.select().from(driveRoles).where(eq(driveRoles.driveId, drive.id));
     const positionById = new Map(updated.map((r) => [r.id, r.position]));
     expect(positionById.get(roles[0].id)).toBe(11);
     expect(positionById.get(roles[1].id)).toBe(12);
     expect(positionById.get(roles[2].id)).toBe(10);
+  });
+
+  it('returns only the ids that actually existed in scope, leaving out-of-scope ids un-updated', async () => {
+    if (!dbAvailable) return;
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const otherDrive = await factories.createDrive(owner.id);
+    const [inScope] = await db
+      .insert(driveRoles)
+      .values([{ driveId: drive.id, name: 'role-in-scope', permissions: {}, position: 0 }])
+      .returning();
+    const [outOfScope] = await db
+      .insert(driveRoles)
+      .values([{ driveId: otherDrive.id, name: 'role-out-of-scope', permissions: {}, position: 0 }])
+      .returning();
+
+    // Plan names a real row from another drive alongside the in-scope one —
+    // scopeWhere excludes it, so it must not be reported as locked or updated.
+    const plan = computeReorderPlan([
+      { id: inScope.id, position: 5 },
+      { id: outOfScope.id, position: 6 },
+    ]);
+
+    let lockedIds: string[] = [];
+    await db.transaction(async (tx) => {
+      lockedIds = await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan,
+      });
+    });
+
+    expect(lockedIds).toEqual([inScope.id]);
+
+    const [updatedInScope] = await db.select().from(driveRoles).where(eq(driveRoles.id, inScope.id));
+    const [updatedOutOfScope] = await db.select().from(driveRoles).where(eq(driveRoles.id, outOfScope.id));
+    expect(updatedInScope.position).toBe(5);
+    expect(updatedOutOfScope.position).toBe(0);
   });
 
   it('two concurrent reorders touching overlapping rows in different orders never deadlock', async () => {

--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
@@ -151,4 +151,70 @@ describe('lockedBatchReorder concurrency (Postgres row lock)', () => {
     const matchesPlanTwo = bPos === 201 && cPos === 202;
     expect(matchesPlanOne || matchesPlanTwo).toBe(true);
   });
+
+  it('stamps touchColumns with the current time, bypassing nothing Drizzle would have set', async () => {
+    if (!dbAvailable) return;
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const stale = new Date('2020-01-01T00:00:00Z');
+    const roles = await db
+      .insert(driveRoles)
+      .values([
+        { driveId: drive.id, name: 'role-x', permissions: {}, position: 0, updatedAt: stale },
+        { driveId: drive.id, name: 'role-y', permissions: {}, position: 1, updatedAt: stale },
+      ])
+      .returning();
+
+    const plan = computeReorderPlan([
+      { id: roles[0].id, position: 5 },
+      { id: roles[1].id, position: 6 },
+    ]);
+
+    const before = Date.now();
+    await db.transaction(async (tx) => {
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan,
+        touchColumns: [driveRoles.updatedAt],
+      });
+    });
+
+    const updated = await db.select().from(driveRoles).where(eq(driveRoles.driveId, drive.id));
+    for (const role of updated) {
+      expect(role.updatedAt.getTime()).toBeGreaterThan(stale.getTime());
+      expect(role.updatedAt.getTime()).toBeGreaterThanOrEqual(before - 1000);
+    }
+  });
+
+  it('leaves touchColumns untouched (and thus stale) when the caller opts out', async () => {
+    if (!dbAvailable) return;
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const stale = new Date('2020-01-01T00:00:00Z');
+    const role = (
+      await db
+        .insert(driveRoles)
+        .values([{ driveId: drive.id, name: 'role-z', permissions: {}, position: 0, updatedAt: stale }])
+        .returning()
+    )[0];
+
+    const plan = computeReorderPlan([{ id: role.id, position: 9 }]);
+
+    await db.transaction(async (tx) => {
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan,
+      });
+    });
+
+    const [updated] = await db.select().from(driveRoles).where(eq(driveRoles.id, role.id));
+    expect(updated.position).toBe(9);
+    expect(updated.updatedAt.getTime()).toBe(stale.getTime());
+  });
 });

--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.test.ts
@@ -13,7 +13,7 @@ describe('lockedBatchReorder (empty-plan no-op)', () => {
     // locked-batch-reorder.integration.test.ts.
     const tx = { select, execute } as unknown as Parameters<typeof lockedBatchReorder>[0];
 
-    await lockedBatchReorder(tx, {
+    const lockedIds = await lockedBatchReorder(tx, {
       table: driveRoles,
       idColumn: driveRoles.id,
       positionColumn: driveRoles.position,
@@ -23,5 +23,6 @@ describe('lockedBatchReorder (empty-plan no-op)', () => {
 
     expect(select).not.toHaveBeenCalled();
     expect(execute).not.toHaveBeenCalled();
+    expect(lockedIds).toEqual([]);
   });
 });

--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { eq } from '@pagespace/db/operators';
+import { driveRoles } from '@pagespace/db/schema/members';
+import { lockedBatchReorder } from '../locked-batch-reorder';
+
+describe('lockedBatchReorder (empty-plan no-op)', () => {
+  it('never touches the transaction when the plan has no ids', async () => {
+    const select = vi.fn();
+    const execute = vi.fn();
+    // Minimal structural stand-in for Tx — this test only proves the empty-plan
+    // guard short-circuits before any transaction call; real locking/update
+    // behavior is proven against a real database in
+    // locked-batch-reorder.integration.test.ts.
+    const tx = { select, execute } as unknown as Parameters<typeof lockedBatchReorder>[0];
+
+    await lockedBatchReorder(tx, {
+      table: driveRoles,
+      idColumn: driveRoles.id,
+      positionColumn: driveRoles.position,
+      scopeWhere: eq(driveRoles.driveId, 'drive-1'),
+      plan: { orderedIds: [], positionById: new Map() },
+    });
+
+    expect(select).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/services/reorder/compute-reorder-plan.ts
+++ b/packages/lib/src/services/reorder/compute-reorder-plan.ts
@@ -1,0 +1,28 @@
+export interface TaskReorderEntry {
+  id: string;
+  position: number;
+}
+
+export interface ReorderPlan {
+  orderedIds: string[];
+  positionById: Map<string, number>;
+}
+
+/**
+ * Reduce a caller-submitted reorder request into the plan every locked-batch
+ * writer executes against: dedup ids (last write wins) and lock/update them
+ * in ascending-id order. Ascending-id order is the shared contract that
+ * prevents deadlocks between concurrent reorders — see
+ * `lockDriveRolesInOrder` in drive-role-service.ts for why a consistent
+ * order matters.
+ */
+export function computeReorderPlan(entries: TaskReorderEntry[]): ReorderPlan {
+  const positionById = new Map<string, number>();
+  for (const entry of entries) {
+    positionById.set(entry.id, entry.position);
+  }
+
+  const orderedIds = Array.from(positionById.keys()).sort();
+
+  return { orderedIds, positionById };
+}

--- a/packages/lib/src/services/reorder/compute-reorder-plan.ts
+++ b/packages/lib/src/services/reorder/compute-reorder-plan.ts
@@ -1,4 +1,4 @@
-export interface TaskReorderEntry {
+export interface ReorderEntry {
   id: string;
   position: number;
 }
@@ -16,7 +16,7 @@ export interface ReorderPlan {
  * `lockDriveRolesInOrder` in drive-role-service.ts for why a consistent
  * order matters.
  */
-export function computeReorderPlan(entries: TaskReorderEntry[]): ReorderPlan {
+export function computeReorderPlan(entries: ReorderEntry[]): ReorderPlan {
   const positionById = new Map<string, number>();
   for (const entry of entries) {
     positionById.set(entry.id, entry.position);

--- a/packages/lib/src/services/reorder/index.ts
+++ b/packages/lib/src/services/reorder/index.ts
@@ -1,0 +1,2 @@
+export * from './compute-reorder-plan';
+export * from './locked-batch-reorder';

--- a/packages/lib/src/services/reorder/locked-batch-reorder.ts
+++ b/packages/lib/src/services/reorder/locked-batch-reorder.ts
@@ -13,6 +13,15 @@ export interface LockedBatchReorderOptions<T extends PgTable> {
   positionColumn: AnyPgColumn;
   scopeWhere: SQL;
   plan: ReorderPlan;
+  /**
+   * Columns to stamp with the current time on every updated row (e.g. an
+   * `updatedAt` column driven by Drizzle's `$onUpdate`). `$onUpdate` only
+   * fires through Drizzle's query builder, never through a raw `execute`, so
+   * without this a caller switching from `tx.update(...).set(...)` to this
+   * primitive would silently stop refreshing those columns. Optional: tables
+   * with no such column (e.g. `favorites`, which has no `updatedAt`) omit it.
+   */
+  touchColumns?: AnyPgColumn[];
 }
 
 /**
@@ -32,7 +41,7 @@ export async function lockedBatchReorder<T extends PgTable>(
   tx: Tx,
   opts: LockedBatchReorderOptions<T>
 ): Promise<void> {
-  const { table, idColumn, positionColumn, scopeWhere, plan } = opts;
+  const { table, idColumn, positionColumn, scopeWhere, plan, touchColumns = [] } = opts;
 
   if (plan.orderedIds.length === 0) {
     return;
@@ -52,9 +61,17 @@ export async function lockedBatchReorder<T extends PgTable>(
     sql`, `
   );
 
+  const setAssignments = sql.join(
+    [
+      sql`${sql.identifier(positionColumn.name)} = v.position`,
+      ...touchColumns.map((column) => sql`${sql.identifier(column.name)} = now()`),
+    ],
+    sql`, `
+  );
+
   await tx.execute(sql`
     UPDATE ${table}
-    SET ${sql.identifier(positionColumn.name)} = v.position
+    SET ${setAssignments}
     FROM (VALUES ${values}) AS v(id, position)
     WHERE ${idColumn} = v.id AND ${scopeWhere}
   `);

--- a/packages/lib/src/services/reorder/locked-batch-reorder.ts
+++ b/packages/lib/src/services/reorder/locked-batch-reorder.ts
@@ -27,7 +27,14 @@ export interface LockedBatchReorderOptions<T extends PgTable> {
 /**
  * Apply a reorder plan inside the caller's transaction: lock every target
  * row `FOR UPDATE` in ascending-id order, then write every position as one
- * batched `UPDATE ... FROM (VALUES ...)` statement.
+ * batched `UPDATE ... FROM (VALUES ...)` statement. Returns the ids from the
+ * plan that actually existed within `scopeWhere` (and were therefore locked
+ * and updated) — ids in the plan that don't exist in scope are silently
+ * skipped by the batched `UPDATE`'s `WHERE`, so this is the caller's signal
+ * to detect that and decide how to react (e.g. `reorderDriveRoles` currently
+ * rejects the whole request when any submitted id doesn't belong to the
+ * drive; a caller adopting this primitive can reproduce that by comparing
+ * this return value against `plan.orderedIds`).
  *
  * Locking in ascending-id order (the order `computeReorderPlan` already
  * produces) is what prevents two concurrent, overlapping reorders from
@@ -40,19 +47,20 @@ export interface LockedBatchReorderOptions<T extends PgTable> {
 export async function lockedBatchReorder<T extends PgTable>(
   tx: Tx,
   opts: LockedBatchReorderOptions<T>
-): Promise<void> {
+): Promise<string[]> {
   const { table, idColumn, positionColumn, scopeWhere, plan, touchColumns = [] } = opts;
 
   if (plan.orderedIds.length === 0) {
-    return;
+    return [];
   }
 
-  await tx
+  const locked = await tx
     .select({ id: idColumn })
     .from(table)
     .where(and(scopeWhere, inArray(idColumn, plan.orderedIds)))
     .orderBy(asc(idColumn))
     .for('update');
+  const lockedIds = locked.map((row) => row.id as string);
 
   const values = sql.join(
     plan.orderedIds.map(
@@ -75,4 +83,6 @@ export async function lockedBatchReorder<T extends PgTable>(
     FROM (VALUES ${values}) AS v(id, position)
     WHERE ${idColumn} = v.id AND ${scopeWhere}
   `);
+
+  return lockedIds;
 }

--- a/packages/lib/src/services/reorder/locked-batch-reorder.ts
+++ b/packages/lib/src/services/reorder/locked-batch-reorder.ts
@@ -1,0 +1,61 @@
+import { and, asc, inArray, sql, type SQL } from '@pagespace/db/operators';
+import type { AnyPgColumn, PgTable } from 'drizzle-orm/pg-core';
+// Type-only: erased at compile time, so this file never carries a runtime
+// dependency on the connected `db` singleton — callers pass their own `tx`.
+import type { db } from '@pagespace/db/db';
+import type { ReorderPlan } from './compute-reorder-plan';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export interface LockedBatchReorderOptions<T extends PgTable> {
+  table: T;
+  idColumn: AnyPgColumn;
+  positionColumn: AnyPgColumn;
+  scopeWhere: SQL;
+  plan: ReorderPlan;
+}
+
+/**
+ * Apply a reorder plan inside the caller's transaction: lock every target
+ * row `FOR UPDATE` in ascending-id order, then write every position as one
+ * batched `UPDATE ... FROM (VALUES ...)` statement.
+ *
+ * Locking in ascending-id order (the order `computeReorderPlan` already
+ * produces) is what prevents two concurrent, overlapping reorders from
+ * deadlocking — see `lockDriveRolesInOrder` in drive-role-service.ts for the
+ * same contract applied to a single call site. Batching the write into one
+ * statement instead of N sequential per-row updates is what closes the
+ * window between those N updates that let concurrent reorders interleave in
+ * the first place.
+ */
+export async function lockedBatchReorder<T extends PgTable>(
+  tx: Tx,
+  opts: LockedBatchReorderOptions<T>
+): Promise<void> {
+  const { table, idColumn, positionColumn, scopeWhere, plan } = opts;
+
+  if (plan.orderedIds.length === 0) {
+    return;
+  }
+
+  await tx
+    .select({ id: idColumn })
+    .from(table)
+    .where(and(scopeWhere, inArray(idColumn, plan.orderedIds)))
+    .orderBy(asc(idColumn))
+    .for('update');
+
+  const values = sql.join(
+    plan.orderedIds.map(
+      (id) => sql`(${id}::text, ${plan.positionById.get(id)}::int)`
+    ),
+    sql`, `
+  );
+
+  await tx.execute(sql`
+    UPDATE ${table}
+    SET ${sql.identifier(positionColumn.name)} = v.position
+    FROM (VALUES ${values}) AS v(id, position)
+    WHERE ${idColumn} = v.id AND ${scopeWhere}
+  `);
+}


### PR DESCRIPTION
## Summary

Adds the generic locked-batch reorder primitive that Phases 4–6 (spawned after this merges) will each apply to one of three call sites with the same or a related bug:

- `apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts` — N unordered sequential `UPDATE`s per reorder
- `apps/web/src/app/api/user/favorites/reorder/route.ts` — identical unordered loop
- `packages/lib/src/services/drive-role-service.ts` `reorderDriveRoles` — gets lock ordering right via `lockDriveRolesInOrder`, but still N sequential updates instead of one batch

This phase touches **only** the two new files under `packages/lib/src/services/reorder/` (+ tests) and the package exports map. It does not modify any of the three consuming routes/services — those are separate phases.

## Why

Production Postgres OOM-crashed on 2026-07-18, preceded by a ~7-minute deadlock storm (17:30–17:37 UTC, repeated `deadlock detected` errors) on `task_items.position` updates. Root cause: `tasks/reorder` issues N sequential single-row `UPDATE`s inside one transaction, in whatever order the client-submitted array happens to be — no lock ordering. The task board is driven by many concurrent AI agents (pu/orchestrate workflows) reordering positions concurrently, so overlapping concurrent reorders are common, not an edge case.

PageSpace epic: `j44e35jwzlhr54fbmruk3k4i` ("Task Board Query & Reorder Safety")

## What

- **`compute-reorder-plan.ts`** — pure function. Dedups ids (last write wins) and returns them canonically sorted ascending by id — the deterministic lock order every caller must share to avoid deadlocks, mirroring `lockDriveRolesInOrder` in `drive-role-service.ts`. Empty input → empty plan.
- **`locked-batch-reorder.ts`** — effect shell, takes `tx` as an explicit parameter (no runtime import of the `db` singleton — the `Tx` type is derived via `import type`, erased at compile time). Locks every target row `FOR UPDATE` in ascending-id order before any write, then applies every position as **one** batched `UPDATE ... FROM (VALUES ...)` statement instead of N sequential updates. Generic over `table`/`idColumn`/`positionColumn`/`scopeWhere` as plain Drizzle runtime values (not over the full row/schema type). Empty plan → no-ops without touching the transaction.
  - Optional `touchColumns?: AnyPgColumn[]`: since the raw `UPDATE` bypasses Drizzle's `$onUpdate`, callers whose current per-row loop relies on it (`taskItems.updatedAt`, `driveRoles.updatedAt`) pass the column(s) here to have them stamped with `now()` in the same batched statement — so adopting this primitive doesn't silently stop refreshing timestamps that downstream code (e.g. `apps/web/src/app/api/tasks/route.ts`'s recency sort) depends on. Added after review feedback.
  - Returns `string[]` — the ids from the plan that actually existed within `scopeWhere` (and were therefore locked and updated). `reorderDriveRoles` currently validates every submitted id belongs to the drive and rejects the whole request otherwise; a caller adopting this primitive can reproduce that by diffing this return value against `plan.orderedIds`. Added during self-review so that guarantee isn't silently lost when Phase 5 adopts this.

## Test plan

- [x] TDD: RED confirmed before implementing both files (missing-module failures), again before adding `touchColumns` (unknown-property typecheck failure)
- [x] `compute-reorder-plan.ts`: 100% branch coverage (empty array, single item, duplicate ids, already-sorted, reverse-order, arbitrary-order input)
- [x] `locked-batch-reorder.ts`: mocked unit test for the empty-plan no-op guard (asserts empty return value too)
- [x] **Real-database (no mocks) concurrency test** — the critical one: fires two concurrent `lockedBatchReorder` calls against real Postgres, on overlapping-but-not-identical row sets (`{a,b,c}` vs `{b,c,d}`), each submitted in an order that doesn't match the other's. Asserts both transactions resolve without a Postgres `deadlock detected` error, and that overlapping rows land in one consistent transaction's values (never a mixed/torn write). This is the exact failure mode that crashed prod — a mocked test would not catch a regression here.
- [x] Real-database tests for `touchColumns`: stamps the column past a seeded stale value when supplied; leaves it stale (proving the opt-in is real, not silently always-on) when omitted.
- [x] Real-database test for the locked-ids return value: a plan naming a real row from a different scope (another drive) returns only the in-scope id, and the out-of-scope row is left unmodified.
- [x] `bun run typecheck` — green across all 16 packages/apps
- [x] `bun run test:unit` — green (`@pagespace/lib`: 370/370 files, 0 failed, 3 pre-existing skips; `web`: 987 passed / 1 pre-existing failure in `src/lib/messages/__tests__/grouping.test.ts`, unrelated file this PR never touches)
- [x] CI: `ci / Lint & TypeScript Check` and `ci / Unit Tests` both green

## Review history

- Codex flagged the raw `UPDATE` bypassing Drizzle's `$onUpdate` → added `touchColumns`.
- CodeRabbit flagged `TaskReorderEntry` as misleadingly task-specific for a generic primitive → renamed to `ReorderEntry`.
- CodeRabbit flagged `drizzle-orm@^0.32.2` being in the affected range for CVE-2026-39356 (SQL identifier escaping). Verified the CVE is real and this call site is not exploitable (only ever passes schema-defined column names, never request input) — CodeRabbit confirmed and withdrew the finding. Filed #2134 to track the repo-wide dependency bump separately, since it touches every app in the monorepo and doesn't belong in this narrow primitive PR.
- Self-review during convergence: the locking select's result was being silently discarded, which would have dropped `reorderDriveRoles`'s existing "reject invalid ids" guarantee if Phase 5 naively adopted this primitive → now returns the locked ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hTNawmAcmE8WzZeoeLW7c