### PR TITLE
test(machine-panes): recover Phase 1's collateral picker-test fix (unblocks pu/panes-agent CI)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -552,7 +552,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, and codex — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +560,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude and codex as secondary AI agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex'],
+      expected: ['shell', 'claude', 'codex', 'pagespace'],
     });
   });
 


### PR DESCRIPTION
## Summary
- Phase 1 (PR #2180, merged) added `pagespace` to `PICKABLE_AGENT_TYPES`, which grows `TerminalPanes`'s agent picker from 3 to 4 options. Phase 1's own `/aidd-review` caught this collateral break and fixed it in commit `033494963` on `pu/panes-agent-p01-registry` — but that fix commit was never part of the squashed PR #2180 that landed on `pu/panes-agent`, so the trunk has carried a failing `ci / Unit Tests` check since Phase 1 merged (confirmed failing on `pu/panes-agent`'s own tip, commit `f5fa45c36`).
- This PR is exactly that orphaned fix, cherry-picked as-is: updates `TerminalPanes.test.tsx`'s picker-option assertion from `['shell', 'claude', 'codex']` to `['shell', 'claude', 'codex', 'pagespace']`. No production code changes — `TerminalPanes.tsx` renders `PICKABLE_AGENT_TYPES` verbatim, and gating the picker to pty-only surfaces is explicitly Phase 2/3/10's job per the epic's dependency graph, not this test's.
- Every phase branch based on `pu/panes-agent` (P2, P3, P4, ...) currently inherits this failing check. Landing this hotfix directly unblocks CI for all of them without any phase needing to carry an unrelated web-app fix in its own diff.

## Test plan
- [x] `TerminalPanes.test.tsx` — 27/27 passing (previously 1 failing) via `cd apps/web && bunx vitest run src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx`.
- [x] Identical to the fix Phase 1's own review already vetted with a 0 blockers/0 majors verdict (see phase page `wgxaet9wjnd4o8op6fnhwn6k`, Findings section, informational note "resolved in 033494963").

Issue #2166. No new scope — recovers a fix that was already reviewed and approved but lost in the squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014S43pM62WTTqZTP3wb5cxN