### PR TITLE
feat(sandbox): Phase 8 — branch acquire seam (attach-only)

### DIFF
--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -32,6 +32,8 @@ import {
   createDbMachineSessionStore,
 } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { acquireMachineSandbox } from '@pagespace/lib/services/sandbox/machine-session';
+import { acquireBranchSandbox } from '@pagespace/lib/services/sandbox/branch-session';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/machine-billing';
 import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
 import { lookupPageOwnerId } from '@pagespace/lib/billing/machine-payer';
@@ -72,6 +74,13 @@ let sandboxClientPromise: Promise<ExecSandboxClient> | null = null;
 function getStore() {
   storePromise ??= createDbMachineSessionStore();
   return storePromise;
+}
+
+let branchStorePromise: ReturnType<typeof createDbMachineBranchStore> | null = null;
+
+function getBranchStore() {
+  branchStorePromise ??= createDbMachineBranchStore();
+  return branchStorePromise;
 }
 
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one.
@@ -120,28 +129,48 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
 export function buildRealSandboxRunDeps(): SandboxRunDeps {
   return {
     isEnabled: isCodeExecutionEnabled,
-    acquireSandbox: async (input) =>
-      acquireMachineSandbox({
-        ...input,
-        deps: {
-          store: await getStore(),
-          client: await getSandboxClient(),
-          authorize: canRunCode,
-          now: () => new Date(),
-          secret: getSandboxSessionSecret(),
-          // Full-egress G-gate: the agent sandbox runs OPEN egress, so refuse to
-          // provision unless containment is verified for the live topology
-          // (SANDBOX_CONTAINMENT_VERIFIED=true after the G1 probes pass). Admin
-          // gate has precedence. Fail-closed when unset.
-          checkFullEgressEnablement: async () =>
-            decideFullEgressEnablement({
-              adminGateEnabled: isCodeExecutionEnabled(),
-              containment: isContainmentVerified() ? { contained: true } : null,
-            }),
-          checkMachineRuntimeGuardrail,
-          recordMachineActivity,
-        },
-      }),
+    // Branch-scoped "PageSpace Agent" panes (issue #2166 phase 8) route to the
+    // attach-only branch seam instead of the machine's own persistent
+    // session — a branch's Sprite is provisioned exclusively by the
+    // branch-spawn path, never lazily here.
+    acquireSandbox: async ({ branchSandbox, ...input }) =>
+      branchSandbox
+        ? acquireBranchSandbox({
+            driveId: input.driveId,
+            userId: input.userId,
+            requestOrigin: input.requestOrigin,
+            agentPageId: input.agentPageId,
+            machineId: branchSandbox.machineId,
+            machineBranchId: branchSandbox.machineBranchId,
+            deps: {
+              authorize: canRunCode,
+              now: () => new Date(),
+              checkMachineRuntimeGuardrail,
+              recordMachineActivity,
+              findBranch: async (machineBranchId) => (await getBranchStore()).findById(machineBranchId),
+            },
+          })
+        : acquireMachineSandbox({
+            ...input,
+            deps: {
+              store: await getStore(),
+              client: await getSandboxClient(),
+              authorize: canRunCode,
+              now: () => new Date(),
+              secret: getSandboxSessionSecret(),
+              // Full-egress G-gate: the agent sandbox runs OPEN egress, so refuse to
+              // provision unless containment is verified for the live topology
+              // (SANDBOX_CONTAINMENT_VERIFIED=true after the G1 probes pass). Admin
+              // gate has precedence. Fail-closed when unset.
+              checkFullEgressEnablement: async () =>
+                decideFullEgressEnablement({
+                  adminGateEnabled: isCodeExecutionEnabled(),
+                  containment: isContainmentVerified() ? { contained: true } : null,
+                }),
+              checkMachineRuntimeGuardrail,
+              recordMachineActivity,
+            },
+          }),
     reconnect: async (sandboxId) => (await getSandboxClient()).get({ sandboxId }),
     quota: {
       acquireSlot: acquireCodeExecutionSlot,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -502,6 +502,11 @@
       "import": "./dist/services/sandbox/machine-session.js",
       "require": "./dist/services/sandbox/machine-session.js"
     },
+    "./services/sandbox/branch-session": {
+      "types": "./dist/services/sandbox/branch-session.d.ts",
+      "import": "./dist/services/sandbox/branch-session.js",
+      "require": "./dist/services/sandbox/branch-session.js"
+    },
     "./services/sandbox/machine-billing": {
       "types": "./dist/services/sandbox/machine-billing.d.ts",
       "import": "./dist/services/sandbox/machine-billing.js",
@@ -1846,6 +1851,9 @@
       ],
       "services/sandbox/machine-session": [
         "./dist/services/sandbox/machine-session.d.ts"
+      ],
+      "services/sandbox/branch-session": [
+        "./dist/services/sandbox/branch-session.d.ts"
       ],
       "services/sandbox/machine-billing": [
         "./dist/services/sandbox/machine-billing.d.ts"

--- a/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
@@ -87,7 +87,7 @@ describe('acquireBranchSandbox', () => {
         },
       }),
     });
-    expect(result).toEqual({ ok: true, sandboxId: BRANCH_SANDBOX_ID, pageId: MACHINE_ID });
+    expect(result).toEqual({ ok: true, sandboxId: BRANCH_SANDBOX_ID });
     // Keyed by the MACHINE page id, not the branch id — mirrors acquireMachineSandbox.
     expect(seenGuardrail).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);
     expect(seenRecord).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);

--- a/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { acquireBranchSandbox, type AcquireBranchSandboxDeps } from '../branch-session';
+import type { MachineRuntimeGuardrailDecision } from '../quota';
+
+const NOW = new Date('2026-07-20T12:00:00.000Z');
+const MACHINE_ID = 'machine-1';
+const BRANCH_ID = 'branch-1';
+const BRANCH_SANDBOX_ID = 'sprite-branch-1';
+
+function makeFindBranch(
+  rows: Record<string, { sandboxId: string; spriteTornDownAt: Date | null }> = {
+    [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: null },
+  },
+): AcquireBranchSandboxDeps['findBranch'] {
+  return async (id) => rows[id] ?? null;
+}
+
+function makeDeps(over: Partial<AcquireBranchSandboxDeps> = {}): AcquireBranchSandboxDeps {
+  return {
+    authorize: async () => ({ ok: true }),
+    now: () => NOW,
+    checkMachineRuntimeGuardrail: (): MachineRuntimeGuardrailDecision => ({ allowed: true }),
+    recordMachineActivity: () => {},
+    findBranch: makeFindBranch(),
+    ...over,
+  };
+}
+
+const base = { driveId: 'd1', userId: 'u1', machineId: MACHINE_ID, machineBranchId: BRANCH_ID };
+
+describe('acquireBranchSandbox', () => {
+  it('given an authorize denial, should propagate the denial reason without checking the branch', async () => {
+    const seenFindBranch: string[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        findBranch: async (id) => {
+          seenFindBranch.push(id);
+          return null;
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+    expect(seenFindBranch).toEqual([]);
+  });
+
+  it('given a guardrail denial, should return machine_runtime_exceeded without checking the branch', async () => {
+    const seenFindBranch: string[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+        findBranch: async (id) => {
+          seenFindBranch.push(id);
+          return null;
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'machine_runtime_exceeded' });
+    expect(seenFindBranch).toEqual([]);
+  });
+
+  it('given a guardrail denial for an UNAUTHORIZED actor, should surface the authz denial first', async () => {
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+  });
+
+  it('given the happy path, should return the branch row\'s sandboxId with no provision call and record activity keyed to the machine page', async () => {
+    const seenGuardrail: Array<{ machineKey: string; now: number }> = [];
+    const seenRecord: Array<{ machineKey: string; now: number }> = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: (input) => {
+          seenGuardrail.push(input);
+          return { allowed: true };
+        },
+        recordMachineActivity: (input) => {
+          seenRecord.push(input);
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: true, sandboxId: BRANCH_SANDBOX_ID, pageId: MACHINE_ID });
+    // Keyed by the MACHINE page id, not the branch id — mirrors acquireMachineSandbox.
+    expect(seenGuardrail).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);
+    expect(seenRecord).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);
+  });
+
+  it('given a destroyed branch (spriteTornDownAt set), should fail closed and never record activity', async () => {
+    const seenRecord: unknown[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        findBranch: makeFindBranch({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: NOW } }),
+        recordMachineActivity: (input) => seenRecord.push(input),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+    expect(seenRecord).toEqual([]);
+  });
+
+  it('given a missing branch row, should fail closed and never record activity', async () => {
+    const seenRecord: unknown[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        findBranch: makeFindBranch({}),
+        recordMachineActivity: (input) => seenRecord.push(input),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+    expect(seenRecord).toEqual([]);
+  });
+});

--- a/packages/lib/src/services/sandbox/branch-session.ts
+++ b/packages/lib/src/services/sandbox/branch-session.ts
@@ -1,0 +1,71 @@
+/**
+ * Branch-scoped sandbox acquisition (IO, dependency-injected).
+ *
+ * "PageSpace Agent" panes bound to a branch-terminal (`machine_branches`,
+ * issue #2166 phase 5/9's `deriveMachinePaneBinding.branchSandbox`) run tools
+ * on that branch's OWN isolated Sprite — never the owning Machine's
+ * persistent one. Unlike `acquireMachineSandbox` (machine-session.ts), this
+ * is attach-only: the branch's Sprite is provisioned exclusively by the
+ * branch-spawn path (`machine-branches.ts`), so a missing or torn-down
+ * branch fails closed here rather than lazily provisioning a replacement.
+ *
+ * Same authorize → guardrail → resolve → record-activity ORDERING as
+ * `acquireMachineSandbox` (load-bearing there, load-bearing here too): an
+ * unauthorized actor is denied on its own merits before the runtime
+ * guardrail is even consulted, and activity is recorded only once the branch
+ * is confirmed live. The guardrail and activity are keyed by the branch's
+ * OWNING MACHINE page id (`machineId`), not the branch row's own id — the
+ * runtime budget and payer (`lookupPageOwnerId(machineId)`) are the
+ * Machine's, shared across its machine/project/branch scopes alike.
+ */
+
+import type { CanRunCodeInput, CanRunCodeResult, CodeExecutionDenialReason } from './can-run-code';
+import type { MachineRuntimeGuardrailDecision, MachineRuntimeGuardrailReason } from './quota';
+
+export interface AcquireBranchSandboxDeps {
+  /** Re-authorize the CURRENT actor. Fail-closed; must never throw (canRunCode). */
+  authorize: (input: CanRunCodeInput) => Promise<CanRunCodeResult>;
+  now: () => Date;
+  /** Same per-machine active-runtime cost backstop `acquireMachineSandbox` checks — see quota.ts. */
+  checkMachineRuntimeGuardrail: (input: { machineKey: string; now: number }) => MachineRuntimeGuardrailDecision;
+  /** Record that the machine was just active, extending (or starting) its continuous-activity window. */
+  recordMachineActivity: (input: { machineKey: string; now: number }) => void;
+  /** Fresh lookup of the branch's own Sprite — mirrors `MachinePaneBindingBranchLookup.findById` (machine-pane-binding.ts). */
+  findBranch: (machineBranchId: string) => Promise<{ sandboxId: string; spriteTornDownAt: Date | null } | null>;
+}
+
+export interface AcquireBranchSandboxInput {
+  /** Absent for global (non-drive) contexts. */
+  driveId?: string;
+  userId: string;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
+  /** The branch's owning Machine page id. */
+  machineId: string;
+  /** The `machine_branches` row id backing this branch-terminal. */
+  machineBranchId: string;
+  deps: AcquireBranchSandboxDeps;
+}
+
+export type AcquireBranchSandboxResult =
+  | { ok: true; sandboxId: string; pageId: string }
+  | { ok: false; reason: CodeExecutionDenialReason | MachineRuntimeGuardrailReason | 'branch_not_found' };
+
+export async function acquireBranchSandbox(
+  input: AcquireBranchSandboxInput,
+): Promise<AcquireBranchSandboxResult> {
+  const { deps, machineId, machineBranchId, userId, driveId, requestOrigin, agentPageId } = input;
+
+  const authorization = await deps.authorize({ userId, driveId, requestOrigin, agentPageId });
+  if (!authorization.ok) return { ok: false, reason: authorization.reason };
+
+  const nowMs = deps.now().getTime();
+  const guardrail = deps.checkMachineRuntimeGuardrail({ machineKey: machineId, now: nowMs });
+  if (!guardrail.allowed) return { ok: false, reason: guardrail.reason };
+
+  const branch = await deps.findBranch(machineBranchId);
+  if (!branch || branch.spriteTornDownAt !== null) return { ok: false, reason: 'branch_not_found' };
+
+  deps.recordMachineActivity({ machineKey: machineId, now: nowMs });
+  return { ok: true, sandboxId: branch.sandboxId, pageId: machineId };
+}

--- a/packages/lib/src/services/sandbox/branch-session.ts
+++ b/packages/lib/src/services/sandbox/branch-session.ts
@@ -48,7 +48,23 @@ export interface AcquireBranchSandboxInput {
 }
 
 export type AcquireBranchSandboxResult =
-  | { ok: true; sandboxId: string; pageId: string }
+  | {
+      ok: true;
+      sandboxId: string;
+      /**
+       * Deliberately omitted (always undefined), NOT the branch's owning
+       * `machineId`: `openSession` (tool-runners.ts) threads this straight
+       * into the opportunistic storage-measurement seam and the Terminal
+       * activity-feed notifier, both of which key off a MACHINE's own
+       * `machine_sessions` row. The awake sandbox here is the branch's OWN,
+       * separate Sprite — attributing its measured bytes (or activity) to
+       * the machine's row would silently corrupt that machine's storage
+       * billing. A dedicated branch-scoped seam for either is future work;
+       * until then, omitting `pageId` cleanly opts branch runs out of both
+       * (`openSession`'s `if (acquired.pageId && ...)` guards).
+       */
+      pageId?: undefined;
+    }
   | { ok: false; reason: CodeExecutionDenialReason | MachineRuntimeGuardrailReason | 'branch_not_found' };
 
 export async function acquireBranchSandbox(
@@ -67,5 +83,5 @@ export async function acquireBranchSandbox(
   if (!branch || branch.spriteTornDownAt !== null) return { ok: false, reason: 'branch_not_found' };
 
   deps.recordMachineActivity({ machineKey: machineId, now: nowMs });
-  return { ok: true, sandboxId: branch.sandboxId, pageId: machineId };
+  return { ok: true, sandboxId: branch.sandboxId };
 }

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -44,6 +44,7 @@ import {
   type AcquireMachineSandboxResult,
   type MachineRefLike,
 } from './machine-session';
+import type { AcquireBranchSandboxResult } from './branch-session';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 
@@ -75,6 +76,15 @@ export interface SandboxActorContext {
    * for that call rather than guessed at.
    */
   turnId?: string;
+  /**
+   * Present when this run is bound to a "PageSpace Agent" branch pane (issue
+   * #2166 phases 5/9's `deriveMachinePaneBinding.branchSandbox`) — the
+   * branch's owning Machine page id plus the `machine_branches` row backing
+   * it. Routes `acquireSandbox` through the attach-only branch seam
+   * (`acquireBranchSandbox`, branch-session.ts) instead of the machine's own
+   * persistent session. Undefined for every other run.
+   */
+  branchSandbox?: { machineId: string; machineBranchId: string };
 }
 
 export interface SandboxQuotaDeps {
@@ -155,10 +165,20 @@ export interface SandboxCheckpointDeps {
   createCheckpoint: (input: { sandbox: ExecutableSandbox; comment: string }) => Promise<void>;
 }
 
+/**
+ * `acquireSandbox`'s request: the machine-session shape plus the optional
+ * branch routing key. `branchSandbox` present → the caller routes to
+ * `acquireBranchSandbox` (attach-only); absent → `acquireMachineSandbox` as
+ * before.
+ */
+export type AcquireSandboxRequest = Omit<AcquireMachineSandboxInput, 'deps'> & {
+  branchSandbox?: { machineId: string; machineBranchId: string };
+};
+
 export interface SandboxRunDeps {
   isEnabled: () => boolean;
-  /** Pre-bound `acquireMachineSandbox` (lifecycle deps already injected). */
-  acquireSandbox: (input: Omit<AcquireMachineSandboxInput, 'deps'>) => Promise<AcquireMachineSandboxResult>;
+  /** Pre-bound `acquireMachineSandbox` / `acquireBranchSandbox` (lifecycle deps already injected). */
+  acquireSandbox: (input: AcquireSandboxRequest) => Promise<AcquireMachineSandboxResult | AcquireBranchSandboxResult>;
   /** Reconnect to the executable handle for an acquired sandbox id. */
   reconnect: (sandboxId: string) => Promise<ExecutableSandbox | null>;
   quota: SandboxQuotaDeps;
@@ -231,7 +251,7 @@ function safeLogWarn(
 // vs infra failures that are genuinely unexpected (error-level).
 const AUTHZ_DENY_REASONS = new Set([
   'no_drive_access', 'insufficient_role', 'no_agent_access', 'app_admin_required', 'kill_switch_off', 'no_machine',
-  'machine_runtime_exceeded',
+  'machine_runtime_exceeded', 'branch_not_found',
 ]);
 
 
@@ -306,9 +326,7 @@ function fail(
   return { success: false, error: DENIAL_MESSAGES[reason], reason };
 }
 
-function acquireRequest(
-  ctx: SandboxActorContext,
-): Omit<AcquireMachineSandboxInput, 'deps'> {
+function acquireRequest(ctx: SandboxActorContext): AcquireSandboxRequest {
   return {
     tenantId: ctx.tenantId,
     driveId: ctx.driveId,
@@ -316,6 +334,7 @@ function acquireRequest(
     requestOrigin: ctx.requestOrigin,
     agentPageId: ctx.agentPageId,
     activeMachine: ctx.activeMachine,
+    branchSandbox: ctx.branchSandbox,
   };
 }
 
@@ -366,7 +385,11 @@ async function safeNotifyTerminalActivity(
 }
 
 // Map a denial from the lifecycle acquire onto the tool-facing reason set.
-function reasonFromAcquire(result: Extract<AcquireMachineSandboxResult, { ok: false }>): SandboxToolDenialReason {
+// `branch_not_found` (acquireBranchSandbox's own fail-closed reason, no
+// tool-facing equivalent) falls through to 'error' with the rest.
+function reasonFromAcquire(
+  result: Extract<AcquireMachineSandboxResult | AcquireBranchSandboxResult, { ok: false }>,
+): SandboxToolDenialReason {
   switch (result.reason) {
     case 'app_admin_required':
     case 'no_drive_access':


### PR DESCRIPTION
## Summary
- Adds `acquireBranchSandbox` (`packages/lib/src/services/sandbox/branch-session.ts`): the branch-scoped, attach-only sandbox acquisition seam for "PageSpace Agent" panes bound to a `machine_branches` row. Mirrors `acquireMachineSandbox`'s authorize → guardrail → resolve → record-activity ordering, but never provisions — a missing/torn-down branch fails closed.
- Wires `buildRealSandboxRunDeps.acquireSandbox` to route to it when the request carries a `branchSandbox` key, falling back to `acquireMachineSandbox` otherwise; threads the routing key through `SandboxActorContext` so a future caller (Phase 7's `machineBinding` integration) can populate `ctx.branchSandbox`.
- New `@pagespace/lib/services/sandbox/branch-session` export subpath.
- Review fix: omits `pageId` from the success result — it would otherwise get fed into the storage-measurement/Terminal-activity seams that key off the MACHINE's own `machine_sessions` row, misattributing the branch's own Sprite's data.

Issue #2166 phase 8. Phase board: `cil7u8van0xvj3g0fl3gwlb5`.

## Test plan
- [x] `acquireBranchSandbox`: 6 unit tests (authorize denial, guardrail denial, guardrail-vs-authz ordering, happy path attach-only + no provision call, destroyed branch, missing branch) — all fail-closed paths covered
- [x] `bun run typecheck` clean for `@pagespace/lib` and `web`
- [x] `bun run lint` clean for `@pagespace/lib` and `web`
- [x] Full `@pagespace/lib` unit suite green (8653 tests)
- [x] `apps/web` sandbox-tools / sandbox-git-tools suites green (188 tests)
- [x] Independent `/aidd-review` pass, findings recorded on the phase board page and fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcoM3RR6u9z9EoYyrvyMsL