### PR TITLE
fix(favorites): bound reorder batch size below Postgres param ceiling

### DIFF
--- a/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
@@ -65,6 +65,7 @@ import { PATCH } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { favorites } from '@pagespace/db/schema/core';
+import { db } from '@pagespace/db/db';
 
 const mockUserId = 'user_123';
 
@@ -158,5 +159,31 @@ describe('PATCH /api/user/favorites/reorder locked-batch reorder', () => {
     expect(response.status).toBe(403);
     expect(mockTransaction).not.toHaveBeenCalled();
     expect(mockLockedBatchReorder).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 and skips all DB work when orderedIds exceeds the batch bound', async () => {
+    // lockedBatchReorder's batched UPDATE ... FROM (VALUES ...) binds 2 params
+    // per row + 1 scope param; an unbounded array can cross Postgres's 65,535
+    // param ceiling and 500 instead of failing cleanly. Reject up front.
+    const oversized = Array.from({ length: 5001 }, (_, i) => `fav-${i}`);
+    const response = await PATCH(createRequest({ orderedIds: oversized }));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toMatch(/must not exceed/);
+    expect(mockTransaction).not.toHaveBeenCalled();
+    expect(mockLockedBatchReorder).not.toHaveBeenCalled();
+  });
+
+  it('allows a batch exactly at the bound', async () => {
+    const atBound = Array.from({ length: 5000 }, (_, i) => `fav-${i}`);
+    vi.mocked(db.query.favorites.findMany).mockResolvedValueOnce(
+      atBound.map((id) => ({ id })) as never
+    );
+
+    const response = await PATCH(createRequest({ orderedIds: atBound }));
+
+    expect(response.status).toBe(200);
+    expect(mockLockedBatchReorder).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/app/api/user/favorites/reorder/route.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/route.ts
@@ -9,6 +9,15 @@ import { computeReorderPlan, lockedBatchReorder } from '@pagespace/lib/services/
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
+/**
+ * lockedBatchReorder's batched `UPDATE ... FROM (VALUES ...)` binds 2
+ * parameters per row plus 1 scope parameter, so an unbounded orderedIds
+ * array can cross PostgreSQL's 65,535-parameter-per-statement ceiling and
+ * 500 instead of failing cleanly. Favorites lists are never legitimately
+ * this large — reject oversized requests up front.
+ */
+const MAX_REORDER_BATCH = 5000;
+
 export async function PATCH(req: Request) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
   if (isAuthError(auth)) return auth.error;
@@ -22,6 +31,10 @@ export async function PATCH(req: Request) {
 
     if (!Array.isArray(orderedIds)) {
       return NextResponse.json({ error: 'orderedIds must be an array' }, { status: 400 });
+    }
+
+    if (orderedIds.length > MAX_REORDER_BATCH) {
+      return NextResponse.json({ error: `orderedIds must not exceed ${MAX_REORDER_BATCH} entries` }, { status: 400 });
     }
 
     // Verify all favorites belong to this user


### PR DESCRIPTION
## Summary

Fast-follow to #2137 (Phase 5 of the task board crash-prevention epic, PageSpace epic page `j44e35jwzlhr54fbmruk3k4i`). #2137 merged with all CI green and zero CodeRabbit findings, but a Codex P2 review thread was left unresolved at merge time:

> **Bound the reorder below PostgreSQL's parameter ceiling**
> When `orderedIds` contains 32,768 or more valid favorites, this plan is passed to `lockedBatchReorder`, whose batched `VALUES` clause uses two bind parameters per row plus the user-scope parameter. That exceeds PostgreSQL's 65,535-parameter limit and makes the route return 500; the previous loop used only a fixed number of parameters per statement.

This PR closes that gap.

## Changes

- `apps/web/src/app/api/user/favorites/reorder/route.ts`: reject `orderedIds` arrays longer than `MAX_REORDER_BATCH = 5000` with a 400, before any DB work (before the validation `findMany`, before `computeReorderPlan`/`lockedBatchReorder`). 5000 is comfortably under the ~32,767-row point where 2 params/row + 1 scope param would cross Postgres's 65,535-parameter ceiling, and far above any legitimate favorites list size.
- Deliberately scoped as a route-level guard, not a fix inside `lockedBatchReorder` itself (`packages/lib/src/services/reorder/`) — that primitive is also used by two other in-flight phases of this epic (drive-roles reorder `#2139`, task reorder `#2140`), so a shared-primitive change risks touching code those PRs are concurrently building on. A per-call-site request-size guard is the surgical fix for this route; the primitive-level fix (or a `pages` subquery scope per Codex's finding on `#2140`) is tracked separately for whichever phase touches those call sites next.

## Test plan

- [x] RED: added a test proving a 5001-entry `orderedIds` array returns 400 and skips all DB work (`db.transaction`/`lockedBatchReorder` never called) — confirmed failing before the guard was added.
- [x] GREEN: added a boundary test proving exactly 5000 entries still succeeds and reaches `lockedBatchReorder`.
- [x] All 8 tests in `apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts` pass, plus the other 2 favorites route test files (11/11 total).
- [x] `bun run typecheck` — clean (16/16 tasks successful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWLccDGtNgmH58Wc1adhLH