### PR TITLE
fix(tasks): tiebreak phase-1 task-list ordering on taskItems.id

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -526,6 +526,32 @@ describe('Task API Routes', () => {
       expect(vi.mocked(ilike).mock.calls[0]?.[1]).toBe('%100\\% done%');
     });
 
+    it('tiebreaks the phase-1 order by taskItems.id (regression: non-deterministic paging when positions collide)', async () => {
+      const mockTaskList = { id: mockTaskListId, title: 'My Tasks', status: 'pending', updatedAt: new Date() };
+      // A read-then-write race in POST's nextPosition, or a backfilled row that never got
+      // a distinct position, can leave two tasks sharing the same page.position — without a
+      // secondary sort key, LIMIT/OFFSET has no guaranteed stable order across repeated calls.
+      const phase1Chain = makeSelectChain([{ id: 'task-1' }]);
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskItems.findMany).mockResolvedValue([] as never);
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => makeSelectChain([{ id: 'p-1', pageId: 'p-1' }]) as never) // childPages
+        .mockImplementationOnce(() => makeSelectChain([{ id: 'p-1', pageId: 'p-1' }]) as never) // backfill existingRows
+        .mockImplementationOnce(() => phase1Chain as never) // phase 1: the query under test
+        .mockImplementation(() => makeSelectChain([]) as never); // trigger / sub-task counts
+
+      const response = await GET(createRequest(), { params: mockParams });
+
+      expect(response.status).toBe(200);
+      expect(phase1Chain.orderBy).toHaveBeenCalledTimes(1);
+      // Primary sort key (page.position/task.position) plus a taskItems.id tiebreaker.
+      expect((phase1Chain.orderBy as ReturnType<typeof vi.fn>).mock.calls[0]).toHaveLength(2);
+    });
+
     it('caps the result to the requested limit and hydrates only the bounded ids (regression: OOM crash fix)', async () => {
       const mockTaskList = { id: mockTaskListId, title: 'My Tasks', status: 'pending', updatedAt: new Date() };
       // 5 TASK_LIST children — more than the ?limit=2 requested below.

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -161,7 +161,11 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       assigneeId ? eq(taskItems.assigneeId, assigneeId) : undefined,
       search ? ilike(pages.title, `%${escapeLikePattern(search)}%`) : undefined,
     ))
-    .orderBy(sortOrder === 'desc' ? desc(positionExpr) : asc(positionExpr))
+    // taskItems.id is a tiebreaker, not a sort key the user chose: without it, two tasks
+    // sharing a position (e.g. a read-then-write race in POST's nextPosition, or backfilled
+    // rows that never got a distinct one) have no guaranteed stable order across repeated
+    // LIMIT/OFFSET calls, so paging (offset=0, then offset=100) can skip or duplicate rows.
+    .orderBy(sortOrder === 'desc' ? desc(positionExpr) : asc(positionExpr), asc(taskItems.id))
     .limit(limit)
     .offset(offset);
   const boundedTaskIds = orderedIdRows.map(r => r.id);


### PR DESCRIPTION
## Summary

Fast-follow to #2128 (merged), which fixed the OOM crash by bounding the GET `/api/pages/[pageId]/tasks` query with `LIMIT`/`OFFSET`. An independent final correctness/security review pass — run *after* #2128 had already been merged — found one real regression that review missed:

`ORDER BY coalesce(pages.position, taskItems.position)` had no secondary sort key. Before #2128, the route fetched every task unconditionally and sorted in JS, so ties in `position` were invisible — the full set came back every time regardless of order. Now that the phase-1 query applies `LIMIT`/`OFFSET` in SQL, ties are exposed: two tasks sharing a position (e.g. a read-then-write race in `POST`'s `nextPosition = (lastChildPage?.position ?? 0) + 1` computation, or a backfilled row that never got a distinct position) have no guaranteed stable order across repeated `LIMIT`/`OFFSET` calls — paging through a list (`offset=0`, then `offset=100`) could silently skip or duplicate rows that share a position.

- Adds `taskItems.id` as a tiebreaker in the phase-1 `ORDER BY`, after the primary sort key (`page.position`/`task.position`).
- No behavior change for the common case (distinct positions); only affects ordering when positions tie.
- Isolated, single-purpose fix — same two files #2128 touched, no other changes.

## Why this landed as a separate PR

The tiebreaker bug was found via a final independent review pass while #2128 was already mid-merge — the merge landed a few minutes before this fix could be pushed to that branch, so it's a fast-follow against current `master` instead of an amendment to the original PR.

## Test plan

- [x] New test: asserts the phase-1 query's `orderBy` call carries both the primary sort key and the `taskItems.id` tiebreaker (2 arguments, up from 1).
- [x] Full existing suite for this route (63 tests) still passes unchanged.
- [x] `bun run typecheck` (root, full monorepo) — green (16/16 turbo tasks).
- [x] `bun run lint` (apps/web) on the touched files — clean.
- [x] Clean cherry-pick onto current `master`, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9HNEnE2gFPs1c7UrjJGcf