### PR TITLE
fix(reorder): stamp touchColumns with clock_timestamp(), not now() — fast-follow to #2139

### DIFF
--- a/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
+++ b/packages/lib/src/services/reorder/__tests__/locked-batch-reorder.integration.test.ts
@@ -370,6 +370,61 @@ describe('lockedBatchReorder concurrency (Postgres row lock)', () => {
     }
   });
 
+  it('stamps touchColumns with the write-time clock, not the transaction-start snapshot (clock_timestamp, not now())', async () => {
+    if (!dbAvailable) return;
+    // Regression test for a P2 Codex finding on PR #2139: `now()` (aka
+    // `transaction_timestamp()`) is fixed at this transaction's BEGIN and
+    // stays fixed for every statement inside it, including the touchColumns
+    // UPDATE. If the transaction is delayed between BEGIN and the write (in
+    // production: blocked waiting on the FOR UPDATE lock behind a concurrent
+    // role mutation), `now()` would stamp a timestamp from before that
+    // delay — potentially older than a concurrent writer's own commit,
+    // silently regressing `updatedAt` backwards. `clock_timestamp()`
+    // reflects the actual wall-clock moment the UPDATE executes, so it must
+    // reflect time elapsed *inside* the transaction, not just its start.
+    const owner = await factories.createUser();
+    const drive = await factories.createDrive(owner.id);
+    const role = (
+      await db
+        .insert(driveRoles)
+        .values([{ driveId: drive.id, name: 'role-clock', permissions: {}, position: 0 }])
+        .returning()
+    )[0];
+
+    const plan = computeReorderPlan([{ id: role.id, position: 7 }]);
+    const IN_TX_DELAY_MS = 150;
+
+    let checkpoint = 0;
+    await db.transaction(async (tx) => {
+      // Forces Postgres to actually issue BEGIN now, rather than pipelining
+      // it with the first "real" statement below — without this, the delay
+      // that follows wouldn't elapse any time *inside* the open transaction
+      // from Postgres's point of view, and now() vs clock_timestamp() would
+      // be indistinguishable.
+      await tx.execute(sql`SELECT 1`);
+      // Elapses real wall-clock time after BEGIN (which already fixed
+      // now()/transaction_timestamp()) but before the touchColumns write —
+      // standing in for time spent blocked on the row lock in production.
+      await new Promise((resolve) => setTimeout(resolve, IN_TX_DELAY_MS));
+      checkpoint = Date.now();
+
+      await lockedBatchReorder(tx, {
+        table: driveRoles,
+        idColumn: driveRoles.id,
+        positionColumn: driveRoles.position,
+        scopeWhere: eq(driveRoles.driveId, drive.id),
+        plan,
+        touchColumns: [driveRoles.updatedAt],
+      });
+    });
+
+    const [updated] = await db.select().from(driveRoles).where(eq(driveRoles.id, role.id));
+    // A margin well under IN_TX_DELAY_MS: with now(), the stamp would trail
+    // checkpoint by roughly IN_TX_DELAY_MS; with clock_timestamp(), it lands
+    // at-or-after checkpoint.
+    expect(updated.updatedAt.getTime()).toBeGreaterThanOrEqual(checkpoint - 50);
+  });
+
   it('leaves touchColumns untouched (and thus stale) when the caller opts out', async () => {
     if (!dbAvailable) return;
     const owner = await factories.createUser();

--- a/packages/lib/src/services/reorder/locked-batch-reorder.ts
+++ b/packages/lib/src/services/reorder/locked-batch-reorder.ts
@@ -20,6 +20,18 @@ export interface LockedBatchReorderOptions<T extends PgTable> {
    * without this a caller switching from `tx.update(...).set(...)` to this
    * primitive would silently stop refreshing those columns. Optional: tables
    * with no such column (e.g. `favorites`, which has no `updatedAt`) omit it.
+   *
+   * Stamped with Postgres `clock_timestamp()`, not `now()`. `now()` (aka
+   * `transaction_timestamp()`) is fixed at the transaction's `BEGIN` and
+   * stays fixed for every statement inside it — including this one. If this
+   * transaction blocks waiting on the `FOR UPDATE` lock above (e.g. a
+   * concurrent role mutation holds it), the wait can outlast a concurrent
+   * writer's own commit, and `now()` would then stamp a timestamp from
+   * *before* that writer's newer one — silently regressing `updatedAt`
+   * backwards. `clock_timestamp()` reflects the actual wall-clock moment
+   * this UPDATE executes (after the lock is acquired), matching the
+   * `new Date()`-evaluated-at-write-time semantics every other writer in
+   * this codebase already has.
    */
   touchColumns?: AnyPgColumn[];
 }
@@ -72,7 +84,7 @@ export async function lockedBatchReorder<T extends PgTable>(
   const setAssignments = sql.join(
     [
       sql`${sql.identifier(positionColumn.name)} = v.position`,
-      ...touchColumns.map((column) => sql`${sql.identifier(column.name)} = now()`),
+      ...touchColumns.map((column) => sql`${sql.identifier(column.name)} = clock_timestamp()`),
     ],
     sql`, `
   );


### PR DESCRIPTION
## Summary

Fast-follow to #2139 (Phase 6 of the "Task Board Query & Reorder Safety" epic, PageSpace page `j44e35jwzlhr54fbmruk3k4i`), which merged before this Codex P2 finding could be addressed in-PR: https://github.com/2witstudios/PageSpace/pull/2139#discussion_r3609940663 (packages/lib/src/services/drive-role-service.ts:414).

- `lockedBatchReorder`'s `touchColumns` stamp used SQL `now()` — which is exactly `transaction_timestamp()`, fixed once at the transaction's `BEGIN` and frozen for every statement inside it, including the `touchColumns` UPDATE.
- If the transaction blocks waiting on the `FOR UPDATE` lock (e.g. a concurrent `updateDriveRole`/`createDriveRole` default-switch holds one of the targeted rows), that wait can outlast a concurrent writer's own commit. `now()` then stamps a timestamp from *before* that writer's newer one — silently regressing `updatedAt` backwards, even though the reorder wrote *after* the other transaction committed.
- Only `reorderDriveRoles` (#2139) calls `lockedBatchReorder` with `touchColumns` today, but the bug lives in the shared primitive (`packages/lib/src/services/reorder/locked-batch-reorder.ts`), so it would have carried forward silently to Phases 4/5's callers too.

**Fix:** `clock_timestamp()` instead of `now()` — reflects the actual wall-clock moment the UPDATE statement executes (i.e. after the lock is acquired), matching the `new Date()`-evaluated-at-write-time semantics every other writer in this codebase already has (`createDriveRole`, `updateDriveRole`, the old per-row `reorderDriveRoles` loop it replaced).

## Verification

This is Postgres-semantics-dependent behavior a mocked unit test can't observe, so I verified against a real Postgres instance rather than trusting the change blind:

1. A raw-`pg` probe confirmed the base semantics: `now()` stays frozen across an in-transaction delay, `clock_timestamp()` advances.
2. A probe through `db.transaction()` (this repo's actual drizzle wrapper) confirmed the same.
3. A probe through the actual `lockedBatchReorder` function showed **-504ms** drift with the old `now()` code vs **+5ms** with the fix, for an artificial 500ms in-transaction delay.
4. Added a deterministic regression test to `locked-batch-reorder.integration.test.ts`: forces `BEGIN` via an explicit statement, delays 150ms *inside* the open transaction before calling `lockedBatchReorder`, then asserts the stamped `updatedAt` lands at-or-after that checkpoint. Confirmed this test fails against the old `now()` implementation and passes against the fix.

## Test plan

- [x] New regression test in `locked-batch-reorder.integration.test.ts`, run against a real test Postgres (`docker-compose.test.yml`) — RED against pre-fix code (verified via `git stash`), GREEN against the fix.
- [x] Full `locked-batch-reorder.integration.test.ts` suite (6 tests, including the existing deadlock-absence and touchColumns-opt-out tests) — green against real Postgres.
- [x] Full `packages/lib` test suite (374 files, 8554 tests) against real test Postgres — green.
- [x] Full monorepo `bun run typecheck` — green (16/16 tasks).
- [x] CI: `ci / Unit Tests` and `ci / Lint & TypeScript Check` both green; Codex automated review reacted 👍 (no findings); CodeRabbit rate-limited (non-blocking, status check reports SUCCESS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwxVmYuWCdDPfjR4vtRi2D