### PR TITLE
feat(webhooks): trigger CRUD — bind a workflow to a page webhook

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAuthenticateRequestWithOptions = vi.fn();
+const mockIsAuthError = vi.fn();
+const mockCanManagePageWebhooks = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequestWithOptions(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  canManagePageWebhooks: (...args: unknown[]) => mockCanManagePageWebhooks(...args),
+}));
+
+const mockWebhookFindFirst = vi.fn();
+const mockTriggerFindFirst = vi.fn();
+const mockUpdateReturning = vi.fn();
+const mockDeleteWhere = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pageWebhooks: { findFirst: (...args: unknown[]) => mockWebhookFindFirst(...args) },
+      webhookTriggers: { findFirst: (...args: unknown[]) => mockTriggerFindFirst(...args) },
+    },
+    update: () => ({
+      set: () => ({
+        where: () => ({
+          returning: () => mockUpdateReturning(),
+        }),
+      }),
+    }),
+    delete: () => ({
+      where: (...args: unknown[]) => mockDeleteWhere(...args),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  and: (...args: unknown[]) => ({ and: args }),
+}));
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({
+  pageWebhooks: { id: 'pageWebhooks.id', pageId: 'pageWebhooks.pageId' },
+}));
+vi.mock('@pagespace/db/schema/webhook-triggers', () => ({
+  webhookTriggers: { id: 'webhookTriggers.id', pageWebhookId: 'webhookTriggers.pageWebhookId' },
+}));
+
+const mockAuditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+import { PATCH, DELETE } from '../route';
+
+const SESSION_AUTH = { userId: 'user-1', kind: 'session' };
+const PARAMS = { params: Promise.resolve({ pageId: 'page-1', id: 'wh-1', triggerId: 't-1' }) };
+const TRIGGER_ROW = { id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1', isEnabled: true };
+
+function makeRequest(method: string, body?: unknown): Request {
+  return new Request('https://example.com/api/pages/page-1/webhooks/wh-1/triggers/t-1', {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { 'content-type': 'application/json' } }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequestWithOptions.mockResolvedValue(SESSION_AUTH);
+  mockIsAuthError.mockReturnValue(false);
+  mockCanManagePageWebhooks.mockResolvedValue(true);
+  mockWebhookFindFirst.mockResolvedValue({ id: 'wh-1' });
+  mockTriggerFindFirst.mockResolvedValue(TRIGGER_ROW);
+});
+
+describe('PATCH /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]', () => {
+  it('toggles isEnabled and audits the change', async () => {
+    mockUpdateReturning.mockResolvedValue([{ ...TRIGGER_ROW, isEnabled: false }]);
+    const response = await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.trigger.isEnabled).toBe(false);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ resourceType: 'webhook_trigger', details: expect.objectContaining({ operation: 'toggle' }) }),
+    );
+  });
+
+  it('rejects an empty body with 400', async () => {
+    const response = await PATCH(makeRequest('PATCH', {}), PARAMS);
+    expect(response.status).toBe(400);
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-owner/admin with 403', async () => {
+    mockCanManagePageWebhooks.mockResolvedValue(false);
+    const response = await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    expect(response.status).toBe(403);
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the trigger is not on this page webhook', async () => {
+    mockTriggerFindFirst.mockResolvedValue(null);
+    const response = await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the webhook is not on this page', async () => {
+    mockWebhookFindFirst.mockResolvedValue(null);
+    const response = await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockUpdateReturning).not.toHaveBeenCalled();
+  });
+});
+
+describe('DELETE /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]', () => {
+  it('detaches an owned trigger and returns 204', async () => {
+    mockDeleteWhere.mockResolvedValue(undefined);
+    const response = await DELETE(makeRequest('DELETE'), PARAMS);
+    expect(response.status).toBe(204);
+    expect(mockDeleteWhere).toHaveBeenCalledTimes(1);
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ resourceType: 'webhook_trigger', details: expect.objectContaining({ operation: 'delete' }) }),
+    );
+  });
+
+  it('rejects a non-owner/admin with 403 without deleting', async () => {
+    mockCanManagePageWebhooks.mockResolvedValue(false);
+    const response = await DELETE(makeRequest('DELETE'), PARAMS);
+    expect(response.status).toBe(403);
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a trigger not on this page webhook, without deleting', async () => {
+    mockTriggerFindFirst.mockResolvedValue(null);
+    const response = await DELETE(makeRequest('DELETE'), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockDeleteWhere).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
@@ -112,6 +112,15 @@ describe('PATCH /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]', () => {
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
 
+  it('returns 404 without auditing when the row vanishes between the check and the update (TOCTOU)', async () => {
+    // Ownership check passes, but a concurrent DELETE removes the row before the
+    // UPDATE lands — returning() yields nothing.
+    mockUpdateReturning.mockResolvedValue([]);
+    const response = await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
   it('scopes both lookups so a trigger on another page/webhook cannot be toggled (IDOR)', async () => {
     mockUpdateReturning.mockResolvedValue([{ ...TRIGGER_ROW, isEnabled: false }]);
     await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/__tests__/route.test.ts
@@ -111,6 +111,25 @@ describe('PATCH /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]', () => {
     expect(response.status).toBe(404);
     expect(mockUpdateReturning).not.toHaveBeenCalled();
   });
+
+  it('scopes both lookups so a trigger on another page/webhook cannot be toggled (IDOR)', async () => {
+    mockUpdateReturning.mockResolvedValue([{ ...TRIGGER_ROW, isEnabled: false }]);
+    await PATCH(makeRequest('PATCH', { isEnabled: false }), PARAMS);
+    // Webhook must be AND-scoped to (id, pageId)...
+    expect(mockWebhookFindFirst.mock.calls[0][0].where).toEqual({
+      and: [
+        { eq: ['pageWebhooks.id', 'wh-1'] },
+        { eq: ['pageWebhooks.pageId', 'page-1'] },
+      ],
+    });
+    // ...and the trigger AND-scoped to (triggerId, pageWebhookId).
+    expect(mockTriggerFindFirst.mock.calls[0][0].where).toEqual({
+      and: [
+        { eq: ['webhookTriggers.id', 't-1'] },
+        { eq: ['webhookTriggers.pageWebhookId', 'wh-1'] },
+      ],
+    });
+  });
 });
 
 describe('DELETE /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]', () => {

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { db } from '@pagespace/db/db';
+import { and, eq } from '@pagespace/db/operators';
+import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
+import { webhookTriggers } from '@pagespace/db/schema/webhook-triggers';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { authenticateRequestWithOptions, isAuthError, canManagePageWebhooks } from '@/lib/auth';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+const patchSchema = z.object({ isEnabled: z.boolean() });
+
+// Returns the trigger only if it is anchored to a webhook owned by this page —
+// scopes toggle/delete to a trigger the caller's page controls.
+async function findOwnedTrigger(pageId: string, webhookId: string, triggerId: string) {
+  const webhook = await db.query.pageWebhooks.findFirst({
+    where: and(eq(pageWebhooks.id, webhookId), eq(pageWebhooks.pageId, pageId)),
+    columns: { id: true },
+  });
+  if (!webhook) return null;
+
+  const trigger = await db.query.webhookTriggers.findFirst({
+    where: and(
+      eq(webhookTriggers.id, triggerId),
+      eq(webhookTriggers.pageWebhookId, webhookId),
+    ),
+  });
+  return trigger ?? null;
+}
+
+// PATCH /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId] — toggle isEnabled
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ pageId: string; id: string; triggerId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+    const { pageId, id, triggerId } = await context.params;
+
+    const canManage = await canManagePageWebhooks(auth, pageId);
+    if (!canManage) {
+      return NextResponse.json({ error: 'Only the drive owner or an admin can manage page webhooks' }, { status: 403 });
+    }
+
+    let body: unknown;
+    try { body = await request.json(); } catch { body = {}; }
+    const validation = patchSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Invalid body', details: validation.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const existing = await findOwnedTrigger(pageId, id, triggerId);
+    if (!existing) return NextResponse.json({ error: 'Trigger not found' }, { status: 404 });
+
+    const [trigger] = await db
+      .update(webhookTriggers)
+      .set({ isEnabled: validation.data.isEnabled })
+      .where(eq(webhookTriggers.id, triggerId))
+      .returning();
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'webhook_trigger',
+      resourceId: triggerId,
+      details: { operation: 'toggle', pageId, pageWebhookId: id, isEnabled: validation.data.isEnabled },
+    });
+    return NextResponse.json({ trigger });
+  } catch (error) {
+    loggers.api.error('Error updating page webhook trigger', error as Error);
+    return NextResponse.json({ error: 'Failed to update trigger' }, { status: 500 });
+  }
+}
+
+// DELETE /api/pages/[pageId]/webhooks/[id]/triggers/[triggerId] — detach a workflow
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ pageId: string; id: string; triggerId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+    const { pageId, id, triggerId } = await context.params;
+
+    const canManage = await canManagePageWebhooks(auth, pageId);
+    if (!canManage) {
+      return NextResponse.json({ error: 'Only the drive owner or an admin can manage page webhooks' }, { status: 403 });
+    }
+
+    const existing = await findOwnedTrigger(pageId, id, triggerId);
+    if (!existing) return NextResponse.json({ error: 'Trigger not found' }, { status: 404 });
+
+    await db.delete(webhookTriggers).where(eq(webhookTriggers.id, triggerId));
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'webhook_trigger',
+      resourceId: triggerId,
+      details: { operation: 'delete', pageId, pageWebhookId: id },
+    });
+    return new Response(null, { status: 204 });
+  } catch (error) {
+    loggers.api.error('Error deleting page webhook trigger', error as Error);
+    return NextResponse.json({ error: 'Failed to delete trigger' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]/route.ts
@@ -65,6 +65,11 @@ export async function PATCH(
       .where(eq(webhookTriggers.id, triggerId))
       .returning();
 
+    // The ownership check and the update are not atomic — a concurrent DELETE
+    // could remove the row in between. Don't report a phantom success or emit a
+    // toggle audit for a change that never landed.
+    if (!trigger) return NextResponse.json({ error: 'Trigger not found' }, { status: 404 });
+
     auditRequest(request, {
       eventType: 'data.write',
       userId,

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const mockWorkflowFindFirst = vi.fn();
 const mockTriggerFindFirst = vi.fn();
 const mockTriggerFindMany = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockCountResult = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: {
@@ -26,6 +27,11 @@ vi.mock('@pagespace/db/db', () => ({
         findMany: (...args: unknown[]) => mockTriggerFindMany(...args),
       },
     },
+    select: () => ({
+      from: () => ({
+        where: () => mockCountResult(),
+      }),
+    }),
     insert: () => ({
       values: () => ({
         onConflictDoNothing: () => ({
@@ -38,6 +44,8 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
   and: (...args: unknown[]) => ({ and: args }),
+  asc: (col: unknown) => ({ asc: col }),
+  count: () => ({ count: true }),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'pages.id' },
@@ -46,7 +54,12 @@ vi.mock('@pagespace/db/schema/page-webhooks', () => ({
   pageWebhooks: { id: 'pageWebhooks.id', pageId: 'pageWebhooks.pageId' },
 }));
 vi.mock('@pagespace/db/schema/webhook-triggers', () => ({
-  webhookTriggers: { id: 'webhookTriggers.id', pageWebhookId: 'webhookTriggers.pageWebhookId', workflowId: 'webhookTriggers.workflowId' },
+  webhookTriggers: {
+    id: 'webhookTriggers.id',
+    pageWebhookId: 'webhookTriggers.pageWebhookId',
+    workflowId: 'webhookTriggers.workflowId',
+    createdAt: 'webhookTriggers.createdAt',
+  },
   PAGE_WEBHOOK_EVENT_TYPE: '*',
 }));
 vi.mock('@pagespace/db/schema/workflows', () => ({
@@ -81,16 +94,20 @@ beforeEach(() => {
   mockWebhookFindFirst.mockResolvedValue({ id: 'wh-1' });
   mockPageFindFirst.mockResolvedValue({ driveId: 'drive-1' });
   mockWorkflowFindFirst.mockResolvedValue({ id: 'wf-1', driveId: 'drive-1' });
+  mockTriggerFindFirst.mockResolvedValue(null); // no existing binding by default
+  mockCountResult.mockResolvedValue([{ value: 0 }]);
 });
 
 describe('GET /api/pages/[pageId]/webhooks/[id]/triggers', () => {
-  it('lists the webhook triggers with a bounded query', async () => {
+  it('lists the webhook triggers with a bounded, deterministically-ordered query', async () => {
     mockTriggerFindMany.mockResolvedValue([{ id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1' }]);
     const response = await GET(makeRequest('GET'), PARAMS);
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.triggers).toHaveLength(1);
-    expect(mockTriggerFindMany).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+    expect(mockTriggerFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 100, orderBy: expect.any(Array) }),
+    );
   });
 
   it('rejects a non-owner/admin with 403', async () => {
@@ -129,13 +146,21 @@ describe('POST /api/pages/[pageId]/webhooks/[id]/triggers', () => {
     expect(mockAuditRequest).not.toHaveBeenCalled();
   });
 
-  it('returns 200 (idempotent) when the binding already exists', async () => {
-    mockInsertReturning.mockResolvedValue([]);
+  it('returns 200 (idempotent) when the binding already exists, without re-inserting or counting', async () => {
     mockTriggerFindFirst.mockResolvedValue({ id: 't-existing', pageWebhookId: 'wh-1', workflowId: 'wf-1' });
     const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.trigger.id).toBe('t-existing');
+    expect(mockCountResult).not.toHaveBeenCalled();
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it('rejects a genuinely-new binding beyond the per-webhook cap with 409', async () => {
+    mockCountResult.mockResolvedValue([{ value: 100 }]);
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-new' }), PARAMS);
+    expect(response.status).toBe(409);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the workflow does not exist', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockAuthenticateRequestWithOptions = vi.fn();
+const mockIsAuthError = vi.fn();
+const mockCanManagePageWebhooks = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequestWithOptions(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  canManagePageWebhooks: (...args: unknown[]) => mockCanManagePageWebhooks(...args),
+}));
+
+const mockWebhookFindFirst = vi.fn();
+const mockPageFindFirst = vi.fn();
+const mockWorkflowFindFirst = vi.fn();
+const mockTriggerFindFirst = vi.fn();
+const mockTriggerFindMany = vi.fn();
+const mockInsertReturning = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pageWebhooks: { findFirst: (...args: unknown[]) => mockWebhookFindFirst(...args) },
+      pages: { findFirst: (...args: unknown[]) => mockPageFindFirst(...args) },
+      workflows: { findFirst: (...args: unknown[]) => mockWorkflowFindFirst(...args) },
+      webhookTriggers: {
+        findFirst: (...args: unknown[]) => mockTriggerFindFirst(...args),
+        findMany: (...args: unknown[]) => mockTriggerFindMany(...args),
+      },
+    },
+    insert: () => ({
+      values: () => ({
+        onConflictDoNothing: () => ({
+          returning: () => mockInsertReturning(),
+        }),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+  and: (...args: unknown[]) => ({ and: args }),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id' },
+}));
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({
+  pageWebhooks: { id: 'pageWebhooks.id', pageId: 'pageWebhooks.pageId' },
+}));
+vi.mock('@pagespace/db/schema/webhook-triggers', () => ({
+  webhookTriggers: { id: 'webhookTriggers.id', pageWebhookId: 'webhookTriggers.pageWebhookId', workflowId: 'webhookTriggers.workflowId' },
+  PAGE_WEBHOOK_EVENT_TYPE: '*',
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: { id: 'workflows.id' },
+}));
+
+const mockAuditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+import { GET, POST } from '../route';
+
+const SESSION_AUTH = { userId: 'user-1', kind: 'session' };
+const PARAMS = { params: Promise.resolve({ pageId: 'page-1', id: 'wh-1' }) };
+
+function makeRequest(method: string, body?: unknown): Request {
+  return new Request('https://example.com/api/pages/page-1/webhooks/wh-1/triggers', {
+    method,
+    ...(body === undefined ? {} : { body: JSON.stringify(body), headers: { 'content-type': 'application/json' } }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequestWithOptions.mockResolvedValue(SESSION_AUTH);
+  mockIsAuthError.mockReturnValue(false);
+  mockCanManagePageWebhooks.mockResolvedValue(true);
+  mockWebhookFindFirst.mockResolvedValue({ id: 'wh-1' });
+  mockPageFindFirst.mockResolvedValue({ driveId: 'drive-1' });
+  mockWorkflowFindFirst.mockResolvedValue({ id: 'wf-1', driveId: 'drive-1' });
+});
+
+describe('GET /api/pages/[pageId]/webhooks/[id]/triggers', () => {
+  it('lists the webhook triggers with a bounded query', async () => {
+    mockTriggerFindMany.mockResolvedValue([{ id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1' }]);
+    const response = await GET(makeRequest('GET'), PARAMS);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.triggers).toHaveLength(1);
+    expect(mockTriggerFindMany).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+  });
+
+  it('rejects a non-owner/admin with 403', async () => {
+    mockCanManagePageWebhooks.mockResolvedValue(false);
+    const response = await GET(makeRequest('GET'), PARAMS);
+    expect(response.status).toBe(403);
+    expect(mockTriggerFindMany).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the webhook is not on this page', async () => {
+    mockWebhookFindFirst.mockResolvedValue(null);
+    const response = await GET(makeRequest('GET'), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockTriggerFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/pages/[pageId]/webhooks/[id]/triggers', () => {
+  it('binds a same-drive workflow and audits the create', async () => {
+    mockInsertReturning.mockResolvedValue([{ id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1' }]);
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.trigger.id).toBe('t-1');
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'webhook_trigger' }),
+    );
+  });
+
+  it('rejects a foreign-drive workflow with 400 and does not insert', async () => {
+    mockWorkflowFindFirst.mockResolvedValue({ id: 'wf-1', driveId: 'drive-OTHER' });
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
+    expect(response.status).toBe(400);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 (idempotent) when the binding already exists', async () => {
+    mockInsertReturning.mockResolvedValue([]);
+    mockTriggerFindFirst.mockResolvedValue({ id: 't-existing', pageWebhookId: 'wh-1', workflowId: 'wf-1' });
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.trigger.id).toBe('t-existing');
+  });
+
+  it('returns 404 when the workflow does not exist', async () => {
+    mockWorkflowFindFirst.mockResolvedValue(null);
+    const response = await POST(makeRequest('POST', { workflowId: 'missing' }), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the webhook is not on this page', async () => {
+    mockWebhookFindFirst.mockResolvedValue(null);
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockWorkflowFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing workflowId with 400', async () => {
+    const response = await POST(makeRequest('POST', {}), PARAMS);
+    expect(response.status).toBe(400);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-owner/admin with 403 before touching the workflow', async () => {
+    mockCanManagePageWebhooks.mockResolvedValue(false);
+    const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
+    expect(response.status).toBe(403);
+    expect(mockWorkflowFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const mockWorkflowFindFirst = vi.fn();
 const mockTriggerFindFirst = vi.fn();
 const mockTriggerFindMany = vi.fn();
 const mockInsertReturning = vi.fn();
+const mockInsertValues = vi.fn();
 const mockCountResult = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
   db: {
@@ -33,11 +34,14 @@ vi.mock('@pagespace/db/db', () => ({
       }),
     }),
     insert: () => ({
-      values: () => ({
-        onConflictDoNothing: () => ({
-          returning: () => mockInsertReturning(),
-        }),
-      }),
+      values: (v: unknown) => {
+        mockInsertValues(v);
+        return {
+          onConflictDoNothing: () => ({
+            returning: () => mockInsertReturning(),
+          }),
+        };
+      },
     }),
   },
 }));
@@ -99,15 +103,31 @@ beforeEach(() => {
 });
 
 describe('GET /api/pages/[pageId]/webhooks/[id]/triggers', () => {
-  it('lists the webhook triggers with a bounded, deterministically-ordered query', async () => {
+  it('lists the webhook triggers with a bounded, deterministically-ordered query scoped to the webhook', async () => {
     mockTriggerFindMany.mockResolvedValue([{ id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1' }]);
     const response = await GET(makeRequest('GET'), PARAMS);
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.triggers).toHaveLength(1);
-    expect(mockTriggerFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({ limit: 100, orderBy: expect.any(Array) }),
-    );
+    const findManyArg = mockTriggerFindMany.mock.calls[0][0];
+    expect(findManyArg.limit).toBe(500);
+    expect(Array.isArray(findManyArg.orderBy)).toBe(true);
+    // The list must be filtered to THIS webhook's id — a dropped filter would leak
+    // every drive's triggers.
+    expect(findManyArg.where).toEqual({ eq: ['webhookTriggers.pageWebhookId', 'wh-1'] });
+  });
+
+  it('scopes the webhook lookup to the URL page (blocks cross-page access)', async () => {
+    await GET(makeRequest('GET'), PARAMS);
+    // findWebhookWithDrive must AND the webhook id with pageId — without the
+    // pageId clause a caller could read another page's webhook triggers.
+    const webhookLookupWhere = mockWebhookFindFirst.mock.calls[0][0].where;
+    expect(webhookLookupWhere).toEqual({
+      and: [
+        { eq: ['pageWebhooks.id', 'wh-1'] },
+        { eq: ['pageWebhooks.pageId', 'page-1'] },
+      ],
+    });
   });
 
   it('rejects a non-owner/admin with 403', async () => {
@@ -126,12 +146,23 @@ describe('GET /api/pages/[pageId]/webhooks/[id]/triggers', () => {
 });
 
 describe('POST /api/pages/[pageId]/webhooks/[id]/triggers', () => {
-  it('binds a same-drive workflow and audits the create', async () => {
+  it('binds a same-drive workflow with a page-anchored row and audits the create', async () => {
     mockInsertReturning.mockResolvedValue([{ id: 't-1', pageWebhookId: 'wh-1', workflowId: 'wf-1' }]);
     const response = await POST(makeRequest('POST', { workflowId: 'wf-1' }), PARAMS);
     expect(response.status).toBe(201);
     const body = await response.json();
     expect(body.trigger.id).toBe('t-1');
+    // The inserted row must anchor to the page webhook (not a connection), tag
+    // the page provider, and carry the imported sentinel eventType — so the
+    // XOR CHECK passes and event-matching is skipped.
+    const inserted = mockInsertValues.mock.calls[0][0];
+    expect(inserted).toEqual({
+      workflowId: 'wf-1',
+      pageWebhookId: 'wh-1',
+      provider: 'page-webhook',
+      eventType: '*',
+    });
+    expect(inserted).not.toHaveProperty('connectionId');
     expect(mockAuditRequest).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ eventType: 'data.write', resourceType: 'webhook_trigger' }),

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
@@ -111,8 +111,9 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
     if (!workflow) return NextResponse.json({ error: 'Workflow not found' }, { status: 404 });
 
     // Cross-drive guard: a webhook must only fire workflows from its own drive —
-    // binding a foreign-drive workflow would let a page in one drive drive
-    // execution (and AI billing) in another.
+    // binding a foreign-drive workflow would let a page in one drive trigger
+    // execution (and AI billing) in another. This is create-time validation;
+    // the move-safe authoritative guard lives at dispatch (see epic T5).
     if (workflow.driveId !== scope.driveId) {
       return NextResponse.json(
         { error: 'Workflow must belong to the same drive as the webhook' },

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
@@ -23,11 +23,18 @@ const createSchema = z.object({
 // tagged with this provider constant (mirrors 'zoom' on connection-anchored rows).
 const PAGE_WEBHOOK_PROVIDER = 'page-webhook';
 
-// A page webhook fans out to at most this many workflow bindings. The list
-// endpoint returns the full set in one bounded query, so the create path caps
-// at the same number — this keeps GET from ever silently truncating (no cursor
-// needed) while staying far above any realistic wiring depth.
+// Create caps genuinely-new bindings per webhook (far above any realistic
+// wiring depth). The check-then-insert is not atomic, so a burst of concurrent
+// binds for DISTINCT workflows could momentarily overshoot the cap by the
+// concurrency count — hence the list ceiling below sits well above it, so GET
+// still returns every row (no silent truncation, no cursor needed) even after
+// a race. The cap is a safety valve, not a hard invariant the list depends on.
 const MAX_TRIGGERS_PER_WEBHOOK = 100;
+
+// Hard upper bound on rows the list returns in its single page. Set generously
+// above MAX_TRIGGERS_PER_WEBHOOK so any concurrent-overshoot past the cap stays
+// fully visible; creation never legitimately reaches it.
+const TRIGGER_LIST_CEILING = 500;
 
 // Returns the webhook only if it belongs to this page — scopes every trigger op
 // to a webhook the caller's page owns, and yields the page's driveId for the
@@ -62,12 +69,12 @@ export async function GET(request: Request, context: { params: Promise<{ pageId:
     const scope = await findWebhookWithDrive(pageId, id);
     if (!scope) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
 
-    // Stable ordering so repeated reads return the same sequence, and the whole
-    // set fits in one page (creation is capped at MAX_TRIGGERS_PER_WEBHOOK).
+    // Stable ordering so repeated reads return the same sequence; the ceiling
+    // sits above the create cap so the whole set always fits in one page.
     const triggers = await db.query.webhookTriggers.findMany({
       where: eq(webhookTriggers.pageWebhookId, id),
       orderBy: [asc(webhookTriggers.createdAt), asc(webhookTriggers.id)],
-      limit: MAX_TRIGGERS_PER_WEBHOOK,
+      limit: TRIGGER_LIST_CEILING,
     });
 
     return NextResponse.json({ triggers });

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db } from '@pagespace/db/db';
-import { and, eq } from '@pagespace/db/operators';
+import { and, eq, asc, count } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
 import { webhookTriggers, PAGE_WEBHOOK_EVENT_TYPE } from '@pagespace/db/schema/webhook-triggers';
@@ -22,6 +22,12 @@ const createSchema = z.object({
 // A page webhook is not an OAuth connection, so a trigger anchored to one is
 // tagged with this provider constant (mirrors 'zoom' on connection-anchored rows).
 const PAGE_WEBHOOK_PROVIDER = 'page-webhook';
+
+// A page webhook fans out to at most this many workflow bindings. The list
+// endpoint returns the full set in one bounded query, so the create path caps
+// at the same number — this keeps GET from ever silently truncating (no cursor
+// needed) while staying far above any realistic wiring depth.
+const MAX_TRIGGERS_PER_WEBHOOK = 100;
 
 // Returns the webhook only if it belongs to this page — scopes every trigger op
 // to a webhook the caller's page owns, and yields the page's driveId for the
@@ -56,9 +62,12 @@ export async function GET(request: Request, context: { params: Promise<{ pageId:
     const scope = await findWebhookWithDrive(pageId, id);
     if (!scope) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
 
+    // Stable ordering so repeated reads return the same sequence, and the whole
+    // set fits in one page (creation is capped at MAX_TRIGGERS_PER_WEBHOOK).
     const triggers = await db.query.webhookTriggers.findMany({
       where: eq(webhookTriggers.pageWebhookId, id),
-      limit: 200,
+      orderBy: [asc(webhookTriggers.createdAt), asc(webhookTriggers.id)],
+      limit: MAX_TRIGGERS_PER_WEBHOOK,
     });
 
     return NextResponse.json({ triggers });
@@ -111,9 +120,31 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
       );
     }
 
-    // Idempotent create: the partial unique on (pageWebhookId, workflowId) makes
-    // repeated POSTs no-ops rather than duplicate fan-out. connectionId is left
-    // NULL to satisfy the anchor XOR check.
+    // Idempotent create: re-binding an already-wired workflow is a no-op (and
+    // never counts against the cap below). The partial unique on
+    // (pageWebhookId, workflowId) still guards the concurrent-insert race.
+    const alreadyBound = await db.query.webhookTriggers.findFirst({
+      where: and(
+        eq(webhookTriggers.pageWebhookId, id),
+        eq(webhookTriggers.workflowId, workflowId),
+      ),
+    });
+    if (alreadyBound) return NextResponse.json({ trigger: alreadyBound }, { status: 200 });
+
+    // Cap genuinely-new bindings so the list endpoint's single bounded page can
+    // always return the complete set.
+    const [{ value: existingCount }] = await db
+      .select({ value: count() })
+      .from(webhookTriggers)
+      .where(eq(webhookTriggers.pageWebhookId, id));
+    if (existingCount >= MAX_TRIGGERS_PER_WEBHOOK) {
+      return NextResponse.json(
+        { error: `A webhook can have at most ${MAX_TRIGGERS_PER_WEBHOOK} workflow bindings` },
+        { status: 409 },
+      );
+    }
+
+    // connectionId is left NULL to satisfy the anchor XOR check.
     const [inserted] = await db
       .insert(webhookTriggers)
       .values({
@@ -126,13 +157,14 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
       .returning();
 
     if (!inserted) {
-      const existing = await db.query.webhookTriggers.findFirst({
+      // Lost the insert race to a concurrent identical bind — return the winner.
+      const raced = await db.query.webhookTriggers.findFirst({
         where: and(
           eq(webhookTriggers.pageWebhookId, id),
           eq(webhookTriggers.workflowId, workflowId),
         ),
       });
-      return NextResponse.json({ trigger: existing }, { status: 200 });
+      return NextResponse.json({ trigger: raced }, { status: 200 });
     }
 
     auditRequest(request, {

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/triggers/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { db } from '@pagespace/db/db';
+import { and, eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
+import { webhookTriggers, PAGE_WEBHOOK_EVENT_TYPE } from '@pagespace/db/schema/webhook-triggers';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { authenticateRequestWithOptions, isAuthError, canManagePageWebhooks } from '@/lib/auth';
+
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+// Page webhooks skip event matching (every enabled trigger fires), so the only
+// binding input is which workflow to run.
+const createSchema = z.object({
+  workflowId: z.string().min(1),
+});
+
+// A page webhook is not an OAuth connection, so a trigger anchored to one is
+// tagged with this provider constant (mirrors 'zoom' on connection-anchored rows).
+const PAGE_WEBHOOK_PROVIDER = 'page-webhook';
+
+// Returns the webhook only if it belongs to this page — scopes every trigger op
+// to a webhook the caller's page owns, and yields the page's driveId for the
+// cross-drive workflow guard.
+async function findWebhookWithDrive(pageId: string, webhookId: string) {
+  const [webhook, page] = await Promise.all([
+    db.query.pageWebhooks.findFirst({
+      where: and(eq(pageWebhooks.id, webhookId), eq(pageWebhooks.pageId, pageId)),
+      columns: { id: true },
+    }),
+    db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { driveId: true },
+    }),
+  ]);
+  if (!webhook || !page) return null;
+  return { webhookId: webhook.id, driveId: page.driveId };
+}
+
+// GET /api/pages/[pageId]/webhooks/[id]/triggers — list a webhook's workflow bindings
+export async function GET(request: Request, context: { params: Promise<{ pageId: string; id: string }> }) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+    const { pageId, id } = await context.params;
+
+    const canManage = await canManagePageWebhooks(auth, pageId);
+    if (!canManage) {
+      return NextResponse.json({ error: 'Only the drive owner or an admin can manage page webhooks' }, { status: 403 });
+    }
+
+    const scope = await findWebhookWithDrive(pageId, id);
+    if (!scope) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
+
+    const triggers = await db.query.webhookTriggers.findMany({
+      where: eq(webhookTriggers.pageWebhookId, id),
+      limit: 200,
+    });
+
+    return NextResponse.json({ triggers });
+  } catch (error) {
+    loggers.api.error('Error listing page webhook triggers', error as Error);
+    return NextResponse.json({ error: 'Failed to list triggers' }, { status: 500 });
+  }
+}
+
+// POST /api/pages/[pageId]/webhooks/[id]/triggers — bind a workflow to a webhook
+export async function POST(request: Request, context: { params: Promise<{ pageId: string; id: string }> }) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+    const { pageId, id } = await context.params;
+
+    const canManage = await canManagePageWebhooks(auth, pageId);
+    if (!canManage) {
+      return NextResponse.json({ error: 'Only the drive owner or an admin can manage page webhooks' }, { status: 403 });
+    }
+
+    let body: unknown;
+    try { body = await request.json(); } catch { body = {}; }
+    const validation = createSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Invalid trigger', details: validation.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+    const { workflowId } = validation.data;
+
+    const scope = await findWebhookWithDrive(pageId, id);
+    if (!scope) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
+
+    const workflow = await db.query.workflows.findFirst({
+      where: eq(workflows.id, workflowId),
+      columns: { id: true, driveId: true },
+    });
+    if (!workflow) return NextResponse.json({ error: 'Workflow not found' }, { status: 404 });
+
+    // Cross-drive guard: a webhook must only fire workflows from its own drive —
+    // binding a foreign-drive workflow would let a page in one drive drive
+    // execution (and AI billing) in another.
+    if (workflow.driveId !== scope.driveId) {
+      return NextResponse.json(
+        { error: 'Workflow must belong to the same drive as the webhook' },
+        { status: 400 },
+      );
+    }
+
+    // Idempotent create: the partial unique on (pageWebhookId, workflowId) makes
+    // repeated POSTs no-ops rather than duplicate fan-out. connectionId is left
+    // NULL to satisfy the anchor XOR check.
+    const [inserted] = await db
+      .insert(webhookTriggers)
+      .values({
+        workflowId,
+        pageWebhookId: id,
+        provider: PAGE_WEBHOOK_PROVIDER,
+        eventType: PAGE_WEBHOOK_EVENT_TYPE,
+      })
+      .onConflictDoNothing()
+      .returning();
+
+    if (!inserted) {
+      const existing = await db.query.webhookTriggers.findFirst({
+        where: and(
+          eq(webhookTriggers.pageWebhookId, id),
+          eq(webhookTriggers.workflowId, workflowId),
+        ),
+      });
+      return NextResponse.json({ trigger: existing }, { status: 200 });
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'webhook_trigger',
+      resourceId: inserted.id,
+      details: { operation: 'create', pageId, pageWebhookId: id, workflowId },
+    });
+    return NextResponse.json({ trigger: inserted }, { status: 201 });
+  } catch (error) {
+    loggers.api.error('Error creating page webhook trigger', error as Error);
+    return NextResponse.json({ error: 'Failed to create trigger' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## What

Human-facing CRUD to attach/detach a workflow to a **page incoming webhook** — the wiring that lets an owner/admin say "when this webhook fires, run that workflow." Part of the universal Incoming Webhooks epic (board `f8h9ww7rrfaxws4bw44fu8nj`).

New routes under the webhook resource:

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/pages/[pageId]/webhooks/[id]/triggers` | Create a binding (idempotent, capped) |
| `GET` | `/api/pages/[pageId]/webhooks/[id]/triggers` | List a webhook's bindings (ordered) |
| `PATCH` | `/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]` | Toggle `isEnabled` |
| `DELETE` | `/api/pages/[pageId]/webhooks/[id]/triggers/[triggerId]` | Detach |

Each inserts/reads a `webhook_triggers` row anchored to `pageWebhookId` (`connectionId` NULL, honoring the XOR CHECK), `provider = 'page-webhook'`, `eventType = PAGE_WEBHOOK_EVENT_TYPE` (the schema sentinel — imported, not hardcoded). Create is idempotent via the partial unique on `(pageWebhookId, workflowId)`.

## Why

The generalized `webhook_triggers` table (migration 0215) can now anchor to a page webhook, but nothing let a human create those rows. This is that CRUD. The generic trigger **dispatch** (firing bindings through `executeWorkflow`) is a separate task — this PR only creates/reads/toggles/deletes the rows.

## Auth & safety (Spec Review items)

- **Permission:** all four routes gate on `canManagePageWebhooks` (owner/admin only; scoped MCP/OAuth principals rejected — identical to the webhook CRUD). Trigger ops are additionally scoped to a webhook owned by the URL's page (no cross-page IDOR — tests assert the exact `(id, pageId)` / `(triggerId, pageWebhookId)` filters).
- **Cross-drive binding rejected:** the bound workflow must belong to the same drive as the webhook's page, else `400`. Test proves a foreign-drive `workflowId` is rejected and never inserted. (This create-time check is early validation; the authoritative, move-safe same-drive guard belongs at dispatch time and is recorded as a hard requirement on the Generic Trigger Dispatch / T5 board task.)
- **Audit:** every create/toggle/delete emits `auditRequest` `data.write` with `resourceType: 'webhook_trigger'`. The new routes pass the security-audit-coverage gate via these calls (no exemption needed).
- **TOCTOU:** the PATCH toggle guards an empty `update().returning()` (row deleted between ownership check and update) with a 404 and no audit — no phantom success.

## Bounded collection (review follow-up)

Create caps genuinely-new bindings at `MAX_TRIGGERS_PER_WEBHOOK` (100, `409` past it); the list orders by `(createdAt, id)`. The list ceiling (500) is decoupled from and sits above the create cap, so even a concurrent-overshoot past the cap stays fully visible in the single page — no cursor needed, no silent truncation. Idempotent re-binds don't count against the cap.

## Test plan

- `bunx vitest run "src/app/api/pages/[pageId]/webhooks/[id]/triggers"` → **22 passing** (create/list/toggle/delete happy paths; 403 non-owner; 404 wrong-page/missing-workflow/vanished-row; 400 foreign-drive; 200 idempotent; 409 over-cap; ordered/scoped list; asserted insert payload + query filters).
- `security-audit-coverage.test.ts` → green (new routes covered).
- `@pagespace/db` + `@pagespace/lib` + `apps/web` typecheck → clean; `apps/web` lint → clean.
- `bun run knip:check` → within baseline.
- Full CI (Security Test Suite, CodeQL, Static/Secret/Dependency, Lint & TypeScript, Unit Tests) → **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)