### PR TITLE
feat(machine-panes): Phase 4 — Spawn API: row ids, code-exec gate & shared-conversation pre-create

### DIFF
--- a/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
@@ -11,9 +11,11 @@ const {
   mockBuildSpawnAgentTerminalDeps,
   mockBuildKillAgentTerminalDeps,
   mockBuildListAgentTerminalsDeps,
+  mockIsCodeExecutionEnabled,
   mockSpawnAgentTerminal,
   mockKillAgentTerminal,
   mockListAgentTerminals,
+  mockCreateConversation,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
@@ -22,9 +24,11 @@ const {
   mockBuildSpawnAgentTerminalDeps: vi.fn(),
   mockBuildKillAgentTerminalDeps: vi.fn(),
   mockBuildListAgentTerminalsDeps: vi.fn(),
+  mockIsCodeExecutionEnabled: vi.fn(),
   mockSpawnAgentTerminal: vi.fn(),
   mockKillAgentTerminal: vi.fn(),
   mockListAgentTerminals: vi.fn(),
+  mockCreateConversation: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -38,12 +42,19 @@ vi.mock('@/lib/machines/agent-terminals-runtime', () => ({
   buildListAgentTerminalsDeps: (...args: unknown[]) => mockBuildListAgentTerminalsDeps(...args),
   canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
   canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
+  isCodeExecutionEnabled: (...args: unknown[]) => mockIsCodeExecutionEnabled(...args),
 }));
 
 vi.mock('@pagespace/lib/services/machines/agent-terminals', () => ({
   spawnAgentTerminal: (...args: unknown[]) => mockSpawnAgentTerminal(...args),
   killAgentTerminal: (...args: unknown[]) => mockKillAgentTerminal(...args),
   listAgentTerminals: (...args: unknown[]) => mockListAgentTerminals(...args),
+}));
+
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    createConversation: (...args: unknown[]) => mockCreateConversation(...args),
+  },
 }));
 
 import { GET, POST, DELETE } from '../route';
@@ -58,6 +69,8 @@ beforeEach(() => {
   mockBuildSpawnAgentTerminalDeps.mockReturnValue(FAKE_DEPS);
   mockBuildKillAgentTerminalDeps.mockResolvedValue(FAKE_DEPS);
   mockBuildListAgentTerminalsDeps.mockReturnValue(FAKE_DEPS);
+  mockIsCodeExecutionEnabled.mockReturnValue(true);
+  mockCreateConversation.mockResolvedValue(undefined);
 });
 
 describe('GET /api/machines/agent-terminals', () => {
@@ -71,12 +84,13 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
+      terminals: [{ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.agentTerminals).toHaveLength(1);
+    expect(body.agentTerminals[0].id).toBe('agent-terminal-1');
     expect(mockCanViewMachine).toHaveBeenCalledWith('user-1', 't1');
     expect(mockListAgentTerminals).toHaveBeenCalledWith(
       expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main' }),
@@ -87,11 +101,16 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
+      terminals: [{ id: 'agent-terminal-legacy', name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     const body = await res.json();
-    expect(body.agentTerminals[0]).toEqual({ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-07-01T00:00:00.000Z' });
+    expect(body.agentTerminals[0]).toEqual({
+      id: 'agent-terminal-legacy',
+      name: 'legacy-cli',
+      agentType: 'pagespace-cli',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
   });
 
   it('given no view access, returns 403 without listing', async () => {
@@ -153,13 +172,13 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
 
-  it('given a fresh spawn of a claude terminal, returns 201', async () => {
+  it('given a fresh spawn of a claude terminal, returns 201 with the row id', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ name: 'cli', agentType: 'claude', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', resumed: false });
     expect(mockSpawnAgentTerminal).toHaveBeenCalledWith(
       expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' }),
     );
@@ -248,6 +267,66 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(res.status).toBe(400);
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
+
+  it('given a pagespace terminal with the code-execution flag off, returns 403 without spawning', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(false);
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(403);
+    expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
+  });
+
+  it('given a pagespace terminal with the code-execution flag on, spawns normally', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-5', agentType: 'pagespace', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    expect(mockSpawnAgentTerminal).toHaveBeenCalled();
+  });
+
+  it('given a non-pagespace terminal, spawns regardless of the code-execution flag', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(false);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-6', agentType: 'claude', resumed: false });
+    const res = await POST(req(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockSpawnAgentTerminal).toHaveBeenCalled();
+  });
+
+  it('given a fresh pagespace spawn, pre-creates the shared conversation keyed on the row id', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-7', agentType: 'pagespace', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    expect(mockCreateConversation).toHaveBeenCalledWith('agent-terminal-7', 'user-1', 't1', { isShared: true });
+  });
+
+  it('given a resumed pagespace spawn, does NOT pre-create the conversation', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-7', agentType: 'pagespace', resumed: true });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(200);
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('given a fresh non-pagespace spawn, does NOT pre-create a conversation', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-8', agentType: 'claude', resumed: false });
+    const res = await POST(req(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('given the pre-create conversation call fails, the spawn still succeeds (non-fatal)', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-9', agentType: 'pagespace', resumed: false });
+    mockCreateConversation.mockRejectedValue(new Error('db unavailable'));
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-9', resumed: false });
+  });
 });
 
 describe('DELETE /api/machines/agent-terminals', () => {
@@ -300,5 +379,12 @@ describe('DELETE /api/machines/agent-terminals', () => {
     mockKillAgentTerminal.mockResolvedValue({ ok: false, reason: 'invalid_target' });
     const res = await DELETE(url('machineId=t1&branchName=main&name=cli'));
     expect(res.status).toBe(400);
+  });
+
+  it('given a chat-surface (not_a_pty_agent) row, returns a pinned status', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockKillAgentTerminal.mockResolvedValue({ ok: false, reason: 'not_a_pty_agent' });
+    const res = await DELETE(url('machineId=t1&projectName=repo&branchName=main&name=cli'));
+    expect(res.status).toBe(409);
   });
 });

--- a/apps/web/src/app/api/machines/agent-terminals/route.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/route.ts
@@ -26,7 +26,9 @@ import {
   buildListAgentTerminalsDeps,
   canAccessMachine,
   canViewMachine,
+  isCodeExecutionEnabled,
 } from '@/lib/machines/agent-terminals-runtime';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -67,6 +69,7 @@ const SPAWN_DENIAL_STATUS: Record<string, number> = {
 const KILL_DENIAL_STATUS: Record<string, number> = {
   ...SCOPE_DENIAL_STATUS,
   not_found: 404,
+  not_a_pty_agent: 409,
   error: 500,
 };
 
@@ -96,7 +99,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: result.reason }, { status: SCOPE_DENIAL_STATUS[result.reason] ?? 500 });
   }
   return NextResponse.json({
-    agentTerminals: result.terminals.map((t) => ({ name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
+    agentTerminals: result.terminals.map((t) => ({ id: t.id, name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
   });
 }
 
@@ -124,6 +127,12 @@ export async function POST(request: Request) {
   const command = optionalString(body.command, 'command');
   if (!command.ok) return command.error;
 
+  // `pagespace` renders the PageSpace AI chat UI rather than a real PTY — refuse it
+  // up front, before any DB access check, when the code-execution kill switch is off.
+  if (agentType.value === 'pagespace' && !isCodeExecutionEnabled()) {
+    return NextResponse.json({ error: 'code_execution_disabled', reason: 'code_execution_disabled' }, { status: 403 });
+  }
+
   if (!(await canAccessMachine(auth.userId, machineId.value))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
@@ -141,8 +150,21 @@ export async function POST(request: Request) {
   if (!result.ok) {
     return NextResponse.json({ error: result.reason, reason: result.reason }, { status: SPAWN_DENIAL_STATUS[result.reason] ?? 500 });
   }
+
+  // A fresh `pagespace` row needs its shared conversation to exist before the client's
+  // first message so co-editors get multi-viewer parity from the start. A resumed
+  // spawn reattaches to whatever the original fresh spawn already created. Non-fatal:
+  // a failed pre-create just means the row gets created lazily on first message instead.
+  if (agentType.value === 'pagespace' && !result.resumed) {
+    try {
+      await conversationRepository.createConversation(result.id, auth.userId, machineId.value, { isShared: true });
+    } catch {
+      // Non-fatal — see comment above.
+    }
+  }
+
   return NextResponse.json(
-    { agentTerminal: { name: name.value, agentType: result.agentType, resumed: result.resumed } },
+    { agentTerminal: { id: result.id, name: name.value, agentType: result.agentType, resumed: result.resumed } },
     { status: result.resumed ? 200 : 201 },
   );
 }

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -6,6 +6,9 @@ import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 
 export interface AgentTerminal {
+  // The row's own id — used client-side as the conversation id for
+  // chat-surface (`pagespace`) terminals.
+  id: string;
   name: string;
   // A raw DB value, not narrowed to AgentRuntimeType — a row can carry an
   // agentType from a since-retired AGENT_LAUNCH_SPECS entry (e.g. the removed
@@ -95,7 +98,7 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
   const addAgentTerminal = useCallback(
     async (name: string, agentType: AgentRuntimeType) => {
       if (!machineId) throw new Error('No active machine');
-      const result = await post<{ agentTerminal: { name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
+      const result = await post<{ agentTerminal: { id: string; name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
         '/api/machines/agent-terminals',
         { machineId, projectName: projectName ?? undefined, branchName: branchName ?? undefined, name, agentType },
       );

--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -49,7 +49,7 @@ import type {
 } from '@pagespace/lib/services/machines/agent-terminals';
 import { canAccessMachine, canViewMachine, getMachineHostForBranches } from './machine-branches-runtime';
 
-export { canAccessMachine, canViewMachine };
+export { canAccessMachine, canViewMachine, isCodeExecutionEnabled };
 
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one —
 // @fly/sprites is ESM-only and @pagespace/lib compiles to CJS. Mirrors the

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -221,6 +221,47 @@ describe('conversationRepository.createConversation', () => {
       expect.objectContaining({ id: 'conv-mine', userId: 'user-1' })
     );
   });
+
+  it('given { isShared: true }, persists a shared row, keeping the squat-guard + onConflictDoNothing', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-shared', 'user-1', 'machine-1', { isShared: true });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-shared', userId: 'user-1', contextId: 'machine-1', isShared: true })
+    );
+    expect(onConflictDoNothing).toHaveBeenCalled();
+  });
+
+  it('given no opts (or isShared omitted), still defaults to isShared: false', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-default', 'user-1', 'agent-1', {});
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-default', isShared: false })
+    );
+  });
+
+  it('given { isShared: true }, still refuses a conversationId owned by a different user (squat-guard applies regardless of isShared)', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([{ userId: 'victim-user' }]));
+
+    await conversationRepository.createConversation('conv-legacy', 'attacker-user', 'machine-1', { isShared: true });
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
 });
 
 describe('conversationRepository.setConversationShared', () => {

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -152,7 +152,7 @@ export const conversationRepository = {
    * so every caller — including pre-existing ones — gets this guarantee.
    */
 
-  async createConversation(conversationId: string, userId: string, pageId: string): Promise<void> {
+  async createConversation(conversationId: string, userId: string, pageId: string, opts?: { isShared?: boolean }): Promise<void> {
     const [existing] = await db
       .select({ id: conversations.id })
       .from(conversations)
@@ -170,7 +170,7 @@ export const conversationRepository = {
         userId,
         type: 'page',
         contextId: pageId,
-        isShared: false,
+        isShared: opts?.isShared ?? false,
         updatedAt: new Date(),
       })
       .onConflictDoNothing();


### PR DESCRIPTION
## Summary

Maps to #2166 step 4 / board page `nhdgxzh26vka08sgbc9link9`. Depends on Phase 1 (pagespace agent type) and Phase 2 (`not_a_pty_agent` union), both already merged into `pu/panes-agent`.

- GET/POST `/api/machines/agent-terminals` responses now include the row `id` — used client-side as the conversation id for `pagespace` (chat-surface) terminals.
- POST gates `pagespace` on `isCodeExecutionEnabled()`: flag off → 403, `spawnAgentTerminal` never called. Non-`pagespace` types spawn regardless of the flag.
- A fresh `pagespace` spawn (`resumed: false`) pre-creates the shared conversation via `conversationRepository.createConversation(row.id, userId, machineId, { isShared: true })`; a resumed spawn does not; a pre-create failure is non-fatal (spawn still succeeds — the conversation gets created lazily on first message otherwise).
- `KILL_DENIAL_STATUS` now pins `not_a_pty_agent` to `409`. (The kill service doesn't produce this reason today — a chat-surface row always takes Phase 2's cheap `streamSessionId === null` path — but the route's status map now has a home for it regardless of caller.)
- `conversationRepository.createConversation` gained an optional `opts?: { isShared?: boolean }` (default `false`, so existing 3-arg callers are unaffected); the squat-guard and `onConflictDoNothing` insert are untouched.

## Test plan

- [x] `bun run typecheck` (apps/web) — clean
- [x] `bun run lint` (apps/web) — pre-existing warnings only, identical baseline confirmed via `git stash`
- [x] `bun run test:unit` — new/changed suites (`agent-terminals/route.test.ts` 35/35, `conversation-repository.test.ts` 12/12) pass; 4 pre-existing failing suites reproduce identically on `git stash` (DB role `"test"` not provisioned locally, an unrelated midnight-boundary test, and an unbuilt `@pagespace/sdk` package) — none touch this phase's files
- [x] `bun run test:security` — Security Audit Route Coverage passes (4/4); pre-existing failures are stale test-file paths in `scripts/test-security.sh` and the same local-DB-role issue, unrelated to this change
- [x] TDD leaves flipped on board page `nhdgxzh26vka08sgbc9link9` (RED/GREEN × 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEjvWVJ8GjD8qTgnScJY5