### PR TITLE
feat(voice): add Read Aloud button for on-demand TTS

### DIFF
--- a/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
+++ b/apps/web/src/app/api/voice/synthesize/__tests__/route.test.ts
@@ -1,3 +1,12 @@
+// @vitest-environment node
+//
+// This tests a Node.js server route handler, not browser code — running it
+// under jsdom (the project default) creates two competing AbortController/
+// AbortSignal globals (jsdom's polyfill vs. Node's native one), and jsdom's
+// Request constructor rejects a signal from the "wrong" realm with
+// "Expected signal to be an instance of AbortSignal". The route itself runs
+// in a real Node/Edge runtime with a single Fetch API implementation, so
+// `node` here is the more accurate environment, not a workaround.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
@@ -142,6 +151,42 @@ describe('POST /api/voice/synthesize — metering', () => {
 
     const res = await POST(ttsRequest({ text: 'hello' }));
 
+    expect(res.status).toBe(500);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold_1');
+  });
+
+  it('propagates the caller abort signal to the upstream OpenAI request, so a cancelled client request releases the hold without billing', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url: string, opts: RequestInit) => {
+      capturedSignal = opts.signal ?? undefined;
+      return new Promise((_resolve, reject) => {
+        const abort = () => reject(new DOMException('The operation was aborted', 'AbortError'));
+        // The route awaits auth/gating before ever reaching fetch(), so by
+        // then the signal may already be aborted — a listener alone would
+        // miss an abort event that already fired in the past.
+        if (opts.signal?.aborted) {
+          abort();
+          return;
+        }
+        opts.signal?.addEventListener('abort', abort);
+      });
+    }));
+
+    const controller = new AbortController();
+    const request = new Request('http://localhost/api/voice/synthesize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: 'hello' }),
+      signal: controller.signal,
+    });
+
+    const resPromise = POST(request);
+    controller.abort();
+    const res = await resPromise;
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(true);
     expect(res.status).toBe(500);
     expect(mockTrackUsage).not.toHaveBeenCalled();
     expect(mockReleaseHold).toHaveBeenCalledWith('hold_1');

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -158,7 +158,10 @@ export async function POST(request: Request) {
     }
     holdId = gate.holdId;
 
-    // Call OpenAI TTS API
+    // Call OpenAI TTS API. Forwards the caller's abort signal so a client
+    // that cancels mid-request (e.g. Read Aloud's Stop button) also cancels
+    // the upstream request — otherwise it runs to completion and gets
+    // billed regardless of the client having already discarded it.
     const response = await fetch('https://api.openai.com/v1/audio/speech', {
       method: 'POST',
       headers: {
@@ -172,6 +175,7 @@ export async function POST(request: Request) {
         speed: clampedSpeed,
         response_format: 'mp3',
       }),
+      signal: request.signal,
     });
 
     if (!response.ok) {

--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -65,6 +65,12 @@ export interface ChatInputProps {
   onVoiceModeClick?: () => void;
   /** Whether voice mode is currently active */
   isVoiceModeActive?: boolean;
+  /** Callback when the read-aloud button is clicked */
+  onReadAloudClick?: () => void;
+  /** Whether read-aloud is currently playing */
+  isReadingAloud?: boolean;
+  /** Whether there is anything eligible to read aloud right now */
+  canReadAloud?: boolean;
   /** Image attachments for vision support */
   attachments?: ImageAttachment[];
   /** Handler to add image files */
@@ -127,6 +133,9 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onProviderModelChange,
       onVoiceModeClick,
       isVoiceModeActive = false,
+      onReadAloudClick,
+      isReadingAloud = false,
+      canReadAloud = false,
       attachments,
       onAddFiles,
       onRemoveFile,
@@ -305,6 +314,9 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           onClearMicError={clearSpeechError}
           onVoiceModeClick={onVoiceModeClick}
           isVoiceModeActive={isVoiceModeActive}
+          onReadAloudClick={onReadAloudClick}
+          isReadingAloud={isReadingAloud}
+          canReadAloud={canReadAloud}
           selectedProvider={currentProvider}
           selectedModel={currentModel}
           onProviderModelChange={handleProviderModelChange}

--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -12,6 +12,7 @@ import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { isImageGenerationAllowed } from '@/lib/ai/core/image-gen-access';
 import { useSpeechRecognition } from '@/hooks/useSpeechRecognition';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
+import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 import type { ImageAttachment } from '@/lib/ai/shared/hooks/useImageAttachments';
 
 export interface ChatInputProps {
@@ -183,6 +184,15 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       },
     });
 
+    // Starting mic dictation stops Read Aloud first — otherwise the mic can
+    // transcribe the TTS audio it hears right back into the draft.
+    const handleMicClick = useCallback(() => {
+      if (!isListening) {
+        stopReadAloud();
+      }
+      toggleListening();
+    }, [isListening, toggleListening]);
+
     // Mobile keyboard management
     const keyboard = useMobileKeyboard();
     const prevStreamingRef = useRef(isStreaming);
@@ -307,7 +317,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           isMcpServerEnabled={isMcpServerEnabled}
           onMcpServerToggle={onMcpServerToggle}
           showMcp={showMcp}
-          onMicClick={toggleListening}
+          onMicClick={handleMicClick}
           isListening={isListening}
           isMicSupported={isSupported}
           micError={speechError}

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -584,12 +584,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const plainMessages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
-  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
-  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  // user's last turn, via a shared playback singleton (see readAloudPlayer).
+  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
+  // one) since a live call elsewhere plays through its own separate
+  // AudioContext and would overlap with this audio.
   const { isReadingAloud, toggleReadAloud } = useReadAloud();
   const canReadAloud = useMemo(
-    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeActive]
+    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeEnabled]
   );
 
   // "Load older" (epic leaf 6.6, scroll-to-top): AiChatView's route IS the agent-conversation

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -50,6 +50,7 @@ import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnCo
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
+import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 
 // Shared hooks and components
 import {
@@ -1256,6 +1257,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
+      // Voice Mode's mic capture would otherwise pick up read-aloud audio
+      // still playing through the shared singleton.
+      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -585,7 +585,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
   const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
-  const canReadAloud = canReadAloudFor(plainMessages);
+  const canReadAloud = useMemo(() => canReadAloudFor(plainMessages), [canReadAloudFor, plainMessages]);
   const handleReadAloudClick = useCallback(
     () => toggleReadAloud(plainMessages),
     [toggleReadAloud, plainMessages]

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -48,6 +48,8 @@ import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo'
 import { shouldPrependConversation } from '@/lib/ai/streams/shouldPrependConversation';
 import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
+import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
+import { useReadAloud } from '@/hooks/useReadAloud';
 
 // Shared hooks and components
 import {
@@ -580,6 +582,15 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // (see loadMessagesForConversation's docblock for why it is still kept in sync).
   const renderedMessages = useRenderedMessages(page.id, currentConversationId);
   const plainMessages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
+
+  // Read Aloud: on-demand TTS for everything the assistant said since the
+  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
+  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  const { isReadingAloud, toggleReadAloud } = useReadAloud();
+  const canReadAloud = useMemo(
+    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeActive]
+  );
 
   // "Load older" (epic leaf 6.6, scroll-to-top): AiChatView's route IS the agent-conversation
   // route (page.id is the agentId), so the shared agent-mode loader applies directly.
@@ -1518,6 +1529,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                   }}
                   onVoiceModeClick={handleVoiceModeToggle}
                   isVoiceModeActive={isVoiceModeActive}
+                  onReadAloudClick={() => toggleReadAloud(plainMessages)}
+                  isReadingAloud={isReadingAloud}
+                  canReadAloud={canReadAloud}
                   attachments={attachments}
                   onAddFiles={addFiles}
                   onRemoveFile={removeFile}

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -48,9 +48,7 @@ import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo'
 import { shouldPrependConversation } from '@/lib/ai/streams/shouldPrependConversation';
 import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
-import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
-import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 
 // Shared hooks and components
 import {
@@ -586,13 +584,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
-  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
-  // one) since a live call elsewhere plays through its own separate
-  // AudioContext and would overlap with this audio.
-  const { isReadingAloud, toggleReadAloud } = useReadAloud();
-  const canReadAloud = useMemo(
-    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeEnabled]
+  const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
+  const canReadAloud = canReadAloudFor(plainMessages);
+  const handleReadAloudClick = useCallback(
+    () => toggleReadAloud(plainMessages),
+    [toggleReadAloud, plainMessages]
   );
 
   // "Load older" (epic leaf 6.6, scroll-to-top): AiChatView's route IS the agent-conversation
@@ -1252,14 +1248,13 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     prepareSend,
   ]);
 
-  // Voice mode toggle handler
+  // Voice mode toggle handler. Enabling Voice Mode also stops any
+  // in-progress read-aloud playback — enforced inside readAloudPlayer itself
+  // (subscribed to the voice-mode store), not here.
   const handleVoiceModeToggle = useCallback(() => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
-      // Voice Mode's mic capture would otherwise pick up read-aloud audio
-      // still playing through the shared singleton.
-      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);
@@ -1535,7 +1530,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                   }}
                   onVoiceModeClick={handleVoiceModeToggle}
                   isVoiceModeActive={isVoiceModeActive}
-                  onReadAloudClick={() => toggleReadAloud(plainMessages)}
+                  onReadAloudClick={handleReadAloudClick}
                   isReadingAloud={isReadingAloud}
                   canReadAloud={canReadAloud}
                   attachments={attachments}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -108,9 +108,7 @@ import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimi
 import { selectVoiceStreamText } from '@/lib/ai/streams/selectVoiceStreamText';
 import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActivationBaseline';
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
-import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
-import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 import { createId } from '@paralleldrive/cuid2';
 
 const VOICE_OWNER: VoiceModeOwner = 'global-assistant';
@@ -442,13 +440,11 @@ const GlobalAssistantView: React.FC = () => {
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
-  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
-  // one) since a live call elsewhere plays through its own separate
-  // AudioContext and would overlap with this audio.
-  const { isReadingAloud, toggleReadAloud } = useReadAloud();
-  const canReadAloud = useMemo(
-    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeEnabled]
+  const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
+  const canReadAloud = canReadAloudFor(plainMessages);
+  const handleReadAloudClick = useCallback(
+    () => toggleReadAloud(plainMessages),
+    [toggleReadAloud, plainMessages]
   );
   // Loading/error UI reads the cache entry's state (replaces the context's
   // isMessagesLoading and the dashboard store's isConversationMessagesLoading).
@@ -913,14 +909,13 @@ const GlobalAssistantView: React.FC = () => {
     setLastAIResponse((current) => (current?.id === next.id ? current : next));
   }, [renderedMessages, isVoiceModeActive]);
 
-  // Voice mode toggle handler
+  // Voice mode toggle handler. Enabling Voice Mode also stops any
+  // in-progress read-aloud playback — enforced inside readAloudPlayer itself
+  // (subscribed to the voice-mode store), not here.
   const handleVoiceModeToggle = useCallback(() => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
-      // Voice Mode's mic capture would otherwise pick up read-aloud audio
-      // still playing through the shared singleton.
-      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);
@@ -1112,7 +1107,7 @@ const GlobalAssistantView: React.FC = () => {
               popupPlacement={props.inputPosition === 'centered' ? 'bottom' : 'top'}
               onVoiceModeClick={handleVoiceModeToggle}
               isVoiceModeActive={isVoiceModeActive}
-              onReadAloudClick={() => toggleReadAloud(plainMessages)}
+              onReadAloudClick={handleReadAloudClick}
               isReadingAloud={isReadingAloud}
               canReadAloud={canReadAloud}
               attachments={attachments}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -110,6 +110,7 @@ import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActiv
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
 import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
+import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 import { createId } from '@paralleldrive/cuid2';
 
 const VOICE_OWNER: VoiceModeOwner = 'global-assistant';
@@ -917,6 +918,9 @@ const GlobalAssistantView: React.FC = () => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
+      // Voice Mode's mic capture would otherwise pick up read-aloud audio
+      // still playing through the shared singleton.
+      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -440,12 +440,14 @@ const GlobalAssistantView: React.FC = () => {
   const plainMessages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
-  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
-  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  // user's last turn, via a shared playback singleton (see readAloudPlayer).
+  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
+  // one) since a live call elsewhere plays through its own separate
+  // AudioContext and would overlap with this audio.
   const { isReadingAloud, toggleReadAloud } = useReadAloud();
   const canReadAloud = useMemo(
-    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeActive]
+    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeEnabled]
   );
   // Loading/error UI reads the cache entry's state (replaces the context's
   // isMessagesLoading and the dashboard store's isConversationMessagesLoading).

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -441,7 +441,7 @@ const GlobalAssistantView: React.FC = () => {
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
   const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
-  const canReadAloud = canReadAloudFor(plainMessages);
+  const canReadAloud = useMemo(() => canReadAloudFor(plainMessages), [canReadAloudFor, plainMessages]);
   const handleReadAloudClick = useCallback(
     () => toggleReadAloud(plainMessages),
     [toggleReadAloud, plainMessages]

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -108,6 +108,8 @@ import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimi
 import { selectVoiceStreamText } from '@/lib/ai/streams/selectVoiceStreamText';
 import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActivationBaseline';
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
+import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
+import { useReadAloud } from '@/hooks/useReadAloud';
 import { createId } from '@paralleldrive/cuid2';
 
 const VOICE_OWNER: VoiceModeOwner = 'global-assistant';
@@ -436,6 +438,15 @@ const GlobalAssistantView: React.FC = () => {
   // above) never renders post-cutover — it stays the transport/controller only.
   const renderedMessages = useRenderedMessages(streamChannelId ?? '', currentConversationId);
   const plainMessages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
+
+  // Read Aloud: on-demand TTS for everything the assistant said since the
+  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
+  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  const { isReadingAloud, toggleReadAloud } = useReadAloud();
+  const canReadAloud = useMemo(
+    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeActive]
+  );
   // Loading/error UI reads the cache entry's state (replaces the context's
   // isMessagesLoading and the dashboard store's isConversationMessagesLoading).
   const messagesLoadState = useConversationLoadState(currentConversationId);
@@ -1095,6 +1106,9 @@ const GlobalAssistantView: React.FC = () => {
               popupPlacement={props.inputPosition === 'centered' ? 'bottom' : 'top'}
               onVoiceModeClick={handleVoiceModeToggle}
               isVoiceModeActive={isVoiceModeActive}
+              onReadAloudClick={() => toggleReadAloud(plainMessages)}
+              isReadingAloud={isReadingAloud}
+              canReadAloud={canReadAloud}
               attachments={attachments}
               onAddFiles={addFiles}
               onRemoveFile={removeFile}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -44,6 +44,8 @@ import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimi
 import { selectVoiceStreamText } from '@/lib/ai/streams/selectVoiceStreamText';
 import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActivationBaseline';
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
+import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
+import { useReadAloud } from '@/hooks/useReadAloud';
 import { createId } from '@paralleldrive/cuid2';
 import { useStopStream } from '@/hooks/useStopStream';
 import { useOwnStreamMirror } from '@/hooks/useOwnStreamMirror';
@@ -541,6 +543,15 @@ const SidebarChatTab: React.FC = () => {
   const enableVoiceMode = useVoiceModeStore((s) => s.enable);
   const disableVoiceMode = useVoiceModeStore((s) => s.disable);
   const isVoiceModeActive = isVoiceModeEnabled && voiceOwner === VOICE_OWNER;
+
+  // Read Aloud: on-demand TTS for everything the assistant said since the
+  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
+  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  const { isReadingAloud, toggleReadAloud } = useReadAloud();
+  const canReadAloud = useMemo(
+    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeActive]
+  );
 
   // Display preferences
   const { preferences: displayPreferences } = useDisplayPreferences();
@@ -1115,6 +1126,9 @@ const SidebarChatTab: React.FC = () => {
           variant="sidebar"
           onVoiceModeClick={handleVoiceModeToggle}
           isVoiceModeActive={isVoiceModeActive}
+          onReadAloudClick={() => toggleReadAloud(plainMessages)}
+          isReadingAloud={isReadingAloud}
+          canReadAloud={canReadAloud}
           attachments={attachments}
           onAddFiles={addFiles}
           onRemoveFile={removeFile}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -545,12 +545,14 @@ const SidebarChatTab: React.FC = () => {
   const isVoiceModeActive = isVoiceModeEnabled && voiceOwner === VOICE_OWNER;
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
-  // user's last turn. Owns its own useVoiceMode() instance, so it's disabled
-  // whenever VoiceCallPanel's live-call instance is active on this surface.
+  // user's last turn, via a shared playback singleton (see readAloudPlayer).
+  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
+  // one) since a live call elsewhere plays through its own separate
+  // AudioContext and would overlap with this audio.
   const { isReadingAloud, toggleReadAloud } = useReadAloud();
   const canReadAloud = useMemo(
-    () => !isVoiceModeActive && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeActive]
+    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
+    [plainMessages, isVoiceModeEnabled]
   );
 
   // Display preferences

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -44,9 +44,7 @@ import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimi
 import { selectVoiceStreamText } from '@/lib/ai/streams/selectVoiceStreamText';
 import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActivationBaseline';
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
-import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
-import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 import { createId } from '@paralleldrive/cuid2';
 import { useStopStream } from '@/hooks/useStopStream';
 import { useOwnStreamMirror } from '@/hooks/useOwnStreamMirror';
@@ -547,13 +545,11 @@ const SidebarChatTab: React.FC = () => {
 
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
-  // Disabled whenever Voice Mode is enabled on ANY surface (not just this
-  // one) since a live call elsewhere plays through its own separate
-  // AudioContext and would overlap with this audio.
-  const { isReadingAloud, toggleReadAloud } = useReadAloud();
-  const canReadAloud = useMemo(
-    () => !isVoiceModeEnabled && getTextSinceLastUserTurn(plainMessages).trim().length > 0,
-    [plainMessages, isVoiceModeEnabled]
+  const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
+  const canReadAloud = canReadAloudFor(plainMessages);
+  const handleReadAloudClick = useCallback(
+    () => toggleReadAloud(plainMessages),
+    [toggleReadAloud, plainMessages]
   );
 
   // Display preferences
@@ -878,14 +874,13 @@ const SidebarChatTab: React.FC = () => {
     ),
   });
 
-  // Voice mode toggle handler
+  // Voice mode toggle handler. Enabling Voice Mode also stops any
+  // in-progress read-aloud playback — enforced inside readAloudPlayer itself
+  // (subscribed to the voice-mode store), not here.
   const handleVoiceModeToggle = useCallback(() => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
-      // Voice Mode's mic capture would otherwise pick up read-aloud audio
-      // still playing through the shared singleton.
-      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);
@@ -1132,7 +1127,7 @@ const SidebarChatTab: React.FC = () => {
           variant="sidebar"
           onVoiceModeClick={handleVoiceModeToggle}
           isVoiceModeActive={isVoiceModeActive}
-          onReadAloudClick={() => toggleReadAloud(plainMessages)}
+          onReadAloudClick={handleReadAloudClick}
           isReadingAloud={isReadingAloud}
           canReadAloud={canReadAloud}
           attachments={attachments}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -546,7 +546,7 @@ const SidebarChatTab: React.FC = () => {
   // Read Aloud: on-demand TTS for everything the assistant said since the
   // user's last turn, via a shared playback singleton (see readAloudPlayer).
   const { isReadingAloud, toggleReadAloud, canReadAloud: canReadAloudFor } = useReadAloud();
-  const canReadAloud = canReadAloudFor(plainMessages);
+  const canReadAloud = useMemo(() => canReadAloudFor(plainMessages), [canReadAloudFor, plainMessages]);
   const handleReadAloudClick = useCallback(
     () => toggleReadAloud(plainMessages),
     [toggleReadAloud, plainMessages]

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -46,6 +46,7 @@ import { selectVoiceActivationBaseline } from '@/lib/ai/streams/selectVoiceActiv
 import { selectPostBaselineAssistantMessage } from '@/lib/ai/streams/selectPostBaselineAssistantMessage';
 import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { useReadAloud } from '@/hooks/useReadAloud';
+import { stopReadAloud } from '@/lib/voice/readAloudPlayer';
 import { createId } from '@paralleldrive/cuid2';
 import { useStopStream } from '@/hooks/useStopStream';
 import { useOwnStreamMirror } from '@/hooks/useOwnStreamMirror';
@@ -882,6 +883,9 @@ const SidebarChatTab: React.FC = () => {
     if (isVoiceModeActive) {
       disableVoiceMode();
     } else {
+      // Voice Mode's mic capture would otherwise pick up read-aloud audio
+      // still playing through the shared singleton.
+      stopReadAloud();
       enableVoiceMode(VOICE_OWNER);
     }
   }, [isVoiceModeActive, enableVoiceMode, disableVoiceMode]);

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -181,7 +181,7 @@ export function InputFooter({
               variant="ghost"
               size="sm"
               onClick={onReadAloudClick}
-              disabled={!isReadingAloud && (disabled || isVoiceProGated || !canReadAloud)}
+              disabled={!isReadingAloud && (disabled || isVoiceProGated || !canReadAloud || isListening)}
               className={cn(
                 'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
                 isReadingAloud
@@ -195,7 +195,9 @@ export function InputFooter({
                   ? 'Read aloud requires Pro'
                   : isReadingAloud
                     ? 'Stop reading aloud'
-                    : 'Read aloud'}
+                    : isListening
+                      ? 'Read aloud unavailable while dictating'
+                      : 'Read aloud'}
               </span>
             </Button>
           </TooltipTrigger>
@@ -204,7 +206,9 @@ export function InputFooter({
               ? 'Read aloud requires a Pro plan'
               : isReadingAloud
                 ? 'Stop reading aloud'
-                : 'Read aloud'}
+                : isListening
+                  ? 'Read aloud unavailable while dictating'
+                  : 'Read aloud'}
           </TooltipContent>
         </Tooltip>
 

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -180,8 +180,8 @@ export function InputFooter({
             <Button
               variant="ghost"
               size="sm"
-              onClick={isReadingAloud || !isVoiceProGated ? onReadAloudClick : undefined}
-              disabled={isReadingAloud ? false : disabled || isVoiceProGated || !canReadAloud}
+              onClick={onReadAloudClick}
+              disabled={!isReadingAloud && (disabled || isVoiceProGated || !canReadAloud)}
               className={cn(
                 'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
                 isReadingAloud

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -181,7 +181,7 @@ export function InputFooter({
               variant="ghost"
               size="sm"
               onClick={onReadAloudClick}
-              disabled={!isReadingAloud && (disabled || isVoiceProGated || !canReadAloud || isListening)}
+              disabled={!isReadingAloud && (disabled || isVoiceProGated || !canReadAloud)}
               className={cn(
                 'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
                 isReadingAloud

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
-import { Mic, AudioLines, MicOff } from 'lucide-react';
+import { Mic, AudioLines, MicOff, Volume2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProviderModelSelector } from '@/components/ai/chat/input/ProviderModelSelector';
 import { ToolsPopover } from './ToolsPopover';
@@ -61,6 +61,12 @@ export interface InputFooterProps {
   onVoiceModeClick?: () => void;
   /** Whether voice mode is currently active */
   isVoiceModeActive?: boolean;
+  /** Callback when the read-aloud button is clicked */
+  onReadAloudClick?: () => void;
+  /** Whether read-aloud is currently playing */
+  isReadingAloud?: boolean;
+  /** Whether there is anything eligible to read aloud right now */
+  canReadAloud?: boolean;
   /** Error message from microphone/speech recognition */
   micError?: string | null;
   /** Callback to clear the mic error */
@@ -110,6 +116,9 @@ export function InputFooter({
   isMicSupported = true,
   onVoiceModeClick,
   isVoiceModeActive = false,
+  onReadAloudClick,
+  isReadingAloud = false,
+  canReadAloud = false,
   micError,
   onClearMicError,
   selectedProvider,
@@ -164,6 +173,40 @@ export function InputFooter({
             disabled={disabled}
           />
         )}
+
+        {/* Read Aloud button (on-demand TTS for the assistant's last turn) */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={isVoiceProGated ? undefined : onReadAloudClick}
+              disabled={disabled || isVoiceProGated || (!isReadingAloud && !canReadAloud)}
+              className={cn(
+                'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
+                isReadingAloud
+                  ? 'animate-pulse text-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+            >
+              <Volume2 className="h-4 w-4" />
+              <span className="sr-only">
+                {isVoiceProGated
+                  ? 'Read aloud requires Pro'
+                  : isReadingAloud
+                    ? 'Stop reading aloud'
+                    : 'Read aloud'}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            {isVoiceProGated
+              ? 'Read aloud requires a Pro plan'
+              : isReadingAloud
+                ? 'Stop reading aloud'
+                : 'Read aloud'}
+          </TooltipContent>
+        </Tooltip>
 
         {/* Voice Mode button (hands-free STT/TTS) */}
         <Tooltip>

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -180,8 +180,8 @@ export function InputFooter({
             <Button
               variant="ghost"
               size="sm"
-              onClick={isVoiceProGated ? undefined : onReadAloudClick}
-              disabled={disabled || isVoiceProGated || (!isReadingAloud && !canReadAloud)}
+              onClick={isReadingAloud || !isVoiceProGated ? onReadAloudClick : undefined}
+              disabled={isReadingAloud ? false : disabled || isVoiceProGated || !canReadAloud}
               className={cn(
                 'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
                 isReadingAloud

--- a/apps/web/src/hooks/__tests__/useReadAloud.test.ts
+++ b/apps/web/src/hooks/__tests__/useReadAloud.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { useReadAloud } from '../useReadAloud';
+import { startReadAloud, stopReadAloud, isReadAloudPlaying } from '@/lib/voice/readAloudPlayer';
+
+class FakeAudioBufferSourceNode {
+  buffer: unknown = null;
+  onended: (() => void) | null = null;
+  connect(): void {}
+  start(): void {}
+  stop(): void {}
+}
+
+class FakeAudioContext {
+  state = 'running';
+  destination = {};
+  createBufferSource(): FakeAudioBufferSourceNode {
+    return new FakeAudioBufferSourceNode();
+  }
+  decodeAudioData(): Promise<unknown> {
+    return Promise.resolve({});
+  }
+  resume(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('useReadAloud — unmount lifecycle', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+  });
+
+  afterEach(() => {
+    stopReadAloud();
+    vi.unstubAllGlobals();
+  });
+
+  it('stops playback when the only mounted consumer unmounts', () => {
+    const { unmount } = renderHook(() => useReadAloud());
+    startReadAloud(['hello there']);
+    expect(isReadAloudPlaying()).toBe(true);
+
+    unmount();
+
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('does not stop playback when one of several mounted consumers unmounts, only when the last one does', () => {
+    // Simulates the sidebar chat and main chat both being mounted at once.
+    const first = renderHook(() => useReadAloud());
+    const second = renderHook(() => useReadAloud());
+    startReadAloud(['hello there']);
+    expect(isReadAloudPlaying()).toBe(true);
+
+    first.unmount();
+    expect(isReadAloudPlaying()).toBe(true);
+
+    second.unmount();
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useReadAloud.ts
+++ b/apps/web/src/hooks/useReadAloud.ts
@@ -1,33 +1,39 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import type { UIMessage } from 'ai';
-import { useVoiceMode } from './useVoiceMode';
 import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { flushForTts } from '@/lib/voice/chunkForTts';
+import {
+  startReadAloud,
+  stopReadAloud,
+  isReadAloudPlaying,
+  subscribeReadAloud,
+} from '@/lib/voice/readAloudPlayer';
+
+const getServerSnapshot = () => false;
 
 /**
  * On-demand TTS for "read the assistant's last turn aloud" — distinct from
- * full hands-free Voice Mode. Owns its own `useVoiceMode()` instance, so
- * callers must not use this while Voice Mode is active on the same surface:
- * both instances share the same global voice-state store but have
- * independent audio playback, so one can't stop audio started by the other.
+ * full hands-free Voice Mode. Every call site shares the same module-level
+ * playback singleton (`readAloudPlayer`), so starting or stopping from any
+ * mounted chat surface acts on the one real audio source.
  */
 export function useReadAloud() {
-  const { isSpeaking, queueSentence, stopSpeaking } = useVoiceMode();
+  const isReadingAloud = useSyncExternalStore(subscribeReadAloud, isReadAloudPlaying, getServerSnapshot);
 
   const toggleReadAloud = useCallback(
     (messages: readonly UIMessage[]) => {
-      if (isSpeaking) {
-        stopSpeaking();
+      if (isReadAloudPlaying()) {
+        stopReadAloud();
         return;
       }
       const text = getTextSinceLastUserTurn(messages);
       if (!text.trim()) return;
-      flushForTts(text).forEach((chunk) => queueSentence(chunk));
+      startReadAloud(flushForTts(text));
     },
-    [isSpeaking, stopSpeaking, queueSentence]
+    []
   );
 
-  return { isReadingAloud: isSpeaking, toggleReadAloud };
+  return { isReadingAloud, toggleReadAloud };
 }

--- a/apps/web/src/hooks/useReadAloud.ts
+++ b/apps/web/src/hooks/useReadAloud.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import type { UIMessage } from 'ai';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
 import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
@@ -24,7 +24,29 @@ import {
  * itself also stops any in-progress read-aloud the moment either turns on,
  * so this is a pre-check for starting a new read, not the only guard.
  */
+
+// The player is deliberately independent of any one component's lifecycle
+// (that's the whole point of the module singleton — see readAloudPlayer.ts),
+// but if EVERY mounted chat surface unmounts (e.g. the user navigates to a
+// route with no chat UI at all) there is no longer a Stop control reachable
+// anywhere, while synthesis keeps running and billing and audio keeps
+// playing. Ref-counts how many useReadAloud() consumers are currently
+// mounted; stops playback only when the count drops to zero, not on every
+// individual unmount (closing just the sidebar while the main chat is still
+// open must not interrupt a main-chat-initiated read).
+let mountedConsumers = 0;
+
 export function useReadAloud() {
+  useEffect(() => {
+    mountedConsumers += 1;
+    return () => {
+      mountedConsumers -= 1;
+      if (mountedConsumers === 0) {
+        stopReadAloud();
+      }
+    };
+  }, []);
+
   const isReadingAloud = useReadAloudPlayerStore((s) => s.isPlaying);
   const isVoiceModeEnabled = useVoiceModeStore((s) => s.isEnabled);
   const isDictationActive = useDictationActivityStore((s) => s.activeCount > 0);

--- a/apps/web/src/hooks/useReadAloud.ts
+++ b/apps/web/src/hooks/useReadAloud.ts
@@ -1,39 +1,50 @@
 'use client';
 
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback } from 'react';
 import type { UIMessage } from 'ai';
-import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
+import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
+import { getTextSinceLastUserTurn, hasTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { flushForTts } from '@/lib/voice/chunkForTts';
 import {
   startReadAloud,
   stopReadAloud,
-  isReadAloudPlaying,
-  subscribeReadAloud,
+  useReadAloudPlayerStore,
 } from '@/lib/voice/readAloudPlayer';
-
-const getServerSnapshot = () => false;
 
 /**
  * On-demand TTS for "read the assistant's last turn aloud" — distinct from
  * full hands-free Voice Mode. Every call site shares the same module-level
  * playback singleton (`readAloudPlayer`), so starting or stopping from any
  * mounted chat surface acts on the one real audio source.
+ *
+ * Unavailable while Voice Mode is enabled on ANY surface (not just the
+ * current one): a live call elsewhere plays through its own separate
+ * AudioContext and would overlap with this audio. `readAloudPlayer` itself
+ * also stops any in-progress read-aloud the moment Voice Mode turns on, so
+ * this is a pre-check for starting a new read, not the only guard.
  */
 export function useReadAloud() {
-  const isReadingAloud = useSyncExternalStore(subscribeReadAloud, isReadAloudPlaying, getServerSnapshot);
+  const isReadingAloud = useReadAloudPlayerStore((s) => s.isPlaying);
+  const isVoiceModeEnabled = useVoiceModeStore((s) => s.isEnabled);
 
   const toggleReadAloud = useCallback(
     (messages: readonly UIMessage[]) => {
-      if (isReadAloudPlaying()) {
+      if (useReadAloudPlayerStore.getState().isPlaying) {
         stopReadAloud();
         return;
       }
+      if (isVoiceModeEnabled) return;
       const text = getTextSinceLastUserTurn(messages);
       if (!text.trim()) return;
       startReadAloud(flushForTts(text));
     },
-    []
+    [isVoiceModeEnabled]
   );
 
-  return { isReadingAloud, toggleReadAloud };
+  const canReadAloud = useCallback(
+    (messages: readonly UIMessage[]) => !isVoiceModeEnabled && hasTextSinceLastUserTurn(messages),
+    [isVoiceModeEnabled]
+  );
+
+  return { isReadingAloud, toggleReadAloud, canReadAloud };
 }

--- a/apps/web/src/hooks/useReadAloud.ts
+++ b/apps/web/src/hooks/useReadAloud.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useCallback } from 'react';
+import type { UIMessage } from 'ai';
+import { useVoiceMode } from './useVoiceMode';
+import { getTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
+import { flushForTts } from '@/lib/voice/chunkForTts';
+
+/**
+ * On-demand TTS for "read the assistant's last turn aloud" — distinct from
+ * full hands-free Voice Mode. Owns its own `useVoiceMode()` instance, so
+ * callers must not use this while Voice Mode is active on the same surface:
+ * both instances share the same global voice-state store but have
+ * independent audio playback, so one can't stop audio started by the other.
+ */
+export function useReadAloud() {
+  const { isSpeaking, queueSentence, stopSpeaking } = useVoiceMode();
+
+  const toggleReadAloud = useCallback(
+    (messages: readonly UIMessage[]) => {
+      if (isSpeaking) {
+        stopSpeaking();
+        return;
+      }
+      const text = getTextSinceLastUserTurn(messages);
+      if (!text.trim()) return;
+      flushForTts(text).forEach((chunk) => queueSentence(chunk));
+    },
+    [isSpeaking, stopSpeaking, queueSentence]
+  );
+
+  return { isReadingAloud: isSpeaking, toggleReadAloud };
+}

--- a/apps/web/src/hooks/useReadAloud.ts
+++ b/apps/web/src/hooks/useReadAloud.ts
@@ -3,6 +3,7 @@
 import { useCallback } from 'react';
 import type { UIMessage } from 'ai';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
+import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
 import { getTextSinceLastUserTurn, hasTextSinceLastUserTurn } from '@/lib/ai/streams/getTextSinceLastUserTurn';
 import { flushForTts } from '@/lib/voice/chunkForTts';
 import {
@@ -17,15 +18,17 @@ import {
  * playback singleton (`readAloudPlayer`), so starting or stopping from any
  * mounted chat surface acts on the one real audio source.
  *
- * Unavailable while Voice Mode is enabled on ANY surface (not just the
- * current one): a live call elsewhere plays through its own separate
- * AudioContext and would overlap with this audio. `readAloudPlayer` itself
- * also stops any in-progress read-aloud the moment Voice Mode turns on, so
- * this is a pre-check for starting a new read, not the only guard.
+ * Unavailable while Voice Mode is enabled, or mic dictation is active, on
+ * ANY surface (not just the current one) — both are separate microphone
+ * captures elsewhere that would overlap with this audio.  `readAloudPlayer`
+ * itself also stops any in-progress read-aloud the moment either turns on,
+ * so this is a pre-check for starting a new read, not the only guard.
  */
 export function useReadAloud() {
   const isReadingAloud = useReadAloudPlayerStore((s) => s.isPlaying);
   const isVoiceModeEnabled = useVoiceModeStore((s) => s.isEnabled);
+  const isDictationActive = useDictationActivityStore((s) => s.activeCount > 0);
+  const blocked = isVoiceModeEnabled || isDictationActive;
 
   const toggleReadAloud = useCallback(
     (messages: readonly UIMessage[]) => {
@@ -33,17 +36,17 @@ export function useReadAloud() {
         stopReadAloud();
         return;
       }
-      if (isVoiceModeEnabled) return;
+      if (blocked) return;
       const text = getTextSinceLastUserTurn(messages);
       if (!text.trim()) return;
       startReadAloud(flushForTts(text));
     },
-    [isVoiceModeEnabled]
+    [blocked]
   );
 
   const canReadAloud = useCallback(
-    (messages: readonly UIMessage[]) => !isVoiceModeEnabled && hasTextSinceLastUserTurn(messages),
-    [isVoiceModeEnabled]
+    (messages: readonly UIMessage[]) => !blocked && hasTextSinceLastUserTurn(messages),
+    [blocked]
   );
 
   return { isReadingAloud, toggleReadAloud, canReadAloud };

--- a/apps/web/src/hooks/useSpeechRecognition.ts
+++ b/apps/web/src/hooks/useSpeechRecognition.ts
@@ -1,6 +1,28 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { create } from 'zustand';
+
+/**
+ * Cross-surface dictation activity. Each `useSpeechRecognition()` instance
+ * is otherwise local state — a mounted sidebar chat and main chat each own
+ * an independent SpeechRecognition object — so consumers that need to know
+ * "is dictation active ANYWHERE" (e.g. to avoid Read Aloud's TTS getting
+ * transcribed back into a draft) can't read that off any single instance.
+ * A count (not a boolean) so two simultaneously-listening surfaces don't
+ * have one's stop clear the other's still-active state.
+ */
+interface DictationActivityState {
+  activeCount: number;
+}
+
+export const useDictationActivityStore = create<DictationActivityState>(() => ({
+  activeCount: 0,
+}));
+
+export function isDictationActive(): boolean {
+  return useDictationActivityStore.getState().activeCount > 0;
+}
 
 export interface UseSpeechRecognitionOptions {
   /** Callback when speech is transcribed */
@@ -45,6 +67,10 @@ export function useSpeechRecognition({
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onTranscriptRef = useRef(onTranscript);
+  // Guards against double-decrementing the shared activeCount — onerror is
+  // typically followed by onend for the same session, and this instance's
+  // unmount cleanup could otherwise also fire after one of those already did.
+  const isCountedActiveRef = useRef(false);
 
   // Keep callback ref updated
   onTranscriptRef.current = onTranscript;
@@ -67,12 +93,25 @@ export function useSpeechRecognition({
     recognition.interimResults = true;
     recognition.lang = lang;
 
+    const markActive = () => {
+      if (isCountedActiveRef.current) return;
+      isCountedActiveRef.current = true;
+      useDictationActivityStore.setState((s) => ({ activeCount: s.activeCount + 1 }));
+    };
+    const markInactive = () => {
+      if (!isCountedActiveRef.current) return;
+      isCountedActiveRef.current = false;
+      useDictationActivityStore.setState((s) => ({ activeCount: Math.max(0, s.activeCount - 1) }));
+    };
+
     recognition.onstart = () => {
       setIsListening(true);
+      markActive();
     };
 
     recognition.onend = () => {
       setIsListening(false);
+      markInactive();
     };
 
     recognition.onresult = (event) => {
@@ -93,6 +132,7 @@ export function useSpeechRecognition({
     recognition.onerror = (event) => {
       console.error('Speech recognition error:', event.error);
       setIsListening(false);
+      markInactive();
 
       const errorMessages: Record<string, string> = {
         'not-allowed': 'Microphone access denied. Check your browser permissions.',
@@ -115,6 +155,9 @@ export function useSpeechRecognition({
 
     return () => {
       recognition.stop();
+      // Belt-and-suspenders in case onend never fires before unmount —
+      // guarded by isCountedActiveRef, so this is a no-op when it already did.
+      markInactive();
       if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
     };
   }, [lang, continuous]);

--- a/apps/web/src/hooks/useSpeechRecognition.ts
+++ b/apps/web/src/hooks/useSpeechRecognition.ts
@@ -20,10 +20,6 @@ export const useDictationActivityStore = create<DictationActivityState>(() => ({
   activeCount: 0,
 }));
 
-export function isDictationActive(): boolean {
-  return useDictationActivityStore.getState().activeCount > 0;
-}
-
 export interface UseSpeechRecognitionOptions {
   /** Callback when speech is transcribed */
   onTranscript: (text: string) => void;

--- a/apps/web/src/lib/ai/streams/__tests__/getTextSinceLastUserTurn.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/getTextSinceLastUserTurn.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { getTextSinceLastUserTurn } from '../getTextSinceLastUserTurn';
+
+const msg = (id: string, role: UIMessage['role'], parts: UIMessage['parts']): UIMessage => ({
+  id,
+  role,
+  parts,
+});
+
+const text = (t: string) => ({ type: 'text' as const, text: t });
+
+describe('getTextSinceLastUserTurn', () => {
+  it('given no user message at all, returns empty string', () => {
+    const messages = [msg('a1', 'assistant', [text('hello')])];
+    expect(getTextSinceLastUserTurn(messages)).toBe('');
+  });
+
+  it('given a single assistant reply, returns its text', () => {
+    const messages = [msg('u1', 'user', [text('hi')]), msg('a1', 'assistant', [text('hello there')])];
+    expect(getTextSinceLastUserTurn(messages)).toBe('hello there');
+  });
+
+  it('given multiple consecutive assistant messages, joins their text in order', () => {
+    const messages = [
+      msg('u1', 'user', [text('go')]),
+      msg('a1', 'assistant', [text('step one')]),
+      msg('a2', 'assistant', [text('step two')]),
+    ];
+    expect(getTextSinceLastUserTurn(messages)).toBe('step one\n\nstep two');
+  });
+
+  it('skips tool-call parts and only reads text parts within a message', () => {
+    const messages = [
+      msg('u1', 'user', [text('run it')]),
+      msg('a1', 'assistant', [
+        { type: 'tool-run', toolCallId: 't1', state: 'output-available' } as unknown as UIMessage['parts'][number],
+        text('done running'),
+      ]),
+    ];
+    expect(getTextSinceLastUserTurn(messages)).toBe('done running');
+  });
+
+  it('given a trailing tool-only message with no text, drops it from the joined output', () => {
+    const messages = [
+      msg('u1', 'user', [text('go')]),
+      msg('a1', 'assistant', [text('here is the answer')]),
+      msg('a2', 'assistant', [
+        { type: 'tool-run', toolCallId: 't2', state: 'output-available' } as unknown as UIMessage['parts'][number],
+      ]),
+    ];
+    expect(getTextSinceLastUserTurn(messages)).toBe('here is the answer');
+  });
+
+  it('given the last user message has no reply yet, returns empty string', () => {
+    const messages = [msg('a1', 'assistant', [text('old reply')]), msg('u1', 'user', [text('new question')])];
+    expect(getTextSinceLastUserTurn(messages)).toBe('');
+  });
+
+  it('given an empty array, returns empty string', () => {
+    expect(getTextSinceLastUserTurn([])).toBe('');
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/getTextSinceLastUserTurn.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/getTextSinceLastUserTurn.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { UIMessage } from 'ai';
-import { getTextSinceLastUserTurn } from '../getTextSinceLastUserTurn';
+import { getTextSinceLastUserTurn, hasTextSinceLastUserTurn } from '../getTextSinceLastUserTurn';
 
 const msg = (id: string, role: UIMessage['role'], parts: UIMessage['parts']): UIMessage => ({
   id,
@@ -59,5 +59,36 @@ describe('getTextSinceLastUserTurn', () => {
 
   it('given an empty array, returns empty string', () => {
     expect(getTextSinceLastUserTurn([])).toBe('');
+  });
+});
+
+describe('hasTextSinceLastUserTurn', () => {
+  it('given no user message at all, returns false', () => {
+    expect(hasTextSinceLastUserTurn([msg('a1', 'assistant', [text('hello')])])).toBe(false);
+  });
+
+  it('given a single assistant reply with text, returns true', () => {
+    const messages = [msg('u1', 'user', [text('hi')]), msg('a1', 'assistant', [text('hello there')])];
+    expect(hasTextSinceLastUserTurn(messages)).toBe(true);
+  });
+
+  it('given only tool-call parts and no text, returns false', () => {
+    const messages = [
+      msg('u1', 'user', [text('run it')]),
+      msg('a1', 'assistant', [
+        { type: 'tool-run', toolCallId: 't1', state: 'output-available' } as unknown as UIMessage['parts'][number],
+      ]),
+    ];
+    expect(hasTextSinceLastUserTurn(messages)).toBe(false);
+  });
+
+  it('given a text part that is only whitespace, returns false', () => {
+    const messages = [msg('u1', 'user', [text('hi')]), msg('a1', 'assistant', [text('   ')])];
+    expect(hasTextSinceLastUserTurn(messages)).toBe(false);
+  });
+
+  it('given the last user message has no reply yet, returns false', () => {
+    const messages = [msg('a1', 'assistant', [text('old reply')]), msg('u1', 'user', [text('new question')])];
+    expect(hasTextSinceLastUserTurn(messages)).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/streams/getTextSinceLastUserTurn.ts
+++ b/apps/web/src/lib/ai/streams/getTextSinceLastUserTurn.ts
@@ -20,3 +20,16 @@ export function getTextSinceLastUserTurn(messages: readonly UIMessage[]): string
     .filter(Boolean)
     .join('\n\n');
 }
+
+/**
+ * Cheap yes/no check for "is there anything to read aloud" — short-circuits
+ * on the first non-empty text part instead of joining the full reply text.
+ * Callers that only need a boolean (e.g. to enable/disable a button on every
+ * render, including every token of a live stream) should use this instead of
+ * checking `getTextSinceLastUserTurn(...).trim().length > 0`.
+ */
+export function hasTextSinceLastUserTurn(messages: readonly UIMessage[]): boolean {
+  return getAssistantMessagesAfterLastUser(messages).some((message) =>
+    (message.parts ?? []).some((p) => p.type === 'text' && p.text.trim().length > 0)
+  );
+}

--- a/apps/web/src/lib/ai/streams/getTextSinceLastUserTurn.ts
+++ b/apps/web/src/lib/ai/streams/getTextSinceLastUserTurn.ts
@@ -1,0 +1,22 @@
+import type { UIMessage } from 'ai';
+import { getAssistantMessagesAfterLastUser } from './getAssistantMessagesAfterLastUser';
+
+const textOf = (message: UIMessage): string =>
+  (message.parts ?? [])
+    .filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+    .map((p) => p.text)
+    .join('');
+
+/**
+ * Plain-text speech source for "read aloud": every assistant message since
+ * the user's last turn, joined in order. An agent can emit several
+ * consecutive assistant messages (tool calls, intermediate steps, a final
+ * reply) before control returns to the user, so this reads all of them
+ * rather than just the latest one.
+ */
+export function getTextSinceLastUserTurn(messages: readonly UIMessage[]): string {
+  return getAssistantMessagesAfterLastUser(messages)
+    .map(textOf)
+    .filter(Boolean)
+    .join('\n\n');
+}

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.audioContextFailure.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.audioContextFailure.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Kept in its own file, separate from readAloudPlayer.test.ts: the module's
+// AudioContext is a lazy singleton, created once and never recreated — a
+// prior test in the same file that successfully starts playback leaves it
+// cached, so a throwing AudioContext stub registered in a LATER test would
+// never actually get invoked. A fresh file gives Vitest a fresh module
+// registry, guaranteeing this is the first (and only) call to
+// getAudioContext() in this environment.
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { startReadAloud, isReadAloudPlaying } from '../readAloudPlayer';
+
+describe('readAloudPlayer — AudioContext construction failure', () => {
+  it('surfaces an error and stops the run when creating the AudioContext itself fails', async () => {
+    vi.stubGlobal(
+      'AudioContext',
+      class {
+        constructor() {
+          throw new Error('Web Audio unavailable');
+        }
+      }
+    );
+
+    startReadAloud(['hello there']);
+
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+    expect(toastErrorMock).toHaveBeenCalledWith('Could not read this reply aloud. Please try again.');
+    // Never even reached the network call — failed before fetchWithAuth.
+    expect(fetchWithAuth).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -219,4 +219,19 @@ describe('readAloudPlayer', () => {
 
     expect(isReadAloudPlaying()).toBe(false);
   });
+
+  it('aborts the in-flight synthesis fetch when stopped, instead of only discarding its result', () => {
+    let capturedSignal: AbortSignal | undefined;
+    vi.mocked(fetchWithAuth).mockImplementation((_url, options) => {
+      capturedSignal = (options as RequestInit | undefined)?.signal ?? undefined;
+      return new Promise(() => {}); // never resolves — only the signal matters here
+    });
+
+    startReadAloud(['only chunk']);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    stopReadAloud();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -5,11 +5,12 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
 import {
   startReadAloud,
   stopReadAloud,
   isReadAloudPlaying,
-  subscribeReadAloud,
+  useReadAloudPlayerStore,
 } from '../readAloudPlayer';
 
 class FakeAudioBufferSourceNode {
@@ -50,6 +51,7 @@ describe('readAloudPlayer', () => {
 
   afterEach(() => {
     stopReadAloud();
+    useVoiceModeStore.getState().disable();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -79,8 +81,8 @@ describe('readAloudPlayer', () => {
     // main content) both observing the one shared player.
     const surfaceA = vi.fn();
     const surfaceB = vi.fn();
-    const unsubscribeA = subscribeReadAloud(surfaceA);
-    const unsubscribeB = subscribeReadAloud(surfaceB);
+    const unsubscribeA = useReadAloudPlayerStore.subscribe(surfaceA);
+    const unsubscribeB = useReadAloudPlayerStore.subscribe(surfaceB);
 
     startReadAloud(['hello there']);
     expect(surfaceA).toHaveBeenCalledTimes(1);
@@ -99,7 +101,7 @@ describe('readAloudPlayer', () => {
 
   it('unsubscribing stops further notifications', () => {
     const listener = vi.fn();
-    const unsubscribe = subscribeReadAloud(listener);
+    const unsubscribe = useReadAloudPlayerStore.subscribe(listener);
     unsubscribe();
 
     startReadAloud(['hello there']);
@@ -203,5 +205,18 @@ describe('readAloudPlayer', () => {
     resolveSecond?.();
     await vi.waitFor(() => expect(createdSources).toHaveLength(1));
     expect(isReadAloudPlaying()).toBe(true);
+  });
+
+  it('stops playback the moment Voice Mode is enabled, regardless of how it was enabled', () => {
+    // Enforced at the module level (subscribed to useVoiceModeStore) rather
+    // than by any specific UI call site — so calling the store's enable()
+    // action directly, bypassing every view's own handleVoiceModeToggle,
+    // must still stop read-aloud.
+    startReadAloud(['hello there']);
+    expect(isReadAloudPlaying()).toBe(true);
+
+    useVoiceModeStore.getState().enable('ai-page');
+
+    expect(isReadAloudPlaying()).toBe(false);
   });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -16,15 +16,19 @@ class FakeAudioBufferSourceNode {
   buffer: unknown = null;
   onended: (() => void) | null = null;
   connect(): void {}
-  start(): void {}
+  start = vi.fn();
   stop = vi.fn();
 }
+
+const createdSources: FakeAudioBufferSourceNode[] = [];
 
 class FakeAudioContext {
   state = 'running';
   destination = {};
   createBufferSource(): FakeAudioBufferSourceNode {
-    return new FakeAudioBufferSourceNode();
+    const node = new FakeAudioBufferSourceNode();
+    createdSources.push(node);
+    return node;
   }
   decodeAudioData(): Promise<unknown> {
     return Promise.resolve({});
@@ -36,6 +40,7 @@ class FakeAudioContext {
 
 describe('readAloudPlayer', () => {
   beforeEach(() => {
+    createdSources.length = 0;
     vi.stubGlobal('AudioContext', FakeAudioContext);
     vi.mocked(fetchWithAuth).mockResolvedValue({
       ok: true,
@@ -109,6 +114,56 @@ describe('readAloudPlayer', () => {
 
   it('stopping when nothing is playing is a no-op that does not throw', () => {
     expect(() => stopReadAloud()).not.toThrow();
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('synthesizes and starts playback of a single chunk, then finishes naturally when it ends', async () => {
+    startReadAloud(['only chunk']);
+    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    expect(createdSources[0].start).toHaveBeenCalledTimes(1);
+    expect(isReadAloudPlaying()).toBe(true);
+
+    // Simulate the browser firing onended once the clip finishes.
+    createdSources[0].onended?.();
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+  });
+
+  it('plays multiple queued chunks back to back in order', async () => {
+    startReadAloud(['first', 'second']);
+    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+
+    createdSources[0].onended?.();
+    await vi.waitFor(() => expect(createdSources).toHaveLength(2));
+    expect(isReadAloudPlaying()).toBe(true);
+
+    createdSources[1].onended?.();
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+  });
+
+  it('skips a chunk that fails to synthesize and continues with the rest', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce({ ok: false } as Response)
+      .mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      } as Response);
+
+    startReadAloud(['broken chunk', 'good chunk']);
+    // The first chunk's failed synthesis is skipped without ever creating a
+    // source; only the second, successful chunk should end up playing.
+    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    expect(isReadAloudPlaying()).toBe(true);
+
+    createdSources[0].onended?.();
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+  });
+
+  it('discards a chunk that finishes synthesizing after stop was already called', async () => {
+    startReadAloud(['only chunk']);
+    stopReadAloud();
+    // Let the in-flight synthesis resolve; it must not resurrect playback.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(createdSources).toHaveLength(0);
     expect(isReadAloudPlaying()).toBe(false);
   });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -6,6 +6,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
+import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
 import {
   startReadAloud,
   stopReadAloud,
@@ -52,6 +53,7 @@ describe('readAloudPlayer', () => {
   afterEach(() => {
     stopReadAloud();
     useVoiceModeStore.getState().disable();
+    useDictationActivityStore.setState({ activeCount: 0 });
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -233,5 +235,27 @@ describe('readAloudPlayer', () => {
 
     stopReadAloud();
     expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it('stops playback the moment mic dictation becomes active anywhere, regardless of which ChatInput instance started it', () => {
+    // Dictation is per-ChatInput-instance local state (useSpeechRecognition),
+    // unlike Voice Mode's single global store — this simulates a DIFFERENT
+    // mounted surface's mic starting, via the shared activeCount it feeds.
+    startReadAloud(['hello there']);
+    expect(isReadAloudPlaying()).toBe(true);
+
+    useDictationActivityStore.setState({ activeCount: 1 });
+
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('reloads persisted voice settings on every start, not just once', () => {
+    const loadSettingsSpy = vi.spyOn(useVoiceModeStore.getState(), 'loadSettings');
+
+    startReadAloud(['first']);
+    stopReadAloud();
+    startReadAloud(['second']);
+
+    expect(loadSettingsSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -166,4 +166,42 @@ describe('readAloudPlayer', () => {
     expect(createdSources).toHaveLength(0);
     expect(isReadAloudPlaying()).toBe(false);
   });
+
+  it('given a stop-then-restart while the stopped run is still synthesizing, only the new run ever plays', async () => {
+    // Two independently-resolvable synthesis calls, so the first run's
+    // fetch can be made to resolve AFTER a second run has already started —
+    // reproducing the exact race the generation token guards against.
+    let resolveFirst: (() => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = () => resolve({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      } as Response);
+    });
+    const secondResponse = new Promise<Response>((resolve) => {
+      resolveSecond = () => resolve({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      } as Response);
+    });
+    vi.mocked(fetchWithAuth)
+      .mockReturnValueOnce(firstResponse)
+      .mockReturnValueOnce(secondResponse);
+
+    startReadAloud(['stale chunk']); // run A: fetch is now pending
+    stopReadAloud(); // stopped before run A's fetch ever resolved
+    startReadAloud(['fresh chunk']); // run B: a second, independent fetch is pending
+
+    // Resolve the STALE run's fetch first, after the fresh run has already
+    // begun — without the generation guard this would create and start a
+    // second, overlapping AudioBufferSourceNode.
+    resolveFirst?.();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(createdSources).toHaveLength(0);
+
+    resolveSecond?.();
+    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
+    expect(isReadAloudPlaying()).toBe(true);
+  });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -150,24 +150,6 @@ describe('readAloudPlayer', () => {
     await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
   });
 
-  it('skips a chunk that fails to synthesize and continues with the rest', async () => {
-    vi.mocked(fetchWithAuth)
-      .mockResolvedValueOnce({ ok: false } as Response)
-      .mockResolvedValue({
-        ok: true,
-        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-      } as Response);
-
-    startReadAloud(['broken chunk', 'good chunk']);
-    // The first chunk's failed synthesis is skipped without ever creating a
-    // source; only the second, successful chunk should end up playing.
-    await vi.waitFor(() => expect(createdSources).toHaveLength(1));
-    expect(isReadAloudPlaying()).toBe(true);
-
-    createdSources[0].onended?.();
-    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
-  });
-
   it('discards a chunk that finishes synthesizing after stop was already called', async () => {
     startReadAloud(['only chunk']);
     stopReadAloud();
@@ -299,5 +281,64 @@ describe('readAloudPlayer', () => {
     expect(toastErrorMock).toHaveBeenCalledWith('Voice synthesis is not configured on this deployment.');
     // Stopped after the first failure — never even attempted the second chunk.
     expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not surface an error toast when synthesis is cancelled by an intentional stop', async () => {
+    // Mirrors a real fetch()'s behavior on abort: rejects with an AbortError,
+    // either immediately (if already aborted) or once the signal fires.
+    vi.mocked(fetchWithAuth).mockImplementation((_url, options) => {
+      const signal = (options as RequestInit | undefined)?.signal;
+      return new Promise((_resolve, reject) => {
+        const onAbort = () => reject(new DOMException('The operation was aborted', 'AbortError'));
+        if (signal?.aborted) {
+          onAbort();
+          return;
+        }
+        signal?.addEventListener('abort', onAbort);
+      });
+    });
+
+    startReadAloud(['only chunk']);
+    stopReadAloud();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error toast and stops the run when synthesis throws for a reason other than an intentional stop', async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error('network blip'));
+
+    startReadAloud(['first chunk', 'second chunk']);
+
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+    expect(toastErrorMock).toHaveBeenCalledWith('Could not read this reply aloud. Please try again.');
+    // Stopped after the first failure — never even attempted the second chunk.
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not surface a toast for a stale, already-superseded run that fails on its own after a restart', async () => {
+    let rejectFirst: ((err: Error) => void) | undefined;
+    const firstResponse = new Promise<Response>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+    vi.mocked(fetchWithAuth)
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValue({
+        ok: true,
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+      } as Response);
+
+    startReadAloud(['stale chunk']); // run A: fetch pending
+    stopReadAloud(); // stopped before run A's fetch ever resolved
+    startReadAloud(['fresh chunk']); // run B: a fresh, successful fetch
+
+    // Run A's fetch fails for its own, unrelated reason — AFTER run B has
+    // already begun. The user already moved on; this shouldn't surface a
+    // confusing error about a read they're no longer waiting on.
+    rejectFirst?.(new Error('unrelated network blip'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(isReadAloudPlaying()).toBe(true);
   });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -4,6 +4,11 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(),
 }));
 
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}));
+
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
 import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
@@ -43,6 +48,7 @@ class FakeAudioContext {
 describe('readAloudPlayer', () => {
   beforeEach(() => {
     createdSources.length = 0;
+    toastErrorMock.mockClear();
     vi.stubGlobal('AudioContext', FakeAudioContext);
     vi.mocked(fetchWithAuth).mockResolvedValue({
       ok: true,
@@ -257,5 +263,41 @@ describe('readAloudPlayer', () => {
     startReadAloud(['second']);
 
     expect(loadSettingsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses to start when Voice Mode is already enabled at call time, even with no prior transition to observe', () => {
+    // Not a "stop while playing" case — Voice Mode was ALREADY on before
+    // startReadAloud() ever ran, so the subscription (which only fires on a
+    // future inactive-to-active transition) never gets a chance to fire.
+    useVoiceModeStore.getState().enable('ai-page');
+
+    startReadAloud(['hello there']);
+
+    expect(isReadAloudPlaying()).toBe(false);
+    expect(createdSources).toHaveLength(0);
+  });
+
+  it('refuses to start when dictation is already active at call time, even with no prior transition to observe', () => {
+    useDictationActivityStore.setState({ activeCount: 1 });
+
+    startReadAloud(['hello there']);
+
+    expect(isReadAloudPlaying()).toBe(false);
+    expect(createdSources).toHaveLength(0);
+  });
+
+  it('surfaces a systemic synthesis failure and stops the run instead of retry-skipping every remaining chunk', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ message: 'Voice synthesis is not configured on this deployment.' }),
+    } as Response);
+
+    startReadAloud(['first chunk', 'second chunk']);
+
+    await vi.waitFor(() => expect(isReadAloudPlaying()).toBe(false));
+    expect(createdSources).toHaveLength(0);
+    expect(toastErrorMock).toHaveBeenCalledWith('Voice synthesis is not configured on this deployment.');
+    // Stopped after the first failure — never even attempted the second chunk.
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
+++ b/apps/web/src/lib/voice/__tests__/readAloudPlayer.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import {
+  startReadAloud,
+  stopReadAloud,
+  isReadAloudPlaying,
+  subscribeReadAloud,
+} from '../readAloudPlayer';
+
+class FakeAudioBufferSourceNode {
+  buffer: unknown = null;
+  onended: (() => void) | null = null;
+  connect(): void {}
+  start(): void {}
+  stop = vi.fn();
+}
+
+class FakeAudioContext {
+  state = 'running';
+  destination = {};
+  createBufferSource(): FakeAudioBufferSourceNode {
+    return new FakeAudioBufferSourceNode();
+  }
+  decodeAudioData(): Promise<unknown> {
+    return Promise.resolve({});
+  }
+  resume(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('readAloudPlayer', () => {
+  beforeEach(() => {
+    vi.stubGlobal('AudioContext', FakeAudioContext);
+    vi.mocked(fetchWithAuth).mockResolvedValue({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+    } as Response);
+  });
+
+  afterEach(() => {
+    stopReadAloud();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('is not playing before anything starts', () => {
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('flips to playing synchronously when starting, before synthesis resolves', () => {
+    startReadAloud(['hello there']);
+    expect(isReadAloudPlaying()).toBe(true);
+  });
+
+  it('given no chunks, does not start playing', () => {
+    startReadAloud([]);
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('stop clears the playing state immediately', () => {
+    startReadAloud(['hello there']);
+    stopReadAloud();
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+
+  it('notifies subscribers on start and stop, regardless of which call site triggers it', () => {
+    // Simulates two independent useReadAloud() call sites (e.g. sidebar +
+    // main content) both observing the one shared player.
+    const surfaceA = vi.fn();
+    const surfaceB = vi.fn();
+    const unsubscribeA = subscribeReadAloud(surfaceA);
+    const unsubscribeB = subscribeReadAloud(surfaceB);
+
+    startReadAloud(['hello there']);
+    expect(surfaceA).toHaveBeenCalledTimes(1);
+    expect(surfaceB).toHaveBeenCalledTimes(1);
+
+    // A stop triggered from "surface B" must be observable by "surface A" —
+    // this is the cross-surface ownership guarantee the singleton provides.
+    stopReadAloud();
+    expect(surfaceA).toHaveBeenCalledTimes(2);
+    expect(surfaceB).toHaveBeenCalledTimes(2);
+    expect(isReadAloudPlaying()).toBe(false);
+
+    unsubscribeA();
+    unsubscribeB();
+  });
+
+  it('unsubscribing stops further notifications', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeReadAloud(listener);
+    unsubscribe();
+
+    startReadAloud(['hello there']);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('starting a new read-aloud while one is in flight replaces the previous queue', () => {
+    startReadAloud(['first attempt', 'more of the first']);
+    startReadAloud(['second attempt']);
+    expect(isReadAloudPlaying()).toBe(true);
+  });
+
+  it('stopping when nothing is playing is a no-op that does not throw', () => {
+    expect(() => stopReadAloud()).not.toThrow();
+    expect(isReadAloudPlaying()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -3,6 +3,7 @@
 import { create } from 'zustand';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
+import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
 
 /**
  * Module-singleton "read aloud" audio player, deliberately independent of
@@ -25,6 +26,13 @@ import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
  * `useVoiceModeStore`). The actual audio machinery (AudioContext, the
  * current source, the chunk queue, the race-guard generation counter) stays
  * in plain module variables outside React entirely.
+ *
+ * Mutually exclusive with two other microphone-capturing features, each
+ * with the same cross-surface problem: a live Voice Mode call
+ * (`useVoiceModeStore`) and basic mic dictation (`useDictationActivityStore`
+ * in `useSpeechRecognition.ts`, one per `ChatInput` instance). Either one's
+ * mic could otherwise pick up this module's own TTS audio and transcribe it
+ * back into a draft or into Voice Mode's own turn. See `ensureReadAloudReady`.
  */
 
 interface ReadAloudPlayerState {
@@ -132,7 +140,14 @@ async function playNext(runId: number): Promise<void> {
 }
 
 export function startReadAloud(chunks: string[]): void {
-  ensureVoiceModeStopsReadAloud();
+  ensureMutualExclusionSubscriptions();
+  // synthesize() reads ttsVoice/ttsSpeed straight from useVoiceModeStore
+  // without ever mounting useVoiceMode() — which is what used to trigger
+  // this load on mount — so a user's persisted voice choice would otherwise
+  // be silently ignored the first time they use Read Aloud without ever
+  // having opened the full Voice Mode panel. Idempotent and cheap, so it's
+  // just re-run on every start rather than gated behind a one-time flag.
+  useVoiceModeStore.getState().loadSettings();
   stopReadAloud();
   if (chunks.length === 0) return;
   queue = [...chunks];
@@ -165,23 +180,30 @@ export function isReadAloudPlaying(): boolean {
   return useReadAloudPlayerStore.getState().isPlaying;
 }
 
-// Enforced here (not per call-site) so the invariant holds no matter which UI
-// entry point enables Voice Mode, present or future: a mic-capturing live
-// call must never run concurrently with this module's own TTS audio, since
-// each has its own separate AudioContext and would otherwise be picked up by
-// Voice Mode's microphone as if it were user speech.
-//
 // Registered lazily (on first startReadAloud(), not at module import time)
-// so merely importing this module — e.g. a component under test that renders
-// but never exercises Read Aloud — never touches useVoiceModeStore.subscribe.
-// By the time any audio could actually be playing, this has always already
-// run, since startReadAloud() is the only path that starts playback.
-let voiceModeSubscriptionRegistered = false;
-function ensureVoiceModeStopsReadAloud(): void {
-  if (voiceModeSubscriptionRegistered) return;
-  voiceModeSubscriptionRegistered = true;
+// so merely importing this module — e.g. a component under test that
+// renders but never exercises Read Aloud — never touches these other
+// stores' `.subscribe`. By the time any audio could actually be playing,
+// this has always already run, since startReadAloud() is the only path
+// that starts playback. Guarded by a one-time flag (unlike loadSettings()
+// above) because subscribing more than once would leak duplicate listeners.
+//
+// A live Voice Mode call or active mic dictation each capture the
+// microphone — this module's own TTS audio must never play concurrently
+// with either, or it risks being picked up as if it were user speech.
+// Enforced here (not per call-site) so the invariant holds no matter which
+// UI entry point triggers either, present or future.
+let subscriptionsRegistered = false;
+function ensureMutualExclusionSubscriptions(): void {
+  if (subscriptionsRegistered) return;
+  subscriptionsRegistered = true;
   useVoiceModeStore.subscribe((state, prevState) => {
     if (state.isEnabled && !prevState.isEnabled) {
+      stopReadAloud();
+    }
+  });
+  useDictationActivityStore.subscribe((state, prevState) => {
+    if (state.activeCount > 0 && prevState.activeCount === 0) {
       stopReadAloud();
     }
   });

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -27,6 +27,15 @@ let queue: string[] = [];
 let playing = false;
 const listeners = new Set<Listener>();
 
+// Bumped by every stopReadAloud() call (including the implicit one at the
+// start of startReadAloud()). A `playNext`/`synthesize` chain captures the
+// generation it was started under and re-checks it after every await:
+// `playing` alone can't tell "this run was stopped" apart from "this run was
+// stopped AND THEN a newer run began" — in the latter case `playing` is true
+// again by the time the stale chain resumes, so it would otherwise create a
+// second AudioBufferSourceNode that plays concurrently with the new run's.
+let generation = 0;
+
 function notify(): void {
   listeners.forEach((listener) => { listener(); });
 }
@@ -60,8 +69,8 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
   }
 }
 
-async function playNext(): Promise<void> {
-  if (!playing) return;
+async function playNext(runId: number): Promise<void> {
+  if (runId !== generation) return;
   const text = queue.shift();
   if (text === undefined) {
     playing = false;
@@ -70,11 +79,12 @@ async function playNext(): Promise<void> {
   }
 
   const buffer = await synthesize(text);
-  // Stopped while this chunk was being synthesized — discard the result.
-  if (!playing) return;
+  // A stop, or a stop-then-restart, happened while this chunk was
+  // synthesizing — discard the result rather than letting a stale run play.
+  if (runId !== generation) return;
   if (!buffer) {
     // Skip a chunk that failed to synthesize rather than abandoning the rest.
-    void playNext();
+    void playNext(runId);
     return;
   }
 
@@ -84,9 +94,10 @@ async function playNext(): Promise<void> {
   source.connect(ctx.destination);
   audioSource = source;
   source.onended = () => {
+    if (runId !== generation) return;
     if (audioSource === source) {
       audioSource = null;
-      void playNext();
+      void playNext(runId);
     }
   };
   source.start();
@@ -98,10 +109,11 @@ export function startReadAloud(chunks: string[]): void {
   queue = [...chunks];
   playing = true;
   notify();
-  void playNext();
+  void playNext(generation);
 }
 
 export function stopReadAloud(): void {
+  generation++;
   const wasPlaying = playing;
   if (audioSource) {
     try {

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { create } from 'zustand';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
 
@@ -17,28 +18,40 @@ import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
  * an unmounting instance never resets that shared state either. Keeping the
  * one real audio source at module scope means there is only ever one thing
  * to stop, reachable from anywhere `useReadAloud()` is called.
+ *
+ * Only the boolean "is something playing" needs to be observable by React,
+ * so that alone lives in a tiny zustand store (this codebase's established
+ * pattern for shared, cross-component state — see the sibling
+ * `useVoiceModeStore`). The actual audio machinery (AudioContext, the
+ * current source, the chunk queue, the race-guard generation counter) stays
+ * in plain module variables outside React entirely.
  */
 
-type Listener = () => void;
+interface ReadAloudPlayerState {
+  isPlaying: boolean;
+}
+
+export const useReadAloudPlayerStore = create<ReadAloudPlayerState>(() => ({
+  isPlaying: false,
+}));
+
+function setPlaying(isPlaying: boolean): void {
+  useReadAloudPlayerStore.setState({ isPlaying });
+}
 
 let audioContext: AudioContext | null = null;
 let audioSource: AudioBufferSourceNode | null = null;
 let queue: string[] = [];
-let playing = false;
-const listeners = new Set<Listener>();
 
 // Bumped by every stopReadAloud() call (including the implicit one at the
 // start of startReadAloud()). A `playNext`/`synthesize` chain captures the
 // generation it was started under and re-checks it after every await:
-// `playing` alone can't tell "this run was stopped" apart from "this run was
-// stopped AND THEN a newer run began" — in the latter case `playing` is true
-// again by the time the stale chain resumes, so it would otherwise create a
-// second AudioBufferSourceNode that plays concurrently with the new run's.
+// `isPlaying` alone can't tell "this run was stopped" apart from "this run
+// was stopped AND THEN a newer run began" — in the latter case `isPlaying`
+// is true again by the time the stale chain resumes, so it would otherwise
+// create a second AudioBufferSourceNode that plays concurrently with the
+// new run's.
 let generation = 0;
-
-function notify(): void {
-  listeners.forEach((listener) => { listener(); });
-}
 
 function getAudioContext(): AudioContext {
   if (!audioContext) {
@@ -73,8 +86,7 @@ async function playNext(runId: number): Promise<void> {
   if (runId !== generation) return;
   const text = queue.shift();
   if (text === undefined) {
-    playing = false;
-    notify();
+    setPlaying(false);
     return;
   }
 
@@ -95,10 +107,12 @@ async function playNext(runId: number): Promise<void> {
   audioSource = source;
   source.onended = () => {
     if (runId !== generation) return;
-    if (audioSource === source) {
-      audioSource = null;
-      void playNext(runId);
-    }
+    // Within one generation only one source is ever live at a time — a new
+    // one is only created after the previous one's onended fired (or after a
+    // stop, which bumps generation and is already excluded above) — so
+    // audioSource is guaranteed to still be this source here.
+    audioSource = null;
+    void playNext(runId);
   };
   source.start();
 }
@@ -107,14 +121,12 @@ export function startReadAloud(chunks: string[]): void {
   stopReadAloud();
   if (chunks.length === 0) return;
   queue = [...chunks];
-  playing = true;
-  notify();
+  setPlaying(true);
   void playNext(generation);
 }
 
 export function stopReadAloud(): void {
   generation++;
-  const wasPlaying = playing;
   if (audioSource) {
     try {
       audioSource.stop();
@@ -124,15 +136,25 @@ export function stopReadAloud(): void {
     audioSource = null;
   }
   queue = [];
-  playing = false;
-  if (wasPlaying) notify();
+  // Guard against a redundant store update (and subscriber notification):
+  // startReadAloud() always calls this first to reset any prior run, even
+  // when nothing was playing.
+  if (useReadAloudPlayerStore.getState().isPlaying) {
+    setPlaying(false);
+  }
 }
 
 export function isReadAloudPlaying(): boolean {
-  return playing;
+  return useReadAloudPlayerStore.getState().isPlaying;
 }
 
-export function subscribeReadAloud(listener: Listener): () => void {
-  listeners.add(listener);
-  return () => listeners.delete(listener);
-}
+// Enforced here (not per call-site) so the invariant holds no matter which
+// UI entry point enables Voice Mode, present or future: a mic-capturing live
+// call must never run concurrently with this module's own TTS audio, since
+// each has its own separate AudioContext and would otherwise be picked up by
+// Voice Mode's microphone as if it were user speech.
+useVoiceModeStore.subscribe((state, prevState) => {
+  if (state.isEnabled && !prevState.isEnabled) {
+    stopReadAloud();
+  }
+});

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -42,6 +42,9 @@ function setPlaying(isPlaying: boolean): void {
 let audioContext: AudioContext | null = null;
 let audioSource: AudioBufferSourceNode | null = null;
 let queue: string[] = [];
+// The in-flight synthesis request, if any — aborted by stopReadAloud() so a
+// stopped chunk's billed TTS call is actually cancelled, not just ignored.
+let activeAbortController: AbortController | null = null;
 
 // Bumped by every stopReadAloud() call (including the implicit one at the
 // start of startReadAloud()). A `playNext`/`synthesize` chain captures the
@@ -65,11 +68,14 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
   // Created before the network await so the browser still credits this
   // AudioContext to the user gesture that triggered playback.
   const ctx = getAudioContext();
+  const controller = new AbortController();
+  activeAbortController = controller;
   try {
     const response = await fetchWithAuth('/api/voice/synthesize', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text, voice: ttsVoice, speed: ttsSpeed }),
+      signal: controller.signal,
     });
     if (!response.ok) return null;
     const audioData = await response.arrayBuffer();
@@ -79,6 +85,14 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
     return await ctx.decodeAudioData(audioData);
   } catch {
     return null;
+  } finally {
+    // Only clear if still ours — a stop-then-restart race can leave a newer
+    // call's controller as the active one while this (stale) call is still
+    // unwinding; clearing unconditionally would drop the newer reference and
+    // leave IT un-abortable by a later stop.
+    if (activeAbortController === controller) {
+      activeAbortController = null;
+    }
   }
 }
 
@@ -128,6 +142,8 @@ export function startReadAloud(chunks: string[]): void {
 
 export function stopReadAloud(): void {
   generation++;
+  activeAbortController?.abort();
+  activeAbortController = null;
   if (audioSource) {
     try {
       audioSource.stop();

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -74,9 +74,6 @@ function getAudioContext(): AudioContext {
 
 async function synthesize(text: string, runId: number): Promise<AudioBuffer | null> {
   const { ttsVoice, ttsSpeed } = useVoiceModeStore.getState();
-  // Created before the network await so the browser still credits this
-  // AudioContext to the user gesture that triggered playback.
-  const ctx = getAudioContext();
   const controller = new AbortController();
   activeAbortController = controller;
   // A stale, already-superseded run (from a stop-then-restart) failing for
@@ -90,6 +87,14 @@ async function synthesize(text: string, runId: number): Promise<AudioBuffer | nu
     stopReadAloud();
   };
   try {
+    // Created before the network await so the browser still credits this
+    // AudioContext to the user gesture that triggered playback. Inside the
+    // try block (not before it) so a creation failure — quota exhausted,
+    // Web Audio unsupported — gets the same surface-and-stop handling as any
+    // other synthesis failure, rather than rejecting playNext()'s
+    // fire-and-forget call unhandled and leaving isPlaying stuck true with
+    // no explanation and no audio.
+    const ctx = getAudioContext();
     const response = await fetchWithAuth('/api/voice/synthesize', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { toast } from 'sonner';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
 import { useDictationActivityStore } from '@/hooks/useSpeechRecognition';
@@ -85,7 +86,21 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
       body: JSON.stringify({ text, voice: ttsVoice, speed: ttsSpeed }),
       signal: controller.signal,
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      // A systemic failure (out of credits, rate-limited, misconfigured) —
+      // every remaining chunk would fail identically, so surface it and stop
+      // the whole run instead of silently skip-retrying it chunk by chunk.
+      // playNext()'s generation check (bumped by the stopReadAloud() call
+      // below) is what actually prevents the skip-retry, not this branch.
+      const errorData = await response.json().catch(() => ({}) as Record<string, unknown>);
+      const message =
+        (typeof errorData.message === 'string' && errorData.message) ||
+        (typeof errorData.error === 'string' && errorData.error) ||
+        'Could not read this reply aloud.';
+      toast.error(message);
+      stopReadAloud();
+      return null;
+    }
     const audioData = await response.arrayBuffer();
     if (ctx.state === 'suspended') {
       await ctx.resume();
@@ -150,6 +165,14 @@ export function startReadAloud(chunks: string[]): void {
   useVoiceModeStore.getState().loadSettings();
   stopReadAloud();
   if (chunks.length === 0) return;
+  // Re-validate live state here, not just via the subscriptions above: a
+  // caller's "may I start?" check (useReadAloud's `blocked`) can be a stale
+  // React closure, and the subscriptions only fire on a FUTURE
+  // inactive-to-active transition — neither catches "already active by the
+  // time this specific call runs" (e.g. rapid clicks across two surfaces).
+  if (useVoiceModeStore.getState().isEnabled || useDictationActivityStore.getState().activeCount > 0) {
+    return;
+  }
   queue = [...chunks];
   setPlaying(true);
   void playNext(generation);

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -72,13 +72,23 @@ function getAudioContext(): AudioContext {
   return audioContext;
 }
 
-async function synthesize(text: string): Promise<AudioBuffer | null> {
+async function synthesize(text: string, runId: number): Promise<AudioBuffer | null> {
   const { ttsVoice, ttsSpeed } = useVoiceModeStore.getState();
   // Created before the network await so the browser still credits this
   // AudioContext to the user gesture that triggered playback.
   const ctx = getAudioContext();
   const controller = new AbortController();
   activeAbortController = controller;
+  // A stale, already-superseded run (from a stop-then-restart) failing for
+  // its own unrelated reason must be a full no-op: no toast, and — crucially
+  // — no stopReadAloud() either, since that would tear down a newer run that
+  // has nothing to do with this one's failure. Only the run that is still
+  // current gets to surface an error and stop the queue.
+  const handleFailure = (message: string) => {
+    if (runId !== generation) return;
+    toast.error(message);
+    stopReadAloud();
+  };
   try {
     const response = await fetchWithAuth('/api/voice/synthesize', {
       method: 'POST',
@@ -90,15 +100,15 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
       // A systemic failure (out of credits, rate-limited, misconfigured) —
       // every remaining chunk would fail identically, so surface it and stop
       // the whole run instead of silently skip-retrying it chunk by chunk.
-      // playNext()'s generation check (bumped by the stopReadAloud() call
-      // below) is what actually prevents the skip-retry, not this branch.
+      // playNext()'s generation check (bumped by handleFailure's
+      // stopReadAloud() call) is what actually prevents the skip-retry, not
+      // this branch.
       const errorData = await response.json().catch(() => ({}) as Record<string, unknown>);
       const message =
         (typeof errorData.message === 'string' && errorData.message) ||
         (typeof errorData.error === 'string' && errorData.error) ||
         'Could not read this reply aloud.';
-      toast.error(message);
-      stopReadAloud();
+      handleFailure(message);
       return null;
     }
     const audioData = await response.arrayBuffer();
@@ -106,7 +116,16 @@ async function synthesize(text: string): Promise<AudioBuffer | null> {
       await ctx.resume();
     }
     return await ctx.decodeAudioData(audioData);
-  } catch {
+  } catch (err) {
+    // An AbortError here means WE intentionally cancelled this request (via
+    // stopReadAloud()'s controller.abort()) — expected, nothing to surface.
+    // Any other exception (network failure, a corrupted/undecodable
+    // response, AudioContext.resume() failing) is unexpected and would
+    // otherwise silently truncate or drop the reply with zero explanation,
+    // so it gets the same surface-and-stop treatment as a non-ok response.
+    if (!(err instanceof DOMException && err.name === 'AbortError')) {
+      handleFailure('Could not read this reply aloud. Please try again.');
+    }
     return null;
   } finally {
     // Only clear if still ours — a stop-then-restart race can leave a newer
@@ -127,7 +146,7 @@ async function playNext(runId: number): Promise<void> {
     return;
   }
 
-  const buffer = await synthesize(text);
+  const buffer = await synthesize(text, runId);
   // A stop, or a stop-then-restart, happened while this chunk was
   // synthesizing — discard the result rather than letting a stale run play.
   if (runId !== generation) return;

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -1,0 +1,126 @@
+'use client';
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useVoiceModeStore } from '@/stores/useVoiceModeStore';
+
+/**
+ * Module-singleton "read aloud" audio player, deliberately independent of
+ * React component lifecycles and of `useVoiceMode`'s per-instance
+ * AudioContext/audioSource refs.
+ *
+ * Read Aloud can be triggered from multiple mounted chat surfaces at once
+ * (e.g. the right-sidebar chat tab alongside the main AiChatView/
+ * GlobalAssistantView content). A per-component `useVoiceMode()` instance
+ * only tracks its OWN AudioContext locally while sharing global voice state
+ * via the store — so a second instance's "stop" call clears shared state but
+ * can't reach the first instance's actual playing AudioBufferSourceNode, and
+ * an unmounting instance never resets that shared state either. Keeping the
+ * one real audio source at module scope means there is only ever one thing
+ * to stop, reachable from anywhere `useReadAloud()` is called.
+ */
+
+type Listener = () => void;
+
+let audioContext: AudioContext | null = null;
+let audioSource: AudioBufferSourceNode | null = null;
+let queue: string[] = [];
+let playing = false;
+const listeners = new Set<Listener>();
+
+function notify(): void {
+  listeners.forEach((listener) => { listener(); });
+}
+
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+async function synthesize(text: string): Promise<AudioBuffer | null> {
+  const { ttsVoice, ttsSpeed } = useVoiceModeStore.getState();
+  // Created before the network await so the browser still credits this
+  // AudioContext to the user gesture that triggered playback.
+  const ctx = getAudioContext();
+  try {
+    const response = await fetchWithAuth('/api/voice/synthesize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, voice: ttsVoice, speed: ttsSpeed }),
+    });
+    if (!response.ok) return null;
+    const audioData = await response.arrayBuffer();
+    if (ctx.state === 'suspended') {
+      await ctx.resume();
+    }
+    return await ctx.decodeAudioData(audioData);
+  } catch {
+    return null;
+  }
+}
+
+async function playNext(): Promise<void> {
+  if (!playing) return;
+  const text = queue.shift();
+  if (text === undefined) {
+    playing = false;
+    notify();
+    return;
+  }
+
+  const buffer = await synthesize(text);
+  // Stopped while this chunk was being synthesized — discard the result.
+  if (!playing) return;
+  if (!buffer) {
+    // Skip a chunk that failed to synthesize rather than abandoning the rest.
+    void playNext();
+    return;
+  }
+
+  const ctx = getAudioContext();
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(ctx.destination);
+  audioSource = source;
+  source.onended = () => {
+    if (audioSource === source) {
+      audioSource = null;
+      void playNext();
+    }
+  };
+  source.start();
+}
+
+export function startReadAloud(chunks: string[]): void {
+  stopReadAloud();
+  if (chunks.length === 0) return;
+  queue = [...chunks];
+  playing = true;
+  notify();
+  void playNext();
+}
+
+export function stopReadAloud(): void {
+  const wasPlaying = playing;
+  if (audioSource) {
+    try {
+      audioSource.stop();
+    } catch {
+      // Already stopped.
+    }
+    audioSource = null;
+  }
+  queue = [];
+  playing = false;
+  if (wasPlaying) notify();
+}
+
+export function isReadAloudPlaying(): boolean {
+  return playing;
+}
+
+export function subscribeReadAloud(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/web/src/lib/voice/readAloudPlayer.ts
+++ b/apps/web/src/lib/voice/readAloudPlayer.ts
@@ -118,6 +118,7 @@ async function playNext(runId: number): Promise<void> {
 }
 
 export function startReadAloud(chunks: string[]): void {
+  ensureVoiceModeStopsReadAloud();
   stopReadAloud();
   if (chunks.length === 0) return;
   queue = [...chunks];
@@ -148,13 +149,24 @@ export function isReadAloudPlaying(): boolean {
   return useReadAloudPlayerStore.getState().isPlaying;
 }
 
-// Enforced here (not per call-site) so the invariant holds no matter which
-// UI entry point enables Voice Mode, present or future: a mic-capturing live
+// Enforced here (not per call-site) so the invariant holds no matter which UI
+// entry point enables Voice Mode, present or future: a mic-capturing live
 // call must never run concurrently with this module's own TTS audio, since
 // each has its own separate AudioContext and would otherwise be picked up by
 // Voice Mode's microphone as if it were user speech.
-useVoiceModeStore.subscribe((state, prevState) => {
-  if (state.isEnabled && !prevState.isEnabled) {
-    stopReadAloud();
-  }
-});
+//
+// Registered lazily (on first startReadAloud(), not at module import time)
+// so merely importing this module — e.g. a component under test that renders
+// but never exercises Read Aloud — never touches useVoiceModeStore.subscribe.
+// By the time any audio could actually be playing, this has always already
+// run, since startReadAloud() is the only path that starts playback.
+let voiceModeSubscriptionRegistered = false;
+function ensureVoiceModeStopsReadAloud(): void {
+  if (voiceModeSubscriptionRegistered) return;
+  voiceModeSubscriptionRegistered = true;
+  useVoiceModeStore.subscribe((state, prevState) => {
+    if (state.isEnabled && !prevState.isEnabled) {
+      stopReadAloud();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a single "Read Aloud" button next to the existing Voice Mode/Mic buttons in the chat input footer, so a reply can be spoken on demand without entering a full hands-free voice call.
- Reads everything the assistant said since the user's last turn (not just the latest message) — an agent can emit several consecutive assistant messages (tool calls, intermediate steps, a final reply) before control returns to the user, so a `getTextSinceLastUserTurn` helper joins all of them.
- Playback is a **module-level singleton** (`apps/web/src/lib/voice/readAloudPlayer.ts`), decoupled from any single component's lifecycle. This app can have multiple chat surfaces mounted at once (the right-sidebar chat tab alongside the main AiChatView/GlobalAssistantView content); every `useReadAloud()` call site subscribes to the one real audio source via a tiny Zustand store, so starting or stopping — or a failure — from any surface acts on the same audio.
- A monotonic generation token guards the async synthesis pipeline against a stop-then-restart race, and is also what makes error handling safe: only the run that is still current gets to surface a toast or stop the queue, so a stale, already-superseded run failing for its own reason can never disturb a newer run in progress.
- Mutually exclusive, in both directions and across mounted surfaces, with the two other microphone-capturing features: full Voice Mode calls and basic mic dictation. A small shared `useDictationActivityStore` (a count, not a boolean) lets `readAloudPlayer` know when dictation is active on ANY `ChatInput` instance, not just the current one.
- Synthesis failures (non-ok responses, network/decode errors, AudioContext creation failures) surface a toast and stop the run instead of silently skip-retrying or dropping part of the reply. Stopping mid-synthesis cancels the client fetch AND propagates the abort to the server's upstream OpenAI request, so a cancelled chunk isn't billed.
- Stops playback (and cancels billing) when the last mounted chat surface unmounts — e.g. navigating to a route with no chat UI — since there would otherwise be no Stop control reachable anywhere.
- Reuses existing voice infrastructure for text processing: `getAssistantMessagesAfterLastUser` for the turn boundary, `flushForTts` for markdown-to-speech normalization/chunking. No new TTS API routes — talks directly to the existing `/api/voice/synthesize` (OpenAI TTS, Pro+ gated), now updated to forward the caller's abort signal upstream.
- Same Pro+ gating as Voice Mode, since it hits the same `/api/voice/synthesize` endpoint.

## Review history
Seven rounds of Codex/CodeRabbit automated review findings were addressed and replied to inline — every thread has a concrete reply explaining the fix and is left open for reviewer verification (not self-resolved, since all were fixed during this same review cycle):
1. Per-instance `useVoiceMode()` couldn't be stopped cross-surface, and unmount never reset shared state → centralized into the module singleton.
2. Stale-synthesis race after stop-then-restart → generation token; Voice Mode enabling didn't stop read-aloud → explicit `stopReadAloud()`; Stop control unreachable during streaming → footer disabled-state fix.
3. A 4-agent `/simplify` pass: hand-rolled pub-sub → Zustand store (matching the sibling `useVoiceModeStore` convention); voice-mode-exclusivity folded into the hook; centralized enforcement via a store subscription instead of duplicated call-site fixes; dead ternary/redundant check removed. (Caught and fixed a self-introduced double-notify regression along the way.)
4. Persisted voice settings never loaded without opening the full Voice Mode panel first → now reloaded on every start; basic Mic dictation wasn't coordinated with Read Aloud at all (only Voice Mode was) → same-surface stop + cross-surface `useDictationActivityStore`.
5. `startReadAloud` could start even if Voice Mode/dictation had *just* become active with no transition to observe → live-state recheck at start; systemic synthesis failures (non-ok responses) were silently skip-retried → surfaced via toast + stop.
6. The catch block still silently dropped genuine exceptions (network/decode failures) → same surface-and-stop treatment, distinguishing an intentional Stop-abort from a real failure. Threading the run ID through for this caught a real regression: `stopReadAloud()` was firing unconditionally on any non-abort failure, so a stale run's own independent failure could tear down a newer, legitimately-playing run — fixed by gating both the toast and the stop behind "is this run still current."
7. Closing every chat surface left playback (and billing) running with no reachable Stop control → ref-counted mount tracking stops it when the last surface unmounts; `AudioContext` creation failures rejected unhandled outside the try block, leaving the UI stuck showing "Stop" forever → moved inside the handled path.

**Latest Codex review (commit `7b5edc2e3`): "Didn't find any major issues. Breezy!"** — first fully clean pass after the above.

## Test plan
- [x] `bun run typecheck` (apps/web) — clean
- [x] `bun run lint` (apps/web) — no new warnings
- [x] `bun run knip:check` — clean, no new dead-code findings
- [x] `bunx vitest run` — 100 tests across `readAloudPlayer` (+ a dedicated AudioContext-failure file), `useReadAloud` (unmount lifecycle), both voice API routes, `getTextSinceLastUserTurn`, `AiChatView` ×2, `ChatInput` — all passing, including several regression tests that caught real races/bugs during this review cycle
- [x] CI green across all 11 checks (Unit Tests, Lint & TypeScript Check, CodeQL, Dependency Audit, Secret Scanning, Security Test Suite, Static Security Analysis, CodeRabbit, Security Summary) on the final commit; branch merges cleanly against `master` with zero conflicts, verified repeatedly across 7 pushes
- [ ] Manual browser check: not completed in this environment (missing `DATABASE_URL`/env config in the worktree) — recommend clicking through on a branch deploy or locally with env configured: send a prompt that triggers a tool call before the final reply, click Read Aloud, confirm it speaks all assistant turns in order; confirm Stop works immediately (including mid-stream and mid-synthesis-failure); confirm entering Voice Mode or starting mic dictation while Read Aloud is playing stops it first, from any surface; try it with both the sidebar chat tab and the main content view open at once; confirm navigating away entirely stops playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHGBY8FgjREJXDGaPRAyig