### PR TITLE
test(machine-panes): fix picker assertion left broken by Phase 1 (#2166)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -552,7 +552,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, and codex — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +560,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude and codex as secondary AI agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex'],
+      expected: ['shell', 'claude', 'codex', 'pagespace'],
     });
   });
 


### PR DESCRIPTION
## Summary

Phase 1 of the "PageSpace Agent" epic (#2166) — the `pagespace` registry entry + `surface` discriminator — already merged into `pu/panes-agent` via #2180. That PR added `pagespace` (`pickable: true`) to `AGENT_LAUNCH_SPECS`, which grows `PICKABLE_AGENT_TYPES` from 3 to 4 entries. One pre-existing test in `apps/web` hard-codes the old 3-entry array and has been failing on trunk since #2180 merged; #2180 didn't touch this file. This PR fixes just that.

- `TerminalPanes.test.tsx`: the agent-picker test asserted `['shell', 'claude', 'codex']` for the rendered `<Select>` options. Updated to `['shell', 'claude', 'codex', 'pagespace']`, matching the picker's actual (registry-driven) output.
- No production code touched. Gating this picker to pty-only surfaces (so `pagespace` doesn't attempt a real PTY spawn) is explicitly Phase 2/3/10's scope per the epic's dependency graph (Orchestration Runbook §1) — not this fix.

## Context

This supersedes #2185, which was opened from a stale local branch that (unknown to that session) duplicated work already merged via #2180 — same RED/GREEN commits, different SHAs from a squash merge. #2185 is being closed as a duplicate; this PR carries forward the one genuinely new, currently-needed piece of it.

## Test plan

- [x] `bunx vitest run src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx` — 27/27 pass
- [x] Diff against `pu/panes-agent` tip is exactly this one file, 3 lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUcvihQnpBmXyXEqEf2btW