### PR TITLE
feat(ai): Phase 6 — chat route machine-pane binding wiring

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -151,6 +151,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
 
 vi.mock('ai', () => ({
   streamText: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
@@ -55,6 +55,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
@@ -89,12 +90,17 @@ vi.mock('@pagespace/db/db', () => {
         })),
       })),
     },
+    // Accessed by start-generation-exclusive's advisory lock (real, unmocked
+    // implementation) — its own error handling degrades to running unlocked
+    // when the pool/lock query fails, which a bare object triggers harmlessly.
+    getAdvisoryLockPool: vi.fn(() => ({})),
   };
 });
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   ne: vi.fn(),
+  desc: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },
@@ -182,8 +188,17 @@ vi.mock('ai', () => ({
   stepCountIs: vi.fn(),
   hasToolCall: vi.fn(() => () => false),
   tool: vi.fn((config) => config),
-  createUIMessageStream: vi.fn(),
-  createUIMessageStreamResponse: vi.fn(),
+  // Real createUIMessageStream runs `execute` as a detached producer (the
+  // route never awaits it — the returned stream is consumed by piping into
+  // the HTTP response). Mirror that: fire it without awaiting, so the route
+  // under test returns the same way it does in production, and this file's
+  // tests poll (vi.waitFor) for streamText to have been invoked once its
+  // microtasks settle.
+  createUIMessageStream: vi.fn((opts: { execute?: (args: { writer: { write: () => void } }) => Promise<void> }) => {
+    void opts.execute?.({ writer: { write: vi.fn() } })?.catch(() => {});
+    return {};
+  }),
+  createUIMessageStreamResponse: vi.fn(() => new Response(null, { status: 200 })),
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({
@@ -243,6 +258,7 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: {
     getConversation: vi.fn().mockResolvedValue(null),
     hasConflictingMessageOwner: vi.fn().mockResolvedValue(false),
+    createConversation: vi.fn().mockResolvedValue(undefined),
   },
 }));
 
@@ -315,7 +331,7 @@ describe('POST /api/ai/chat - machine-pane binding', () => {
     expect(filtered).not.toHaveProperty('list_machines');
     expect(filtered).toHaveProperty('read_page');
 
-    expect(streamTextMock).toHaveBeenCalled();
+    await vi.waitFor(() => expect(streamTextMock).toHaveBeenCalled());
     const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
     expect(streamTextArgs.experimental_context?.machineBinding).toEqual({
       machineId: chatId,
@@ -350,7 +366,7 @@ describe('POST /api/ai/chat - machine-pane binding', () => {
     expect(filtered).toHaveProperty('switch_machine');
     expect(filtered).toHaveProperty('list_machines');
 
-    expect(streamTextMock).toHaveBeenCalled();
+    await vi.waitFor(() => expect(streamTextMock).toHaveBeenCalled());
     const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
     expect(streamTextArgs.experimental_context?.machineBinding).toBeUndefined();
     expect(streamTextArgs.experimental_context?.activeMachine).toBeUndefined();

--- a/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../route';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// Machine Pane binding tests for POST /api/ai/chat (Phase 6, issue #2166)
+//
+// Verifies the route's wiring of deriveMachinePaneBinding (Phase 5 pure core):
+//  - bound conversation -> machineBinding + activeMachine seeded into
+//    experimental_context, switch_machine/list_machines dropped from tools
+//  - row.machineId !== chatId -> 400 before streaming
+//  - non-bound conversation -> derivation null, passthrough unchanged
+//
+// Mirrors mcp-scope-tool-filtering.test.ts's idiom: mocks every module the
+// route imports, calls the real POST with a real Request, and spies on the
+// REAL filterToolsForMachineBinding (via importOriginal) to assert on its
+// actual isBound argument and return value.
+// ============================================================================
+
+const deriveMachinePaneBindingMock = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
+  isMCPAuthResult: vi.fn(() => false),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
+  isScopedMCPAuth: vi.fn(() => false),
+  canPrincipalViewPage: vi.fn().mockResolvedValue(true),
+  canPrincipalEditPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+  canUserEditPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      child: vi.fn(() => ({
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+        trace: vi.fn(),
+      })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => {
+  const pageRow = {
+    id: 'page_123',
+    title: 'Test Page',
+    systemPrompt: null,
+    enabledTools: null,
+    aiProvider: 'openai',
+    aiModel: 'openai/gpt-5.3-chat',
+    driveId: 'drive_A',
+    includeDrivePrompt: false,
+    includePageTree: false,
+    pageTreeScope: null,
+    revision: 0,
+    type: 'AI_CHAT',
+  };
+  return {
+    db: {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => {
+            const result = Promise.resolve([pageRow]);
+            return Object.assign(result, {
+              orderBy: vi.fn().mockResolvedValue([]),
+              limit: vi.fn().mockResolvedValue([]),
+            });
+          }),
+        })),
+      })),
+    },
+  };
+});
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  ne: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id' },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', status: 'status' },
+  pages: { id: 'id' },
+  drives: { id: 'id', drivePrompt: 'drivePrompt' },
+}));
+
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  requiresProSubscription: vi.fn().mockReturnValue(false),
+  createSubscriptionRequiredResponse: vi.fn(),
+  createAdminRestrictedResponse: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/billing/credit-gate', () => ({
+  canConsumeAI: vi.fn().mockResolvedValue({ allowed: true, reason: 'unlimited' }),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastCreditsEvent: vi.fn(),
+  broadcastAiStreamStart: vi.fn().mockResolvedValue(undefined),
+  broadcastAiStreamComplete: vi.fn().mockResolvedValue(undefined),
+  broadcastChatUserMessage: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core/provider-factory', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {} }),
+  updateUserProviderSettings: vi.fn(),
+  createProviderErrorResponse: vi.fn(),
+  isProviderError: vi.fn().mockReturnValue(false),
+}));
+// pageSpaceTools includes switch_machine/list_machines so filtering behavior is observable.
+vi.mock('@/lib/ai/core/ai-tools', () => ({
+  pageSpaceTools: {
+    switch_machine: { description: 'switch_machine' },
+    list_machines: { description: 'list_machines' },
+    read_page: { description: 'read_page' },
+  },
+}));
+vi.mock('@/lib/ai/core/message-utils', () => ({
+  extractMessageContent: vi.fn().mockReturnValue('test content'),
+  extractToolCalls: vi.fn().mockReturnValue([]),
+  extractToolResults: vi.fn().mockReturnValue([]),
+  saveMessageToDatabase: vi.fn(),
+  sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
+  convertDbMessageToUIMessage: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/mention-processor', () => ({
+  processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
+}));
+vi.mock('@/lib/ai/core/timestamp-utils', () => ({
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+}));
+vi.mock('@/lib/ai/core/system-prompt', () => ({
+  buildSystemPrompt: vi.fn().mockReturnValue(''),
+  buildPersonalizationPrompt: vi.fn().mockReturnValue(''),
+}));
+// Spy on the REAL implementation so we can assert on its actual behavior
+// (isBound argument + filtered return value), instead of stubbing it away.
+vi.mock('@/lib/ai/core/tool-filtering', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../lib/ai/core/tool-filtering')>();
+  return {
+    ...actual,
+    filterToolsForMachineBinding: vi.fn(actual.filterToolsForMachineBinding),
+  };
+});
+vi.mock('@/lib/ai/core/page-tree-context', () => ({
+  getPageTreeContext: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
+  convertMCPToolsToAISDKSchemas: vi.fn(),
+  parseMCPToolName: vi.fn(),
+  sanitizeToolNamesForProvider: vi.fn(),
+}));
+vi.mock('@/lib/ai/core/personalization-utils', () => ({
+  getUserPersonalization: vi.fn().mockResolvedValue(null),
+}));
+
+const streamTextMock = vi.fn();
+vi.mock('ai', () => ({
+  streamText: (...args: unknown[]) => streamTextMock(...args),
+  convertToModelMessages: vi.fn().mockReturnValue([]),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+  tool: vi.fn((config) => config),
+  createUIMessageStream: vi.fn(),
+  createUIMessageStreamResponse: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn().mockReturnValue('generated_id'),
+  init: vi.fn(() => vi.fn(() => 'test-cuid')),
+  isCuid: vi.fn(() => true),
+}));
+
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => `***${id.slice(-3)}`),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackFeature: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: {
+    trackUsage: vi.fn(),
+    trackToolUsage: vi.fn(),
+  },
+  extractOpenRouterCostDollars: vi.fn(() => undefined),
+  extractOpenRouterGenerationIds: vi.fn(() => []),
+}));
+
+vi.mock('@/lib/mcp', () => ({
+  getMCPBridge: vi.fn(),
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
+  createStreamAbortController: vi.fn().mockReturnValue({ streamId: 'stream_123', signal: new AbortController().signal }),
+  removeStream: vi.fn(),
+  attachStreamFinisher: vi.fn(),
+  STREAM_ID_HEADER: 'x-stream-id',
+}));
+
+vi.mock('@/lib/ai/core/validate-image-parts', () => ({
+  validateUserMessageFileParts: vi.fn().mockReturnValue({ valid: true }),
+  hasFileParts: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  getModelCapabilities: vi.fn(),
+  hasVisionCapability: vi.fn().mockReturnValue(true),
+  DEFAULT_IMAGE_MODEL: 'default-image-model',
+}));
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    getConversation: vi.fn().mockResolvedValue(null),
+    hasConflictingMessageOwner: vi.fn().mockResolvedValue(false),
+  },
+}));
+
+// The module under test in this file: deriveMachinePaneBinding is the Phase 5
+// pure core the route must call. buildMachinePaneBindingDeps is its DB-backed
+// wiring (Phase 5 runtime shell) — stubbed to a no-op object since the pure
+// core itself is fully mocked below.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: (...args: unknown[]) => deriveMachinePaneBindingMock(...args),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
+
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { filterToolsForMachineBinding } from '@/lib/ai/core/tool-filtering';
+
+const mockUserId = 'user_123';
+const chatId = 'page_123'; // in drive_A per db mock above
+const conversationId = 'conversation_abc';
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const createChatRequest = () => {
+  return new Request('https://example.com/api/ai/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'content-length': '200', 'X-Browser-Session-Id': 'session-1' },
+    body: JSON.stringify({
+      messages: [
+        { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+      ],
+      chatId,
+      conversationId,
+      selectedProvider: 'openai',
+      selectedModel: 'openai/gpt-5.3-chat',
+    }),
+  });
+};
+
+describe('POST /api/ai/chat - machine-pane binding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    streamTextMock.mockReturnValue({});
+  });
+
+  it('injects machineBinding + seeds activeMachine, and drops switch_machine/list_machines when bound', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue({
+      ok: true,
+      binding: { cwd: '/workspace' },
+    });
+
+    await POST(createChatRequest());
+
+    expect(deriveMachinePaneBindingMock).toHaveBeenCalledWith(
+      { chatId, conversationId },
+      expect.anything(),
+    );
+
+    expect(filterToolsForMachineBinding).toHaveBeenCalledWith(expect.anything(), true);
+    const filtered = vi.mocked(filterToolsForMachineBinding).mock.results[0]?.value as Record<string, unknown>;
+    expect(filtered).not.toHaveProperty('switch_machine');
+    expect(filtered).not.toHaveProperty('list_machines');
+    expect(filtered).toHaveProperty('read_page');
+
+    expect(streamTextMock).toHaveBeenCalled();
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
+    expect(streamTextArgs.experimental_context?.machineBinding).toEqual({
+      machineId: chatId,
+      cwd: '/workspace',
+      branchSandbox: undefined,
+    });
+    expect(streamTextArgs.experimental_context?.activeMachine).toEqual({
+      kind: 'existing',
+      machineId: chatId,
+    });
+  });
+
+  it('returns 400 before streaming when row.machineId !== chatId', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue({
+      ok: false,
+      reason: 'binding_page_mismatch',
+    });
+
+    const response = await POST(createChatRequest());
+
+    expect(response.status).toBe(400);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves behavior unchanged for a non-bound conversation (derivation null)', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue(null);
+
+    await POST(createChatRequest());
+
+    expect(filterToolsForMachineBinding).toHaveBeenCalledWith(expect.anything(), false);
+    const filtered = vi.mocked(filterToolsForMachineBinding).mock.results[0]?.value as Record<string, unknown>;
+    expect(filtered).toHaveProperty('switch_machine');
+    expect(filtered).toHaveProperty('list_machines');
+
+    expect(streamTextMock).toHaveBeenCalled();
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
+    expect(streamTextArgs.experimental_context?.machineBinding).toBeUndefined();
+    expect(streamTextArgs.experimental_context?.activeMachine).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -165,6 +165,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
 
 vi.mock('ai', () => ({
   streamText: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/sandbox-github-suppression.test.ts
@@ -167,6 +167,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
 
 vi.mock('ai', () => ({
   streamText: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -179,6 +179,7 @@ vi.mock('@/lib/ai/core/tool-filtering', () => ({
   filterToolsForReadOnly: vi.fn().mockReturnValue({}),
   filterToolsForWebSearch: vi.fn().mockReturnValue({}),
   filterToolsForMcpScope: vi.fn().mockReturnValue({}),
+  filterToolsForMachineBinding: vi.fn().mockReturnValue({}),
   buildPageAITools: vi.fn().mockReturnValue({}),
 }));
 vi.mock('@/lib/ai/core/page-tree-context', () => ({
@@ -191,6 +192,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 }));
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
+}));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
 }));
 
 vi.mock('ai', () => ({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -64,7 +64,9 @@ import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-
 import { getAgentContextDrives } from '@pagespace/lib/services/drive-agent-service';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
-import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForMcpScope, filterToolsForMachineBinding } from '@/lib/ai/core/tool-filtering';
+import { deriveMachinePaneBinding } from '@pagespace/lib/services/machines/machine-pane-binding';
+import { buildMachinePaneBindingDeps } from '@/lib/ai/machine-pane/machine-pane-binding-runtime';
 import { shouldExposeImageGen } from '@/lib/ai/core/image-gen-access';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
@@ -556,6 +558,36 @@ export async function POST(request: Request) {
       isNewConversation: !requestConversationId
     });
 
+    // Machine Pane binding (Phase 5's deriveMachinePaneBinding pure core): a
+    // conversation whose id is a machine_agent_terminals row bound to THIS
+    // page is pinned to that machine for the rest of the request — tools,
+    // system prompt, and default active machine all follow from it below.
+    // No additional access check is needed here: canPrincipalViewPage /
+    // canPrincipalEditPage against chatId (above) already authorizes the
+    // acting user for this page, which is the precondition the pure core's
+    // own docstring requires of its caller. A non-bound conversation (a
+    // brand-new cuid, or any conversation not backed by a machine_agent_terminals
+    // row) derives to null and leaves everything below byte-identical to today.
+    const machinePaneBindingResult = await deriveMachinePaneBinding(
+      { chatId: chatId!, conversationId: conversationId! },
+      buildMachinePaneBindingDeps()
+    );
+    if (machinePaneBindingResult && !machinePaneBindingResult.ok) {
+      loggers.ai.warn('AI Chat API: machine-pane binding rejected', {
+        chatId: maskedChatId,
+        conversationId,
+        reason: machinePaneBindingResult.reason,
+      });
+      return NextResponse.json({ error: 'This conversation is not bound to this machine' }, { status: 400 });
+    }
+    const machineBinding = machinePaneBindingResult?.ok
+      ? {
+          machineId: chatId!,
+          cwd: machinePaneBindingResult.binding.cwd,
+          branchSandbox: machinePaneBindingResult.binding.branchSandbox,
+        }
+      : undefined;
+
     // Process @mentions in the user's message
     let mentionSystemPrompt = '';
     let mentionedPageIds: string[] = [];
@@ -855,11 +887,16 @@ export async function POST(request: Request) {
     const webSearchMode = webSearchEnabled === true;
     loggers.ai.debug('AI Page Chat API: Tool modes', { isReadOnly: readOnlyMode, webSearchEnabled: webSearchMode });
 
-    // Step 1: Apply isReadOnly filter, then hide account-level-only tools
-    // (e.g. create_drive) from drive-scoped MCP tokens' tool list.
-    const baseTools = filterToolsForMcpScope(
-      filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
-      isScopedMCPAuth(authResult)
+    // Step 1: Apply isReadOnly filter, hide account-level-only tools
+    // (e.g. create_drive) from drive-scoped MCP tokens' tool list, then drop
+    // switch_machine/list_machines when this conversation is bound to one
+    // machine (see machinePaneBindingResult above).
+    const baseTools = filterToolsForMachineBinding(
+      filterToolsForMcpScope(
+        filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
+        isScopedMCPAuth(authResult)
+      ),
+      machineBinding != null
     );
 
     // Step 2: Extract web_search + generate_image so they can be handled as
@@ -1151,6 +1188,14 @@ export async function POST(request: Request) {
     // a custom system prompt is set (unlike drivePromptPrefix above, which is
     // only prepended in the customSystemPrompt branch).
     systemPrompt = memberDriveContextPrefix + systemPrompt;
+
+    // Machine binding section — applies uniformly (custom or default system
+    // prompt) for the same reason as memberDriveContextPrefix above. Fixed
+    // for the conversation's lifetime, so it belongs in the STABLE section,
+    // not the per-turn locationPrompt below.
+    if (machineBinding) {
+      systemPrompt += `\n\nMACHINE BINDING (this conversation)\n• This conversation is bound to machine "${machineBinding.machineId}" — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${machineBinding.cwd}\n• switch_machine and list_machines are unavailable — this conversation cannot leave its bound machine`;
+    }
 
     // Build timestamp system prompt for temporal awareness
     const userTimezone = user?.timezone ?? undefined;
@@ -1509,6 +1554,15 @@ export async function POST(request: Request) {
                 // exceed its own membership role — via the agent's broader ACL.
                 mcpAllowedDriveIds: getAllowedDriveIds(authResult),
                 mcpTokenId: isMCPAuthResult(authResult) ? authResult.tokenId : undefined,
+                // Computed once above from deriveMachinePaneBinding — undefined
+                // for every conversation that isn't a machine-bound pagespace
+                // pane. activeMachine seeds the default-mode sandbox tools'
+                // active machine so they operate on the bound machine from the
+                // first tool call, without waiting for a switch_machine call.
+                machineBinding,
+                activeMachine: machineBinding
+                  ? { kind: 'existing' as const, machineId: machineBinding.machineId }
+                  : undefined,
               }, // Pass userId, timezone, AI context, location context, model capabilities, and chat source to tools
               maxRetries: 20, // Increase from default 2 to 20 for better handling of rate limits
               onChunk: ({ chunk }) => {

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -4,6 +4,7 @@ import {
   filterToolsForReadOnly,
   filterToolsForWebSearch,
   filterToolsForMcpScope,
+  filterToolsForMachineBinding,
   isWebSearchTool,
   isImageGenTool,
   filterToolsForImageGen,
@@ -125,6 +126,28 @@ describe('filterToolsForMcpScope', () => {
     const result = filterToolsForMcpScope(withDrive, true);
     expect(result.create_drive).toBeUndefined();
     expect(result.list_pages).toBe('list_pages');
+    expect(result.read_page).toBe('read_page');
+  });
+});
+
+describe('filterToolsForMachineBinding', () => {
+  const withMachineTools = {
+    switch_machine: 'switch_machine',
+    list_machines: 'list_machines',
+    read_page: 'read_page',
+  };
+
+  it('returns input unchanged when not bound', () => {
+    const result = filterToolsForMachineBinding(withMachineTools, false);
+    expect(result).toEqual(withMachineTools);
+    expect(result.switch_machine).toBe('switch_machine');
+    expect(result.list_machines).toBe('list_machines');
+  });
+
+  it('removes switch_machine and list_machines when bound to a machine pane', () => {
+    const result = filterToolsForMachineBinding(withMachineTools, true);
+    expect(result.switch_machine).toBeUndefined();
+    expect(result.list_machines).toBeUndefined();
     expect(result.read_page).toBe('read_page');
   });
 });

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -118,6 +118,13 @@ export const WRITE_TOOLS = new Set([
 // Web search tools (excluded when web search is disabled)
 const WEB_SEARCH_TOOLS = new Set(['web_search', 'web_fetch']);
 
+// Tools that let the agent discover or switch to a different machine —
+// dropped when the conversation is bound to one specific machine via a
+// Machine Pane binding (deriveMachinePaneBinding). The bound machine is the
+// only one this conversation may ever act on, so offering a way to leave it
+// is moot.
+const MACHINE_BINDING_LOCKED_TOOLS = new Set(['switch_machine', 'list_machines']);
+
 // Image-generation tools (a runtime composer toggle, like web search — filtered
 // independently of the saved per-agent allow-list).
 const IMAGE_GEN_TOOLS = new Set(['generate_image']);
@@ -233,6 +240,22 @@ export function filterToolsForMcpScope<T>(
 
   return Object.fromEntries(
     Object.entries(tools).filter(([name]) => !isAccountLevelOnlyTool(name))
+  );
+}
+
+/**
+ * Filter tools based on machine-pane binding.
+ * Returns all tools when not bound, or drops switch_machine/list_machines
+ * when the conversation is bound to a specific machine.
+ */
+export function filterToolsForMachineBinding<T>(
+  tools: Record<string, T>,
+  isBound: boolean
+): Record<string, T> {
+  if (!isBound) return tools;
+
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => !MACHINE_BINDING_LOCKED_TOOLS.has(name))
   );
 }
 


### PR DESCRIPTION
## Summary
- Wires `deriveMachinePaneBinding` (Phase 5 pure core) into `POST /api/ai/chat`, right after `conversationId` settles: `ok:false` → 400 before streaming, `ok:true` → `machineBinding` computed once and threaded through tool filtering / system prompt / `experimental_context`, `null` → byte-identical passthrough for non-bound conversations.
- Adds the pure `filterToolsForMachineBinding` helper (`apps/web/src/lib/ai/core/tool-filtering.ts`) that drops `switch_machine`/`list_machines` when bound, applied ahead of the per-agent allowlist so a locked tool can never be re-added.
- Seeds `experimental_context.activeMachine = { kind: 'existing', machineId }` and appends a stable system-prompt section naming the machine + cwd (mirrors `buildLocationTurnPrompt`'s section style).
- Route stays a thin host — all decisions live in the pure core + `filterToolsForMachineBinding`; the route only branches on the `ok`/not-ok/`null` result.

## Test plan
- [x] RED → GREEN TDD: pure helper test (`tool-filtering.test.ts`) + route seam test (`machine-binding-route.test.ts`, mirrors `mcp-scope-tool-filtering.test.ts`) covering bind / 400-on-mismatch / passthrough.
- [x] Updated 4 pre-existing route seam tests (`mcp-scope-tool-filtering`, `credit-gate`, `sandbox-github-suppression`, `stream-socket-events`) to mock the new `deriveMachinePaneBinding` dependency (resolves `null` — none of those requests are machine-bound).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — clean (only pre-existing unrelated warnings).
- [x] Full `apps/web` unit suite — 1002/1006 files pass; the 4 pre-existing failures (`admin-role-version`, `grouping`, `activity-tools`, `version-sdk-contract`) are unrelated DB-connectivity/package-resolution environment issues, confirmed present on `pu/panes-agent` baseline too (no local Postgres/Docker in this sandbox).
- [x] `test:security` — same pre-existing DB-dependent suites fail for the same environment reason; all non-DB security suites pass.
- [x] Independent review (`/aidd-review`) completed and recorded on board page `yg9eby67zpoag06vnqv343rd`: 0 blockers / 0 majors / 1 minor / 1 nit / 1 info, approved with no required fixes.

Part of #2166 phase 6. Board: `yg9eby67zpoag06vnqv343rd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VoG6khtycMfERfoQqR9V7M