### PR TITLE
feat(ai-tools): Phase 7 — sandbox tools honor the machine-pane binding

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -328,6 +328,43 @@ describe('createMachineDirectory', () => {
       await directory.listMachines({ userId: 'u1', parentAgentId: 'parent-agent-1' });
       expect(seen).toEqual(['parent-agent-1']);
     });
+
+    describe('machine-bound "PageSpace Agent" panes (machineBinding)', () => {
+      it('given a machineBinding, should collapse to exactly the bound machine — ignoring the agent\'s own configured machine list entirely', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            getAgentConfig: async () => ({
+              machineAccess: true,
+              machines: [{ kind: 'own' }, { kind: 'existing', machineId: 'other-1' }],
+            }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        await expect(directory.listMachines(context)).resolves.toEqual([
+          { kind: 'existing', machineId: 'bound-1' },
+        ]);
+      });
+
+      it('given a machineBinding on the global assistant context, should still collapse to the bound machine (not resolve the global config at all)', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            getGlobalConfig: async () => ({ machineAccess: false, machines: [] }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'global' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        await expect(directory.listMachines(context)).resolves.toEqual([
+          { kind: 'existing', machineId: 'bound-1' },
+        ]);
+      });
+    });
   });
 
   describe('describeMachine', () => {
@@ -517,6 +554,81 @@ describe('createMachineDirectory', () => {
         );
         const decision = await directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' });
         expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
+      });
+    });
+
+    describe('machine-bound "PageSpace Agent" panes (machineBinding)', () => {
+      const machineDenyingPageAgents = async () => ({
+        title: 'Locked Machine',
+        type: 'MACHINE',
+        driveId: 'drive-1',
+        isTrashed: false,
+        allowPageAgents: false,
+        visibleToGlobalAssistant: true,
+      });
+
+      it('given the BOUND machine, should allow even though its allowPageAgents toggle is off — the binding IS the entitlement', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given a DIFFERENT machine than the one bound, should keep the full toggle checks and deny', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        const decision = await directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' });
+        expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
+      });
+
+      it('given the BOUND machine but its page is trashed, should still deny — existence/trash checks are never bypassed', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            findPage: async () => ({
+              title: 'Trashed Machine',
+              type: 'MACHINE',
+              driveId: 'drive-1',
+              isTrashed: true,
+              allowPageAgents: false,
+              visibleToGlobalAssistant: true,
+            }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
+      });
+
+      it('given the BOUND machine but the actor cannot view its page, should still deny — canActorViewPage is never bypassed', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, canViewPage: async () => false }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -643,6 +643,121 @@ describe('createSandboxTools', () => {
     });
   });
 
+  describe('machine-pane binding (machineBinding)', () => {
+    function runDepsCapturingCwd() {
+      const seenCwds: Array<string | undefined> = [];
+      const runDeps = fakeRunDeps();
+      runDeps.reconnect = async () => ({
+        sandboxId: 'sbx',
+        spriteInstanceId: null,
+        runCommand: async (args: { cwd?: string }) => {
+          seenCwds.push(args.cwd);
+          return { exitCode: 0, stdout: 'hi', stderr: '' };
+        },
+        writeFiles: async () => {},
+        readFileToBuffer: async () => Buffer.from('data'),
+        createCheckpoint: async () => {},
+      });
+      return { runDeps, seenCwds };
+    }
+
+    it('bash: given a binding and no explicit cwd, should default the runner cwd to the binding\'s cwd', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: { machineId: 'm1', cwd: '/workspace/repo' },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace/repo']);
+    });
+
+    it('bash: given a binding AND an explicit cwd, the explicit cwd should win', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: { machineId: 'm1', cwd: '/workspace/repo' },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi', cwd: '/workspace/other' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace/other']);
+    });
+
+    it('bash: given no binding, should leave the default cwd behavior unchanged (the runner\'s own SANDBOX_ROOT default)', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace']);
+    });
+
+    it('bash: given a binding with a branchSandbox, acquireSandbox should carry the branch target', async () => {
+      const seenAcquisitions: unknown[] = [];
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async (input) => {
+        seenAcquisitions.push(input);
+        return { ok: true, sandboxId: 'sbx', resumed: false };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: {
+          machineId: 'm1',
+          cwd: '/workspace/repo',
+          branchSandbox: { machineBranchId: 'branch-1', sandboxId: 'sbx-1' },
+        },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenAcquisitions).toEqual([
+        expect.objectContaining({ branchSandbox: { machineId: 'm1', machineBranchId: 'branch-1' } }),
+      ]);
+    });
+
+    it('bash: given no binding, acquireSandbox should carry no branchSandbox', async () => {
+      const seenAcquisitions: unknown[] = [];
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async (input) => {
+        seenAcquisitions.push(input);
+        return { ok: true, sandboxId: 'sbx', resumed: false };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+      expect(seenAcquisitions).toEqual([expect.objectContaining({ branchSandbox: undefined })]);
+    });
+
+    it('bash: given the branch acquire fails, should surface a tool error and run no command', async () => {
+      let reconnected = false;
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async () => ({ ok: false, reason: 'branch_not_found' });
+      runDeps.reconnect = async () => {
+        reconnected = true;
+        return {
+          sandboxId: 'sbx',
+          spriteInstanceId: null,
+          runCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+          writeFiles: async () => {},
+          readFileToBuffer: async () => Buffer.from(''),
+          createCheckpoint: async () => {},
+        };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: {
+          machineId: 'm1',
+          cwd: '/workspace/repo',
+          branchSandbox: { machineBranchId: 'branch-1', sandboxId: 'sbx-1' },
+        },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: false });
+      expect(reconnected).toBe(false);
+    });
+  });
+
   describe('terminal tools resolve the active machine before delegating', () => {
     it('bash/writeFile/readFile/editFile should each resolve the configured machines to determine the active one', async () => {
       const listMachines = vi.fn().mockResolvedValue([{ kind: 'own' }]);

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -497,8 +497,17 @@ export function createMachineDirectory(
   deps: MachineDirectoryRuntimeDeps = defaultMachineDirectoryDeps,
 ): MachineDirectoryDeps {
   return {
-    listMachines: (rawContext) =>
-      resolveConfiguredMachines(activeMachineAgentPageId(rawContext), rawContext?.userId, deps),
+    listMachines: (rawContext) => {
+      // A machine-bound "PageSpace Agent" pane (issue #2166 phase 7): the
+      // binding IS the entitlement (established by the route's page-edit
+      // check before deriveMachinePaneBinding ran), so the agent's/global
+      // assistant's own configured machine list is never consulted — the
+      // bound machine is the ONLY machine this run may ever see or switch to.
+      if (rawContext?.machineBinding) {
+        return Promise.resolve([{ kind: 'existing' as const, machineId: rawContext.machineBinding.machineId }]);
+      }
+      return resolveConfiguredMachines(activeMachineAgentPageId(rawContext), rawContext?.userId, deps);
+    },
     describeMachine: async (_rawContext, machine) => {
       if (machine.kind === 'own') return { name: 'My Machine' };
       const page = await deps.findPage(machine.machineId);
@@ -516,6 +525,15 @@ export function createMachineDirectory(
       if (!page || page.isTrashed || !isMachinePage(page.type as PageType)) return { allowed: false };
       const canView = await deps.canViewPage(rawContext, machine.machineId);
       if (!canView) return { allowed: false };
+      // A machine-bound "PageSpace Agent" pane (issue #2166 phase 7): the
+      // pane's OWN bound machine is exempt from the Settings-toggle decision
+      // below — same rationale as the user-scoped-agent exemption just below
+      // (the binding IS the entitlement, established by the route's
+      // page-edit check before deriveMachinePaneBinding ran) — but existence/
+      // trash/type/canActorViewPage above are NEVER bypassed. A DIFFERENT
+      // machine (e.g. an attempted switch_machine away from the bound
+      // checkout) still gets the full toggle check below.
+      if (rawContext.machineBinding?.machineId === machine.machineId) return { allowed: true };
       // Machine access toggles (Settings tab): pure policy in @pagespace/lib
       // machines/machine-access.ts. An agentPageId — the agent's own page or
       // the parent's for a sub-agent — marks the actor page-scoped; without

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -45,6 +45,19 @@ export function machineRefEquals(a: MachineRef, b: MachineRef): boolean {
   return machineRefId(a) === machineRefId(b);
 }
 
+/**
+ * `bash`'s cwd-default policy for a machine-bound "PageSpace Agent" pane
+ * (issue #2166 phase 7): an explicit `cwd` argument always wins; absent one,
+ * the binding's own `cwd` (the pane's checkout) is used. Returns `undefined`
+ * when neither is present, preserving the runner's own SANDBOX_ROOT default.
+ */
+export function bindingCwdFor(
+  explicitCwd: string | undefined,
+  binding: { cwd: string } | undefined,
+): string | undefined {
+  return explicitCwd ?? binding?.cwd;
+}
+
 /** Resolves an agent-facing id (from switch_machine's input) back to a configured MachineRef. */
 export function machineRefFromId(id: string, configured: MachineRef[]): MachineRef | undefined {
   return configured.find((m) => machineRefId(m) === id);
@@ -346,7 +359,15 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
     const tenantId = machines.resolveTenantId
       ? await machines.resolveTenantId(rawContext, activeMachine, ctx.tenantId)
       : ctx.tenantId;
-    return { ok: true, ctx: { ...ctx, driveId, tenantId, activeMachine } };
+    // A machine-bound "PageSpace Agent" pane's branchSandbox (issue #2166
+    // phase 7) routes acquireSandbox through the attach-only branch seam
+    // (acquireRequest in tool-runners.ts already forwards ctx.branchSandbox) —
+    // this is the one place that binding is translated onto the actor ctx.
+    const binding = rawContext?.machineBinding;
+    const branchSandbox = binding?.branchSandbox
+      ? { machineId: binding.machineId, machineBranchId: binding.branchSandbox.machineBranchId }
+      : undefined;
+    return { ok: true, ctx: { ...ctx, driveId, tenantId, activeMachine, branchSandbox } };
   };
 
   return {
@@ -357,7 +378,14 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
       execute: async ({ command, cwd, timeoutMs }, options) => {
         const opened = await open(options);
         if (!opened.ok) return opened.error;
-        return runBashInSandbox({ command, cwd, timeoutMs, ctx: opened.ctx, deps: runDeps });
+        const rawContext = readContext(options);
+        return runBashInSandbox({
+          command,
+          cwd: bindingCwdFor(cwd, rawContext?.machineBinding),
+          timeoutMs,
+          ctx: opened.ctx,
+          deps: runDeps,
+        });
       },
     }),
 


### PR DESCRIPTION
## Summary
- `listMachines` collapses to exactly `[{ kind: 'existing', machineId }]` when a `machineBinding` is present — the binding IS the pane's machine entitlement.
- `isMachineAccessible` skips `decideMachineToggleAccess` for the bound machine only (existence/trash/type/`canActorViewPage` still enforced); a different machine keeps the full check.
- `bash` defaults its `cwd` to `binding.cwd` via a new pure `bindingCwdFor` helper when no explicit `cwd` is given; an explicit `cwd` still wins.
- `open()` threads `binding.branchSandbox` onto the actor ctx so `acquireSandbox` routes through the attach-only branch seam (existing `acquireRequest`/`buildRealSandboxRunDeps` plumbing from phase 8 — no new code needed there); a failing acquire surfaces a tool error with no command run.

Maps to issue #2166 phase 7 / board page `qffgvp5ez26hve6a2mt4if5k`. Depends on phase 5 (`deriveMachinePaneBinding`) and phase 8 (`acquireBranchSandbox`), both already merged into `pu/panes-agent`.

## Test plan
- [x] RED: added failing tests to both `__tests__` files (no `vi.mock` of pure/DI seams), confirmed against pre-GREEN code.
- [x] GREEN: 101/101 tests pass in `sandbox-tools.test.ts` + `sandbox-tools-runtime.test.ts`.
- [x] `bun run typecheck` (apps/web) — clean.
- [x] `bun run lint` (apps/web) — only pre-existing warnings in unrelated files.
- [x] `@pagespace/lib` unit suite — 8653/8664 passed (skips only).
- [x] `apps/web` unit suite — 4 pre-existing/unrelated failures (missing Postgres `test` role for DB-integration tests; a TZ-dependent date test), none touching the changed files.
- [x] `bun run test:security` — 7/50 suites fail on stale `scripts/test-security.sh` paths / DB-integration exclusions unrelated to this change (documented in memory for future reviewers).
- [x] Independent `/aidd-review` pass — 0 blockers/majors, 2 nits, recorded on the phase board page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013pTKLrp52oFK3Q5PvkTpLQ