### PR TITLE
feat(machine-panes): Phase 2 — Lib service: PTY paths refuse chat rows; cheap kill (#2166)

### DIFF
--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -178,8 +178,8 @@ export async function resolveMachineSandbox(
   }
 
   // Both `projectName` AND `branchName` must be set for true branch scope —
-  // matching `resolveScopeKey`/`resolveScopeLocation`'s own discriminator
-  // (`agent-terminals.ts`), rather than relying on the implicit invariant
+  // matching `resolveScopeKey`'s own discriminator (`agent-terminals.ts`),
+  // rather than relying on the implicit invariant
   // that a real `resolveAgentTerminal` already rejects `branchName` without
   // `projectName` as `invalid_target` before ever reaching here. Checking
   // both explicitly means this gate stays correct even if that upstream

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -467,6 +467,70 @@ describe('spawnAgentTerminal — machine scope', () => {
   });
 });
 
+describe('spawnAgentTerminal — pagespace (chat-surface) has NO spawn-side type restriction', () => {
+  it('given a fresh pagespace spawn at branch scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, agentType: 'pagespace' });
+  });
+
+  it('given a fresh pagespace spawn at project scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null, agentType: 'pagespace' });
+  });
+
+  it('given a fresh pagespace spawn at machine scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'machine', projectName: null, machineBranchId: null, agentType: 'pagespace' });
+  });
+
+  it('given a repeat pagespace spawn of the same name, should resume idempotently rather than duplicate', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const first = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    const second = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    expect(first.ok && second.ok && first.id === second.id).toBe(true);
+    expect(second).toMatchObject({ resumed: true });
+  });
+
+  it('given the same name reused under a DIFFERENT agent type (claude then pagespace), should reject as name_in_use', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'claude', actor, deps });
+    const conflicting = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    expect(conflicting).toEqual({ ok: false, reason: 'name_in_use' });
+  });
+});
+
 describe('resolveAgentTerminalRow', () => {
   // The whole point of this resolver: it answers "does this target still exist?"
   // with DB reads alone. Passing `machineSandbox: undefined` throughout is the
@@ -534,6 +598,16 @@ describe('resolveAgentTerminalRow', () => {
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, branchName: BRANCH_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: false, reason: 'invalid_target' });
+  });
+
+  it('given a pagespace (chat-surface) row, should deny not_a_pty_agent WITHOUT any machineSandbox', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup(), machineSandbox: undefined });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
   });
 });
 
@@ -681,6 +755,51 @@ describe('resolveAgentTerminal', () => {
 
     expect(result).toEqual({ ok: false, reason: 'machine_unavailable' });
   });
+
+  it('given a pagespace (chat-surface) row at machine scope, should deny not_a_pty_agent WITHOUT acquiring the machine Sprite', async () => {
+    const { store } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+    expect(acquireCalls).toEqual([]);
+  });
+
+  it('given a pagespace (chat-surface) row at branch scope, should deny not_a_pty_agent', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store });
+    await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+
+    const result = await resolveAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      deps,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+  });
 });
 
 describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} parity)', () => {
@@ -775,6 +894,27 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
 
     expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
   });
+
+  it('given a pagespace (chat-surface) row id, should deny not_a_pty_agent WITHOUT acquiring the machine Sprite', async () => {
+    const { store } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+    expect(acquireCalls).toEqual([]);
+  });
 });
 
 describe('listAgentTerminals', () => {
@@ -839,6 +979,74 @@ describe('killAgentTerminal', () => {
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: true });
+    expect(attachCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a PROJECT-scoped agent terminal whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'claude', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a MACHINE-scoped agent terminal whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a pagespace (chat-surface) agent terminal (never has a streamSessionId), should drop the row WITHOUT touching the Sprite at all', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const attachCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+      host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
     expect(attachCalls).toEqual([]);
     expect(rows.size).toBe(0);
   });
@@ -1119,14 +1327,50 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
     expect(rows.size).toBe(0);
   });
 
-  it('given a machine-scoped row id, should acquire the machine Sprite and drop the row', async () => {
+  it('given a machine-scoped row id whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
     const { store, rows } = makeStore();
-    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
     const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
     expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a pagespace (chat-surface) row id (never has a streamSessionId), should drop the row WITHOUT touching the Sprite at all', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const attachCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+      host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
+    });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(attachCalls).toEqual([]);
     expect(rows.size).toBe(0);
   });
 });

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -47,7 +47,13 @@ import {
   type AgentTerminalScope,
   deriveAgentTerminalScope,
 } from './agent-terminals-store';
-import { isValidAgentTerminalName, isValidAgentTerminalCommand, isAgentRuntimeType, type AgentRuntimeType } from './agent-terminal-types';
+import {
+  isValidAgentTerminalName,
+  isValidAgentTerminalCommand,
+  isAgentRuntimeType,
+  isPtyAgentType,
+  type AgentRuntimeType,
+} from './agent-terminal-types';
 
 export type { AgentTerminalScopeKey, AgentTerminalScope };
 export { deriveAgentTerminalScope };
@@ -176,45 +182,6 @@ async function resolveProjectOrMachineLocation({
   return { ok: true, sandboxId: acquired.sandboxId, cwd };
 }
 
-type ScopeLocationResolution =
-  | { ok: true; scopeKey: AgentTerminalScopeKey; sandboxId: string; cwd: string }
-  | { ok: false; reason: AgentTerminalScopeDenialReason };
-
-/** Resolve WHERE a scope target's Sprite + working directory live, by (project, branch) NAME — used by the by-name resolve/kill path. */
-async function resolveScopeLocation({
-  machineId,
-  projectName,
-  branchName,
-  deps,
-}: {
-  machineId: string;
-  projectName?: string;
-  branchName?: string;
-  deps: Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox'>;
-}): Promise<ScopeLocationResolution> {
-  if (branchName !== undefined) {
-    if (!projectName) return { ok: false, reason: 'invalid_target' };
-    const branch = await deps.branchStore.findByName(machineId, projectName, branchName);
-    if (!branch) return { ok: false, reason: 'branch_not_found' };
-    return {
-      ok: true,
-      scopeKey: { machineId, projectName, machineBranchId: branch.id },
-      sandboxId: branch.sandboxId,
-      cwd: BRANCH_REPO_PATH,
-    };
-  }
-
-  const resolvedProjectName = projectName ?? null;
-  const located = await resolveProjectOrMachineLocation({ machineId, projectName: resolvedProjectName, deps });
-  if (!located.ok) return located;
-  return {
-    ok: true,
-    scopeKey: { machineId, projectName: resolvedProjectName, machineBranchId: null },
-    sandboxId: located.sandboxId,
-    cwd: located.cwd,
-  };
-}
-
 /** Resolve WHERE an already-known ROW's Sprite + working directory live, by its OWN scope columns — the level-agnostic path (no name lookup at all). */
 async function resolveLocationForRow(
   row: Pick<MachineAgentTerminalRecord, 'machineId' | 'projectName' | 'machineBranchId'>,
@@ -321,16 +288,33 @@ export type ResolveAgentTerminalResult =
       command: string | null;
       streamSessionId: string | null;
     }
-  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' | 'not_a_pty_agent' };
 
-function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId: string; cwd: string }): ResolveAgentTerminalResult {
+/**
+ * Is this row's agentType valid AND does it actually spawn a PTY (as opposed
+ * to a `'chat'`-surface type like `pagespace`)? Every resolve/kill path that
+ * would otherwise wake or attach a Sprite must run this check FIRST — a row
+ * nothing can ever launch a PTY on has no business touching a Sprite at all.
+ */
+function checkPtyAgentRow(
+  row: Pick<MachineAgentTerminalRecord, 'agentType'>,
+): { ok: true; agentType: AgentRuntimeType } | { ok: false; reason: 'not_found' | 'not_a_pty_agent' } {
   if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
+  if (!isPtyAgentType(row.agentType)) return { ok: false, reason: 'not_a_pty_agent' };
+  return { ok: true, agentType: row.agentType };
+}
+
+function toResolveResult(
+  row: MachineAgentTerminalRecord,
+  agentType: AgentRuntimeType,
+  location: { sandboxId: string; cwd: string },
+): ResolveAgentTerminalResult {
   return {
     ok: true,
     agentTerminalId: row.id,
     sandboxId: location.sandboxId,
     cwd: location.cwd,
-    agentType: row.agentType,
+    agentType,
     command: row.command,
     streamSessionId: row.streamSessionId,
   };
@@ -338,7 +322,7 @@ function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId:
 
 export type ResolveAgentTerminalRowResult =
   | { ok: true; agentTerminalId: string; agentType: AgentRuntimeType }
-  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' | 'not_a_pty_agent' };
 
 export type ResolveAgentTerminalRowDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store'>;
 
@@ -372,8 +356,9 @@ export async function resolveAgentTerminalRow({
 
   const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
-  if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
-  return { ok: true, agentTerminalId: row.id, agentType: row.agentType };
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
+  return { ok: true, agentTerminalId: row.id, agentType: check.agentType };
 }
 
 /**
@@ -392,12 +377,17 @@ export async function resolveAgentTerminal({
   name,
   deps,
 }: AgentTerminalTarget & { deps: ResolveAgentTerminalDeps }): Promise<ResolveAgentTerminalResult> {
-  const location = await resolveScopeLocation({ machineId, projectName, branchName, deps });
-  if (!location.ok) return location;
+  const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
 
-  const row = await deps.store.findByName(location.scopeKey, name);
+  const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
-  return toResolveResult(row, location);
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+  return toResolveResult(row, check.agentType, location);
 }
 
 /**
@@ -422,10 +412,12 @@ export async function resolveAgentTerminalById({
 }): Promise<ResolveAgentTerminalResult> {
   const row = await deps.store.findById(agentTerminalId);
   if (!row) return { ok: false, reason: 'not_found' };
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
 
   const location = await resolveLocationForRow(row, deps);
   if (!location.ok) return location;
-  return toResolveResult(row, location);
+  return toResolveResult(row, check.agentType, location);
 }
 
 export async function listAgentTerminals({
@@ -501,6 +493,25 @@ async function killAtLocation(
 }
 
 /**
+ * A row with `streamSessionId === null` (a chat-surface row, which never has
+ * one, or a PTY row whose stream was never opened) has nothing running to
+ * kill — drop it with a DB-only write, no Sprite touch at all. Only a row
+ * whose PTY IS running needs its scope's Sprite resolved (which, for
+ * machine/project scope, may acquire/reconnect it) before `killAtLocation`
+ * can reach in and kill that specific session.
+ */
+async function killRow(row: MachineAgentTerminalRecord, deps: KillAgentTerminalDeps): Promise<KillAgentTerminalResult> {
+  if (row.streamSessionId === null) {
+    await deps.store.remove({ machineId: row.machineId, projectName: row.projectName, machineBranchId: row.machineBranchId }, row.name);
+    return { ok: true };
+  }
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+  return killAtLocation(row, location, deps);
+}
+
+/**
  * Tear down a named agent terminal: if its process was ever actually
  * launched (`streamSessionId` set), attach the scope's Sprite through the
  * `MachineHost` seam and kill that specific PTY session, then drop the
@@ -515,13 +526,13 @@ export async function killAgentTerminal({
   name,
   deps,
 }: AgentTerminalTarget & { deps: KillAgentTerminalDeps }): Promise<KillAgentTerminalResult> {
-  const location = await resolveScopeLocation({ machineId, projectName, branchName, deps });
-  if (!location.ok) return location;
+  const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
 
-  const row = await deps.store.findByName(location.scopeKey, name);
+  const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
 
-  return killAtLocation(row, location, deps);
+  return killRow(row, deps);
 }
 
 /**
@@ -543,8 +554,5 @@ export async function killAgentTerminalById({
   const row = await deps.store.findById(agentTerminalId);
   if (!row) return { ok: false, reason: 'not_found' };
 
-  const location = await resolveLocationForRow(row, deps);
-  if (!location.ok) return location;
-
-  return killAtLocation(row, location, deps);
+  return killRow(row, deps);
 }


### PR DESCRIPTION
## Summary

Phase 2/13 of the "PageSpace Agent" pane epic (#2166 step 2). The `agent-terminals.ts` service layer now:

- Refuses Sprite-launch paths for `chat`-surface rows (`agentType: 'pagespace'`) with `{ ok: false, reason: 'not_a_pty_agent' }`, **without ever touching the machine Sprite** — guarded via a new `checkPtyAgentRow` check that runs before any `resolveLocationForRow`/`machineSandbox.acquire` call, shared by `resolveAgentTerminalRow`, `resolveAgentTerminal`, and `resolveAgentTerminalById`.
- Drops a never-launched row (`streamSessionId === null` — every chat row, plus any PTY row whose stream was never opened) via a DB-only `store.remove()`, skipping `resolveLocationForRow`/`machineSandbox.acquire`/`host.attach` entirely — a new `killRow` helper shared by `killAgentTerminal` and `killAgentTerminalById`.
- Leaves `spawnAgentTerminal` untouched — no spawn-side type restriction, `pagespace` reserves at all 3 scopes (machine/project/branch) with identical `resumed`/`name_in_use` semantics to `claude`/`codex`/`shell`.

`resolveScopeLocation` (the old combined scope+Sprite resolver) is now dead and removed — `resolveAgentTerminal`/`killAgentTerminal` (by name) switched to the cheap `resolveScopeKey` followed by `resolveLocationForRow`, so the pty-type guard can run in between before any Sprite is touched. One stale doc-comment reference to the removed function fixed in `apps/realtime/src/terminal/agent-terminal-access.ts`.

**Resolved:** trunk (`pu/panes-agent`) briefly carried a stale `TerminalPanes.test.tsx` assertion (orphaned when Phase 1/#2180 added `pagespace` as `pickable: true`). I initially fixed it on this branch, reverted on discovering two dedicated hotfix PRs already in flight for the same gap (#2186, #2187 — flagged to each other [here](https://github.com/2witstudios/PageSpace/pull/2187#issuecomment-5026422709)), and both were then closed once Phase 9 (#2181, merged) turned out to carry the identical fix. Rebased this branch onto the now-green trunk (`1e9272854`) — diff is back to exactly the 3 files this phase owns.

## Test plan

- [x] RED: 14 new/modified failing tests added to `agent-terminals.test.ts` per the phase `## Spec` (refusal + no-Sprite-touch across resolve-by-name/row/id at machine+branch scope; cheap kill across branch/project/machine scope + chat rows for both kill paths; spawn-at-3-scopes parity for `pagespace`) — confirmed failing for the intended reason, no import errors.
- [x] GREEN: implementation makes all 68 tests in `agent-terminals.test.ts` pass.
- [x] `bun run typecheck && bun run lint` green in `packages/lib`.
- [x] Full `packages/lib` test suite green (8636 passed, 11 pre-existing skips); `services/machines/` suite (572 tests) green.
- [x] `bun run knip:check` within baseline.
- [x] `apps/web` and `apps/realtime` typecheck green (no exhaustive reason-union switches over the resolve/kill denial types needed updating — both route.ts and realtime consume `reason` as an open string).
- [x] Independent review (`/aidd-review`) completed — 0 blockers/majors/minors, 3 nits (no fixes required); findings recorded on the phase page.
- [x] Rebased onto green trunk (`1e9272854`); local gate re-verified post-rebase: `packages/lib` typecheck/lint/tests (68/68) green, `apps/web` + `apps/realtime` typecheck green.

Linked: #2166, phase page `hst4q8i5x9qfikl0z40qqfhi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017acFp1Lc2SkUEWjdt62tbi


