### PR TITLE
feat(webhooks): Incoming Webhooks dialog — page-agnostic, mounted on channels + agent pages

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -1584,6 +1584,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         open={webhooksOpen}
         onOpenChange={setWebhooksOpen}
         pageId={page.id}
+        pageType={page.type}
       />
     </div>
     </AskUserAnswerProvider>

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -13,7 +13,7 @@ import { useChat } from '@ai-sdk/react';
 import { useParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Loader2, Settings, MessageSquare, History, Plus, Save } from 'lucide-react';
+import { Loader2, Settings, MessageSquare, History, Plus, Save, Webhook } from 'lucide-react';
 import { UIMessage } from 'ai';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
@@ -24,6 +24,7 @@ import { PageAgentSettingsTab, PageAgentHistoryTab, ConversationShareToggle, typ
 import { AgentIntegrationsPanel } from '@/components/ai/page-agents/AgentIntegrationsPanel';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
+import { PageWebhooksDialog } from '@/components/shared/PageWebhooksDialog';
 
 import { useEditingStore } from '@/stores/useEditingStore';
 import { canResumeRecovery } from '@/lib/ai/streams/canResumeRecovery';
@@ -114,6 +115,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const [showError, setShowError] = useState(true);
   const [isReadOnly, setIsReadOnly] = useState<boolean>(false);
   const [isSettingsSaving, setIsSettingsSaving] = useState(false);
+  const [webhooksOpen, setWebhooksOpen] = useState(false);
   const [lastAIResponse, setLastAIResponse] = useState<{ id: string; text: string } | null>(null);
   // Message-load state — tracks in-progress DB fetches and their failures independently
   // of the useChat streaming state so blank → spinner instead of blank → blank.
@@ -1341,60 +1343,74 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
               </TabsTrigger>
             </TabsList>
 
-            {/* Chat tab actions */}
-            {activeTab === 'chat' && (
-              <div className="flex items-center gap-3">
-                {displayPreferences.showTokenCounts && (
-                  <AiUsageMonitor pageId={page.id} compact />
-                )}
+            <div className="flex items-center gap-3">
+              {/* Chat tab actions */}
+              {activeTab === 'chat' && (
+                <>
+                  {displayPreferences.showTokenCounts && (
+                    <AiUsageMonitor pageId={page.id} compact />
+                  )}
 
-                <TasksDropdown messages={plainMessages} driveId={driveId} />
+                  <TasksDropdown messages={plainMessages} driveId={driveId} />
 
-                {currentConversation && (
-                  <ConversationShareToggle
-                    isShared={currentConversation.isShared}
-                    isOwner={currentConversation.isOwner}
-                    onToggle={() =>
-                      toggleConversationShare(
-                        currentConversation.id,
-                        !currentConversation.isShared,
-                      )
-                    }
-                  />
-                )}
+                  {currentConversation && (
+                    <ConversationShareToggle
+                      isShared={currentConversation.isShared}
+                      isOwner={currentConversation.isOwner}
+                      onToggle={() =>
+                        toggleConversationShare(
+                          currentConversation.id,
+                          !currentConversation.isShared,
+                        )
+                      }
+                    />
+                  )}
 
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => createConversation()}
+                    className="flex items-center gap-2"
+                  >
+                    <Plus className="h-4 w-4" />
+                    <span className="hidden sm:inline">New Chat</span>
+                  </Button>
+                </>
+              )}
+
+              {/* Settings tab actions */}
+              {activeTab === 'settings' && (
                 <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => createConversation()}
-                  className="flex items-center gap-2"
+                  onClick={() => agentSettingsRef.current?.submitForm()}
+                  disabled={isSettingsSaving}
+                  className="min-w-[100px] sm:min-w-[120px]"
                 >
-                  <Plus className="h-4 w-4" />
-                  <span className="hidden sm:inline">New Chat</span>
+                  {isSettingsSaving ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      <span className="hidden sm:inline">Saving...</span>
+                    </>
+                  ) : (
+                    <>
+                      <Save className="h-4 w-4 sm:mr-2" />
+                      <span className="hidden sm:inline">Save Settings</span>
+                    </>
+                  )}
                 </Button>
-              </div>
-            )}
+              )}
 
-            {/* Settings tab actions */}
-            {activeTab === 'settings' && (
+              {/* Deliberately not permission-gated: the dialog itself explains the
+                  owner/admin requirement, so the feature stays discoverable. */}
               <Button
-                onClick={() => agentSettingsRef.current?.submitForm()}
-                disabled={isSettingsSaving}
-                className="min-w-[100px] sm:min-w-[120px]"
+                variant="ghost"
+                size="sm"
+                onClick={() => setWebhooksOpen(true)}
+                title="Incoming Webhooks"
+                className="px-2 text-muted-foreground hover:text-foreground"
               >
-                {isSettingsSaving ? (
-                  <>
-                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    <span className="hidden sm:inline">Saving...</span>
-                  </>
-                ) : (
-                  <>
-                    <Save className="h-4 w-4 sm:mr-2" />
-                    <span className="hidden sm:inline">Save Settings</span>
-                  </>
-                )}
+                <Webhook className="h-4 w-4" />
               </Button>
-            )}
+            </div>
           </div>
         </div>
 
@@ -1563,6 +1579,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         </TabsContent>
       </Tabs>
 
+      <PageWebhooksDialog
+        open={webhooksOpen}
+        onOpenChange={setWebhooksOpen}
+        pageId={page.id}
+      />
     </div>
     </AskUserAnswerProvider>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -1406,6 +1406,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                 size="sm"
                 onClick={() => setWebhooksOpen(true)}
                 title="Incoming Webhooks"
+                aria-label="Incoming Webhooks"
                 className="px-2 text-muted-foreground hover:text-foreground"
               >
                 <Webhook className="h-4 w-4" />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -647,6 +647,7 @@ function ChannelView({ page }: ChannelViewProps) {
             type="button"
             onClick={() => setWebhooksOpen(true)}
             title="Incoming Webhooks"
+            aria-label="Incoming Webhooks"
             className="absolute top-2 right-4 z-10 flex items-center justify-center size-7 rounded-full bg-background/80 backdrop-blur border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
             <Webhook size={14} aria-hidden />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -20,7 +20,7 @@ import { MessageReactions, type Reaction } from '@/components/shared/MessageReac
 import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Lock, Check, X, MessageSquareText, Webhook } from 'lucide-react';
-import { ChannelWebhooksDialog } from './ChannelWebhooksDialog';
+import { PageWebhooksDialog } from '@/components/shared/PageWebhooksDialog';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
@@ -641,17 +641,17 @@ function ChannelView({ page }: ChannelViewProps) {
     <div className="flex h-full w-full">
     <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full flex-1 min-w-0">
         <div className="flex-grow overflow-hidden relative">
-          {canEdit && (
-            <button
-              type="button"
-              onClick={() => setWebhooksOpen(true)}
-              title="Webhooks"
-              className="absolute top-2 right-4 z-10 flex items-center justify-center size-7 rounded-full bg-background/80 backdrop-blur border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-            >
-              <Webhook size={14} aria-hidden />
-            </button>
-          )}
-          <ChannelWebhooksDialog
+          {/* Deliberately not permission-gated: the dialog itself explains the
+              owner/admin requirement, so the feature stays discoverable. */}
+          <button
+            type="button"
+            onClick={() => setWebhooksOpen(true)}
+            title="Incoming Webhooks"
+            className="absolute top-2 right-4 z-10 flex items-center justify-center size-7 rounded-full bg-background/80 backdrop-blur border text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+          >
+            <Webhook size={14} aria-hidden />
+          </button>
+          <PageWebhooksDialog
             open={webhooksOpen}
             onOpenChange={setWebhooksOpen}
             pageId={page.id}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -656,6 +656,7 @@ function ChannelView({ page }: ChannelViewProps) {
             open={webhooksOpen}
             onOpenChange={setWebhooksOpen}
             pageId={page.id}
+            pageType="CHANNEL"
           />
           <Conversation className="h-full">
             <ConversationContent className="max-w-4xl mx-auto p-4">

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -32,10 +32,10 @@ interface PageWebhooksDialogProps {
   pageId: string;
 }
 
-const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string }> => {
+const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
   const res = await fetchWithAuth(url);
   const body = await res.json().catch(() => ({}));
-  if (!res.ok) return { error: body.error ?? 'Failed to load webhooks' };
+  if (!res.ok) return { error: body.error ?? 'Failed to load webhooks', status: res.status };
   return body;
 };
 
@@ -55,7 +55,8 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
     }
   }, [open]);
 
-  const forbidden = data && 'error' in data;
+  const forbidden = data && 'error' in data && data.status === 403;
+  const loadFailed = data && 'error' in data && data.status !== 403;
   const webhooks = data && 'webhooks' in data ? data.webhooks : [];
 
   const createWebhook = async () => {
@@ -131,6 +132,13 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
           <p className="text-sm text-muted-foreground py-4">
             Only this drive&apos;s owner or an admin can manage webhooks.
           </p>
+        ) : loadFailed ? (
+          <div className="flex items-center justify-between gap-2 py-4">
+            <p className="text-sm text-muted-foreground">Failed to load webhooks.</p>
+            <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </div>
         ) : revealed ? (
           <div className="space-y-3 py-2">
             <p className="text-sm">

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -119,8 +119,9 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
             Incoming Webhooks
           </DialogTitle>
           <DialogDescription>
-            External systems can send signed requests to a webhook URL and they appear in this
-            page&apos;s context.
+            External systems can push events to this page by sending signed requests to a webhook
+            URL. On channels, deliveries post as messages; other page types act on deliveries as
+            their integrations are wired up.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Check, Copy, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
@@ -30,6 +30,7 @@ interface PageWebhooksDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   pageId: string;
+  pageType: string;
 }
 
 const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
@@ -39,7 +40,7 @@ const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } 
   return body;
 };
 
-export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksDialogProps) {
+function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWebhooksDialogProps) {
   const key = open ? `/api/pages/${pageId}/webhooks` : null;
   const { data, isLoading, mutate: refetch } = useSWR(key, webhooksFetcher, { revalidateOnFocus: false });
 
@@ -55,8 +56,9 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
     }
   }, [open]);
 
-  const forbidden = data && 'error' in data && data.status === 403;
-  const loadFailed = data && 'error' in data && data.status !== 403;
+  const errorStatus = data && 'error' in data ? data.status : null;
+  const forbidden = errorStatus === 403;
+  const loadFailed = errorStatus !== null && errorStatus !== 403;
   const webhooks = data && 'webhooks' in data ? data.webhooks : [];
 
   const createWebhook = async () => {
@@ -120,9 +122,11 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
             Incoming Webhooks
           </DialogTitle>
           <DialogDescription>
-            External systems can push events to this page by sending signed requests to a webhook
-            URL. On channels, deliveries post as messages; other page types act on deliveries as
-            their integrations are wired up.
+            {/* CHANNEL is the one type with a default delivery action today — the same
+                special case the intake route carries until the dispatch map lands. */}
+            {pageType === 'CHANNEL'
+              ? 'External systems can post messages into this channel by sending signed requests to a webhook URL.'
+              : 'External systems can push events to this page by sending signed requests to a webhook URL.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -228,3 +232,7 @@ export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksD
     </Dialog>
   );
 }
+
+// Memoized: AiChatView re-renders per streaming token, and every prop here is
+// stable/primitive — memo skips the closed dialog's subtree on all of them.
+export const PageWebhooksDialog = memo(PageWebhooksDialogImpl);

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -26,7 +26,7 @@ interface WebhookRow {
   lastFireError: string | null;
 }
 
-interface ChannelWebhooksDialogProps {
+interface PageWebhooksDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   pageId: string;
@@ -39,7 +39,7 @@ const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } 
   return body;
 };
 
-export function ChannelWebhooksDialog({ open, onOpenChange, pageId }: ChannelWebhooksDialogProps) {
+export function PageWebhooksDialog({ open, onOpenChange, pageId }: PageWebhooksDialogProps) {
   const key = open ? `/api/pages/${pageId}/webhooks` : null;
   const { data, isLoading, mutate: refetch } = useSWR(key, webhooksFetcher, { revalidateOnFocus: false });
 
@@ -116,10 +116,11 @@ export function ChannelWebhooksDialog({ open, onOpenChange, pageId }: ChannelWeb
         <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <Webhook className="h-4 w-4" />
-            Webhooks
+            Incoming Webhooks
           </DialogTitle>
           <DialogDescription>
-            External systems can post messages into this channel by sending signed requests to a webhook URL.
+            External systems can send signed requests to a webhook URL and they appear in this
+            page&apos;s context.
           </DialogDescription>
         </DialogHeader>
 
@@ -127,7 +128,7 @@ export function ChannelWebhooksDialog({ open, onOpenChange, pageId }: ChannelWeb
           <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
         ) : forbidden ? (
           <p className="text-sm text-muted-foreground py-4">
-            Only this drive&apos;s owner or an admin can manage webhooks for a channel.
+            Only this drive&apos;s owner or an admin can manage webhooks.
           </p>
         ) : revealed ? (
           <div className="space-y-3 py-2">
@@ -170,7 +171,8 @@ export function ChannelWebhooksDialog({ open, onOpenChange, pageId }: ChannelWeb
 
             {webhooks.length === 0 ? (
               <p className="text-xs text-muted-foreground">
-                No webhooks yet — create one to let an external system (CI, monitoring, a script) post messages here.
+                No webhooks yet — create one to let an external system (CI, monitoring, a script) send
+                events to this page.
               </p>
             ) : (
               <div className="space-y-2">

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -88,6 +88,26 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('distinguishes a server failure from missing permission', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(500, { error: 'Failed to list webhooks' }),
+    );
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Failed to load webhooks.'));
+
+    assert({
+      given: 'the webhook list request fails with a non-403 error',
+      should: 'show a retryable failure message, NOT the owner/admin explanation',
+      actual: {
+        failure: screen.getByText('Failed to load webhooks.') !== null,
+        retry: screen.getByRole('button', { name: /Retry/ }) !== null,
+        permissionCopy: screen.queryByText(/Only this drive's owner or an admin/),
+      },
+      expected: { failure: true, retry: true, permissionCopy: null },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -1,0 +1,125 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SWRConfig } from 'swr';
+import { assert } from '@/stores/__tests__/riteway';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  post: vi.fn(),
+  patch: vi.fn(),
+  del: vi.fn(),
+}));
+
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { PageWebhooksDialog } from '../PageWebhooksDialog';
+
+const PAGE_ID = 'page-1';
+
+const remoteWebhook = () => ({
+  id: 'wh-1',
+  name: 'Deploys',
+  webhookToken: 'tok_abcdef12345678',
+  isEnabled: true,
+  lastFiredAt: null,
+  lastFireError: null,
+});
+
+const listResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const renderDialog = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <PageWebhooksDialog open onOpenChange={() => {}} pageId={PAGE_ID} />
+    </SWRConfig>,
+  );
+
+describe('PageWebhooksDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('lists webhooks under the Incoming Webhooks title', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    assert({
+      given: 'an open dialog whose webhook list loads successfully',
+      should: 'render the page-agnostic "Incoming Webhooks" title and the webhook row',
+      actual: {
+        title: screen.getByText('Incoming Webhooks') !== null,
+        row: screen.getByText('Deploys') !== null,
+      },
+      expected: { title: true, row: true },
+    });
+  });
+
+  test('shows the owner/admin explanation on a 403 — disabled, not hidden', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(403, { error: 'Forbidden' }),
+    );
+
+    renderDialog();
+    await waitFor(() =>
+      screen.getByText(/Only this drive's owner or an admin can manage webhooks/),
+    );
+
+    assert({
+      given: 'a viewer without owner/admin rights (webhook list returns 403)',
+      should: 'explain the permission requirement instead of rendering the create form',
+      actual: {
+        explanation:
+          screen.getByText(/Only this drive's owner or an admin can manage webhooks/) !== null,
+        createForm: screen.queryByPlaceholderText(/Webhook name/),
+      },
+      expected: { explanation: true, createForm: null },
+    });
+  });
+
+  test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_only_shown_once',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByPlaceholderText(/Webhook name/));
+
+    await userEvent.type(screen.getByPlaceholderText(/Webhook name/), 'Deploys');
+    await userEvent.click(screen.getByRole('button', { name: /Create webhook/ }));
+    await waitFor(() => screen.getByText('whsec_only_shown_once'));
+
+    assert({
+      given: 'a webhook was just created',
+      should: 'show the secret with a copy affordance and an explicit dismiss button',
+      actual: {
+        secret: screen.getByText('whsec_only_shown_once') !== null,
+        copy: screen.getByRole('button', { name: /Copy/ }) !== null,
+        dismiss: screen.getByRole('button', { name: /Done, I've saved it/ }) !== null,
+      },
+      expected: { secret: true, copy: true, dismiss: true },
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+
+    assert({
+      given: 'the user confirmed they saved the secret',
+      should: 'remove the secret from the DOM for good',
+      actual: screen.queryByText('whsec_only_shown_once'),
+      expected: null,
+    });
+  });
+});

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -35,10 +35,10 @@ const listResponse = (status: number, body: unknown) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
-const renderDialog = () =>
+const renderDialog = (pageType = 'AI_CHAT') =>
   render(
     <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
-      <PageWebhooksDialog open onOpenChange={() => {}} pageId={PAGE_ID} />
+      <PageWebhooksDialog open onOpenChange={() => {}} pageId={PAGE_ID} pageType={pageType} />
     </SWRConfig>,
   );
 
@@ -85,6 +85,29 @@ describe('PageWebhooksDialog', () => {
         createForm: screen.queryByPlaceholderText(/Webhook name/),
       },
       expected: { explanation: true, createForm: null },
+    });
+  });
+
+  test('description copy states the channel default action only on channels', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
+
+    const channelRender = renderDialog('CHANNEL');
+    await waitFor(() => screen.getByText(/post messages into this channel/));
+    const channelCopyShown = screen.getByText(/post messages into this channel/) !== null;
+    channelRender.unmount();
+
+    renderDialog('AI_CHAT');
+    await waitFor(() => screen.getByText(/push events to this page/));
+
+    assert({
+      given: 'the dialog mounted on a CHANNEL page and then on an AI_CHAT page',
+      should: 'describe the post-as-messages default only for the channel, neutral copy elsewhere',
+      actual: {
+        channelCopyShown,
+        aiPageNeutralCopy: screen.getByText(/push events to this page/) !== null,
+        aiPageChannelCopy: screen.queryByText(/post messages into this channel/),
+      },
+      expected: { channelCopyShown: true, aiPageNeutralCopy: true, aiPageChannelCopy: null },
     });
   });
 


### PR DESCRIPTION
Stacked on #2168 (`pu/webhooks-receiver`) — retarget to `master` when that merges.

## What

The webhook receiver is already page-agnostic (`/api/pages/[pageId]/webhooks`), but the settings dialog was still channel-named and channel-mounted. This PR generalizes the UI:

- **Move + rename** `page-views/channel/ChannelWebhooksDialog.tsx` → `components/shared/PageWebhooksDialog.tsx`. User-facing copy is now "Incoming Webhooks". Fetching/URLs unchanged.
- **ChannelView mount kept** — same floating webhook icon button, updated import. Channel behavior unchanged.
- **New AI_CHAT mount** — `AiChatView` gets an unobtrusive webhook icon button in its header actions row (visible on every tab), opening the same dialog. Until the stacked trigger-dispatch work (#2172 dispatch map, T5 fan-out) lands, a verified delivery to an agent page returns 202 + records `lastFireError: 'no action configured'`, which this dialog surfaces per webhook.
- **Page-type-aware copy** (Codex review thread) — the description is keyed on `pageType`: CHANNEL states its real default action ("post messages into this channel"), every other type gets neutral "push events to this page" copy that stays true regardless of which handlers the dispatch map adds later.
- **Permission UX** — both triggers are deliberately *not* permission-gated (the channel one previously hid behind `canEdit`). Any viewer can open the dialog; a 403 renders "Only this drive's owner or an admin can manage webhooks" — discoverable, not hidden. Non-403 failures render a retryable "Failed to load webhooks." instead of misleading permission copy.
- **Once-only secret reveal preserved** — URL + secret shown exactly once with a copy affordance and an explicit "Done, I've saved it" dismiss.
- **A11y + perf** — both icon-only triggers carry `aria-label="Incoming Webhooks"`; the dialog is memoized (AiChatView re-renders per streaming token; all dialog props are stable/primitive).
- **No trigger-wiring UI** — explicit v1 exclusion per the epic board.

## Tests

`PageWebhooksDialog.test.tsx` (riteway pattern, following `TaskAgentTriggersDialog.test.tsx`):
1. lists webhooks under the "Incoming Webhooks" title
2. description copy states the channel default action only on channels
3. 403 → owner/admin explanation, create form absent
4. 500 → retryable failure message, NOT the permission explanation
5. secret revealed once with copy + explicit dismiss; gone from the DOM after confirming

## Verification

- `bun run typecheck` (apps/web) exit 0
- eslint clean on all touched files; `bun run knip:check` within baseline
- 5 new + 76 existing ai-page/channel view tests green (81 total)
- `git grep -i ChannelWebhooksDialog` → no matches
- No `findMany` / no new API routes in this diff (new master CI gates n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYaUAPYsZrge6R65sLR7Fp