### PR TITLE
fix(auth): stop intermittent desktop logouts (session-refresh hardening)

### DIFF
--- a/apps/desktop/src/main/__tests__/auth-session-deviceid.test.ts
+++ b/apps/desktop/src/main/__tests__/auth-session-deviceid.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mutable test state shared with the module mocks (hoisted above vi.mock).
+const h = vi.hoisted(() => ({
+  cachedMachineId: null as string | null,
+  hostname: 'host-A',
+  fileContents: null as string | null, // null => ENOENT
+  writeShouldThrow: false,
+  writes: [] as string[],
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp/userData') },
+}));
+
+vi.mock('node-machine-id', () => ({
+  default: {
+    machineIdSync: vi.fn(() => {
+      throw new Error('machine id unavailable');
+    }),
+  },
+}));
+
+vi.mock('node:os', () => ({
+  hostname: () => h.hostname,
+}));
+
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(() => {
+    if (h.fileContents === null) {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return h.fileContents;
+  }),
+  writeFileSync: vi.fn((_path: string, data: string) => {
+    if (h.writeShouldThrow) throw new Error('EROFS: read-only file system');
+    h.writes.push(data);
+    h.fileContents = data; // persistence succeeded
+  }),
+}));
+
+vi.mock('../state', () => ({
+  get cachedMachineId() { return h.cachedMachineId; },
+  setCachedMachineId: (id: string | null) => { h.cachedMachineId = id; },
+  get cachedSession() { return undefined; },
+  setCachedSession: vi.fn(),
+}));
+
+vi.mock('../auth-storage', () => ({
+  loadAuthSession: vi.fn(),
+}));
+
+vi.mock('../logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { getMachineIdentifier } from '../auth-session';
+
+const legacyId = () => `${h.hostname}-${process.platform}-${process.arch}`;
+
+describe('getMachineIdentifier fallback (machineIdSync unavailable)', () => {
+  beforeEach(() => {
+    h.cachedMachineId = null;
+    h.hostname = 'host-A';
+    h.fileContents = null;
+    h.writeShouldThrow = false;
+    h.writes = [];
+    vi.clearAllMocks();
+  });
+
+  it('with no persisted file, seeds from the legacy machine-derived id and persists it (P1)', () => {
+    const id = getMachineIdentifier();
+
+    expect(id).toBe(legacyId());
+    expect(h.writes).toEqual([legacyId()]); // persisted for future launches
+  });
+
+  it('reuses the persisted id and does NOT re-derive it after a hostname change', () => {
+    h.fileContents = 'host-A-darwin-arm64'; // seeded on a previous launch
+    h.hostname = 'host-B';                  // hostname since changed (VPN/network)
+
+    const id = getMachineIdentifier();
+
+    expect(id).toBe('host-A-darwin-arm64'); // persisted value wins → no device_id_mismatch
+    expect(h.writes).toEqual([]);           // nothing re-persisted
+  });
+
+  it('stays stable across launches even when persistence fails (P2)', () => {
+    h.writeShouldThrow = true; // read-only profile / full disk
+
+    const first = getMachineIdentifier();
+    h.cachedMachineId = null; // simulate a fresh process (new launch)
+    const second = getMachineIdentifier();
+
+    expect(first).toBe(legacyId());
+    expect(second).toBe(legacyId()); // deterministic seed → identical, no churn
+  });
+});

--- a/apps/desktop/src/main/__tests__/device-id-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/device-id-fallback.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveFallbackDeviceId, type DeviceIdFallbackDeps } from '../device-id-fallback';
+
+describe('resolveFallbackDeviceId', () => {
+  it('reuses a previously-persisted id without generating or re-persisting', () => {
+    const deps: DeviceIdFallbackDeps = {
+      readPersistedId: vi.fn().mockReturnValue('stored-uuid'),
+      persistId: vi.fn(),
+      generateId: vi.fn().mockReturnValue('should-not-be-used'),
+    };
+
+    expect(resolveFallbackDeviceId(deps)).toBe('stored-uuid');
+    expect(deps.generateId).not.toHaveBeenCalled();
+    expect(deps.persistId).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a new id when none is stored', () => {
+    const deps: DeviceIdFallbackDeps = {
+      readPersistedId: vi.fn().mockReturnValue(null),
+      persistId: vi.fn(),
+      generateId: vi.fn().mockReturnValue('fresh-uuid'),
+    };
+
+    expect(resolveFallbackDeviceId(deps)).toBe('fresh-uuid');
+    expect(deps.persistId).toHaveBeenCalledWith('fresh-uuid');
+  });
+
+  it('is STABLE across a simulated hostname change (persisted uuid, never hostname-derived)', () => {
+    // In-memory persistence store. The hostname is irrelevant to the result:
+    // the fallback only ever reads/writes the persisted uuid.
+    let stored: string | null = null;
+    let generateCount = 0;
+    const deps: DeviceIdFallbackDeps = {
+      readPersistedId: () => stored,
+      persistId: (id) => { stored = id; },
+      generateId: () => `uuid-${++generateCount}`,
+    };
+
+    // First launch (hostname "host-A"): generates + persists.
+    const first = resolveFallbackDeviceId(deps);
+    // Second launch after a hostname change (hostname "host-B"): reuses the same id.
+    const second = resolveFallbackDeviceId(deps);
+
+    expect(first).toBe('uuid-1');
+    expect(second).toBe('uuid-1');
+    expect(generateCount).toBe(1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/device-id-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/device-id-fallback.test.ts
@@ -2,47 +2,64 @@ import { describe, it, expect, vi } from 'vitest';
 import { resolveFallbackDeviceId, type DeviceIdFallbackDeps } from '../device-id-fallback';
 
 describe('resolveFallbackDeviceId', () => {
-  it('reuses a previously-persisted id without generating or re-persisting', () => {
+  it('reuses a previously-persisted id without seeding or re-persisting', () => {
     const deps: DeviceIdFallbackDeps = {
-      readPersistedId: vi.fn().mockReturnValue('stored-uuid'),
+      readPersistedId: vi.fn().mockReturnValue('stored-id'),
       persistId: vi.fn(),
-      generateId: vi.fn().mockReturnValue('should-not-be-used'),
+      seedId: vi.fn().mockReturnValue('should-not-be-used'),
     };
 
-    expect(resolveFallbackDeviceId(deps)).toBe('stored-uuid');
-    expect(deps.generateId).not.toHaveBeenCalled();
+    expect(resolveFallbackDeviceId(deps)).toBe('stored-id');
+    expect(deps.seedId).not.toHaveBeenCalled();
     expect(deps.persistId).not.toHaveBeenCalled();
   });
 
-  it('generates and persists a new id when none is stored', () => {
-    const deps: DeviceIdFallbackDeps = {
-      readPersistedId: vi.fn().mockReturnValue(null),
-      persistId: vi.fn(),
-      generateId: vi.fn().mockReturnValue('fresh-uuid'),
-    };
-
-    expect(resolveFallbackDeviceId(deps)).toBe('fresh-uuid');
-    expect(deps.persistId).toHaveBeenCalledWith('fresh-uuid');
-  });
-
-  it('is STABLE across a simulated hostname change (persisted uuid, never hostname-derived)', () => {
-    // In-memory persistence store. The hostname is irrelevant to the result:
-    // the fallback only ever reads/writes the persisted uuid.
+  it('seeds from the legacy machine-derived id on first run and persists it (P1 upgrade continuity)', () => {
+    // On upgrade there is no device-id file yet, but the device token is already
+    // bound to the legacy `${hostname}-${platform}-${arch}` value. Seeding from
+    // that value (not a fresh random id) preserves the binding, then persisting
+    // it freezes it for future launches.
     let stored: string | null = null;
-    let generateCount = 0;
     const deps: DeviceIdFallbackDeps = {
       readPersistedId: () => stored,
       persistId: (id) => { stored = id; },
-      generateId: () => `uuid-${++generateCount}`,
+      seedId: () => 'oldhost-darwin-arm64',
     };
 
-    // First launch (hostname "host-A"): generates + persists.
-    const first = resolveFallbackDeviceId(deps);
-    // Second launch after a hostname change (hostname "host-B"): reuses the same id.
-    const second = resolveFallbackDeviceId(deps);
+    expect(resolveFallbackDeviceId(deps)).toBe('oldhost-darwin-arm64');
+    expect(stored).toBe('oldhost-darwin-arm64');
+  });
 
-    expect(first).toBe('uuid-1');
-    expect(second).toBe('uuid-1');
-    expect(generateCount).toBe(1);
+  it('is STABLE across a simulated hostname change once persisted (never re-derived)', () => {
+    let stored: string | null = null;
+    let seedCount = 0;
+    const deps: DeviceIdFallbackDeps = {
+      readPersistedId: () => stored,
+      persistId: (id) => { stored = id; },
+      // Simulate the hostname changing between launches: the seed would differ,
+      // but the persisted value must win so the id never flips.
+      seedId: () => `host-${++seedCount}-darwin-arm64`,
+    };
+
+    const first = resolveFallbackDeviceId(deps);   // launch on host-1 → seeds + persists
+    const second = resolveFallbackDeviceId(deps);  // launch on host-2 → reads persisted
+
+    expect(first).toBe('host-1-darwin-arm64');
+    expect(second).toBe('host-1-darwin-arm64');
+    expect(seedCount).toBe(1);
+  });
+
+  it('stays stable across launches even when persistence FAILS, thanks to a deterministic seed (P2)', () => {
+    // Simulate a read-only profile / full disk: persistId is a no-op, so the
+    // file never appears. A deterministic seed means each launch regenerates the
+    // SAME id — no device-binding churn, no repeated logouts.
+    const deps: DeviceIdFallbackDeps = {
+      readPersistedId: () => null,           // file never exists (write kept failing)
+      persistId: () => { /* swallowed failure */ },
+      seedId: () => 'host-darwin-arm64',     // deterministic for this machine
+    };
+
+    expect(resolveFallbackDeviceId(deps)).toBe('host-darwin-arm64');
+    expect(resolveFallbackDeviceId(deps)).toBe('host-darwin-arm64'); // next launch, same id
   });
 });

--- a/apps/desktop/src/main/auth-session.ts
+++ b/apps/desktop/src/main/auth-session.ts
@@ -1,8 +1,33 @@
-import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { app } from 'electron';
 import nodeMachineId from 'node-machine-id';
 import { loadAuthSession, type StoredAuthSession } from './auth-storage';
 import { setCachedSession, setCachedMachineId, cachedMachineId, cachedSession } from './state';
+import { resolveFallbackDeviceId } from './device-id-fallback';
 import { logger } from './logger';
+
+function deviceIdFilePath(): string {
+  return path.join(app.getPath('userData'), 'device-id');
+}
+
+function readPersistedDeviceId(): string | null {
+  try {
+    const id = readFileSync(deviceIdFilePath(), 'utf8').trim();
+    return id.length > 0 ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistDeviceId(id: string): void {
+  try {
+    writeFileSync(deviceIdFilePath(), id, 'utf8');
+  } catch (error) {
+    logger.warn('[Auth] Failed to persist fallback device id', { error });
+  }
+}
 
 export async function preloadAuthSession(): Promise<void> {
   try {
@@ -26,8 +51,15 @@ export function getMachineIdentifier(): string {
     setCachedMachineId(id);
     return id;
   } catch (error) {
-    logger.warn('[Auth] Failed to read machine identifier, falling back to hostname', { error });
-    const fallbackId = `${os.hostname()}-${process.platform}-${process.arch}`;
+    // Do NOT derive the fallback from the hostname — it flips on network/VPN
+    // changes and triggers a device_id_mismatch 401 → logout. Use a persisted
+    // UUID that is stable across launches and hostname changes.
+    logger.warn('[Auth] Failed to read machine identifier, falling back to persisted device id', { error });
+    const fallbackId = resolveFallbackDeviceId({
+      readPersistedId: readPersistedDeviceId,
+      persistId: persistDeviceId,
+      generateId: randomUUID,
+    });
     setCachedMachineId(fallbackId);
     return fallbackId;
   }

--- a/apps/desktop/src/main/auth-session.ts
+++ b/apps/desktop/src/main/auth-session.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
 import { readFileSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { app } from 'electron';
@@ -25,8 +25,21 @@ function persistDeviceId(id: string): void {
   try {
     writeFileSync(deviceIdFilePath(), id, 'utf8');
   } catch (error) {
+    // A write failure is non-fatal: `legacyMachineDerivedId` is deterministic,
+    // so the next launch regenerates the identical id (no device-binding churn).
     logger.warn('[Auth] Failed to persist fallback device id', { error });
   }
+}
+
+/**
+ * The historical fallback deviceId. It is DETERMINISTIC for a given machine,
+ * which is exactly why we seed the persisted id from it: an existing install
+ * whose device token was bound to this value keeps that binding across the
+ * upgrade to the persisted-id scheme (no forced `device_id_mismatch` logout).
+ * Persisting it once then makes it stable even if the hostname later changes.
+ */
+function legacyMachineDerivedId(): string {
+  return `${os.hostname()}-${process.platform}-${process.arch}`;
 }
 
 export async function preloadAuthSession(): Promise<void> {
@@ -51,14 +64,16 @@ export function getMachineIdentifier(): string {
     setCachedMachineId(id);
     return id;
   } catch (error) {
-    // Do NOT derive the fallback from the hostname — it flips on network/VPN
-    // changes and triggers a device_id_mismatch 401 → logout. Use a persisted
-    // UUID that is stable across launches and hostname changes.
+    // Persist the deviceId once, then reuse it verbatim — so it stays stable
+    // even if the hostname later changes (VPN/network switch), which otherwise
+    // flips a recomputed hostname-derived id and triggers a device_id_mismatch
+    // 401 → logout. The seed is the legacy machine-derived id so an existing
+    // install's token binding survives the upgrade to this scheme.
     logger.warn('[Auth] Failed to read machine identifier, falling back to persisted device id', { error });
     const fallbackId = resolveFallbackDeviceId({
       readPersistedId: readPersistedDeviceId,
       persistId: persistDeviceId,
-      generateId: randomUUID,
+      seedId: legacyMachineDerivedId,
     });
     setCachedMachineId(fallbackId);
     return fallbackId;

--- a/apps/desktop/src/main/device-id-fallback.ts
+++ b/apps/desktop/src/main/device-id-fallback.ts
@@ -1,0 +1,38 @@
+/**
+ * Functional core for the desktop deviceId fallback.
+ *
+ * When `machineIdSync` is unavailable, the desktop app must still produce a
+ * STABLE deviceId. The previous fallback derived it from `os.hostname()`, which
+ * flips when the machine's hostname changes (VPN/network switch on macOS). A
+ * flipped deviceId no longer matches the device-token binding, so the server
+ * returns a `device_id_mismatch` 401 and the user is logged out.
+ *
+ * This resolver instead reuses a persisted UUID — generated once and stored under
+ * userData — so the deviceId is invariant across launches and network changes.
+ * All I/O is injected so the decision is unit-testable without Electron or a disk.
+ */
+
+export interface DeviceIdFallbackDeps {
+  /** Read the persisted deviceId, or null if none has been stored yet. */
+  readPersistedId: () => string | null;
+  /** Persist a freshly-generated deviceId for future launches. */
+  persistId: (id: string) => void;
+  /** Generate a new opaque, stable deviceId (e.g. a UUID). */
+  generateId: () => string;
+}
+
+/**
+ * Resolve a stable fallback deviceId: reuse the persisted one if present,
+ * otherwise generate one, persist it, and return it. Never derives the id from
+ * volatile machine state such as the hostname.
+ */
+export function resolveFallbackDeviceId(deps: DeviceIdFallbackDeps): string {
+  const existing = deps.readPersistedId();
+  if (existing) {
+    return existing;
+  }
+
+  const generated = deps.generateId();
+  deps.persistId(generated);
+  return generated;
+}

--- a/apps/desktop/src/main/device-id-fallback.ts
+++ b/apps/desktop/src/main/device-id-fallback.ts
@@ -2,29 +2,41 @@
  * Functional core for the desktop deviceId fallback.
  *
  * When `machineIdSync` is unavailable, the desktop app must still produce a
- * STABLE deviceId. The previous fallback derived it from `os.hostname()`, which
- * flips when the machine's hostname changes (VPN/network switch on macOS). A
- * flipped deviceId no longer matches the device-token binding, so the server
- * returns a `device_id_mismatch` 401 and the user is logged out.
+ * deviceId that is STABLE across launches. The previous fallback recomputed
+ * `${hostname}-${platform}-${arch}` on every call, so it flipped when the
+ * machine's hostname changed (VPN/network switch on macOS). A flipped deviceId
+ * no longer matches the device-token binding, so the server returns a
+ * `device_id_mismatch` 401 and the user is logged out.
  *
- * This resolver instead reuses a persisted UUID — generated once and stored under
- * userData — so the deviceId is invariant across launches and network changes.
- * All I/O is injected so the decision is unit-testable without Electron or a disk.
+ * This resolver makes the id stable by persisting it once and reusing it
+ * verbatim thereafter. Stability comes from the persist-once step, NOT from the
+ * seed value being hostname-independent — which is why the injected `seedId`
+ * MUST be deterministic (see below). All I/O is injected so the decision is
+ * unit-testable without Electron or a disk.
  */
 
 export interface DeviceIdFallbackDeps {
   /** Read the persisted deviceId, or null if none has been stored yet. */
   readPersistedId: () => string | null;
-  /** Persist a freshly-generated deviceId for future launches. */
+  /** Persist the seeded deviceId so future launches read it back verbatim. */
   persistId: (id: string) => void;
-  /** Generate a new opaque, stable deviceId (e.g. a UUID). */
-  generateId: () => string;
+  /**
+   * Produce the seed deviceId on first run. This value MUST be DETERMINISTIC
+   * (e.g. the legacy `${hostname}-${platform}-${arch}` id) rather than random,
+   * so that:
+   *  - it MATCHES any device token already bound to the legacy fallback before
+   *    this persisted-id scheme existed (upgrade continuity — no forced logout);
+   *  - if persistence fails, the next launch regenerates the IDENTICAL value
+   *    instead of churning a new id every launch (which would itself trigger
+   *    repeated `device_id_mismatch` logouts).
+   */
+  seedId: () => string;
 }
 
 /**
  * Resolve a stable fallback deviceId: reuse the persisted one if present,
- * otherwise generate one, persist it, and return it. Never derives the id from
- * volatile machine state such as the hostname.
+ * otherwise seed it (from the deterministic `seedId`), persist it for future
+ * launches, and return it.
  */
 export function resolveFallbackDeviceId(deps: DeviceIdFallbackDeps): string {
   const existing = deps.readPersistedId();
@@ -32,7 +44,7 @@ export function resolveFallbackDeviceId(deps: DeviceIdFallbackDeps): string {
     return existing;
   }
 
-  const generated = deps.generateId();
-  deps.persistId(generated);
-  return generated;
+  const seeded = deps.seedId();
+  deps.persistId(seeded);
+  return seeded;
 }

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-reason.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-reason.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+  getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+  sessionService: {
+    createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
+    validateSession: vi.fn().mockResolvedValue({ sessionId: 'sid_123' }),
+    revokeSessionByHash: vi.fn().mockResolvedValue(undefined),
+    expireSessionByHashSoon: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+  validateDeviceToken: vi.fn(),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
+}));
+vi.mock('@pagespace/lib/auth/token-lifecycle-policy', () => ({
+  shouldAllowDeviceRefresh: vi.fn().mockReturnValue({ ok: true }),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+  generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
+}));
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({ trackAuthEvent: vi.fn() }));
+vi.mock('@/lib/repositories/auth-repository', () => ({
+  authRepository: {
+    findUserById: vi.fn().mockResolvedValue({ id: 'user_1', email: 'test@example.com' }),
+  },
+}));
+vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
+  atomicDeviceTokenRotation: vi.fn(),
+}));
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  appendSessionCookie: vi.fn(),
+  getSessionFromCookies: vi.fn(() => null),
+}));
+
+import { POST } from '../refresh/route';
+import { validateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { shouldAllowDeviceRefresh } from '@pagespace/lib/auth/token-lifecycle-policy';
+import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/auth/device/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const validRecord = {
+  id: 'dt_1',
+  userId: 'user_1',
+  deviceId: 'device_123',
+  platform: 'desktop',
+  expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+};
+
+describe('device refresh 401 reason codes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(shouldAllowDeviceRefresh).mockReturnValue({ ok: true });
+  });
+
+  it('invalid/expired device token → reason "invalid_device_token"', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce(null as never);
+
+    const res = await POST(makeRequest({ deviceToken: 'bad', deviceId: 'device_123' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.reason).toBe('invalid_device_token');
+  });
+
+  it('unknown stored deviceId → reason "unknown_stored_device"', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce(validRecord as never);
+    vi.mocked(shouldAllowDeviceRefresh).mockReturnValueOnce({ ok: false, reason: 'unknown_stored_device' });
+
+    const res = await POST(makeRequest({ deviceToken: 'valid', deviceId: 'device_123' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.reason).toBe('unknown_stored_device');
+  });
+
+  it('device mismatch → reason "device_id_mismatch"', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce(validRecord as never);
+    vi.mocked(shouldAllowDeviceRefresh).mockReturnValueOnce({ ok: false, reason: 'device_mismatch' });
+
+    const res = await POST(makeRequest({ deviceToken: 'valid', deviceId: 'other_device' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.reason).toBe('device_id_mismatch');
+  });
+
+  it('rotation failure → reason "rotation_failed"', async () => {
+    // Token within 60d of expiry so rotation is attempted, then fails.
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce({
+      ...validRecord,
+      expiresAt: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000),
+    } as never);
+    vi.mocked(atomicDeviceTokenRotation).mockResolvedValueOnce({
+      success: false,
+      error: 'Device token already rotated',
+    } as never);
+
+    const res = await POST(makeRequest({ deviceToken: 'valid', deviceId: 'device_123' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.reason).toBe('rotation_failed');
+  });
+});

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -92,6 +92,7 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       scopes: ['*'],
     }),
     revokeSessionByHash: vi.fn().mockResolvedValue(undefined),
+    expireSessionByHashSoon: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -176,6 +177,7 @@ describe('POST /api/auth/device/refresh', () => {
       scopes: ['*'],
     } as never);
     vi.mocked(sessionService.revokeSessionByHash).mockResolvedValue(undefined);
+    vi.mocked(sessionService.expireSessionByHashSoon).mockResolvedValue(undefined);
 
     // No replaced session cookie by default (existing tests exercise the
     // no-cookie path); retirement tests override this per-case.
@@ -632,7 +634,7 @@ describe('POST /api/auth/device/refresh', () => {
   });
 
   describe('replaced-session retirement', () => {
-    it('revokes the session the refresh replaces (same user) with replaced_by_refresh — web', async () => {
+    it('grace-expires the session the refresh replaces (same user) — web', async () => {
       vi.mocked(validateDeviceToken).mockResolvedValue({
         ...mockDeviceRecord,
         platform: 'web',
@@ -646,15 +648,17 @@ describe('POST /api/auth/device/refresh', () => {
 
       expect(response.status).toBe(200);
       // Ownership resolved via the old cookie's session (same user-123), then
-      // revoked by its hash.
+      // grace-expired by its hash (NOT hard-revoked — in-flight requests must
+      // stay valid for the grace window).
       expect(hashToken).toHaveBeenCalledWith('old-web-session-token');
-      expect(sessionService.revokeSessionByHash).toHaveBeenCalledWith(
+      expect(sessionService.revokeSessionByHash).not.toHaveBeenCalled();
+      expect(sessionService.expireSessionByHashSoon).toHaveBeenCalledWith(
         'hashed-old-session',
-        'replaced_by_refresh',
+        expect.any(Number),
       );
     });
 
-    it('revokes the replaced session on the desktop branch too', async () => {
+    it('grace-expires the replaced session on the desktop branch too', async () => {
       vi.mocked(getSessionFromCookies).mockReturnValue('old-desktop-session-token');
 
       const request = createRefreshRequest(validRefreshPayload, {
@@ -663,23 +667,23 @@ describe('POST /api/auth/device/refresh', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(sessionService.revokeSessionByHash).toHaveBeenCalledWith(
+      expect(sessionService.expireSessionByHashSoon).toHaveBeenCalledWith(
         'hashed-old-session',
-        'replaced_by_refresh',
+        expect.any(Number),
       );
     });
 
-    it('does NOT revoke anything when no session cookie accompanies the refresh', async () => {
+    it('does NOT touch anything when no session cookie accompanies the refresh', async () => {
       vi.mocked(getSessionFromCookies).mockReturnValue(null);
 
       const request = createRefreshRequest(validRefreshPayload);
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(sessionService.revokeSessionByHash).not.toHaveBeenCalled();
+      expect(sessionService.expireSessionByHashSoon).not.toHaveBeenCalled();
     });
 
-    it('does NOT revoke when the old cookie session belongs to a different user', async () => {
+    it('does NOT grace-expire when the old cookie session belongs to a different user', async () => {
       vi.mocked(getSessionFromCookies).mockReturnValue('someone-elses-token');
       // First validateSession call is for the new session (user-123); the second
       // (owner lookup for the old token) resolves to a different user.
@@ -707,12 +711,12 @@ describe('POST /api/auth/device/refresh', () => {
       const response = await POST(request);
 
       expect(response.status).toBe(200);
-      expect(sessionService.revokeSessionByHash).not.toHaveBeenCalled();
+      expect(sessionService.expireSessionByHashSoon).not.toHaveBeenCalled();
     });
 
-    it('never fails the refresh when the retirement revoke throws', async () => {
+    it('never fails the refresh when the retirement grace-expiry throws', async () => {
       vi.mocked(getSessionFromCookies).mockReturnValue('old-web-session-token');
-      vi.mocked(sessionService.revokeSessionByHash).mockRejectedValue(new Error('db down'));
+      vi.mocked(sessionService.expireSessionByHashSoon).mockRejectedValue(new Error('db down'));
 
       const request = createRefreshRequest(validRefreshPayload, {
         Cookie: 'session=old-web-session-token',

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/v4';
-import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
+import { atomicDeviceTokenRotation, type DeviceRotationResult } from '@pagespace/db/transactions/auth-transactions';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { shouldAllowDeviceRefresh } from '@pagespace/lib/auth/token-lifecycle-policy';
@@ -16,6 +16,14 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP, appendSessionCookie, getSessionFromCookies } from '@/lib/auth';
 import { retireReplacedSession } from '@/lib/auth/session-retirement';
+import { selectDeviceTokenForResponse } from '@/lib/auth/device-refresh-token-selection';
+
+// Grace window for retiring the session a device refresh replaces. The old
+// session is expired ~60s out (not hard-revoked) so in-flight requests carrying
+// the old Bearer token — notably the 1s active-streams poll — keep validating
+// until the client has switched to the new token. 60s comfortably outlasts the
+// client token switch plus the 5s post-refresh cooldown.
+const REPLACED_SESSION_GRACE_MS = 60 * 1000;
 
 const deviceRefreshSchema = z.object({
   deviceToken: z.string().min(1, { message: 'Device token is required' }),
@@ -48,7 +56,8 @@ export async function POST(req: Request) {
         getSessionOwnerId: async (token) =>
           (await sessionService.validateSession(token))?.userId ?? null,
         hashToken,
-        revokeByHash: (tokenHash, reason) => sessionService.revokeSessionByHash(tokenHash, reason),
+        graceExpireByHash: (tokenHash) =>
+          sessionService.expireSessionByHashSoon(tokenHash, REPLACED_SESSION_GRACE_MS),
         logWarn: (message, meta) => loggers.auth.warn(message, meta),
       });
 
@@ -77,7 +86,10 @@ export async function POST(req: Request) {
 
     const deviceRecord = await validateDeviceToken(deviceToken);
     if (!deviceRecord) {
-      return Response.json({ error: 'Invalid or expired device token.' }, { status: 401 });
+      return Response.json(
+        { error: 'Invalid or expired device token.', reason: 'invalid_device_token' },
+        { status: 401 }
+      );
     }
 
     // SECURITY (L4): strict device-binding check. A stored deviceId that is
@@ -94,7 +106,7 @@ export async function POST(req: Request) {
           userId: deviceRecord.userId,
         });
         return Response.json(
-          { error: 'Device must be re-registered. Please sign in again.' },
+          { error: 'Device must be re-registered. Please sign in again.', reason: 'unknown_stored_device' },
           { status: 401 }
         );
       }
@@ -105,7 +117,10 @@ export async function POST(req: Request) {
         providedDeviceId: deviceId,
         userId: deviceRecord.userId,
       });
-      return Response.json({ error: 'Device token does not match this device.' }, { status: 401 });
+      return Response.json(
+        { error: 'Device token does not match this device.', reason: 'device_id_mismatch' },
+        { status: 401 }
+      );
     }
 
     const user = await authRepository.findUserById(deviceRecord.userId);
@@ -116,14 +131,13 @@ export async function POST(req: Request) {
 
     // Rotate device token if it is within 60 days of expiration
     // Increased from 30 to 60 days to ensure proactive rotation with overlap
-    let activeDeviceToken = deviceToken;
-    let activeDeviceTokenId = deviceRecord.id;
     const sixtyDaysMs = 60 * 24 * 60 * 60 * 1000;
+    let rotation: DeviceRotationResult | null = null;
 
     if (deviceRecord.expiresAt && deviceRecord.expiresAt.getTime() - Date.now() < sixtyDaysMs) {
       // SECURITY: Atomic device token rotation with FOR UPDATE locking
       // Prevents race conditions in concurrent rotation attempts
-      const rotated = await atomicDeviceTokenRotation(
+      rotation = await atomicDeviceTokenRotation(
         deviceToken,
         {
           userAgent: userAgent ?? req.headers.get('user-agent') ?? undefined,
@@ -134,25 +148,26 @@ export async function POST(req: Request) {
         generateDeviceToken
       );
 
-      if (!rotated.success) {
+      if (!rotation.success) {
         // SECURITY: Rotation failed - do not continue with potentially revoked token
         // Token may have been revoked, expired, or already rotated by concurrent request
         loggers.auth.warn('Device token rotation failed - aborting refresh', {
           userId: deviceRecord.userId,
           deviceId: deviceRecord.deviceId,
-          error: rotated.error,
+          error: rotation.error,
         });
         return Response.json(
-          { error: rotated.error ?? 'Device token rotation failed. Please re-authenticate.' },
+          { error: rotation.error ?? 'Device token rotation failed. Please re-authenticate.', reason: 'rotation_failed' },
           { status: 401 }
         );
       }
-
-      if (rotated.newToken && rotated.deviceTokenId) {
-        activeDeviceToken = rotated.newToken;
-        activeDeviceTokenId = rotated.deviceTokenId;
-      }
     }
+
+    // Choose which token to return to the client. On a grace-period rotation
+    // retry this yields NO token (the old one is revoked; the client keeps its
+    // good token) — the fix for the device-token grace-clobber logout.
+    const { deviceToken: activeDeviceToken, activeDeviceTokenId } =
+      selectDeviceTokenForResponse(deviceToken, deviceRecord.id, rotation);
 
     const normalizedIP = clientIP === 'unknown' ? undefined : clientIP;
 

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-desktop-401-retry.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-desktop-401-retry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/logging/client-logger', () => ({
+  createClientLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@/lib/analytics/device-fingerprint', () => ({
+  getOrCreateDeviceId: () => 'mock-device-id-12345',
+}));
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    platform: 'desktop',
+    getSessionToken: vi.fn().mockResolvedValue(null),
+    getStoredSession: vi.fn().mockResolvedValue(null),
+    storeSession: vi.fn().mockResolvedValue(undefined),
+    clearSession: vi.fn().mockResolvedValue(undefined),
+    getDeviceInfo: vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'ua' }),
+    usesBearer: vi.fn().mockReturnValue(true),
+    supportsCSRF: vi.fn().mockReturnValue(false),
+    dispatchAuthEvent: vi.fn(),
+  }),
+  resetPlatformStorage: vi.fn(),
+}));
+
+type RefreshInternals = {
+  refreshDesktopSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+};
+
+describe('desktop device-refresh 401 single retry before logout', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof global.fetch;
+  let originalWindow: typeof global.window;
+  let storeSession: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    originalWindow = global.window;
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    storeSession = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(global, 'window', {
+      value: {
+        dispatchEvent: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        electron: {
+          on: vi.fn(() => () => {}),
+          auth: {
+            getSession: vi.fn().mockResolvedValue({ sessionToken: 'old', deviceToken: 'old-device-token' }),
+            getDeviceInfo: vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'ua', appVersion: '1.0.0' }),
+            storeSession,
+          },
+        },
+      },
+      writable: true,
+    });
+
+    delete (globalThis as typeof globalThis & { [key: symbol]: unknown })[
+      Symbol.for('pagespace.authfetch.singleton')
+    ];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'window', { value: originalWindow, writable: true });
+  });
+
+  it('two consecutive 401s: retries exactly once, then logs out', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'nope', reason: 'invalid_device_token' }), { status: 401 }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result).toEqual({ success: false, shouldLogout: true });
+    // One original attempt + exactly one retry = 2 calls (no infinite loop).
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('401 then success: the retry recovers and does NOT log out', async () => {
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'nope', reason: 'invalid_device_token' }), { status: 401 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ sessionToken: 'new-session', csrfToken: 'csrf', deviceToken: 'new-device-token' }),
+          { status: 200 },
+        ),
+      );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result).toEqual({ success: true, shouldLogout: false });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(storeSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionToken: 'new-session', deviceToken: 'new-device-token' }),
+    );
+  });
+
+  it('immediate success: no retry, single request', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ sessionToken: 'new-session', csrfToken: 'csrf', deviceToken: 'new-device-token' }), {
+        status: 200,
+      }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result).toEqual({ success: true, shouldLogout: false });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-device-token-preservation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-device-token-preservation.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/logging/client-logger', () => ({
+  createClientLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/analytics/device-fingerprint', () => ({
+  getOrCreateDeviceId: () => 'mock-device-id-12345',
+}));
+
+// Desktop platform storage so the singleton constructs cleanly.
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    platform: 'desktop',
+    getSessionToken: vi.fn().mockResolvedValue(null),
+    getStoredSession: vi.fn().mockResolvedValue(null),
+    storeSession: vi.fn().mockResolvedValue(undefined),
+    clearSession: vi.fn().mockResolvedValue(undefined),
+    getDeviceInfo: vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'test-agent' }),
+    usesBearer: vi.fn().mockReturnValue(true),
+    supportsCSRF: vi.fn().mockReturnValue(false),
+    dispatchAuthEvent: vi.fn(),
+  }),
+  resetPlatformStorage: vi.fn(),
+}));
+
+type RefreshInternals = {
+  refreshDesktopSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+  refreshWebSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+};
+
+describe('device token preservation on refresh (grace-clobber client fix)', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof global.fetch;
+  let originalWindow: typeof global.window;
+  let originalLocalStorage: typeof global.localStorage;
+  let storeSession: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    originalWindow = global.window;
+    originalLocalStorage = global.localStorage;
+
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+
+    storeSession = vi.fn().mockResolvedValue(undefined);
+
+    Object.defineProperty(global, 'window', {
+      value: {
+        dispatchEvent: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        electron: {
+          on: vi.fn(() => () => {}),
+          auth: {
+            getSession: vi.fn().mockResolvedValue({
+              sessionToken: 'old-session',
+              deviceToken: 'old-device-token',
+            }),
+            getDeviceInfo: vi.fn().mockResolvedValue({
+              deviceId: 'device-1',
+              userAgent: 'test-agent',
+              appVersion: '1.0.0',
+            }),
+            storeSession,
+          },
+        },
+      },
+      writable: true,
+    });
+
+    const globalObj = globalThis as typeof globalThis & { [key: symbol]: unknown };
+    delete globalObj[Symbol.for('pagespace.authfetch.singleton')];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'window', { value: originalWindow, writable: true });
+    Object.defineProperty(global, 'localStorage', { value: originalLocalStorage, writable: true });
+  });
+
+  it('desktop: KEEPS the existing device token when the refresh response omits deviceToken', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ sessionToken: 'new-session', csrfToken: 'csrf' }), {
+        status: 200,
+      }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result).toEqual({ success: true, shouldLogout: false });
+    expect(storeSession).toHaveBeenCalledTimes(1);
+    expect(storeSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionToken: 'new-session',
+        deviceToken: 'old-device-token', // preserved, NOT undefined
+      }),
+    );
+  });
+
+  it('desktop: persists the NEW device token when the response includes one', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(
+        JSON.stringify({ sessionToken: 'new-session', csrfToken: 'csrf', deviceToken: 'new-device-token' }),
+        { status: 200 },
+      ),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    await authFetch.refreshDesktopSession();
+
+    expect(storeSession).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceToken: 'new-device-token' }),
+    );
+  });
+
+  it('web: does NOT overwrite the stored device token when the response omits deviceToken', async () => {
+    const setItem = vi.fn();
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => (key === 'deviceToken' ? 'old-device-token' : null)),
+        setItem,
+        removeItem: vi.fn(),
+      },
+      writable: true,
+    });
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ csrfToken: 'csrf' }), { status: 200 }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshWebSession();
+
+    expect(result.success).toBe(true);
+    expect(setItem).not.toHaveBeenCalledWith('deviceToken', expect.anything());
+  });
+
+  it('web: persists the new device token when the response includes one', async () => {
+    const setItem = vi.fn();
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => (key === 'deviceToken' ? 'old-device-token' : null)),
+        setItem,
+        removeItem: vi.fn(),
+      },
+      writable: true,
+    });
+
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ csrfToken: 'csrf', deviceToken: 'new-device-token' }), { status: 200 }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    await authFetch.refreshWebSession();
+
+    expect(setItem).toHaveBeenCalledWith('deviceToken', 'new-device-token');
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/auth-fetch-logout-reason.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-fetch-logout-reason.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/logging/client-logger', () => ({
+  createClientLogger: () => mockLogger,
+}));
+
+vi.mock('@/lib/analytics/device-fingerprint', () => ({
+  getOrCreateDeviceId: () => 'mock-device-id-12345',
+}));
+
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({
+    platform: 'desktop',
+    getSessionToken: vi.fn().mockResolvedValue(null),
+    getStoredSession: vi.fn().mockResolvedValue(null),
+    storeSession: vi.fn().mockResolvedValue(undefined),
+    clearSession: vi.fn().mockResolvedValue(undefined),
+    getDeviceInfo: vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'test-agent' }),
+    usesBearer: vi.fn().mockReturnValue(true),
+    supportsCSRF: vi.fn().mockReturnValue(false),
+    dispatchAuthEvent: vi.fn(),
+  }),
+  resetPlatformStorage: vi.fn(),
+}));
+
+type RefreshInternals = {
+  refreshDesktopSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+  refreshWebSession: () => Promise<{ success: boolean; shouldLogout: boolean }>;
+};
+
+function makeElectron(session: { sessionToken: string; deviceToken?: string | null } | null) {
+  return {
+    on: vi.fn(() => () => {}),
+    auth: {
+      getSession: vi.fn().mockResolvedValue(session),
+      getDeviceInfo: vi.fn().mockResolvedValue({ deviceId: 'device-1', userAgent: 'ua', appVersion: '1.0.0' }),
+      storeSession: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+describe('correlated logout reason at shouldLogout branches', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof global.fetch;
+  let originalWindow: typeof global.window;
+  let originalLocalStorage: typeof global.localStorage;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    originalWindow = global.window;
+    originalLocalStorage = global.localStorage;
+    mockFetch = vi.fn();
+    global.fetch = mockFetch;
+    mockLogger.warn.mockClear();
+
+    Object.defineProperty(global, 'window', {
+      value: {
+        dispatchEvent: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        electron: makeElectron({ sessionToken: 'old', deviceToken: 'old-device-token' }),
+      },
+      writable: true,
+    });
+
+    delete (globalThis as typeof globalThis & { [key: symbol]: unknown })[
+      Symbol.for('pagespace.authfetch.singleton')
+    ];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = originalFetch;
+    Object.defineProperty(global, 'window', { value: originalWindow, writable: true });
+    Object.defineProperty(global, 'localStorage', { value: originalLocalStorage, writable: true });
+  });
+
+  it('desktop 401: logs the server-provided reason on logout', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'nope', reason: 'device_id_mismatch' }), { status: 401 }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result.shouldLogout).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ logoutReason: 'device_id_mismatch' }),
+    );
+  });
+
+  it('desktop no-device-token: logs a no_device_token reason on logout', async () => {
+    Object.defineProperty(global, 'window', {
+      value: {
+        dispatchEvent: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        electron: makeElectron({ sessionToken: 'old', deviceToken: null }),
+      },
+      writable: true,
+    });
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshDesktopSession();
+
+    expect(result.shouldLogout).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ logoutReason: 'no_device_token' }),
+    );
+  });
+
+  it('web 401: logs the server-provided reason on logout', async () => {
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => (key === 'deviceToken' ? 'old-device-token' : null)),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true,
+    });
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'nope', reason: 'rotation_failed' }), { status: 401 }),
+    );
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshWebSession();
+
+    expect(result.shouldLogout).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ logoutReason: 'rotation_failed' }),
+    );
+  });
+
+  it('web no-device-token: logs a no_device_token reason on logout', async () => {
+    Object.defineProperty(global, 'localStorage', {
+      value: {
+        getItem: vi.fn().mockReturnValue(null),
+        setItem: vi.fn(),
+        removeItem: vi.fn(),
+      },
+      writable: true,
+    });
+
+    const { AuthFetch } = await import('../auth-fetch');
+    const authFetch = new AuthFetch() as unknown as RefreshInternals;
+
+    const result = await authFetch.refreshWebSession();
+
+    expect(result.shouldLogout).toBe(true);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ logoutReason: 'no_device_token' }),
+    );
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/device-refresh-token-selection.test.ts
+++ b/apps/web/src/lib/auth/__tests__/device-refresh-token-selection.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type { DeviceRotationResult } from '@pagespace/db/transactions/auth-transactions';
+import { selectDeviceTokenForResponse } from '../device-refresh-token-selection';
+
+const CURRENT_TOKEN = 'ps_dev_current';
+const CURRENT_ID = 'dt_current';
+
+describe('selectDeviceTokenForResponse', () => {
+  it('returns the newly rotated token and adopts its record id', () => {
+    const rotation: DeviceRotationResult = {
+      success: true,
+      newToken: 'ps_dev_rotated',
+      deviceTokenId: 'dt_rotated',
+    };
+
+    expect(selectDeviceTokenForResponse(CURRENT_TOKEN, CURRENT_ID, rotation)).toEqual({
+      deviceToken: 'ps_dev_rotated',
+      activeDeviceTokenId: 'dt_rotated',
+    });
+  });
+
+  it('returns NO device token on a grace-period retry, but adopts the replacement record id', () => {
+    // Rotation raced: this request lost, so it has no fresh token. Returning the
+    // old (now-revoked) token here is the clobber bug — the client would persist
+    // it and 401 on the next cycle. We must return no token instead.
+    const rotation: DeviceRotationResult = {
+      success: true,
+      gracePeriodRetry: true,
+      deviceTokenId: 'dt_replacement',
+    };
+
+    expect(selectDeviceTokenForResponse(CURRENT_TOKEN, CURRENT_ID, rotation)).toEqual({
+      deviceToken: undefined,
+      activeDeviceTokenId: 'dt_replacement',
+    });
+  });
+
+  it('on a grace-period retry with no replacement id, falls back to the current record id and still returns no token', () => {
+    const rotation: DeviceRotationResult = {
+      success: true,
+      gracePeriodRetry: true,
+    };
+
+    expect(selectDeviceTokenForResponse(CURRENT_TOKEN, CURRENT_ID, rotation)).toEqual({
+      deviceToken: undefined,
+      activeDeviceTokenId: CURRENT_ID,
+    });
+  });
+
+  it('returns the current token unchanged when no rotation occurred (token not near expiry)', () => {
+    expect(selectDeviceTokenForResponse(CURRENT_TOKEN, CURRENT_ID, null)).toEqual({
+      deviceToken: CURRENT_TOKEN,
+      activeDeviceTokenId: CURRENT_ID,
+    });
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/session-retirement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/session-retirement.test.ts
@@ -1,20 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   retireReplacedSession,
-  REPLACED_BY_REFRESH_REASON,
   type SessionRetirementDeps,
 } from '../session-retirement';
 
 const makeDeps = (overrides: Partial<SessionRetirementDeps> = {}): SessionRetirementDeps => ({
   getSessionOwnerId: vi.fn().mockResolvedValue('user-1'),
   hashToken: vi.fn((t: string) => `hash(${t})`),
-  revokeByHash: vi.fn().mockResolvedValue(undefined),
+  graceExpireByHash: vi.fn().mockResolvedValue(undefined),
   logWarn: vi.fn(),
   ...overrides,
 });
 
 describe('retireReplacedSession', () => {
-  it('returns no_session_cookie and revokes nothing when no old token is present', async () => {
+  it('returns no_session_cookie and grace-expires nothing when no old token is present', async () => {
     const deps = makeDeps();
 
     expect(await retireReplacedSession(null, 'user-1', deps)).toBe('no_session_cookie');
@@ -22,36 +21,36 @@ describe('retireReplacedSession', () => {
     expect(await retireReplacedSession('', 'user-1', deps)).toBe('no_session_cookie');
 
     expect(deps.getSessionOwnerId).not.toHaveBeenCalled();
-    expect(deps.revokeByHash).not.toHaveBeenCalled();
+    expect(deps.graceExpireByHash).not.toHaveBeenCalled();
   });
 
-  it('revokes the old session by hash with replaced_by_refresh when it belongs to the same user', async () => {
+  it('grace-expires the old session by hash when it belongs to the same user', async () => {
     const deps = makeDeps();
 
     const outcome = await retireReplacedSession('old-token', 'user-1', deps);
 
-    expect(outcome).toBe('revoked');
+    expect(outcome).toBe('grace_expired');
     expect(deps.hashToken).toHaveBeenCalledWith('old-token');
-    expect(deps.revokeByHash).toHaveBeenCalledWith('hash(old-token)', REPLACED_BY_REFRESH_REASON);
+    expect(deps.graceExpireByHash).toHaveBeenCalledWith('hash(old-token)');
     expect(deps.logWarn).not.toHaveBeenCalled();
   });
 
-  it('does NOT revoke when the old session belongs to a different user', async () => {
+  it('does NOT grace-expire when the old session belongs to a different user', async () => {
     const deps = makeDeps({ getSessionOwnerId: vi.fn().mockResolvedValue('other-user') });
 
     const outcome = await retireReplacedSession('old-token', 'user-1', deps);
 
     expect(outcome).toBe('not_same_user');
-    expect(deps.revokeByHash).not.toHaveBeenCalled();
+    expect(deps.graceExpireByHash).not.toHaveBeenCalled();
   });
 
-  it('does NOT revoke when the old session resolves to no owner (inactive/expired)', async () => {
+  it('does NOT grace-expire when the old session resolves to no owner (inactive/expired)', async () => {
     const deps = makeDeps({ getSessionOwnerId: vi.fn().mockResolvedValue(null) });
 
     const outcome = await retireReplacedSession('old-token', 'user-1', deps);
 
     expect(outcome).toBe('not_same_user');
-    expect(deps.revokeByHash).not.toHaveBeenCalled();
+    expect(deps.graceExpireByHash).not.toHaveBeenCalled();
   });
 
   it('swallows and logs when owner resolution throws (never fails the refresh)', async () => {
@@ -61,22 +60,22 @@ describe('retireReplacedSession', () => {
 
     const outcome = await retireReplacedSession('old-token', 'user-1', deps);
 
-    expect(outcome).toBe('revoke_failed');
-    expect(deps.revokeByHash).not.toHaveBeenCalled();
+    expect(outcome).toBe('grace_expiry_failed');
+    expect(deps.graceExpireByHash).not.toHaveBeenCalled();
     expect(deps.logWarn).toHaveBeenCalledWith(
       'Failed to retire replaced session on device refresh',
       expect.objectContaining({ error: 'db down' }),
     );
   });
 
-  it('swallows and logs when the revoke itself throws', async () => {
+  it('swallows and logs when the grace-expiry itself throws', async () => {
     const deps = makeDeps({
-      revokeByHash: vi.fn().mockRejectedValue('boom'),
+      graceExpireByHash: vi.fn().mockRejectedValue('boom'),
     });
 
     const outcome = await retireReplacedSession('old-token', 'user-1', deps);
 
-    expect(outcome).toBe('revoke_failed');
+    expect(outcome).toBe('grace_expiry_failed');
     expect(deps.logWarn).toHaveBeenCalledWith(
       'Failed to retire replaced session on device refresh',
       expect.objectContaining({ error: 'boom' }),

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -512,6 +512,22 @@ class AuthFetch {
     }
   }
 
+  /**
+   * Extract the machine-readable `reason` the device-refresh route attaches to a
+   * 401 body (e.g. `invalid_device_token`, `device_id_mismatch`, `rotation_failed`).
+   * Returns undefined if the body is missing/not JSON/has no string reason, so the
+   * caller can fall back to a generic label. Uses `clone()` so the caller can still
+   * read the body if needed.
+   */
+  private async readServerLogoutReason(response: Response): Promise<string | undefined> {
+    try {
+      const body = await response.clone().json();
+      return typeof body?.reason === 'string' ? body.reason : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
   private async doRefresh(): Promise<SessionRefreshResult> {
     const storage = this.getStorage();
 
@@ -604,7 +620,9 @@ class AuthFetch {
         : null;
 
       if (!deviceToken) {
-        this.logger.warn('Web: No device token - session expired, must re-authenticate');
+        this.logger.warn('Web: No device token - session expired, must re-authenticate', {
+          logoutReason: 'no_device_token',
+        });
         return { success: false, shouldLogout: true };
       }
 
@@ -654,7 +672,10 @@ class AuthFetch {
       }
 
       if (response.status === 401) {
-        this.logger.warn('Web: Device token invalid - logging out');
+        const logoutReason = await this.readServerLogoutReason(response);
+        this.logger.warn('Web: Device token invalid - logging out', {
+          logoutReason: logoutReason ?? 'device_refresh_401',
+        });
         return { success: false, shouldLogout: true };
       }
 
@@ -685,85 +706,31 @@ class AuthFetch {
     }
 
     try {
-      const session = await window.electron.auth.getSession();
-      const deviceInfo = await window.electron.auth.getDeviceInfo();
-
-      const deviceToken = session?.deviceToken;
-
-      // Desktop REQUIRES a device token for long-lived sessions
-      // If no device token exists, user needs to re-authenticate
-      if (!deviceToken) {
-        this.logger.warn('Desktop: No device token found - user must re-authenticate');
-        return { success: false, shouldLogout: true };
+      const first = await this.attemptDesktopDeviceRefresh();
+      if (first.kind !== 'unauthorized') {
+        return first.result;
       }
 
-      let response: Response;
-
-      // Device token refresh (90-day validity)
-      // This is the PRIMARY auth mechanism for desktop - designed for long-lived sessions
-      try {
-        response = await fetch('/api/auth/device/refresh', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            deviceToken,
-            deviceId: deviceInfo.deviceId,
-            userAgent: deviceInfo.userAgent,
-            appVersion: deviceInfo.appVersion,
-          }),
-        });
-
-        if (response.ok) {
-          this.logger.debug('Desktop: Device token refresh succeeded');
-        }
-      } catch (networkError) {
-        // Network error - don't logout, let retry logic handle it
-        this.logger.warn('Desktop: Device token refresh network error', {
-          error: networkError instanceof Error ? networkError.message : String(networkError),
-        });
-        return { success: false, shouldLogout: false };
-      }
-
-      if (response.status === 401) {
-        // 401 = device token is genuinely invalid (expired or revoked)
-        // User must re-authenticate
-        this.logger.warn('Desktop: Device token rejected - user must re-authenticate');
-        return { success: false, shouldLogout: true };
-      }
-
-      if (response.status === 429) {
-        // Rate limited - don't logout, let retry logic handle it
-        this.logger.warn('Desktop: Token refresh rate limited');
-        return { success: false, shouldLogout: false };
-      }
-
-      if (response.status >= 500) {
-        // Server error - don't logout, let retry logic handle it
-        this.logger.warn('Desktop: Token refresh server error', { status: response.status });
-        return { success: false, shouldLogout: false };
-      }
-
-      if (!response.ok) {
-        this.logger.error('Desktop: Token refresh failed with unexpected status', {
-          status: response.status,
-        });
-        return { success: false, shouldLogout: false };
-      }
-
-      const data = await response.json();
-
-      await window.electron.auth.storeSession({
-        sessionToken: data.sessionToken,
-        csrfToken: data.csrfToken,
-        deviceToken: data.deviceToken,
+      // A single 401 is not proof the session is dead: a concurrent refresh may
+      // have just rotated the device token, leaving this attempt with a
+      // momentarily-stale token. Retry EXACTLY ONCE with a freshly-read token
+      // before logging out. This runs inside the single-flight refreshPromise
+      // (:refreshToken/:refreshAuthSession) and the 5s post-success cooldown, so
+      // it is one extra attempt — it cannot loop.
+      this.logger.warn('Desktop: device refresh returned 401 - retrying once with a fresh token before logout', {
+        reason: first.reason,
       });
-
       this.clearSessionCache();
-      this.logger.info('Desktop: Session refreshed successfully via secure storage');
-      if (typeof window !== 'undefined' && window.dispatchEvent) {
-        window.dispatchEvent(new CustomEvent('auth:refreshed'));
+
+      const second = await this.attemptDesktopDeviceRefresh();
+      if (second.kind === 'unauthorized') {
+        // Second consecutive 401 - the device token is genuinely invalid.
+        this.logger.warn('Desktop: Device token rejected on retry - user must re-authenticate', {
+          logoutReason: second.reason ?? 'device_refresh_401',
+        });
+        return { success: false, shouldLogout: true };
       }
-      return { success: true, shouldLogout: false };
+      return second.result;
     } catch (error) {
       this.logger.error('Desktop: Token refresh request threw an error', {
         error: error instanceof Error ? error : String(error),
@@ -771,6 +738,106 @@ class AuthFetch {
       // Don't logout on unexpected errors - let retry logic handle it
       return { success: false, shouldLogout: false };
     }
+  }
+
+  /**
+   * One desktop device-refresh attempt. Returns `unauthorized` (with the server
+   * reason) on a 401 so the caller can decide whether to retry; every other
+   * outcome (success, no-token logout, network/429/5xx/unexpected) is terminal
+   * and returned as a `result`.
+   */
+  private async attemptDesktopDeviceRefresh(): Promise<
+    { kind: 'result'; result: SessionRefreshResult } | { kind: 'unauthorized'; reason?: string }
+  > {
+    const electron = window.electron;
+    if (!electron) {
+      return { kind: 'result', result: { success: false, shouldLogout: false } };
+    }
+
+    // Freshly read the session each attempt so a retry picks up a token a
+    // concurrent refresh may have just stored.
+    const session = await electron.auth.getSession();
+    const deviceInfo = await electron.auth.getDeviceInfo();
+
+    const deviceToken = session?.deviceToken;
+
+    // Desktop REQUIRES a device token for long-lived sessions
+    // If no device token exists, user needs to re-authenticate
+    if (!deviceToken) {
+      this.logger.warn('Desktop: No device token found - user must re-authenticate', {
+        logoutReason: 'no_device_token',
+      });
+      return { kind: 'result', result: { success: false, shouldLogout: true } };
+    }
+
+    let response: Response;
+
+    // Device token refresh (90-day validity)
+    // This is the PRIMARY auth mechanism for desktop - designed for long-lived sessions
+    try {
+      response = await fetch('/api/auth/device/refresh', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deviceToken,
+          deviceId: deviceInfo.deviceId,
+          userAgent: deviceInfo.userAgent,
+          appVersion: deviceInfo.appVersion,
+        }),
+      });
+
+      if (response.ok) {
+        this.logger.debug('Desktop: Device token refresh succeeded');
+      }
+    } catch (networkError) {
+      // Network error - don't logout, let retry logic handle it
+      this.logger.warn('Desktop: Device token refresh network error', {
+        error: networkError instanceof Error ? networkError.message : String(networkError),
+      });
+      return { kind: 'result', result: { success: false, shouldLogout: false } };
+    }
+
+    if (response.status === 401) {
+      const reason = await this.readServerLogoutReason(response);
+      return { kind: 'unauthorized', reason };
+    }
+
+    if (response.status === 429) {
+      // Rate limited - don't logout, let retry logic handle it
+      this.logger.warn('Desktop: Token refresh rate limited');
+      return { kind: 'result', result: { success: false, shouldLogout: false } };
+    }
+
+    if (response.status >= 500) {
+      // Server error - don't logout, let retry logic handle it
+      this.logger.warn('Desktop: Token refresh server error', { status: response.status });
+      return { kind: 'result', result: { success: false, shouldLogout: false } };
+    }
+
+    if (!response.ok) {
+      this.logger.error('Desktop: Token refresh failed with unexpected status', {
+        status: response.status,
+      });
+      return { kind: 'result', result: { success: false, shouldLogout: false } };
+    }
+
+    const data = await response.json();
+
+    await electron.auth.storeSession({
+      sessionToken: data.sessionToken,
+      csrfToken: data.csrfToken,
+      // Grace-clobber guard: a rotation-race loser refresh returns NO
+      // deviceToken. Persisting `undefined` would wipe the good token and
+      // guarantee a 401 → logout on the next cycle. Keep the existing token.
+      deviceToken: data.deviceToken ?? deviceToken,
+    });
+
+    this.clearSessionCache();
+    this.logger.info('Desktop: Session refreshed successfully via secure storage');
+    if (typeof window !== 'undefined' && window.dispatchEvent) {
+      window.dispatchEvent(new CustomEvent('auth:refreshed'));
+    }
+    return { kind: 'result', result: { success: true, shouldLogout: false } };
   }
 
   async refreshAuthSession(): Promise<SessionRefreshResult> {

--- a/apps/web/src/lib/auth/device-refresh-token-selection.ts
+++ b/apps/web/src/lib/auth/device-refresh-token-selection.ts
@@ -1,0 +1,53 @@
+/**
+ * Functional core for choosing which device token the refresh route returns to
+ * the client, and which device-token record its activity update should target.
+ *
+ * The grace-clobber bug: `atomicDeviceTokenRotation` can return `success` with
+ * `gracePeriodRetry: true` and NO `newToken` when this request lost a rotation
+ * race (a concurrent refresh already rotated the token within the 30s grace
+ * window). The route previously fell through and returned the OLD — now revoked —
+ * token, which the client persisted, guaranteeing a 401 on the next refresh and a
+ * full logout. The fix: on a grace-period retry, return NO device token so the
+ * client keeps the good token it already holds, while still adopting the
+ * replacement record id so the activity update lands on the live row.
+ */
+
+import type { DeviceRotationResult } from '@pagespace/db/transactions/auth-transactions';
+
+export interface DeviceTokenSelection {
+  /**
+   * Token to send back to the client. `undefined` means "send no deviceToken" —
+   * the client must keep whatever token it already has.
+   */
+  deviceToken: string | undefined;
+  /** Device-token record id the activity update should target. */
+  activeDeviceTokenId: string;
+}
+
+/**
+ * Decide the response device token given the rotation outcome.
+ *
+ * - `rotation` is `null` when no rotation was attempted (token not near expiry):
+ *   return the current token unchanged.
+ * - A real rotation (`newToken` + `deviceTokenId`): return the new token and its id.
+ * - A grace-period retry (`success`, no `newToken`): return NO token, adopting the
+ *   replacement `deviceTokenId` (falling back to the current id if absent).
+ */
+export function selectDeviceTokenForResponse(
+  currentDeviceToken: string,
+  currentDeviceTokenId: string,
+  rotation: DeviceRotationResult | null,
+): DeviceTokenSelection {
+  if (rotation?.newToken && rotation.deviceTokenId) {
+    return { deviceToken: rotation.newToken, activeDeviceTokenId: rotation.deviceTokenId };
+  }
+
+  if (rotation?.success && rotation.gracePeriodRetry) {
+    return {
+      deviceToken: undefined,
+      activeDeviceTokenId: rotation.deviceTokenId ?? currentDeviceTokenId,
+    };
+  }
+
+  return { deviceToken: currentDeviceToken, activeDeviceTokenId: currentDeviceTokenId };
+}

--- a/apps/web/src/lib/auth/session-retirement.ts
+++ b/apps/web/src/lib/auth/session-retirement.ts
@@ -7,6 +7,13 @@
  * decision function retires the exact session a refresh replaces — and ONLY that
  * one, and ONLY when it belongs to the same user — with every side effect injected
  * so the branch table can be covered without a database.
+ *
+ * Retirement uses a GRACE-EXPIRY, not an instant hard-revoke: the replaced
+ * session's expiry is merely brought forward to a short grace window. Hard-revoke
+ * (the previous behaviour) invalidated the old Bearer token the instant the new
+ * session landed, so the 1s `active-streams` poll — still carrying the old token —
+ * failed validation and produced an `auth_failed` storm. A grace window lets those
+ * in-flight requests drain before the retired session dies.
  */
 
 export interface SessionRetirementDeps {
@@ -14,8 +21,8 @@ export interface SessionRetirementDeps {
   getSessionOwnerId: (token: string) => Promise<string | null>;
   /** Hash a session token to its stored form. */
   hashToken: (token: string) => string;
-  /** Revoke a session by its token hash. */
-  revokeByHash: (tokenHash: string, reason: string) => Promise<void>;
+  /** Grace-expire a session by its token hash (bring its expiry forward, never extend). */
+  graceExpireByHash: (tokenHash: string) => Promise<void>;
   /** Structured warn logger — retirement must never fail the refresh. */
   logWarn: (message: string, meta: Record<string, unknown>) => void;
 }
@@ -23,21 +30,20 @@ export interface SessionRetirementDeps {
 export type RetirementOutcome =
   | 'no_session_cookie'
   | 'not_same_user'
-  | 'revoked'
-  | 'revoke_failed';
-
-export const REPLACED_BY_REFRESH_REASON = 'replaced_by_refresh';
+  | 'grace_expired'
+  | 'grace_expiry_failed';
 
 /**
  * Retire the session a device refresh is replacing.
  *
  * - No old cookie present → nothing to retire (`no_session_cookie`).
  * - Old session resolves to a different (or no) user → leave it alone
- *   (`not_same_user`); never revoke another user's session on the strength of a
+ *   (`not_same_user`); never touch another user's session on the strength of a
  *   cookie the request happened to carry.
- * - Old session belongs to the same user → revoke it by hash (`revoked`).
- * - Any effect throws → swallow, log, and report `revoke_failed`; the caller
- *   must still complete the refresh.
+ * - Old session belongs to the same user → grace-expire it by hash
+ *   (`grace_expired`).
+ * - Any effect throws → swallow, log, and report `grace_expiry_failed`; the
+ *   caller must still complete the refresh.
  */
 export async function retireReplacedSession(
   oldSessionToken: string | null | undefined,
@@ -54,12 +60,12 @@ export async function retireReplacedSession(
       return 'not_same_user';
     }
 
-    await deps.revokeByHash(deps.hashToken(oldSessionToken), REPLACED_BY_REFRESH_REASON);
-    return 'revoked';
+    await deps.graceExpireByHash(deps.hashToken(oldSessionToken));
+    return 'grace_expired';
   } catch (error) {
     deps.logWarn('Failed to retire replaced session on device refresh', {
       error: error instanceof Error ? error.message : String(error),
     });
-    return 'revoke_failed';
+    return 'grace_expiry_failed';
   }
 }

--- a/packages/lib/src/auth/__tests__/session-service-expire.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-expire.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../session-repository', () => ({
+  sessionRepository: {
+    findUserById: vi.fn(),
+    findActiveSession: vi.fn(),
+    getActiveSessionExpiry: vi.fn(),
+    setExpiresAtByHash: vi.fn(),
+    insertSession: vi.fn(),
+    touchSession: vi.fn(),
+    revokeByHash: vi.fn(),
+    revokeAllForUser: vi.fn(),
+    revokeWebForUser: vi.fn(),
+    revokeAdminForUser: vi.fn(),
+    revokeForUserDevice: vi.fn(),
+    deleteExpired: vi.fn(),
+  },
+}));
+
+vi.mock('../opaque-tokens', () => ({
+  generateOpaqueToken: vi.fn(),
+  isValidTokenFormat: vi.fn(),
+}));
+
+vi.mock('../token-utils', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+}));
+
+vi.mock('../constants', () => ({
+  IDLE_TIMEOUT_MS: 0,
+}));
+
+import { SessionService, clampExpiry } from '../session-service';
+import { sessionRepository } from '../session-repository';
+
+describe('clampExpiry (pure)', () => {
+  it('returns now+grace target when the current expiry is later (clamps down)', () => {
+    const current = new Date('2030-01-01T01:00:00.000Z');
+    const target = new Date('2030-01-01T00:01:00.000Z');
+    expect(clampExpiry(current, target)).toBe(target);
+  });
+
+  it('returns the current expiry when it is already sooner (never extends)', () => {
+    const current = new Date('2030-01-01T00:00:10.000Z');
+    const target = new Date('2030-01-01T00:01:00.000Z');
+    expect(clampExpiry(current, target)).toBe(current);
+  });
+
+  it('returns the current expiry when the two are equal (boundary, no extend)', () => {
+    const current = new Date('2030-01-01T00:01:00.000Z');
+    const target = new Date('2030-01-01T00:01:00.000Z');
+    expect(clampExpiry(current, target)).toBe(current);
+  });
+});
+
+describe('SessionService.expireSessionByHashSoon', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+  });
+
+  it('clamps a longer-lived session down to now+grace', async () => {
+    const now = Date.now();
+    vi.mocked(sessionRepository.getActiveSessionExpiry).mockResolvedValue(
+      new Date(now + 60 * 60 * 1000), // expires in 1h
+    );
+
+    await service.expireSessionByHashSoon('hash-1', 60_000);
+
+    expect(sessionRepository.setExpiresAtByHash).toHaveBeenCalledTimes(1);
+    const [tokenHash, clamped] = vi.mocked(sessionRepository.setExpiresAtByHash).mock.calls[0];
+    expect(tokenHash).toBe('hash-1');
+    // Clamped to ~now+grace, never the original 1h expiry.
+    expect(clamped.getTime()).toBeGreaterThanOrEqual(now + 60_000 - 1000);
+    expect(clamped.getTime()).toBeLessThanOrEqual(now + 60_000 + 1000);
+  });
+
+  it('never extends a session already expiring sooner than now+grace', async () => {
+    const now = Date.now();
+    vi.mocked(sessionRepository.getActiveSessionExpiry).mockResolvedValue(
+      new Date(now + 5_000), // expires in 5s, sooner than the 60s grace
+    );
+
+    await service.expireSessionByHashSoon('hash-1', 60_000);
+
+    expect(sessionRepository.setExpiresAtByHash).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when there is no active session for the hash', async () => {
+    vi.mocked(sessionRepository.getActiveSessionExpiry).mockResolvedValue(undefined);
+
+    await expect(service.expireSessionByHashSoon('hash-missing', 60_000)).resolves.toBeUndefined();
+
+    expect(sessionRepository.setExpiresAtByHash).not.toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -73,6 +73,34 @@ export const sessionRepository = {
       .catch((err) => { console.error('[auth] Failed to update session lastUsedAt', err); });
   },
 
+  // Read the expiry of a single active (non-revoked, unexpired) session by hash.
+  // Used by the grace-expiry op to clamp — returns undefined when there is no
+  // such session (already revoked/expired/absent), so the caller no-ops.
+  getActiveSessionExpiry: async (tokenHash: string): Promise<Date | undefined> => {
+    const row = await db.query.sessions.findFirst({
+      where: and(
+        eq(sessions.tokenHash, tokenHash),
+        isNull(sessions.revokedAt),
+        gt(sessions.expiresAt, new Date()),
+      ),
+      columns: { expiresAt: true },
+    });
+    return row?.expiresAt;
+  },
+
+  // Bring a session's expiry forward (grace-expiry). The `gt` guard makes this
+  // update physically unable to EXTEND a session even under a stale-read race —
+  // it only ever writes an earlier expiry.
+  setExpiresAtByHash: async (tokenHash: string, expiresAt: Date): Promise<void> => {
+    await db.update(sessions)
+      .set({ expiresAt })
+      .where(and(
+        eq(sessions.tokenHash, tokenHash),
+        isNull(sessions.revokedAt),
+        gt(sessions.expiresAt, expiresAt),
+      ));
+  },
+
   revokeByHash: async (tokenHash: string, reason: string): Promise<void> => {
     await db.update(sessions)
       .set({ revokedAt: new Date(), revokedReason: reason })

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -5,6 +5,15 @@ import { sessionRepository } from './session-repository';
 
 const SESSION_CLEANUP_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * Pure clamp: the earlier of `currentExpiresAt` and `notLaterThan`. Never
+ * returns a time later than `currentExpiresAt`, so a grace-expiry can only ever
+ * bring a session's death forward — never postpone it.
+ */
+export function clampExpiry(currentExpiresAt: Date, notLaterThan: Date): Date {
+  return currentExpiresAt.getTime() <= notLaterThan.getTime() ? currentExpiresAt : notLaterThan;
+}
+
 export interface SessionClaims {
   sessionId: string;
   userId: string;
@@ -143,6 +152,27 @@ export class SessionService {
       resourceId: session.resourceId ?? undefined,
       driveId: session.driveId ?? undefined,
     };
+  }
+
+  /**
+   * Bring a session's expiry forward to at most `now + graceMs`, clamping so it
+   * NEVER extends a live session (`min(current, now+grace)`). Used by device
+   * refresh to retire the session it replaces WITHOUT an instant hard-revoke, so
+   * in-flight requests (e.g. the 1s active-streams poll) stay valid for the
+   * grace window instead of 401-storming. The retired session then dies on its
+   * own via `validateSession`'s expiry check.
+   *
+   * No active session for the hash → no-op (never throws).
+   */
+  async expireSessionByHashSoon(tokenHash: string, graceMs: number): Promise<void> {
+    const currentExpiresAt = await sessionRepository.getActiveSessionExpiry(tokenHash);
+    if (!currentExpiresAt) return;
+
+    const notLaterThan = new Date(Date.now() + graceMs);
+    const clamped = clampExpiry(currentExpiresAt, notLaterThan);
+    if (clamped.getTime() < currentExpiresAt.getTime()) {
+      await sessionRepository.setExpiresAtByHash(tokenHash, clamped);
+    }
   }
 
   async revokeSession(token: string, reason: string): Promise<void> {


### PR DESCRIPTION
## Summary

Registering `apps/web/src/middleware.ts` for the first time in ~10 months (#1932) turned on an edge session-cookie gate that exposed two latent device-token-refresh defects intermittently signing desktop (Electron) users out. This closes both, adds self-identifying logout diagnostics, and hardens the two deferred paths — one cohesive epic, RED-first, functional-core/imperative-shell.

Epic (source of truth): PageSpace `mpzherjnbuj767z18670xha8`.

## Root cause 1 — session-retirement instant-revoke storm
`retireReplacedSession` (#2084) **hard-revoked** the replaced session the instant a refresh minted its replacement. The 1s `active-streams` poll — still carrying the old Bearer token — then failed validation, producing the logged `auth_failed` storm.

**Fix:** retirement now **grace-expires** instead of revoking. New `sessionService.expireSessionByHashSoon(hash, graceMs)` clamps the replaced session's expiry to `min(current, now+grace)` (pure `clampExpiry`, **never extends**; the repo write additionally guards `expiresAt > new`). Wired at `~60s` so in-flight requests drain before the session dies via `validateSession`'s existing expiry check.

## Root cause 2 — device-token grace-clobber
`atomicDeviceTokenRotation` can return `success` + `gracePeriodRetry: true` with **no** `newToken` when a request loses a rotation race. The route fell through and returned the OLD — now revoked — token; the client persisted it, guaranteeing a 401 → full logout on the next cycle.

**Fix (two sides):**
- Server: pure `selectDeviceTokenForResponse` returns **no** deviceToken on a grace-period retry (adopting the replacement `deviceTokenId` for the activity update); all three branches — `rotated` / `gracePeriodRetry` / `no-rotation` — unit-covered.
- Client: desktop `storeSession` keeps the existing token when the response omits one (`data.deviceToken ?? stored`); web path (already guarded) locked in with tests.

## The four phases
| Phase | What |
|-------|------|
| **P1 — Grace window** | `expireSessionByHashSoon` + `clampExpiry`; `session-retirement` swaps `revokeByHash` → `graceExpireByHash` (`revoked`→`grace_expired`); `REPLACED_SESSION_GRACE_MS = 60s` wired at the route |
| **P2 — Grace-clobber** | `selectDeviceTokenForResponse` (omit token on grace-retry); desktop client preserves stored device token |
| **P3 — Diagnostics** | Machine-readable `reason` on all four device-refresh 401s (`invalid_device_token` / `unknown_stored_device` / `device_id_mismatch` / `rotation_failed`); client threads the server reason into every `shouldLogout` warn as `logoutReason` |
| **P4 — Hardening** | Persisted, deterministic desktop `deviceId` fallback — seeded once from the legacy machine-derived id (preserves an existing install's token binding on upgrade), reused verbatim so it's stable across hostname/VPN change and across launches even if the write fails → no `device_id_mismatch` logout; single **guarded retry** with a fresh token before logout on a desktop 401 (respects the single-flight `refreshPromise` + 5s cooldown, so it cannot loop) |

## Diagnostic evidence (anchors, not changes)
- **Trigger:** `apps/web/src/middleware.ts` session-cookie gate (`d57701900`, #1932).
- **Storm:** `retireReplacedSession` @ `route.ts` revoked old session immediately; poller `apps/web/src/lib/ai/core/stream-join-poll-fallback.ts:9` (1s).
- **Clobber:** `route.ts` fell through on grace-retry; `packages/db/src/transactions/auth-transactions.ts:163-176` returns no `newToken`; client persisted old token @ `auth-fetch.ts:635/755-759`.
- **Logout trigger:** `auth-fetch.ts:656-658/695-698/727-732` → `useAuthStore.ts:759-789`.
- **deviceId fallback:** `apps/desktop/src/main/auth-session.ts` — was recomputed `${os.hostname()}-…` every call (flips on hostname change); now seeded once from that value and persisted.

## Tests
RED-first for every task. New: `session-service-expire`, `device-refresh-token-selection`, `auth-fetch-device-token-preservation`, `refresh-reason`, `auth-fetch-logout-reason`, `device-id-fallback`, `auth-fetch-desktop-401-retry`; `session-retirement` + route `route.test.ts` retirement block updated to grace-expiry.

`typecheck` green (lib/web/desktop). All changed-package unit suites green. `admin-role-version.test.ts` fails **only** under a bare `vitest` run (`role "test" does not exist`) — a pre-existing DB integration test needing the `bun run test` harness; untouched by this change.

## Notes / minimal choices
- Grace-expiry uses a read-clamp-write in the service (pure `clampExpiry`, fully branch-covered) so the "never extend" invariant is genuinely unit-tested; the repo write also guards `expiresAt > new` as a belt-and-suspenders against a stale-read race.
- `REPLACED_BY_REFRESH_REASON` dropped (grace-expiry records no revoke reason; had no other consumers).
- `changelog:generate` is broken repo-wide (pre-existing) — not run.
- **Review follow-up (`a57bdfb9d`):** per Codex P1/P2, the deviceId fallback seeds from the legacy `${hostname}-${platform}-${arch}` value (not a random UUID) so existing token bindings survive the upgrade, and the seed is deterministic so a failed persist doesn't churn a new id each launch. `generateId`→`seedId`; added `auth-session-deviceid.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01He2Y98M6i8UUAofT94sxbU
