### PR TITLE
feat(webhooks): shared scheme-pluggable webhook signature helper (sign+verify)

### DIFF
--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -1,37 +1,16 @@
 import { NextResponse } from 'next/server';
-import { createHmac } from 'crypto';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
 import { pages } from '@pagespace/db/schema/core';
 import { decryptField } from '@pagespace/lib/encryption/field-crypto';
-import { secureCompare } from '@pagespace/lib/auth/secure-compare';
+import { v0Scheme, DEFAULT_REPLAY_WINDOW_MS } from '@pagespace/lib/security/webhook-signature';
 import { publishWebhookMessage } from '@pagespace/lib/services/page-webhook-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-
-const REPLAY_WINDOW_MS = 5 * 60 * 1000;
 
 // Arbitrary-JSON envelope cap — checked on the raw bytes BEFORE JSON.parse so
 // an oversized body never costs a parse.
 const MAX_BODY_BYTES = 64 * 1024;
-
-/**
- * Verify `x-pagespace-signature`/`x-pagespace-timestamp` the same way the
- * Zoom webhook does (`zoom/verify-webhook.ts`): HMAC-SHA256 over
- * `v0:{timestamp}:{rawBody}`, `secureCompare` for the comparison (never raw
- * `crypto.timingSafeEqual` on an unhashed secret — see secure-compare.ts),
- * and a 5-minute replay window.
- */
-function verifySignature(signature: string | null, timestamp: string | null, rawBody: string, secret: string): boolean {
-  if (!signature || !timestamp) return false;
-
-  const ts = Number(timestamp);
-  if (!Number.isFinite(ts) || Math.abs(Date.now() - ts * 1000) > REPLAY_WINDOW_MS) return false;
-
-  const message = `v0:${timestamp}:${rawBody}`;
-  const expected = 'v0=' + createHmac('sha256', secret).update(message).digest('hex');
-  return secureCompare(signature, expected);
-}
 
 const NOT_FOUND = () => NextResponse.json({ error: 'Not found' }, { status: 404 });
 
@@ -56,9 +35,15 @@ export async function POST(request: Request, context: { params: Promise<{ token:
     }
 
     const secret = await decryptField(webhook.webhookSecretEncrypted);
-    const signature = request.headers.get('x-pagespace-signature');
-    const timestamp = request.headers.get('x-pagespace-timestamp');
-    if (!verifySignature(signature, timestamp, rawBody, secret)) {
+    const verified = v0Scheme.verify({
+      secret,
+      signature: request.headers.get('x-pagespace-signature'),
+      timestamp: request.headers.get('x-pagespace-timestamp'),
+      rawBody,
+      nowMs: Date.now(),
+      replayWindowMs: DEFAULT_REPLAY_WINDOW_MS,
+    });
+    if (!verified) {
       return NextResponse.json({ error: 'Invalid signature' }, { status: 403 });
     }
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1317,6 +1317,11 @@
       "import": "./dist/security/path-validator.js",
       "require": "./dist/security/path-validator.js"
     },
+    "./security/webhook-signature": {
+      "types": "./dist/security/webhook-signature.d.ts",
+      "import": "./dist/security/webhook-signature.js",
+      "require": "./dist/security/webhook-signature.js"
+    },
     "./auth/constants": {
       "types": "./dist/auth/constants.d.ts",
       "import": "./dist/auth/constants.js",

--- a/packages/lib/src/security/__tests__/webhook-signature.test.ts
+++ b/packages/lib/src/security/__tests__/webhook-signature.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'crypto';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import {
+  v0Scheme,
+  DEFAULT_REPLAY_WINDOW_MS,
+  type SignatureScheme,
+} from '../webhook-signature';
+
+const SECRET = 'test-webhook-secret';
+const BODY = JSON.stringify({ content: 'deploy finished' });
+
+// A fixed "now" so every case is deterministic — the module itself never reads a clock.
+const NOW_MS = 1_752_900_000_000;
+const NOW_SECONDS = Math.floor(NOW_MS / 1000);
+
+function verifyAt(overrides: Partial<Parameters<SignatureScheme['verify']>[0]> = {}) {
+  const timestamp = String(NOW_SECONDS);
+  return v0Scheme.verify({
+    secret: SECRET,
+    signature: v0Scheme.sign(SECRET, NOW_SECONDS, BODY),
+    timestamp,
+    rawBody: BODY,
+    nowMs: NOW_MS,
+    replayWindowMs: DEFAULT_REPLAY_WINDOW_MS,
+    ...overrides,
+  });
+}
+
+describe('v0Scheme.sign', () => {
+  it('produces v0=hex(HMAC-SHA256(secret, "v0:{timestamp}:{rawBody}"))', () => {
+    const expected =
+      'v0=' + createHmac('sha256', SECRET).update(`v0:${NOW_SECONDS}:${BODY}`).digest('hex');
+    expect(v0Scheme.sign(SECRET, NOW_SECONDS, BODY)).toBe(expected);
+  });
+
+  it('is deterministic for identical inputs and differs when any input changes', () => {
+    const base = v0Scheme.sign(SECRET, NOW_SECONDS, BODY);
+    expect(v0Scheme.sign(SECRET, NOW_SECONDS, BODY)).toBe(base);
+    expect(v0Scheme.sign('other-secret', NOW_SECONDS, BODY)).not.toBe(base);
+    expect(v0Scheme.sign(SECRET, NOW_SECONDS + 1, BODY)).not.toBe(base);
+    expect(v0Scheme.sign(SECRET, NOW_SECONDS, BODY + 'x')).not.toBe(base);
+  });
+});
+
+describe('v0Scheme.verify', () => {
+  it('accepts a valid sign → verify roundtrip', () => {
+    expect(verifyAt()).toBe(true);
+  });
+
+  it('rejects a signature produced with the wrong secret', () => {
+    expect(verifyAt({ signature: v0Scheme.sign('wrong-secret', NOW_SECONDS, BODY) })).toBe(false);
+  });
+
+  it('rejects a stale timestamp outside the replay window', () => {
+    const stale = NOW_SECONDS - 6 * 60;
+    expect(
+      verifyAt({
+        signature: v0Scheme.sign(SECRET, stale, BODY),
+        timestamp: String(stale),
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a future timestamp outside the replay window', () => {
+    const future = NOW_SECONDS + 6 * 60;
+    expect(
+      verifyAt({
+        signature: v0Scheme.sign(SECRET, future, BODY),
+        timestamp: String(future),
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a timestamp exactly at the replay-window boundary', () => {
+    const edge = NOW_SECONDS - DEFAULT_REPLAY_WINDOW_MS / 1000;
+    expect(
+      verifyAt({
+        signature: v0Scheme.sign(SECRET, edge, BODY),
+        timestamp: String(edge),
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a signature computed over a different body than the one delivered (tampered body)', () => {
+    expect(
+      verifyAt({ signature: v0Scheme.sign(SECRET, NOW_SECONDS, JSON.stringify({ content: 'other' })) }),
+    ).toBe(false);
+  });
+
+  it('rejects a missing signature', () => {
+    expect(verifyAt({ signature: null })).toBe(false);
+    expect(verifyAt({ signature: '' })).toBe(false);
+  });
+
+  it('rejects a missing timestamp', () => {
+    expect(verifyAt({ timestamp: null })).toBe(false);
+    expect(verifyAt({ timestamp: '' })).toBe(false);
+  });
+
+  it('rejects a malformed signature that is not in v0=hex form', () => {
+    expect(verifyAt({ signature: 'not-a-signature' })).toBe(false);
+    expect(verifyAt({ signature: 'v0=' })).toBe(false);
+  });
+
+  it('rejects a non-numeric timestamp', () => {
+    for (const bad of ['not-a-number', 'NaN', 'Infinity', '-Infinity', '12abc']) {
+      expect(verifyAt({ timestamp: bad })).toBe(false);
+    }
+  });
+
+  it('verifies against the raw header string, so a re-encoded timestamp ("0" + digits) fails', () => {
+    // The sender signs the exact header bytes; verify must recompute over the
+    // header string as delivered, not a normalized number.
+    const padded = '0' + String(NOW_SECONDS);
+    expect(verifyAt({ timestamp: padded })).toBe(false);
+  });
+});
+
+describe('scheme pluggability', () => {
+  it('exposes a stable scheme name for registry keying', () => {
+    expect(v0Scheme.name).toBe('v0');
+  });
+
+  it('accepts any SignatureScheme-shaped adapter — a provider scheme slots in without intake rework', () => {
+    // Compile-time seam check: a GitHub-style adapter is just another object
+    // implementing the same interface. It must typecheck and be callable
+    // through the same shape the intake uses.
+    const fakeGithubStyle: SignatureScheme = {
+      name: 'sha256',
+      sign: (secret, _timestampSeconds, rawBody) =>
+        'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex'),
+      verify: ({ secret, signature, rawBody }) =>
+        signature === 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex'),
+    };
+    const sig = fakeGithubStyle.sign(SECRET, NOW_SECONDS, BODY);
+    expect(
+      fakeGithubStyle.verify({
+        secret: SECRET,
+        signature: sig,
+        timestamp: null,
+        rawBody: BODY,
+        nowMs: NOW_MS,
+        replayWindowMs: DEFAULT_REPLAY_WINDOW_MS,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('webhook-signature purity', () => {
+  it('imports no db client, fetch, env, or clock — current time arrives as a parameter', () => {
+    const src = readFileSync(fileURLToPath(new URL('../webhook-signature.ts', import.meta.url)), 'utf8');
+    expect(src).not.toMatch(/from ['"][^'"]*\/db['"]/);
+    expect(src).not.toMatch(/\bfetch\(/);
+    expect(src).not.toMatch(/process\.env/);
+    expect(src).not.toMatch(/Date\.now/);
+    expect(src).not.toMatch(/new Date\(/);
+    // Only type-only imports are allowed from schema modules (erased at compile time).
+    const schemaImports = src.match(/^import .*from ['"][^'"]*\/schema\/[^'"]*['"];?$/gm) ?? [];
+    for (const line of schemaImports) {
+      expect(line.startsWith('import type')).toBe(true);
+    }
+  });
+});

--- a/packages/lib/src/security/webhook-signature.ts
+++ b/packages/lib/src/security/webhook-signature.ts
@@ -1,0 +1,69 @@
+import { createHmac } from 'crypto';
+import { secureCompare } from '../auth/secure-compare';
+
+/**
+ * Shared, pure webhook signature helper — the ONE place inbound intake
+ * verification and (future) outbound delivery signing agree on crypto.
+ *
+ * Pure by contract: no db, no fetch, no env, no clock — the current time
+ * arrives as `nowMs` (enforced by the purity test alongside this module).
+ */
+
+/** Default replay window for timestamped schemes: 5 minutes, matching the intake route. */
+export const DEFAULT_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+
+export type VerifyInput = {
+  secret: string;
+  /** Signature header value as delivered, or null if the header was absent. */
+  signature: string | null;
+  /**
+   * Timestamp header value as delivered (seconds since epoch), or null if
+   * absent. Schemes that verify a timestamp MUST recompute over this exact
+   * string — the sender signed these bytes, not a normalized number.
+   */
+  timestamp: string | null;
+  rawBody: string;
+  /** Current time in ms — injected so the module stays clock-free. */
+  nowMs: number;
+  /** Max allowed |nowMs - timestamp| for replay protection. */
+  replayWindowMs: number;
+};
+
+/**
+ * The pluggability seam: one adapter per signature scheme. A provider adapter
+ * (e.g. GitHub `X-Hub-Signature-256`) slots in as just another object
+ * implementing this interface — intake code never changes shape. Schemes
+ * without a timestamp simply ignore the timestamp/replay fields.
+ */
+export interface SignatureScheme {
+  /** Stable identifier for registry keying (e.g. 'v0'). */
+  name: string;
+  sign(secret: string, timestampSeconds: number, rawBody: string): string;
+  verify(input: VerifyInput): boolean;
+}
+
+/**
+ * PageSpace's native scheme (Slack-style): HMAC-SHA256 over
+ * `v0:{timestamp}:{rawBody}`, rendered as `v0=<hex>`, with a replay-window
+ * check on the timestamp. Comparison goes through `secureCompare` — never raw
+ * `crypto.timingSafeEqual` on unhashed input (see auth/secure-compare.ts).
+ */
+export const v0Scheme: SignatureScheme = {
+  name: 'v0',
+
+  sign(secret, timestampSeconds, rawBody) {
+    const message = `v0:${timestampSeconds}:${rawBody}`;
+    return 'v0=' + createHmac('sha256', secret).update(message).digest('hex');
+  },
+
+  verify({ secret, signature, timestamp, rawBody, nowMs, replayWindowMs }) {
+    if (!signature || !timestamp) return false;
+
+    const ts = Number(timestamp);
+    if (!Number.isFinite(ts) || Math.abs(nowMs - ts * 1000) > replayWindowMs) return false;
+
+    const message = `v0:${timestamp}:${rawBody}`;
+    const expected = 'v0=' + createHmac('sha256', secret).update(message).digest('hex');
+    return secureCompare(signature, expected);
+  },
+};


### PR DESCRIPTION
## What

New pure module `packages/lib/src/security/webhook-signature.ts` — the single shared crypto helper for webhook signatures, replacing the third hand-rolled inline HMAC verification in the repo (the universal intake route's). Stacked on #2168 — base `pu/webhooks-receiver`; retargets to master when the receiver PR merges.

- **`SignatureScheme` adapter interface** (`name`, `sign`, `verify`) — the pluggability seam. A future GitHub `X-Hub-Signature-256` adapter is just another scheme object; intake code never changes shape.
- **`v0` scheme** (only implementation for now, Slack-style): `sign(secret, timestampSeconds, rawBody)` → `"v0=" + hex(HMAC-SHA256(secret, "v0:{timestamp}:{rawBody}"))`; `verify` recomputes over the **raw header string** (the sender signed those bytes, not a normalized number), enforces the replay window against an injected `nowMs`, and compares via the existing `secureCompare` (repo rule: never raw `timingSafeEqual` on unhashed input).
- **Both `sign` and `verify`** — the planned outbound realtime-event-subscription epic reuses `sign` for delivery signing.
- **Pure**: no db, no fetch, no `process.env`, no clock — current time arrives as a parameter. Enforced by a `readFileSync` + regex purity test mirroring `page-webhook-core.test.ts`.
- `packages/lib/package.json` gains the `./security/webhook-signature` exports entry.
- The intake route `apps/web/src/app/api/webhooks/[token]/route.ts` drops its inline `verifySignature` for the `v0Scheme.verify` call — same header names, same 5-minute window, behavior identical.

**Untouched (explicitly out of scope, live traffic):** `apps/web/src/lib/integrations/zoom/verify-webhook.ts` and Google Calendar webhook auth. `git diff` contains zero changes under either.

## Why

The Incoming Webhooks epic (board `f8h9ww7rrfaxws4bw44fu8nj`) needs one scheme-pluggable signature helper instead of per-route hand-rolled HMAC: the intake route verifies inbound deliveries today, provider adapters (GitHub etc.) slot in per-webhook tomorrow, and the outbound subscription epic signs deliveries with the same scheme.

## Test plan

- [x] TDD: [RED] 16-test suite written first (roundtrip, wrong secret, stale/future timestamp outside window, window-boundary, tampered body, missing/malformed signature + timestamp, non-numeric timestamp, padded-timestamp re-encoding, scheme name, adapter-shape pluggability, purity) — confirmed failing, then [GREEN]
- [x] `cd packages/lib && bunx vitest run src/security/__tests__/webhook-signature.test.ts` — 16/16 green
- [x] `cd apps/web && bunx vitest run "src/app/api/webhooks/[token]/__tests__/route.test.ts"` — all 19 existing route tests green **unmodified** (16 at branch time; the receiver base later added 3 more — still untouched by this PR)
- [x] `bun run --filter=@pagespace/lib typecheck` + `apps/web` typecheck — exit 0
- [x] Zero diff under zoom/ or google-calendar/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151CqYmkmaAbcfyrYbH2iXm

