### PR TITLE
refactor(db): centralize escapeLikePattern into packages/lib/src/db/like-pattern

### DIFF
--- a/apps/admin/src/app/api/admin/audit-logs/route.ts
+++ b/apps/admin/src/app/api/admin/audit-logs/route.ts
@@ -5,6 +5,7 @@ import { activityLogs } from '@pagespace/db/schema/monitoring';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { decryptFieldValuesOnce } from '@pagespace/lib/encryption/field-crypto';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
@@ -68,11 +69,7 @@ export const GET = withAdminAuth(async (_adminUser, request) => {
 
     if (search) {
       // Escape LIKE pattern special characters to prevent pattern injection
-      const escapedSearch = search
-        .replace(/\\/g, '\\\\')
-        .replace(/%/g, '\\%')
-        .replace(/_/g, '\\_');
-      const searchPattern = `%${escapedSearch}%`;
+      const searchPattern = `%${escapeLikePattern(search)}%`;
 
       // Use Drizzle's ilike function for proper parameterization
       conditions.push(

--- a/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
@@ -69,6 +69,7 @@ import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pag
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { db } from '@pagespace/db/db';
+import * as dbOperators from '@pagespace/db/operators';
 
 // ============================================================================
 // Test Fixtures
@@ -379,6 +380,28 @@ describe('GET /api/mentions/search', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(200);
+    });
+  });
+
+  describe('search term escaping', () => {
+    it('escapes LIKE metacharacters in the search term before building the ilike condition (regression: over-matching fix)', async () => {
+      vi.mocked(getUserDriveAccess).mockResolvedValue(true);
+      vi.mocked(getUserAccessLevel).mockResolvedValue('VIEW' as never);
+      vi.mocked(getDriveRecipientUserIds).mockResolvedValue([mockUserId]);
+
+      const ilikeSpy = vi.spyOn(dbOperators, 'ilike');
+
+      // A search for "50% off" contains a literal '%' — if it reaches ilike()
+      // unescaped, Postgres reads it as a wildcard instead of a literal character.
+      const request = new Request(
+        `https://example.com/api/mentions/search?q=${encodeURIComponent('50% off')}&driveId=${mockDriveId}&types=page`
+      );
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const patterns = ilikeSpy.mock.calls.map(([, pattern]) => pattern);
+      expect(patterns).toContain('%50\\%%');
+      expect(patterns).toContain('%off%');
     });
   });
 });

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -4,6 +4,7 @@ import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-s
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { buildSearchAuditDetails } from '@pagespace/lib/audit/search-audit-details';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
 import { and, eq, ilike, inArray, desc, SQL } from '@pagespace/db/operators'
@@ -13,17 +14,6 @@ import { pages, drives, pageType, type PageTypeEnum } from '@pagespace/db/schema
 import { driveRoles } from '@pagespace/db/schema/members';
 import { MentionSuggestion, MentionType } from '@/types/mentions';
 import { z } from 'zod';
-
-/**
- * Escape LIKE pattern metacharacters (%, _) in user input
- * Prevents user input from being interpreted as wildcards
- */
-function escapeLikePattern(input: string): string {
-  return input
-    .replace(/\\/g, '\\\\')  // Escape backslashes first
-    .replace(/%/g, '\\%')    // Escape percent
-    .replace(/_/g, '\\_');   // Escape underscore
-}
 
 /**
  * Build a multi-word search condition

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/query-spec.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/query-spec.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseTaskQuerySpec, escapeLikePattern } from '../query-spec';
+import { parseTaskQuerySpec } from '../query-spec';
 
 const assert = ({ given, should, actual, expected }: {
   given: string; should: string; actual: unknown; expected: unknown;
@@ -147,53 +147,6 @@ describe('parseTaskQuerySpec', () => {
       should: 'be undefined',
       actual: parseTaskQuerySpec(new URLSearchParams('')).search,
       expected: undefined,
-    });
-  });
-});
-
-describe('escapeLikePattern', () => {
-  it('plain text', () => {
-    assert({
-      given: 'a search term with no special characters',
-      should: 'pass through unmodified',
-      actual: escapeLikePattern('groceries'),
-      expected: 'groceries',
-    });
-  });
-
-  it('literal percent sign', () => {
-    assert({
-      given: 'a search term containing a % character',
-      should: 'escape it so ILIKE treats it as a literal char, not a wildcard',
-      actual: escapeLikePattern('50% off'),
-      expected: '50\\% off',
-    });
-  });
-
-  it('literal underscore', () => {
-    assert({
-      given: 'a search term containing a _ character',
-      should: 'escape it so ILIKE treats it as a literal char, not a single-char wildcard',
-      actual: escapeLikePattern('foo_bar'),
-      expected: 'foo\\_bar',
-    });
-  });
-
-  it('literal backslash', () => {
-    assert({
-      given: 'a search term containing a backslash',
-      should: 'escape the backslash itself so it is not read as an escape character',
-      actual: escapeLikePattern('a\\b'),
-      expected: 'a\\\\b',
-    });
-  });
-
-  it('multiple special characters', () => {
-    assert({
-      given: 'a search term containing %, _, and \\ together',
-      should: 'escape every occurrence',
-      actual: escapeLikePattern('100%_done\\ish'),
-      expected: '100\\%\\_done\\\\ish',
     });
   });
 });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/query-spec.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/query-spec.ts
@@ -44,14 +44,3 @@ export function parseTaskQuerySpec(params: URLSearchParams): TaskQuerySpec {
     offset,
   };
 }
-
-/**
- * Escapes ILIKE wildcard/escape characters (`%`, `_`, `\`) in a search term so it
- * matches as a literal substring. Postgres's default LIKE/ILIKE escape character is
- * backslash — without this, a search term containing one of these characters (e.g.
- * a task titled "50% off") would be interpreted as a pattern, not literal text,
- * silently over- or under-matching against the bounded query's ilike(pages.title, ...).
- */
-export function escapeLikePattern(value: string): string {
-  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
-}

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -16,7 +16,8 @@ import { computeHasContent } from './task-utils';
 import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 import { getUserTimezone } from '@/lib/ai/core/personalization-utils';
 import { decryptTaskUserRelations, decryptTaskUserRelationsOne } from '@/lib/tasks/decrypt-task-relations';
-import { parseTaskQuerySpec, escapeLikePattern } from './query-spec';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
+import { parseTaskQuerySpec } from './query-spec';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/search/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+vi.mock('@/lib/auth', () => ({
+  verifyAuth: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getBatchPagePermissions: vi.fn().mockResolvedValue(new Map()),
+}));
+vi.mock('@pagespace/lib/auth/user-repository', () => ({
+  decryptUserRows: vi.fn((rows: unknown[]) => Promise.resolve(rows)),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { debug: vi.fn(), error: vi.fn() } },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+import { db } from '@pagespace/db/db';
+import { verifyAuth } from '@/lib/auth';
+import * as dbOperators from '@pagespace/db/operators';
+import { GET } from '../route';
+
+// ============================================================================
+// Contract test for /api/search — LIKE pattern escaping.
+//
+// This route has no other test coverage of its GET handler, so this is a
+// minimal contract test rather than a full suite: it verifies the search
+// term reaches ilike() escaped, not the full ranking/permission behavior.
+// ============================================================================
+
+describe('GET /api/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(verifyAuth).mockResolvedValue({ id: 'user_1' } as never);
+
+    // Drizzle query builders are thenables — some call sites in the route
+    // `await` the chain directly without a trailing `.limit()`, so `where()`
+    // must resolve to an (empty) array on its own, not just return `this`.
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn(() => chain);
+    chain.leftJoin = vi.fn(() => chain);
+    chain.where = vi.fn(() => chain);
+    chain.limit = vi.fn(() => Promise.resolve([]));
+    chain.then = (resolve: (value: unknown[]) => unknown) => Promise.resolve([]).then(resolve);
+    vi.mocked(db.select).mockReturnValue(chain as never);
+  });
+
+  it('escapes LIKE metacharacters in the search term before building ilike conditions (regression: over-matching fix)', async () => {
+    const ilikeSpy = vi.spyOn(dbOperators, 'ilike');
+
+    // A search for "50% off" contains a literal '%' — if it reaches ilike()
+    // unescaped, Postgres reads it as a wildcard instead of a literal character.
+    const request = new Request(`https://example.com/api/search?q=${encodeURIComponent('50% off')}`);
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const patterns = ilikeSpy.mock.calls.map(([, pattern]) => pattern);
+    expect(patterns).toContain('%50\\%%');
+    expect(patterns).toContain('%off%');
+  });
+});

--- a/apps/web/src/app/api/search/route.ts
+++ b/apps/web/src/app/api/search/route.ts
@@ -11,6 +11,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { buildSearchAuditDetails } from '@pagespace/lib/audit/search-audit-details';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 
 interface SearchResult {
   id: string;
@@ -23,16 +24,6 @@ interface SearchResult {
   avatarUrl?: string | null;
   matchLocation?: 'title' | 'content' | 'both';
   relevanceScore?: number;
-}
-
-/**
- * Escape LIKE pattern metacharacters to prevent injection
- */
-function escapeLikePattern(input: string): string {
-  return input
-    .replace(/\\/g, '\\\\')
-    .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_');
 }
 
 /**

--- a/apps/web/src/app/api/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/__tests__/route.test.ts
@@ -103,7 +103,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { isNull } from '@pagespace/db/operators';
+import { isNull, sql } from '@pagespace/db/operators';
 import { taskItems } from '@pagespace/db/schema/tasks';
 
 // ============================================================================
@@ -519,6 +519,17 @@ describe('GET /api/tasks', () => {
       await GET(request);
 
       expect(db.query.taskItems.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('escapes LIKE metacharacters in the search term before building the ILIKE subquery pattern (regression: over-matching fix)', async () => {
+      // A task titled "100% done" contains a literal '%' — if it reaches the
+      // ILIKE subquery unescaped, Postgres reads it as a wildcard instead of a
+      // literal character.
+      const request = new Request(`https://example.com/api/tasks?context=user&search=${encodeURIComponent('100% done')}`);
+      await GET(request);
+
+      const [, , searchPattern] = vi.mocked(sql).mock.calls[0] as unknown as [unknown, unknown, string];
+      expect(searchPattern).toBe('%100\\% done%');
     });
   });
 

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -7,6 +7,7 @@ import { taskItems, taskLists, taskStatusConfigs } from '@pagespace/db/schema/ta
 import { DEFAULT_STATUS_CONFIG, type TaskStatusGroup } from '@/lib/task-status-config';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { escapeLikePattern } from '@pagespace/lib/db/like-pattern';
 import {
   authenticateRequestWithOptions,
   isAuthError,
@@ -44,17 +45,6 @@ const querySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
 });
-
-/**
- * Escape SQL LIKE pattern special characters to prevent wildcard injection.
- * Must be used with ESCAPE '\\' clause in the query.
- */
-function escapeLikePattern(value: string): string {
-  return value
-    .replace(/\\/g, '\\\\')  // Escape backslashes first
-    .replace(/%/g, '\\%')    // Escape percent
-    .replace(/_/g, '\\_');   // Escape underscore
-}
 
 /**
  * GET /api/tasks

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/db/bounded-query.js",
       "require": "./dist/db/bounded-query.js"
     },
+    "./db/like-pattern": {
+      "types": "./dist/db/like-pattern.d.ts",
+      "import": "./dist/db/like-pattern.js",
+      "require": "./dist/db/like-pattern.js"
+    },
     "./ai/normalize-parts": {
       "types": "./dist/ai/normalize-parts.d.ts",
       "import": "./dist/ai/normalize-parts.js",

--- a/packages/lib/src/db/__tests__/like-pattern.test.ts
+++ b/packages/lib/src/db/__tests__/like-pattern.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { escapeLikePattern } from '../like-pattern';
+
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+describe('escapeLikePattern', () => {
+  it('plain text', () => {
+    assert({
+      given: 'a search term with no special characters',
+      should: 'pass through unmodified',
+      actual: escapeLikePattern('groceries'),
+      expected: 'groceries',
+    });
+  });
+
+  it('literal percent sign', () => {
+    assert({
+      given: 'a search term containing a % character',
+      should: 'escape it so ILIKE treats it as a literal char, not a wildcard',
+      actual: escapeLikePattern('50% off'),
+      expected: '50\\% off',
+    });
+  });
+
+  it('literal underscore', () => {
+    assert({
+      given: 'a search term containing a _ character',
+      should: 'escape it so ILIKE treats it as a literal char, not a single-char wildcard',
+      actual: escapeLikePattern('foo_bar'),
+      expected: 'foo\\_bar',
+    });
+  });
+
+  it('literal backslash', () => {
+    assert({
+      given: 'a search term containing a backslash',
+      should: 'escape the backslash itself so it is not read as an escape character',
+      actual: escapeLikePattern('a\\b'),
+      expected: 'a\\\\b',
+    });
+  });
+
+  it('multiple special characters', () => {
+    assert({
+      given: 'a search term containing %, _, and \\ together',
+      should: 'escape every occurrence',
+      actual: escapeLikePattern('100%_done\\ish'),
+      expected: '100\\%\\_done\\\\ish',
+    });
+  });
+});

--- a/packages/lib/src/db/like-pattern.ts
+++ b/packages/lib/src/db/like-pattern.ts
@@ -1,0 +1,16 @@
+/**
+ * LIKE/ILIKE pattern escaping — pure, no DB access.
+ *
+ * Postgres's default LIKE/ILIKE escape character is backslash, so an unescaped
+ * `%`, `_`, or `\` in a user-supplied search term is read as pattern syntax
+ * instead of literal text — silently over- or under-matching (e.g. a search for
+ * a task titled "50% off" would otherwise treat `%` as a wildcard).
+ */
+
+/**
+ * Escape LIKE/ILIKE special characters (`%`, `_`, `\`) in a search term so it
+ * matches as a literal substring.
+ */
+export function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}

--- a/tasks/reviews/pu-escape-like-centralize.md
+++ b/tasks/reviews/pu-escape-like-centralize.md
@@ -1,0 +1,73 @@
+# Review: pu/escape-like-centralize (PR #2178)
+
+Reviewer: Claude (aidd-review skill, self-review pass during ralph-loop convergence)
+Date: 2026-07-20
+Scope reviewed: `git diff master...pu/escape-like-centralize`
+
+## Summary
+
+Pure mechanical consolidation of 4 duplicate `escapeLikePattern` implementations
+(tasks, search, mentions/search, pages/[pageId]/tasks/query-spec) plus one inline
+duplicate (admin audit-logs) into a single exported+tested helper at
+`packages/lib/src/db/like-pattern.ts`. Diff reviewed line-by-line against every
+touched call site; all 5 sites correctly import the shared helper, the local
+definitions are fully deleted, and the `ESCAPE '\\'` raw-SQL clause in
+`apps/web/src/app/api/tasks/route.ts` is preserved unchanged. Tests pass:
+packages/lib (378 files / 8616 tests), apps/web (998 files / 14977 tests, 3
+pre-existing unrelated failures — DB-role integration tests needing a live
+Postgres container, plus one unrelated midnight-boundary date test), apps/admin
+audit-logs suite (7/7). Repo-wide typecheck and eslint clean. No hotspot files
+touched (aidd-churn: none of the 7 touched files appear in the top-20 list).
+
+**Verdict for PR #2178 as scoped: 0 blockers / 0 majors / 0 minors / 0 nits.**
+Ready to merge on its own defined scope.
+
+## Findings
+
+### Out-of-scope (NOT fixed in this PR — filed here for follow-up)
+
+While digging for "any missed duplicate copies of this pattern elsewhere in the
+repo" (per review instructions), found 5 **additional** call sites that build an
+ILIKE/`ilike()` pattern from raw, **unescaped** user-supplied search input — the
+same defect class this PR consolidates a fix for, but these sites never had any
+escaping to begin with (not duplicates of `escapeLikePattern`, so they weren't in
+the original task's confirmed-call-site list, and expanding this PR's scope to
+touch 5 more files would violate the explicit "do not touch anything else"
+scope constraint given for this PR). Severity is LOW: all interpolations go
+through Drizzle's parameterized `sql` tag / `ilike()` helper, so there is **no
+SQL injection** — the only effect of an unescaped `%`/`_` in the search term is
+over-broad matching within data the caller is already authorized to query (a
+precision/correctness issue, not an access-control bypass).
+
+- [ ] MINOR · `apps/web/src/app/api/search/multi-drive/route.ts:109,112` · `searchPattern = \`%${searchQuery}%\`` built from raw `searchQuery` with no escaping before the ILIKE branch (the sibling regex branch at line 108 IS escaped) · should call `escapeLikePattern(searchQuery)` before wrapping in `%...%`
+- [ ] MINOR · `apps/web/src/app/api/users/search/route.ts:55` · `searchPattern = \`%${query}%\`` built from raw `query` with no escaping, used in `ilike(userProfiles.username/displayName, searchPattern)` · should escape `query` first
+- [ ] MINOR · `apps/web/src/lib/ai/tools/search-tools.ts:544` · same unescaped pattern as multi-drive/route.ts (likely a copy of it — AI tool variant of the same search) · should escape `searchQuery` first
+- [ ] MINOR · `apps/admin/src/app/api/admin/audit-logs/export/route.ts:139-142` · `ILIKE ${'%' + search + '%'}` built from raw `search` with no escaping — the export variant of the audit-logs route fixed in this PR · should escape `search` first (note: this route already imports `@pagespace/lib` subpaths, so `@pagespace/lib/db/like-pattern` is trivially importable)
+- [ ] MINOR · `apps/admin/src/app/api/admin/contact/route.ts:34-37` · `ilike(contactSubmissions.*, \`%${searchTerm}%\`)` built from raw `searchTerm` with no escaping · should escape `searchTerm` first
+
+**Recommendation:** file a fast-follow task (same shape as `an995k8yse0phctrvwfqipse`)
+to sweep these 5 sites using the now-available `@pagespace/lib/db/like-pattern`
+helper. Not a blocker for PR #2178.
+
+### Checked and clear (no finding)
+
+- OWASP Top 10 pass over the diff: no injection risk introduced (all query
+  values remain parameterized through Drizzle), no auth/authz logic touched,
+  no secrets, no new external inputs, no XSS surface (server-side DB query
+  helper only).
+- `apps/admin/src/app/api/admin/users/list-params.ts`'s ILIKE-adjacent comment
+  is a red herring — that route deliberately searches in Node, not SQL,
+  because `users.name`/`users.email` are AES-256-GCM ciphertext at rest; not
+  related to this pattern.
+- No stray/orphaned files, no dead code, no leftover `TODO`/`FIXME` from this
+  change.
+- Test quality: the two new minimal regression tests (`search/route.test.ts`,
+  addition to `mentions/search/__tests__/route.test.ts`) use `vi.spyOn` on the
+  real (unmocked) `@pagespace/db/operators` module to observe the actual
+  `ilike()` call arguments rather than asserting against a mock's stub return —
+  this exercises the real escaping code path end-to-end through the route
+  handler, not just the unit in isolation. Confirmed correct escaped-pattern
+  assertions (`'%50\\%%'`, `'%off%'`) match `escapeLikePattern`'s actual output.
+- Mock-heavy test style in the two new test files matches 100% of existing
+  precedent in the same directories (`db.select` chain mocking is the
+  established pattern throughout apps/web's route tests); not a new smell.


### PR DESCRIPTION
## Summary

- Four independent, near-identical private copies of ILIKE-wildcard-escaping logic existed across the codebase — `apps/web/src/app/api/tasks/route.ts`, `apps/web/src/app/api/search/route.ts`, `apps/web/src/app/api/mentions/search/route.ts`, and `apps/web/src/app/api/pages/[pageId]/tasks/query-spec.ts` — plus an inline duplicate in `apps/admin/src/app/api/admin/audit-logs/route.ts`. Each escaped `%`, `_`, and `\` before building an `ilike()`/`ILIKE` pattern, never reused.
- Consolidated into a single exported, tested helper: `packages/lib/src/db/like-pattern.ts` (sibling to `bounded-query.ts`, following the precedent from Phase 1 of the Task Board Query & Reorder Safety epic — PR #2127), exported as `@pagespace/lib/db/like-pattern`.
- Updated all 5 call sites to import the shared helper and deleted the local definitions. `apps/web/src/app/api/tasks/route.ts`'s explicit `ILIKE ... ESCAPE '\\'` raw-SQL clause is preserved unchanged — Postgres's default LIKE/ILIKE escape character is backslash regardless of whether `ilike()` or a raw `ESCAPE` clause is used, so both call patterns are correct.
- Added minimal regression coverage for `apps/web/src/app/api/search/route.ts` and `apps/web/src/app/api/mentions/search/route.ts`, which previously had no test asserting the escaping behavior end-to-end.

Pure refactor — no behavior change. Every existing test passes unchanged except import-path updates (the `escapeLikePattern` describe block moved from `query-spec.test.ts` to the new `like-pattern.test.ts`, same test cases).

PageSpace task: `an995k8yse0phctrvwfqipse` — logged as an explicit out-of-scope fast-follow from PR #2128 (Task Board Query & Reorder Safety epic, Phase 2), which only touched `apps/web/src/app/api/pages/[pageId]/tasks/` and deliberately didn't expand into the other 3+ unrelated route files.

## Test plan

- [x] `packages/lib` test suite: 378 files / 8616 tests passed (includes new `like-pattern.test.ts`, 5 tests, 100% branch coverage)
- [x] `apps/web` test suite: 998 test files passed, 14977 tests passed (3 pre-existing failing files are unrelated — DB-role integration tests needing a live Postgres test container, plus one unrelated midnight-boundary date test; none touch the routes changed here)
- [x] `apps/admin` audit-logs suite (`search-security.test.ts`): 7/7 passed
- [x] Repo-wide `bun run typecheck`: passed
- [x] `bunx eslint` on all touched files: clean

## Self-review

Full findings recorded at [`tasks/reviews/pu-escape-like-centralize.md`](https://github.com/2witstudios/PageSpace/blob/pu/escape-like-centralize/tasks/reviews/pu-escape-like-centralize.md) — verdict for this PR as scoped: 0 blockers / 0 majors / 0 minors / 0 nits. Also surfaces 5 additional call sites with unescaped LIKE-pattern input found while sweeping for missed duplicates (`multi-drive/route.ts`, `users/search/route.ts`, `lib/ai/tools/search-tools.ts`, admin's `audit-logs/export/route.ts`, `contact/route.ts`) — same defect class, but out of this PR's confirmed-call-site scope; recommended as a fast-follow, not fixed here. See the PR comment thread for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RyPfT9PKXuCmtsMNxLuDEX