### PR TITLE
feat(webhooks): generic trigger dispatch — page webhook fires bound workflows via executeWorkflow

### DIFF
--- a/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
@@ -295,15 +295,16 @@ describe('POST /api/webhooks/[token]', () => {
     expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 
-  it('treats a trigger lookup failure as no triggers — never crashes, dispatcher told hasEnabledTriggers:false', async () => {
-    mockDispatch.mockResolvedValue({ kind: 'no_action' });
+  it('returns a retryable 503 (no dispatch, no fan-out) when the trigger lookup fails — never silently drops bound workflows', async () => {
     mockFindTriggers.mockResolvedValue({ success: false, error: 'db down' });
 
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
 
-    expect(response.status).toBe(202);
-    expect(await response.json()).toEqual({ accepted: true, action: 'none' });
-    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ hasEnabledTriggers: false }));
+    // A transient lookup failure must reject the whole delivery as retryable —
+    // not post to the channel, not fire workflows, not answer 2xx (which would
+    // stop the sender retrying and permanently drop the bound workflows).
+    expect(response.status).toBe(503);
+    expect(mockDispatch).not.toHaveBeenCalled();
     expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
@@ -273,7 +273,7 @@ describe('POST /api/webhooks/[token]', () => {
     expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 
-  it('still fires triggers when the default handler fails for a non-not_found reason (independent envelopes)', async () => {
+  it('does NOT fire triggers when the default handler fails (429) — a retryable non-2xx must not perform AI side effects', async () => {
     mockDispatch.mockResolvedValue({ kind: 'failed', error: 'rate_limited' });
     const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
     mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
@@ -281,7 +281,18 @@ describe('POST /api/webhooks/[token]', () => {
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
 
     expect(response.status).toBe(429);
-    expect(mockFireTriggers).toHaveBeenCalledTimes(1);
+    expect(mockFireTriggers).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire triggers for a rejected/malformed envelope (400) — no AI side effects on a rejected, retryable delivery', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'payload must be a JSON object' });
+    const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
+    mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
+
+    const response = await POST(signedRequest('not json'), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    expect(response.status).toBe(400);
+    expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 
   it('treats a trigger lookup failure as no triggers — never crashes, dispatcher told hasEnabledTriggers:false', async () => {

--- a/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/route.test.ts
@@ -35,6 +35,23 @@ vi.mock('@pagespace/lib/services/page-webhook-dispatch', () => ({
   dispatchWebhookDelivery: (...args: unknown[]) => mockDispatch(...args),
 }));
 
+// `after()` schedules post-response work. In the test it runs the callback
+// immediately so the fan-out scheduling is observable synchronously.
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return { ...actual, after: (fn: () => unknown) => { void fn(); } };
+});
+
+const mockFindTriggers = vi.fn();
+vi.mock('@/lib/webhooks/page-webhook-trigger-queries', () => ({
+  findEnabledPageWebhookTriggers: (...args: unknown[]) => mockFindTriggers(...args),
+}));
+
+const mockFireTriggers = vi.fn();
+vi.mock('@/lib/webhooks/fire-page-webhook-triggers', () => ({
+  firePageWebhookTriggers: (...args: unknown[]) => mockFireTriggers(...args),
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
 }));
@@ -67,6 +84,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockFindFirst.mockResolvedValue(WEBHOOK);
   mockDispatch.mockResolvedValue({ kind: 'handled' });
+  // Default: no workflow triggers bound. Composability tests override this.
+  mockFindTriggers.mockResolvedValue({ success: true, data: [] });
+  mockFireTriggers.mockResolvedValue(undefined);
 });
 
 describe('POST /api/webhooks/[token]', () => {
@@ -79,6 +99,7 @@ describe('POST /api/webhooks/[token]', () => {
       webhookId: 'wh-1',
       pageId: 'page-1',
       payload: { content: 'deploy finished' },
+      hasEnabledTriggers: false,
     });
   });
 
@@ -157,6 +178,7 @@ describe('POST /api/webhooks/[token]', () => {
 
     expect(response.status).toBe(202);
     expect(await response.json()).toEqual({ accepted: true, action: 'none' });
+    expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 
   it('still requires a valid signature before the no-action 202 path — no unauthenticated probe', async () => {
@@ -177,7 +199,7 @@ describe('POST /api/webhooks/[token]', () => {
     mockDispatch.mockResolvedValue({ kind: 'failed', error: 'payload must be a JSON object' });
     const response = await POST(signedRequest('not json'), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(400);
-    expect(mockDispatch).toHaveBeenCalledWith({ webhookId: 'wh-1', pageId: 'page-1', payload: null });
+    expect(mockDispatch).toHaveBeenCalledWith({ webhookId: 'wh-1', pageId: 'page-1', payload: null, hasEnabledTriggers: false });
   });
 
   it('maps not_found to the generic 404', async () => {
@@ -202,5 +224,75 @@ describe('POST /api/webhooks/[token]', () => {
     mockDispatch.mockResolvedValue({ kind: 'failed', error: 'internal_error' });
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(500);
+  });
+
+  // ── Trigger fan-out composability ───────────────────────────────────────
+
+  it('does not fan out to triggers when none are bound (default handled path)', async () => {
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+    expect(response.status).toBe(200);
+    expect(mockFireTriggers).not.toHaveBeenCalled();
+  });
+
+  it('COMPOSES: one handled CHANNEL delivery both runs the default action AND fires the bound workflow', async () => {
+    const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
+    mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    // Default action still runs, sender still gets 200 — and the dispatcher is
+    // told triggers are firing (so it never records 'no action configured').
+    expect(response.status).toBe(200);
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ hasEnabledTriggers: true }));
+    // Workflow fan-out fired alongside, with the resolved triggers + parsed envelope.
+    expect(mockFireTriggers).toHaveBeenCalledTimes(1);
+    expect(mockFireTriggers).toHaveBeenCalledWith(triggers, { content: 'deploy finished' });
+  });
+
+  it('fires bound workflows for a no-handler page and returns 202 action:triggers (no no-action write)', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'no_action' });
+    const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
+    mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ accepted: true, action: 'triggers' });
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ hasEnabledTriggers: true }));
+    expect(mockFireTriggers).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT fire triggers when the delivery never reached a valid page (trashed/missing → not_found)', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'not_found' });
+    const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
+    mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    expect(response.status).toBe(404);
+    expect(mockFireTriggers).not.toHaveBeenCalled();
+  });
+
+  it('still fires triggers when the default handler fails for a non-not_found reason (independent envelopes)', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'failed', error: 'rate_limited' });
+    const triggers = [{ id: 't1', workflowId: 'wf1', pageWebhookId: 'wh-1' }];
+    mockFindTriggers.mockResolvedValue({ success: true, data: triggers });
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    expect(response.status).toBe(429);
+    expect(mockFireTriggers).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a trigger lookup failure as no triggers — never crashes, dispatcher told hasEnabledTriggers:false', async () => {
+    mockDispatch.mockResolvedValue({ kind: 'no_action' });
+    mockFindTriggers.mockResolvedValue({ success: false, error: 'db down' });
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ accepted: true, action: 'none' });
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ hasEnabledTriggers: false }));
+    expect(mockFireTriggers).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -55,19 +55,27 @@ export async function POST(request: Request, context: { params: Promise<{ token:
       body = null;
     }
 
-    // Resolve the enabled workflow triggers bound to this webhook once. The
-    // count tells the dispatcher a page with triggers isn't a no-op (it records
-    // the delivery as fired instead of 'no action configured') and decides the
-    // route's no-action vs triggers 202. This is the single trigger lookup for
-    // the delivery.
+    // Resolve the enabled workflow triggers bound to this webhook once, BEFORE
+    // dispatch. The count tells the dispatcher a page with triggers isn't a
+    // no-op (it records the delivery as fired instead of 'no action configured')
+    // and decides the route's no-action vs triggers 202.
+    //
+    // A transient failure here must NOT be silently treated as "no triggers":
+    // that would drop every bound workflow while returning a 2xx the sender
+    // won't retry (and mis-report action:'none' on a no-handler page). Reject
+    // the whole delivery as retryable (5xx) BEFORE dispatch, so no channel post
+    // happens either and the sender's retry can't duplicate it — a healthy
+    // retry then resolves the triggers and dispatches both actions. (v1 has no
+    // durable delivery queue; retry is the at-least-once mechanism.)
     const triggerLookup = await findEnabledPageWebhookTriggers(webhook.id);
     if (!triggerLookup.success) {
-      loggers.api.warn('Page webhook: trigger lookup failed', {
+      loggers.api.error('Page webhook: trigger lookup failed — returning retryable 503', {
         webhookId: webhook.id,
         error: triggerLookup.error,
       });
+      return NextResponse.json({ error: 'Service unavailable' }, { status: 503 });
     }
-    const enabledTriggers = triggerLookup.success ? triggerLookup.data : [];
+    const enabledTriggers = triggerLookup.data;
 
     const result = await dispatchWebhookDelivery({
       webhookId: webhook.id,

--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -77,14 +77,17 @@ export async function POST(request: Request, context: { params: Promise<{ token:
 
     // Fire bound workflows AFTER the HTTP response so the sender is never held
     // on AI latency — one signed delivery both runs its default page-type
-    // action (above) AND fires any bound workflows. Skipped only for a delivery
-    // that never reached a valid page: the dispatcher returns 'not_found'
-    // BEFORE any handler for a trashed/missing target, and firing into the
-    // trash makes no sense. A default-handler failure (rate limit, bad channel
-    // payload) does NOT suppress the fan-out — the workflow envelope is
-    // arbitrary JSON, independent of the channel handler's own contract.
-    const reachedPage = !(result.kind === 'failed' && result.error === 'not_found');
-    if (reachedPage && enabledTriggers.length > 0) {
+    // action (above) AND fires any bound workflows. Gated on an ACCEPTED (2xx)
+    // delivery only: 'handled' (default action ran) or 'no_action' (no default
+    // handler). Every 'failed' outcome — a malformed/rejected envelope (400), a
+    // rate limit (429), a trashed/missing page (404), an internal error (500) —
+    // is a non-2xx the sender is expected to RETRY, so firing AI/tool side
+    // effects there would both act on a rejected delivery and duplicate on the
+    // retry. A valid delivery to a channel with bound triggers still composes:
+    // it posts (handled → 200) AND fires; an arbitrary-JSON delivery to a
+    // no-handler page fires via no_action → 202.
+    const deliveryAccepted = result.kind === 'handled' || result.kind === 'no_action';
+    if (deliveryAccepted && enabledTriggers.length > 0) {
       after(() => firePageWebhookTriggers(enabledTriggers, body));
     }
 

--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -1,10 +1,12 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
 import { decryptField } from '@pagespace/lib/encryption/field-crypto';
 import { v0Scheme, DEFAULT_REPLAY_WINDOW_MS } from '@pagespace/lib/security/webhook-signature';
 import { dispatchWebhookDelivery } from '@pagespace/lib/services/page-webhook-dispatch';
+import { findEnabledPageWebhookTriggers } from '@/lib/webhooks/page-webhook-trigger-queries';
+import { firePageWebhookTriggers } from '@/lib/webhooks/fire-page-webhook-triggers';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Arbitrary-JSON envelope cap — checked on the raw bytes BEFORE JSON.parse so
@@ -53,15 +55,49 @@ export async function POST(request: Request, context: { params: Promise<{ token:
       body = null;
     }
 
-    const result = await dispatchWebhookDelivery({ webhookId: webhook.id, pageId: webhook.pageId, payload: body });
+    // Resolve the enabled workflow triggers bound to this webhook once. The
+    // count both suppresses the dispatcher's 'no action configured' write (a
+    // page with triggers isn't a no-op) and decides the no-action vs triggers
+    // 202. This is the single trigger lookup for the delivery.
+    const triggerLookup = await findEnabledPageWebhookTriggers(webhook.id);
+    if (!triggerLookup.success) {
+      loggers.api.warn('Page webhook: trigger lookup failed', {
+        webhookId: webhook.id,
+        error: triggerLookup.error,
+      });
+    }
+    const enabledTriggers = triggerLookup.success ? triggerLookup.data : [];
+
+    const result = await dispatchWebhookDelivery({
+      webhookId: webhook.id,
+      pageId: webhook.pageId,
+      payload: body,
+      hasEnabledTriggers: enabledTriggers.length > 0,
+    });
+
+    // Fire bound workflows AFTER the HTTP response so the sender is never held
+    // on AI latency — one signed delivery both runs its default page-type
+    // action (above) AND fires any bound workflows. Skipped only for a delivery
+    // that never reached a valid page: the dispatcher returns 'not_found'
+    // BEFORE any handler for a trashed/missing target, and firing into the
+    // trash makes no sense. A default-handler failure (rate limit, bad channel
+    // payload) does NOT suppress the fan-out — the workflow envelope is
+    // arbitrary JSON, independent of the channel handler's own contract.
+    const reachedPage = !(result.kind === 'failed' && result.error === 'not_found');
+    if (reachedPage && enabledTriggers.length > 0) {
+      after(() => firePageWebhookTriggers(enabledTriggers, body));
+    }
+
     if (result.kind === 'handled') {
       return NextResponse.json({ ok: true });
     }
-    // A verified delivery to a page type with no default handler is accepted —
-    // the sender never breaks while wiring is in progress; the dispatcher has
-    // recorded 'no action configured' on the row for the settings UI to surface.
     if (result.kind === 'no_action') {
-      return NextResponse.json({ accepted: true, action: 'none' }, { status: 202 });
+      // No default handler for this page type. If workflow triggers are firing,
+      // the delivery still has an action; only a webhook with neither is truly
+      // 'no action configured' (recorded on the row by the dispatcher).
+      return enabledTriggers.length > 0
+        ? NextResponse.json({ accepted: true, action: 'triggers' }, { status: 202 })
+        : NextResponse.json({ accepted: true, action: 'none' }, { status: 202 });
     }
 
     switch (result.error) {

--- a/apps/web/src/app/api/webhooks/[token]/route.ts
+++ b/apps/web/src/app/api/webhooks/[token]/route.ts
@@ -56,9 +56,10 @@ export async function POST(request: Request, context: { params: Promise<{ token:
     }
 
     // Resolve the enabled workflow triggers bound to this webhook once. The
-    // count both suppresses the dispatcher's 'no action configured' write (a
-    // page with triggers isn't a no-op) and decides the no-action vs triggers
-    // 202. This is the single trigger lookup for the delivery.
+    // count tells the dispatcher a page with triggers isn't a no-op (it records
+    // the delivery as fired instead of 'no action configured') and decides the
+    // route's no-action vs triggers 202. This is the single trigger lookup for
+    // the delivery.
     const triggerLookup = await findEnabledPageWebhookTriggers(webhook.id);
     if (!triggerLookup.success) {
       loggers.api.warn('Page webhook: trigger lookup failed', {

--- a/apps/web/src/lib/webhooks/__tests__/fire-page-webhook-triggers.test.ts
+++ b/apps/web/src/lib/webhooks/__tests__/fire-page-webhook-triggers.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../page-webhook-trigger-queries', () => ({
+  claimTriggerFired: vi.fn(),
+  setTriggerError: vi.fn(),
+}));
+
+vi.mock('../page-webhook-trigger-executor', () => ({
+  executePageWebhookTrigger: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: { PAGE_WEBHOOK_TRIGGER: { maxAttempts: 5 } },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) } },
+}));
+
+import { claimTriggerFired, setTriggerError } from '../page-webhook-trigger-queries';
+import { executePageWebhookTrigger } from '../page-webhook-trigger-executor';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+import { firePageWebhookTriggers } from '../fire-page-webhook-triggers';
+
+const mockClaim = claimTriggerFired as unknown as ReturnType<typeof vi.fn>;
+const mockSetError = setTriggerError as unknown as ReturnType<typeof vi.fn>;
+const mockExecute = executePageWebhookTrigger as unknown as ReturnType<typeof vi.fn>;
+const mockRateLimit = checkDistributedRateLimit as unknown as ReturnType<typeof vi.fn>;
+
+const envelope = { content: 'deploy finished', meta: { sha: 'abc' } };
+const aTrigger = (id: string) => ({ id, workflowId: `wf_${id}`, pageWebhookId: 'wh_1' }) as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClaim.mockResolvedValue({ success: true, data: undefined });
+  mockSetError.mockResolvedValue({ success: true, data: undefined });
+  mockRateLimit.mockResolvedValue({ allowed: true });
+});
+
+describe('firePageWebhookTriggers', () => {
+  it('does nothing when there are no triggers', async () => {
+    await firePageWebhookTriggers([], envelope);
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it('executes the workflow and claims the trigger on success', async () => {
+    mockExecute.mockResolvedValue({ success: true, durationMs: 1 });
+
+    await firePageWebhookTriggers([aTrigger('t1')], envelope);
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ id: 't1' }), envelope);
+    expect(mockClaim).toHaveBeenCalledWith('t1');
+    expect(mockSetError).not.toHaveBeenCalled();
+  });
+
+  it('records an error when the execution reports failure', async () => {
+    mockExecute.mockResolvedValue({ success: false, durationMs: 1, error: 'boom' });
+
+    await firePageWebhookTriggers([aTrigger('t1')], envelope);
+
+    expect(mockSetError).toHaveBeenCalledWith('t1', 'boom');
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it('records an error and continues when one execution throws', async () => {
+    mockExecute
+      .mockRejectedValueOnce(new Error('exploded'))
+      .mockResolvedValueOnce({ success: true, durationMs: 1 });
+
+    await firePageWebhookTriggers([aTrigger('t1'), aTrigger('t2')], envelope);
+
+    expect(mockSetError).toHaveBeenCalledWith('t1', 'exploded');
+    expect(mockClaim).toHaveBeenCalledWith('t2');
+  });
+
+  it('skips a trigger that is rate limited and records rate_limited without executing', async () => {
+    mockRateLimit.mockResolvedValue({ allowed: false });
+
+    await firePageWebhookTriggers([aTrigger('t1')], envelope);
+
+    expect(mockRateLimit).toHaveBeenCalledWith('page-webhook-trigger:t1', expect.anything());
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockSetError).toHaveBeenCalledWith('t1', 'rate_limited');
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
+
+  it('isolates a rate-limited trigger from a healthy one in the same delivery', async () => {
+    mockRateLimit
+      .mockResolvedValueOnce({ allowed: false })
+      .mockResolvedValueOnce({ allowed: true });
+    mockExecute.mockResolvedValue({ success: true, durationMs: 1 });
+
+    await firePageWebhookTriggers([aTrigger('t1'), aTrigger('t2')], envelope);
+
+    expect(mockSetError).toHaveBeenCalledWith('t1', 'rate_limited');
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+    expect(mockClaim).toHaveBeenCalledWith('t2');
+  });
+
+  it('never throws even if the whole fan-out misbehaves', async () => {
+    mockExecute.mockResolvedValue({ success: true, durationMs: 1 });
+    await expect(
+      firePageWebhookTriggers([aTrigger('t1')], envelope),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-executor.test.ts
+++ b/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-executor.test.ts
@@ -63,11 +63,11 @@ const WORKFLOW = {
 
 function queueHappyPath() {
   selectResults = [
-    [WORKFLOW],                                   // workflows
-    [{ pageId: 'wpage-1' }],                       // pageWebhooks
-    [{ driveId: 'drive-1', isTrashed: false }],    // webhook page (same drive)
-    [{ id: 'agent-1', isTrashed: false }],         // agent page
-    [{ subscriptionTier: 'pro' }],                 // owner
+    [WORKFLOW],                                                  // workflows
+    [{ pageId: 'wpage-1' }],                                     // pageWebhooks
+    [{ driveId: 'drive-1', isTrashed: false }],                 // webhook page (same drive)
+    [{ id: 'agent-1', isTrashed: false, driveId: 'drive-1' }],  // agent page (same drive)
+    [{ subscriptionTier: 'pro' }],                              // owner
   ];
 }
 
@@ -137,6 +137,15 @@ describe('executePageWebhookTrigger', () => {
     const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
     expect(result.success).toBe(false);
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('skips + does NOT execute when the AGENT page was bulk-moved to a different drive than the workflow', async () => {
+    selectResults[3] = [{ id: 'agent-1', isTrashed: false, driveId: 'drive-OTHER' }];
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/different drives/);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockCanConsume).not.toHaveBeenCalled();
   });
 
   it('does not execute when the billed user is no longer a drive member', async () => {

--- a/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-executor.test.ts
+++ b/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-executor.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// db.select().from(table).where() resolves the next queued result in a fixed
+// order: [workflow], [webhook], [webhookPage], [agentPage], [owner]. Each test
+// sets `selectResults` to reflect how far the executor gets before returning.
+let selectResults: unknown[][] = [];
+let selectIdx = 0;
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(selectResults[selectIdx++] ?? []),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: (a: unknown, b: unknown) => ({ a, b }) }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'u.id', subscriptionTier: 'u.tier' } }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'p.id', driveId: 'p.driveId', isTrashed: 'p.isTrashed' } }));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'w.id' } }));
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({ pageWebhooks: { id: 'pw.id', pageId: 'pw.pageId' } }));
+
+const mockExecuteWorkflow = vi.fn();
+vi.mock('@/lib/workflows/workflow-executor', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args),
+}));
+
+const mockIsMember = vi.fn();
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: (...args: unknown[]) => mockIsMember(...args),
+}));
+
+const mockCanConsume = vi.fn();
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: (...args: unknown[]) => mockCanConsume(...args),
+}));
+
+const mockReleaseHold = vi.fn();
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({
+  releaseHold: (...args: unknown[]) => mockReleaseHold(...args),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }) } },
+}));
+
+import { executePageWebhookTrigger } from '../page-webhook-trigger-executor';
+
+const TRIGGER = { id: 't1', workflowId: 'wf1', pageWebhookId: 'pw1' } as never;
+const ENVELOPE = { content: 'ship it', meta: { sha: 'abc' } };
+
+const WORKFLOW = {
+  id: 'wf1',
+  driveId: 'drive-1',
+  createdBy: 'user-1',
+  agentPageId: 'agent-1',
+  prompt: 'Do the thing.',
+  contextPageIds: ['ctx-1'],
+  instructionPageId: 'instr-1',
+  timezone: 'UTC',
+};
+
+function queueHappyPath() {
+  selectResults = [
+    [WORKFLOW],                                   // workflows
+    [{ pageId: 'wpage-1' }],                       // pageWebhooks
+    [{ driveId: 'drive-1', isTrashed: false }],    // webhook page (same drive)
+    [{ id: 'agent-1', isTrashed: false }],         // agent page
+    [{ subscriptionTier: 'pro' }],                 // owner
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectIdx = 0;
+  queueHappyPath();
+  mockIsMember.mockResolvedValue(true);
+  mockCanConsume.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+  mockExecuteWorkflow.mockResolvedValue({ success: true, durationMs: 5, runId: 'run-1' });
+  mockReleaseHold.mockResolvedValue(undefined);
+});
+
+describe('executePageWebhookTrigger', () => {
+  it('calls executeWorkflow UNMODIFIED with source webhookTriggers + the trigger id, billed to workflow.createdBy', async () => {
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+
+    expect(result.success).toBe(true);
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    const input = mockExecuteWorkflow.mock.calls[0][0];
+    expect(input.workflowId).toBe('wf1');
+    expect(input.createdBy).toBe('user-1');
+    expect(input.driveId).toBe('drive-1');
+    expect(input.source).toMatchObject({ table: 'webhookTriggers', id: 't1' });
+    expect(input.source.triggerAt).toBeInstanceOf(Date);
+  });
+
+  it('hands the full JSON envelope to the agent as prompt context', async () => {
+    await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    const input = mockExecuteWorkflow.mock.calls[0][0];
+    expect(input.eventContext.promptOverride).toContain(JSON.stringify(ENVELOPE));
+    expect(input.eventContext.promptOverride).toContain('Do the thing.');
+  });
+
+  it('bills the credit gate to workflow.createdBy and releases the hold', async () => {
+    await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(mockCanConsume).toHaveBeenCalledWith('user-1', 'pro', { skipDailyCap: true });
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('releases the credit hold even when executeWorkflow throws', async () => {
+    mockExecuteWorkflow.mockRejectedValue(new Error('model exploded'));
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(mockReleaseHold).toHaveBeenCalledWith('hold-1');
+  });
+
+  it('skips + does NOT execute when the webhook page is now in a different drive than the workflow', async () => {
+    selectResults[2] = [{ driveId: 'drive-OTHER', isTrashed: false }];
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/different drives/);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockCanConsume).not.toHaveBeenCalled();
+  });
+
+  it('errors when the linked workflow is missing', async () => {
+    selectResults[0] = [];
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('errors when the webhook page was trashed after binding', async () => {
+    selectResults[2] = [{ driveId: 'drive-1', isTrashed: true }];
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('does not execute when the billed user is no longer a drive member', async () => {
+    mockIsMember.mockResolvedValue(false);
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('does not execute when the credit gate denies', async () => {
+    mockCanConsume.mockResolvedValue({ allowed: false, reason: 'insufficient_credits' });
+    const result = await executePageWebhookTrigger(TRIGGER, ENVELOPE);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/credit gate denied/);
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    expect(mockReleaseHold).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-queries.test.ts
+++ b/apps/web/src/lib/webhooks/__tests__/page-webhook-trigger-queries.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFindMany = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: { webhookTriggers: { findMany: (...a: unknown[]) => mockFindMany(...a) } } },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: (...a: unknown[]) => ({ and: a }),
+  eq: (a: unknown, b: unknown) => ({ eq: [a, b] }),
+}));
+vi.mock('@pagespace/db/schema/webhook-triggers', () => ({
+  webhookTriggers: { pageWebhookId: 'pwid', isEnabled: 'enabled' },
+}));
+
+import {
+  findEnabledPageWebhookTriggers,
+  MAX_PAGE_WEBHOOK_TRIGGERS,
+} from '../page-webhook-trigger-queries';
+
+const rows = (n: number) => Array.from({ length: n }, (_, i) => ({ id: `t${i}` }));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('findEnabledPageWebhookTriggers', () => {
+  it('fetches one more than the cap so overflow is detectable', async () => {
+    mockFindMany.mockResolvedValue(rows(3));
+    await findEnabledPageWebhookTriggers('wh-1');
+    expect(mockFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: MAX_PAGE_WEBHOOK_TRIGGERS + 1 }),
+    );
+  });
+
+  it('returns the full set when at or under the cap', async () => {
+    mockFindMany.mockResolvedValue(rows(MAX_PAGE_WEBHOOK_TRIGGERS));
+    const result = await findEnabledPageWebhookTriggers('wh-1');
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.length).toBe(MAX_PAGE_WEBHOOK_TRIGGERS);
+  });
+
+  it('fails (does NOT return a truncated set) when the webhook has more than the cap of enabled triggers', async () => {
+    mockFindMany.mockResolvedValue(rows(MAX_PAGE_WEBHOOK_TRIGGERS + 1));
+    const result = await findEnabledPageWebhookTriggers('wh-1');
+    expect(result.success).toBe(false);
+    expect(result.success === false && result.error).toMatch(/more than/);
+  });
+
+  it('returns a failure result (never throws) when the query errors', async () => {
+    mockFindMany.mockRejectedValue(new Error('db down'));
+    const result = await findEnabledPageWebhookTriggers('wh-1');
+    expect(result.success).toBe(false);
+    expect(result.success === false && result.error).toBe('db down');
+  });
+});

--- a/apps/web/src/lib/webhooks/fire-page-webhook-triggers.ts
+++ b/apps/web/src/lib/webhooks/fire-page-webhook-triggers.ts
@@ -1,0 +1,59 @@
+import type { WebhookTrigger } from '@pagespace/db/schema/webhook-triggers';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { claimTriggerFired, setTriggerError } from './page-webhook-trigger-queries';
+import { executePageWebhookTrigger } from './page-webhook-trigger-executor';
+
+const logger = loggers.api.child({ module: 'fire-page-webhook-triggers' });
+
+/**
+ * Fan out a verified page-webhook delivery to every enabled workflow trigger
+ * bound to it — the page-anchored mirror of fireZoomWebhookTriggers.
+ *
+ * The trigger rows are pre-resolved by the caller: the intake route looks them
+ * up once (it needs the count to decide the no-action 202) and shares the list
+ * here, exactly as the Zoom route pre-resolves the connection. This runs inside
+ * `after()`, so the sender already has its HTTP response — the AI latency here
+ * never blocks the delivery.
+ *
+ * Never throws: per-trigger failures are isolated (Promise.allSettled) and
+ * recorded via setTriggerError; a success stamps lastFiredAt via
+ * claimTriggerFired — identical bookkeeping to Zoom's.
+ */
+export async function firePageWebhookTriggers(
+  triggers: WebhookTrigger[],
+  envelope: unknown,
+): Promise<void> {
+  if (triggers.length === 0) return;
+
+  await Promise.allSettled(
+    triggers.map(async (trigger) => {
+      try {
+        // Per-trigger rate limit, TIGHTER than the channel-post path (an AI run
+        // costs ~1000x a message insert). On top of executeWorkflow's
+        // single-running claim, this bounds the run RATE for a runaway sender.
+        const rl = await checkDistributedRateLimit(
+          `page-webhook-trigger:${trigger.id}`,
+          DISTRIBUTED_RATE_LIMITS.PAGE_WEBHOOK_TRIGGER,
+        );
+        if (!rl.allowed) {
+          logger.warn('Page webhook trigger: rate limited', { triggerId: trigger.id });
+          await setTriggerError(trigger.id, 'rate_limited');
+          return;
+        }
+
+        const result = await executePageWebhookTrigger(trigger, envelope);
+        if (result.success) {
+          await claimTriggerFired(trigger.id);
+        } else {
+          await setTriggerError(trigger.id, result.error ?? 'Workflow execution failed');
+        }
+      } catch (e) {
+        await setTriggerError(trigger.id, e instanceof Error ? e.message : String(e));
+      }
+    }),
+  );
+}

--- a/apps/web/src/lib/webhooks/page-webhook-trigger-executor.ts
+++ b/apps/web/src/lib/webhooks/page-webhook-trigger-executor.ts
@@ -112,9 +112,15 @@ export async function executePageWebhookTrigger(
       };
     }
 
-    // 4. Cheap preflight: verify the agent page still exists.
+    // 4. Preflight the agent page: it must still exist, be untrashed, AND live
+    //    in the workflow's drive. Same authoritative fire-time guard as the
+    //    webhook page (step 2) — the agent page can ALSO be bulk-moved after
+    //    binding, and executeWorkflow loads it by id and writes the webhook
+    //    prompt + AI response into it. The owner staying a member of
+    //    workflow.driveId says nothing about a drive the agent was moved into,
+    //    so a moved agent must be rejected, not written to across drives.
     const [agentPage] = await db
-      .select({ id: pages.id, isTrashed: pages.isTrashed })
+      .select({ id: pages.id, isTrashed: pages.isTrashed, driveId: pages.driveId })
       .from(pages)
       .where(eq(pages.id, workflow.agentPageId));
     if (!agentPage || agentPage.isTrashed) {
@@ -123,6 +129,16 @@ export async function executePageWebhookTrigger(
         durationMs: Date.now() - startTime,
         error: `Trigger agent page ${workflow.agentPageId} not found or trashed`,
       };
+    }
+    if (agentPage.driveId !== workflow.driveId) {
+      const error =
+        'Agent page and workflow are in different drives (binding stale after a page move)';
+      logger.warn('Page webhook trigger: skipped (agent page drive mismatch)', {
+        triggerId: trigger.id,
+        agentDriveId: agentPage.driveId,
+        workflowDriveId: workflow.driveId,
+      });
+      return { success: false, durationMs: Date.now() - startTime, error };
     }
 
     // 5. Credit gate on the billed user — blocks out-of-credits users before

--- a/apps/web/src/lib/webhooks/page-webhook-trigger-executor.ts
+++ b/apps/web/src/lib/webhooks/page-webhook-trigger-executor.ts
@@ -1,0 +1,216 @@
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { pages } from '@pagespace/db/schema/core';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
+import type { WebhookTrigger } from '@pagespace/db/schema/webhook-triggers';
+import {
+  executeWorkflow,
+  type WorkflowExecutionResult,
+  type WorkflowExecutionInput,
+} from '@/lib/workflows/workflow-executor';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { releaseHold } from '@pagespace/lib/billing/credit-consume';
+import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const logger = loggers.api.child({ module: 'page-webhook-trigger-executor' });
+
+/**
+ * Execute a single page-webhook-triggered agent invocation.
+ *
+ * The page-anchored counterpart to Zoom's executeWebhookTrigger: the
+ * webhook_triggers row holds only the (pageWebhook → workflow) wiring, so we
+ * load the linked workflows row for the execution payload, preflight
+ * access/agent-page, gate credit, and delegate to the shared executor
+ * UNMODIFIED. Two things differ from the Zoom path:
+ *  - Billing resolves to `workflow.createdBy` (there is no OAuth connection
+ *    owner); membership + credit gate + the released hold all key off them.
+ *  - A page can be bulk-moved to a different drive AFTER a trigger is bound
+ *    (rewriting pages.driveId), so the webhook page's CURRENT drive is the
+ *    authoritative same-drive guard here — the create-time CRUD check cannot
+ *    survive a later move. A mismatch is skipped and recorded, never executed.
+ *
+ * Per-fire state lives in workflow_runs (written by executeWorkflow). Never
+ * throws — every failure is returned as a result so the fan-out records it.
+ */
+export async function executePageWebhookTrigger(
+  trigger: WebhookTrigger,
+  envelope: unknown,
+): Promise<WorkflowExecutionResult> {
+  const startTime = Date.now();
+
+  try {
+    // 1. Load the linked workflow (the trigger holds only the wiring).
+    const [workflow] = await db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.id, trigger.workflowId));
+
+    if (!workflow) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: `Linked workflow ${trigger.workflowId} not found`,
+      };
+    }
+
+    // 2. Authoritative same-drive guard. The trigger must be page-anchored;
+    //    resolve the webhook's page and compare its CURRENT drive to the
+    //    workflow's drive. A page moved out of the workflow's drive after the
+    //    binding was created is stale — skip + record, never execute.
+    if (!trigger.pageWebhookId) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: 'Trigger is not anchored to a page webhook',
+      };
+    }
+    const [webhook] = await db
+      .select({ pageId: pageWebhooks.pageId })
+      .from(pageWebhooks)
+      .where(eq(pageWebhooks.id, trigger.pageWebhookId));
+    if (!webhook) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: `Page webhook ${trigger.pageWebhookId} not found`,
+      };
+    }
+    const [webhookPage] = await db
+      .select({ driveId: pages.driveId, isTrashed: pages.isTrashed })
+      .from(pages)
+      .where(eq(pages.id, webhook.pageId));
+    if (!webhookPage || webhookPage.isTrashed) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: `Webhook page ${webhook.pageId} not found or trashed`,
+      };
+    }
+    if (webhookPage.driveId !== workflow.driveId) {
+      const error =
+        'Webhook page and workflow are in different drives (binding stale after a page move)';
+      logger.warn('Page webhook trigger: skipped (drive mismatch)', {
+        triggerId: trigger.id,
+        webhookDriveId: webhookPage.driveId,
+        workflowDriveId: workflow.driveId,
+      });
+      return { success: false, durationMs: Date.now() - startTime, error };
+    }
+
+    // 3. Billing resolves to workflow.createdBy — verify they still belong to
+    //    the workflow's drive before spending their credit.
+    const hasDriveAccess = await isUserDriveMember(workflow.createdBy, workflow.driveId);
+    if (!hasDriveAccess) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: 'Workflow owner no longer has access to the drive',
+      };
+    }
+
+    // 4. Cheap preflight: verify the agent page still exists.
+    const [agentPage] = await db
+      .select({ id: pages.id, isTrashed: pages.isTrashed })
+      .from(pages)
+      .where(eq(pages.id, workflow.agentPageId));
+    if (!agentPage || agentPage.isTrashed) {
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: `Trigger agent page ${workflow.agentPageId} not found or trashed`,
+      };
+    }
+
+    // 5. Credit gate on the billed user — blocks out-of-credits users before
+    //    the model is invoked. skipDailyCap: server-triggered, not interactive.
+    const [owner] = await db
+      .select({ subscriptionTier: users.subscriptionTier })
+      .from(users)
+      .where(eq(users.id, workflow.createdBy));
+    const gate = await canConsumeAI(
+      workflow.createdBy,
+      (owner?.subscriptionTier ?? 'free') as SubscriptionTier,
+      { skipDailyCap: true },
+    );
+    if (!gate.allowed) {
+      logger.info('Page webhook trigger: skipped (credit gate denied)', {
+        triggerId: trigger.id,
+        reason: gate.reason,
+      });
+      return {
+        success: false,
+        durationMs: Date.now() - startTime,
+        error: `AI credit gate denied: ${gate.reason}`,
+      };
+    }
+    const holdId = gate.holdId;
+
+    // 6. Hand the FULL JSON envelope to the agent as prompt context, prepended
+    //    to the workflow's stored prompt.
+    const promptOverride = buildPageWebhookTriggerPrompt(workflow.prompt, envelope);
+
+    // 7. Compose execution input — executeWorkflow writes workflow_runs and
+    //    owns the single-running claim. Called UNMODIFIED.
+    const input: WorkflowExecutionInput = {
+      workflowId: workflow.id,
+      workflowName: `page-webhook-trigger-${trigger.id}`,
+      driveId: workflow.driveId,
+      createdBy: workflow.createdBy,
+      agentPageId: workflow.agentPageId,
+      prompt: workflow.prompt,
+      contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+      instructionPageId: workflow.instructionPageId,
+      timezone: workflow.timezone,
+      source: { table: 'webhookTriggers', id: trigger.id, triggerAt: new Date() },
+      eventContext: { promptOverride },
+    };
+
+    // executeWorkflow calls AIMonitoring.trackUsage → consumeCredits internally.
+    // Release the hold here so the user's spendable balance is accurate after
+    // execution, whether it succeeds, fails, or throws.
+    let result: WorkflowExecutionResult;
+    try {
+      result = await executeWorkflow(input);
+    } finally {
+      if (holdId) void releaseHold(holdId).catch(() => {});
+    }
+
+    logger.info('Page webhook trigger executed', {
+      triggerId: trigger.id,
+      workflowId: workflow.id,
+      success: result.success,
+      durationMs: result.durationMs,
+    });
+
+    return result;
+  } catch (error) {
+    const durationMs = Date.now() - startTime;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    logger.error('Page webhook trigger execution failed', {
+      triggerId: trigger.id,
+      error: errorMessage,
+      durationMs,
+    });
+
+    return { success: false, durationMs, error: errorMessage };
+  }
+}
+
+/**
+ * The agent sees the raw delivery envelope verbatim (JSON-serialized) followed
+ * by the workflow's configured prompt — the whole point of a webhook trigger is
+ * "the payload drives the run".
+ */
+function buildPageWebhookTriggerPrompt(workflowPrompt: string, envelope: unknown): string {
+  const parts: string[] = [];
+  parts.push('<webhook-delivery>');
+  parts.push(JSON.stringify(envelope));
+  parts.push('</webhook-delivery>');
+  parts.push(`\n${workflowPrompt}`);
+  return parts.join('\n');
+}

--- a/apps/web/src/lib/webhooks/page-webhook-trigger-queries.ts
+++ b/apps/web/src/lib/webhooks/page-webhook-trigger-queries.ts
@@ -27,6 +27,14 @@ export const MAX_PAGE_WEBHOOK_TRIGGERS = 100;
 /**
  * Every enabled trigger bound to a page webhook. Page-anchored rows skip
  * event-type matching (v1): all enabled triggers on the webhook fire.
+ *
+ * Fetches one MORE than the fan-out cap so an over-capped webhook is DETECTED,
+ * not silently truncated. Returning only the first MAX rows as if they were the
+ * complete set would drop the excess workflows on every delivery while the
+ * route still answered 2xx (the sender never learns). Overflow is surfaced as a
+ * failure instead, so the route rejects the delivery loudly (retryable 5xx)
+ * rather than dispatching a partial fan-out. Enforcing the cap at binding
+ * creation is the T6 Trigger-CRUD job; this is the fan-out-side safety net.
  */
 export async function findEnabledPageWebhookTriggers(
   pageWebhookId: string,
@@ -37,8 +45,14 @@ export async function findEnabledPageWebhookTriggers(
         eq(webhookTriggers.pageWebhookId, pageWebhookId),
         eq(webhookTriggers.isEnabled, true),
       ),
-      limit: MAX_PAGE_WEBHOOK_TRIGGERS,
+      limit: MAX_PAGE_WEBHOOK_TRIGGERS + 1,
     });
+    if (triggers.length > MAX_PAGE_WEBHOOK_TRIGGERS) {
+      return {
+        success: false,
+        error: `page webhook ${pageWebhookId} has more than ${MAX_PAGE_WEBHOOK_TRIGGERS} enabled triggers; refusing to fan out a truncated set`,
+      };
+    }
     return { success: true, data: triggers };
   } catch (e) {
     return { success: false, error: toError(e) };

--- a/apps/web/src/lib/webhooks/page-webhook-trigger-queries.ts
+++ b/apps/web/src/lib/webhooks/page-webhook-trigger-queries.ts
@@ -1,0 +1,75 @@
+import { db } from '@pagespace/db/db';
+import { and, eq } from '@pagespace/db/operators';
+import { webhookTriggers, type WebhookTrigger } from '@pagespace/db/schema/webhook-triggers';
+
+const toError = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/**
+ * Pure DB lookups for the page-webhook trigger firing path — the page-anchored
+ * counterpart to the Zoom connection-anchored webhook-trigger-queries. Each
+ * returns a Result and never throws; errors are returned as data so the
+ * orchestrator (fire-page-webhook-triggers) can decide per-trigger.
+ */
+export type PageTriggerQueryResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/**
+ * Upper bound on triggers loaded per delivery. The partial unique index is
+ * (pageWebhookId, workflowId), so a single webhook can bind many workflows;
+ * this bounds the fan-out well above any realistic wiring count so a
+ * pathological webhook can never load an unbounded set into memory. Also
+ * satisfies the required-`limit` lint rule (unbounded findMany OOM-crashed
+ * prod on 2026-07-18).
+ */
+export const MAX_PAGE_WEBHOOK_TRIGGERS = 100;
+
+/**
+ * Every enabled trigger bound to a page webhook. Page-anchored rows skip
+ * event-type matching (v1): all enabled triggers on the webhook fire.
+ */
+export async function findEnabledPageWebhookTriggers(
+  pageWebhookId: string,
+): Promise<PageTriggerQueryResult<WebhookTrigger[]>> {
+  try {
+    const triggers = await db.query.webhookTriggers.findMany({
+      where: and(
+        eq(webhookTriggers.pageWebhookId, pageWebhookId),
+        eq(webhookTriggers.isEnabled, true),
+      ),
+      limit: MAX_PAGE_WEBHOOK_TRIGGERS,
+    });
+    return { success: true, data: triggers };
+  } catch (e) {
+    return { success: false, error: toError(e) };
+  }
+}
+
+/** Success clears lastFireError and stamps lastFiredAt. Mirrors Zoom's bookkeeping. */
+export async function claimTriggerFired(triggerId: string): Promise<PageTriggerQueryResult<void>> {
+  try {
+    await db
+      .update(webhookTriggers)
+      .set({ lastFiredAt: new Date(), lastFireError: null })
+      .where(eq(webhookTriggers.id, triggerId));
+    return { success: true, data: undefined };
+  } catch (e) {
+    return { success: false, error: toError(e) };
+  }
+}
+
+/** Failure records the error without touching lastFiredAt. Mirrors Zoom's bookkeeping. */
+export async function setTriggerError(
+  triggerId: string,
+  error: string,
+): Promise<PageTriggerQueryResult<void>> {
+  try {
+    await db
+      .update(webhookTriggers)
+      .set({ lastFireError: error })
+      .where(eq(webhookTriggers.id, triggerId));
+    return { success: true, data: undefined };
+  } catch (e) {
+    return { success: false, error: toError(e) };
+  }
+}

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -683,6 +683,19 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 60 * 1000,
     progressiveDelay: false,
   },
+  // Per-trigger cap on page-webhook-fired workflow runs (key:
+  // `page-webhook-trigger:{triggerId}`). Deliberately far TIGHTER than the
+  // 30/min PAGE_WEBHOOK channel-post limit: a fired trigger runs an agent
+  // (LLM calls, tool use) that costs on the order of 1000x a single channel
+  // message insert, so a runaway sender must be throttled hard here — on top
+  // of executeWorkflow's single-running claim, which already serializes runs
+  // of the same workflow but does not bound their rate over time.
+  PAGE_WEBHOOK_TRIGGER: {
+    maxAttempts: 5,
+    windowMs: 60 * 1000,
+    blockDurationMs: 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================

--- a/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
@@ -76,16 +76,18 @@ describe('dispatchWebhookDelivery', () => {
     expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
   });
 
-  it('suppresses the no-action write when triggers are firing — a no-handler page with triggers is not a no-op', async () => {
+  it('records a successful dispatch on the webhook row when triggers are firing — a no-handler page with triggers is not a no-op', async () => {
     mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT', isTrashed: false });
 
     const result = await dispatchWebhookDelivery({ ...DELIVERY, hasEnabledTriggers: true });
 
     // Still no default handler, so still no_action — but the triggers ARE the
-    // delivery's action, so the misleading 'no action configured' isn't written.
+    // delivery's action, so the webhook row is stamped fired (lastFireError
+    // cleared) rather than left showing a stale 'no action configured'.
     expect(result).toEqual({ kind: 'no_action' });
     expect(mockPublish).not.toHaveBeenCalled();
-    expect(mockMarkFired).not.toHaveBeenCalled();
+    expect(mockMarkFired).toHaveBeenCalledTimes(1);
+    expect(mockMarkFired).toHaveBeenCalledWith('wh-1', null);
   });
 
   it('reports not_found for a trashed target page — no write into the trash, no bookkeeping, indistinguishable from an unknown token', async () => {

--- a/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
+++ b/packages/lib/src/services/__tests__/page-webhook-dispatch.test.ts
@@ -76,6 +76,18 @@ describe('dispatchWebhookDelivery', () => {
     expect(mockMarkFired).toHaveBeenCalledWith('wh-1', 'no action configured');
   });
 
+  it('suppresses the no-action write when triggers are firing — a no-handler page with triggers is not a no-op', async () => {
+    mockPageFindFirst.mockResolvedValue({ type: 'DOCUMENT', isTrashed: false });
+
+    const result = await dispatchWebhookDelivery({ ...DELIVERY, hasEnabledTriggers: true });
+
+    // Still no default handler, so still no_action — but the triggers ARE the
+    // delivery's action, so the misleading 'no action configured' isn't written.
+    expect(result).toEqual({ kind: 'no_action' });
+    expect(mockPublish).not.toHaveBeenCalled();
+    expect(mockMarkFired).not.toHaveBeenCalled();
+  });
+
   it('reports not_found for a trashed target page — no write into the trash, no bookkeeping, indistinguishable from an unknown token', async () => {
     mockPageFindFirst.mockResolvedValue({ type: 'CHANNEL', isTrashed: true });
 

--- a/packages/lib/src/services/page-webhook-dispatch.ts
+++ b/packages/lib/src/services/page-webhook-dispatch.ts
@@ -99,12 +99,13 @@ export async function dispatchWebhookDelivery({
 
     const handlerKey = resolveWebhookHandler(page.type);
     if (handlerKey === 'none') {
-      // Only record 'no action configured' when there is genuinely nothing to
-      // do. Firing workflow triggers count as the delivery's action even
-      // without a default page-type handler.
-      if (!hasEnabledTriggers) {
-        await markWebhookFired(webhookId, 'no action configured');
-      }
+      // Firing workflow triggers ARE the delivery's action even without a
+      // default page-type handler. Record a successful dispatch on the webhook
+      // row in that case (stamp lastFiredAt, clear any stale lastFireError) so
+      // the settings UI reflects the accepted delivery instead of a leftover
+      // 'no action configured' failure. Genuinely-idle webhooks (no handler,
+      // no triggers) still record the no-action error.
+      await markWebhookFired(webhookId, hasEnabledTriggers ? null : 'no action configured');
       return { kind: 'no_action' };
     }
 

--- a/packages/lib/src/services/page-webhook-dispatch.ts
+++ b/packages/lib/src/services/page-webhook-dispatch.ts
@@ -63,10 +63,19 @@ export async function dispatchWebhookDelivery({
   webhookId,
   pageId,
   payload,
+  hasEnabledTriggers = false,
 }: {
   webhookId: string;
   pageId: string;
   payload: unknown;
+  /**
+   * True when the caller (the intake route) has resolved enabled workflow
+   * triggers bound to this webhook and will fire them via `after()`. A page
+   * with no default handler but firing triggers is NOT a no-op, so the
+   * dispatcher suppresses its 'no action configured' bookkeeping write in that
+   * case — the triggers are the delivery's action.
+   */
+  hasEnabledTriggers?: boolean;
 }): Promise<WebhookDispatchResult> {
   try {
     const page = await db.query.pages.findFirst({
@@ -90,7 +99,12 @@ export async function dispatchWebhookDelivery({
 
     const handlerKey = resolveWebhookHandler(page.type);
     if (handlerKey === 'none') {
-      await markWebhookFired(webhookId, 'no action configured');
+      // Only record 'no action configured' when there is genuinely nothing to
+      // do. Firing workflow triggers count as the delivery's action even
+      // without a default page-type handler.
+      if (!hasEnabledTriggers) {
+        await markWebhookFired(webhookId, 'no action configured');
+      }
       return { kind: 'no_action' };
     }
 


### PR DESCRIPTION
## What

Adds the **trigger fan-out** for page incoming webhooks: a verified delivery now fires every enabled workflow trigger bound to the webhook, through the existing `executeWorkflow` engine — **alongside** the T3 default-handler dispatch (`dispatchWebhookDelivery`, #2172).

- `apps/web/src/lib/webhooks/page-webhook-trigger-queries.ts` — enabled-trigger lookup (bounded `limit`) + `claimTriggerFired`/`setTriggerError` bookkeeping identical to Zoom's.
- `apps/web/src/lib/webhooks/page-webhook-trigger-executor.ts` — per trigger: load workflow, **authoritative same-drive guard** (webhook page's *current* `driveId` vs `workflow.driveId`), bill `workflow.createdBy` (drive-membership + `canConsumeAI` + credit hold released in `finally`), hand the full JSON envelope to the agent, call `executeWorkflow` **unmodified** with `source: { table: 'webhookTriggers', id: trigger.id }`.
- `apps/web/src/lib/webhooks/fire-page-webhook-triggers.ts` — `Promise.allSettled` fan-out, per-trigger isolation, and a **tighter per-trigger rate limit** (`PAGE_WEBHOOK_TRIGGER`, 5/min) than the 30/min channel-post path.
- Intake route `apps/web/src/app/api/webhooks/[token]/route.ts`: resolves bound triggers once, calls `dispatchWebhookDelivery` for the default action, then fires the fan-out via `after()`. `dispatchWebhookDelivery` gains `hasEnabledTriggers` so a no-handler page with firing triggers is not recorded as `'no action configured'` and the route answers `202 { action: 'triggers' }`.

## Why

The keystone of the Page Webhooks epic: it turns a signed inbound URL into an agentic trigger, firing bound workflows into the existing agentic engine.

### Composability (the whole point)
One signed POST to a **channel** webhook that also has an enabled workflow trigger does **both**: the verbatim message posts (default handler, inline) **and** the workflow fires (fan-out, in `after()`). Composable, not duplicative — proven by the route tests and the T8 manual E2E later.

## Scope guard
No new execution engine, no new action-type enum, no new per-page-type tools. **Same-drive guard runs at fire time** because a page can be bulk-moved to another drive after a trigger is bound; the CRUD create-time check cannot survive that. The fan-out is skipped only when the delivery never reached a valid page (dispatcher `not_found` — trashed/missing); a default-handler failure does **not** suppress it (the workflow envelope is arbitrary JSON, independent of the channel handler's contract).

## Test plan
- New unit tests mirroring Zoom's style: `fire-page-webhook-triggers` (fan-out isolation, rate-limit skip, claim/error bookkeeping) + `page-webhook-trigger-executor` (source table + trigger id, billing→createdBy, hold released in finally, drive-mismatch skip, gate denial).
- Dispatch `hasEnabledTriggers` suppression test.
- Route composability tests: CHANNEL post **and** workflow fan-out both fire on one POST; no-handler page → 202 `action:triggers`; trashed page fires nothing; independent-envelope failure (rate-limited channel) still fires; lookup-failure degrades to no-action.
- **48 tests green** across the touched suites. `@pagespace/lib` + web typecheck, web lint, `knip:check`, and the security route-coverage suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Review fixes (Codex, commit 87fb49d18)
- **P1 — agent-page drive guard:** the fire-time same-drive guard now covers the workflow's **agent page** too, not just the webhook page. A bulk-moved agent page (owner still a member of `workflow.driveId` but the agent moved elsewhere) is skipped + recorded rather than written to across drives by `executeWorkflow`.
- **P2 — webhook-row bookkeeping:** a no-handler page with firing triggers now stamps `page_webhooks.lastFiredAt` and clears `lastFireError` (symmetric with the CHANNEL success path), so a stale `no action configured` no longer sticks in the settings UI after a workflow is bound and delivered.

- **P2 (round 2) — fan-out only on accepted (2xx) deliveries:** the fan-out gate is now `handled || no_action`, not "any result except not_found". A rejected/malformed envelope (400) or rate-limited channel (429) no longer fires workflows, so a rejected + retried delivery can't perform or duplicate AI side effects. Valid-delivery composability unchanged.
- **P2 (round 3) — retryable failure on trigger-lookup error:** a transient DB error resolving bound triggers now returns a retryable 503 before dispatch, instead of silently treating it as "no triggers" (which returned a 2xx the sender wouldn't retry and permanently dropped every bound workflow). No channel post on the failed attempt, so the retry can't duplicate it.
- **P2 (round 4) — trigger-set overflow detection:** the lookup fetches `MAX+1` and fails (routing to the retryable 5xx) when a webhook has more than the 100-trigger fan-out cap, instead of representing a truncated 100-row subset as the complete set and silently dropping the excess on every delivery. (CRUD-side cap enforcement is T6.)
