### PR TITLE
feat(realtime): Phase 3 — defensive refusal of chat-surface rows (#2166)

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -458,7 +458,7 @@ function buildDeps(overrides: Partial<AgentTerminalCheckAuthDeps> = {}): {
     }),
     resolveMachineRow: async () => {
       calls.resolveMachineRow += 1;
-      return { ok: true };
+      return { ok: true, agentType: 'shell' };
     },
     writeAudit: () => {},
     buildSessionKey: () => 'session-key-1',
@@ -843,6 +843,43 @@ describe('buildAgentTerminalCheckAuth', () => {
       should: 'deny with not_found from the access half, touching no Sprite',
       actual: { result, spriteCalls: sandbox.getSpriteCalls.length },
       expected: { result: { ok: false, reason: 'not_found' }, spriteCalls: 0 },
+    });
+  });
+
+  it('DENIES a pagespace (chat-surface) row from the ACCESS half itself, before the lazy sandbox thunk could ever acquire/wake the machine\'s Sprite', async () => {
+    // This is the gap a machine/project-scope target has that a direct
+    // resolveMachineSandbox() call can't see: the real resolveAgentTerminal
+    // (agent-terminals.ts) resolves the Sprite's LOCATION via
+    // machineSandbox.acquire — which can resume or reprovision a hibernating
+    // Sprite — BEFORE it even reads the row's agentType. Gating only inside
+    // resolveMachineSandbox (which only runs from the lazy resolveSandbox
+    // thunk, i.e. AFTER resolveAgentTerminal has already resolved/acquired)
+    // is too late for that scope. resolveMachineRow uses resolveScopeKey
+    // instead, which never touches machineSandbox at all, so denying here is
+    // the earliest point that's both correct and Sprite-free.
+    const sandbox = sandboxSpy(async () => ({ ...resolvedOk, agentType: 'pagespace' }));
+    const denials: string[] = [];
+    const { deps } = buildDeps({
+      resolveSandbox: sandbox.fn,
+      resolveMachineRow: async () => ({ ok: true, agentType: 'pagespace' }),
+      logDenied: (reason) => {
+        denials.push(reason);
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'assistant' });
+
+    assert({
+      given: 'a resolveMachineRow that reports a chat-surface (pagespace) agentType for a machine-scope target',
+      should: 'deny with not_a_pty_agent from the access half alone, never calling resolveSandbox or touching a Sprite',
+      actual: { result, denials, sandboxCalls: sandbox.calls, spriteCalls: sandbox.getSpriteCalls.length },
+      expected: {
+        result: { ok: false, reason: 'not_a_pty_agent' },
+        denials: ['not_a_pty_agent'],
+        sandboxCalls: 0,
+        spriteCalls: 0,
+      },
     });
   });
 

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -203,6 +203,24 @@ describe('resolveMachineSandbox', () => {
     });
   });
 
+  it('refuses a pagespace (chat-surface) target WITHOUT reading the Sprite', async () => {
+    const getSprite = spyGetSprite();
+    const result = await resolveMachineSandbox(
+      { machineId: 'm-1', name: 'assistant' },
+      {
+        resolveAgentTerminal: async () => ({ ...resolvedOk, agentType: 'pagespace' }),
+        getSprite: getSprite.fn,
+      },
+    );
+
+    assert({
+      given: 'a resolved agent terminal whose agentType is pagespace (chat surface, not pty)',
+      should: 'deny with not_a_pty_agent without touching the Sprite',
+      actual: { result, spriteCalls: getSprite.calls.length },
+      expected: { result: { ok: false, reason: 'not_a_pty_agent' }, spriteCalls: 0 },
+    });
+  });
+
   it('denies with provision_failed (and the sandboxId) when the Sprite lookup throws', async () => {
     const result = await resolveMachineSandbox(
       { machineId: 'm-1', name: 'shell' },

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -20,7 +20,7 @@
  * testable with none.
  */
 
-import { resolveAgentLaunchSpec } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { isPtyAgentType, resolveAgentLaunchSpec } from '@pagespace/lib/services/machines/agent-terminal-types';
 import type { ResolveAgentTerminalResult } from '@pagespace/lib/services/machines/agent-terminals';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -167,6 +167,12 @@ export async function resolveMachineSandbox(
 ): Promise<ResolveMachineSandboxResult> {
   const resolved = await deps.resolveAgentTerminal(target);
   if (!resolved.ok) return { ok: false, reason: resolved.reason };
+
+  // Belt-and-suspenders over the socket layer's own `not_a_pty_agent` deny: a
+  // buggy client emitting `agent-terminal:connect` for a chat-surface
+  // (`pagespace`) session must be refused here too, before ever touching the
+  // Sprite — the socket deny path and this one share the same reason string.
+  if (!isPtyAgentType(resolved.agentType)) return { ok: false, reason: 'not_a_pty_agent' };
 
   const spec = resolveAgentLaunchSpec(resolved.agentType);
 

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -158,8 +158,9 @@ export type ResolveMachineSandboxResult =
 /**
  * Resolve the Sprite a FRESH PTY will attach to: resolve the agent-terminal row
  * to its sandbox, then read that Sprite once. A read-only resolve failure never
- * touches the Sprite; a vanished Sprite (getSprite throws) denies with
- * `provision_failed`.
+ * touches the Sprite; a chat-surface agentType (e.g. `pagespace`) denies with
+ * `not_a_pty_agent` before the Sprite is touched; a vanished Sprite (getSprite
+ * throws) denies with `provision_failed`.
  */
 export async function resolveMachineSandbox(
   target: ResolveMachineSandboxTarget,

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -20,7 +20,7 @@
  * testable with none.
  */
 
-import { isPtyAgentType, resolveAgentLaunchSpec } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { isPtyAgentType, resolveAgentLaunchSpec, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import type { ResolveAgentTerminalResult } from '@pagespace/lib/services/machines/agent-terminals';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -248,8 +248,16 @@ export interface AgentTerminalCheckAuthDeps {
    * Part of the ACCESS half precisely because it is cheap: authorization must
    * keep noticing that a terminal's project/branch/row was deleted, and the 60s
    * re-auth tick (which never resolves a sandbox) is the only thing that will.
+   *
+   * Surfaces `agentType` on success — unlike `resolveAgentTerminal`, resolving
+   * this row's SCOPE (`resolveScopeKey`) never touches `machineSandbox.acquire`
+   * even for machine/project scope, so this is the earliest point a chat-surface
+   * (`pagespace`) row can be denied `not_a_pty_agent` WITHOUT first waking or
+   * reprovisioning the Machine's Sprite — `resolveMachineSandbox`'s own guard
+   * runs too late for that (it only sees the row after `resolveAgentTerminal`
+   * has already resolved the Sprite's location via `machineSandbox.acquire`).
    */
-  resolveMachineRow: (target: ResolveMachineSandboxTarget) => Promise<{ ok: true } | { ok: false; reason: string }>;
+  resolveMachineRow: (target: ResolveMachineSandboxTarget) => Promise<{ ok: true; agentType: AgentRuntimeType } | { ok: false; reason: string }>;
   writeAudit: (input: { userId: string; actorEmail: string; driveId: string; command: string }) => void;
   buildSessionKey: (args: { machineId: string; projectName?: string; branchName?: string; name: string }) => string;
   logDenied: (reason: string, context: Record<string, unknown>) => void;
@@ -313,6 +321,17 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
     if (!machineRow.ok) {
       deps.logDenied(machineRow.reason, { userId, machineId, projectName, branchName, name });
       return { ok: false, reason: machineRow.reason };
+    }
+
+    // Belt-and-suspenders over the socket layer's own `not_a_pty_agent` deny,
+    // enforced HERE (not only in `resolveMachineSandbox`) because this is the
+    // earliest point the row's agentType is known WITHOUT having already
+    // acquired (and possibly woken/reprovisioned) the machine/project scope's
+    // Sprite — that acquisition happens inside `resolveAgentTerminal`, which
+    // the lazy `resolveSandbox` thunk below only calls for pty-surface rows.
+    if (!isPtyAgentType(machineRow.agentType)) {
+      deps.logDenied('not_a_pty_agent', { userId, machineId, projectName, branchName, name });
+      return { ok: false, reason: 'not_a_pty_agent' };
     }
 
     // Decrypt the actor email BEFORE anything is reserved (a decrypt throw here


### PR DESCRIPTION
## Summary
- Belt-and-suspenders guard over Phase 2's `not_a_pty_agent` deny: `resolveMachineSandbox` now refuses a chat-surface (`pagespace`) agentType with `{ ok: false, reason: 'not_a_pty_agent' }` before ever calling `getSprite`.
- Guards against a buggy client emitting `agent-terminal:connect` for a `pagespace` session, mirroring the reason string the socket deny path already uses.
- Depends on Phase 1's `isPtyAgentType` (merged into `pu/panes-agent`).

## Test plan
- [x] RED: failing test added first — `resolveMachineSandbox` returned `ok: true` and called `getSprite` once for a `pagespace` target.
- [x] GREEN: guard added before `resolveAgentLaunchSpec`; realtime suite green (23 files / 883 tests).
- [x] `bun run --filter 'realtime' typecheck` and `lint` green.
- [x] Independent `/aidd-review` pass — 1 minor finding (stale docblock), fixed in a follow-up commit. 0 blockers/majors.
- [x] Board leaves flipped completed: https://app.pagespace.ai (phase page `yop3evtth9l5joj44do53uv5`)

Issue #2166, phase page `yop3evtth9l5joj44do53uv5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014S43pM62WTTqZTP3wb5cxN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal access validation by rejecting unsupported chat-surface terminal types earlier.
  * Prevented invalid terminal requests from waking or accessing the underlying machine.
  * Ensured denied requests return a consistent `not_a_pty_agent` error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->