### PR TITLE
fix(tasks): migrate reorder route onto locked-batch primitive — Phase 4 of task board crash-prevention epic

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
@@ -41,9 +41,9 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 }));
 
 vi.mock('@pagespace/db/db', () => {
-  const mockTxUpdate = vi.fn(() => ({
-    set: vi.fn(() => ({
-      where: vi.fn().mockResolvedValue(undefined),
+  const mockSelect = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn().mockResolvedValue([]),
     })),
   }));
   return {
@@ -52,26 +52,40 @@ vi.mock('@pagespace/db/db', () => {
         taskLists: { findFirst: vi.fn() },
         pages: { findFirst: vi.fn() },
       },
+      select: mockSelect,
       transaction: vi.fn(async (callback) => {
-        const tx = { update: mockTxUpdate };
+        const tx = {};
         return callback(tx);
       }),
     },
   };
 });
 vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn((a, b) => ({ field: a, value: b })),
+  eq: vi.fn((a, b) => ({ op: 'eq', field: a, value: b })),
+  and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: {},
+  pages: { id: 'pages.id', parentId: 'pages.parentId', type: 'pages.type', isTrashed: 'pages.isTrashed' },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
-  taskItems: {},
+  taskItems: { id: 'taskItems.id', position: 'taskItems.position', pageId: 'taskItems.pageId', updatedAt: 'taskItems.updatedAt' },
   taskLists: {},
 }));
 
 vi.mock('@/lib/websocket', () => ({
   broadcastTaskEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/services/reorder', () => ({
+  computeReorderPlan: vi.fn((entries: { id: string; position: number }[]) => {
+    const positionById = new Map<string, number>();
+    for (const entry of entries) {
+      positionById.set(entry.id, entry.position);
+    }
+    return { orderedIds: Array.from(positionById.keys()).sort(), positionById };
+  }),
+  lockedBatchReorder: vi.fn(),
 }));
 
 // ---------- Imports (after mocks) ----------
@@ -82,6 +96,8 @@ import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
+import { taskItems } from '@pagespace/db/schema/tasks';
 
 // ---------- Helpers ----------
 
@@ -114,6 +130,9 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(checkMCPPageScope).mockResolvedValue(null as never);
+    // Default: every submitted task id resolves within scope (the "happy path").
+    // Individual tests override this to simulate out-of-scope/invalid ids.
+    vi.mocked(lockedBatchReorder).mockImplementation(async (_tx, opts) => opts.plan.orderedIds);
   });
 
   it('returns 401 when not authenticated', async () => {
@@ -208,13 +227,69 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(body.success).toBe(true);
 
     expect(db.transaction).toHaveBeenCalledTimes(1);
-    expect(typeof vi.mocked(db.transaction).mock.calls[0][0]).toBe('function');
+    expect(lockedBatchReorder).toHaveBeenCalledTimes(1);
+    expect(lockedBatchReorder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        table: taskItems,
+        idColumn: taskItems.id,
+        positionColumn: taskItems.position,
+        touchColumns: [taskItems.updatedAt],
+        plan: expect.objectContaining({ orderedIds: ['task-a', 'task-b'] }),
+      }),
+    );
     expect(broadcastTaskEvent).toHaveBeenCalledWith(expect.objectContaining({
       type: 'tasks_reordered',
       taskId: 'task-a',
       taskListId: mockTaskListId,
       pageId: mockPageId,
     }));
+  });
+
+  it('issues a single batched reorder call instead of N sequential per-row updates', async () => {
+    setupAuth();
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+
+    const tasks = [
+      { id: 'task-a', position: 0 },
+      { id: 'task-b', position: 1 },
+      { id: 'task-c', position: 2 },
+      { id: 'task-d', position: 3 },
+      { id: 'task-e', position: 4 },
+    ];
+
+    const response = await PATCH(createRequest({ tasks }), context);
+    expect(response.status).toBe(200);
+
+    // The N-sequential-update loop that deadlocked production would have
+    // issued one write per task. The batched primitive issues exactly one,
+    // regardless of how many tasks are being reordered.
+    expect(computeReorderPlan).toHaveBeenCalledWith(tasks);
+    expect(lockedBatchReorder).toHaveBeenCalledTimes(1);
+    expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 when a submitted task id falls outside the task list scope', async () => {
+    setupAuth();
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    // Simulate lockedBatchReorder's scopeWhere excluding one of the submitted ids
+    // (e.g. it belongs to a different task list) — only 'task-a' actually locked.
+    vi.mocked(lockedBatchReorder).mockResolvedValue(['task-a']);
+
+    const tasks = [
+      { id: 'task-a', position: 0 },
+      { id: 'task-b', position: 1 },
+    ];
+
+    const response = await PATCH(createRequest({ tasks }), context);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('Invalid task IDs');
+    expect(broadcastTaskEvent).not.toHaveBeenCalled();
   });
 
   it('logs page activity when taskListPage exists', async () => {
@@ -295,5 +370,8 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(broadcastTaskEvent).toHaveBeenCalledWith(expect.objectContaining({
       taskId: '',
     }));
+    // Empty plan is a no-op: no transaction should be opened for zero tasks.
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(lockedBatchReorder).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq } from '@pagespace/db/operators'
+import { eq, and, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
@@ -8,6 +8,7 @@ import { canPrincipalEditPage } from '@/lib/auth'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -64,14 +65,48 @@ export async function PATCH(
     }
   }
 
-  // Update positions in a transaction
-  await db.transaction(async (tx) => {
-    for (const task of tasks) {
-      await tx.update(taskItems)
-        .set({ position: task.position })
-        .where(eq(taskItems.id, task.id));
+  // Update positions via the locked-batch primitive (Phase 3): locks every
+  // target row FOR UPDATE in ascending-id order, then writes all positions in
+  // one batched statement — replaces the N-sequential-unordered-update loop
+  // that deadlocked production Postgres on 2026-07-18.
+  const plan = computeReorderPlan(tasks);
+  if (plan.orderedIds.length > 0) {
+    // task_items has no direct FK to its task list — membership is derived
+    // the same way GET does, via pages that are direct TASK_LIST children of
+    // this list's page. Scoping the write to that set closes a gap the old
+    // per-row loop never checked (it trusted every submitted id blindly).
+    const childPages = await db
+      .select({ id: pages.id })
+      .from(pages)
+      .where(and(
+        eq(pages.parentId, pageId),
+        eq(pages.type, 'TASK_LIST'),
+        eq(pages.isTrashed, false),
+      ));
+    const childPageIds = childPages.map(p => p.id);
+
+    try {
+      await db.transaction(async (tx) => {
+        const lockedIds = await lockedBatchReorder(tx, {
+          table: taskItems,
+          idColumn: taskItems.id,
+          positionColumn: taskItems.position,
+          scopeWhere: inArray(taskItems.pageId, childPageIds),
+          plan,
+          touchColumns: [taskItems.updatedAt],
+        });
+
+        if (lockedIds.length !== plan.orderedIds.length) {
+          throw new Error('Invalid task IDs');
+        }
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Invalid task IDs') {
+        return NextResponse.json({ error: 'Invalid task IDs' }, { status: 400 });
+      }
+      throw error;
     }
-  });
+  }
 
   // Broadcast reorder event
   await broadcastTaskEvent({


### PR DESCRIPTION
## Summary

- Replaces the N-sequential, unordered per-row `UPDATE` transaction loop in `apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts` with the shared `computeReorderPlan` + `lockedBatchReorder` primitive from Phase 3 (`@pagespace/lib/services/reorder`, already merged to `master`).
- This is the actual call site that deadlocked production Postgres on 2026-07-18 (~7-minute deadlock storm on `task_items.position`, 17:30-17:37 UTC). The new primitive locks target rows `FOR UPDATE` in ascending-id order and writes all positions as a single batched `UPDATE ... FROM (VALUES ...)` statement, closing the interleaving window that let concurrent reorders deadlock.
- Request/response contract is unchanged: `{ tasks: [{id, position}] }` in, `{success: true}` out, same broadcast + audit log + activity log side effects.

## `scopeWhere` decision

`task_items` has no direct FK to its task list — list membership is derived the same way the sibling `GET` route already does it: via `pages` rows that are direct `TASK_LIST` children of the list's page (`pages.parentId = pageId AND pages.type = 'TASK_LIST' AND pages.isTrashed = false`). The old per-row loop trusted every submitted task id blindly with no scoping at all.

I scoped the new write to `inArray(taskItems.pageId, childPageIds)` — reusing that exact, already-established derivation rather than guessing at a new one. `lockedBatchReorder`'s returned locked-ids are compared against the submitted plan's ids; a mismatch (an id outside the list's scope) now returns `400 { error: 'Invalid task IDs' }` instead of the previous code's implicit any-id-goes behavior. Since the original route had zero scope validation, this is a net-positive tightening, not a behavior regression.

## Test plan

- [x] New test: single tasks-list reorder issues exactly one batched `lockedBatchReorder` call regardless of task count (was previously N sequential `tx.update` calls) — proves the batching fix.
- [x] New test: a submitted task id outside the derived scope returns `400 Invalid task IDs` and does not broadcast.
- [x] Updated existing test: empty `tasks: []` array opens no transaction (explicit no-op, matches the epic's spec for this phase).
- [x] All pre-existing assertions in `route.test.ts` still pass (auth, permission, validation, broadcast, activity logging).
- [x] `bun run typecheck` — 16/16 tasks green.
- [x] `bun run test` (apps/web) — 990/994 files pass; 3 pre-existing, unrelated failures (missing local test-DB role `"test"` in this sandbox + one flaky date-boundary test in `grouping.test.ts`), none touching the reorder route.

PageSpace epic page: `j44e35jwzlhr54fbmruk3k4i` ("Task Board Query & Reorder Safety", Phase 4 of 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnsHCW5mvGrTi66fBm3HUU