### PR TITLE
fix(auth): stop middleware CSP from clobbering the OAuth handoff-bridge page

### DIFF
--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -5,6 +5,7 @@ const mockValidateOriginForMiddleware = vi.hoisted(() => vi.fn());
 const mockIsOriginValidationBlocking = vi.hoisted(() => vi.fn());
 const mockGetSessionFromCookies = vi.hoisted(() => vi.fn());
 const mockLogSecurityEvent = vi.hoisted(() => vi.fn());
+const mockCreateSecureResponse = vi.hoisted(() => vi.fn());
 
 vi.mock('@/middleware/monitoring', () => ({
   monitoringMiddleware: (_req: unknown, handler: () => unknown) => handler(),
@@ -18,7 +19,7 @@ const MOCK_API_CORS_HEADERS: Record<string, string> = {
 };
 
 vi.mock('@/middleware/security-headers', () => ({
-  createSecureResponse: () => ({ response: NextResponse.json({ ok: true }, { status: 200 }) }),
+  createSecureResponse: mockCreateSecureResponse,
   // Kept faithful to the real implementation's rewrite: the whole point of the
   // /dashboard branch is that Next emits an x-middleware-rewrite header instead
   // of a 307, so a stub that dropped it would assert nothing.
@@ -27,6 +28,11 @@ vi.mock('@/middleware/security-headers', () => ({
     nonce: 'test-nonce',
   }),
   createSecureErrorResponse: (body: unknown, status: number) => NextResponse.json(body, { status }),
+  // Real predicate logic — middleware passes its result as `skipCSP` so the
+  // handoff-bridge OAuth callbacks don't get a middleware CSP layered on top of
+  // their own (see the isHandoffBridgeRoute describe block below).
+  isHandoffBridgeRoute: (pathname: string) =>
+    pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback',
   isPublicPageRoute: () => false,
   isPublishedSiteHost: () => false,
   isSecureRequest: () => true,
@@ -66,6 +72,12 @@ vi.mock('@/lib/well-known/rewrites', () => ({
 }));
 
 import { middleware } from '../middleware';
+
+// clearAllMocks() (used in every beforeEach) resets calls but keeps this
+// implementation, so a single default set here survives the whole suite.
+mockCreateSecureResponse.mockImplementation(() => ({
+  response: NextResponse.json({ ok: true }, { status: 200 }),
+}));
 
 const buildRequest = (pathname: string, headers: Record<string, string> = {}, method = 'GET') =>
   new NextRequest(new URL(`http://localhost${pathname}`), { headers, method });
@@ -332,5 +344,42 @@ describe('middleware — unauthenticated /dashboard rewrites instead of redirect
 
     expect(response.status).toBe(401);
     expect(rewriteTarget(response)).toBeNull();
+  });
+});
+
+// The desktop/native OAuth callbacks return their own styled HTML "handoff
+// bridge" with a bespoke CSP that allows an inline <style> block. Middleware
+// must tell createSecureResponse to skip its own CSP for these paths, so the two
+// policies don't intersect and fall style-src back to default-src 'none'
+// (which blocked the bridge's inline styles — the reported regression).
+describe('middleware — handoff-bridge OAuth callbacks skip the middleware CSP', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionFromCookies.mockReturnValue(undefined);
+    mockValidateOriginForMiddleware.mockReturnValue({ valid: true, origin: null, skipped: true, reason: '' });
+    mockIsOriginValidationBlocking.mockReturnValue(false);
+  });
+
+  it.each(['/api/auth/google/callback', '/api/auth/apple/callback'])(
+    'calls createSecureResponse with skipCSP: true for %s',
+    async (pathname) => {
+      await middleware(buildRequest(pathname));
+
+      expect(mockCreateSecureResponse).toHaveBeenCalledWith(
+        expect.any(Boolean),
+        expect.anything(),
+        expect.objectContaining({ skipCSP: true }),
+      );
+    },
+  );
+
+  it('does NOT skip the CSP for a normal public API route (control)', async () => {
+    await middleware(buildRequest('/api/auth/csrf'));
+
+    expect(mockCreateSecureResponse).toHaveBeenCalledWith(
+      expect.any(Boolean),
+      expect.anything(),
+      expect.objectContaining({ skipCSP: false }),
+    );
   });
 });

--- a/apps/web/src/app/api/auth/_shared/handoffBridgeRoutes.ts
+++ b/apps/web/src/app/api/auth/_shared/handoffBridgeRoutes.ts
@@ -1,0 +1,16 @@
+// Single source of truth for the OAuth callback request paths that return the
+// styled HTML "handoff bridge" page (buildHandoffBridgeResponse) with its own
+// bespoke CSP. The edge middleware reads this (via isHandoffBridgeRoute) to skip
+// its restrictive API CSP for these paths, so it doesn't intersect with and
+// clobber the route's own policy — see ./handoffBridgeResponse.ts.
+//
+// Keep in sync with the routes that actually call buildHandoffBridgeResponse:
+//   ../google/callback/route.ts (desktop branch)
+//   ../apple/callback/route.ts  (desktop branch)
+//
+// Pure leaf (no imports) so it stays safe to pull into the Edge-runtime
+// middleware graph — same rationale as the token-prefixes leaf.
+export const HANDOFF_BRIDGE_ROUTE_PATHS = [
+  '/api/auth/google/callback',
+  '/api/auth/apple/callback',
+] as const;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,6 +6,7 @@ import {
   createSecureResponse,
   createSecureRewrite,
   createSecureErrorResponse,
+  isHandoffBridgeRoute,
   isPublicPageRoute,
   isPublishedSiteHost,
   isSecureRequest,
@@ -306,7 +307,13 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
       pathname === '/api/health' ||
       pathname === '/api/version'
     ) {
-      const { response } = createSecureResponse(isProduction, req, { isAPIRoute });
+      // Handoff-bridge OAuth callbacks (google/apple) return their own styled HTML
+      // with a bespoke CSP — skip the middleware CSP so it doesn't intersect with
+      // and clobber the route's policy (which allows the page's inline styles).
+      const { response } = createSecureResponse(isProduction, req, {
+        isAPIRoute,
+        skipCSP: isHandoffBridgeRoute(pathname),
+      });
       return response;
     }
 

--- a/apps/web/src/middleware/__tests__/matcher.test.ts
+++ b/apps/web/src/middleware/__tests__/matcher.test.ts
@@ -9,6 +9,7 @@ vi.mock('@/middleware/monitoring', () => ({ monitoringMiddleware: vi.fn() }));
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse: vi.fn(),
   createSecureErrorResponse: vi.fn(),
+  isHandoffBridgeRoute: vi.fn(),
   isPublicPageRoute: vi.fn(),
   isPublishedSiteHost: vi.fn(),
   shouldDisableCOEP: vi.fn(),

--- a/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/oauth-public-endpoints.test.ts
@@ -13,6 +13,7 @@ const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: ne
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse,
   createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isHandoffBridgeRoute: vi.fn((pathname: string) => pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback'),
   isPublicPageRoute: vi.fn(() => false),
   isPublishedSiteHost: vi.fn(() => false),
   isSecureRequest: vi.fn(() => true),

--- a/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/pre-session-and-asset-endpoints.test.ts
@@ -13,6 +13,7 @@ const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: ne
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse,
   createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isHandoffBridgeRoute: vi.fn((pathname: string) => pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback'),
   isPublicPageRoute: vi.fn(() => false),
   isPublishedSiteHost: vi.fn(() => false),
   isSecureRequest: vi.fn(() => true),

--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -14,6 +14,7 @@ import {
   API_CORS_HEADERS,
   createSecureResponse,
   createSecureErrorResponse,
+  isHandoffBridgeRoute,
   isPublicPageRoute,
   isPublishedSiteHost,
   shouldDisableCOEP,
@@ -491,6 +492,40 @@ describe('Security Headers', () => {
 
       const requestHeaders = getLastRequestHeaders();
       expect(requestHeaders?.get('Content-Security-Policy')).toBeNull();
+    });
+
+    it('omits the CSP header entirely when skipCSP is true (route owns its own CSP)', () => {
+      const { response } = createSecureResponse(false, undefined, {
+        isAPIRoute: true,
+        skipCSP: true,
+      });
+
+      // No middleware CSP — so it can't intersect with the route's own policy.
+      expect(response.headers.has('Content-Security-Policy')).toBe(false);
+      // Every other security header is still applied.
+      expect(response.headers.get('X-Frame-Options')).toBe('DENY');
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    });
+
+    it('does not set CSP in request headers when skipCSP is true', () => {
+      createSecureResponse(false, undefined, { skipCSP: true });
+
+      const requestHeaders = getLastRequestHeaders();
+      expect(requestHeaders?.get('Content-Security-Policy')).toBeNull();
+    });
+  });
+
+  describe('isHandoffBridgeRoute', () => {
+    it('is true for the google and apple OAuth callback paths', () => {
+      expect(isHandoffBridgeRoute('/api/auth/google/callback')).toBe(true);
+      expect(isHandoffBridgeRoute('/api/auth/apple/callback')).toBe(true);
+    });
+
+    it('is false for other auth/API paths', () => {
+      expect(isHandoffBridgeRoute('/api/auth/google/signin')).toBe(false);
+      expect(isHandoffBridgeRoute('/api/auth/apple/native')).toBe(false);
+      expect(isHandoffBridgeRoute('/api/auth/csrf')).toBe(false);
+      expect(isHandoffBridgeRoute('/api/foo')).toBe(false);
     });
   });
 

--- a/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/signup-public-endpoints.test.ts
@@ -13,6 +13,7 @@ const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: ne
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse,
   createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isHandoffBridgeRoute: vi.fn((pathname: string) => pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback'),
   isPublicPageRoute: vi.fn(() => false),
   isPublishedSiteHost: vi.fn(() => false),
   isSecureRequest: vi.fn(() => true),

--- a/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
+++ b/apps/web/src/middleware/__tests__/webhook-public-endpoints.test.ts
@@ -13,6 +13,7 @@ const createSecureResponse = vi.fn(() => ({ response: { status: 200, headers: ne
 vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse,
   createSecureErrorResponse: vi.fn((body: unknown, status: number) => new Response(JSON.stringify(body), { status })),
+  isHandoffBridgeRoute: vi.fn((pathname: string) => pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback'),
   isPublicPageRoute: vi.fn(() => false),
   isPublishedSiteHost: vi.fn(() => false),
   isSecureRequest: vi.fn(() => true),

--- a/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
+++ b/apps/web/src/middleware/__tests__/well-known-oauth-discovery.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/middleware/security-headers', () => ({
   createSecureResponse,
   createSecureRewrite,
   createSecureErrorResponse: vi.fn(),
+  isHandoffBridgeRoute: vi.fn((pathname: string) => pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback'),
   isPublicPageRoute: vi.fn(() => false),
   isPublishedSiteHost: vi.fn(() => false),
   shouldDisableCOEP: vi.fn(() => false),

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -204,15 +204,21 @@ type SecurityHeadersOptions = {
   isSecure?: boolean;
   isAPIRoute?: boolean;
   disableCOEP?: boolean;
+  skipCSP?: boolean;
 };
 
 export const applySecurityHeaders = (
   response: NextResponse,
-  { nonce, isProduction, isSecure = false, isAPIRoute = false, disableCOEP = false }: SecurityHeadersOptions
+  { nonce, isProduction, isSecure = false, isAPIRoute = false, disableCOEP = false, skipCSP = false }: SecurityHeadersOptions
 ): NextResponse => {
-  const csp = isAPIRoute ? buildAPICSPPolicy() : buildCSPPolicy(nonce);
-
-  response.headers.set('Content-Security-Policy', csp);
+  // `skipCSP` lets a route own its own Content-Security-Policy header (see
+  // isHandoffBridgeRoute). Browsers enforce the INTERSECTION of every CSP header
+  // delivered, so if middleware also set one here it would combine with — and
+  // override — the route's policy. We still emit every other security header.
+  if (!skipCSP) {
+    const csp = isAPIRoute ? buildAPICSPPolicy() : buildCSPPolicy(nonce);
+    response.headers.set('Content-Security-Policy', csp);
+  }
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -282,6 +288,18 @@ export const isPublishedSiteHost = (host: string | null | undefined): boolean =>
   return hostname === PUBLISH_BASE_HOST || hostname.endsWith(`.${PUBLISH_BASE_HOST}`);
 };
 
+// OAuth callback routes that return their OWN styled HTML "handoff bridge" page
+// (buildHandoffBridgeResponse) with a bespoke CSP allowing an inline <style> block.
+// Middleware must NOT layer its restrictive API CSP (default-src 'none', no style-src)
+// on top — browsers enforce the intersection of all delivered CSPs, which would fall
+// style-src back to 'none' and block the page's inline styles. See:
+//   apps/web/src/app/api/auth/google/callback/route.ts (desktop branch)
+//   apps/web/src/app/api/auth/apple/callback/route.ts  (desktop branch)
+//   apps/web/src/app/api/auth/_shared/handoffBridgeResponse.ts (the route-owned CSP)
+// Their other returns are redirects, which need no CSP, so skipping is safe path-wide.
+export const isHandoffBridgeRoute = (pathname: string): boolean =>
+  pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback';
+
 export const shouldDisableCOEP = (pathname: string): boolean =>
   pathname.startsWith('/settings/plan') ||
   pathname.startsWith('/settings/billing') ||
@@ -291,6 +309,7 @@ export const shouldDisableCOEP = (pathname: string): boolean =>
 type CreateSecureResponseOptions = {
   isAPIRoute?: boolean;
   disableCOEP?: boolean;
+  skipCSP?: boolean;
 };
 
 const buildSecureResponse = (
@@ -299,7 +318,7 @@ const buildSecureResponse = (
   request?: Request,
   options: CreateSecureResponseOptions = {},
 ): { response: NextResponse; nonce: string } => {
-  const { isAPIRoute = false, disableCOEP = false } = options;
+  const { isAPIRoute = false, disableCOEP = false, skipCSP = false } = options;
   const nonce = generateNonce();
   const isSecure = isSecureRequest(request);
   const csp = isAPIRoute ? buildAPICSPPolicy() : buildCSPPolicy(nonce);
@@ -309,14 +328,14 @@ const buildSecureResponse = (
   // and automatically apply it to framework scripts (via getScriptNonceFromHeader)
   const requestHeaders = new Headers(request?.headers);
   requestHeaders.set(NONCE_HEADER, nonce);
-  if (!isAPIRoute) {
+  if (!isAPIRoute && !skipCSP) {
     requestHeaders.set('Content-Security-Policy', csp);
   }
 
   const response = make(requestHeaders);
 
   // Also set CSP on response headers for browser enforcement
-  applySecurityHeaders(response, { nonce, isProduction, isSecure, isAPIRoute, disableCOEP });
+  applySecurityHeaders(response, { nonce, isProduction, isSecure, isAPIRoute, disableCOEP, skipCSP });
 
   return { response, nonce };
 };

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { API_CONTRACT_VERSION } from '@pagespace/lib/api-contract-version';
+import { HANDOFF_BRIDGE_ROUTE_PATHS } from '@/app/api/auth/_shared/handoffBridgeRoutes';
 
 export const NONCE_HEADER = 'x-nonce';
 
@@ -289,16 +290,14 @@ export const isPublishedSiteHost = (host: string | null | undefined): boolean =>
 };
 
 // OAuth callback routes that return their OWN styled HTML "handoff bridge" page
-// (buildHandoffBridgeResponse) with a bespoke CSP allowing an inline <style> block.
-// Middleware must NOT layer its restrictive API CSP (default-src 'none', no style-src)
-// on top — browsers enforce the intersection of all delivered CSPs, which would fall
-// style-src back to 'none' and block the page's inline styles. See:
-//   apps/web/src/app/api/auth/google/callback/route.ts (desktop branch)
-//   apps/web/src/app/api/auth/apple/callback/route.ts  (desktop branch)
-//   apps/web/src/app/api/auth/_shared/handoffBridgeResponse.ts (the route-owned CSP)
-// Their other returns are redirects, which need no CSP, so skipping is safe path-wide.
+// with a bespoke CSP allowing an inline <style> block. Middleware must NOT layer
+// its restrictive API CSP (default-src 'none', no style-src) on top — browsers
+// enforce the intersection of all delivered CSPs, which would fall style-src back
+// to 'none' and block the page's inline styles. The path list is the shared
+// HANDOFF_BRIDGE_ROUTE_PATHS constant (colocated with the CSP it protects); their
+// other returns are redirects, which need no CSP, so skipping is safe path-wide.
 export const isHandoffBridgeRoute = (pathname: string): boolean =>
-  pathname === '/api/auth/google/callback' || pathname === '/api/auth/apple/callback';
+  (HANDOFF_BRIDGE_ROUTE_PATHS as readonly string[]).includes(pathname);
 
 export const shouldDisableCOEP = (pathname: string): boolean =>
   pathname.startsWith('/settings/plan') ||


### PR DESCRIPTION
## Problem

Desktop (and Apple) Google OAuth sign-in lands on `/api/auth/google/callback`, which returns a small styled HTML **handoff-bridge** page ("You're signed in") that uses an inline `<style>` block and a `<meta http-equiv="refresh">` to launch the `pagespace://auth-exchange` deep link. The browser blocks the inline styles:

> Applying inline style violates the following Content Security Policy directive `default-src 'none'`. … `style-src` was not explicitly set, so `default-src` is used as a fallback.

## Root cause

Regressed when middleware was actually registered in the build (#1932 — the old `apps/web/middleware.ts` had never run). Middleware now applies a strict API CSP (`buildAPICSPPolicy()` = `default-src 'none'; frame-ancestors 'none'`, **no `style-src`**) to every `/api/*` response. The bridge sets its **own** permissive CSP (`… style-src 'unsafe-inline' …`) — but **browsers enforce the intersection of every delivered CSP header**, so `style-src` falls back to the middleware's `default-src 'none'` and the inline styles are blocked, regardless of the route's policy.

## Fix

Let the two handoff-bridge routes own their CSP by having middleware skip emitting *its* CSP for just those paths:

- `apps/web/src/middleware/security-headers.ts` — add a `skipCSP` option (threaded `createSecureResponse` → `buildSecureResponse` → `applySecurityHeaders`; when set, no `Content-Security-Policy` is emitted, all other security headers stay) and an exported `isHandoffBridgeRoute(pathname)` predicate for `/api/auth/google/callback` and `/api/auth/apple/callback`.
- `apps/web/src/middleware.ts` — pass `skipCSP: isHandoffBridgeRoute(pathname)` in the public-route block.

The bridge's own CSP becomes the sole policy → inline styles allowed → deep-link meta-refresh works. Strict CSP is unchanged for every other API route. The two other HTML-returning API routes (`oauth/authorize`, `step-up/magic-link/verify`) emit only plain `<h1>`/`<p>` with no inline style/script, so they need no change.

### Why not the alternatives
- **Widening the API CSP** to include `style-src 'unsafe-inline'` would weaken CSP for every JSON API route.
- **Moving the bridge CSP into middleware** splits the HTML from its policy across files — worse colocation.

## Tests
- `security-headers.test.ts` — `skipCSP` omits the CSP header while keeping other headers; `isHandoffBridgeRoute` predicate cases. **71 passed**
- `middleware.test.ts` — callbacks call `createSecureResponse` with `skipCSP: true`; control route (`/api/auth/csrf`) with `skipCSP: false`. **22 passed**
- google + apple callback route tests — **129 passed**, no regressions
- `bun run typecheck` clean; eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FtpnEpGsz9saKYey1jAJyp

---

**Follow-up commit `f236dd79f`** (`test(middleware)`): the new `isHandoffBridgeRoute` export is imported by `middleware.ts`, and six sibling middleware suites mock `@/middleware/security-headers` wholesale — they didn't provide the new export, so CI's full unit run threw "No isHandoffBridgeRoute export is defined on the mock" in the oauth/signup/webhook/pre-session/asset suites. Added the export to each mock (mirroring the real predicate). All 10 middleware suites (155 tests) green locally and in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Google and Apple OAuth callback handoff pages by preventing conflicting Content Security Policy headers.
  - Preserved other security headers while allowing these callback pages to render correctly.

- **Tests**
  - Added regression coverage for OAuth handoff callbacks and verified that CSP remains enabled for standard public API routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->