### PR TITLE
fix(favorites): migrate reorder route onto locked-batch primitive — Phase 5 of task board crash-prevention epic

### DIFF
--- a/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
@@ -1,6 +1,9 @@
 /**
- * Security audit tests for /api/user/favorites/reorder
- * Verifies auditRequest is called for PATCH.
+ * Tests for /api/user/favorites/reorder
+ * Verifies auditRequest is called for PATCH, and that reordering is delegated
+ * to the shared locked-batch-reorder primitive as a single batched write
+ * instead of N sequential per-row updates (the deadlock-prone pattern fixed
+ * in Phase 3 of the task board crash-prevention epic, j44e35jwzlhr54fbmruk3k4i).
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
@@ -9,28 +12,26 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
 }));
 
+const { mockTransaction } = vi.hoisted(() => ({
+  mockTransaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
+    await fn({});
+  }),
+}));
+
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: {
       favorites: {
-        findMany: vi.fn().mockResolvedValue([{ id: 'fav-1' }, { id: 'fav-2' }]),
+        findMany: vi.fn().mockResolvedValue([{ id: 'fav-1' }, { id: 'fav-2' }, { id: 'fav-3' }]),
       },
     },
-    transaction: vi.fn().mockImplementation(async (fn: (tx: unknown) => Promise<void>) => {
-      await fn({
-        update: vi.fn().mockReturnValue({
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockResolvedValue(undefined),
-          }),
-        }),
-      });
-    }),
+    transaction: mockTransaction,
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn(),
-  and: vi.fn(),
-  inArray: vi.fn(),
+  eq: vi.fn((a: unknown, b: unknown) => ({ op: 'eq', a, b })),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ op: 'inArray', a, b })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   favorites: { id: 'id', userId: 'userId', position: 'position' },
@@ -49,9 +50,21 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));
 
+const { mockLockedBatchReorder } = vi.hoisted(() => ({
+  mockLockedBatchReorder: vi.fn().mockResolvedValue(['fav-1', 'fav-2', 'fav-3']),
+}));
+vi.mock('@pagespace/lib/services/reorder', () => ({
+  computeReorderPlan: vi.fn((entries: { id: string; position: number }[]) => {
+    const positionById = new Map(entries.map((e) => [e.id, e.position]));
+    return { orderedIds: Array.from(positionById.keys()).sort(), positionById };
+  }),
+  lockedBatchReorder: mockLockedBatchReorder,
+}));
+
 import { PATCH } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { favorites } from '@pagespace/db/schema/core';
 
 const mockUserId = 'user_123';
 
@@ -66,6 +79,14 @@ const mockAuth = () => {
   });
 };
 
+function createRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/user/favorites/reorder', {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
 describe('PATCH /api/user/favorites/reorder audit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -73,11 +94,7 @@ describe('PATCH /api/user/favorites/reorder audit', () => {
   });
 
   it('logs write audit event with reorder action', async () => {
-    const request = new Request('http://localhost/api/user/favorites/reorder', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ orderedIds: ['fav-1', 'fav-2'] }),
-    });
+    const request = createRequest({ orderedIds: ['fav-1', 'fav-2'] });
 
     await PATCH(request);
 
@@ -85,5 +102,61 @@ describe('PATCH /api/user/favorites/reorder audit', () => {
       request,
       { eventType: 'data.write', userId: mockUserId, resourceType: 'favorites', resourceId: 'self', details: { action: 'reorder' } }
     );
+  });
+});
+
+describe('PATCH /api/user/favorites/reorder locked-batch reorder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  it('issues one batched lockedBatchReorder call instead of N sequential updates', async () => {
+    const orderedIds = ['fav-1', 'fav-2', 'fav-3'];
+    const response = await PATCH(createRequest({ orderedIds }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+
+    expect(mockTransaction).toHaveBeenCalledTimes(1);
+    expect(mockLockedBatchReorder).toHaveBeenCalledTimes(1);
+
+    const [, opts] = mockLockedBatchReorder.mock.calls[0];
+    expect(opts.table).toBe(favorites);
+    expect(opts.idColumn).toBe(favorites.id);
+    expect(opts.positionColumn).toBe(favorites.position);
+    expect(opts.plan.orderedIds.slice().sort()).toEqual(orderedIds.slice().sort());
+    expect(opts.touchColumns).toBeUndefined();
+  });
+
+  it('scopes the reorder to the authenticated user', async () => {
+    await PATCH(createRequest({ orderedIds: ['fav-1', 'fav-2'] }));
+
+    const [, opts] = mockLockedBatchReorder.mock.calls[0];
+    expect(opts.scopeWhere).toEqual({ op: 'eq', a: favorites.userId, b: mockUserId });
+  });
+
+  it('is a no-op and skips the transaction when orderedIds is empty', async () => {
+    const response = await PATCH(createRequest({ orderedIds: [] }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.success).toBe(true);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockLockedBatchReorder).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when orderedIds is not an array', async () => {
+    const response = await PATCH(createRequest({ orderedIds: 'not-an-array' }));
+    expect(response.status).toBe(400);
+    expect(mockLockedBatchReorder).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 and skips the reorder when a submitted id does not belong to the user', async () => {
+    const response = await PATCH(createRequest({ orderedIds: ['fav-1', 'not-mine'] }));
+    expect(response.status).toBe(403);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockLockedBatchReorder).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/user/favorites/reorder/route.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/route.ts
@@ -5,6 +5,7 @@ import { eq, and, inArray } from '@pagespace/db/operators'
 import { favorites } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -37,15 +38,18 @@ export async function PATCH(req: Request) {
       return NextResponse.json({ error: 'Some favorite IDs do not belong to this user' }, { status: 403 });
     }
 
-    // Update positions in a transaction
-    await db.transaction(async tx => {
-      for (let i = 0; i < orderedIds.length; i++) {
-        await tx
-          .update(favorites)
-          .set({ position: i })
-          .where(and(eq(favorites.id, orderedIds[i]), eq(favorites.userId, userId)));
-      }
-    });
+    const plan = computeReorderPlan(orderedIds.map((id, i) => ({ id, position: i })));
+    if (plan.orderedIds.length > 0) {
+      await db.transaction(async (tx) => {
+        await lockedBatchReorder(tx, {
+          table: favorites,
+          idColumn: favorites.id,
+          positionColumn: favorites.position,
+          scopeWhere: eq(favorites.userId, userId),
+          plan,
+        });
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Migrates `apps/web/src/app/api/user/favorites/reorder/route.ts` off the N-sequential single-row `UPDATE` loop (no lock ordering) onto the shared `computeReorderPlan` + `lockedBatchReorder` primitive from `@pagespace/lib/services/reorder`.
- Same deadlock-prone bug class that crashed production Postgres on 2026-07-18 (`tasks/reorder/route.ts`) — this route hadn't incident'd yet but carries the identical pattern.
- This is **Phase 5 of 8** of the task board crash-prevention epic. PageSpace epic page: `j44e35jwzlhr54fbmruk3k4i`. Phase 3 (`#2130`, merged to master) built the shared primitive this phase adopts.

## Changes

- `orderedIds: string[]` (position = array index) is converted to `{id, position}[]` before calling `computeReorderPlan`, since this route's request shape differs from the Phase 4 task_items route (which already takes pairs).
- `scopeWhere: eq(favorites.userId, userId)` reproduces the route's existing per-user scoping inside the shared primitive.
- No `touchColumns` — `favorites` has no `updatedAt` column.
- Empty `orderedIds` remains a no-op (transaction skipped entirely).
- Left untouched, as explicitly out of scope for this phase: the pre-existing `findMany` validation query and its Phase 8 `eslint-disable-next-line no-restricted-syntax` follow-up marker, and the route's existing request/response shape and error handling.

## Test plan

- [x] RED: wrote `apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts` assertions proving the route issues one batched `lockedBatchReorder` call instead of N sequential updates — confirmed failing against the old loop-based route.
- [x] GREEN: after the migration, all 6 tests in that file pass (audit logging, single batched call w/ correct plan/table/columns, per-user scoping, empty-array no-op, 400 on non-array, 403 on foreign id).
- [x] `bun run typecheck` — clean.
- [x] `bun run test:unit` (from `apps/web`) — the 16 failures present are pre-existing and unrelated: 14 are DB-integration tests failing on `role "test" does not exist` (a local Postgres role/env issue outside this change, in `admin-role-version.test.ts` and `activity-tools.test.ts`), and 1 is an unrelated date-boundary test in `grouping.test.ts`. All favorites/reorder tests (9 across the 3 files in that directory) pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWLccDGtNgmH58Wc1adhLH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved favorites reordering reliability by applying changes as one consistent batch operation.
  - Ensured reordering remains limited to favorites owned by the signed-in user.
  - Empty reorder requests now complete without unnecessary database activity.
  - Invalid requests and unauthorized favorite IDs continue to return appropriate errors.
  - Reordering actions continue to generate audit records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->