### PR TITLE
docs(webhooks): Incoming Webhooks guide + composability integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Incoming Webhooks** — mint a signed, page-scoped URL (owner/admin only, from the webhook icon
+  on a Channel or AI Chat page) so an external system — CI, monitoring, a script — can push events
+  into PageSpace without a full drive-scoped credential. A signed delivery to a Channel webhook
+  posts its `content` verbatim as a message; binding one or more workflows to a webhook (via the
+  new `/api/pages/[pageId]/webhooks/[id]/triggers` API) makes the same delivery also fire those
+  workflows with the full payload as context — the two actions compose rather than being mutually
+  exclusive. See [the Incoming Webhooks docs](https://pagespace.ai/docs/integrations/incoming-webhooks)
+  for the HMAC signing scheme and a working curl example. This is distinct from the existing
+  outbound "Generic Webhook" AI tool provider, which lets an agent call out to an arbitrary URL —
+  Incoming Webhooks is the opposite direction.
 - **`pagespace drives update-context` and a full `pagespace roles` command family** — the CLI can
   now set a drive's AI context prompt (`drives update-context <driveId> <drivePrompt>`) and
   manage custom drive roles end-to-end (`roles list|get|create|update|delete`,

--- a/apps/marketing/src/app/docs/docs-nav.ts
+++ b/apps/marketing/src/app/docs/docs-nav.ts
@@ -27,6 +27,7 @@ import {
   Github,
   Package,
   Terminal,
+  Webhook,
 } from "lucide-react";
 
 export interface NavItem {
@@ -92,6 +93,7 @@ export const docsNav: NavSection[] = [
       { title: "GitHub", href: "/docs/integrations/github", icon: Github },
       { title: "MCP", href: "/docs/integrations/mcp", icon: Server },
       { title: "Desktop MCP", href: "/docs/integrations/mcp/desktop", icon: Monitor },
+      { title: "Incoming Webhooks", href: "/docs/integrations/incoming-webhooks", icon: Webhook },
     ],
   },
   {

--- a/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
@@ -17,7 +17,7 @@ Incoming Webhooks let an external system — CI, a monitoring tool, a cron job, 
 
 ## What you can do
 
-- Mint a named webhook on a **Channel** or an **AI Chat (agent)** page — only the drive's **owner** or an **admin** can create, toggle, or delete one.
+- Mint a named webhook on any non-trashed page — only the drive's **owner** or an **admin** can create, toggle, or delete one. The **Incoming Webhooks** dialog that does this from the UI is currently wired up on **Channel** and **AI Chat (agent)** pages; other page types can still mint one via the API.
 - Get back a URL (\`/api/webhooks/<token>\`) and a secret shown exactly once — save it, PageSpace never shows it again and can't recover it for you.
 - POST any JSON object to that URL, signed with the secret. A **Channel** webhook with no other wiring posts the payload's \`content\` into the channel verbatim, as if a bot had typed it.
 - Bind one or more **workflows** to a webhook (via the API — see below) so the same delivery also kicks off an agent run, with the full payload handed to it as context.

--- a/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
@@ -1,0 +1,126 @@
+import { DocsMarkdown } from "@/components/DocsContent";
+import { createMetadata } from "@/lib/metadata";
+
+export const metadata = createMetadata({
+  title: "Incoming Webhooks — Integration",
+  description: "Mint a signed, page-scoped URL so an external system (CI, monitoring, a script) can push events into a PageSpace channel or trigger a workflow — HMAC signing, curl example, and how it composes with workflow triggers.",
+  path: "/docs/integrations/incoming-webhooks",
+  keywords: ["webhooks", "incoming webhooks", "HMAC", "signature", "CI", "monitoring", "workflow trigger", "curl"],
+});
+
+const content = `
+# Incoming Webhooks
+
+Incoming Webhooks let an external system — CI, a monitoring tool, a cron job, any script that can send an HTTP POST — push events into PageSpace, without handing it a full account credential. Mint a URL scoped to one page, and every delivery to it is signed and verified.
+
+> **Not the same thing as the "Generic Webhook" AI tool.** PageSpace also has an *outbound* AI tool provider (used by agents to call out to an arbitrary URL as part of a tool call). Incoming Webhooks is the opposite direction: an external system calling *into* PageSpace. If you're looking for how an agent posts data out to a webhook, that's a different feature — this page is about receiving.
+
+## What you can do
+
+- Mint a named webhook on a **Channel** or an **AI Chat (agent)** page — only the drive's **owner** or an **admin** can create, toggle, or delete one.
+- Get back a URL (\`/api/webhooks/<token>\`) and a secret shown exactly once — save it, PageSpace never shows it again and can't recover it for you.
+- POST any JSON object to that URL, signed with the secret. A **Channel** webhook with no other wiring posts the payload's \`content\` into the channel verbatim, as if a bot had typed it.
+- Bind one or more **workflows** to a webhook (via the API — see below) so the same delivery also kicks off an agent run, with the full payload handed to it as context.
+- Disable a webhook without deleting it (its URL stops accepting deliveries but its history and bindings stay), or delete it outright.
+
+## The POST contract
+
+- **Body**: any JSON object, up to **64KB** raw. Larger bodies are rejected with \`413\` before PageSpace even attempts to parse them.
+- **Headers**: \`x-pagespace-signature\` and \`x-pagespace-timestamp\` (see signing below). A missing or invalid signature, or a timestamp more than 5 minutes old, gets a generic \`403\`.
+- **Unknown or disabled webhook**: a generic \`404\` — PageSpace never reveals whether a token used to exist.
+- **Channel pages** additionally require \`{ "content": string, "username"?: string }\` — this is deliberately Discord's incoming-webhook shape. \`content\` is posted verbatim (up to 4000 characters); \`username\`, if set, overrides the webhook's configured name as the message's displayed sender (up to 80 characters).
+- **Pages with no default action** (anything that isn't a Channel today) still accept any JSON object — there's just nothing to post it into unless a workflow trigger is bound.
+
+## Signing a delivery
+
+PageSpace's native scheme (\`v0\`) is HMAC-SHA256 over \`v0:{timestamp}:{rawBody}\`, sent as two headers:
+
+- \`x-pagespace-timestamp\` — Unix seconds when you signed the request.
+- \`x-pagespace-signature\` — \`v0=<hex-encoded HMAC-SHA256 of the message above, using your webhook's secret>\`.
+
+The signature must be computed over the **exact bytes** you send as the body — sign first, then send that same string unmodified.
+
+**Bash / openssl:**
+
+\`\`\`bash
+SECRET="the-secret-shown-when-you-created-the-webhook"
+URL="https://your-pagespace-host/api/webhooks/<token>"
+BODY='{"content":"Deploy finished ✅","username":"CI"}'
+
+TIMESTAMP=$(date +%s)
+SIGNATURE="v0=$(printf '%s' "v0:\${TIMESTAMP}:\${BODY}" \\
+  | openssl dgst -sha256 -hmac "$SECRET" \\
+  | sed 's/^.* //')"
+
+curl -X POST "$URL" \\
+  -H "Content-Type: application/json" \\
+  -H "x-pagespace-timestamp: $TIMESTAMP" \\
+  -H "x-pagespace-signature: $SIGNATURE" \\
+  -d "$BODY"
+\`\`\`
+
+**Node.js:**
+
+\`\`\`js
+import { createHmac } from "crypto";
+
+const secret = "the-secret-shown-when-you-created-the-webhook";
+const url = "https://your-pagespace-host/api/webhooks/<token>";
+const timestamp = Math.floor(Date.now() / 1000);
+const body = JSON.stringify({ content: "Deploy finished ✅", username: "CI" });
+const signature = "v0=" + createHmac("sha256", secret).update(\`v0:\${timestamp}:\${body}\`).digest("hex");
+
+await fetch(url, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-pagespace-timestamp": String(timestamp),
+    "x-pagespace-signature": signature,
+  },
+  body,
+});
+\`\`\`
+
+A \`200\` means the default action ran (a Channel post, for example). A \`202 { accepted: true, action: "none" | "triggers" }\` means the delivery was accepted but had no channel action, bound workflows, or both — \`action\` tells you which. Any \`4xx\`/\`5xx\` means nothing ran; a well-behaved sender should retry those.
+
+## Composability: one delivery, two actions
+
+A single signed delivery can do **both** things at once — post the default action for the page type **and** fire every enabled workflow bound to that webhook. They're not alternatives; binding a workflow doesn't turn off the channel post, and the channel post doesn't block the workflow from also running.
+
+Bindings are managed through the API (there's no dedicated UI for this yet):
+
+\`\`\`bash
+# Bind a workflow to a webhook — owner/admin only, workflow must be in the same drive as the page
+curl -X POST "https://your-pagespace-host/api/pages/<pageId>/webhooks/<webhookId>/triggers" \\
+  -H "Content-Type: application/json" \\
+  -H "Cookie: <your session cookie>" \\
+  -d '{"workflowId":"<workflowId>"}'
+\`\`\`
+
+Once bound, the workflow receives the full JSON payload as context (wrapped so the agent sees it verbatim) prepended to its configured prompt, and runs under the workflow owner's billing and credit limits — the sender never waits on it, since it fires after the HTTP response goes out.
+
+### Try it yourself (manual end-to-end check)
+
+1. Create a Channel page and open its **Incoming Webhooks** dialog (the webhook icon in the page toolbar, titled "Incoming Webhooks") to mint a webhook. Save the URL and secret.
+2. Create a workflow (an AI Chat agent with a scheduled/triggerable prompt) in the same drive, then bind it to the webhook with the API call above.
+3. Send one signed \`POST\` with \`{"content": "Deploy finished"}\` using either signing example above.
+4. Confirm **both** things happened from that single request: the message \`Deploy finished\` appears verbatim in the channel, **and** a new run shows up for the bound workflow (its agent page picks up the delivery as context).
+
+## Good to know
+
+- **Least privilege by design.** A webhook secret only ever authenticates deliveries to the one page it was minted on — it can't read, list, or act on anything else in the drive, unlike a full API key or OAuth token.
+- **No dedupe, no event-type filtering (yet).** Every enabled trigger on a webhook fires on every accepted delivery; if you need "only fire on this kind of event," filter in the payload you send or in the workflow's own prompt.
+- **A page moved to a different drive after a trigger was bound** is re-checked at fire time — if the page's current drive no longer matches the workflow's drive, that trigger is skipped and recorded as a stale binding rather than silently executed.
+- **The secret is shown once.** If you lose it, delete the webhook and mint a new one — PageSpace stores it encrypted and can't display it again.
+
+## Related
+
+- [Channels](/docs/page-types/channel) — the page type with a built-in default webhook action today.
+- [AI Chat](/docs/page-types/ai-chat) — where bound workflows run and how agent prompts work.
+- [AI in your Workspace](/docs/features/ai) — how workflows and agent runs fit into the bigger picture.
+- [Zero-Trust](/docs/security/zero-trust) — the broader signing/verification model this shares with Google Calendar and Zoom.
+`;
+
+export default function IncomingWebhooksPage() {
+  return <DocsMarkdown content={content} />;
+}

--- a/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
@@ -81,19 +81,19 @@ await fetch(url, {
 });
 \`\`\`
 
-A \`200\` means the default action ran (a Channel post, for example). A \`202 { accepted: true, action: "none" | "triggers" }\` means the delivery was accepted but had no channel action, bound workflows, or both — \`action\` tells you which. Any \`4xx\`/\`5xx\` means nothing ran; a well-behaved sender should retry those.
+A \`200\` means the default action ran (a Channel post, for example). A \`202 { accepted: true, action: "none" | "triggers" }\` means the delivery was accepted but had no channel action, bound workflows, or both — \`action\` tells you which. Only retry a \`429\` (rate limited) or a \`5xx\`/\`503\` (transient) — those are the sole retryable outcomes. \`400\` (malformed payload), \`403\` (bad/missing signature), \`404\` (unknown or disabled token), and \`413\` (body too large) are permanent failures: fix the request before sending it again, since an unmodified retry can only fail the same way, and retrying it in a loop risks a retry storm against your own integration.
 
 ## Composability: one delivery, two actions
 
 A single signed delivery can do **both** things at once — post the default action for the page type **and** fire every enabled workflow bound to that webhook. They're not alternatives; binding a workflow doesn't turn off the channel post, and the channel post doesn't block the workflow from also running.
 
-Bindings are managed through the API (there's no dedicated UI for this yet):
+Bindings are managed through the API (there's no dedicated UI for this yet). Managing webhooks (minting, and binding triggers) is deliberately a human console action — a *drive-scoped* \`mcp_...\` token is rejected outright, on purpose. Script it with an **all-drives** token instead: \`pagespace keys create --all-drives --name ci-webhooks --show-token --yes\` (see [MCP](/docs/integrations/mcp)), or mint one from **Settings > MCP**. That token carries your own owner/admin authority and authenticates as a \`Bearer\` token, which also sidesteps this write endpoint's CSRF check (CSRF only applies to cookie-based session auth):
 
 \`\`\`bash
 # Bind a workflow to a webhook — owner/admin only, workflow must be in the same drive as the page
 curl -X POST "https://your-pagespace-host/api/pages/<pageId>/webhooks/<webhookId>/triggers" \\
   -H "Content-Type: application/json" \\
-  -H "Cookie: <your session cookie>" \\
+  -H "Authorization: Bearer mcp_your_token_here" \\
   -d '{"workflowId":"<workflowId>"}'
 \`\`\`
 

--- a/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
@@ -102,7 +102,7 @@ Once bound, the workflow receives the full JSON payload as context (wrapped so t
 ### Try it yourself (manual end-to-end check)
 
 1. Create a Channel page and open its **Incoming Webhooks** dialog (the webhook icon in the page toolbar, titled "Incoming Webhooks") to mint a webhook. Save the URL and secret.
-2. Create a workflow (an AI Chat agent with a scheduled/triggerable prompt) in the same drive, then bind it to the webhook with the API call above.
+2. Create a workflow from the drive's **Workflows** dashboard (\`/dashboard/<driveId>/workflows\`) — it needs a name, a prompt, an AI Chat agent page to run against, and a cron schedule (the schedule still applies; binding a trigger just adds "also run on a webhook delivery" on top of it). Bind it to the webhook with the API call above.
 3. Send one signed \`POST\` with \`{"content": "Deploy finished"}\` using either signing example above.
 4. Confirm **both** things happened from that single request: the message \`Deploy finished\` appears verbatim in the channel, **and** a new run shows up for the bound workflow (its agent page picks up the delivery as context).
 

--- a/apps/marketing/src/app/docs/integrations/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
-import { ArrowRight, Calendar, Github, Server, Monitor } from "lucide-react";
+import { ArrowRight, Calendar, Github, Server, Monitor, Webhook } from "lucide-react";
 import { createMetadata } from "@/lib/metadata";
 
 export const metadata = createMetadata({
   title: "Integrations",
-  description: "Google Calendar, GitHub, and MCP — the three ways PageSpace connects to what lives outside it.",
+  description: "Google Calendar, GitHub, MCP, and Incoming Webhooks — how PageSpace connects to what lives outside it, in both directions.",
   path: "/docs/integrations",
-  keywords: ["integrations", "Google Calendar", "GitHub", "MCP", "Claude Desktop", "Cursor"],
+  keywords: ["integrations", "Google Calendar", "GitHub", "MCP", "Claude Desktop", "Cursor", "webhooks"],
 });
 
 const integrations = [
@@ -14,6 +14,7 @@ const integrations = [
   { title: "GitHub", href: "/docs/integrations/github", icon: Github, description: "Give agents a GitHub identity — browse repos, leave PR reviews, file issues, all under your account." },
   { title: "MCP", href: "/docs/integrations/mcp", icon: Server, description: "Connect Claude Desktop, Cursor, or any MCP client to your workspace using a scoped token." },
   { title: "Desktop MCP", href: "/docs/integrations/mcp/desktop", icon: Monitor, description: "Run local MCP servers inside the PageSpace desktop app — your AI chats get the same external tools you use everywhere else." },
+  { title: "Incoming Webhooks", href: "/docs/integrations/incoming-webhooks", icon: Webhook, description: "Mint a signed, page-scoped URL so CI, monitoring, or a script can push events into a channel or fire a workflow." },
 ];
 
 export default function IntegrationsIndexPage() {
@@ -21,7 +22,7 @@ export default function IntegrationsIndexPage() {
     <div>
       <h1 className="text-3xl font-bold tracking-tight mb-4">Integrations</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>. That&#39;s the full list.
+        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>, and external systems push events in through <strong>Incoming Webhooks</strong>.
       </p>
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/web/src/app/api/webhooks/[token]/__tests__/composability.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/composability.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'crypto';
+
+/**
+ * Deep composability proof for the Incoming Webhooks primitive.
+ *
+ * route.test.ts already proves, at the route-orchestration layer, that
+ * `dispatchWebhookDelivery` and `firePageWebhookTriggers` are BOTH invoked for
+ * one delivery — but it mocks `firePageWebhookTriggers` away entirely, so it
+ * can't tell a real workflow invocation from a stub.
+ *
+ * This file keeps the CHANNEL default action (`dispatchWebhookDelivery`,
+ * `packages/lib`) mocked at the same boundary as route.test.ts — that path
+ * already has its own dedicated unit coverage in packages/lib — but lets the
+ * ENTIRE trigger fan-out run for real: `firePageWebhookTriggers` ->
+ * `executePageWebhookTrigger` -> the drive-match guard, billing/credit gate,
+ * and prompt construction all execute as written, mocked only at the true
+ * leaves (`executeWorkflow`, permissions, credit gate/consume, rate limit,
+ * db). One signed POST to a CHANNEL webhook with an enabled workflow trigger
+ * must invoke BOTH the channel handler AND `executeWorkflow` exactly once —
+ * proving the two action paths compose instead of being mutually exclusive.
+ */
+
+const SECRET = 'test-webhook-secret';
+const WEBHOOK = {
+  id: 'wh-1',
+  pageId: 'page-1',
+  name: 'Deploys',
+  isEnabled: true,
+  webhookToken: 'tok-abc',
+  webhookSecretEncrypted: 'encrypted-form-of-secret',
+};
+const TRIGGER = { id: 'trigger-1', workflowId: 'workflow-1', pageWebhookId: 'wh-1', isEnabled: true };
+const WORKFLOW = {
+  id: 'workflow-1',
+  driveId: 'drive-1',
+  createdBy: 'user-1',
+  agentPageId: 'agent-page-1',
+  prompt: 'Summarize the delivery',
+  contextPageIds: [],
+  instructionPageId: null,
+  timezone: 'UTC',
+};
+
+const mockPageWebhookFindFirst = vi.fn();
+const mockWebhookTriggersFindMany = vi.fn();
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pageWebhooks: { findFirst: (...args: unknown[]) => mockPageWebhookFindFirst(...args) },
+      webhookTriggers: { findMany: (...args: unknown[]) => mockWebhookTriggersFindMany(...args) },
+    },
+    // executePageWebhookTrigger walks a fixed sequence of select().from().where()
+    // lookups for a single trigger fire: 1) the linked workflow row, 2) the
+    // webhook -> pageId, 3) the webhook's page (drive/trashed), 4) the agent
+    // page (drive/trashed), 5) the billing owner row. A queue is simpler and
+    // just as accurate as matching on table identity for one delivery.
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(selectQueue[selectCallIndex++] ?? []),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => Promise.resolve(),
+      }),
+    }),
+  },
+}));
+
+let selectQueue: unknown[][] = [];
+let selectCallIndex = 0;
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  and: (...conds: unknown[]) => ({ and: conds }),
+}));
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({
+  pageWebhooks: { id: 'pageWebhooks.id', webhookToken: 'pageWebhooks.webhookToken', pageId: 'pageWebhooks.pageId' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', driveId: 'pages.driveId', isTrashed: 'pages.isTrashed' },
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'workflows.id' } }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'users.id', subscriptionTier: 'users.subscriptionTier' } }));
+vi.mock('@pagespace/db/schema/webhook-triggers', () => ({
+  webhookTriggers: {
+    id: 'webhookTriggers.id',
+    pageWebhookId: 'webhookTriggers.pageWebhookId',
+    isEnabled: 'webhookTriggers.isEnabled',
+  },
+}));
+
+vi.mock('@pagespace/lib/encryption/field-crypto', () => ({
+  decryptField: vi.fn(async (v: string) => (v === WEBHOOK.webhookSecretEncrypted ? SECRET : v)),
+}));
+
+// The CHANNEL default action — same mocking boundary route.test.ts uses.
+// Its real payload-validation/rate-limit/insert logic has dedicated unit
+// coverage in packages/lib; this file's job is proving composability, not
+// re-testing that logic.
+const mockDispatch = vi.fn();
+vi.mock('@pagespace/lib/services/page-webhook-dispatch', () => ({
+  dispatchWebhookDelivery: (...args: unknown[]) => mockDispatch(...args),
+}));
+
+const mockCheckDistributedRateLimit = vi.fn();
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: (...args: unknown[]) => mockCheckDistributedRateLimit(...args),
+  DISTRIBUTED_RATE_LIMITS: { PAGE_WEBHOOK: {}, PAGE_WEBHOOK_TRIGGER: {} },
+}));
+
+const mockIsUserDriveMember = vi.fn();
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: (...args: unknown[]) => mockIsUserDriveMember(...args),
+}));
+
+const mockCanConsumeAI = vi.fn();
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: (...args: unknown[]) => mockCanConsumeAI(...args),
+}));
+
+const mockReleaseHold = vi.fn();
+vi.mock('@pagespace/lib/billing/credit-consume', () => ({
+  releaseHold: (...args: unknown[]) => mockReleaseHold(...args),
+}));
+
+const mockExecuteWorkflow = vi.fn();
+vi.mock('@/lib/workflows/workflow-executor', () => ({
+  executeWorkflow: (...args: unknown[]) => mockExecuteWorkflow(...args),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const child = () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() });
+  return {
+    loggers: {
+      api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child },
+      system: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child },
+    },
+  };
+});
+
+// `after()` schedules post-response work in real Next.js. The test captures
+// the callback instead of firing it inline, so it can explicitly await the
+// trigger fan-out after the sender's response — deterministic, no race
+// between the HTTP response and the background fan-out.
+let capturedAfter: (() => unknown) | null = null;
+vi.mock('next/server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return { ...actual, after: (fn: () => unknown) => { capturedAfter = fn; } };
+});
+
+import { POST } from '../route';
+
+function sign(body: string, timestamp: string, secret = SECRET): string {
+  return 'v0=' + createHmac('sha256', secret).update(`v0:${timestamp}:${body}`).digest('hex');
+}
+
+function signedRequest(body: string): Request {
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  return new Request('https://example.com/api/webhooks/tok-abc', {
+    method: 'POST',
+    body,
+    headers: {
+      'content-type': 'application/json',
+      'x-pagespace-signature': sign(body, timestamp),
+      'x-pagespace-timestamp': timestamp,
+    },
+  });
+}
+
+const VALID_PAYLOAD = JSON.stringify({ content: 'deploy finished' });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedAfter = null;
+  selectCallIndex = 0;
+
+  mockPageWebhookFindFirst.mockResolvedValue(WEBHOOK);
+  mockWebhookTriggersFindMany.mockResolvedValue([TRIGGER]);
+  mockDispatch.mockResolvedValue({ kind: 'handled' });
+
+  mockCheckDistributedRateLimit.mockResolvedValue({ allowed: true });
+  mockIsUserDriveMember.mockResolvedValue(true);
+  mockCanConsumeAI.mockResolvedValue({ allowed: true, holdId: 'hold-1' });
+  mockReleaseHold.mockResolvedValue(undefined);
+  mockExecuteWorkflow.mockResolvedValue({ success: true, durationMs: 5 });
+
+  // Fixed sequence executePageWebhookTrigger walks for a single trigger fire:
+  // 1) workflows row, 2) webhook -> pageId, 3) webhook page (drive/trashed),
+  // 4) agent page (drive/trashed), 5) billing owner row.
+  selectQueue = [
+    [WORKFLOW],
+    [{ pageId: WEBHOOK.pageId }],
+    [{ driveId: WORKFLOW.driveId, isTrashed: false }],
+    [{ id: WORKFLOW.agentPageId, isTrashed: false, driveId: WORKFLOW.driveId }],
+    [{ subscriptionTier: 'free' }],
+  ];
+});
+
+describe('Incoming Webhooks: composability (real trigger fan-out reaches executeWorkflow)', () => {
+  it('one signed POST to a CHANNEL webhook with an enabled trigger runs the default action AND fires the bound workflow — exactly once each', async () => {
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+    expect(response.status).toBe(200);
+
+    // The default CHANNEL action ran for this delivery, and was told triggers
+    // are firing alongside it (not instead of it).
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookId: WEBHOOK.id, pageId: WEBHOOK.pageId, hasEnabledTriggers: true }),
+    );
+
+    // The bound workflow trigger hasn't run yet — it's deferred to after().
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+
+    // Flush the after() fan-out: the REAL firePageWebhookTriggers ->
+    // executePageWebhookTrigger pipeline runs (drive-match guard, credit gate,
+    // prompt construction all execute as written) and reaches the mocked
+    // executeWorkflow boundary — for the SAME delivery that already ran the
+    // channel action above.
+    expect(capturedAfter).not.toBeNull();
+    await capturedAfter?.();
+
+    expect(mockExecuteWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockExecuteWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: WORKFLOW.id,
+        driveId: WORKFLOW.driveId,
+        createdBy: WORKFLOW.createdBy,
+        source: expect.objectContaining({ table: 'webhookTriggers', id: TRIGGER.id }),
+      }),
+    );
+    // The channel action still only ran once — the fan-out didn't duplicate it.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch executeWorkflow when the webhook has no bound triggers (paths are decoupled, not implicitly linked)', async () => {
+    mockWebhookTriggersFindMany.mockResolvedValue([]);
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+    expect(response.status).toBe(200);
+
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(expect.objectContaining({ hasEnabledTriggers: false }));
+    expect(capturedAfter).toBeNull();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('skips (and does not execute) a trigger whose webhook page has moved to a different drive than the workflow — the fire-time guard runs for real', async () => {
+    selectQueue = [
+      [WORKFLOW],
+      [{ pageId: WEBHOOK.pageId }],
+      [{ driveId: 'some-other-drive', isTrashed: false }], // webhook page moved out of the workflow's drive
+    ];
+
+    const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
+    expect(response.status).toBe(200);
+
+    await capturedAfter?.();
+
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+    // The channel action still ran — a stale trigger binding doesn't block it.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/webhooks/[token]/__tests__/composability.test.ts
+++ b/apps/web/src/app/api/webhooks/[token]/__tests__/composability.test.ts
@@ -257,6 +257,11 @@ describe('Incoming Webhooks: composability (real trigger fan-out reaches execute
     const response = await POST(signedRequest(VALID_PAYLOAD), { params: Promise.resolve({ token: 'tok-abc' }) });
     expect(response.status).toBe(200);
 
+    // The fan-out WAS scheduled — the guard, not a missing after(), is what
+    // must prevent execution. Without this, a regression that stopped after()
+    // from firing at all would make the not-called assertion below pass for
+    // the wrong reason.
+    expect(capturedAfter).not.toBeNull();
     await capturedAfter?.();
 
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();


### PR DESCRIPTION
## What

Final task on the Page Webhooks epic: user docs, a changelog entry, and an automated proof that one signed delivery composes the default page-type action with workflow triggers.

- **Docs** — new `/docs/integrations/incoming-webhooks` page: the least-privilege page-scoped credential value prop, how to mint one (owner/admin only), the POST contract (64KB envelope cap, the CHANNEL handler's `{content, username?}` shape), a complete working curl+openssl and Node.js example computing the `v0` HMAC signature, how to bind a workflow trigger via the API, and an explicit "this is not the outbound Generic Webhook AI tool provider" disambiguation. Wired into `docs-nav.ts` and the integrations index (updated the "MCP is the only inward integration" copy).
- **Changelog** — hand-written `CHANGELOG.md` entry. `bun run changelog:generate` errors (`ERR_MODULE_NOT_FOUND` — `scripts/changelog/index.ts` doesn't exist in this checkout); that's a pre-existing repo issue, not touched here.
- **Composability test** — `apps/web/src/app/api/webhooks/[token]/__tests__/composability.test.ts`, alongside the existing route tests. It mocks only the true leaves (`executeWorkflow`, permissions, credit gate/consume, rate limiting, db) and lets the real trigger fan-out run for real — `firePageWebhookTriggers` → `executePageWebhookTrigger`, including its cross-drive fire-time guard — while `dispatchWebhookDelivery` stays mocked at the same boundary the existing `route.test.ts` already uses (its packages/lib logic has its own dedicated unit coverage, and packages/lib's compiled dist is externalized by Vite's SSR pipeline so `vi.mock` can't reach nested `require()`s inside it from an apps/web test — confirmed by reproducing the failure before scoping the mock boundary back).

Three assertions:
1. One signed POST to a CHANNEL webhook with an enabled trigger runs the default action AND reaches `executeWorkflow` exactly once for the same delivery.
2. No trigger bound → `executeWorkflow` is never touched (the paths are decoupled, not implicitly linked).
3. A trigger whose webhook page has moved to a different drive than the workflow is skipped (guard runs for real) without blocking the channel post.

## Manual E2E runbook (owner's verification step)

A true live-stack E2E needs a running web+realtime+db+AI stack, which is out of scope for an automated test. Documented as a runbook in the new doc:

1. Create a Channel page, open its Incoming Webhooks dialog, mint a webhook.
2. Create a workflow in the same drive, bind it to the webhook via `POST /api/pages/<pageId>/webhooks/<webhookId>/triggers`.
3. Send one signed POST with `{"content": "Deploy finished"}`.
4. Confirm both: the message appears verbatim in the channel, and a new run shows up for the bound workflow.

This live verification is the epic owner's manual step — not re-attempted here.

## Test plan

- [x] `cd apps/web && bunx vitest run "src/app/api/webhooks/[token]/__tests__/"` — 27/27 green (24 existing + 3 new)
- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` — exit 0 (pre-existing warnings only, unrelated to this change)
- [x] `bun run knip:check` — passes (within baseline)
- [x] `bun run --filter=marketing typecheck` — exit 0 (new docs page)
- [ ] Owner: live-stack manual E2E per the runbook above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkDLzrXqUmBF3niKyM1TJe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Incoming Webhooks for securely sending signed events into PageSpace.
  * Webhooks can post messages to channels and trigger workflows using the full event payload as context.
  * Added owner/admin controls and page-scoped webhook configuration.

* **Documentation**
  * Added setup, request, signing, retry, workflow-binding, and API guidance.
  * Added Incoming Webhooks to the Integrations documentation and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->