### PR TITLE
feat(machine-panes): Phase 9 — Pane state: content kind on the bound scope (#2166)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -552,7 +552,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, and codex — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +560,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude and codex as secondary AI agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex'],
+      expected: ['shell', 'claude', 'codex', 'pagespace'],
     });
   });
 

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -598,17 +598,6 @@ describe('useMachineWorkspaceStore', () => {
     });
   });
 
-  it('given hydrateFromServer for an unknown machine id, should still create a usable entry (no-op-on-unknown baseline)', () => {
-    store().hydrateFromServer('never-seen', []);
-
-    assert({
-      given: 'a hydrate call for a machine this browser never ensured',
-      should: 'converge on an empty, renderable machine rather than error',
-      actual: { active: selectMachine('never-seen')(store())?.activeWorkspaceId, workspaces: workspacesOf(selectMachine('never-seen')(store())).length },
-      expected: { active: '', workspaces: 0 },
-    });
-  });
-
   it('given applyServerUpsert for an unseen workspace id, should add it', () => {
     seedMachine('m1');
     const existing = activeOf('m1')!;

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -580,6 +580,35 @@ describe('useMachineWorkspaceStore', () => {
     });
   });
 
+  it('given hydrateFromServer with a pane scope carrying the content kind, should round-trip it (#2166 phase 9)', () => {
+    store().hydrateFromServer('m1', [
+      {
+        id: 'ws-1',
+        name: 'Workspace 1',
+        scope: {},
+        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: "the sync hook's initial hydrate carrying a pane tagged kind: 'chat'",
+      should: 'round-trip the content kind into the store',
+      actual: panesOf(activeOf('m1')!)[0]?.scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
+  it('given hydrateFromServer for an unknown machine id, should still create a usable entry (no-op-on-unknown baseline)', () => {
+    store().hydrateFromServer('never-seen', []);
+
+    assert({
+      given: 'a hydrate call for a machine this browser never ensured',
+      should: 'converge on an empty, renderable machine rather than error',
+      actual: { active: selectMachine('never-seen')(store())?.activeWorkspaceId, workspaces: workspacesOf(selectMachine('never-seen')(store())).length },
+      expected: { active: '', workspaces: 0 },
+    });
+  });
+
   it('given applyServerUpsert for an unseen workspace id, should add it', () => {
     seedMachine('m1');
     const existing = activeOf('m1')!;

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -206,6 +206,19 @@ describe('sessionWorkspaceId', () => {
     });
   });
 
+  it('given scopes that differ only by content kind, should resolve to the same workspace id', () => {
+    assert({
+      given: 'the same session scope tagged "chat", "terminal", and untagged',
+      should: 'produce the identical workspace id — the content kind is not part of session identity',
+      actual: new Set([
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3', kind: 'chat' }),
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3', kind: 'terminal' }),
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3' }),
+      ]).size,
+      expected: 1,
+    });
+  });
+
   it('given any scope, should never contain a NUL byte', () => {
     const id = sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3' });
 
@@ -337,6 +350,28 @@ describe('assignPane (split-and-pick landing)', () => {
       should:
         'return the state untouched — the store reads that identity to know the session it just created is orphaned, and removes it',
       actual: assignPane(state, 'closed-pane', { name: 'claude-a1b2c3' }),
+      expected: state,
+    });
+  });
+});
+
+describe('assignPane — content kind round-trips on the bound scope (#2166 phase 9)', () => {
+  it('given a scope carrying the content kind, should round-trip it onto the pane', () => {
+    assert({
+      given: 'assignPane with a scope tagged kind: "chat"',
+      should: "round-trip the kind onto the pane's scope, unchanged",
+      actual: panesOf(assignPane(aWorkspace(), 'pane-1', { name: 'claude-a1b2c3', kind: 'chat' }))[0].scope,
+      expected: { name: 'claude-a1b2c3', kind: 'chat' },
+    });
+  });
+
+  it('given an unknown pane id, should be a no-op even when the scope carries a content kind', () => {
+    const state = aWorkspace();
+
+    assert({
+      given: 'a pane id that does not resolve, with a scope carrying a content kind',
+      should: 'be a no-op, same as any other assignPane call',
+      actual: assignPane(state, 'gone', { name: 'claude-a1b2c3', kind: 'chat' }),
       expected: state,
     });
   });
@@ -806,6 +841,48 @@ describe('mergeServerWorkspaces — reconciling the server\'s workspace list', (
   });
 });
 
+describe('mergeServerWorkspaces — round-trips the content kind (#2166 phase 9)', () => {
+  it('given a server workspace whose pane scope carries the content kind, should round-trip it', () => {
+    const merged = mergeServerWorkspaces(undefined, [
+      {
+        id: 'ws-1',
+        name: 'Workspace 1',
+        scope: {},
+        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: 'a server payload whose pane scope is tagged kind: "chat"',
+      should: 'round-trip the tag into local state — server isValidLayout is lenient, so this is not stripped in transit',
+      actual: panesOf(merged.workspaces['ws-1'])[0].scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
+  it("given a surviving pane with a local pendingPrompt, should preserve both the prompt and the server's content kind", () => {
+    const local = initialMachineWorkspaces(
+      assignPane(aWorkspace('ws-1', 'pane-1'), 'pane-1', { name: 'claude-a1' }, 'fix the build')
+    );
+
+    const merged = mergeServerWorkspaces(local, [
+      {
+        id: 'ws-1',
+        name: 'ws-1',
+        scope: BRANCH_SCOPE,
+        columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: 'an incoming layout for a pane that survives locally with an undelivered prompt, whose server scope now carries a content kind',
+      should: 'keep the local pendingPrompt AND adopt the server content kind together — same merge, two fields',
+      actual: panesOf(merged.workspaces['ws-1'])[0],
+      expected: { id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' }, pendingPrompt: 'fix the build' },
+    });
+  });
+});
+
 describe('applyServerWorkspaceUpsert', () => {
   it('given a brand-new workspace id, should add it to the end of order', () => {
     const machine = initialMachineWorkspaces(aWorkspace('ws-a', 'a1'));
@@ -990,6 +1067,61 @@ describe('sanitizeMachines — what comes back from storage is untrusted', () =>
         'point active at a real pane — every grid transition no-ops on a pane it cannot resolve, so a split anchored on a phantom would silently do nothing',
       actual: sanitizeMachines(persisted).m1.workspaces['ws-1'].activePaneId,
       expected: 'pane-1',
+    });
+  });
+
+  it('given a persisted pane scope carrying the content kind, should preserve it (#2166 phase 9)', () => {
+    const persisted = {
+      m1: {
+        workspaces: {
+          'ws-1': {
+            id: 'ws-1',
+            name: 'ws-1',
+            scope: {},
+            columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+            activePaneId: 'pane-1',
+          },
+        },
+        order: ['ws-1'],
+        activeWorkspaceId: 'ws-1',
+      },
+    };
+
+    const actual = sanitizeMachines(persisted).m1.workspaces['ws-1'];
+
+    assert({
+      given: 'a rehydrated pane whose scope carries kind: "chat"',
+      should: 'preserve the content kind on the way through, not strip it as an unrecognized field',
+      actual: panesOf(actual)[0].scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
+  it('given a persisted activePaneId that does not resolve, should still repoint it while preserving the content kind on surviving panes', () => {
+    const persisted = {
+      m1: {
+        workspaces: {
+          'ws-1': {
+            id: 'ws-1',
+            name: 'ws-1',
+            scope: {},
+            columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+            activePaneId: 'pane-that-was-closed',
+          },
+        },
+        order: ['ws-1'],
+        activeWorkspaceId: 'ws-1',
+      },
+    };
+
+    const actual = sanitizeMachines(persisted).m1.workspaces['ws-1'];
+
+    assert({
+      given: 'an activePaneId that no longer resolves, on a workspace whose surviving pane carries a content kind',
+      should:
+        'repoint active at the real pane and keep the content kind intact — same no-op-on-unknown-id contract as every other transition here',
+      actual: { activePaneId: actual.activePaneId, scope: panesOf(actual)[0].scope },
+      expected: { activePaneId: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } },
     });
   });
 });

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -28,6 +28,14 @@ export interface OpenTerminalScope {
   projectName?: string;
   branchName?: string;
   name: string;
+  /** What the pane renders once bound: an xterm PTY, or the PageSpace Agent
+   * chat UI (#2166). Omitted means `'terminal'` — every session bound before
+   * this tag existed is a PTY, so the renderer can treat a missing kind the
+   * same as an explicit one without a migration. Lives on the scope, not a
+   * loose `agentType` string, so it survives every place a scope already
+   * flows opaquely (assignPane, sanitizeMachines, mergeServerWorkspaces)
+   * without those transitions needing to know about it. */
+  kind?: 'terminal' | 'chat';
 }
 
 /**

--- a/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
@@ -10,6 +10,7 @@ import {
   isBootstrapped,
   bootstrapWorkspaces,
   type MachineWorkspacesDeps,
+  type WorkspaceLayoutInput,
 } from '../machine-workspaces';
 import type { MachineWorkspaceStore, MachineWorkspaceRecord, NewMachineWorkspaceInput } from '../machine-workspaces-store';
 
@@ -153,6 +154,19 @@ describe('isValidWorkspaceName / planWorkspacePayload', () => {
   it('accepts a well-shaped payload', () => {
     const plan = planWorkspacePayload({ name: 'Workspace 1', layout: VALID_COLUMNS });
     expect(plan).toEqual({ ok: true, name: 'Workspace 1', layout: VALID_COLUMNS });
+  });
+
+  // #2166 phase 9 — the client tags a pane's bound scope with a content kind
+  // ('terminal' | 'chat'); this mirror type and its lenient runtime check must
+  // tolerate it so a workspace layout carrying the tag round-trips through create/update.
+  it('accepts a pane scope carrying the content kind — mirrors the client\'s tagged bound scope, lenient by design', () => {
+    const layoutWithKind: WorkspaceLayoutInput = {
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+    };
+
+    const plan = planWorkspacePayload({ name: 'Workspace 1', layout: layoutWithKind });
+
+    expect(plan).toEqual({ ok: true, name: 'Workspace 1', layout: layoutWithKind });
   });
 });
 

--- a/packages/lib/src/services/machines/machine-workspaces.ts
+++ b/packages/lib/src/services/machines/machine-workspaces.ts
@@ -31,7 +31,7 @@ export interface WorkspaceScopeInput {
 /** Mirrors the client's `OpenTerminalScope`/pane shape — see machine-workspaces-store.ts's DTOs. */
 export interface WorkspaceLayoutPaneInput {
   id: string;
-  scope: { projectName?: string; branchName?: string; name: string } | null;
+  scope: { projectName?: string; branchName?: string; name: string; kind?: 'terminal' | 'chat' } | null;
 }
 export interface WorkspaceLayoutColumnInput {
   id: string;


### PR DESCRIPTION
## Summary

Phase 9 of the PageSpace Agent pane epic (2witstudios/pagespace#2166, board phase page `ddwcd2jyvv2cgvvuri6rnbvo`). Tags a pane's bound scope (`OpenTerminalScope`) with an optional content kind — `'terminal' | 'chat'` — so Phase 10's renderer can branch honestly between an xterm PTY and the PageSpace Agent chat UI, without re-plumbing every place a scope already flows.

- `kind?: 'terminal' | 'chat'` added to `OpenTerminalScope` (`apps/web/src/stores/machine-workspace/workspace-reducer.ts`). Omitted means `'terminal'` — no migration needed for existing sessions.
- Mirrored into `packages/lib`'s `WorkspaceLayoutPaneInput` scope type (server truth stays the row; `isValidLayout` stays lenient and unchanged).
- No reducer transition logic changed: `assignPane`, `sanitizeMachines`, and `mergeServerWorkspaces` already treat a pane's `scope` as opaque pass-through data, so the round-trip/tolerate/ignore behavior in the spec was already true at runtime — this PR makes the *type* honest about it.

## Spec coverage (board `## Spec`)

- [x] `assignPane` with a scope carrying the content kind round-trips the kind (+ unknown-pane-id no-op pairing).
- [x] `sessionWorkspaceId` ignores the content kind when deriving the workspace id.
- [x] `sanitizeMachines` rehydration tolerates the content kind (+ unknown-activePaneId no-op pairing).
- [x] `mergeServerWorkspaces` round-trips the content kind — reducer test, store test (`hydrateFromServer`), and a lib layout test (`planWorkspacePayload`/`isValidLayout`).

## TDD trail

- RED: tests added first. They pass at the `vitest` runtime layer immediately (the reducer's pass-through architecture already satisfies the spec structurally), so the genuine RED signal is `bun run typecheck` — TS2353 "'kind' does not exist" on `OpenTerminalScope` / the lib mirror type, confirmed failing before the GREEN commit.
- GREEN: adds the `kind` field to both types. `bun run typecheck && bun run lint` clean on `apps/web` and `@pagespace/lib`.
- Review: independent `/aidd-review` pass — one minor scope-creep finding (an unrelated "unknown machine id" store test not exercising content kind) fixed. Findings recorded on the phase page's `## Findings` section.

## Trunk drift note (rebase fixup)

Phase 1 (#2180, `feat(machines): pagespace agent type + surface discriminator`) merged into `pu/panes-agent` after this branch was cut, adding a 4th `pickable` agent type (`pagespace`) to the registry. Rebasing this branch onto the updated trunk surfaced a pre-existing CI failure unrelated to Phase 9's own diff: `TerminalPanes.test.tsx`'s agent-picker test still hardcoded the old 3-option list, which Phase 1's PR didn't update. Fixed here (`8ceda270d`) so this PR's CI is green.

**Note for reviewers/point-guard:** #2187 (`test(machine-panes): fix picker assertion left broken by Phase 1`) is a dedicated, canonical fix for this exact same trunk-level issue, opened independently around the same time. My fix here is a duplicate, scoped narrowly to unblock *this* PR's own CI without waiting on #2187's merge timing — it is not this phase's own responsibility and should collapse to a no-op the next time this branch rebases onto `pu/panes-agent` after #2187 lands. Not merging #2187 myself; that's outside Phase 9's scope.

## Test plan

- [x] `bun run vitest run src/stores/machine-workspace` (apps/web) — 104 tests passing
- [x] `bun run vitest run` on `packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts` — 23 tests passing
- [x] `bun run vitest run src/components/layout/middle-content/page-views/machine/workspace` — 124 tests passing (incl. the picker-test fixup)
- [x] `bun run typecheck` clean on `apps/web` and `@pagespace/lib`
- [x] `bun run lint` clean on `apps/web` and `@pagespace/lib` (only pre-existing, unrelated warnings elsewhere in `apps/web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3uEPRoFj7RYecWppqg9g3