### PR TITLE
feat(machines): Phase 5 — deriveMachinePaneBinding pure core + runtime shell (#2166)

### DIFF
--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -102,4 +102,19 @@ export interface ToolExecutionContext {
   // pre-batch checkpoint's "at most once per turn" throttle
   // (`checkpoint-policy.ts`). Undefined until first stamped.
   turnId?: string;
+
+  // "PageSpace Agent" panes (Terminal epics, issue #2166): the server-derived
+  // binding that pins THIS run's default-mode code-exec tools (bash/readFile/
+  // writeFile/editFile) to the machine checkout the pane is bound to —
+  // computed once per request from `deriveMachinePaneBinding`
+  // (@pagespace/lib/services/machines/machine-pane-binding) and never
+  // mutated in place afterward (unlike `activeMachine`, a pagespace pane's
+  // binding is fixed for the conversation's lifetime, not switchable
+  // mid-turn). Undefined for every conversation that isn't a machine-bound
+  // pagespace pane.
+  machineBinding?: {
+    machineId: string;
+    cwd: string;
+    branchSandbox?: { machineBranchId: string; sandboxId: string };
+  };
 }

--- a/apps/web/src/lib/ai/machine-pane/machine-pane-binding-runtime.ts
+++ b/apps/web/src/lib/ai/machine-pane/machine-pane-binding-runtime.ts
@@ -1,0 +1,47 @@
+/**
+ * Production wiring for the Machine Pane binding pure core
+ * (`@pagespace/lib/services/machines/machine-pane-binding`).
+ *
+ * Memoizes the DB stores — same idiom as `agent-terminals-runtime.ts` /
+ * `machine-branches-runtime.ts` (`apps/web/src/lib/machines/`) — and holds NO
+ * decision logic: narrowing each store down to the minimal-slice interfaces
+ * `deriveMachinePaneBinding` expects is plumbing, not policy.
+ */
+
+import { createDbMachineAgentTerminalStore } from '@pagespace/lib/services/machines/agent-terminals-store';
+import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/machine-projects-store';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+import type { DeriveMachinePaneBindingDeps } from '@pagespace/lib/services/machines/machine-pane-binding';
+
+let terminalStorePromise: ReturnType<typeof createDbMachineAgentTerminalStore> | null = null;
+function getMachineAgentTerminalStore() {
+  terminalStorePromise ??= createDbMachineAgentTerminalStore();
+  return terminalStorePromise;
+}
+
+let projectStorePromise: ReturnType<typeof createDbMachineProjectStore> | null = null;
+function getMachineProjectStore() {
+  projectStorePromise ??= createDbMachineProjectStore();
+  return projectStorePromise;
+}
+
+let branchStorePromise: ReturnType<typeof createDbMachineBranchStore> | null = null;
+function getMachineBranchStore() {
+  branchStorePromise ??= createDbMachineBranchStore();
+  return branchStorePromise;
+}
+
+/** Wires `deriveMachinePaneBinding`'s deps to the real DB-backed stores. */
+export function buildMachinePaneBindingDeps(): DeriveMachinePaneBindingDeps {
+  return {
+    terminalStore: {
+      findById: async (id) => (await getMachineAgentTerminalStore()).findById(id),
+    },
+    projectLookup: {
+      findByName: async (machineId, name) => (await getMachineProjectStore()).findByName(machineId, name),
+    },
+    branchLookup: {
+      findById: async (machineBranchId) => (await getMachineBranchStore()).findById(machineBranchId),
+    },
+  };
+}

--- a/knip.json
+++ b/knip.json
@@ -428,6 +428,7 @@
         "src/services/machines/machine-branches.ts",
         "src/services/machines/machine-list.ts",
         "src/services/machines/machine-orphan-reconcile.ts",
+        "src/services/machines/machine-pane-binding.ts",
         "src/services/machines/machine-projects-store.ts",
         "src/services/machines/machine-projects.ts",
         "src/services/machines/machine-settings.ts",

--- a/knip.json
+++ b/knip.json
@@ -42,7 +42,8 @@
         "src/lib/auth/platform-storage/web-storage.ts",
         "src/test/next-server-stub.ts",
         "src/__fixtures__/eslint-unbounded-findmany/**",
-        "src/components/ai/ui/web-preview.tsx"
+        "src/components/ai/ui/web-preview.tsx",
+        "src/lib/ai/machine-pane/machine-pane-binding-runtime.ts"
       ],
       "ignoreDependencies": [
         "eslint-config-next",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -682,6 +682,11 @@
       "import": "./dist/services/machines/agent-terminals.js",
       "require": "./dist/services/machines/agent-terminals.js"
     },
+    "./services/machines/machine-pane-binding": {
+      "types": "./dist/services/machines/machine-pane-binding.d.ts",
+      "import": "./dist/services/machines/machine-pane-binding.js",
+      "require": "./dist/services/machines/machine-pane-binding.js"
+    },
     "./services/machines/machine-access": {
       "types": "./dist/services/machines/machine-access.d.ts",
       "import": "./dist/services/machines/machine-access.js",

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -60,8 +60,15 @@ describe('deriveMachinePaneBinding', () => {
     expect(result).toBeNull();
   });
 
-  it('given a non-pagespace row, should return null', async () => {
+  it('given a non-pagespace (pty-surface) row, should return null', async () => {
     const row = makeRow({ agentType: 'claude' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given a row with an unrecognized/retired agentType (e.g. pagespace-cli), should return null', async () => {
+    const row = makeRow({ agentType: 'pagespace-cli' });
     const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
     const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
     expect(result).toBeNull();

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { deriveMachinePaneBinding, type DeriveMachinePaneBindingDeps } from '../machine-pane-binding';
+import type { MachineAgentTerminalRecord } from '../agent-terminals-store';
+import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from '../machine-branches';
+
+const NOW = new Date('2026-07-20T12:00:00.000Z');
+const MACHINE_ID = 'machine-1';
+const CONVERSATION_ID = 'agent-terminal-1';
+const PROJECT_NAME = 'my-repo';
+const PROJECT_PATH = '/workspace/projects/my-repo';
+const BRANCH_ID = 'branch-1';
+const BRANCH_SANDBOX_ID = 'sprite-branch-1';
+
+function makeRow(overrides: Partial<MachineAgentTerminalRecord> = {}): MachineAgentTerminalRecord {
+  return {
+    id: CONVERSATION_ID,
+    ownerId: 'user-1',
+    machineId: MACHINE_ID,
+    scope: 'machine',
+    projectName: null,
+    machineBranchId: null,
+    name: 'pagespace-agent',
+    agentType: 'pagespace',
+    command: null,
+    streamSessionId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeTerminalStore(row: MachineAgentTerminalRecord | null): DeriveMachinePaneBindingDeps['terminalStore'] {
+  return { findById: async (id) => (id === CONVERSATION_ID ? row : null) };
+}
+
+function makeProjectLookup(rows: Record<string, { path: string }> = {}): DeriveMachinePaneBindingDeps['projectLookup'] {
+  return { findByName: async (machineId, name) => rows[`${machineId}\0${name}`] ?? null };
+}
+
+function makeBranchLookup(
+  rows: Record<string, { sandboxId: string; spriteTornDownAt: Date | null }> = {},
+): DeriveMachinePaneBindingDeps['branchLookup'] {
+  return { findById: async (id) => rows[id] ?? null };
+}
+
+function makeDeps(overrides: Partial<DeriveMachinePaneBindingDeps> = {}): DeriveMachinePaneBindingDeps {
+  return {
+    terminalStore: makeTerminalStore(null),
+    projectLookup: makeProjectLookup(),
+    branchLookup: makeBranchLookup(),
+    ...overrides,
+  };
+}
+
+describe('deriveMachinePaneBinding', () => {
+  it('given no row, should return null', async () => {
+    const deps = makeDeps({ terminalStore: makeTerminalStore(null) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given a non-pagespace row, should return null', async () => {
+    const row = makeRow({ agentType: 'claude' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given row.machineId !== chatId, should fail closed with binding_page_mismatch', async () => {
+    const row = makeRow({ machineId: 'a-different-machine' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'binding_page_mismatch' });
+  });
+
+  it('given machine scope, should bind cwd to SANDBOX_ROOT', async () => {
+    const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: true, binding: { cwd: SANDBOX_ROOT } });
+  });
+
+  it('given project scope with a known project, should bind cwd to the project path', async () => {
+    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      projectLookup: makeProjectLookup({ [`${MACHINE_ID}\0${PROJECT_NAME}`]: { path: PROJECT_PATH } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: true, binding: { cwd: PROJECT_PATH } });
+  });
+
+  it('given project scope with a missing project, should fail closed with project_not_found', async () => {
+    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row), projectLookup: makeProjectLookup({}) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given branch scope with a live branch, should bind cwd to BRANCH_REPO_PATH with the branchSandbox', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      branchLookup: makeBranchLookup({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: null } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({
+      ok: true,
+      binding: { cwd: BRANCH_REPO_PATH, branchSandbox: { machineBranchId: BRANCH_ID, sandboxId: BRANCH_SANDBOX_ID } },
+    });
+  });
+
+  it('given branch scope with a missing branch row, should fail closed with branch_not_found', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row), branchLookup: makeBranchLookup({}) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+  });
+
+  it('given branch scope with a destroyed branch (spriteTornDownAt set), should fail closed with branch_not_found', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      branchLookup: makeBranchLookup({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: NOW } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+  });
+});

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -19,6 +19,8 @@
  */
 
 import type { MachineAgentTerminalStore } from './agent-terminals-store';
+import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from './machine-branches';
 
 /** The agent-terminal `agentType` that marks a row as a PageSpace Agent pane (not a PTY session). */
 const PAGESPACE_AGENT_TYPE = 'pagespace';
@@ -71,10 +73,32 @@ export interface DeriveMachinePaneBindingDeps {
  * scope-existence checks fails CLOSED (`ok: false`) rather than falling back
  * to an unbound run.
  */
-// RED: intentionally unimplemented — see __tests__/machine-pane-binding.test.ts.
 export async function deriveMachinePaneBinding(
-  _input: DeriveMachinePaneBindingInput,
-  _deps: DeriveMachinePaneBindingDeps,
+  input: DeriveMachinePaneBindingInput,
+  deps: DeriveMachinePaneBindingDeps,
 ): Promise<MachinePaneBindingResult> {
-  throw new Error('deriveMachinePaneBinding: not implemented');
+  const row = await deps.terminalStore.findById(input.conversationId);
+  if (!row) return null;
+  if (row.agentType !== PAGESPACE_AGENT_TYPE) return null;
+  if (row.machineId !== input.chatId) return { ok: false, reason: 'binding_page_mismatch' };
+
+  if (row.machineBranchId) {
+    const branch = await deps.branchLookup.findById(row.machineBranchId);
+    if (!branch || branch.spriteTornDownAt !== null) return { ok: false, reason: 'branch_not_found' };
+    return {
+      ok: true,
+      binding: {
+        cwd: BRANCH_REPO_PATH,
+        branchSandbox: { machineBranchId: row.machineBranchId, sandboxId: branch.sandboxId },
+      },
+    };
+  }
+
+  if (row.projectName) {
+    const project = await deps.projectLookup.findByName(row.machineId, row.projectName);
+    if (!project) return { ok: false, reason: 'project_not_found' };
+    return { ok: true, binding: { cwd: project.path } };
+  }
+
+  return { ok: true, binding: { cwd: SANDBOX_ROOT } };
 }

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -21,16 +21,7 @@
 import type { MachineAgentTerminalStore } from './agent-terminals-store';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
-
-/**
- * The agent-terminal `agentType` that marks a row as a PageSpace Agent pane
- * (not a PTY session). Hardcoded here rather than imported from
- * `agent-terminal-types.ts`'s `AGENT_LAUNCH_SPECS` registry because that
- * registry's own `pagespace` entry (issue #2166 step 1) lands in a separate,
- * parallel phase not yet on this branch — reconcile against its canonical
- * constant once that phase merges, instead of duplicating the literal.
- */
-const PAGESPACE_AGENT_TYPE = 'pagespace';
+import { isAgentRuntimeType, isPtyAgentType } from './agent-terminal-types';
 
 export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
 
@@ -74,11 +65,15 @@ export interface DeriveMachinePaneBindingDeps {
 
 /**
  * Derive the machine-pane tool binding for a conversation, or `null` when
- * this conversation isn't a machine-bound PageSpace Agent pane at all (no
- * row, or a page agent's own `agentType` — its conversation is never
- * machine-bound). A resolved `pagespace` row that fails page-identity or
- * scope-existence checks fails CLOSED (`ok: false`) rather than falling back
- * to an unbound run.
+ * this conversation isn't a machine-bound PageSpace Agent pane at all — no
+ * row, an unrecognized/retired `agentType` (e.g. `pagespace-cli`), or a
+ * `'pty'`-surface type (`shell`/`claude`/`codex`) whose own conversation is
+ * never machine-bound. Uses `isAgentRuntimeType`/`isPtyAgentType`
+ * (`agent-terminal-types.ts`) rather than comparing against a hardcoded
+ * `'pagespace'` literal, per that module's own doc comment — this stays
+ * correct if a future `'chat'`-surface type joins the registry. A resolved
+ * chat-surface row that fails page-identity or scope-existence checks fails
+ * CLOSED (`ok: false`) rather than falling back to an unbound run.
  *
  * PERFORMS NO ACCESS CHECK on `input.chatId` itself (mirrors the same
  * explicit caveat on `resolveAgentTerminalById` in `agent-terminals.ts`) —
@@ -95,7 +90,8 @@ export async function deriveMachinePaneBinding(
 ): Promise<MachinePaneBindingResult> {
   const row = await deps.terminalStore.findById(input.conversationId);
   if (!row) return null;
-  if (row.agentType !== PAGESPACE_AGENT_TYPE) return null;
+  if (!isAgentRuntimeType(row.agentType)) return null;
+  if (isPtyAgentType(row.agentType)) return null;
   if (row.machineId !== input.chatId) return { ok: false, reason: 'binding_page_mismatch' };
 
   if (row.machineBranchId) {

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -1,0 +1,80 @@
+/**
+ * Machine Pane binding: pure core (IO injected, no DB, no clock).
+ *
+ * The "PageSpace Agent" pane type (issue #2166) reuses `POST /api/ai/chat` in
+ * DEFAULT mode with `conversationId := machine_agent_terminals.id` — a
+ * `pagespace`-typed agent-terminal row IS the pane's identity. This module
+ * derives that row into the server-authoritative binding that pins the run's
+ * default-mode code-exec tools (bash/readFile/writeFile/editFile) to the
+ * right machine checkout, mirroring `resolveLocationForRow` in
+ * `agent-terminals.ts` (same branch → project → machine dispatch, by the
+ * row's own nullable scope columns) but for the pane's tool-context seam
+ * instead of the realtime PTY bridge.
+ *
+ * `chatId` (the Machine page id the client claims to be talking to) is
+ * checked against the resolved row's OWN `machineId` — never trusted from the
+ * row alone — because `conversationId` is client-suppliable and a stale or
+ * forged pairing must not silently bind tools to a DIFFERENT machine than the
+ * pane the user is actually looking at.
+ */
+
+import type { MachineAgentTerminalStore } from './agent-terminals-store';
+
+/** The agent-terminal `agentType` that marks a row as a PageSpace Agent pane (not a PTY session). */
+const PAGESPACE_AGENT_TYPE = 'pagespace';
+
+export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
+
+export interface MachinePaneBindingBranchSandbox {
+  machineBranchId: string;
+  sandboxId: string;
+}
+
+export interface MachinePaneBinding {
+  cwd: string;
+  branchSandbox?: MachinePaneBindingBranchSandbox;
+}
+
+export type MachinePaneBindingResult =
+  | null
+  | { ok: true; binding: MachinePaneBinding }
+  | { ok: false; reason: MachinePaneBindingFailureReason };
+
+export interface DeriveMachinePaneBindingInput {
+  /** The Machine page id the client claims this pane belongs to. */
+  chatId: string;
+  /** The agent-terminal row id (`machine_agent_terminals.id`) backing this pane. */
+  conversationId: string;
+}
+
+/** The minimal slice of the Projects store this module needs — just enough to resolve a project's clone path. */
+export interface MachinePaneBindingProjectLookup {
+  findByName(machineId: string, name: string): Promise<{ path: string } | null>;
+}
+
+/** The minimal slice of the Branches store this module needs — a branch's Sprite plus whether it's been confirmed destroyed. */
+export interface MachinePaneBindingBranchLookup {
+  findById(machineBranchId: string): Promise<{ sandboxId: string; spriteTornDownAt: Date | null } | null>;
+}
+
+export interface DeriveMachinePaneBindingDeps {
+  terminalStore: Pick<MachineAgentTerminalStore, 'findById'>;
+  projectLookup: MachinePaneBindingProjectLookup;
+  branchLookup: MachinePaneBindingBranchLookup;
+}
+
+/**
+ * Derive the machine-pane tool binding for a conversation, or `null` when
+ * this conversation isn't a machine-bound PageSpace Agent pane at all (no
+ * row, or a page agent's own `agentType` — its conversation is never
+ * machine-bound). A resolved `pagespace` row that fails page-identity or
+ * scope-existence checks fails CLOSED (`ok: false`) rather than falling back
+ * to an unbound run.
+ */
+// RED: intentionally unimplemented — see __tests__/machine-pane-binding.test.ts.
+export async function deriveMachinePaneBinding(
+  _input: DeriveMachinePaneBindingInput,
+  _deps: DeriveMachinePaneBindingDeps,
+): Promise<MachinePaneBindingResult> {
+  throw new Error('deriveMachinePaneBinding: not implemented');
+}

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -22,7 +22,14 @@ import type { MachineAgentTerminalStore } from './agent-terminals-store';
 import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
 import { BRANCH_REPO_PATH } from './machine-branches';
 
-/** The agent-terminal `agentType` that marks a row as a PageSpace Agent pane (not a PTY session). */
+/**
+ * The agent-terminal `agentType` that marks a row as a PageSpace Agent pane
+ * (not a PTY session). Hardcoded here rather than imported from
+ * `agent-terminal-types.ts`'s `AGENT_LAUNCH_SPECS` registry because that
+ * registry's own `pagespace` entry (issue #2166 step 1) lands in a separate,
+ * parallel phase not yet on this branch — reconcile against its canonical
+ * constant once that phase merges, instead of duplicating the literal.
+ */
 const PAGESPACE_AGENT_TYPE = 'pagespace';
 
 export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
@@ -72,6 +79,15 @@ export interface DeriveMachinePaneBindingDeps {
  * machine-bound). A resolved `pagespace` row that fails page-identity or
  * scope-existence checks fails CLOSED (`ok: false`) rather than falling back
  * to an unbound run.
+ *
+ * PERFORMS NO ACCESS CHECK on `input.chatId` itself (mirrors the same
+ * explicit caveat on `resolveAgentTerminalById` in `agent-terminals.ts`) —
+ * the `binding_page_mismatch` check only verifies that the resolved row is
+ * INTERNALLY CONSISTENT with the `chatId` the caller supplied, not that the
+ * caller is entitled to that machine. Whoever wires the actual call site
+ * (issue #2166 phases 6/7) MUST authorize the acting user against `chatId`
+ * BEFORE calling this — the same way the chat route already authorizes page
+ * access for every request.
  */
 export async function deriveMachinePaneBinding(
   input: DeriveMachinePaneBindingInput,


### PR DESCRIPTION
## Summary

Phase 5 of the "PageSpace Agent" pane epic (2witstudios/pagespace#2166). Implements `deriveMachinePaneBinding`, the pure core that pins a machine-bound PageSpace Agent pane's default-mode code-exec tools (bash/readFile/writeFile/editFile) to the right machine checkout, plus its DI runtime shell.

Phase page: `g32klxs0ukt58w5w0r5nyxj8` · Runbook: `sqkxty7n6yce4nj2irtcial3`

- **Pure core** (`packages/lib/src/services/machines/machine-pane-binding.ts`): `deriveMachinePaneBinding(input, deps) → null | {ok:true,binding} | {ok:false,reason}`. Dispatches on the resolved agent-terminal row's own scope columns (branch → project → machine, mirroring `resolveLocationForRow` in `agent-terminals.ts`), validates the row is chat-surface via the registry (`isAgentRuntimeType`/`isPtyAgentType`, not a hardcoded string) and its `machineId` matches the caller's `chatId`, and fails closed on a missing project or missing/torn-down branch.
- **Runtime shell** (`apps/web/src/lib/ai/machine-pane/machine-pane-binding-runtime.ts`): `buildMachinePaneBindingDeps()` — DI wiring only, memoized DB stores, no decision logic.
- **`ToolExecutionContext.machineBinding?`** added to `apps/web/src/lib/ai/core/types.ts`.
- New `@pagespace/lib` subpath export + knip entries for both new modules.

## Acceptance (phase page checklist)

- [x] RED leaf: exhaustive per-branch failing tests (100% branch) for the pure core.
- [x] GREEN leaf: pure `deriveMachinePaneBinding` + `ToolExecutionContext.machineBinding`.
- [x] GREEN leaf: `buildMachinePaneBindingDeps` runtime shell (DI wiring only).
- [x] Review leaf: independent `/aidd-review` of the phase diff — 2 minor doc-only findings, both fixed. Findings recorded on the phase page.

Coverage: 100% branch on `machine-pane-binding.ts` (10 test cases covering all 6 spec bullets + the registry-driven unrecognized-agentType path). `bun run typecheck && bun run lint && bun run knip:check` all green for `@pagespace/lib` + `web`.

Not yet wired into the chat route — the call site lands in phases 6/7 per the runbook's dependency graph (P5 blocks P6, P7).

## Post-open convergence

- Rebased twice onto `pu/panes-agent` as sibling phases landed: Phase 1 (#2180, pagespace registry entry) and Phase 9 (#2181, pane content-kind — no overlap with this diff).
- Refactored the pagespace-row check to use Phase 1's `isAgentRuntimeType`/`isPtyAgentType` accessors instead of the hardcoded `'pagespace'` literal I'd used as a stand-in before Phase 1 existed on this branch — the reconciliation my own `/aidd-review` pass had flagged. Added the one new branch case (unrecognized/retired `agentType`) to hold 100% coverage.
- Briefly bundled a fix for an unrelated trunk-level test regression (Phase 1 made `pagespace` pickable but a pre-existing `TerminalPanes.test.tsx` assertion wasn't updated), then reverted it on discovering a dedicated hotfix PR (#2187) already existed for that exact issue — avoided creating a third duplicate after #2186 had already been closed as one. That fix has since landed on `pu/panes-agent` (via #2181's merge) and this branch now carries it via rebase.

## Test plan

- [x] `bunx vitest run src/services/machines/__tests__/machine-pane-binding.test.ts` — 10/10 passing, 100% branch coverage
- [x] `bun run typecheck --filter=@pagespace/lib --filter=web`
- [x] `bun run lint --filter=@pagespace/lib --filter=web`
- [x] `bun run knip:check`
- [x] `services/machines` suite (569 tests) and `ai/core` suite (1058 tests) green post-rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFMcudbh2dqDh5DfBdmnJv