### PR TITLE
feat(tasks): paginate task list with Load More (fixes silent >100 truncation)

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -602,6 +602,98 @@ describe('Task API Routes', () => {
       // an `inArray` scoped to an already-bounded id list.
       expect(vi.mocked(db.query.taskItems.findMany).mock.calls[0]?.[0]).toMatchObject({ limit: 2 });
     });
+
+    it('sets hasMore=true when the phase-1 query returns more than the requested limit (frontend Load More signal)', async () => {
+      const mockTaskList = { id: mockTaskListId, title: 'My Tasks', status: 'pending', updatedAt: new Date() };
+      const childPageRows = [
+        { id: 'p-1', pageId: 'p-1' },
+        { id: 'p-2', pageId: 'p-2' },
+        { id: 'p-3', pageId: 'p-3' },
+      ];
+      // Requests limit+1 rows under the hood to detect a next page without an extra COUNT(*)
+      // query — 3 rows come back for a ?limit=2 request, so one is beyond the page.
+      const boundedIdRowsPlusOne = [{ id: 'task-1' }, { id: 'task-2' }, { id: 'task-3' }];
+      const allTasks = [
+        { id: 'task-1', position: 0, page: { id: 'p-1', title: 'Task One', isTrashed: false, position: 0 } },
+        { id: 'task-2', position: 1, page: { id: 'p-2', title: 'Task Two', isTrashed: false, position: 1 } },
+        { id: 'task-3', position: 2, page: { id: 'p-3', title: 'Task Three', isTrashed: false, position: 2 } },
+      ];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => makeSelectChain(childPageRows) as never) // childPages
+        .mockImplementationOnce(() => makeSelectChain(childPageRows) as never) // backfill existingRows
+        .mockImplementationOnce(() => makeSelectChain(boundedIdRowsPlusOne) as never) // phase 1
+        .mockImplementation(() => makeSelectChain([]) as never); // trigger / sub-task counts
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(db.query.taskItems.findMany).mockImplementation(((args: any) => {
+        const ids: string[] = args?.where?.values ?? [];
+        return Promise.resolve(allTasks.filter(t => ids.includes(t.id)));
+      }) as never);
+
+      const response = await GET(createRequest('?limit=2'), { params: mockParams });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.tasks).toHaveLength(2);
+      expect(body.hasMore).toBe(true);
+    });
+
+    it('sets hasMore=false when the phase-1 query returns no more than the requested limit', async () => {
+      const mockTaskList = { id: mockTaskListId, title: 'My Tasks', status: 'pending', updatedAt: new Date() };
+      const childPageRows = [
+        { id: 'p-1', pageId: 'p-1' },
+        { id: 'p-2', pageId: 'p-2' },
+      ];
+      const boundedIdRows = [{ id: 'task-1' }, { id: 'task-2' }];
+      const allTasks = [
+        { id: 'task-1', position: 0, page: { id: 'p-1', title: 'Task One', isTrashed: false, position: 0 } },
+        { id: 'task-2', position: 1, page: { id: 'p-2', title: 'Task Two', isTrashed: false, position: 1 } },
+      ];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+
+      vi.mocked(db.select)
+        .mockImplementationOnce(() => makeSelectChain(childPageRows) as never) // childPages
+        .mockImplementationOnce(() => makeSelectChain(childPageRows) as never) // backfill existingRows
+        .mockImplementationOnce(() => makeSelectChain(boundedIdRows) as never) // phase 1
+        .mockImplementation(() => makeSelectChain([]) as never); // trigger / sub-task counts
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(db.query.taskItems.findMany).mockImplementation(((args: any) => {
+        const ids: string[] = args?.where?.values ?? [];
+        return Promise.resolve(allTasks.filter(t => ids.includes(t.id)));
+      }) as never);
+
+      const response = await GET(createRequest('?limit=2'), { params: mockParams });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.tasks).toHaveLength(2);
+      expect(body.hasMore).toBe(false);
+    });
+
+    it('reports hasMore=false on the empty-tasks response (no TASK_LIST children)', async () => {
+      const mockTaskList = { id: mockTaskListId, title: 'My Tasks', status: 'pending', updatedAt: new Date() };
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.select).mockImplementation(() => makeSelectChain([]) as never); // no child pages
+
+      const response = await GET(createRequest(), { params: mockParams });
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.tasks).toEqual([]);
+      expect(body.hasMore).toBe(false);
+    });
   });
 
   describe('POST /api/pages/[pageId]/tasks', () => {

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -136,6 +136,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     },
     tasks: [],
     statusConfigs,
+    hasMore: false,
   });
 
   if (childPageIds.length === 0) {
@@ -150,6 +151,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
   // truth, falling back to task.position), filtered, bounded set of task ids —
   // this is what keeps the query from pulling every task into memory (the OOM
   // crash this route caused). Phase 2 hydrates only those ids' relations.
+  // Requesting limit+1 rows and slicing lets the response report `hasMore` (for the
+  // frontend's Load More) without a separate COUNT(*) query.
   const positionExpr = sql`coalesce(${pages.position}, ${taskItems.position})`;
   const orderedIdRows = await db
     .select({ id: taskItems.id })
@@ -166,9 +169,10 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     // rows that never got a distinct one) have no guaranteed stable order across repeated
     // LIMIT/OFFSET calls, so paging (offset=0, then offset=100) can skip or duplicate rows.
     .orderBy(sortOrder === 'desc' ? desc(positionExpr) : asc(positionExpr), asc(taskItems.id))
-    .limit(limit)
+    .limit(limit + 1)
     .offset(offset);
-  const boundedTaskIds = orderedIdRows.map(r => r.id);
+  const hasMore = orderedIdRows.length > limit;
+  const boundedTaskIds = orderedIdRows.slice(0, limit).map(r => r.id);
 
   if (boundedTaskIds.length === 0) {
     return emptyTasksResponse();
@@ -325,6 +329,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     },
     tasks: enrichedTasks,
     statusConfigs,
+    hasMore,
   });
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -354,10 +354,17 @@ export type TaskLoadMoreState = 'idle' | 'loading' | 'failed';
 // sets `error` alongside it rather than clearing it. Disambiguates those two so the
 // "Load More" control can show a spinner vs. a retry state instead of getting stuck.
 export const getTaskLoadMoreState = (
-  pages: unknown[] | undefined,
+  pages: { hasMore: boolean }[] | undefined,
   size: number,
   hasError: boolean,
 ): TaskLoadMoreState => {
+  // The last resolved page is authoritative over `size`: if the server says there's
+  // nothing more, that holds even when `size` (how many "Load More" clicks the user
+  // has made) is stale — e.g. concurrent deletes shrink the total across a page
+  // boundary, getTasksPageKey starts returning null for the pages beyond it, and
+  // `pages.length` permanently stops growing to match `size`. Without this check that
+  // reads as "still loading" forever instead of "there's nothing left to load".
+  if (getHasMoreTasks(pages) === false && pages && pages.length > 0) return 'idle';
   if (!isLoadingNextTaskPage(pages, size)) return 'idle';
   return hasError ? 'failed' : 'loading';
 };

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -347,6 +347,21 @@ export const getHasMoreTasks = (pages: { hasMore: boolean }[] | undefined): bool
 export const isLoadingNextTaskPage = (pages: unknown[] | undefined, size: number): boolean =>
   size > 0 && (pages === undefined || pages.length < size);
 
+export type TaskLoadMoreState = 'idle' | 'loading' | 'failed';
+
+// A requested page hasn't resolved into `pages` yet — true both while it's still in
+// flight and after it's permanently failed, since SWR keeps the last-good `data` and
+// sets `error` alongside it rather than clearing it. Disambiguates those two so the
+// "Load More" control can show a spinner vs. a retry state instead of getting stuck.
+export const getTaskLoadMoreState = (
+  pages: unknown[] | undefined,
+  size: number,
+  hasError: boolean,
+): TaskLoadMoreState => {
+  if (!isLoadingNextTaskPage(pages, size)) return 'idle';
+  return hasError ? 'failed' : 'loading';
+};
+
 // Splits a reordered task list back into the same number of pages, each keeping its
 // original size (and every other field, e.g. hasMore, untouched) — used for the
 // drag-reorder optimistic update so getHasMoreTasks/isLoadingNextTaskPage stay correct
@@ -548,7 +563,9 @@ function TaskListView({ page }: TaskListViewProps) {
     };
   }, [taskPages]);
   const hasMoreTasks = data?.hasMore ?? false;
-  const isLoadingMoreTasks = isLoadingNextTaskPage(taskPages, size);
+  const loadMoreState = getTaskLoadMoreState(taskPages, size, !!error);
+  const isLoadingMoreTasks = loadMoreState === 'loading';
+  const loadMoreFailed = loadMoreState === 'failed';
   const handleLoadMoreTasks = () => setSize(size + 1);
 
   // Stable ref so the page:moved handler always sees the current task list
@@ -905,15 +922,18 @@ function TaskListView({ page }: TaskListViewProps) {
 
   // Shared between the table, kanban, and mobile card renders — the bounded GET route
   // (limit=100 default) means any of them can silently truncate without this.
-  const loadMoreControl = (hasMoreTasks || isLoadingMoreTasks) && (
-    <div className="flex justify-center py-4">
+  const loadMoreControl = (hasMoreTasks || isLoadingMoreTasks || loadMoreFailed) && (
+    <div className="flex flex-col items-center gap-2 py-4">
+      {loadMoreFailed && (
+        <p className="text-sm text-destructive">Failed to load more tasks.</p>
+      )}
       <Button
         variant="outline"
         size="sm"
-        onClick={handleLoadMoreTasks}
+        onClick={loadMoreFailed ? mutateTasks : handleLoadMoreTasks}
         disabled={isLoadingMoreTasks}
       >
-        {isLoadingMoreTasks ? 'Loading…' : 'Load more tasks'}
+        {isLoadingMoreTasks ? 'Loading…' : loadMoreFailed ? 'Retry' : 'Load more tasks'}
       </Button>
     </div>
   );
@@ -955,7 +975,10 @@ function TaskListView({ page }: TaskListViewProps) {
     );
   }
 
-  if (error) {
+  // Only a fatal error — no pages ever loaded successfully — replaces the whole view.
+  // A failed "Load More" (data already has earlier pages) surfaces via loadMoreFailed
+  // in the shared control instead, so already-loaded tasks stay visible.
+  if (error && !data) {
     return (
       <div className="flex items-center justify-center h-full text-destructive">
         Failed to load tasks

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react';
 import { type Editor } from '@tiptap/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import { mutate } from 'swr';
 import useSWRInfinite from 'swr/infinite';
 import { formatDistanceToNow } from 'date-fns';
 import { useAuth } from '@/hooks/useAuth';
@@ -511,11 +510,12 @@ function TaskListView({ page }: TaskListViewProps) {
     }
   );
 
-  // Any cache entry for this task list, across every loaded offset — lets write
-  // handlers below revalidate everything fetched so far via a single call.
-  const mutateTasks = useCallback(() => mutate(
-    (key: unknown) => typeof key === 'string' && (key === tasksKeyPrefix || key.startsWith(`${tasksKeyPrefix}?`))
-  ), [tasksKeyPrefix]);
+  // useSWRInfinite's reactive cache entry lives under a synthetic `$inf$<firstPageKey>`
+  // key, not under each page's own URL — a plain-string key matcher here would silently
+  // touch dead cache entries and never actually revalidate. Only the hook's own bound
+  // `mutate` (with no args, forcing every loaded page to refetch — see swr/infinite's
+  // `_i` "revalidate all" flag) reaches the right key.
+  const mutateTasks = useCallback(() => mutateTaskPages(), [mutateTaskPages]);
 
   const data: TaskListData | undefined = useMemo(() => {
     if (!taskPages || taskPages.length === 0) return undefined;

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -347,6 +347,22 @@ export const getHasMoreTasks = (pages: { hasMore: boolean }[] | undefined): bool
 export const isLoadingNextTaskPage = (pages: unknown[] | undefined, size: number): boolean =>
   size > 0 && (pages === undefined || pages.length < size);
 
+// Splits a reordered task list back into the same number of pages, each keeping its
+// original size (and every other field, e.g. hasMore, untouched) — used for the
+// drag-reorder optimistic update so getHasMoreTasks/isLoadingNextTaskPage stay correct
+// through the optimistic window instead of collapsing every loaded page into one.
+export const redistributeTasksAcrossPages = <P extends { tasks: TaskItem[] }>(
+  pages: P[],
+  reorderedTasks: TaskItem[],
+): P[] => {
+  let cursor = 0;
+  return pages.map((p) => {
+    const chunk = reorderedTasks.slice(cursor, cursor + p.tasks.length);
+    cursor += p.tasks.length;
+    return { ...p, tasks: chunk };
+  });
+};
+
 // Sortable row component for drag-and-drop
 interface SortableTaskRowProps {
   task: TaskItem;
@@ -503,7 +519,12 @@ function TaskListView({ page }: TaskListViewProps) {
     fetcher,
     {
       revalidateOnFocus: false,
-      revalidateFirstPage: false,
+      // Keep the default (true): with this off, `shouldFetchPage` in swr/infinite has no
+      // remaining trigger that fires from time passing alone, which silently turns the
+      // refreshInterval below into a no-op safety net (verified against swr/infinite's
+      // source — every other condition needs an explicit mutate() or a missing cache
+      // entry). The cost is an extra page-0 refetch on every "Load More" click, which is
+      // cheap and infrequent — worth it to keep the periodic staleness fallback alive.
       isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000, // 5 minutes
@@ -833,14 +854,16 @@ function TaskListView({ page }: TaskListViewProps) {
       newPosition = (beforePos + afterPos) / 2;
     }
 
-    // Optimistic update: collapse every loaded page into one synthetic page holding
-    // the reordered (filtered) list. Same trade-off the single-page version of this
-    // view always made — a filtered-out task briefly disappears from the cache
-    // until the revalidate below restores the real, multi-page server state.
+    // Optimistic update: redistribute the reordered (filtered) list back across the
+    // same pages, preserving each page's size and hasMore — the pre-existing,
+    // single-page version of this view already dropped filtered-out tasks from the
+    // cache during this same optimistic window (arrayMove over `filteredTasks`, not
+    // the full list); redistributing by page here just keeps getHasMoreTasks /
+    // isLoadingNextTaskPage accurate through it instead of collapsing every loaded
+    // page into one. The revalidate below always restores the real server state.
     const reorderedTasks = arrayMove(tasks, oldIndex, newIndex);
-    const firstPage = taskPages?.[0];
-    if (firstPage) {
-      mutateTaskPages([{ ...firstPage, tasks: reorderedTasks }], false);
+    if (taskPages && taskPages.length > 0) {
+      mutateTaskPages(redistributeTasksAcrossPages(taskPages, reorderedTasks), false);
     }
 
     try {

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -344,7 +344,7 @@ export const getHasMoreTasks = (pages: { hasMore: boolean }[] | undefined): bool
 
 // True while a "Load More" click has bumped useSWRInfinite's `size` but the newly
 // requested page hasn't resolved into `pages` yet.
-export const isLoadingNextTaskPage = (pages: unknown[] | undefined, size: number): boolean =>
+export const isLoadingNextTaskPage = (pages: { hasMore: boolean }[] | undefined, size: number): boolean =>
   size > 0 && (pages === undefined || pages.length < size);
 
 export type TaskLoadMoreState = 'idle' | 'loading' | 'failed';
@@ -547,6 +547,17 @@ function TaskListView({ page }: TaskListViewProps) {
       // source — every other condition needs an explicit mutate() or a missing cache
       // entry). The cost is an extra page-0 refetch on every "Load More" click, which is
       // cheap and infrequent — worth it to keep the periodic staleness fallback alive.
+      // Pre-existing pattern, not new to pagination: `isAnyEditing` is global (any
+      // document/form edit anywhere in the app, not just this page — see
+      // useEditingStore.ts), and SWR's `isPaused()` gates every revalidation trigger
+      // for this key, not just background ones — including this PR's new "Load More"/
+      // Retry clicks (verified in swr's core `revalidate()`). If a user clicks either
+      // while some other edit session is active, that click's fetch is silently
+      // dropped; `size` still advances, leaving the control on "Loading…" until it
+      // self-heals via the next unpaused trigger (the refreshInterval below, at most).
+      // Every pre-existing write handler in this file already had this exact exposure
+      // through its own post-write mutate() call — fixing it needs a change to how
+      // `isPaused` composes with explicit user actions, which is out of scope here.
       isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000, // 5 minutes

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState, useEffect, useRef, memo, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react';
 import { type Editor } from '@tiptap/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
-import useSWR, { mutate } from 'swr';
+import { mutate } from 'swr';
+import useSWRInfinite from 'swr/infinite';
 import { formatDistanceToNow } from 'date-fns';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, canManageDrive } from '@/hooks/usePermissions';
@@ -108,6 +109,10 @@ const fetcher = async (url: string) => {
   if (!res.ok) throw new Error('Failed to fetch');
   return res.json();
 };
+
+// Matches DEFAULT_LIMIT in the GET route's query-spec.ts; must stay <= that route's
+// MAX_LIMIT (200) or every "Load More" page would silently get clamped down server-side.
+const TASKS_PAGE_SIZE = 100;
 
 // Mobile task card component
 interface MobileTaskCardProps {
@@ -331,6 +336,18 @@ export const toggleSet = (set: Set<string>, id: string): Set<string> => {
   return next;
 };
 
+// Only the most recently loaded page's hasMore matters — earlier pages are stale
+// snapshots of a bound that may have shifted as tasks were added/removed since.
+export const getHasMoreTasks = (pages: { hasMore: boolean }[] | undefined): boolean => {
+  if (!pages || pages.length === 0) return false;
+  return pages[pages.length - 1].hasMore;
+};
+
+// True while a "Load More" click has bumped useSWRInfinite's `size` but the newly
+// requested page hasn't resolved into `pages` yet.
+export const isLoadingNextTaskPage = (pages: unknown[] | undefined, size: number): boolean =>
+  size > 0 && (pages === undefined || pages.length < size);
+
 // Sortable row component for drag-and-drop
 interface SortableTaskRowProps {
   task: TaskItem;
@@ -467,18 +484,51 @@ function TaskListView({ page }: TaskListViewProps) {
     componentName: 'TaskListView',
   });
 
-  // Fetch tasks with refresh protection
+  // Fetch tasks with refresh protection, paginated via useSWRInfinite (bounded route:
+  // apps/web/src/app/api/pages/[pageId]/tasks/route.ts defaults to limit=100/offset=0).
   // CRITICAL: Only pause AFTER initial load - never block the first fetch
-  const { data, error, isLoading } = useSWR<TaskListData>(
-    `/api/pages/${page.id}/tasks`,
+  const tasksKeyPrefix = `/api/pages/${page.id}/tasks`;
+  const getTasksPageKey = (pageIndex: number, previousPageData: TaskListData | null) => {
+    if (previousPageData && !previousPageData.hasMore) return null;
+    return `${tasksKeyPrefix}?limit=${TASKS_PAGE_SIZE}&offset=${pageIndex * TASKS_PAGE_SIZE}`;
+  };
+  const {
+    data: taskPages,
+    error,
+    isLoading,
+    size,
+    setSize,
+    mutate: mutateTaskPages,
+  } = useSWRInfinite<TaskListData>(
+    getTasksPageKey,
     fetcher,
     {
       revalidateOnFocus: false,
+      revalidateFirstPage: false,
       isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000, // 5 minutes
     }
   );
+
+  // Any cache entry for this task list, across every loaded offset — lets write
+  // handlers below revalidate everything fetched so far via a single call.
+  const mutateTasks = useCallback(() => mutate(
+    (key: unknown) => typeof key === 'string' && (key === tasksKeyPrefix || key.startsWith(`${tasksKeyPrefix}?`))
+  ), [tasksKeyPrefix]);
+
+  const data: TaskListData | undefined = useMemo(() => {
+    if (!taskPages || taskPages.length === 0) return undefined;
+    return {
+      taskList: taskPages[0].taskList,
+      statusConfigs: taskPages[0].statusConfigs,
+      tasks: taskPages.flatMap(p => p.tasks),
+      hasMore: getHasMoreTasks(taskPages),
+    };
+  }, [taskPages]);
+  const hasMoreTasks = data?.hasMore ?? false;
+  const isLoadingMoreTasks = isLoadingNextTaskPage(taskPages, size);
+  const handleLoadMoreTasks = () => setSize(size + 1);
 
   // Stable ref so the page:moved handler always sees the current task list
   // regardless of when the socket effect was installed relative to the SWR load.
@@ -503,19 +553,19 @@ function TaskListView({ page }: TaskListViewProps) {
 
     // Handle task events (event names match backend broadcast format: task:${operation})
     const handleTaskAdded = () => {
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     };
 
     const handleTaskUpdated = () => {
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     };
 
     const handleTaskDeleted = () => {
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     };
 
     const handleTasksReordered = () => {
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     };
 
     // Handle tasks moved between lists via drag-and-drop. The reorder API emits
@@ -526,7 +576,7 @@ function TaskListView({ page }: TaskListViewProps) {
     const handlePageMoved = (payload: { pageId: string; parentId: string | null }) => {
       const movedIn  = payload.parentId === page.id;
       const movedOut = tasksRef.current?.some(t => t.pageId === payload.pageId);
-      if (movedIn || movedOut) mutate(`/api/pages/${page.id}/tasks`);
+      if (movedIn || movedOut) mutateTasks();
     };
 
     socket.on('task:task_added', handleTaskAdded);
@@ -542,7 +592,7 @@ function TaskListView({ page }: TaskListViewProps) {
       socket.off('task:tasks_reordered', handleTasksReordered);
       socket.off('page:moved', handlePageMoved);
     };
-  }, [socket, connectionStatus, page.id]);
+  }, [socket, connectionStatus, page.id, mutateTasks]);
 
   // Derive dynamic status config from API response
   const statusConfigs = useMemo(() => data?.statusConfigs ?? [], [data?.statusConfigs]);
@@ -550,6 +600,14 @@ function TaskListView({ page }: TaskListViewProps) {
   const statusOrder = useMemo(() => getStatusOrder(statusConfigs), [statusConfigs]);
 
   const activeSearch = isFindOpen ? findQuery : search;
+
+  // Filter/search are applied client-side over whatever pages have been loaded so
+  // far. Changing either resets "Load More" progress back to just the first page,
+  // so a previously-expanded load doesn't linger in a state inconsistent with a
+  // fresh filter (cached pages are reused instantly if the user re-expands).
+  useEffect(() => {
+    setSize(1);
+  }, [filter, activeSearch, setSize]);
 
   // Filter tasks
   const filteredTasks = useMemo(() => data?.tasks.filter(task => {
@@ -595,7 +653,7 @@ function TaskListView({ page }: TaskListViewProps) {
         ...(status && { status }),
       });
       if (!title) setNewTaskTitle('');
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to create task');
     }
@@ -607,7 +665,7 @@ function TaskListView({ page }: TaskListViewProps) {
 
     try {
       await patch(`/api/pages/${page.id}/tasks/${taskId}`, { status: newStatus });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update status');
     }
@@ -619,7 +677,7 @@ function TaskListView({ page }: TaskListViewProps) {
 
     try {
       await patch(`/api/pages/${page.id}/tasks/${taskId}`, { priority: newPriority });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update priority');
     }
@@ -666,7 +724,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const handleSaveTaskTitle = async (taskId: string, title: string) => {
     try {
       await patch(`/api/pages/${page.id}/tasks/${taskId}`, { title });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update task');
     }
@@ -689,7 +747,7 @@ function TaskListView({ page }: TaskListViewProps) {
 
     try {
       await del(`/api/pages/${page.id}/tasks/${taskId}`);
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
       toast.success('Task deleted');
     } catch {
       toast.error('Failed to delete task');
@@ -705,7 +763,7 @@ function TaskListView({ page }: TaskListViewProps) {
         assigneeId,
         assigneeAgentId: agentId,
       });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update assignee');
     }
@@ -717,7 +775,7 @@ function TaskListView({ page }: TaskListViewProps) {
 
     try {
       await patch(`/api/pages/${page.id}/tasks/${taskId}`, { assigneeIds });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update assignees');
     }
@@ -731,7 +789,7 @@ function TaskListView({ page }: TaskListViewProps) {
       await patch(`/api/pages/${page.id}/tasks/${taskId}`, {
         dueDate: dueDate?.toISOString() || null,
       });
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       toast.error('Failed to update due date');
     }
@@ -775,13 +833,15 @@ function TaskListView({ page }: TaskListViewProps) {
       newPosition = (beforePos + afterPos) / 2;
     }
 
-    // Optimistic update
+    // Optimistic update: collapse every loaded page into one synthetic page holding
+    // the reordered (filtered) list. Same trade-off the single-page version of this
+    // view always made — a filtered-out task briefly disappears from the cache
+    // until the revalidate below restores the real, multi-page server state.
     const reorderedTasks = arrayMove(tasks, oldIndex, newIndex);
-    mutate(
-      `/api/pages/${page.id}/tasks`,
-      { ...data, tasks: reorderedTasks },
-      false
-    );
+    const firstPage = taskPages?.[0];
+    if (firstPage) {
+      mutateTaskPages([{ ...firstPage, tasks: reorderedTasks }], false);
+    }
 
     try {
       // Call page reorder API (page position is source of truth)
@@ -791,10 +851,10 @@ function TaskListView({ page }: TaskListViewProps) {
         newPosition,
       });
       // Refetch to get server state
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
     } catch {
       // Revert on error
-      mutate(`/api/pages/${page.id}/tasks`);
+      mutateTasks();
       toast.error('Failed to reorder task');
     }
   };
@@ -819,6 +879,21 @@ function TaskListView({ page }: TaskListViewProps) {
     onStartEdit: handleStartEdit,
     onConfigureTriggers: setTriggerDialogTask,
   };
+
+  // Shared between the table, kanban, and mobile card renders — the bounded GET route
+  // (limit=100 default) means any of them can silently truncate without this.
+  const loadMoreControl = (hasMoreTasks || isLoadingMoreTasks) && (
+    <div className="flex justify-center py-4">
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleLoadMoreTasks}
+        disabled={isLoadingMoreTasks}
+      >
+        {isLoadingMoreTasks ? 'Loading…' : 'Load more tasks'}
+      </Button>
+    </div>
+  );
 
   if (viewMode === 'editor') {
     return (
@@ -923,7 +998,7 @@ function TaskListView({ page }: TaskListViewProps) {
               <StatusConfigManager
                 pageId={page.id}
                 statusConfigs={statusConfigs}
-                onConfigsChanged={() => mutate(`/api/pages/${page.id}/tasks`)}
+                onConfigsChanged={() => mutateTasks()}
               />
             )}
 
@@ -992,6 +1067,8 @@ function TaskListView({ page }: TaskListViewProps) {
           />
           </div>
         ))}
+
+        {loadMoreControl}
 
         {/* Mobile new task input */}
         {canEdit && (
@@ -1306,6 +1383,8 @@ function TaskListView({ page }: TaskListViewProps) {
             )}
           </>
         )}
+
+        {loadMoreControl}
       </div>
 
       {/* Footer stats */}
@@ -1327,7 +1406,7 @@ function TaskListView({ page }: TaskListViewProps) {
           pageId={page.id}
           driveId={page.driveId}
           hasDueDate={!!triggerDialogTask.dueDate}
-          onSaved={() => mutate(`/api/pages/${page.id}/tasks`)}
+          onSaved={() => mutateTasks()}
         />
       )}
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -369,6 +369,21 @@ export const getTaskLoadMoreState = (
   return hasError ? 'failed' : 'loading';
 };
 
+// `isPaused` (an app-wide "any document/form editing session" flag — see the config
+// comment where it's set) gates every SWR revalidation for this hook, including this
+// button's own click, not just background polling. There's no public SWR API to bypass
+// it for one call, so instead of leaving the button clickable and silently doing
+// nothing, disable it and say why while editing is active — the safe, honest fallback.
+export const getLoadMoreButtonLabel = (
+  loadMoreState: TaskLoadMoreState,
+  isEditingElsewhere: boolean,
+): string => {
+  if (isEditingElsewhere) return 'Finish editing to load more';
+  if (loadMoreState === 'loading') return 'Loading…';
+  if (loadMoreState === 'failed') return 'Retry';
+  return 'Load more tasks';
+};
+
 // Splits a reordered task list back into the same number of pages, each keeping its
 // original size (and every other field, e.g. hasMore, untouched) — used for the
 // drag-reorder optimistic update so getHasMoreTasks/isLoadingNextTaskPage stay correct
@@ -541,23 +556,26 @@ function TaskListView({ page }: TaskListViewProps) {
     fetcher,
     {
       revalidateOnFocus: false,
-      // Keep the default (true): with this off, `shouldFetchPage` in swr/infinite has no
-      // remaining trigger that fires from time passing alone, which silently turns the
-      // refreshInterval below into a no-op safety net (verified against swr/infinite's
-      // source — every other condition needs an explicit mutate() or a missing cache
-      // entry). The cost is an extra page-0 refetch on every "Load More" click, which is
-      // cheap and infrequent — worth it to keep the periodic staleness fallback alive.
-      // Pre-existing pattern, not new to pagination: `isAnyEditing` is global (any
-      // document/form edit anywhere in the app, not just this page — see
-      // useEditingStore.ts), and SWR's `isPaused()` gates every revalidation trigger
-      // for this key, not just background ones — including this PR's new "Load More"/
-      // Retry clicks (verified in swr's core `revalidate()`). If a user clicks either
-      // while some other edit session is active, that click's fetch is silently
-      // dropped; `size` still advances, leaving the control on "Loading…" until it
-      // self-heals via the next unpaused trigger (the refreshInterval below, at most).
-      // Every pre-existing write handler in this file already had this exact exposure
-      // through its own post-write mutate() call — fixing it needs a change to how
-      // `isPaused` composes with explicit user actions, which is out of scope here.
+      // swr/infinite's default (revalidateFirstPage: true, revalidateAll: false) only
+      // ever refreshes page 0 on the interval tick below — pages 1+ only refetch when
+      // an explicit mutate() targets them (verified against swr/infinite's source: a
+      // page's own cache entry has to be missing or explicitly marked "revalidate all"
+      // for it to refetch; time passing alone isn't enough once it's cached). Without
+      // revalidateAll, a missed socket event for a task on page 2+ would stay stale
+      // until the next explicit write anywhere in this list. The cost is that every
+      // "Load More" click also refetches every already-loaded page, not just the new
+      // one — acceptable for a background task list, and worth it for correctness.
+      revalidateAll: true,
+      // `isAnyEditing` is app-wide (any document/form edit anywhere, not just this
+      // page — useEditingStore.ts), and SWR's isPaused() gates every revalidation for
+      // this key, not just background ones — including this PR's "Load More"/Retry
+      // clicks (verified in swr's core revalidate()). There's no public SWR API to
+      // bypass isPaused for one call, so instead of a click that silently no-ops,
+      // getLoadMoreButtonLabel + the disabled prop below surface it honestly: the
+      // control disables with an explanation while any edit session is active, and
+      // works normally again once it ends. This isPaused gate itself is a pre-existing
+      // pattern, not new to pagination — every write handler in this file already had
+      // the identical exposure through its own post-write mutate() call.
       isPaused: () => hasLoadedRef.current && isAnyEditing,
       onSuccess: () => { hasLoadedRef.current = true; },
       refreshInterval: 300000, // 5 minutes
@@ -661,9 +679,15 @@ function TaskListView({ page }: TaskListViewProps) {
   // far. Changing either resets "Load More" progress back to just the first page,
   // so a previously-expanded load doesn't linger in a state inconsistent with a
   // fresh filter (cached pages are reused instantly if the user re-expands).
+  //
+  // Deliberately keyed on `search` (the toolbar filter box), not `activeSearch`: the
+  // in-page Cmd+F Find bar (`findQuery`) fires this on every keystroke while typing,
+  // which would truncate `data.tasks` back to page 1 mid-search — silently hiding
+  // matches on already-loaded pages 2+ and under-reporting the match count to
+  // useFindStore. Find should search whatever's already loaded, not reset it.
   useEffect(() => {
     setSize(1);
-  }, [filter, activeSearch, setSize]);
+  }, [filter, search, setSize]);
 
   // Filter tasks
   const filteredTasks = useMemo(() => data?.tasks.filter(task => {
@@ -942,16 +966,18 @@ function TaskListView({ page }: TaskListViewProps) {
   // (limit=100 default) means any of them can silently truncate without this.
   const loadMoreControl = (hasMoreTasks || isLoadingMoreTasks || loadMoreFailed) && (
     <div className="flex flex-col items-center gap-2 py-4">
-      {loadMoreFailed && (
+      {isAnyEditing ? (
+        <p className="text-sm text-muted-foreground">Finish editing elsewhere to load more.</p>
+      ) : loadMoreFailed && (
         <p className="text-sm text-destructive">Failed to load more tasks.</p>
       )}
       <Button
         variant="outline"
         size="sm"
         onClick={loadMoreFailed ? mutateTasks : handleLoadMoreTasks}
-        disabled={isLoadingMoreTasks}
+        disabled={isLoadingMoreTasks || isAnyEditing}
       >
-        {isLoadingMoreTasks ? 'Loading…' : loadMoreFailed ? 'Retry' : 'Load more tasks'}
+        {getLoadMoreButtonLabel(loadMoreState, isAnyEditing)}
       </Button>
     </div>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import { assert } from '@/hooks/__tests__/riteway';
-import { getHasMoreTasks, isLoadingNextTaskPage, redistributeTasksAcrossPages } from '../TaskListView';
+import { getHasMoreTasks, isLoadingNextTaskPage, redistributeTasksAcrossPages, getTaskLoadMoreState } from '../TaskListView';
 import type { TaskItem } from '../task-list-types';
 
 // Minimal stand-ins — redistributeTasksAcrossPages only reads/copies `id` and `.tasks.length`.
@@ -159,6 +159,53 @@ describe('redistributeTasksAcrossPages', () => {
       should: 'return an empty array',
       actual: redistributeTasksAcrossPages([], []),
       expected: [],
+    });
+  });
+});
+
+describe('getTaskLoadMoreState', () => {
+  it('nothing requested yet', () => {
+    assert({
+      given: 'size 0',
+      should: 'return idle',
+      actual: getTaskLoadMoreState(undefined, 0, false),
+      expected: 'idle',
+    });
+  });
+
+  it('all requested pages have resolved, no error', () => {
+    assert({
+      given: 'page count matching size and no error',
+      should: 'return idle',
+      actual: getTaskLoadMoreState([{}, {}], 2, false),
+      expected: 'idle',
+    });
+  });
+
+  it('a new page was requested and is still in flight', () => {
+    assert({
+      given: 'page count behind size and no error',
+      should: 'return loading',
+      actual: getTaskLoadMoreState([{}], 2, false),
+      expected: 'loading',
+    });
+  });
+
+  it('a new page was requested and permanently failed', () => {
+    assert({
+      given: 'page count behind size and an error is present (SWR keeps stale data + error together)',
+      should: 'return failed, not loading',
+      actual: getTaskLoadMoreState([{}], 2, true),
+      expected: 'failed',
+    });
+  });
+
+  it('an error exists but every requested page already resolved', () => {
+    assert({
+      given: 'page count matching size even though an error field happens to be set',
+      should: 'return idle — nothing is behind, so there is nothing to retry',
+      actual: getTaskLoadMoreState([{}, {}], 2, true),
+      expected: 'idle',
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
 import { assert } from '@/hooks/__tests__/riteway';
-import { getHasMoreTasks, isLoadingNextTaskPage, redistributeTasksAcrossPages, getTaskLoadMoreState } from '../TaskListView';
+import { getHasMoreTasks, isLoadingNextTaskPage, redistributeTasksAcrossPages, getTaskLoadMoreState, getLoadMoreButtonLabel } from '../TaskListView';
 import type { TaskItem } from '../task-list-types';
 
 // Minimal stand-ins — redistributeTasksAcrossPages only reads/copies `id` and `.tasks.length`.
@@ -218,6 +218,53 @@ describe('getTaskLoadMoreState', () => {
       should: 'return idle — the last page is authoritative over a stale size, not stuck loading forever',
       actual: getTaskLoadMoreState([{ hasMore: false }], 2, false),
       expected: 'idle',
+    });
+  });
+});
+
+describe('getLoadMoreButtonLabel', () => {
+  it('editing elsewhere takes priority over every other state', () => {
+    assert({
+      given: 'isEditingElsewhere true, regardless of the load-more state',
+      should: 'return the editing-blocked label',
+      actual: getLoadMoreButtonLabel('idle', true),
+      expected: 'Finish editing to load more',
+    });
+  });
+
+  it('editing elsewhere takes priority even while genuinely loading', () => {
+    assert({
+      given: 'loadMoreState loading and isEditingElsewhere true',
+      should: 'still return the editing-blocked label, not "Loading…"',
+      actual: getLoadMoreButtonLabel('loading', true),
+      expected: 'Finish editing to load more',
+    });
+  });
+
+  it('loading, not editing', () => {
+    assert({
+      given: 'loadMoreState loading and isEditingElsewhere false',
+      should: 'return the loading label',
+      actual: getLoadMoreButtonLabel('loading', false),
+      expected: 'Loading…',
+    });
+  });
+
+  it('failed, not editing', () => {
+    assert({
+      given: 'loadMoreState failed and isEditingElsewhere false',
+      should: 'return the retry label',
+      actual: getLoadMoreButtonLabel('failed', false),
+      expected: 'Retry',
+    });
+  });
+
+  it('idle, not editing', () => {
+    assert({
+      given: 'loadMoreState idle and isEditingElsewhere false',
+      should: 'return the default label',
+      actual: getLoadMoreButtonLabel('idle', false),
+      expected: 'Load more tasks',
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from 'vitest';
+import { assert } from '@/hooks/__tests__/riteway';
+import { getHasMoreTasks, isLoadingNextTaskPage } from '../TaskListView';
+
+describe('getHasMoreTasks', () => {
+  it('no pages loaded yet', () => {
+    assert({
+      given: 'undefined pages (still loading the first page)',
+      should: 'return false',
+      actual: getHasMoreTasks(undefined),
+      expected: false,
+    });
+  });
+
+  it('empty pages array', () => {
+    assert({
+      given: 'an empty pages array',
+      should: 'return false',
+      actual: getHasMoreTasks([]),
+      expected: false,
+    });
+  });
+
+  it('last loaded page reports more tasks exist', () => {
+    assert({
+      given: 'the most recently loaded page has hasMore=true',
+      should: 'return true',
+      actual: getHasMoreTasks([{ hasMore: true }, { hasMore: true }]),
+      expected: true,
+    });
+  });
+
+  it('last loaded page reports no more tasks', () => {
+    assert({
+      given: 'the most recently loaded page has hasMore=false',
+      should: 'return false, even though an earlier page had hasMore=true',
+      actual: getHasMoreTasks([{ hasMore: true }, { hasMore: false }]),
+      expected: false,
+    });
+  });
+});
+
+describe('isLoadingNextTaskPage', () => {
+  it('size is 0', () => {
+    assert({
+      given: 'size 0 (nothing requested yet)',
+      should: 'return false',
+      actual: isLoadingNextTaskPage(undefined, 0),
+      expected: false,
+    });
+  });
+
+  it('a new page was requested but has not resolved yet', () => {
+    assert({
+      given: 'size incremented past the number of loaded pages',
+      should: 'return true',
+      actual: isLoadingNextTaskPage([{ hasMore: true }], 2),
+      expected: true,
+    });
+  });
+
+  it('all requested pages have resolved', () => {
+    assert({
+      given: 'the number of loaded pages matches size',
+      should: 'return false',
+      actual: isLoadingNextTaskPage([{ hasMore: true }, { hasMore: false }], 2),
+      expected: false,
+    });
+  });
+
+  it('pages is undefined but a page was requested', () => {
+    assert({
+      given: 'size 1 and no pages resolved yet (first load)',
+      should: 'return true',
+      actual: isLoadingNextTaskPage(undefined, 1),
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
@@ -175,27 +175,27 @@ describe('getTaskLoadMoreState', () => {
 
   it('all requested pages have resolved, no error', () => {
     assert({
-      given: 'page count matching size and no error',
+      given: 'page count matching size, last page still reports more, no error',
       should: 'return idle',
-      actual: getTaskLoadMoreState([{}, {}], 2, false),
+      actual: getTaskLoadMoreState([{ hasMore: true }, { hasMore: true }], 2, false),
       expected: 'idle',
     });
   });
 
   it('a new page was requested and is still in flight', () => {
     assert({
-      given: 'page count behind size and no error',
+      given: 'page count behind size, the one resolved page still reports more, no error',
       should: 'return loading',
-      actual: getTaskLoadMoreState([{}], 2, false),
+      actual: getTaskLoadMoreState([{ hasMore: true }], 2, false),
       expected: 'loading',
     });
   });
 
   it('a new page was requested and permanently failed', () => {
     assert({
-      given: 'page count behind size and an error is present (SWR keeps stale data + error together)',
+      given: 'page count behind size, the one resolved page still reports more, and an error is present (SWR keeps stale data + error together)',
       should: 'return failed, not loading',
-      actual: getTaskLoadMoreState([{}], 2, true),
+      actual: getTaskLoadMoreState([{ hasMore: true }], 2, true),
       expected: 'failed',
     });
   });
@@ -204,7 +204,19 @@ describe('getTaskLoadMoreState', () => {
     assert({
       given: 'page count matching size even though an error field happens to be set',
       should: 'return idle — nothing is behind, so there is nothing to retry',
-      actual: getTaskLoadMoreState([{}, {}], 2, true),
+      actual: getTaskLoadMoreState([{ hasMore: true }, { hasMore: true }], 2, true),
+      expected: 'idle',
+    });
+  });
+
+  it('the total shrank across a page boundary while `size` stayed stale (regression: permanently stuck "Loading…")', () => {
+    // e.g. 101 tasks (page 0 hasMore=true) drop to 100 after a delete; on revalidate,
+    // page 0 now resolves with hasMore=false and getTasksPageKey returns null for page
+    // 1, so `pages` permanently stops growing past length 1 even though `size` is 2.
+    assert({
+      given: 'page count behind size, but the one resolved (last) page says hasMore=false',
+      should: 'return idle — the last page is authoritative over a stale size, not stuck loading forever',
+      actual: getTaskLoadMoreState([{ hasMore: false }], 2, false),
       expected: 'idle',
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from 'vitest';
 import { assert } from '@/hooks/__tests__/riteway';
-import { getHasMoreTasks, isLoadingNextTaskPage } from '../TaskListView';
+import { getHasMoreTasks, isLoadingNextTaskPage, redistributeTasksAcrossPages } from '../TaskListView';
+import type { TaskItem } from '../task-list-types';
+
+// Minimal stand-ins — redistributeTasksAcrossPages only reads/copies `id` and `.tasks.length`.
+const task = (id: string) => ({ id }) as unknown as TaskItem;
 
 describe('getHasMoreTasks', () => {
   it('no pages loaded yet', () => {
@@ -74,6 +78,87 @@ describe('isLoadingNextTaskPage', () => {
       should: 'return true',
       actual: isLoadingNextTaskPage(undefined, 1),
       expected: true,
+    });
+  });
+});
+
+describe('redistributeTasksAcrossPages', () => {
+  it('preserves each page\'s original size', () => {
+    const pages = [
+      { hasMore: true, tasks: [task('a'), task('b')] },
+      { hasMore: false, tasks: [task('c')] },
+    ];
+    const reordered = [task('c'), task('a'), task('b')];
+    const result = redistributeTasksAcrossPages(pages, reordered);
+    assert({
+      given: 'pages of size 2 and 1',
+      should: 'keep the same per-page task counts after redistributing',
+      actual: result.map(p => p.tasks.length),
+      expected: [2, 1],
+    });
+  });
+
+  it('preserves order within the redistribution', () => {
+    const pages = [
+      { hasMore: true, tasks: [task('a'), task('b')] },
+      { hasMore: false, tasks: [task('c')] },
+    ];
+    const reordered = [task('c'), task('a'), task('b')];
+    const result = redistributeTasksAcrossPages(pages, reordered);
+    assert({
+      given: 'a reordered list where "c" moved to the front',
+      should: 'fill each page sequentially from the reordered list',
+      actual: result.map(p => p.tasks.map(t => t.id)),
+      expected: [['c', 'a'], ['b']],
+    });
+  });
+
+  it('preserves non-tasks fields (e.g. hasMore) untouched', () => {
+    const pages = [
+      { hasMore: true, tasks: [task('a')] },
+      { hasMore: false, tasks: [task('b')] },
+    ];
+    const result = redistributeTasksAcrossPages(pages, [task('b'), task('a')]);
+    assert({
+      given: 'pages with distinct hasMore flags',
+      should: 'leave hasMore on each page exactly as it was',
+      actual: result.map(p => p.hasMore),
+      expected: [true, false],
+    });
+  });
+
+  it('does not mutate the input pages array', () => {
+    const pages = [{ hasMore: true, tasks: [task('a')] }];
+    redistributeTasksAcrossPages(pages, [task('a')]);
+    assert({
+      given: 'the original pages array after redistributing',
+      should: 'remain referentially the same objects (pure function)',
+      actual: pages[0].tasks[0].id,
+      expected: 'a',
+    });
+  });
+
+  it('shorter reordered list (e.g. a filtered subset) truncates later pages instead of throwing', () => {
+    const pages = [
+      { hasMore: true, tasks: [task('a'), task('b')] },
+      { hasMore: false, tasks: [task('c'), task('d')] },
+    ];
+    // Only 2 of the original 4 tasks are in the reordered (filtered) list.
+    const result = redistributeTasksAcrossPages(pages, [task('a'), task('b')]);
+    assert({
+      given: 'a reordered list shorter than the total task count across pages',
+      should: 'fill leading pages fully and leave trailing pages empty rather than throwing',
+      actual: result.map(p => p.tasks.length),
+      expected: [2, 0],
+    });
+  });
+
+  it('empty pages array', () => {
+    assert({
+      given: 'no loaded pages',
+      should: 'return an empty array',
+      actual: redistributeTasksAcrossPages([], []),
+      expected: [],
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -89,6 +89,7 @@ export interface TaskListData {
   };
   tasks: TaskItem[];
   statusConfigs: TaskStatusConfig[];
+  hasMore: boolean;
 }
 
 export type TaskPriority = 'low' | 'medium' | 'high';


### PR DESCRIPTION
## Summary

Phase 2 of the Task Board Query & Reorder Safety epic (#2128 + tiebreak fast-follow #2138) bounded the previously-unbounded `GET /api/pages/[pageId]/tasks` query to fix a production OOM crash (2026-07-18, 3.5GB RSS on a 4GB box). That fix defaults `limit=100` (max 200), which was intentional — but it left task lists with more than `limit` direct children silently showing only the first page, with zero indication more tasks exist.

This PR adds "Load More" pagination so those tasks are actually reachable.

- **Backend** (`apps/web/src/app/api/pages/[pageId]/tasks/route.ts`): the phase-1 bounded/ordered id query now requests `limit + 1` rows and slices, so the route can report a `hasMore` boolean in the response without a separate `COUNT(*)` query. No relational-hydrate query became unbounded — `hasMore` is derived purely from the already-bounded phase-1 result.
- **Frontend** (`TaskListView.tsx`): switched from `useSWR` to `useSWRInfinite`, fetching in pages of 100 (matching the route's default limit). `TaskKanbanView.tsx` needed no changes — it renders whatever `filteredTasks` it's handed by `TaskListView`, so fixing the one fetch covers both the list and kanban views.
  - A shared "Load More" control (table, kanban, and mobile card renders) appears whenever `hasMore` is true.
  - Changing the status/search filter (not the in-page Cmd+F Find query) resets pagination back to page one (`setSize(1)`), so a previously-expanded load doesn't linger inconsistently with a fresh filter — already-fetched pages are reused instantly from the SWR cache if the user re-expands.
  - Every write handler's revalidation call (create/update/delete/reorder/status-config-change/socket events) goes through `mutateTasks()`, which calls the hook's own bound `mutateTaskPages()` — the key `useSWRInfinite` actually subscribes to (see "Review history" below for why this matters).
  - The drag-reorder optimistic update redistributes the reordered (filtered) list back across the currently-loaded pages, preserving each page's size and `hasMore`, rather than collapsing everything into one synthetic page.
  - A failed "Load More" (page 2+) no longer blanks the whole view — only a fatal error with no page ever loaded does that; a partial failure shows already-loaded tasks plus a Retry affordance in the shared control.
  - `revalidateAll: true` so the periodic staleness fallback (and every other revalidation trigger) refreshes every loaded page, not just page 0.
  - The Load More/Retry control disables itself with "Finish editing to load more" while any document/form edit session is active anywhere in the app, instead of silently no-oping (SWR's `isPaused` blocks explicit clicks too, and there's no public API to bypass it for one call).
- Extracted `getHasMoreTasks` / `isLoadingNextTaskPage` / `redistributeTasksAcrossPages` / `getTaskLoadMoreState` / `getLoadMoreButtonLabel` as pure, unit-tested helper functions exported from `TaskListView.tsx`, matching the file's existing `toggleSet` / `getExpansionRowClass` pattern.

PageSpace task: `mnwqxwmppyjkc1vzdcnzg9o4`
Epic: Page/Task Board Query & Reorder Safety

## Review history

- **Codex (automated, P1):** the first revision's `mutateTasks()` used a global `mutate()` call with a plain-string key matcher (`/api/pages/[id]/tasks?...`) to revalidate after writes. `useSWRInfinite` actually registers its reactive cache entry under a separate, synthetic `$inf$<firstPageKey>` key (confirmed by reading `swr/infinite`'s source directly) — so that matcher silently touched dead cache entries and writes never triggered a real revalidation; the list only refreshed on the 5-minute interval or a fresh mount. Fixed in `5dd8a1d47` by delegating straight to the hook's own bound `mutateTaskPages()`.
- **Self-review pass (adversarial, post-fix):** while re-verifying the above fix was complete, found two more issues, both fixed in `ef59522d8`:
  - `revalidateFirstPage: false` (added to avoid a redundant page-0 refetch on every "Load More" click) also silently neutered the kept `refreshInterval: 300000` fallback — traced through `swr/infinite`'s source, with that flag off nothing makes `shouldFetchPage` become true from time passing alone. Removed the override; the periodic fallback works again, at the cost of a cheap extra page-0 refetch per "Load More" click.
  - The drag-reorder optimistic update collapsed every loaded page into one synthetic page, which briefly threw off `getHasMoreTasks`/`isLoadingNextTaskPage` (both read page count / the last page) whenever 2+ pages were loaded. Replaced with `redistributeTasksAcrossPages`, which preserves page count and each page's `hasMore` through the optimistic window.
- **Codex (automated, P2):** the unconditional `if (error)` guard replaced the entire view with "Failed to load tasks" even when earlier pages had already loaded successfully — SWR keeps that last-good `data` around alongside a fresh `error` instead of clearing it, so a transient failure on a "Load More" request was hiding perfectly good, already-loaded tasks. Fixed in `94da284ce`: the fatal guard is now `error && !data`; a partial failure surfaces via a new pure `getTaskLoadMoreState` (idle/loading/failed) and a Retry affordance in the shared Load More control instead.
- **Codex (automated, P2):** `getTaskLoadMoreState` only compared page count to `size`, but `size` (how many "Load More" clicks the user made) and `pages.length` (how many pages actually resolved) can permanently diverge: if a concurrent delete shrinks the total across a page boundary, `getTasksPageKey` starts returning `null` for the page beyond the new end, and `swr/infinite`'s fetcher loop `break`s there — `pages.length` never catches up to `size` again. That read as "still loading" forever, leaving the control stuck on a disabled spinner. Fixed in `ad32ea51c`: the last resolved page's `hasMore` is now checked first and treated as authoritative over a stale `size`.
- **Second adversarial self-review pass, then independently confirmed by both Codex and CodeRabbit:** three more issues, all fixed in `1614c7f45`:
  - **CodeRabbit (Major):** the pagination-reset effect was keyed on `activeSearch`, which follows `findQuery` while the in-page Cmd+F Find bar is open — every keystroke in Find truncated `taskPages` back to page 1 mid-search, silently hiding matches on already-loaded pages 2+ and under-reporting the match count. Rekeyed the effect on `search` (the toolbar filter box) instead.
  - **Codex (P2) + CodeRabbit (independently, same root cause):** `swr/infinite`'s default config only auto-refreshes page 0 on the `refreshInterval` tick; pages 1+ only refetch on an explicit `mutate()` targeting them. A missed socket event for a task on page 2+ would stay stale until the next unrelated write anywhere in the list. Added `revalidateAll: true`.
  - **Codex (P2) + CodeRabbit (independently, same root cause):** verified against `swr`'s core `revalidate()` source that `isPaused` gates *every* revalidation for a key, not just background ones — including "Load More"/Retry clicks. `isAnyEditing` is app-wide (any document/form edit anywhere, not scoped to this page — `useEditingStore.ts`), so a click during an unrelated edit session silently no-oped, with `size` still advancing and the control stuck on "Loading…" until the next unpaused trigger. There's no public SWR API to bypass `isPaused` for a single call (confirmed by CodeRabbit's own research) — went with CodeRabbit's suggested mitigation instead: the control now disables itself with "Finish editing to load more" via a new pure `getLoadMoreButtonLabel` helper, and returns to normal once editing ends.

## Known limitation (pre-existing, not introduced by this PR)

The drag-reorder optimistic update operates on `filteredTasks` (the status/search-filtered subset), not the full task list. When a filter or search term is active, filtered-out tasks are briefly absent from the client cache during a drag, until the follow-up revalidate restores the real server state. This pattern predates this PR (`git show master:.../TaskListView.tsx` has the same behavior against a single-page list); pagination increases its blast radius (more tasks can be affected) but doesn't change its nature. A proper fix means reconciling drag indices against the full unfiltered list, which is a distinct, non-trivial change to `handleDragEnd` — out of scope here.

## Test plan

- [x] RED→GREEN: `apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts` — 3 new tests for `hasMore` (true when more rows exist, false when exact/under limit, false on the empty-children response). All 45 tests in the file pass.
- [x] RED→GREEN: `apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/taskPagination.test.ts` — 25 unit tests for the extracted pure helpers (`getHasMoreTasks`, `isLoadingNextTaskPage`, `redistributeTasksAcrossPages`, `getTaskLoadMoreState`, `getLoadMoreButtonLabel`).
- [x] Full `apps/web/src/app/api/pages/[pageId]/tasks/` + `apps/web/src/components/layout/middle-content/page-views/task-list/` vitest suites: 13 files, 257 tests, all passing.
- [x] `bun run typecheck` (full monorepo `next build`) passes clean.
- [x] `eslint` on all touched files: 0 errors, 0 warnings.
- [ ] All CI checks green for the latest commit (in progress — watching).
- [ ] Manual browser verification (create >100 tasks, click Load More) — not performed; no browser automation tool was available in this session. Please sanity-check in a dev server before merging if possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XqB71jz2DnSaWqMpc9aqcW
