### PR TITLE
feat(machines): pagespace agent type + surface discriminator (Phase 1/13)

### DIFF
--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -6,6 +6,8 @@ import {
   resolveAgentLaunchSpec,
   isValidAgentTerminalName,
   isValidAgentTerminalCommand,
+  isPtyAgentType,
+  agentSurfaceOf,
 } from '../agent-terminal-types';
 
 describe('isAgentRuntimeType', () => {
@@ -23,6 +25,10 @@ describe('isAgentRuntimeType', () => {
 
   it('given the retired pagespace-cli agent type, should reject it as unrecognized (not crash)', () => {
     expect(isAgentRuntimeType('pagespace-cli')).toBe(false);
+  });
+
+  it('given the pagespace agent type, should recognize it', () => {
+    expect(isAgentRuntimeType('pagespace')).toBe(true);
   });
 });
 
@@ -47,7 +53,7 @@ describe('resolveAgentLaunchSpec', () => {
   });
 
   it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex']);
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex', 'pagespace']);
   });
 
   it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
@@ -56,12 +62,49 @@ describe('resolveAgentLaunchSpec', () => {
 });
 
 describe('PICKABLE_AGENT_TYPES', () => {
-  it('should include shell (primary) plus claude and codex (secondary) — only the retired pagespace-cli is excluded', () => {
-    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex']);
+  it('should include shell (primary) plus claude, codex, and pagespace (secondary) — only the retired pagespace-cli is excluded', () => {
+    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex', 'pagespace']);
   });
 
   it('should list shell FIRST — a plain interactive shell is the default, primary way to work on a Machine', () => {
     expect(PICKABLE_AGENT_TYPES[0]).toBe('shell');
+  });
+});
+
+describe('agentSurfaceOf', () => {
+  it('given pagespace, should return chat', () => {
+    expect(agentSurfaceOf('pagespace')).toBe('chat');
+  });
+
+  it('given shell, claude, or codex, should return pty', () => {
+    expect(agentSurfaceOf('shell')).toBe('pty');
+    expect(agentSurfaceOf('claude')).toBe('pty');
+    expect(agentSurfaceOf('codex')).toBe('pty');
+  });
+});
+
+describe('isPtyAgentType', () => {
+  it('given pagespace, should return false', () => {
+    expect(isPtyAgentType('pagespace')).toBe(false);
+  });
+
+  it('given shell, claude, or codex, should return true', () => {
+    expect(isPtyAgentType('shell')).toBe(true);
+    expect(isPtyAgentType('claude')).toBe(true);
+    expect(isPtyAgentType('codex')).toBe(true);
+  });
+});
+
+describe('agent type identifiers stay compatible with autoSessionName', () => {
+  // autoSessionName (apps/web/src/stores/machine-workspace/workspace-reducer.ts) builds
+  // `${agentType}-${suffix}` or bare `agentType` for the split-and-pick spawn name — this
+  // guards that every registry key, including the new `pagespace` type, still produces a
+  // name isValidAgentTerminalName accepts.
+  it('given every pickable agent type, should produce identifiers that satisfy isValidAgentTerminalName', () => {
+    for (const type of PICKABLE_AGENT_TYPES) {
+      expect(isValidAgentTerminalName(type)).toBe(true);
+      expect(isValidAgentTerminalName(`${type}-a1b2c3`)).toBe(true);
+    }
   });
 });
 

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -25,17 +25,28 @@
  * `pickable` gates the empty-pane "spawn an agent" picker (`TerminalPanes.tsx`
  * — see `PICKABLE_AGENT_TYPES` below). `shell` is PRIMARY here — a plain
  * interactive shell is the default, first-class way to work on a Machine —
- * with `claude`/`codex` as secondary, opt-in AI agents. Only the retired
- * `pagespace-cli` is excluded. Keeping the marker on the registry entry
- * itself (rather than a hardcoded list living in the UI file) is what keeps
- * the picker in sync when a new entry is added here: forgetting to set
+ * with `claude`/`codex`/`pagespace` as secondary, opt-in AI agents. Only the
+ * retired `pagespace-cli` is excluded. Keeping the marker on the registry
+ * entry itself (rather than a hardcoded list living in the UI file) is what
+ * keeps the picker in sync when a new entry is added here: forgetting to set
  * `pickable: true` fails safe (excluded, not silently spawnable).
+ *
+ * `surface` is the rendering discriminator every pane-hosting layer branches
+ * on: `'pty'` types spawn a real PTY process (`command`/`args` are launched
+ * for real); `'chat'` types render the PageSpace AI chat UI in the pane
+ * instead — `pagespace`'s `command` is a dead sentinel, never launched. See
+ * `agentSurfaceOf`/`isPtyAgentType` below for the pure accessors callers
+ * should use rather than reading `.surface` off the registry directly.
  */
 export const AGENT_LAUNCH_SPECS = {
-  shell: { command: 'shell', args: [], pickable: true },
-  claude: { command: 'claude', args: [], pickable: true },
-  codex: { command: 'codex', args: [], pickable: true },
-} as const satisfies Record<string, { command: string; args: readonly string[]; pickable: boolean }>;
+  shell: { command: 'shell', args: [], pickable: true, surface: 'pty' },
+  claude: { command: 'claude', args: [], pickable: true, surface: 'pty' },
+  codex: { command: 'codex', args: [], pickable: true, surface: 'pty' },
+  pagespace: { command: 'pagespace', args: [], pickable: true, surface: 'chat' },
+} as const satisfies Record<
+  string,
+  { command: string; args: readonly string[]; pickable: boolean; surface: 'pty' | 'chat' }
+>;
 
 export type AgentRuntimeType = keyof typeof AGENT_LAUNCH_SPECS;
 
@@ -57,6 +68,18 @@ export function isAgentRuntimeType(value: string): value is AgentRuntimeType {
 export function resolveAgentLaunchSpec(type: AgentRuntimeType): AgentLaunchSpec {
   const spec = AGENT_LAUNCH_SPECS[type];
   return { command: spec.command, args: [...spec.args] };
+}
+
+export type AgentSurface = 'pty' | 'chat';
+
+/** The pane surface a given agent type renders: a real PTY process, or the PageSpace AI chat UI. */
+export function agentSurfaceOf(type: AgentRuntimeType): AgentSurface {
+  return AGENT_LAUNCH_SPECS[type].surface;
+}
+
+/** Whether an agent type spawns a real PTY process (as opposed to a `'chat'`-surface type like `pagespace`). */
+export function isPtyAgentType(type: AgentRuntimeType): boolean {
+  return agentSurfaceOf(type) === 'pty';
 }
 
 const MAX_AGENT_TERMINAL_NAME_LENGTH = 100;


### PR DESCRIPTION
## Summary

Phase 1 of 13 for #2166 — adds a first-party **"PageSpace Agent"** session type to machine terminal panes. This phase is registry-only, pure data + pure predicates, no IO:

- Adds `surface: 'pty' | 'chat'` to the `AGENT_LAUNCH_SPECS` registry (all existing entries `'pty'`).
- Adds a `pagespace` registry entry (`surface: 'chat'`, `pickable: true`). Its `command` is a dead sentinel, never launched — the picker label is "PageSpace Agent".
- Exports pure `agentSurfaceOf` and `isPtyAgentType` for phases 2/3/10 to consume.

Phase page: `wgxaet9wjnd4o8op6fnhwn6k` (findings + acceptance recorded there).

## Acceptance criteria

- [x] `pagespace` is in `PICKABLE_AGENT_TYPES`.
- [x] `agentSurfaceOf('pagespace') === 'chat'`; `'pty'` for shell/claude/codex.
- [x] `isPtyAgentType('pagespace') === false`; `true` for shell/claude/codex.
- [x] `autoSessionName('pagespace', …)` passes `isValidAgentTerminalName`.
- [x] `resolveAgentLaunchSpec` for pty types unchanged.

## Test plan

- [x] RED commit (`05d839542`): failing tests added first, confirmed failing for the right reason (missing exports / real assertion gaps, not import errors).
- [x] GREEN commit (`a7e95ba0f`): registry + predicates implemented; full lib suite green (8623 passed / 11 skipped).
- [x] `bun run typecheck` clean (lib + monorepo-wide).
- [x] `bun run lint` clean.
- [x] `knip:check` ratchet unchanged at baseline (no new unused-export issues).
- [x] Independent `/aidd-review` pass — 0 blockers/majors/minors, findings recorded on the phase page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4mobkBmcpwppgp4dEkB1n