### PR TITLE
fix(db): exclude migration/backfill scripts from app pool timeouts (fast-follow to #2126)

### DIFF
--- a/packages/db/src/__tests__/db-pool-timeouts.test.ts
+++ b/packages/db/src/__tests__/db-pool-timeouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAppPoolOptions, pool, getAdvisoryLockPool } from '../db';
+import { buildAppPoolOptions, pool, getAdvisoryLockPool, getMigrationPool } from '../db';
 
 describe('buildAppPoolOptions (Phase 7 — statement_timeout/lock_timeout on the main pool)', () => {
   it('should set statement_timeout to 15000ms', () => {
@@ -26,5 +26,25 @@ describe('buildAppPoolOptions (Phase 7 — statement_timeout/lock_timeout on the
   it('given the advisory-lock pool, should also not inherit statement_timeout from the main pool options', () => {
     const advisoryPool = getAdvisoryLockPool();
     expect(advisoryPool.options.options ?? '').not.toContain('statement_timeout');
+  });
+
+  it('given the migration pool (migrate.ts / migrate-pending-invites.ts), should NOT carry statement_timeout — DDL/backfills can legitimately run past 15s', () => {
+    const migrationPool = getMigrationPool();
+    expect(migrationPool.options.options ?? '').not.toContain('statement_timeout');
+  });
+
+  it('given the migration pool, should NOT carry lock_timeout — it can legitimately queue behind an in-flight app transaction past 5s', () => {
+    const migrationPool = getMigrationPool();
+    expect(migrationPool.options.options ?? '').not.toContain('lock_timeout');
+  });
+
+  it('given the migration pool, should be a distinct pool instance from both the main pool and the advisory-lock pool', () => {
+    const migrationPool = getMigrationPool();
+    expect(migrationPool).not.toBe(pool);
+    expect(migrationPool).not.toBe(getAdvisoryLockPool());
+  });
+
+  it('given the migration pool, should be a singleton across repeated calls (lazy init, one pool)', () => {
+    expect(getMigrationPool()).toBe(getMigrationPool());
   });
 });

--- a/packages/db/src/__tests__/db-pool-timeouts.test.ts
+++ b/packages/db/src/__tests__/db-pool-timeouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildAppPoolOptions, pool, getAdvisoryLockPool, getMigrationPool } from '../db';
+import { buildAppPoolOptions, pool, getAdvisoryLockPool, getMigrationPool, getMigrationDb } from '../db';
 
 describe('buildAppPoolOptions (Phase 7 — statement_timeout/lock_timeout on the main pool)', () => {
   it('should set statement_timeout to 15000ms', () => {
@@ -46,5 +46,20 @@ describe('buildAppPoolOptions (Phase 7 — statement_timeout/lock_timeout on the
 
   it('given the migration pool, should be a singleton across repeated calls (lazy init, one pool)', () => {
     expect(getMigrationPool()).toBe(getMigrationPool());
+  });
+
+  it('given getMigrationDb(), should be bound to the migration pool, not the app pool', () => {
+    // drizzle's node-postgres session exposes the underlying pool as `client`.
+    const migrationDb = getMigrationDb() as unknown as { session: { client: unknown } };
+    expect(migrationDb.session.client).toBe(getMigrationPool());
+  });
+
+  it('given getMigrationDb(), should be schema-bound (relational db.query API available for scripts that need it)', () => {
+    const migrationDb = getMigrationDb();
+    expect(migrationDb.query).toBeDefined();
+  });
+
+  it('given getMigrationDb(), should be a singleton across repeated calls', () => {
+    expect(getMigrationDb()).toBe(getMigrationDb());
   });
 });

--- a/packages/db/src/__tests__/migrate.test.ts
+++ b/packages/db/src/__tests__/migrate.test.ts
@@ -2,9 +2,12 @@
  * @scaffold - migrate.ts Tests
  *
  * migrate.ts is a custom migration runner that executes each migration in its
- * own transaction (fixing PostgreSQL enum ADD VALUE limitations).
- * We mock out readMigrationFiles and the db to avoid any real database connections,
- * then dynamically import the module to trigger its top-level IIFE.
+ * own transaction (fixing PostgreSQL enum ADD VALUE limitations). It runs on
+ * getMigrationPool() (Phase 7 of #j44e35jwzlhr54fbmruk3k4i) — NOT the
+ * app-throttled `db` — so DDL isn't bounded by the app pool's
+ * statement_timeout/lock_timeout. We mock out readMigrationFiles, the pool,
+ * and drizzle() to avoid any real database connections, then dynamically
+ * import the module to trigger its top-level IIFE.
  */
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
 
@@ -24,18 +27,26 @@ vi.mock('drizzle-orm', () => ({
   }),
 }));
 
-// Mock the db index so no real PG pool is created
+// Mock the migration pool (db.ts's getMigrationPool) so no real PG pool is created
+const mockPoolEnd = vi.fn().mockResolvedValue(undefined);
+const mockGetMigrationPool = vi.fn(() => ({ end: mockPoolEnd }));
+
+vi.mock('../db', () => ({
+  getMigrationPool: mockGetMigrationPool,
+}));
+
+// Mock drizzle(pool) -> the {execute, transaction} surface migration-runner.ts drives
 const mockExecute = vi.fn();
 const mockTxExecute = vi.fn();
 const mockTransaction = vi.fn(async (fn: (tx: { execute: typeof mockTxExecute }) => Promise<void>) => {
   await fn({ execute: mockTxExecute });
 });
 
-vi.mock('../db', () => ({
-  db: {
+vi.mock('drizzle-orm/node-postgres', () => ({
+  drizzle: vi.fn(() => ({
     execute: mockExecute,
     transaction: mockTransaction,
-  },
+  })),
 }));
 
 describe('migrate.ts', () => {
@@ -61,6 +72,8 @@ describe('migrate.ts', () => {
     mockTransaction.mockClear();
     mockTxExecute.mockReset();
     mockReadMigrationFiles.mockReset();
+    mockGetMigrationPool.mockClear();
+    mockPoolEnd.mockReset().mockResolvedValue(undefined);
   });
 
   it('runs migrations and exits with 0 on success', async () => {
@@ -74,6 +87,16 @@ describe('migrate.ts', () => {
     expect(mockReadMigrationFiles).toHaveBeenCalledTimes(1);
     expect(mockTransaction).toHaveBeenCalledTimes(1);
     expect(processExitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it('runs on the dedicated migration pool (getMigrationPool), not the app-throttled db, and ends it before exiting', async () => {
+    mockReadMigrationFiles.mockReturnValue([]);
+
+    await import('../migrate');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mockGetMigrationPool).toHaveBeenCalledTimes(1);
+    expect(mockPoolEnd).toHaveBeenCalledTimes(1);
   });
 
   it('reads migrations from the drizzle folder', async () => {

--- a/packages/db/src/__tests__/migrate.test.ts
+++ b/packages/db/src/__tests__/migrate.test.ts
@@ -145,4 +145,14 @@ describe('migrate.ts', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.any(Error));
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
+
+  it('given migration fails, should still end the pool (finally, not just the success path)', async () => {
+    const migrationError = new TypeError('db.execute is not a function');
+    mockExecute.mockRejectedValueOnce(migrationError);
+
+    await import('../migrate');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mockPoolEnd).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,4 +1,4 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { schema } from './schema';
 import { registerPool, getPoolStats } from './pool-stats';
@@ -108,4 +108,25 @@ export function getMigrationPool(): Pool {
     migrationPool.on('error', (_err, _client) => {});
   }
   return migrationPool;
+}
+
+/**
+ * Schema-bound drizzle client over getMigrationPool() — the single
+ * entrypoint one-shot maintenance/backfill scripts (scripts/*.ts) should
+ * import instead of `db`, so they never inherit the app pool's
+ * statement_timeout/lock_timeout on a large table's bulk update/aggregate
+ * query. Schema-bound (unlike the plain `drizzle(migrationPool)` calls in
+ * migrate.ts/migrate-pending-invites.ts) because several backfill scripts
+ * use the `db.query.*` relational API, not just the query builder.
+ *
+ * Lazy + memoized like getMigrationPool() itself — see that function's doc
+ * comment for why this can't be an eagerly-constructed module-level const.
+ */
+let migrationDb: NodePgDatabase<typeof schema> | null = null;
+
+export function getMigrationDb(): NodePgDatabase<typeof schema> {
+  if (!migrationDb) {
+    migrationDb = drizzle(getMigrationPool(), { schema });
+  }
+  return migrationDb;
 }

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -81,3 +81,31 @@ export function getAdvisoryLockPool(): Pool {
   }
   return advisoryLockPool;
 }
+
+/**
+ * Dedicated pool for the main-DB migration entrypoint (migrate.ts) and other
+ * one-shot maintenance/backfill scripts (e.g. migrate-pending-invites.ts) —
+ * deliberately built from basePoolConfig() with NO `options`, so it never
+ * inherits the app pool's statement_timeout/lock_timeout. Migrations run DDL
+ * (index builds, table rewrites) that can legitimately run past 15s on a
+ * populated table, and can legitimately queue behind a lock held by an
+ * in-flight app transaction for longer than 5s — applying the app pool's
+ * request-serving limits there would abort a migration mid-run and block
+ * deployment instead of completing it. `max: 1` matches these scripts'
+ * actual concurrency: each runs its statements sequentially on a single
+ * connection, never in parallel.
+ *
+ * Lazily constructed like getAdvisoryLockPool(): only migration/backfill
+ * scripts ever call this, and each is a short-lived process that exits when
+ * done, so it isn't registered with pool-stats (nothing long-running is ever
+ * around to report on it).
+ */
+let migrationPool: Pool | null = null;
+
+export function getMigrationPool(): Pool {
+  if (!migrationPool) {
+    migrationPool = new Pool({ ...basePoolConfig(), max: 1 });
+    migrationPool.on('error', (_err, _client) => {});
+  }
+  return migrationPool;
+}

--- a/packages/db/src/migrate-pending-invites.ts
+++ b/packages/db/src/migrate-pending-invites.ts
@@ -19,14 +19,21 @@
  * Usage:
  *   bun run --filter '@pagespace/db' migrate-pending-invites
  *   bun run --filter '@pagespace/db' migrate-pending-invites -- --dry-run
+ *
+ * Runs on getMigrationPool(), NOT the app-throttled `db` — this is a one-shot
+ * ops script, not request-serving traffic, and the bulk select/delete below
+ * can legitimately run past the app pool's statement_timeout on a large
+ * drive_members table (see getMigrationPool()'s doc comment in db.ts).
  */
 
-import { db } from './db';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { getMigrationPool } from './db';
 import { driveMembers } from './schema/members';
 import { users, passkeys } from './schema/auth';
 import { and, eq, inArray, isNull, sql } from './operators';
 
 const dryRun = process.argv.includes('--dry-run');
+const db = drizzle(getMigrationPool());
 
 async function main() {
   const wiped: Array<{ driveId: string; email: string }> = [];

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,26 +1,33 @@
 
+import { drizzle } from "drizzle-orm/node-postgres";
 import { readMigrationFiles } from "drizzle-orm/migrator";
-import { db } from "./db";
+import { getMigrationPool } from "./db";
 import { runMigrations } from "./migration-runner";
 
 /**
  * Main-DB migration entrypoint. The per-migration-transaction logic lives in
  * migration-runner.ts (shared with the Admin PG runner, migrate-admin.ts);
  * this shell only binds the main journal: ./drizzle + the 'drizzle' schema.
+ *
+ * Runs on getMigrationPool(), NOT the app-throttled `db` — migrations run
+ * DDL that can legitimately exceed the app pool's statement_timeout/
+ * lock_timeout (see getMigrationPool()'s doc comment in db.ts).
  */
 async function main() {
   console.log("Running migrations...");
   console.log("DATABASE_URL:", process.env.DATABASE_URL ? "Set" : "Not set");
 
   const migrations = readMigrationFiles({ migrationsFolder: "drizzle" });
+  const migrationPool = getMigrationPool();
 
   await runMigrations(
-    db,
+    drizzle(migrationPool),
     migrations,
     { migrationsSchema: "drizzle", migrationsTable: "__drizzle_migrations" },
     console.log,
   );
 
+  await migrationPool.end();
   console.log("Migrations finished.");
   process.exit(0);
 }

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -20,14 +20,17 @@ async function main() {
   const migrations = readMigrationFiles({ migrationsFolder: "drizzle" });
   const migrationPool = getMigrationPool();
 
-  await runMigrations(
-    drizzle(migrationPool),
-    migrations,
-    { migrationsSchema: "drizzle", migrationsTable: "__drizzle_migrations" },
-    console.log,
-  );
+  try {
+    await runMigrations(
+      drizzle(migrationPool),
+      migrations,
+      { migrationsSchema: "drizzle", migrationsTable: "__drizzle_migrations" },
+      console.log,
+    );
+  } finally {
+    await migrationPool.end();
+  }
 
-  await migrationPool.end();
   console.log("Migrations finished.");
   process.exit(0);
 }

--- a/scripts/__tests__/backfill-home-drives.test.ts
+++ b/scripts/__tests__/backfill-home-drives.test.ts
@@ -9,7 +9,7 @@ const { selectMock, insertMock } = vi.hoisted(() => ({
 }));
 
 vi.mock('@pagespace/db/db', () => ({
-  db: { select: selectMock, insert: insertMock },
+  getMigrationDb: () => ({ select: selectMock, insert: insertMock }),
 }));
 
 vi.mock('@pagespace/db/schema/auth', () => ({

--- a/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
+++ b/scripts/__tests__/backfill-legacy-ciphertext-reencrypt.test.ts
@@ -15,7 +15,7 @@ import { scryptSync, randomBytes, createCipheriv } from 'crypto';
 // hands out successive batches would pass even with a broken cursor).
 const { gtCursors } = vi.hoisted(() => ({ gtCursors: [] as unknown[] }));
 
-vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('@pagespace/db/db', () => ({ getMigrationDb: () => ({ select: vi.fn(), update: vi.fn() }) }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id', email: 'email', name: 'name', updatedAt: 'updatedAt' },
 }));

--- a/scripts/__tests__/backfill-user-pii-encryption.test.ts
+++ b/scripts/__tests__/backfill-user-pii-encryption.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@pagespace/db/db', () => ({ db: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('@pagespace/db/db', () => ({ getMigrationDb: () => ({ select: vi.fn(), update: vi.fn() }) }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id', email: 'email', name: 'name', emailBidx: 'emailBidx' },
 }));

--- a/scripts/__tests__/promote-admin.test.ts
+++ b/scripts/__tests__/promote-admin.test.ts
@@ -31,14 +31,14 @@ mockSet.mockReturnValue({ where: mockWhere });
 mockUpdate.mockReturnValue({ set: mockSet });
 
 vi.mock('@pagespace/db/db', () => ({
-  db: {
+  getMigrationDb: () => ({
     query: {
       users: {
         findFirst: mockFindFirst,
       },
     },
     update: mockUpdate,
-  },
+  }),
 }));
 
 vi.mock('@pagespace/db/schema/auth', () => ({

--- a/scripts/__tests__/setup-onprem-admin.test.ts
+++ b/scripts/__tests__/setup-onprem-admin.test.ts
@@ -23,11 +23,11 @@ mockSet.mockReturnValue({ where: mockWhere });
 mockUpdate.mockReturnValue({ set: mockSet });
 
 vi.mock('@pagespace/db/db', () => ({
-  db: {
+  getMigrationDb: () => ({
     query: { users: { findFirst: mockFindFirst } },
     update: mockUpdate,
     insert: mockInsert,
-  },
+  }),
 }));
 
 vi.mock('@pagespace/db/schema/auth', () => ({

--- a/scripts/add-community-members.ts
+++ b/scripts/add-community-members.ts
@@ -16,10 +16,14 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { driveMembers } from '@pagespace/db/schema/members';
 import { eq, gt, notInArray, sql } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 function parseArgs() {
   const args = process.argv.slice(2);

--- a/scripts/backfill-credit-ledger.ts
+++ b/scripts/backfill-credit-ledger.ts
@@ -1,7 +1,11 @@
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { creditBalances, creditLedger } from '@pagespace/db/schema/credits';
 import { eq, sql } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 // Mirror the STRIPE_REF_ARBITER from credit-gate / credit-funding (same partial index).
 const STRIPE_REF_ARBITER = {

--- a/scripts/backfill-file-storage.ts
+++ b/scripts/backfill-file-storage.ts
@@ -1,8 +1,12 @@
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { files, filePages } from '@pagespace/db/schema/storage';
 import { sql } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function backfill(): Promise<void> {
   const rows = await db

--- a/scripts/backfill-gifted-subscriptions.ts
+++ b/scripts/backfill-gifted-subscriptions.ts
@@ -15,9 +15,13 @@
  */
 
 import Stripe from 'stripe';
-import { db as defaultDb } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import { eq, asc } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const defaultDb = getMigrationDb();
 
 const isDryRun = process.argv.includes('--dry-run');
 const BATCH_SIZE = 10;

--- a/scripts/backfill-home-drives.ts
+++ b/scripts/backfill-home-drives.ts
@@ -38,11 +38,16 @@
  */
 
 import { createId } from '@paralleldrive/cuid2';
-import { db as defaultDb } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { drives } from '@pagespace/db/schema/core';
 import { eq, and, gt, asc, inArray, sql } from '@pagespace/db/operators';
 import { computeHomeBackfillInserts } from './lib/home-drive-backfill';
+
+// One-shot backfill script — runs on the unthrottled migration pool, not the
+// app-throttled `db`, so a slow full-table scan on a large `users` table
+// can't be aborted by the app pool's statement_timeout.
+const defaultDb = getMigrationDb();
 
 const BATCH_SIZE = 500;
 

--- a/scripts/backfill-legacy-ciphertext-reencrypt.ts
+++ b/scripts/backfill-legacy-ciphertext-reencrypt.ts
@@ -49,10 +49,15 @@
  * ────────────────────────────────────────────────────────────────────────────
  */
 
-import { db as defaultDb } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { eq, gt, asc, and } from '@pagespace/db/operators';
 import { planLegacyCiphertextReencrypt } from '@pagespace/lib/encryption/legacy-ciphertext-reencrypt';
+
+// One-shot backfill script — runs on the unthrottled migration pool, not the
+// app-throttled `db`, so a slow full-table scan/rewrite can't be aborted by
+// the app pool's statement_timeout.
+const defaultDb = getMigrationDb();
 
 const BATCH_SIZE = 500;
 

--- a/scripts/backfill-publish-subdomains.ts
+++ b/scripts/backfill-publish-subdomains.ts
@@ -24,11 +24,15 @@
  * Idempotent: a re-run only touches drives still missing a subdomain.
  */
 
-import { db as defaultDb } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { drives } from '@pagespace/db/schema/core';
 import { eq, and, isNull, isNotNull, gt, asc } from '@pagespace/db/operators';
 import { computePublishSubdomainBackfill } from './lib/publish-subdomain-backfill';
 import { isUniqueViolation } from '@pagespace/lib/services/subdomain-allocation';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const defaultDb = getMigrationDb();
 
 const BATCH_SIZE = 500;
 

--- a/scripts/backfill-task-verb-tools.ts
+++ b/scripts/backfill-task-verb-tools.ts
@@ -24,10 +24,14 @@
  *   --dry-run   Report what would change without writing to the database.
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { eq, sql } from '@pagespace/db/operators';
 import { addTaskVerbTools, TRIGGER_TOOL } from './lib/task-verb-tools';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function backfill(dryRun: boolean): Promise<void> {
   console.log(

--- a/scripts/backfill-trash-verb-tools.ts
+++ b/scripts/backfill-trash-verb-tools.ts
@@ -25,7 +25,7 @@
  *   --dry-run   Report what would change without writing to the database.
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { eq, sql } from '@pagespace/db/operators';
 import {
@@ -33,6 +33,10 @@ import {
   TRASH_TRIGGER,
   RESTORE_TRIGGER,
 } from './lib/trash-verb-tools';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function backfill(dryRun: boolean): Promise<void> {
   console.log(

--- a/scripts/backfill-user-pii-encryption.ts
+++ b/scripts/backfill-user-pii-encryption.ts
@@ -34,11 +34,16 @@
  * ────────────────────────────────────────────────────────────────────────────
  */
 
-import { db as defaultDb } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { eq, gt, asc } from '@pagespace/db/operators';
 import { planUserPiiBackfill } from '@pagespace/lib/encryption/user-pii-backfill';
 import { getPiiIndexKey } from '@pagespace/lib/encryption/user-crypto';
+
+// One-shot backfill script — runs on the unthrottled migration pool, not the
+// app-throttled `db`, so a slow full-table scan/rewrite can't be aborted by
+// the app pool's statement_timeout.
+const defaultDb = getMigrationDb();
 
 const BATCH_SIZE = 500;
 

--- a/scripts/cleanup-ephemeral-tasks.ts
+++ b/scripts/cleanup-ephemeral-tasks.ts
@@ -1,7 +1,11 @@
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { taskLists } from '@pagespace/db/schema/tasks';
 import { and, isNull, isNotNull } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 /**
  * Cleanup script to remove ephemeral (conversation-scoped) task lists.

--- a/scripts/migrate-ai-models-to-openrouter.ts
+++ b/scripts/migrate-ai-models-to-openrouter.ts
@@ -21,10 +21,14 @@
  * Run with: bun run scripts/migrate-ai-models-to-openrouter.ts
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { pages } from '@pagespace/db/schema/core';
 import { and, or, eq, inArray, like, sql } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 const DEFAULT_PROVIDER = 'openai';
 const DEFAULT_MODEL = 'openai/gpt-5.3-chat';

--- a/scripts/migrate-provider-types.ts
+++ b/scripts/migrate-provider-types.ts
@@ -9,9 +9,13 @@
  * Run with: npx tsx scripts/migrate-provider-types.ts
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { aiUsageDaily } from '@pagespace/db/schema/ai';
 import { eq } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function migrateProviderTypes() {
   console.log('🚀 Starting provider type migration...');

--- a/scripts/normalize-dead-ai-models.ts
+++ b/scripts/normalize-dead-ai-models.ts
@@ -26,7 +26,7 @@
  *   bun run scripts/normalize-dead-ai-models.ts --apply    # apply
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { pages } from '@pagespace/db/schema/core';
 import { eq, inArray } from '@pagespace/db/operators';
@@ -36,6 +36,10 @@ import {
   DEFAULT_PROVIDER,
   DEFAULT_MODEL,
 } from '../apps/web/src/lib/ai/core/ai-providers-config';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 const APPLY = process.argv.includes('--apply');
 

--- a/scripts/promote-admin.ts
+++ b/scripts/promote-admin.ts
@@ -1,8 +1,12 @@
 #!/usr/bin/env bun
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { eq } from '@pagespace/db/operators';
 import { userEmailMatch } from '@pagespace/lib/auth/user-repository';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 const email = process.argv[2];
 

--- a/scripts/reenqueue-unprocessed-uploads.ts
+++ b/scripts/reenqueue-unprocessed-uploads.ts
@@ -1,11 +1,15 @@
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { and, eq, isNotNull, sql } from '@pagespace/db/operators';
 import {
   createUploadServiceToken,
   isPermissionDeniedError,
 } from '@pagespace/lib/services/validated-service-token';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 /**
  * Re-enqueue processor ingestion for FILE pages whose post-upload enqueue was

--- a/scripts/rehash-activity-logs.ts
+++ b/scripts/rehash-activity-logs.ts
@@ -21,9 +21,13 @@
  */
 
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { isNotNull, count, sql } from 'drizzle-orm';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 const DRY_RUN = process.argv.includes('--dry-run');
 

--- a/scripts/repair-orphaned-trashed-pages.ts
+++ b/scripts/repair-orphaned-trashed-pages.ts
@@ -1,7 +1,11 @@
 import 'dotenv/config';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { inArray, sql } from '@pagespace/db/operators';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 /**
  * Repair pages orphaned by past non-cascading trashes.

--- a/scripts/send-sdk-launch-notifications.ts
+++ b/scripts/send-sdk-launch-notifications.ts
@@ -62,7 +62,7 @@
 import type { FileHandle } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { emailNotificationPreferences } from '@pagespace/db/schema/email-notifications';
 import { dataSubjectRequests } from '@pagespace/db/schema/data-subject-requests';
@@ -89,6 +89,10 @@ import {
   resolveMarketingBase,
   runBroadcast,
 } from './lib/sdk-launch-broadcast';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 /** One person the broadcast is about to mail. */
 interface Recipient {

--- a/scripts/send-verification-notifications.ts
+++ b/scripts/send-verification-notifications.ts
@@ -11,10 +11,14 @@
  * 3. Reports the number of notifications sent
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { eq, isNull } from '@pagespace/db/operators';
 import { createNotification } from '@pagespace/lib/notifications/notifications';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function sendVerificationNotifications() {
   console.log('🔍 Finding users with unverified emails...');

--- a/scripts/setup-onprem-admin.ts
+++ b/scripts/setup-onprem-admin.ts
@@ -11,7 +11,7 @@
  * 3. Generates a one-time magic link for initial sign-in (no SMTP required)
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { eq } from '@pagespace/db/operators';
 import { createId } from '@paralleldrive/cuid2';
@@ -19,6 +19,10 @@ import { getOnPremUserDefaults } from '@pagespace/lib/onprem-defaults';
 import { generateOnPremSetupLink } from '@pagespace/lib/auth/onprem-setup-link';
 import { userEmailMatch, prepareUserWrite } from '@pagespace/lib/auth/user-repository';
 import { parseArgs } from 'node:util';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 async function main() {
   const { values } = parseArgs({

--- a/scripts/sync-legacy-subscriptions.ts
+++ b/scripts/sync-legacy-subscriptions.ts
@@ -10,11 +10,15 @@
 
 import 'dotenv/config';
 import Stripe from 'stripe';
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { users } from '@pagespace/db/schema/auth';
 import { subscriptions } from '@pagespace/db/schema/subscriptions';
 import { eq, and, inArray, ne } from '@pagespace/db/operators';
 import { stripeConfig, stripeMode } from '../apps/web/src/lib/stripe-config';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   apiVersion: '2025-08-27.basil',

--- a/scripts/verify-token-migration.ts
+++ b/scripts/verify-token-migration.ts
@@ -17,8 +17,12 @@
  *   2 - Error during verification
  */
 
-import { db } from '@pagespace/db/db';
+import { getMigrationDb } from '@pagespace/db/db';
 import { sql } from 'drizzle-orm';
+
+// One-shot ops script — runs on the unthrottled migration pool, not the
+// app-throttled `db` (see getMigrationDb()'s doc comment in packages/db).
+const db = getMigrationDb();
 
 export interface VerificationResult {
   table: string;


### PR DESCRIPTION
## Context

PR #2126 (Phase 7 of the "Task Board Query & Reorder Safety" epic, PageSpace page `j44e35jwzlhr54fbmruk3k4i`) applied `statement_timeout=15000`/`lock_timeout=5000` to the main DB pool. Shortly after opening it, Codex flagged a **P1**: `migrate.ts`'s DDL runner and `migrate-pending-invites.ts`'s bulk backfill both ran on that same app-throttled pool, so an index build/table rewrite past 15s, or DDL queued behind an app transaction's lock for more than 5s, would abort a migration mid-run and block deployment.

I fixed this and pushed it to the same branch (`pu/db-pool-timeouts`) — but #2126 was merged (commit `aec891498`) before those follow-up commits landed, so **the P1 was live on `master`**: `bun run db:migrate` ran on the throttled pool. This PR is the fast-follow carrying that fix — originally scoped to just `packages/db`, then expanded (see below) after a second review finding.

## What this PR does

**Migration pool (the original P1 fix):**
- Adds `getMigrationPool()` to `db.ts`: a dedicated pool built from `basePoolConfig()` only (no `options`/timeouts), mirroring the existing `getAdvisoryLockPool()` pattern. `max: 1` since these scripts run their statements sequentially on a single connection, never in parallel.
- `migrate.ts` and `migrate-pending-invites.ts` now build their own drizzle client from `getMigrationPool()` instead of importing the app-throttled `db`. `migrate-admin.ts` already used its own separate pool and was never affected.
- `migrate.ts` now wraps `runMigrations()` in try/finally so the migration pool is closed on both the success and failure paths — matching `migrate-admin.ts`'s existing pattern (it previously only closed on success).
- Updates `migrate.test.ts`'s mocks for the new `getMigrationPool()`/`drizzle()` call shape and adds tests for: the migration pool being used and ended on success, and still being ended when a migration throws.
- Adds coverage in `db-pool-timeouts.test.ts` asserting the migration pool carries neither `statement_timeout` nor `lock_timeout`, and is a distinct singleton from both the main pool and the advisory-lock pool.

**Repo-wide maintenance-script sweep (P2, added after Codex flagged it — see PR comments):**
- Codex named 2 more affected files (`rehash-activity-logs.ts`, `backfill-credit-ledger.ts`); a repo-wide search found **23 total** `scripts/*.ts` files importing the app-throttled `db`.
- Adds `getMigrationDb()` to `db.ts`: a schema-bound drizzle client over `getMigrationPool()` (schema-bound because several backfill scripts use the `db.query.*` relational API, not just the query builder). Lazy + memoized like `getMigrationPool()` itself.
- Every script in `scripts/` that imported `db` now imports `getMigrationDb()` instead.
- 5 of those scripts have real test coverage with `vi.mock('@pagespace/db/db', ...)` module mocks — updated each mock factory in lockstep (`db: {...}` → `getMigrationDb: () => ({...})`) and re-ran their suites; all green.
- One intentional exception: `scripts/verify-token-migration.ts`'s test already mocks the wrong module path (pre-existing, unrelated bug) and isn't in CI's test file list — fixed the source script for consistency, left that already-broken/unrun test alone.

## Verification

- `bun run typecheck` — green across the monorepo (one run hit a stale/incomplete `.next/types` build-artifact failure unrelated to this diff, cleared on rebuild).
- `bun run lint`, `bun run build` (packages/db) — green.
- `bun run test` / `test:coverage` (packages/db) — green; global coverage thresholds (lines 77/branches 94/functions 0/statements 77) still met. Only failure is the same pre-existing, unrelated `database "jono" does not exist` local-env gap.
- Root `bun run test:unit` — green aside from the same 3 pre-existing unrelated failures confirmed against the unmodified baseline.
- **`scripts/` test suite** — ran the exact CI command (`cd scripts && bunx vitest run __tests__/backfill-home-drives.test.ts __tests__/backfill-task-verb-tools.test.ts __tests__/backfill-trash-verb-tools.test.ts __tests__/backfill-legacy-ciphertext-reencrypt.test.ts __tests__/promote-admin.test.ts __tests__/setup-onprem-admin.test.ts __tests__/coverage-ratchet-sentinel.test.ts __tests__/send-sdk-launch-notifications.test.ts __tests__/send-sdk-launch-broadcast-loop.test.ts`) plus `backfill-user-pii-encryption.test.ts` (not in that CI list but has real db mocks) — all green.
- Verified zero remaining `import { db }`/`import { db as X }` from `@pagespace/db/db` anywhere under `scripts/`.
- The main pool's `statement_timeout`/`lock_timeout` behavior itself (unchanged by this PR) was already live-verified against a local Postgres container in #2126.

## Scope

`packages/db/src/db.ts` + tests, `migrate.ts`, `migrate-pending-invites.ts`, and all 23 `scripts/*.ts` files (+ 5 of their tests) that imported the app-throttled `db`. No other epic phase touches these files.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:unit`
- [x] `bun run test` (packages/db)
- [x] `scripts/` CI test command + `backfill-user-pii-encryption.test.ts`
- [x] Zero remaining `db` imports left in `scripts/` (grep-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015UYq2XfZfwAovm1PJhBoad
