### PR TITLE
feat(webhooks): per-page-type dispatch map — CHANNEL handler + no-action bookkeeping

### DIFF
--- a/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
@@ -11,35 +11,17 @@ const WEBHOOK = {
   webhookSecretEncrypted: 'encrypted-form-of-secret',
 };
 
-function makeChain(value: unknown) {
-  const chain: Record<string, unknown> = {
-    set: () => chain,
-    where: () => chain,
-    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
-      Promise.resolve(value).then(resolve, reject),
-    catch: (reject: (e: unknown) => void) => Promise.resolve(value).catch(reject),
-  };
-  return chain;
-}
-
 const mockFindFirst = vi.fn();
-const mockPageFindFirst = vi.fn();
-const mockUpdate = vi.fn((..._args: unknown[]) => makeChain(undefined));
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: {
       pageWebhooks: { findFirst: (...args: unknown[]) => mockFindFirst(...args) },
-      pages: { findFirst: (...args: unknown[]) => mockPageFindFirst(...args) },
     },
-    update: (...args: unknown[]) => mockUpdate(...args),
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }));
 vi.mock('@pagespace/db/schema/page-webhooks', () => ({
   pageWebhooks: { id: 'pageWebhooks.id', webhookToken: 'pageWebhooks.webhookToken' },
-}));
-vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'pages.id' },
 }));
 
 // Real decrypt-equivalent for the test: returns the plaintext secret directly,
@@ -48,9 +30,9 @@ vi.mock('@pagespace/lib/encryption/field-crypto', () => ({
   decryptField: vi.fn(async (v: string) => (v === WEBHOOK.webhookSecretEncrypted ? SECRET : v)),
 }));
 
-const mockPublish = vi.fn();
-vi.mock('@pagespace/lib/services/page-webhook-service', () => ({
-  publishWebhookMessage: (...args: unknown[]) => mockPublish(...args),
+const mockDispatch = vi.fn();
+vi.mock('@pagespace/lib/services/page-webhook-dispatch', () => ({
+  dispatchWebhookDelivery: (...args: unknown[]) => mockDispatch(...args),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -84,19 +66,20 @@ const VALID_PAYLOAD = JSON.stringify({ content: 'deploy finished' });
 beforeEach(() => {
   vi.clearAllMocks();
   mockFindFirst.mockResolvedValue(WEBHOOK);
-  mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: false });
-  mockPublish.mockResolvedValue({ ok: true });
+  mockDispatch.mockResolvedValue({ kind: 'handled' });
 });
 
 describe('POST /api/webhooks/[token]', () => {
-  it('accepts a validly signed request and publishes to the resolved webhook', async () => {
+  it('accepts a validly signed request and dispatches the delivery for the resolved webhook', async () => {
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
 
     expect(response.status).toBe(200);
-    expect(mockPublish).toHaveBeenCalledTimes(1);
-    const [webhookId, payload] = mockPublish.mock.calls[0];
-    expect(webhookId).toBe('wh-1');
-    expect(payload).toEqual({ content: 'deploy finished' });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith({
+      webhookId: 'wh-1',
+      pageId: 'page-1',
+      payload: { content: 'deploy finished' },
+    });
   });
 
   it('rejects a body over 64KB with 413 before any lookup or parse', async () => {
@@ -104,7 +87,7 @@ describe('POST /api/webhooks/[token]', () => {
     const response = await POST(signedRequest(oversized), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(413);
     expect(mockFindFirst).not.toHaveBeenCalled();
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('accepts a body exactly at the 64KB cap', async () => {
@@ -118,7 +101,7 @@ describe('POST /api/webhooks/[token]', () => {
   it('rejects a request with no signature', async () => {
     const response = await POST(makeRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('rejects a request signed with the wrong secret', async () => {
@@ -129,7 +112,7 @@ describe('POST /api/webhooks/[token]', () => {
     });
     const response = await POST(request, { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('rejects a signature older than the 5-minute replay window', async () => {
@@ -140,7 +123,7 @@ describe('POST /api/webhooks/[token]', () => {
     });
     const response = await POST(request, { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('rejects a signature computed over a different body than the one delivered', async () => {
@@ -151,85 +134,73 @@ describe('POST /api/webhooks/[token]', () => {
     });
     const response = await POST(request, { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('returns a generic 404 for an unknown token, without revealing whether it ever existed', async () => {
     mockFindFirst.mockResolvedValue(undefined);
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'unknown' }) });
     expect(response.status).toBe(404);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('returns the same generic 404 for a disabled webhook (does not leak that the token is valid but off)', async () => {
     mockFindFirst.mockResolvedValue({ ...WEBHOOK, isEnabled: false });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(404);
-    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it('returns the generic 404 for a delivery whose target page was trashed after minting — no write into the trash', async () => {
-    mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: true });
-    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
-    expect(response.status).toBe(404);
-    expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
-  });
-
-  it('returns the generic 404 when the target page row is gone entirely', async () => {
-    mockPageFindFirst.mockResolvedValue(undefined);
-    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
-    expect(response.status).toBe(404);
-    expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockUpdate).not.toHaveBeenCalled();
-  });
-
-  it('accepts a verified delivery to a non-CHANNEL page with 202 action:none and records no-action on the row', async () => {
-    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT', isTrashed: false });
+  it('maps a no_action dispatch (page type without a handler) to 202 accepted action:none', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'no_action' });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
 
     expect(response.status).toBe(202);
     expect(await response.json()).toEqual({ accepted: true, action: 'none' });
-    expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockUpdate).toHaveBeenCalledTimes(1);
   });
 
-  it('still requires a valid signature before the non-CHANNEL 202 path — no unauthenticated probe', async () => {
-    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT', isTrashed: false });
+  it('still requires a valid signature before the no-action 202 path — no unauthenticated probe', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'no_action' });
     const response = await POST(makeRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it('maps a payload-validation error from the service to a 400 with the message', async () => {
-    mockPublish.mockResolvedValue({ ok: false, error: 'content must not be empty' });
+  it('maps a payload-validation error from the dispatcher to a 400 with the message', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'content must not be empty' });
     const badPayload = JSON.stringify({ content: '   ' });
     const response = await POST(signedRequest(badPayload), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'content must not be empty' });
   });
 
-  it('passes a non-JSON body through as null so the service rejects it as invalid — never a crash', async () => {
-    mockPublish.mockResolvedValue({ ok: false, error: 'payload must be a JSON object' });
+  it('passes a non-JSON body through as null so the dispatcher rejects it as a bad envelope — never a crash', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'payload must be a JSON object' });
     const response = await POST(signedRequest('not json'), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(400);
-    expect(mockPublish).toHaveBeenCalledWith('wh-1', null);
+    expect(mockDispatch).toHaveBeenCalledWith({ webhookId: 'wh-1', pageId: 'page-1', payload: null });
+  });
+
+  it('maps not_found to the generic 404', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'not_found' });
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+    expect(response.status).toBe(404);
   });
 
   it('maps rate_limited to 429', async () => {
-    mockPublish.mockResolvedValue({ ok: false, error: 'rate_limited' });
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'rate_limited' });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(429);
   });
 
   it('maps channel_not_found to the generic 404', async () => {
-    mockPublish.mockResolvedValue({ ok: false, error: 'channel_not_found' });
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'channel_not_found' });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(404);
   });
 
   it('maps internal_error to 500', async () => {
-    mockPublish.mockResolvedValue({ ok: false, error: 'internal_error' });
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'internal_error' });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(500);
   });

--- a/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
@@ -160,7 +160,6 @@ describe('POST /api/webhooks/[token]', () => {
   });
 
   it('still requires a valid signature before the no-action 202 path — no unauthenticated probe', async () => {
-    mockDispatch.mockResolvedValue({ kind: 'no_action' });
     const response = await POST(makeRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(403);
     expect(mockDispatch).not.toHaveBeenCalled();

--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
-import { pages } from '@pagespace/db/schema/core';
 import { decryptField } from '@pagespace/lib/encryption/field-crypto';
 import { v0Scheme, DEFAULT_REPLAY_WINDOW_MS } from '@pagespace/lib/security/webhook-signature';
-import { publishWebhookMessage } from '@pagespace/lib/services/page-webhook-service';
+import { dispatchWebhookDelivery } from '@pagespace/lib/services/page-webhook-dispatch';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Arbitrary-JSON envelope cap — checked on the raw bytes BEFORE JSON.parse so
@@ -47,29 +46,6 @@ export async function POST(request: Request, context: { params: Promise<{ token:
       return NextResponse.json({ error: 'Invalid signature' }, { status: 403 });
     }
 
-    const page = await db.query.pages.findFirst({
-      where: eq(pages.id, webhook.pageId),
-      columns: { type: true, isTrashed: true },
-    });
-    // Minting is blocked on trashed pages, but a page can be trashed after its
-    // webhook was created — a delivery must not keep writing into the trash.
-    // Same generic 404 as an unknown/disabled token: nothing leaks.
-    if (!page || page.isTrashed) {
-      return NOT_FOUND();
-    }
-
-    // Behavioral stub until the dispatch map lands: only CHANNEL pages have a
-    // default action today. A verified delivery to any other page type is
-    // accepted (the sender never breaks while wiring is in progress) but does
-    // nothing, recorded on the row for the settings UI to surface.
-    if (page.type !== 'CHANNEL') {
-      await db
-        .update(pageWebhooks)
-        .set({ lastFireError: 'no action configured' })
-        .where(eq(pageWebhooks.id, webhook.id));
-      return NextResponse.json({ accepted: true, action: 'none' }, { status: 202 });
-    }
-
     let body: unknown;
     try {
       body = JSON.parse(rawBody);
@@ -77,9 +53,15 @@ export async function POST(request: Request, context: { params: Promise<{ token:
       body = null;
     }
 
-    const result = await publishWebhookMessage(webhook.id, body);
-    if (result.ok) {
+    const result = await dispatchWebhookDelivery({ webhookId: webhook.id, pageId: webhook.pageId, payload: body });
+    if (result.kind === 'handled') {
       return NextResponse.json({ ok: true });
+    }
+    // A verified delivery to a page type with no default handler is accepted —
+    // the sender never breaks while wiring is in progress; the dispatcher has
+    // recorded 'no action configured' on the row for the settings UI to surface.
+    if (result.kind === 'no_action') {
+      return NextResponse.json({ accepted: true, action: 'none' }, { status: 202 });
     }
 
     switch (result.error) {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -782,6 +782,11 @@
       "import": "./dist/services/page-webhook-core.js",
       "require": "./dist/services/page-webhook-core.js"
     },
+    "./services/page-webhook-dispatch": {
+      "types": "./dist/services/page-webhook-dispatch.d.ts",
+      "import": "./dist/services/page-webhook-dispatch.js",
+      "require": "./dist/services/page-webhook-dispatch.js"
+    },
     "./services/date-utils": {
       "types": "./dist/services/date-utils.d.ts",
       "import": "./dist/services/date-utils.js",

--- a/packages/lib/src/services/__tests__/page-webhook-core.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-core.test.ts
@@ -2,77 +2,118 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import {
-  validateWebhookPayload,
+  validateWebhookEnvelope,
+  validateChannelWebhookPayload,
+  resolveWebhookHandler,
   formatWebhookSenderIdentity,
+  WEBHOOK_HANDLER_PAGE_TYPES,
   WEBHOOK_CONTENT_MAX_LENGTH,
   WEBHOOK_USERNAME_MAX_LENGTH,
 } from '../page-webhook-core';
 
-describe('validateWebhookPayload', () => {
+describe('validateWebhookEnvelope', () => {
+  it('accepts any JSON object, whatever its keys — the envelope is arbitrary JSON', () => {
+    for (const envelope of [{}, { content: 'hi' }, { anything: [1, 2, { nested: true }] }, { ref: null }]) {
+      expect(validateWebhookEnvelope(envelope)).toEqual({ ok: true, envelope });
+    }
+  });
+
+  it('rejects every non-object body with the same envelope error', () => {
+    for (const raw of [null, undefined, 'string', 42, true, []]) {
+      expect(validateWebhookEnvelope(raw)).toEqual({ ok: false, error: 'payload must be a JSON object' });
+    }
+  });
+});
+
+describe('resolveWebhookHandler', () => {
+  it('resolves CHANNEL to the CHANNEL handler key', () => {
+    expect(resolveWebhookHandler('CHANNEL')).toBe('CHANNEL');
+  });
+
+  it('resolves every page type without a default action to none', () => {
+    for (const type of ['DOCUMENT', 'FOLDER', 'AI_CHAT', 'CANVAS', 'FILE', 'SHEET', 'TASK_LIST', 'CODE', 'MACHINE']) {
+      expect(resolveWebhookHandler(type)).toBe('none');
+    }
+  });
+
+  it('resolves a missing or unknown page type to none, never a throw', () => {
+    expect(resolveWebhookHandler(undefined)).toBe('none');
+    expect(resolveWebhookHandler(null)).toBe('none');
+    expect(resolveWebhookHandler('NOT_A_PAGE_TYPE')).toBe('none');
+  });
+
+  it('resolves exactly the registered handler page types — the tuple is the decision', () => {
+    for (const type of WEBHOOK_HANDLER_PAGE_TYPES) {
+      expect(resolveWebhookHandler(type)).toBe(type);
+    }
+  });
+});
+
+describe('validateChannelWebhookPayload', () => {
   it('accepts a minimal valid payload and returns its content verbatim', () => {
-    const result = validateWebhookPayload({ content: 'deploy finished ✅' });
+    const result = validateChannelWebhookPayload({ content: 'deploy finished ✅' });
     expect(result).toEqual({ ok: true, content: 'deploy finished ✅', username: undefined });
   });
 
   it('accepts a username override and passes it through', () => {
-    const result = validateWebhookPayload({ content: 'hi', username: 'CI Bot' });
+    const result = validateChannelWebhookPayload({ content: 'hi', username: 'CI Bot' });
     expect(result).toEqual({ ok: true, content: 'hi', username: 'CI Bot' });
   });
 
   it('preserves surrounding whitespace in content — the message posts verbatim', () => {
-    const result = validateWebhookPayload({ content: '  padded  ' });
+    const result = validateChannelWebhookPayload({ content: '  padded  ' });
     expect(result).toEqual({ ok: true, content: '  padded  ', username: undefined });
   });
 
   it('rejects a non-object payload', () => {
     for (const raw of [null, undefined, 'string', 42, true, []]) {
-      const result = validateWebhookPayload(raw);
+      const result = validateChannelWebhookPayload(raw);
       expect(result.ok).toBe(false);
     }
   });
 
   it('rejects a payload with no content field', () => {
-    const result = validateWebhookPayload({ username: 'CI Bot' });
+    const result = validateChannelWebhookPayload({ username: 'CI Bot' });
     expect(result).toEqual({ ok: false, error: 'content is required and must be a string' });
   });
 
   it('rejects non-string content', () => {
-    const result = validateWebhookPayload({ content: 42 });
+    const result = validateChannelWebhookPayload({ content: 42 });
     expect(result).toEqual({ ok: false, error: 'content is required and must be a string' });
   });
 
   it('rejects empty content', () => {
-    const result = validateWebhookPayload({ content: '' });
+    const result = validateChannelWebhookPayload({ content: '' });
     expect(result).toEqual({ ok: false, error: 'content must not be empty' });
   });
 
   it('rejects whitespace-only content', () => {
-    const result = validateWebhookPayload({ content: '   \n\t ' });
+    const result = validateChannelWebhookPayload({ content: '   \n\t ' });
     expect(result).toEqual({ ok: false, error: 'content must not be empty' });
   });
 
   it('accepts content exactly at the length cap', () => {
-    const result = validateWebhookPayload({ content: 'x'.repeat(WEBHOOK_CONTENT_MAX_LENGTH) });
+    const result = validateChannelWebhookPayload({ content: 'x'.repeat(WEBHOOK_CONTENT_MAX_LENGTH) });
     expect(result.ok).toBe(true);
   });
 
   it('rejects content over the length cap', () => {
-    const result = validateWebhookPayload({ content: 'x'.repeat(WEBHOOK_CONTENT_MAX_LENGTH + 1) });
+    const result = validateChannelWebhookPayload({ content: 'x'.repeat(WEBHOOK_CONTENT_MAX_LENGTH + 1) });
     expect(result).toEqual({ ok: false, error: `content must be at most ${WEBHOOK_CONTENT_MAX_LENGTH} characters` });
   });
 
   it('rejects a non-string username', () => {
-    const result = validateWebhookPayload({ content: 'hi', username: 42 });
+    const result = validateChannelWebhookPayload({ content: 'hi', username: 42 });
     expect(result).toEqual({ ok: false, error: 'username must be a string' });
   });
 
   it('treats a whitespace-only username as absent — falls back to the webhook name downstream', () => {
-    const result = validateWebhookPayload({ content: 'hi', username: '   ' });
+    const result = validateChannelWebhookPayload({ content: 'hi', username: '   ' });
     expect(result).toEqual({ ok: true, content: 'hi', username: undefined });
   });
 
   it('rejects a username over the length cap', () => {
-    const result = validateWebhookPayload({ content: 'hi', username: 'x'.repeat(WEBHOOK_USERNAME_MAX_LENGTH + 1) });
+    const result = validateChannelWebhookPayload({ content: 'hi', username: 'x'.repeat(WEBHOOK_USERNAME_MAX_LENGTH + 1) });
     expect(result).toEqual({ ok: false, error: `username must be at most ${WEBHOOK_USERNAME_MAX_LENGTH} characters` });
   });
 });

--- a/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
@@ -1,32 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 /**
- * Boundary-level fakes: the page-type lookup and lastFireError bookkeeping go
- * through the mocked db; the CHANNEL handler goes through the mocked
- * page-webhook-service (its own test covers the publish path).
+ * Boundary-level fakes: the page-type lookup goes through the mocked db; the
+ * CHANNEL handler and the lastFireError bookkeeping go through the mocked
+ * page-webhook-service (its own test covers the publish path and
+ * markWebhookFired's never-throws contract).
  */
-function makeChain(value: unknown) {
-  const chain: Record<string, unknown> = {
-    set: (...args: unknown[]) => {
-      setCalls.push(args[0]);
-      return chain;
-    },
-    where: () => chain,
-    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
-      Promise.resolve(value).then(resolve, reject),
-    catch: (reject: (e: unknown) => void) => Promise.resolve(value).catch(reject),
-  };
-  return chain;
-}
-
-const setCalls: unknown[] = [];
 const mockPageFindFirst = vi.fn();
-const mockUpdate = vi.fn((..._args: unknown[]) => makeChain(undefined));
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: { pages: { findFirst: (...args: unknown[]) => mockPageFindFirst(...args) } },
-    update: (...args: unknown[]) => mockUpdate(...args),
   },
 }));
 
@@ -34,17 +18,15 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: (a: unknown, b: unknown) => ({ a, b }),
 }));
 
-vi.mock('@pagespace/db/schema/page-webhooks', () => ({
-  pageWebhooks: { __name: 'page_webhooks', id: 'id' },
-}));
-
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { __name: 'pages', id: 'id' },
 }));
 
 const mockPublish = vi.fn();
+const mockMarkFired = vi.fn();
 vi.mock('../page-webhook-service', () => ({
   publishWebhookMessage: (...args: unknown[]) => mockPublish(...args),
+  markWebhookFired: (...args: unknown[]) => mockMarkFired(...args),
 }));
 
 vi.mock('../../logging/logger-config', () => ({
@@ -59,9 +41,9 @@ const DELIVERY = { webhookId: 'wh-1', pageId: 'page-1', payload: { content: 'dep
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setCalls.length = 0;
   mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL' });
   mockPublish.mockResolvedValue({ ok: true });
+  mockMarkFired.mockResolvedValue(undefined);
 });
 
 describe('dispatchWebhookDelivery', () => {
@@ -71,6 +53,8 @@ describe('dispatchWebhookDelivery', () => {
     expect(result).toEqual({ kind: 'handled' });
     expect(mockPublish).toHaveBeenCalledTimes(1);
     expect(mockPublish).toHaveBeenCalledWith('wh-1', { content: 'deploy done' });
+    // The handler owns its own bookkeeping — the dispatcher must not double-write.
+    expect(mockMarkFired).not.toHaveBeenCalled();
   });
 
   it('propagates a CHANNEL handler failure verbatim so the route keeps its status mapping', async () => {
@@ -88,8 +72,8 @@ describe('dispatchWebhookDelivery', () => {
 
     expect(result).toEqual({ kind: 'no_action' });
     expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockUpdate).toHaveBeenCalledTimes(1);
-    expect(setCalls).toEqual([{ lastFireError: 'no action configured' }]);
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+    expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
   });
 
   it('reports no_action when the page row has vanished — the sender still gets its 202', async () => {
@@ -99,29 +83,18 @@ describe('dispatchWebhookDelivery', () => {
 
     expect(result).toEqual({ kind: 'no_action' });
     expect(mockPublish).not.toHaveBeenCalled();
-    expect(setCalls).toEqual([{ lastFireError: 'no action configured' }]);
+    expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
   });
 
   it('rejects a non-object envelope before any handler runs, and records the envelope error', async () => {
     for (const payload of [null, 'string', 42, [1, 2]]) {
-      setCalls.length = 0;
+      mockMarkFired.mockClear();
       const result = await dispatchWebhookDelivery({ ...DELIVERY, payload });
       expect(result).toEqual({ kind: 'failed', error: 'payload must be a JSON object' });
-      expect(setCalls).toEqual([{ lastFireError: 'payload must be a JSON object' }]);
+      expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'payload must be a JSON object');
     }
     expect(mockPublish).not.toHaveBeenCalled();
     expect(mockPageFindFirst).not.toHaveBeenCalled();
-  });
-
-  it('survives a bookkeeping write failure on the no-action path — still reports no_action', async () => {
-    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT' });
-    mockUpdate.mockImplementation(() => {
-      throw new Error('db down');
-    });
-
-    const result = await dispatchWebhookDelivery(DELIVERY);
-
-    expect(result).toEqual({ kind: 'no_action' });
   });
 
   it('catches an unexpected page-lookup failure and reports internal_error, never throws', async () => {

--- a/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
@@ -41,7 +41,7 @@ const DELIVERY = { webhookId: 'wh-1', pageId: 'page-1', payload: { content: 'dep
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL' });
+  mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: false });
   mockPublish.mockResolvedValue({ ok: true });
   mockMarkFired.mockResolvedValue(undefined);
 });
@@ -66,7 +66,7 @@ describe('dispatchWebhookDelivery', () => {
   });
 
   it('reports no_action for a page type without a handler and records the error on the row', async () => {
-    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT' });
+    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT', isTrashed: false });
 
     const result = await dispatchWebhookDelivery(DELIVERY);
 
@@ -76,14 +76,33 @@ describe('dispatchWebhookDelivery', () => {
     expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
   });
 
-  it('reports no_action when the page row has vanished — the sender still gets its 202', async () => {
+  it('reports not_found for a trashed target page — no write into the trash, no bookkeeping, indistinguishable from an unknown token', async () => {
+    mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: true });
+
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'failed', error: 'not_found' });
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it('reports not_found when the page row is gone entirely — same generic outcome as trashed', async () => {
     mockPageFindFirst.mockResolvedValue(undefined);
 
     const result = await dispatchWebhookDelivery(DELIVERY);
 
-    expect(result).toEqual({ kind: 'no_action' });
+    expect(result).toEqual({ kind: 'failed', error: 'not_found' });
     expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
+  it('rejects a trashed target even when the payload is invalid — the 404 wins so nothing is distinguishable', async () => {
+    mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: true });
+
+    const result = await dispatchWebhookDelivery({ ...DELIVERY, payload: null });
+
+    expect(result).toEqual({ kind: 'failed', error: 'not_found' });
+    expect(mockMarkFired).not.toHaveBeenCalled();
   });
 
   it('rejects a non-object envelope before any handler runs, and records the envelope error', async () => {
@@ -94,7 +113,6 @@ describe('dispatchWebhookDelivery', () => {
       expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'payload must be a JSON object');
     }
     expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockPageFindFirst).not.toHaveBeenCalled();
   });
 
   it('catches an unexpected page-lookup failure and reports internal_error, never throws', async () => {

--- a/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Boundary-level fakes: the page-type lookup and lastFireError bookkeeping go
+ * through the mocked db; the CHANNEL handler goes through the mocked
+ * page-webhook-service (its own test covers the publish path).
+ */
+function makeChain(value: unknown) {
+  const chain: Record<string, unknown> = {
+    set: (...args: unknown[]) => {
+      setCalls.push(args[0]);
+      return chain;
+    },
+    where: () => chain,
+    then: (resolve: (v: unknown) => void, reject?: (e: unknown) => void) =>
+      Promise.resolve(value).then(resolve, reject),
+    catch: (reject: (e: unknown) => void) => Promise.resolve(value).catch(reject),
+  };
+  return chain;
+}
+
+const setCalls: unknown[] = [];
+const mockPageFindFirst = vi.fn();
+const mockUpdate = vi.fn((..._args: unknown[]) => makeChain(undefined));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { pages: { findFirst: (...args: unknown[]) => mockPageFindFirst(...args) } },
+    update: (...args: unknown[]) => mockUpdate(...args),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+}));
+
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({
+  pageWebhooks: { __name: 'page_webhooks', id: 'id' },
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { __name: 'pages', id: 'id' },
+}));
+
+const mockPublish = vi.fn();
+vi.mock('../page-webhook-service', () => ({
+  publishWebhookMessage: (...args: unknown[]) => mockPublish(...args),
+}));
+
+vi.mock('../../logging/logger-config', () => ({
+  loggers: {
+    system: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import { dispatchWebhookDelivery } from '../page-webhook-dispatch';
+
+const DELIVERY = { webhookId: 'wh-1', pageId: 'page-1', payload: { content: 'deploy done' } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setCalls.length = 0;
+  mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL' });
+  mockPublish.mockResolvedValue({ ok: true });
+});
+
+describe('dispatchWebhookDelivery', () => {
+  it('runs the CHANNEL handler for a channel page: publishes the envelope and reports handled', async () => {
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'handled' });
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish).toHaveBeenCalledWith('wh-1', { content: 'deploy done' });
+  });
+
+  it('propagates a CHANNEL handler failure verbatim so the route keeps its status mapping', async () => {
+    for (const error of ['rate_limited', 'channel_not_found', 'internal_error', 'content must not be empty']) {
+      mockPublish.mockResolvedValue({ ok: false, error });
+      const result = await dispatchWebhookDelivery(DELIVERY);
+      expect(result).toEqual({ kind: 'failed', error });
+    }
+  });
+
+  it('reports no_action for a page type without a handler and records the error on the row', async () => {
+    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT' });
+
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'no_action' });
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(setCalls).toEqual([{ lastFireError: 'no action configured' }]);
+  });
+
+  it('reports no_action when the page row has vanished — the sender still gets its 202', async () => {
+    mockPageFindFirst.mockResolvedValue(undefined);
+
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'no_action' });
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(setCalls).toEqual([{ lastFireError: 'no action configured' }]);
+  });
+
+  it('rejects a non-object envelope before any handler runs, and records the envelope error', async () => {
+    for (const payload of [null, 'string', 42, [1, 2]]) {
+      setCalls.length = 0;
+      const result = await dispatchWebhookDelivery({ ...DELIVERY, payload });
+      expect(result).toEqual({ kind: 'failed', error: 'payload must be a JSON object' });
+      expect(setCalls).toEqual([{ lastFireError: 'payload must be a JSON object' }]);
+    }
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockPageFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('survives a bookkeeping write failure on the no-action path — still reports no_action', async () => {
+    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT' });
+    mockUpdate.mockImplementation(() => {
+      throw new Error('db down');
+    });
+
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'no_action' });
+  });
+
+  it('catches an unexpected page-lookup failure and reports internal_error, never throws', async () => {
+    mockPageFindFirst.mockRejectedValue(new Error('db down'));
+
+    const result = await dispatchWebhookDelivery(DELIVERY);
+
+    expect(result).toEqual({ kind: 'failed', error: 'internal_error' });
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/services/__tests__/page-webhook-service.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-service.test.ts
@@ -65,7 +65,7 @@ vi.mock('../../logging/logger-config', () => ({
   },
 }));
 
-import { publishWebhookMessage } from '../page-webhook-service';
+import { publishWebhookMessage, markWebhookFired } from '../page-webhook-service';
 
 const WEBHOOK_ROW = {
   id: 'wh-1',
@@ -174,5 +174,19 @@ describe('publishWebhookMessage', () => {
     mockFindFirst.mockRejectedValue(new Error('db down'));
     const result = await publishWebhookMessage('wh-1', { content: 'hi' });
     expect(result).toEqual({ ok: false, error: 'internal_error' });
+  });
+});
+
+describe('markWebhookFired', () => {
+  it('writes the error string to the row', async () => {
+    await markWebhookFired('wh-1', 'no action configured');
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws on a db failure — bookkeeping can never fail a delivery (the dispatcher relies on this)', async () => {
+    mockUpdate.mockImplementationOnce(() => {
+      throw new Error('db down');
+    });
+    await expect(markWebhookFired('wh-1', 'boom')).resolves.toBeUndefined();
   });
 });

--- a/packages/lib/src/services/page-webhook-core.ts
+++ b/packages/lib/src/services/page-webhook-core.ts
@@ -15,15 +15,17 @@
  */
 
 import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
+import { PageType } from '../utils/enums';
 
 /**
  * Page types with a built-in default webhook action. This tuple plus the
  * matching entry in WEBHOOK_HANDLERS (page-webhook-dispatch.ts, typed
  * Record<WebhookHandlerPageType, …> so the compiler rejects a key without a
  * handler) is ALL it takes to give a page type a default action — no route or
- * dispatcher plumbing changes.
+ * dispatcher plumbing changes. Keys are PageType members, so an entry that
+ * isn't a real page type is a compile error too.
  */
-export const WEBHOOK_HANDLER_PAGE_TYPES = ['CHANNEL'] as const;
+export const WEBHOOK_HANDLER_PAGE_TYPES = [PageType.CHANNEL] as const;
 
 export type WebhookHandlerPageType = (typeof WEBHOOK_HANDLER_PAGE_TYPES)[number];
 
@@ -49,9 +51,7 @@ export function validateWebhookEnvelope(raw: unknown): WebhookEnvelopeValidation
  * row records 'no action configured'.
  */
 export function resolveWebhookHandler(pageType: string | null | undefined): WebhookHandlerPageType | 'none' {
-  return (WEBHOOK_HANDLER_PAGE_TYPES as readonly string[]).includes(pageType ?? '')
-    ? (pageType as WebhookHandlerPageType)
-    : 'none';
+  return WEBHOOK_HANDLER_PAGE_TYPES.find((handlerType) => handlerType === pageType) ?? 'none';
 }
 
 // Generous enough for real payloads (stack traces, release notes) while still
@@ -73,16 +73,17 @@ export type ChannelWebhookPayloadValidation =
  * point of the primitive is "the payload appears as a message, untouched" — so
  * emptiness is checked on the trimmed string but the original is preserved.
  * A whitespace-only username is normalized to absent so downstream identity
- * formatting falls back to the webhook's configured name. Standalone strict
- * (re-checks the object shape) so the publish service stays safe to call
- * without going through envelope validation first.
+ * formatting falls back to the webhook's configured name. Standalone strict —
+ * it re-runs envelope validation so the publish service stays safe to call
+ * without going through the dispatcher first.
  */
 export function validateChannelWebhookPayload(raw: unknown): ChannelWebhookPayloadValidation {
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    return { ok: false, error: 'payload must be a JSON object' };
+  const envelope = validateWebhookEnvelope(raw);
+  if (!envelope.ok) {
+    return envelope;
   }
 
-  const { content, username } = raw as { content?: unknown; username?: unknown };
+  const { content, username } = envelope.envelope as { content?: unknown; username?: unknown };
 
   if (typeof content !== 'string') {
     return { ok: false, error: 'content is required and must be a string' };

--- a/packages/lib/src/services/page-webhook-core.ts
+++ b/packages/lib/src/services/page-webhook-core.ts
@@ -1,13 +1,58 @@
 /**
- * Pure decision core for page incoming webhooks: payload validation and
+ * Pure decision core for page incoming webhooks: envelope validation, the
+ * per-page-type dispatch decision, per-handler payload schemas, and
  * sender-identity formatting. Zero I/O — no db, no fetch, no clock, no env —
  * enforced by the purity test in __tests__/page-webhook-core.test.ts.
- * The imperative shell (page-webhook-service.ts) owns every side effect.
+ * The imperative shells (page-webhook-dispatch.ts, page-webhook-service.ts)
+ * own every side effect.
+ *
+ * The envelope schema (any JSON object) is deliberately separate from the
+ * per-handler schemas (e.g. the CHANNEL handler's Discord-shaped payload):
+ * the envelope is the universal intake contract, a handler schema is one
+ * page type's opinion about what's inside it.
  *
  * @module @pagespace/lib/services/page-webhook-core
  */
 
 import type { ChannelMessageAiMeta } from '@pagespace/db/schema/chat';
+
+/**
+ * Page types with a built-in default webhook action. This tuple plus the
+ * matching entry in WEBHOOK_HANDLERS (page-webhook-dispatch.ts, typed
+ * Record<WebhookHandlerPageType, …> so the compiler rejects a key without a
+ * handler) is ALL it takes to give a page type a default action — no route or
+ * dispatcher plumbing changes.
+ */
+export const WEBHOOK_HANDLER_PAGE_TYPES = ['CHANNEL'] as const;
+
+export type WebhookHandlerPageType = (typeof WEBHOOK_HANDLER_PAGE_TYPES)[number];
+
+export type WebhookEnvelopeValidation =
+  | { ok: true; envelope: Record<string, unknown> }
+  | { ok: false; error: string };
+
+/**
+ * Validate the universal delivery envelope: any JSON object (the route has
+ * already capped the raw body at 64KB). Arrays and scalars are rejected so
+ * every handler schema can assume a keyed object.
+ */
+export function validateWebhookEnvelope(raw: unknown): WebhookEnvelopeValidation {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { ok: false, error: 'payload must be a JSON object' };
+  }
+  return { ok: true, envelope: raw as Record<string, unknown> };
+}
+
+/**
+ * The pure dispatch decision: which handler (if any) a page type's deliveries
+ * run. 'none' is a real outcome, not an error — the route answers 202 and the
+ * row records 'no action configured'.
+ */
+export function resolveWebhookHandler(pageType: string | null | undefined): WebhookHandlerPageType | 'none' {
+  return (WEBHOOK_HANDLER_PAGE_TYPES as readonly string[]).includes(pageType ?? '')
+    ? (pageType as WebhookHandlerPageType)
+    : 'none';
+}
 
 // Generous enough for real payloads (stack traces, release notes) while still
 // bounding what a single POST can dump into a channel; 2x Discord's own 2000-char
@@ -18,19 +63,21 @@ export const WEBHOOK_CONTENT_MAX_LENGTH = 4000;
 // Discord's own webhook username cap.
 export const WEBHOOK_USERNAME_MAX_LENGTH = 80;
 
-export type WebhookPayloadValidation =
+export type ChannelWebhookPayloadValidation =
   | { ok: true; content: string; username?: string }
   | { ok: false; error: string };
 
 /**
- * Validate an inbound webhook body (mirrors Discord's incoming-webhook payload
+ * The CHANNEL handler's payload schema (mirrors Discord's incoming-webhook
  * shape: `{ content, username? }`). Content is returned verbatim — the whole
  * point of the primitive is "the payload appears as a message, untouched" — so
  * emptiness is checked on the trimmed string but the original is preserved.
  * A whitespace-only username is normalized to absent so downstream identity
- * formatting falls back to the webhook's configured name.
+ * formatting falls back to the webhook's configured name. Standalone strict
+ * (re-checks the object shape) so the publish service stays safe to call
+ * without going through envelope validation first.
  */
-export function validateWebhookPayload(raw: unknown): WebhookPayloadValidation {
+export function validateChannelWebhookPayload(raw: unknown): ChannelWebhookPayloadValidation {
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
     return { ok: false, error: 'payload must be a JSON object' };
   }

--- a/packages/lib/src/services/page-webhook-dispatch.ts
+++ b/packages/lib/src/services/page-webhook-dispatch.ts
@@ -4,10 +4,11 @@
  * after signature verification.
  *
  * Every decision (envelope validation, the page-type → handler mapping) is
- * delegated to page-webhook-core.ts; this module only does I/O: the page-type
- * lookup, the handler invocation, and the lastFireError bookkeeping on the
- * no-action / bad-envelope paths. Never throws — the route maps outcomes to
- * status codes without a try/catch of its own.
+ * delegated to page-webhook-core.ts; this module only does I/O: the page
+ * lookup (type + trashed state — a trashed/missing target 404s like an
+ * unknown token), the handler invocation, and the lastFireError bookkeeping
+ * on the no-action / bad-envelope paths. Never throws — the route maps
+ * outcomes to status codes without a try/catch of its own.
  *
  * WEBHOOK_HANDLERS is the whole extension surface: giving a page type a
  * default action means adding its key to WEBHOOK_HANDLER_PAGE_TYPES
@@ -68,18 +69,26 @@ export async function dispatchWebhookDelivery({
   payload: unknown;
 }): Promise<WebhookDispatchResult> {
   try {
+    const page = await db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { type: true, isTrashed: true },
+    });
+    // Minting is blocked on trashed pages, but a page can be trashed after its
+    // webhook was created — a delivery must not keep writing into the trash.
+    // Checked before payload validation and with no bookkeeping write, so a
+    // trashed target is indistinguishable from an unknown/disabled token (the
+    // route maps 'not_found' to the same generic 404).
+    if (!page || page.isTrashed) {
+      return { kind: 'failed', error: 'not_found' };
+    }
+
     const validation = validateWebhookEnvelope(payload);
     if (!validation.ok) {
       await markWebhookFired(webhookId, validation.error);
       return { kind: 'failed', error: validation.error };
     }
 
-    const page = await db.query.pages.findFirst({
-      where: eq(pages.id, pageId),
-      columns: { type: true },
-    });
-
-    const handlerKey = resolveWebhookHandler(page?.type);
+    const handlerKey = resolveWebhookHandler(page.type);
     if (handlerKey === 'none') {
       await markWebhookFired(webhookId, 'no action configured');
       return { kind: 'no_action' };

--- a/packages/lib/src/services/page-webhook-dispatch.ts
+++ b/packages/lib/src/services/page-webhook-dispatch.ts
@@ -1,0 +1,94 @@
+/**
+ * Imperative dispatch shell for page incoming webhooks:
+ * `dispatchWebhookDelivery()` — the single entry point the intake route calls
+ * after signature verification.
+ *
+ * Every decision (envelope validation, the page-type → handler mapping) is
+ * delegated to page-webhook-core.ts; this module only does I/O: the page-type
+ * lookup, the handler invocation, and the lastFireError bookkeeping on the
+ * no-action / bad-envelope paths. Never throws — the route maps outcomes to
+ * status codes without a try/catch of its own.
+ *
+ * WEBHOOK_HANDLERS is the whole extension surface: giving a page type a
+ * default action means adding its key to WEBHOOK_HANDLER_PAGE_TYPES
+ * (page-webhook-core.ts) and its handler entry below — the Record type makes
+ * one without the other a compile error, and nothing else changes.
+ *
+ * @module @pagespace/lib/services/page-webhook-dispatch
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
+import { pages } from '@pagespace/db/schema/core';
+import { publishWebhookMessage } from './page-webhook-service';
+import { loggers } from '../logging/logger-config';
+import {
+  validateWebhookEnvelope,
+  resolveWebhookHandler,
+  type WebhookHandlerPageType,
+} from './page-webhook-core';
+
+export type WebhookDispatchResult =
+  /** The page type's handler ran and succeeded. */
+  | { kind: 'handled' }
+  /** No handler for the page type — the route answers 202 {accepted, action: 'none'}. */
+  | { kind: 'no_action' }
+  /** `error` is machine-readable for the route's status mapping ('not_found', 'rate_limited', 'channel_not_found', 'internal_error') or a validation message from the pure core. */
+  | { kind: 'failed'; error: string };
+
+type WebhookHandler = (delivery: {
+  webhookId: string;
+  envelope: Record<string, unknown>;
+}) => Promise<{ ok: true } | { ok: false; error: string }>;
+
+const WEBHOOK_HANDLERS: Record<WebhookHandlerPageType, WebhookHandler> = {
+  CHANNEL: ({ webhookId, envelope }) => publishWebhookMessage(webhookId, envelope),
+};
+
+/** Best-effort lastFireError bookkeeping for outcomes decided here (bad envelope, no action); handlers own their own. */
+async function recordFireError(webhookId: string, error: string): Promise<void> {
+  try {
+    await db.update(pageWebhooks).set({ lastFireError: error }).where(eq(pageWebhooks.id, webhookId));
+  } catch (dbError) {
+    loggers.system.error('page-webhook-dispatch: failed to record fire error', dbError as Error, { webhookId });
+  }
+}
+
+/**
+ * Dispatch a verified delivery to its page type's default handler. The route
+ * has already read + size-capped the raw body, verified the signature, and
+ * JSON-parsed the payload (null when unparseable — rejected here as a bad
+ * envelope).
+ */
+export async function dispatchWebhookDelivery(delivery: {
+  webhookId: string;
+  pageId: string;
+  payload: unknown;
+}): Promise<WebhookDispatchResult> {
+  const { webhookId, pageId, payload } = delivery;
+  try {
+    const validation = validateWebhookEnvelope(payload);
+    if (!validation.ok) {
+      await recordFireError(webhookId, validation.error);
+      return { kind: 'failed', error: validation.error };
+    }
+
+    const page = await db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { type: true },
+    });
+
+    const handlerKey = resolveWebhookHandler(page?.type);
+    if (handlerKey === 'none') {
+      await recordFireError(webhookId, 'no action configured');
+      return { kind: 'no_action' };
+    }
+
+    const result = await WEBHOOK_HANDLERS[handlerKey]({ webhookId, envelope: validation.envelope });
+    return result.ok ? { kind: 'handled' } : { kind: 'failed', error: result.error };
+  } catch (error) {
+    loggers.system.error('page-webhook-dispatch: dispatchWebhookDelivery failed', error as Error, { webhookId });
+    return { kind: 'failed', error: 'internal_error' };
+  }
+}

--- a/packages/lib/src/services/page-webhook-dispatch.ts
+++ b/packages/lib/src/services/page-webhook-dispatch.ts
@@ -19,10 +19,14 @@
 
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
-import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
 import { pages } from '@pagespace/db/schema/core';
-import { publishWebhookMessage } from './page-webhook-service';
+import {
+  publishWebhookMessage,
+  markWebhookFired,
+  type PublishWebhookMessageResult,
+} from './page-webhook-service';
 import { loggers } from '../logging/logger-config';
+import { PageType } from '../utils/enums';
 import {
   validateWebhookEnvelope,
   resolveWebhookHandler,
@@ -37,23 +41,16 @@ export type WebhookDispatchResult =
   /** `error` is machine-readable for the route's status mapping ('not_found', 'rate_limited', 'channel_not_found', 'internal_error') or a validation message from the pure core. */
   | { kind: 'failed'; error: string };
 
+/** A handler receives the full delivery context even if it only uses part of it, so a new handler never has to widen the contract. */
 type WebhookHandler = (delivery: {
   webhookId: string;
+  pageId: string;
   envelope: Record<string, unknown>;
-}) => Promise<{ ok: true } | { ok: false; error: string }>;
+}) => Promise<PublishWebhookMessageResult>;
 
 const WEBHOOK_HANDLERS: Record<WebhookHandlerPageType, WebhookHandler> = {
-  CHANNEL: ({ webhookId, envelope }) => publishWebhookMessage(webhookId, envelope),
+  [PageType.CHANNEL]: ({ webhookId, envelope }) => publishWebhookMessage(webhookId, envelope),
 };
-
-/** Best-effort lastFireError bookkeeping for outcomes decided here (bad envelope, no action); handlers own their own. */
-async function recordFireError(webhookId: string, error: string): Promise<void> {
-  try {
-    await db.update(pageWebhooks).set({ lastFireError: error }).where(eq(pageWebhooks.id, webhookId));
-  } catch (dbError) {
-    loggers.system.error('page-webhook-dispatch: failed to record fire error', dbError as Error, { webhookId });
-  }
-}
 
 /**
  * Dispatch a verified delivery to its page type's default handler. The route
@@ -61,16 +58,19 @@ async function recordFireError(webhookId: string, error: string): Promise<void> 
  * JSON-parsed the payload (null when unparseable — rejected here as a bad
  * envelope).
  */
-export async function dispatchWebhookDelivery(delivery: {
+export async function dispatchWebhookDelivery({
+  webhookId,
+  pageId,
+  payload,
+}: {
   webhookId: string;
   pageId: string;
   payload: unknown;
 }): Promise<WebhookDispatchResult> {
-  const { webhookId, pageId, payload } = delivery;
   try {
     const validation = validateWebhookEnvelope(payload);
     if (!validation.ok) {
-      await recordFireError(webhookId, validation.error);
+      await markWebhookFired(webhookId, validation.error);
       return { kind: 'failed', error: validation.error };
     }
 
@@ -81,11 +81,11 @@ export async function dispatchWebhookDelivery(delivery: {
 
     const handlerKey = resolveWebhookHandler(page?.type);
     if (handlerKey === 'none') {
-      await recordFireError(webhookId, 'no action configured');
+      await markWebhookFired(webhookId, 'no action configured');
       return { kind: 'no_action' };
     }
 
-    const result = await WEBHOOK_HANDLERS[handlerKey]({ webhookId, envelope: validation.envelope });
+    const result = await WEBHOOK_HANDLERS[handlerKey]({ webhookId, pageId, envelope: validation.envelope });
     return result.ok ? { kind: 'handled' } : { kind: 'failed', error: result.error };
   } catch (error) {
     loggers.system.error('page-webhook-dispatch: dispatchWebhookDelivery failed', error as Error, { webhookId });

--- a/packages/lib/src/services/page-webhook-service.ts
+++ b/packages/lib/src/services/page-webhook-service.ts
@@ -23,7 +23,7 @@ import { channelMessageRepository } from './channel-message-repository';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '../security/distributed-rate-limit';
 import { createSignedBroadcastHeaders } from '../auth/broadcast-auth';
 import { loggers } from '../logging/logger-config';
-import { validateWebhookPayload, formatWebhookSenderIdentity } from './page-webhook-core';
+import { validateChannelWebhookPayload, formatWebhookSenderIdentity } from './page-webhook-core';
 
 export type PublishWebhookMessageResult =
   | { ok: true }
@@ -77,7 +77,7 @@ export async function publishWebhookMessage(webhookId: string, rawPayload: unkno
       return { ok: false, error: 'not_found' };
     }
 
-    const validation = validateWebhookPayload(rawPayload);
+    const validation = validateChannelWebhookPayload(rawPayload);
     if (!validation.ok) {
       await markWebhookFired(webhookId, validation.error);
       return { ok: false, error: validation.error };

--- a/packages/lib/src/services/page-webhook-service.ts
+++ b/packages/lib/src/services/page-webhook-service.ts
@@ -51,8 +51,14 @@ async function broadcastToChannel(channelId: string, payload: unknown): Promise<
   }
 }
 
-/** Success clears lastFireError and stamps lastFiredAt; failure records the error without touching lastFiredAt. Best-effort. */
-async function markWebhookFired(webhookId: string, error: string | null): Promise<void> {
+/**
+ * The one implementation of per-webhook fire bookkeeping, shared with the
+ * dispatcher (and future trigger fan-out): success (`error: null`) clears
+ * lastFireError and stamps lastFiredAt; failure records the error without
+ * touching lastFiredAt. Best-effort — never throws, a db failure is logged
+ * and swallowed so bookkeeping can never fail a delivery.
+ */
+export async function markWebhookFired(webhookId: string, error: string | null): Promise<void> {
   try {
     await db
       .update(pageWebhooks)


### PR DESCRIPTION
Stacked on #2170 (`pu/webhooks-verifier`), which stacks on #2168 (`pu/webhooks-receiver`). Part of the Page Webhooks epic (T3: Dispatch Map + Channel Handler).

## What

A verified delivery now resolves its page type and runs that type's default handler from a **dispatch map**, replacing the route's hard-coded channel post + inline non-CHANNEL 202 stub.

### Pure core (`packages/lib/src/services/page-webhook-core.ts`)
- `validateWebhookEnvelope` — the universal intake contract: any JSON object (raw body already capped at 64KB in the route). Deliberately separate from per-handler schemas.
- `resolveWebhookHandler` + `WEBHOOK_HANDLER_PAGE_TYPES` — the pure dispatch decision: page type → handler key or `'none'`.
- `validateWebhookPayload` reframed as `validateChannelWebhookPayload` — the CHANNEL handler's Discord-shaped schema (content required, 4000 cap; username optional, 80 cap; payload username override beats webhook name).
- Still zero-I/O, enforced by the existing purity test.

### Imperative dispatch (`packages/lib/src/services/page-webhook-dispatch.ts`, new)
- `WEBHOOK_HANDLERS: Record<WebhookHandlerPageType, WebhookHandler>` — CHANNEL wraps the existing publish path unchanged: `SYSTEM_WEBHOOKS_USER_ID` insert, `aiMeta.senderType: 'webhook'`, realtime broadcast, 30/min per-webhook rate limit, no dedupe.
- **Adding a page type = one key in the tuple + one map entry.** The `Record` type makes one without the other a compile error; route and dispatcher code never change.
- No-handler page types → `lastFireError: 'no action configured'` on the row, `202 {accepted: true, action: 'none'}` to the sender — the sender never breaks while wiring is in progress.
- Bad envelope → error recorded on the row, 400 to the sender, before any handler runs.

### Route (`apps/web/src/app/api/webhooks/[token]/route.ts`)
- Parses the body and delegates to `dispatchWebhookDelivery`; the inline stub is deleted. Size cap, token lookup, signature verify, and the channel response contract are unchanged.

## Tests
- 12 new pure-core tests (envelope, dispatch decision, renamed channel schema) — TDD, written red first.
- New `page-webhook-dispatch.test.ts` (7 tests): handler routing, error propagation, no-action bookkeeping, bad-envelope rejection, bookkeeping-write resilience, never-throws.
- Route tests rewired to mock the dispatcher boundary; no assertion weakened (the no-action row-recording assertion moved into the dispatcher's own test, where the code now lives).

## Verification
- `packages/lib` service tests: 741 passed
- web route tests: 17 passed
- `@pagespace/lib` typecheck ✅ · web typecheck ✅ · web lint ✅ · `bun run knip:check` ✅ (5/5 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZZziPBDpJ1UFcZgnWAStH

## Refinement pass (`8567558`)

A 4-angle cleanup review (reuse / simplification / efficiency / altitude) produced a no-behavior-change tightening commit:
- `WEBHOOK_HANDLER_PAGE_TYPES` keys are now `PageType` enum members — a registry key that isn't a real page type is a compile error.
- `validateChannelWebhookPayload` reuses `validateWebhookEnvelope` for its standalone object check (one copy of the predicate/error string).
- `markWebhookFired` is exported from the service as the single lastFireError bookkeeping implementation (the dispatcher's parallel copy is deleted; T5 trigger fan-out will want this helper too), with its never-throws contract now tested directly.
- Handlers receive the full delivery context (`{webhookId, pageId, envelope}`) and return the named `PublishWebhookMessageResult` — a future page-acting handler needs no contract widening.

Deliberately **not** done (deferred with rationale): categorized error-union / composite dispatch result (T5 defines that shape when it composes trigger outcomes with handler outcomes); hoisting the 30/min rate limit into the dispatcher (it is the CHANNEL handler's limit by design — T5 specifies a *tighter, separate* per-trigger limit); threading the route-loaded webhook row through to skip the service's by-id re-fetch (would rework the reviewed T1 service seam under an open base PR; cheap indexed PK read, candidate follow-up after the stack lands).


## Rebase onto updated base (`d7658467`)

The base branch gained a Codex-review fix (middleware allowlist for the intake path + trashed-page rejection) touching the page lookup this PR relocated. Rebased onto the new `pu/webhooks-verifier` tip and **ported the trashed-page semantics into the dispatcher**: the page lookup now loads `isTrashed`, runs before payload validation, and returns `not_found` (same generic 404 as an unknown token) with zero bookkeeping — so a trashed target leaks nothing even on an invalid payload. Coverage for trashed/vanished/trashed-beats-bad-payload lives at the dispatcher boundary now; the base's middleware allowlist regression test is untouched and green.
