### PR TITLE
fix(tasks): scope reorder route write with a pages subquery — fast-follow to #2140

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.integration.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.integration.test.ts
@@ -17,7 +17,7 @@
  */
 import { describe, it, expect, beforeAll } from 'vitest';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { eq, sql } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { taskItems } from '@pagespace/db/schema/tasks';
 import { factories } from '@pagespace/db/test/factories';
@@ -25,6 +25,34 @@ import { computeReorderPlan } from '@pagespace/lib/services/reorder';
 import { reorderTaskListChildren } from '../reorder-task-list';
 
 let dbAvailable = false;
+
+/**
+ * Polls pg_locks (from a separate connection than the one holding the lock)
+ * until `backendPid` is observed actually holding a granted lock on `pages`.
+ * A fixed sleep-then-fire "head start" would make this test's pass/fail
+ * depend on whether that guess happened to be long enough under whatever
+ * load the CI runner is under that day — this instead confirms the lock is
+ * held before the concurrent trash attempt fires, so the test is
+ * deterministic rather than timing-guessed.
+ */
+async function waitForPagesLock(backendPid: number, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    // mode = 'RowShareLock' is specifically the lock FOR SHARE/FOR UPDATE
+    // selects take — a plain unlocked SELECT only ever takes the much
+    // weaker, always-present AccessShareLock, so filtering by mode is what
+    // makes this a genuine proof that reorderTaskListChildren's FOR SHARE
+    // ran, not just that some connection touched the pages table.
+    const result = await db.execute(sql`
+      SELECT 1 FROM pg_locks
+      WHERE pid = ${backendPid} AND relation = 'pages'::regclass AND mode = 'RowShareLock' AND granted = true
+      LIMIT 1
+    `);
+    if (result.rows.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for backend ${backendPid} to hold a lock on pages`);
+}
 
 describe('reorderTaskListChildren concurrency (Postgres row lock)', () => {
   beforeAll(async () => {
@@ -54,9 +82,12 @@ describe('reorderTaskListChildren concurrency (Postgres row lock)', () => {
     }).returning();
 
     const HOLD_MS = 500;
+    let backendPid: number | undefined;
 
     const plan = computeReorderPlan([{ id: task.id, position: 9 }]);
     const reorderPromise = db.transaction(async (tx) => {
+      const pidResult = await tx.execute(sql`SELECT pg_backend_pid() as pid`);
+      backendPid = (pidResult.rows[0] as { pid: number }).pid;
       const lockedIds = await reorderTaskListChildren(tx, taskListPage.id, plan);
       // Hold the FOR SHARE lock open for a measurable window so the
       // concurrent trash attempt below is provably blocked, not just fast.
@@ -64,9 +95,13 @@ describe('reorderTaskListChildren concurrency (Postgres row lock)', () => {
       return lockedIds;
     });
 
-    // Give the reorder transaction a head start to acquire its FOR SHARE
-    // lock before the trash attempt fires.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    // Wait until the reorder transaction is actually observed holding its
+    // lock (not a fixed delay guess) before firing the concurrent trash.
+    await new Promise((resolve) => setTimeout(resolve, 0)); // let the transaction above start executing
+    while (backendPid === undefined) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    await waitForPagesLock(backendPid);
 
     const trashStart = performance.now();
     await db.update(pages).set({ isTrashed: true }).where(eq(pages.id, childPage.id));

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.integration.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.integration.test.ts
@@ -1,0 +1,92 @@
+/**
+ * reorderTaskListChildren concurrency integration test (real Postgres).
+ *
+ * Requirement: Given a reorder transaction has locked the scope of a task
+ * list's TASK_LIST child pages via reorderTaskListChildren, when a
+ * concurrent transaction attempts to trash one of those pages, the trash
+ * update should block until the reorder transaction commits — so
+ * lockedBatchReorder's two statements (SELECT ... FOR UPDATE, then the
+ * batched UPDATE) observe the same scope instead of racing under READ
+ * COMMITTED. Without the FOR SHARE lock this closes, a page trashed in the
+ * gap between those two statements leaves a task reported as "locked" (and
+ * the route reports success) while its position was silently never written.
+ *
+ * Requires DATABASE_URL → a running Postgres with migrations applied
+ * (scripts/test-with-db.sh, port 5433). Skipped when no DB is reachable —
+ * mirrors packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { taskItems } from '@pagespace/db/schema/tasks';
+import { factories } from '@pagespace/db/test/factories';
+import { computeReorderPlan } from '@pagespace/lib/services/reorder';
+import { reorderTaskListChildren } from '../reorder-task-list';
+
+let dbAvailable = false;
+
+describe('reorderTaskListChildren concurrency (Postgres row lock)', () => {
+  beforeAll(async () => {
+    try {
+      await db.select().from(pages).limit(1);
+      dbAvailable = true;
+    } catch {
+      dbAvailable = false;
+    }
+  });
+
+  it('blocks a concurrent page trash until the reorder transaction commits', async () => {
+    if (!dbAvailable) return;
+
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const taskListPage = await factories.createPage(drive.id, { type: 'FOLDER' });
+    const childPage = await factories.createPage(drive.id, {
+      parentId: taskListPage.id,
+      type: 'TASK_LIST',
+      isTrashed: false,
+    });
+    const [task] = await db.insert(taskItems).values({
+      userId: owner.id,
+      pageId: childPage.id,
+      position: 0,
+    }).returning();
+
+    const HOLD_MS = 500;
+
+    const plan = computeReorderPlan([{ id: task.id, position: 9 }]);
+    const reorderPromise = db.transaction(async (tx) => {
+      const lockedIds = await reorderTaskListChildren(tx, taskListPage.id, plan);
+      // Hold the FOR SHARE lock open for a measurable window so the
+      // concurrent trash attempt below is provably blocked, not just fast.
+      await new Promise((resolve) => setTimeout(resolve, HOLD_MS));
+      return lockedIds;
+    });
+
+    // Give the reorder transaction a head start to acquire its FOR SHARE
+    // lock before the trash attempt fires.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const trashStart = performance.now();
+    await db.update(pages).set({ isTrashed: true }).where(eq(pages.id, childPage.id));
+    const trashDurationMs = performance.now() - trashStart;
+
+    const lockedIds = await reorderPromise;
+
+    // The trash UPDATE must have waited for the reorder transaction's SHARE
+    // lock to release — without the fix it would return almost immediately.
+    expect(trashDurationMs).toBeGreaterThanOrEqual(HOLD_MS - 100);
+
+    // The reorder itself still succeeded: the task was in scope for the
+    // entire transaction (locked before the trash committed), so it must be
+    // reported as locked/updated rather than silently dropped.
+    expect(lockedIds).toEqual([task.id]);
+
+    const [updatedTask] = await db.select().from(taskItems).where(eq(taskItems.id, task.id));
+    expect(updatedTask.position).toBe(9);
+
+    const [updatedPage] = await db.select().from(pages).where(eq(pages.id, childPage.id));
+    expect(updatedPage.isTrashed).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ op: 'eq', field: a, value: b })),
@@ -21,6 +21,11 @@ import { lockedBatchReorder } from '@pagespace/lib/services/reorder';
 import { reorderTaskListChildren } from '../reorder-task-list';
 
 describe('reorderTaskListChildren', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(lockedBatchReorder).mockResolvedValue(['task-a']);
+  });
+
   it('locks the scoped pages FOR SHARE before delegating to lockedBatchReorder', async () => {
     const callOrder: string[] = [];
     const forShare = vi.fn().mockImplementation(async () => {
@@ -72,5 +77,17 @@ describe('reorderTaskListChildren', () => {
     const result = await reorderTaskListChildren(tx, 'page-1', plan);
 
     expect(result).toEqual(['task-a', 'task-b']);
+  });
+
+  it('never touches the transaction for an empty plan (defense in depth, matching lockedBatchReorder\'s own empty-plan guard)', async () => {
+    const select = vi.fn();
+    const tx = { select } as unknown as Parameters<typeof reorderTaskListChildren>[0];
+
+    const plan = { orderedIds: [], positionById: new Map() };
+    const result = await reorderTaskListChildren(tx, 'page-1', plan);
+
+    expect(select).not.toHaveBeenCalled();
+    expect(lockedBatchReorder).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
   });
 });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/reorder-task-list.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ({ op: 'eq', field: a, value: b })),
+  and: vi.fn((...conditions) => ({ op: 'and', conditions })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', parentId: 'pages.parentId', type: 'pages.type', isTrashed: 'pages.isTrashed' },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { id: 'taskItems.id', position: 'taskItems.position', pageId: 'taskItems.pageId', updatedAt: 'taskItems.updatedAt' },
+}));
+vi.mock('@pagespace/lib/services/reorder', () => ({
+  lockedBatchReorder: vi.fn().mockResolvedValue(['task-a']),
+}));
+
+import { inArray } from '@pagespace/db/operators';
+import { taskItems } from '@pagespace/db/schema/tasks';
+import { lockedBatchReorder } from '@pagespace/lib/services/reorder';
+import { reorderTaskListChildren } from '../reorder-task-list';
+
+describe('reorderTaskListChildren', () => {
+  it('locks the scoped pages FOR SHARE before delegating to lockedBatchReorder', async () => {
+    const callOrder: string[] = [];
+    const forShare = vi.fn().mockImplementation(async () => {
+      callOrder.push('lock-pages');
+      return [];
+    });
+    const select = vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ for: forShare })) })) }));
+    const tx = { select } as unknown as Parameters<typeof reorderTaskListChildren>[0];
+
+    vi.mocked(lockedBatchReorder).mockImplementationOnce(async () => {
+      callOrder.push('locked-batch-reorder');
+      return ['task-a'];
+    });
+
+    const plan = { orderedIds: ['task-a'], positionById: new Map([['task-a', 9]]) };
+    await reorderTaskListChildren(tx, 'page-1', plan);
+
+    expect(forShare).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(['lock-pages', 'locked-batch-reorder']);
+  });
+
+  it('scopes the write with a pages subquery, not a materialized id array', async () => {
+    const forShare = vi.fn().mockResolvedValue([]);
+    const select = vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ for: forShare })) })) }));
+    const tx = { select } as unknown as Parameters<typeof reorderTaskListChildren>[0];
+
+    const plan = { orderedIds: ['task-a'], positionById: new Map([['task-a', 9]]) };
+    await reorderTaskListChildren(tx, 'page-1', plan);
+
+    // A large task list must not force every child page id into app memory
+    // and then into a bind-param array — that reintroduces the unbounded-
+    // collection cost this epic exists to remove, and risks the Postgres
+    // bind-parameter limit. inArray's second argument must be the query
+    // builder returned by tx.select(...).from(...).where(...) itself, so
+    // Postgres runs `IN (SELECT ...)`, matching fetchEnrichedTasks in
+    // task-helpers.ts — not a resolved/materialized array of ids.
+    expect(inArray).toHaveBeenCalledWith(taskItems.pageId, expect.anything());
+    const scopeArg = vi.mocked(inArray).mock.calls.at(-1)?.[1];
+    expect(Array.isArray(scopeArg)).toBe(false);
+  });
+
+  it('returns lockedBatchReorder\'s result directly', async () => {
+    const forShare = vi.fn().mockResolvedValue([]);
+    const select = vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => ({ for: forShare })) })) }));
+    const tx = { select } as unknown as Parameters<typeof reorderTaskListChildren>[0];
+    vi.mocked(lockedBatchReorder).mockResolvedValueOnce(['task-a', 'task-b']);
+
+    const plan = { orderedIds: ['task-a', 'task-b'], positionById: new Map() };
+    const result = await reorderTaskListChildren(tx, 'page-1', plan);
+
+    expect(result).toEqual(['task-a', 'task-b']);
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
@@ -176,6 +176,39 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(body.error).toBe('tasks must be an array');
   });
 
+  it('returns 400 and skips all DB work when tasks exceeds the batch bound', async () => {
+    setupAuth();
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+
+    // lockedBatchReorder's batched UPDATE ... FROM (VALUES ...) binds 2 params
+    // per row + 1 scope param; an unbounded array can cross Postgres's 65,535
+    // param ceiling and 500 instead of failing cleanly. Reject up front —
+    // mirrors the bound added to apps/web/src/app/api/user/favorites/reorder/route.ts (#2164).
+    const oversized = Array.from({ length: 5001 }, (_, i) => ({ id: `task-${i}`, position: i }));
+    const response = await PATCH(createRequest({ tasks: oversized }), context);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/must not exceed/);
+    expect(db.transaction).not.toHaveBeenCalled();
+    expect(reorderTaskListChildren).not.toHaveBeenCalled();
+  });
+
+  it('allows a batch exactly at the bound', async () => {
+    setupAuth();
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+
+    const atBound = Array.from({ length: 5000 }, (_, i) => ({ id: `task-${i}`, position: i }));
+    const response = await PATCH(createRequest({ tasks: atBound }), context);
+
+    expect(response.status).toBe(200);
+    expect(reorderTaskListChildren).toHaveBeenCalledTimes(1);
+  });
+
   it('returns 400 when a task entry is missing id', async () => {
     setupAuth();
     vi.mocked(canUserEditPage).mockResolvedValue(true);

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
@@ -98,6 +98,7 @@ import { broadcastTaskEvent } from '@/lib/websocket';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
 import { taskItems } from '@pagespace/db/schema/tasks';
+import { inArray } from '@pagespace/db/operators';
 
 // ---------- Helpers ----------
 
@@ -269,6 +270,28 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(computeReorderPlan).toHaveBeenCalledWith(tasks);
     expect(lockedBatchReorder).toHaveBeenCalledTimes(1);
     expect(db.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes the reorder write with a pages subquery, not a materialized id array', async () => {
+    setupAuth();
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+
+    const tasks = [{ id: 'task-a', position: 0 }];
+    await PATCH(createRequest({ tasks }), context);
+
+    // A large task list must not force every child page id into app memory
+    // and then into a bind-param array (that reintroduces the unbounded-
+    // collection cost this epic exists to remove, and risks the Postgres
+    // bind-parameter limit). inArray's second argument must be the query
+    // builder returned by db.select(...).from(...).where(...) itself, so
+    // Postgres runs `IN (SELECT ...)` — matching fetchEnrichedTasks in
+    // task-helpers.ts, not a resolved/materialized array of ids.
+    expect(db.select).toHaveBeenCalledWith({ id: expect.anything() });
+    expect(inArray).toHaveBeenCalledWith(taskItems.pageId, expect.anything());
+    const scopeArg = vi.mocked(inArray).mock.calls[0][1];
+    expect(Array.isArray(scopeArg)).toBe(false);
   });
 
   it('returns 400 when a submitted task id falls outside the task list scope', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/__tests__/route.test.ts
@@ -41,18 +41,12 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 }));
 
 vi.mock('@pagespace/db/db', () => {
-  const mockSelect = vi.fn(() => ({
-    from: vi.fn(() => ({
-      where: vi.fn().mockResolvedValue([]),
-    })),
-  }));
   return {
     db: {
       query: {
         taskLists: { findFirst: vi.fn() },
         pages: { findFirst: vi.fn() },
       },
-      select: mockSelect,
       transaction: vi.fn(async (callback) => {
         const tx = {};
         return callback(tx);
@@ -62,14 +56,11 @@ vi.mock('@pagespace/db/db', () => {
 });
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ op: 'eq', field: a, value: b })),
-  and: vi.fn((...conditions) => ({ op: 'and', conditions })),
-  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'pages.id', parentId: 'pages.parentId', type: 'pages.type', isTrashed: 'pages.isTrashed' },
+  pages: { id: 'pages.id' },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
-  taskItems: { id: 'taskItems.id', position: 'taskItems.position', pageId: 'taskItems.pageId', updatedAt: 'taskItems.updatedAt' },
   taskLists: {},
 }));
 
@@ -85,7 +76,10 @@ vi.mock('@pagespace/lib/services/reorder', () => ({
     }
     return { orderedIds: Array.from(positionById.keys()).sort(), positionById };
   }),
-  lockedBatchReorder: vi.fn(),
+}));
+
+vi.mock('../reorder-task-list', () => ({
+  reorderTaskListChildren: vi.fn(),
 }));
 
 // ---------- Imports (after mocks) ----------
@@ -96,9 +90,8 @@ import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
-import { taskItems } from '@pagespace/db/schema/tasks';
-import { inArray } from '@pagespace/db/operators';
+import { computeReorderPlan } from '@pagespace/lib/services/reorder';
+import { reorderTaskListChildren } from '../reorder-task-list';
 
 // ---------- Helpers ----------
 
@@ -133,7 +126,7 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     vi.mocked(checkMCPPageScope).mockResolvedValue(null as never);
     // Default: every submitted task id resolves within scope (the "happy path").
     // Individual tests override this to simulate out-of-scope/invalid ids.
-    vi.mocked(lockedBatchReorder).mockImplementation(async (_tx, opts) => opts.plan.orderedIds);
+    vi.mocked(reorderTaskListChildren).mockImplementation(async (_tx, _pageId, plan) => plan.orderedIds);
   });
 
   it('returns 401 when not authenticated', async () => {
@@ -228,16 +221,11 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(body.success).toBe(true);
 
     expect(db.transaction).toHaveBeenCalledTimes(1);
-    expect(lockedBatchReorder).toHaveBeenCalledTimes(1);
-    expect(lockedBatchReorder).toHaveBeenCalledWith(
+    expect(reorderTaskListChildren).toHaveBeenCalledTimes(1);
+    expect(reorderTaskListChildren).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({
-        table: taskItems,
-        idColumn: taskItems.id,
-        positionColumn: taskItems.position,
-        touchColumns: [taskItems.updatedAt],
-        plan: expect.objectContaining({ orderedIds: ['task-a', 'task-b'] }),
-      }),
+      mockPageId,
+      expect.objectContaining({ orderedIds: ['task-a', 'task-b'] }),
     );
     expect(broadcastTaskEvent).toHaveBeenCalledWith(expect.objectContaining({
       type: 'tasks_reordered',
@@ -247,7 +235,7 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     }));
   });
 
-  it('issues a single batched reorder call instead of N sequential per-row updates', async () => {
+  it('issues a single reorderTaskListChildren call regardless of task count', async () => {
     setupAuth();
     vi.mocked(canUserEditPage).mockResolvedValue(true);
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
@@ -265,33 +253,12 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     expect(response.status).toBe(200);
 
     // The N-sequential-update loop that deadlocked production would have
-    // issued one write per task. The batched primitive issues exactly one,
-    // regardless of how many tasks are being reordered.
+    // issued one write per task. reorderTaskListChildren (and the batched
+    // primitive it delegates to) is called exactly once, regardless of how
+    // many tasks are being reordered.
     expect(computeReorderPlan).toHaveBeenCalledWith(tasks);
-    expect(lockedBatchReorder).toHaveBeenCalledTimes(1);
+    expect(reorderTaskListChildren).toHaveBeenCalledTimes(1);
     expect(db.transaction).toHaveBeenCalledTimes(1);
-  });
-
-  it('scopes the reorder write with a pages subquery, not a materialized id array', async () => {
-    setupAuth();
-    vi.mocked(canUserEditPage).mockResolvedValue(true);
-    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
-    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
-
-    const tasks = [{ id: 'task-a', position: 0 }];
-    await PATCH(createRequest({ tasks }), context);
-
-    // A large task list must not force every child page id into app memory
-    // and then into a bind-param array (that reintroduces the unbounded-
-    // collection cost this epic exists to remove, and risks the Postgres
-    // bind-parameter limit). inArray's second argument must be the query
-    // builder returned by db.select(...).from(...).where(...) itself, so
-    // Postgres runs `IN (SELECT ...)` — matching fetchEnrichedTasks in
-    // task-helpers.ts, not a resolved/materialized array of ids.
-    expect(db.select).toHaveBeenCalledWith({ id: expect.anything() });
-    expect(inArray).toHaveBeenCalledWith(taskItems.pageId, expect.anything());
-    const scopeArg = vi.mocked(inArray).mock.calls[0][1];
-    expect(Array.isArray(scopeArg)).toBe(false);
   });
 
   it('returns 400 when a submitted task id falls outside the task list scope', async () => {
@@ -299,9 +266,9 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     vi.mocked(canUserEditPage).mockResolvedValue(true);
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1', title: 'My List' } as never);
     vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
-    // Simulate lockedBatchReorder's scopeWhere excluding one of the submitted ids
-    // (e.g. it belongs to a different task list) — only 'task-a' actually locked.
-    vi.mocked(lockedBatchReorder).mockResolvedValue(['task-a']);
+    // Simulate reorderTaskListChildren's scope excluding one of the submitted
+    // ids (e.g. it belongs to a different task list) — only 'task-a' actually locked.
+    vi.mocked(reorderTaskListChildren).mockResolvedValue(['task-a']);
 
     const tasks = [
       { id: 'task-a', position: 0 },
@@ -395,6 +362,6 @@ describe('PATCH /api/pages/[pageId]/tasks/reorder', () => {
     }));
     // Empty plan is a no-op: no transaction should be opened for zero tasks.
     expect(db.transaction).not.toHaveBeenCalled();
-    expect(lockedBatchReorder).not.toHaveBeenCalled();
+    expect(reorderTaskListChildren).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/reorder-task-list.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/reorder-task-list.ts
@@ -16,8 +16,9 @@ function taskListChildPagesWhere(pageId: string) {
 
 /**
  * Applies a reorder plan to task_items scoped to pageId's TASK_LIST
- * children, inside the caller's transaction. Caller guards the
- * plan.orderedIds.length === 0 case (no-op, no transaction).
+ * children, inside the caller's transaction. No-ops (no lock, no query)
+ * for an empty plan — mirrors lockedBatchReorder's own empty-plan guard,
+ * so this stays safe to call even if a future caller stops pre-filtering.
  *
  * task_items has no direct FK to its task list — membership is derived via
  * pages that are direct TASK_LIST children of this list's page, the same
@@ -39,6 +40,10 @@ export async function reorderTaskListChildren(
   pageId: string,
   plan: ReorderPlan,
 ): Promise<string[]> {
+  if (plan.orderedIds.length === 0) {
+    return [];
+  }
+
   await tx.select({ id: pages.id }).from(pages).where(taskListChildPagesWhere(pageId)).for('share');
 
   return lockedBatchReorder(tx, {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/reorder-task-list.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/reorder-task-list.ts
@@ -1,0 +1,52 @@
+import { and, eq, inArray } from '@pagespace/db/operators'
+import type { db } from '@pagespace/db/db'
+import { pages } from '@pagespace/db/schema/core'
+import { taskItems } from '@pagespace/db/schema/tasks';
+import { lockedBatchReorder, type ReorderPlan } from '@pagespace/lib/services/reorder';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+function taskListChildPagesWhere(pageId: string) {
+  return and(
+    eq(pages.parentId, pageId),
+    eq(pages.type, 'TASK_LIST'),
+    eq(pages.isTrashed, false),
+  );
+}
+
+/**
+ * Applies a reorder plan to task_items scoped to pageId's TASK_LIST
+ * children, inside the caller's transaction. Caller guards the
+ * plan.orderedIds.length === 0 case (no-op, no transaction).
+ *
+ * task_items has no direct FK to its task list — membership is derived via
+ * pages that are direct TASK_LIST children of this list's page, the same
+ * derivation GET/fetchEnrichedTasks use. That predicate is passed to
+ * lockedBatchReorder as a subquery (not a materialized id array) so a large
+ * task list doesn't rebind every child id into the write.
+ *
+ * lockedBatchReorder issues two statements against tx — a locking SELECT,
+ * then a batched UPDATE — and under READ COMMITTED each independently
+ * re-evaluates that subquery. Locking the scoped pages FOR SHARE first
+ * closes the gap: it blocks a concurrent trashPage/move from committing a
+ * scope change between the two statements, so both see the same membership.
+ * (A page inserted into scope between the two statements — a phantom read,
+ * not a modification of an already-scoped row — isn't covered by this lock;
+ * closing that needs SERIALIZABLE isolation and is out of scope here.)
+ */
+export async function reorderTaskListChildren(
+  tx: Tx,
+  pageId: string,
+  plan: ReorderPlan,
+): Promise<string[]> {
+  await tx.select({ id: pages.id }).from(pages).where(taskListChildPagesWhere(pageId)).for('share');
+
+  return lockedBatchReorder(tx, {
+    table: taskItems,
+    idColumn: taskItems.id,
+    positionColumn: taskItems.position,
+    scopeWhere: inArray(taskItems.pageId, tx.select({ id: pages.id }).from(pages).where(taskListChildPagesWhere(pageId))),
+    plan,
+    touchColumns: [taskItems.updatedAt],
+  });
+}

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
@@ -72,18 +72,21 @@ export async function PATCH(
   const plan = computeReorderPlan(tasks);
   if (plan.orderedIds.length > 0) {
     // task_items has no direct FK to its task list — membership is derived
-    // the same way GET does, via pages that are direct TASK_LIST children of
-    // this list's page. Scoping the write to that set closes a gap the old
-    // per-row loop never checked (it trusted every submitted id blindly).
-    const childPages = await db
+    // the same way GET/fetchEnrichedTasks do it, via pages that are direct
+    // TASK_LIST children of this list's page. Passed as a subquery (matching
+    // fetchEnrichedTasks in task-helpers.ts) rather than a materialized id
+    // array so Postgres filters membership itself instead of the app
+    // loading and rebinding every child id — that scales the same way the
+    // rest of this epic's bounded queries do, instead of reintroducing an
+    // unbounded-collection cost for large task lists.
+    const scopeWhere = inArray(taskItems.pageId, db
       .select({ id: pages.id })
       .from(pages)
       .where(and(
         eq(pages.parentId, pageId),
         eq(pages.type, 'TASK_LIST'),
         eq(pages.isTrashed, false),
-      ));
-    const childPageIds = childPages.map(p => p.id);
+      )));
 
     try {
       await db.transaction(async (tx) => {
@@ -91,7 +94,7 @@ export async function PATCH(
           table: taskItems,
           idColumn: taskItems.id,
           positionColumn: taskItems.position,
-          scopeWhere: inArray(taskItems.pageId, childPageIds),
+          scopeWhere,
           plan,
           touchColumns: [taskItems.updatedAt],
         });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
@@ -1,14 +1,15 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, inArray } from '@pagespace/db/operators'
+import { eq } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
-import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
+import { taskLists } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canPrincipalEditPage } from '@/lib/auth'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/reorder';
+import { computeReorderPlan } from '@pagespace/lib/services/reorder';
+import { reorderTaskListChildren } from './reorder-task-list';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -71,33 +72,9 @@ export async function PATCH(
   // that deadlocked production Postgres on 2026-07-18.
   const plan = computeReorderPlan(tasks);
   if (plan.orderedIds.length > 0) {
-    // task_items has no direct FK to its task list — membership is derived
-    // the same way GET/fetchEnrichedTasks do it, via pages that are direct
-    // TASK_LIST children of this list's page. Passed as a subquery (matching
-    // fetchEnrichedTasks in task-helpers.ts) rather than a materialized id
-    // array so Postgres filters membership itself instead of the app
-    // loading and rebinding every child id — that scales the same way the
-    // rest of this epic's bounded queries do, instead of reintroducing an
-    // unbounded-collection cost for large task lists.
-    const scopeWhere = inArray(taskItems.pageId, db
-      .select({ id: pages.id })
-      .from(pages)
-      .where(and(
-        eq(pages.parentId, pageId),
-        eq(pages.type, 'TASK_LIST'),
-        eq(pages.isTrashed, false),
-      )));
-
     try {
       await db.transaction(async (tx) => {
-        const lockedIds = await lockedBatchReorder(tx, {
-          table: taskItems,
-          idColumn: taskItems.id,
-          positionColumn: taskItems.position,
-          scopeWhere,
-          plan,
-          touchColumns: [taskItems.updatedAt],
-        });
+        const lockedIds = await reorderTaskListChildren(tx, pageId, plan);
 
         if (lockedIds.length !== plan.orderedIds.length) {
           throw new Error('Invalid task IDs');

--- a/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/reorder/route.ts
@@ -14,6 +14,16 @@ import { reorderTaskListChildren } from './reorder-task-list';
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
 /**
+ * lockedBatchReorder's batched `UPDATE ... FROM (VALUES ...)` binds 2
+ * parameters per row plus 1 scope parameter, so an unbounded tasks array
+ * can cross PostgreSQL's 65,535-parameter-per-statement ceiling and 500
+ * instead of failing cleanly. Task lists are never legitimately this large —
+ * reject oversized requests up front. Mirrors the bound on
+ * apps/web/src/app/api/user/favorites/reorder/route.ts (#2164).
+ */
+const MAX_REORDER_BATCH = 5000;
+
+/**
  * PATCH /api/pages/[pageId]/tasks/reorder
  * Bulk update task positions for drag-and-drop reordering
  */
@@ -55,6 +65,10 @@ export async function PATCH(
 
   if (!Array.isArray(tasks)) {
     return NextResponse.json({ error: 'tasks must be an array' }, { status: 400 });
+  }
+
+  if (tasks.length > MAX_REORDER_BATCH) {
+    return NextResponse.json({ error: `tasks must not exceed ${MAX_REORDER_BATCH} entries` }, { status: 400 });
   }
 
   // Validate format: [{ id: string, position: number }]


### PR DESCRIPTION
## Summary

Fast-follow to #2140 (Phase 4 of the task board crash-prevention epic, PageSpace epic `j44e35jwzlhr54fbmruk3k4i`). That PR merged before two automated review comments landed. This PR addresses both.

### 1. P1 — scope the reorder without materializing every child page

> For a large task list, every reorder now loads all child IDs into application memory and expands them into the `scopeWhere` parameter list, even if the request changes only one task. Once the list approaches PostgreSQL's bind-parameter limit, `lockedBatchReorder` will fail outright; smaller large lists still make reorder cost and memory scale with the entire board, recreating the scalability problem this epic is addressing. Pass a `pages` subquery as the `inArray` scope (as other task queries do) so PostgreSQL performs membership filtering without returning and rebinding every child ID.
>
> — https://github.com/2witstudios/PageSpace/pull/2140#discussion_r3609940725

**Fix:** pass the `db.select({ id: pages.id }).from(pages).where(...)` query builder directly as `inArray`'s second argument instead of awaiting and mapping it to an array first. Matches the existing `fetchEnrichedTasks` pattern in `apps/web/src/lib/ai/tools/task-helpers.ts` for the identical "task_items has no direct FK to its task list" membership derivation — Postgres now runs `... WHERE task_items."pageId" IN (SELECT id FROM pages WHERE ...)`.

### 2. P2 — stabilize the subquery scope across the transaction

> When a task page is moved, trashed, or restored concurrently with this request, this live subquery can produce different results in the two statements inside `lockedBatchReorder`: the initial `SELECT ... FOR UPDATE` and the subsequent `UPDATE` each receive a new snapshot under PostgreSQL's default READ COMMITTED isolation. For example, if a page is trashed after its task row is locked, `lockedIds` still contains the task, but the repeated subquery excludes it from the update; the length check then passes and the route broadcasts success even though that task's position was not written. Preserve a stable scope for both statements or lock the relevant page rows while retaining the bounded-query behavior.
>
> — https://github.com/2witstudios/PageSpace/pull/2163#discussion_r3611419106

I evaluated and rejected elevating the transaction to `repeatable read` — under concurrent overlapping reorders that would trade a narrow, low-probability silent-write gap for a much more likely regression: Postgres's `could not serialize access due to concurrent update` on the second transaction instead of the block-then-succeed behavior Phase 3's own integration test proves (this codebase has no retry-on-serialization-failure handling today).

**Fix:** take a `FOR SHARE` lock on the scoped TASK_LIST child `pages` rows at the top of the transaction, before calling `lockedBatchReorder`. This blocks a concurrent `trashPage`/move on those specific pages until the transaction commits — closing the race without changing isolation level and without reintroducing a materialized id array. Traced `trashPage`'s own lock order (`recursivelyTrash`/`applyPageMutation` in `apps/web/src/services/api/page-service.ts`): it never touches `task_items`, only `pages` via an unlocked SELECT + revision-guarded UPDATE, so it can't hold a lock this transaction needs — a conflicting concurrent trash just blocks, it can't deadlock. Two concurrent reorders on the same list acquire the SHARE lock concurrently without conflict, so Phase 3's deadlock-free-concurrent-reorder guarantee (task_items `FOR UPDATE` in ascending-id order) is unaffected.

Extracted the reorder-and-lock logic into `reorderTaskListChildren` (`apps/web/src/app/api/pages/[pageId]/tasks/reorder/reorder-task-list.ts`) so it's independently testable, separate from the route's auth/broadcast/audit concerns.

### 3. Self-review passes

Two follow-up commits from a proactive `/aidd-review` + re-test pass on the diff itself:

- `reorderTaskListChildren` didn't guard its own empty-plan case, relying entirely on the caller (`route.ts`) — inconsistent with `lockedBatchReorder` (its own dependency), which defensively no-ops on an empty plan even though its callers already filter. Fixed with the same TDD discipline (failing test confirmed RED, then GREEN).
- The concurrency integration test originally fired its concurrent trash attempt after a fixed 50ms sleep, assuming that was enough time for the reorder transaction to acquire its lock — a genuine flaky-test risk under CI load, independent of whether the production code is correct. Replaced with a deterministic wait: poll `pg_locks` (via a separate connection) until the reorder transaction's backend PID is observed actually holding a `RowShareLock` on `pages`, before firing the trash attempt. Caught and fixed a bug in my first attempt at this during self-testing (didn't filter by lock `mode`, so it matched the trivial `AccessShareLock` every plain `SELECT` takes and never actually proved the `FOR SHARE` ran) — reverified both directions (fails cleanly without the lock, passes with it) after the fix.

### 4. Batch-size bound (picked up from master mid-flight)

While this PR was open, master gained two directly-relevant commits: #2164 (bounds the *favorites* reorder route's batch size below Postgres's 65,535-parameter ceiling — same `lockedBatchReorder` failure mode as this PR's own P1) and #2165 (fixes `lockedBatchReorder`'s `touchColumns` stamp to use `clock_timestamp()` instead of `now()`, since `now()` freezes at transaction `BEGIN` and can regress `updatedAt` backwards if the transaction blocks on its `FOR UPDATE` lock).

#2164's commit message explicitly calls out this PR (Phase 4) as an in-flight consumer of the same primitive that needs the same batch-size guard. Merged master into this branch (clean, no conflicts) and added the identical `MAX_REORDER_BATCH = 5000` bound to this route, matching #2164's implementation and test shape exactly. #2165's fix is inherited for free via the shared `lockedBatchReorder` import — no code change needed here, since `reorderTaskListChildren` already passes `touchColumns: [taskItems.updatedAt]`.

## Test plan

- [x] `reorder-task-list.integration.test.ts` (real Postgres): proves the `FOR SHARE` lock actually blocks a concurrent page-trash `UPDATE`, via deterministic `pg_locks` polling rather than a timing guess — confirmed as a real regression guard by verifying it fails cleanly (`Timed out waiting for a lock`) without the `.for('share')` call, and passes with it.
- [x] `reorder-task-list.test.ts` (mocked): proves lock-then-delegate call order, that the scope passed to `lockedBatchReorder` is a subquery not a materialized array, and the empty-plan no-op guard.
- [x] `route.test.ts`: updated to mock `reorderTaskListChildren` at the new module boundary; all existing assertions (auth, permission, validation, batching, scope-mismatch 400, broadcast, activity logging, empty-array no-op, batch-bound 400/at-bound-200) still pass — 16/16.
- [x] Verified the subquery-vs-array regression test genuinely fails against the pre-fix code (via `git stash`) — real RED → GREEN.
- [x] `bun run typecheck` — 16/16 tasks green.
- [x] `bun run test` (apps/web) with a live test Postgres connected — **995/997 files pass**, only 1 pre-existing unrelated failure (a flaky midnight-boundary date test in `grouping.test.ts`, unrelated to this PR).
- [x] `eslint` on all touched/new files — clean.

PageSpace epic page: `j44e35jwzlhr54fbmruk3k4i` ("Task Board Query & Reorder Safety").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AnsHCW5mvGrTi66fBm3HUU
