### PR TITLE
feat(machine-panes): Phase 11 — MachinePaneChat: third selector surface (dual-mode hook, in-pane tabs)

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/__tests__/route.test.ts
@@ -33,6 +33,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ kind: 'eq', a, b })),
   ne: vi.fn((a, b) => ({ kind: 'ne', a, b })),
   and: vi.fn((...c) => ({ kind: 'and', c })),
+  inArray: vi.fn((f, values) => ({ kind: 'inArray', f, values })),
   desc: vi.fn((f) => ({ kind: 'desc', f })),
   sql: Object.assign(vi.fn(), { as: vi.fn() }),
 }));

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq, and, ne, desc, sql } from '@pagespace/db/operators'
+import { eq, and, ne, desc, sql, inArray } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -19,7 +19,7 @@ const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: fal
  * Messages are returned in UIMessage format compatible with the Vercel AI SDK,
  * including tool calls and tool results if present.
  *
- * @param agentId - The unique identifier of the AI agent (AI_CHAT page ID)
+ * @param agentId - The conversation-hosting page id (AI_CHAT agent or MACHINE page)
  * @param conversationId - The unique identifier of the conversation session
  *
  * Query Parameters:
@@ -66,11 +66,13 @@ export async function GET(
 
     const { agentId, conversationId } = await context.params;
 
-    // Verify agent exists and is AI_CHAT type
+    // Verify the conversation-hosting page exists: an AI_CHAT agent, or a
+    // MACHINE page (machine panes anchor terminal conversations there —
+    // same widening as conversationRepository.getAiAgent, #2166 Phase 11).
     const agent = await db.query.pages.findFirst({
       where: and(
         eq(pages.id, agentId),
-        eq(pages.type, 'AI_CHAT'),
+        inArray(pages.type, ['AI_CHAT', 'MACHINE']),
         eq(pages.isTrashed, false)
       ),
     });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
@@ -229,7 +229,7 @@ export default function MachinePaneChat({
         </TabsContent>
 
         <TabsContent value="settings" className="mt-0 min-h-0 flex-1 overflow-auto">
-          <PaneSettings selectedAgentTitle={pane.selectedAgent?.title ?? null} agent={pane.selectedAgent} />
+          <PaneSettings agent={pane.selectedAgent} />
         </TabsContent>
       </Tabs>
 
@@ -250,10 +250,8 @@ export default function MachinePaneChat({
  * its page, not in a terminal pane.
  */
 function PaneSettings({
-  selectedAgentTitle,
   agent,
 }: {
-  selectedAgentTitle: string | null;
   agent: {
     title: string;
     driveName: string;
@@ -283,7 +281,7 @@ function PaneSettings({
           <SettingsRow label="System prompt" value={agent.systemPrompt ? 'Custom' : 'None'} />
         </dl>
         <p className="text-muted-foreground">
-          Configure {selectedAgentTitle} on its own page.
+          Configure {agent.title} on its own page.
         </p>
       </div>
     );

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+/**
+ * MachinePaneChat — the "PageSpace Agent" pane's UI (Phase 11, #2166).
+ *
+ * The third selector surface: the header's agent picker chooses between the
+ * machine-anchored assistant (null selection — the terminal row's own
+ * conversation, machine-pane binding active) and any page agent. All chat
+ * state lives in useMachinePaneChat; this component is tabs + presentation.
+ *
+ * Presentation is a compact, chrome-free, terminal-leaning skin: Conversation
+ * + CompactMessageRenderer (via the shared SidebarMessagesContent) + ChatInput
+ * (variant="sidebar"). No floating card, no share buttons — History mirrors
+ * PageAgentHistoryTab minus its share controls (omitting onToggleShare hides
+ * them). Rendered inside a split grid, so everything stays min-w-0/min-h-0
+ * and the messages area contains its own layout.
+ */
+import React, { useCallback, useState } from 'react';
+import { MessageSquare, History, Settings, Plus, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+import { ChatInput } from '@/components/ai/chat/input';
+import { ProviderModelSelector } from '@/components/ai/chat/input/ProviderModelSelector';
+import { AISelector } from '@/components/ai/shared';
+import { UndoAiChangesDialog } from '@/components/ai/shared/chat';
+import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
+import {
+  Conversation,
+  ConversationScrollButton,
+} from '@/components/ai/ui/conversation';
+import PageAgentHistoryTab from '@/components/ai/page-agents/PageAgentHistoryTab';
+import { SidebarMessagesContent } from '@/components/layout/right-sidebar/ai-assistant/SidebarChatTab';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
+import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { useMachinePaneChat } from './useMachinePaneChat';
+
+export interface MachinePaneChatProps {
+  /** The machine page this pane belongs to. */
+  machineId: string;
+  /** The terminal row id — the machine-anchored conversation (Phase 4). */
+  terminalId: string;
+  /** The picker's starting prompt, auto-sent once into a fresh conversation. */
+  pendingPrompt?: string;
+  /** Consumed-notification for pendingPrompt. */
+  onPromptSent?: () => void;
+}
+
+type PaneTab = 'chat' | 'history' | 'settings';
+
+export default function MachinePaneChat({
+  machineId,
+  terminalId,
+  pendingPrompt,
+  onPromptSent,
+}: MachinePaneChatProps) {
+  const [activeTab, setActiveTab] = useState<PaneTab>('chat');
+  const [input, setInput] = useState('');
+  const [showError, setShowError] = useState(true);
+  const [undoMessageId, setUndoMessageId] = useState<string | null>(null);
+
+  const pane = useMachinePaneChat({
+    machineId,
+    terminalId,
+    pendingPrompt,
+    onPromptSent,
+    historyEnabled: activeTab === 'history' || activeTab === 'chat',
+  });
+
+  const assistantName = pane.selectedAgent ? pane.selectedAgent.title : 'PageSpace Agent';
+
+  const handleSendClick = useCallback(async () => {
+    const text = input;
+    if (!text.trim()) return;
+    // Clear immediately (typing during the handoff wait must not merge into
+    // the old draft); restore only if the composer is still empty on refusal.
+    setInput('');
+    const dispatched = await pane.handleSend(text);
+    if (!dispatched) {
+      setInput((current) => (current === '' ? text : current));
+    }
+  }, [input, pane]);
+
+  const handleSelectHistoryConversation = useCallback(
+    (conversationId: string) => {
+      void pane.openConversation(conversationId);
+      setActiveTab('chat');
+    },
+    [pane],
+  );
+
+  const handleCreateConversation = useCallback(() => {
+    void pane.createNewConversation().then((created) => {
+      if (created) setActiveTab('chat');
+    });
+  }, [pane]);
+
+  const handleUndoFromHere = useCallback((messageId: string) => {
+    setUndoMessageId(messageId);
+  }, []);
+
+  const handleUndoSuccess = useCallback(async () => {
+    setUndoMessageId(null);
+    await pane.reloadConversation();
+  }, [pane]);
+
+  const remoteStreamingUser = !pane.displayIsStreaming
+    ? pane.remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
+    : null;
+
+  return (
+    <div data-testid="machine-pane-chat" className="flex h-full min-w-0 flex-col bg-background">
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as PaneTab)}
+        className="flex h-full min-h-0 flex-col"
+      >
+        {/* Header: picker + tabs + new conversation — one compact row. */}
+        <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
+          <AISelector
+            selectedAgent={pane.selectedAgent}
+            onSelectAgent={pane.selectAgent}
+            disabled={pane.displayIsStreaming}
+            className="min-w-0 flex-1 text-xs font-medium"
+          />
+          <TabsList className="h-7 shrink-0 p-0.5">
+            <TabsTrigger value="chat" aria-label="Chat" className="h-6 px-1.5">
+              <MessageSquare className="size-3.5" />
+            </TabsTrigger>
+            <TabsTrigger value="history" aria-label="History" className="h-6 px-1.5">
+              <History className="size-3.5" />
+            </TabsTrigger>
+            <TabsTrigger value="settings" aria-label="Settings" className="h-6 px-1.5">
+              <Settings className="size-3.5" />
+            </TabsTrigger>
+          </TabsList>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCreateConversation}
+            title="New conversation"
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="size-3.5" />
+          </Button>
+        </div>
+
+        <TabsContent value="chat" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+          {pane.hasLoadError && (
+            <div className="flex items-center justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+              <span className="truncate">Failed to load messages</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 shrink-0 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => void pane.reloadConversation()}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden" style={{ contain: 'layout' }}>
+            {pane.isMessagesLoading && pane.messages.length === 0 && pane.remoteStreams.length === 0 ? (
+              <div data-testid="machine-pane-chat-loading" className="flex h-full items-center justify-center">
+                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <Conversation className="h-full">
+                <SidebarMessagesContent
+                  messages={pane.messages}
+                  assistantName={assistantName}
+                  contextLabel={null}
+                  handleEdit={pane.handleEdit}
+                  handleDelete={pane.handleDelete}
+                  handleRetry={pane.handleRetry}
+                  handleUndoFromHere={handleUndoFromHere}
+                  lastAssistantMessageId={pane.lastAssistantMessageId}
+                  lastUserMessageId={pane.lastUserMessageId}
+                  displayIsStreaming={pane.displayIsStreaming}
+                  remoteStreams={pane.remoteStreams}
+                  onScrollNearTop={pane.handleScrollNearTop}
+                  isLoadingOlder={pane.isLoadingOlder}
+                  hasMoreOlder={pane.hasMoreOlder}
+                />
+                <ConversationScrollButton className="bottom-6 z-10" />
+              </Conversation>
+            )}
+          </div>
+
+          <div className="shrink-0 space-y-1.5 border-t border-border p-2">
+            <ChatErrorBanner
+              cause={pane.errorCause}
+              show={showError}
+              onClearError={() => {
+                setShowError(false);
+                pane.dismissError();
+              }}
+            />
+            <ChatInput
+              value={input}
+              onChange={setInput}
+              onSend={() => void handleSendClick()}
+              onStop={() => void pane.handleStop()}
+              isStreaming={pane.displayIsStreaming}
+              placeholder={
+                pane.selectedAgent
+                  ? `Message ${pane.selectedAgent.title}...`
+                  : 'Message the machine agent...'
+              }
+              hideModelSelector
+              variant="sidebar"
+              hasVision={hasVisionCapability(pane.selectedAgent?.aiModel || '')}
+              remoteStreamingUser={remoteStreamingUser}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="history" className="mt-0 min-h-0 flex-1 overflow-hidden">
+          {/* No onToggleShare — that is what removes the share controls. */}
+          <PageAgentHistoryTab
+            conversations={pane.conversations}
+            currentConversationId={pane.currentConversationId}
+            onSelectConversation={handleSelectHistoryConversation}
+            onCreateNew={handleCreateConversation}
+            onDeleteConversation={(conversationId) => void pane.deleteConversation(conversationId)}
+            isLoading={pane.isLoadingConversations}
+          />
+        </TabsContent>
+
+        <TabsContent value="settings" className="mt-0 min-h-0 flex-1 overflow-auto">
+          <PaneSettings selectedAgentTitle={pane.selectedAgent?.title ?? null} agent={pane.selectedAgent} />
+        </TabsContent>
+      </Tabs>
+
+      <UndoAiChangesDialog
+        open={!!undoMessageId}
+        onOpenChange={(open) => !open && setUndoMessageId(null)}
+        messageId={undoMessageId}
+        onSuccess={handleUndoSuccess}
+      />
+    </div>
+  );
+}
+
+/**
+ * Slim settings, per mode (kept thin by design — the phase page's "Keep tabs
+ * thin"): default mode edits the shared assistant settings store; agent mode
+ * shows the agent's own configuration read-only — editing an agent belongs on
+ * its page, not in a terminal pane.
+ */
+function PaneSettings({
+  selectedAgentTitle,
+  agent,
+}: {
+  selectedAgentTitle: string | null;
+  agent: {
+    title: string;
+    driveName: string;
+    aiProvider?: string;
+    aiModel?: string;
+    systemPrompt?: string;
+  } | null;
+}) {
+  const currentProvider = useAssistantSettingsStore((state) => state.currentProvider);
+  const currentModel = useAssistantSettingsStore((state) => state.currentModel);
+  const setProviderSettings = useAssistantSettingsStore((state) => state.setProviderSettings);
+  const webSearchEnabled = useAssistantSettingsStore((state) => state.webSearchEnabled);
+  const toggleWebSearch = useAssistantSettingsStore((state) => state.toggleWebSearch);
+  const writeMode = useAssistantSettingsStore((state) => state.writeMode);
+  const toggleWriteMode = useAssistantSettingsStore((state) => state.toggleWriteMode);
+
+  if (agent) {
+    return (
+      <div data-testid="machine-pane-agent-settings" className="space-y-3 p-3 text-xs">
+        <div>
+          <p className="font-medium">{agent.title}</p>
+          <p className="text-muted-foreground">{agent.driveName}</p>
+        </div>
+        <dl className="space-y-1.5">
+          <SettingsRow label="Provider" value={agent.aiProvider ?? 'Default'} />
+          <SettingsRow label="Model" value={agent.aiModel ?? 'Default'} />
+          <SettingsRow label="System prompt" value={agent.systemPrompt ? 'Custom' : 'None'} />
+        </dl>
+        <p className="text-muted-foreground">
+          Configure {selectedAgentTitle} on its own page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="machine-pane-assistant-settings" className="space-y-3 p-3">
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium">Model</p>
+        <ProviderModelSelector
+          provider={currentProvider}
+          model={currentModel}
+          onChange={setProviderSettings}
+        />
+      </div>
+      <SettingsToggle label="Web search" checked={webSearchEnabled} onToggle={toggleWebSearch} />
+      <SettingsToggle label="Write mode" checked={writeMode} onToggle={toggleWriteMode} />
+    </div>
+  );
+}
+
+function SettingsRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="shrink-0 text-muted-foreground">{label}</dt>
+      <dd className="truncate">{value}</dd>
+    </div>
+  );
+}
+
+function SettingsToggle({
+  label,
+  checked,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      role="switch"
+      aria-checked={checked}
+      onClick={onToggle}
+      className={cn('h-7 w-full justify-between px-2 text-xs', checked && 'border-primary')}
+    >
+      <span>{label}</span>
+      <span className="text-muted-foreground">{checked ? 'On' : 'Off'}</span>
+    </Button>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * MachinePaneChat Component Tests — Phase 11 (#2166)
+ *
+ * The behavior contract lives in useMachinePaneChat.test.ts; this suite
+ * covers the component shell: in-pane tabs, the share-control-free History
+ * tab, per-mode Settings, and the composer wiring. The state hook is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AgentInfo } from '@/types/agent';
+
+const paneState = vi.hoisted(() => ({
+  current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../useMachinePaneChat', () => ({
+  useMachinePaneChat: vi.fn(() => paneState.current),
+}));
+
+// Presentation-only children with heavy dependency trees are stubbed — this
+// suite is about MachinePaneChat's own shell, not theirs.
+vi.mock('@/components/layout/right-sidebar/ai-assistant/SidebarChatTab', () => ({
+  SidebarMessagesContent: () => <div data-testid="messages-content" />,
+}));
+
+vi.mock('@/components/ai/chat/input', () => ({
+  ChatInput: ({ value, onChange, onSend }: {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+  }) => (
+    <div>
+      <input
+        data-testid="chat-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button data-testid="chat-send" onClick={onSend}>
+        Send
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ai/chat/input/ProviderModelSelector', () => ({
+  ProviderModelSelector: () => <div data-testid="provider-model-selector" />,
+}));
+
+vi.mock('@/components/ai/shared', () => ({
+  AISelector: ({ onSelectAgent }: { onSelectAgent: (agent: AgentInfo | null) => void }) => (
+    <button data-testid="agent-picker" onClick={() => onSelectAgent(null)}>
+      Picker
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ai/shared/chat', () => ({
+  UndoAiChangesDialog: () => null,
+}));
+
+import MachinePaneChat from '../MachinePaneChat';
+
+function conversationRow(id: string, title: string) {
+  const now = new Date();
+  return {
+    id,
+    title,
+    preview: 'preview',
+    isShared: false,
+    isOwner: true,
+    createdAt: now,
+    updatedAt: now,
+    messageCount: 1,
+    lastMessage: { role: 'user', timestamp: now },
+  };
+}
+
+function basePaneState(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedAgent: null,
+    selectAgent: vi.fn(),
+    currentConversationId: 'terminal-1',
+    channelId: 'machine-1',
+    messages: [],
+    remoteStreams: [],
+    displayIsStreaming: false,
+    isMessagesLoading: false,
+    hasLoadError: false,
+    reloadConversation: vi.fn(),
+    handleSend: vi.fn(async () => true),
+    handleStop: vi.fn(async () => {}),
+    handleEdit: vi.fn(),
+    handleDelete: vi.fn(),
+    handleRetry: vi.fn(),
+    lastAssistantMessageId: undefined,
+    lastUserMessageId: undefined,
+    handleScrollNearTop: vi.fn(),
+    isLoadingOlder: false,
+    hasMoreOlder: false,
+    conversations: [],
+    isLoadingConversations: false,
+    openConversation: vi.fn(async () => {}),
+    createNewConversation: vi.fn(async () => 'new-conv'),
+    deleteConversation: vi.fn(async () => {}),
+    errorCause: null,
+    dismissError: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  paneState.current = basePaneState();
+});
+
+describe('MachinePaneChat', () => {
+  it('renders the chat tab by default and dispatches sends through the hook', async () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    expect(screen.getByTestId('machine-pane-chat')).toBeInTheDocument();
+    expect(screen.getByTestId('messages-content')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'hello' } });
+    fireEvent.click(screen.getByTestId('chat-send'));
+
+    await waitFor(() =>
+      expect(paneState.current.handleSend).toHaveBeenCalledWith('hello'),
+    );
+  });
+
+  it('History tab lists conversations WITHOUT share controls and opens into the chat tab', async () => {
+    paneState.current = basePaneState({
+      conversations: [conversationRow('conv-1', 'Machine chat')],
+    });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'History' }));
+
+    const row = await screen.findByTestId('history-conversation-item');
+    expect(row).toHaveTextContent('Machine chat');
+    // Minus share: PageAgentHistoryTab renders its share toggle only when
+    // onToggleShare is passed — this surface never passes it.
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/share/i)).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(paneState.current.openConversation).toHaveBeenCalledWith('conv-1');
+    await waitFor(() =>
+      expect(screen.getByTestId('messages-content')).toBeInTheDocument(),
+    );
+  });
+
+  it('Settings tab shows slim assistant settings in default mode', async () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    expect(screen.getByTestId('machine-pane-assistant-settings')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-model-selector')).toBeInTheDocument();
+  });
+
+  it('Settings tab shows the agent\'s read-only configuration in agent mode', async () => {
+    paneState.current = basePaneState({
+      selectedAgent: {
+        id: 'agent-1',
+        title: 'Docs Agent',
+        driveId: 'drive-1',
+        driveName: 'Docs Drive',
+        aiProvider: 'anthropic',
+        aiModel: 'claude-sonnet-5',
+      } satisfies AgentInfo,
+      currentConversationId: 'conv-agent',
+      channelId: 'agent-1',
+    });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    const settings = screen.getByTestId('machine-pane-agent-settings');
+    expect(settings).toHaveTextContent('Docs Agent');
+    expect(settings).toHaveTextContent('anthropic');
+    expect(settings).toHaveTextContent('claude-sonnet-5');
+  });
+
+  it('shows the load-error banner with a retry wired to reloadConversation', () => {
+    paneState.current = basePaneState({ hasLoadError: true });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(paneState.current.reloadConversation).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
@@ -361,8 +361,9 @@ describe('useMachinePaneChat', () => {
 
       // Never minted: no conversation row was ever created on the MACHINE page.
       const machineCreates = mockFetchWithAuth.mock.calls.filter(
-        ([url, init]: [string, RequestInit | undefined]) =>
-          url === `/api/ai/page-agents/${machineId}/conversations` && init?.method === 'POST',
+        (call) =>
+          call[0] === `/api/ai/page-agents/${machineId}/conversations` &&
+          (call[1] as RequestInit | undefined)?.method === 'POST',
       );
       expect(machineCreates).toHaveLength(0);
     });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
@@ -1,0 +1,569 @@
+/**
+ * useMachinePaneChat Hook Tests — Phase 11 (#2166)
+ *
+ * The machine pane's dual-mode chat state: null selection = the assistant
+ * identity on the machine-anchored conversation (the terminal row's id,
+ * chatId = machineId); any page agent = that agent's own chat. Behavior under
+ * test (phase page h1jtxfqy280oavmbr1k5v1sz):
+ *
+ * - mode switch swaps surface id + conversation identity, no cross-mode bleed
+ * - return to null RESUMES the machine conversation (row id) — never mints a
+ *   new session row
+ * - default mode sends { chatId: machineId, conversationId: terminalId };
+ *   agent mode sends the agent's own ids
+ * - History lists/opens per-mode conversations
+ * - a fresh empty default-mode conversation auto-sends pendingPrompt exactly
+ *   once, then onPromptSent(); never for a resumed (non-empty) session
+ * - Stop is wired in both modes
+ *
+ * Template: useMachineWorkspaceSync.test.ts (renderHook, auth-fetch mocked,
+ * real swr, real conversation-messages store).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import type { AgentInfo } from '@/types/agent';
+
+// ============================================
+// Mocks
+// ============================================
+
+const { mockFetchWithAuth } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+}));
+
+// Two controllable useChat instances. useDualModeChat calls useChat twice per
+// render, default (global slot) first, agent second — same order every render.
+const chat = vi.hoisted(() => {
+  const instance = () => ({
+    sendMessage: vi.fn(),
+    regenerate: vi.fn(),
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+    clearError: vi.fn(),
+    addToolResult: vi.fn(),
+  });
+  return {
+    capturedConfigs: [] as Array<Record<string, unknown>>,
+    defaultChat: instance(),
+    agentChat: instance(),
+    counter: { n: 0 },
+  };
+});
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: vi.fn((config: Record<string, unknown> | undefined) => {
+    chat.counter.n += 1;
+    if (config && typeof config.id === 'string') chat.capturedConfigs.push(config);
+    const instance = chat.counter.n % 2 === 1 ? chat.defaultChat : chat.agentChat;
+    return {
+      messages: [] as UIMessage[],
+      status: 'ready' as const,
+      error: undefined,
+      ...instance,
+    };
+  }),
+}));
+
+// Cache loaders are spied — the tests seed the real conversation-messages
+// store directly instead of round-tripping through fetches.
+const loaders = vi.hoisted(() => ({
+  loadAgentConversationMessages: vi.fn(async () => {}),
+  loadOlderAgentConversationMessages: vi.fn(async () => {}),
+  loadGlobalConversationMessages: vi.fn(async () => {}),
+  loadOlderGlobalConversationMessages: vi.fn(async () => {}),
+  refreshConversationSnapshot: vi.fn(async () => {}),
+}));
+vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
+
+// Multiplayer wiring is asserted by its inputs, not exercised.
+const multiplayer = vi.hoisted(() => ({
+  calls: [] as Array<{ selectedAgent: { id: string } | null; agentConversationId: string | null }>,
+  rejoin: vi.fn(),
+}));
+vi.mock('@/hooks/useAgentChannelMultiplayer', () => ({
+  useAgentChannelMultiplayer: vi.fn(
+    (opts: { selectedAgent: { id: string } | null; agentConversationId: string | null }) => {
+      multiplayer.calls.push({
+        selectedAgent: opts.selectedAgent,
+        agentConversationId: opts.agentConversationId,
+      });
+      return { rejoinActiveStreams: multiplayer.rejoin };
+    },
+  ),
+}));
+
+vi.mock('@/hooks/useActiveStream', () => ({
+  useActiveStream: () => ({ streams: [] }),
+  useConversationActiveStream: () => undefined,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard/drive-1/machine-page',
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', name: 'Test User', email: 'test@example.com' } }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { useMachinePaneChat } from '../useMachinePaneChat';
+
+// ============================================
+// Fixtures
+// ============================================
+
+function jsonResponse(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+function conversationRow(id: string, title: string) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title,
+    preview: '',
+    isShared: false,
+    isOwner: true,
+    createdAt: now,
+    updatedAt: now,
+    messageCount: 1,
+    lastMessage: { role: 'user', timestamp: now },
+  };
+}
+
+function agentFixture(id: string): AgentInfo {
+  return {
+    id,
+    title: `Agent ${id}`,
+    driveId: 'drive-1',
+    driveName: 'Drive One',
+    aiProvider: 'anthropic',
+    aiModel: 'claude-sonnet-5',
+    systemPrompt: 'You are a page agent.',
+    enabledTools: ['search'],
+  };
+}
+
+function assistantMessage(id: string, text: string): UIMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] } as UIMessage;
+}
+
+/** Unique ids per test — SWR's cache is keyed by URL and survives renderHook
+ * calls within the file, so a reused machine id would serve a previous test's
+ * cached conversation list. */
+function ids(slug: string) {
+  return { machineId: `machine-${slug}`, terminalId: `terminal-${slug}` };
+}
+
+/** fetchWithAuth routing: most-recent lookups (?limit=1) per agent, full
+ * conversation lists per page id. Anything unrouted resolves empty. */
+function routeFetches(routes: {
+  mostRecent?: Record<string, Array<{ id: string }>>;
+  lists?: Record<string, Array<ReturnType<typeof conversationRow>>>;
+}) {
+  mockFetchWithAuth.mockImplementation(async (url: string) => {
+    const match = /\/api\/ai\/page-agents\/([^/]+)\/conversations(\?limit=1)?$/.exec(url);
+    if (match) {
+      const [, pageId, isMostRecent] = match;
+      if (isMostRecent) {
+        return jsonResponse({ conversations: routes.mostRecent?.[pageId] ?? [] });
+      }
+      return jsonResponse({ conversations: routes.lists?.[pageId] ?? [] });
+    }
+    return jsonResponse({});
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chat.capturedConfigs.length = 0;
+  chat.counter.n = 0;
+  multiplayer.calls.length = 0;
+  useConversationMessagesStore.setState({ byConversationId: {} });
+  routeFetches({});
+});
+
+// ============================================
+// Default (machine) mode identity
+// ============================================
+
+describe('useMachinePaneChat', () => {
+  describe('default mode identity', () => {
+    it('mounts on the machine-anchored conversation: surface id machine-pane:<terminalId>, conversation = the terminal row id', async () => {
+      const { machineId, terminalId } = ids('default-identity');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      expect(result.current.selectedAgent).toBeNull();
+      expect(result.current.currentConversationId).toBe(terminalId);
+      expect(
+        chat.capturedConfigs.some((c) => c.id === `machine-pane:${terminalId}`),
+      ).toBe(true);
+
+      // The machine conversation loads through the AGENT loader keyed by the
+      // machine page id — the machine page hosts the conversation row.
+      await waitFor(() =>
+        expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(machineId, terminalId),
+      );
+
+      // Multiplayer is wired to the machine's page channel in default mode.
+      expect(
+        multiplayer.calls.some(
+          (c) => c.selectedAgent?.id === machineId && c.agentConversationId === terminalId,
+        ),
+      ).toBe(true);
+    });
+
+    it('sends { chatId: machineId, conversationId: terminalId } through the DEFAULT chat instance', async () => {
+      const { machineId, terminalId } = ids('default-send');
+      conversationMessagesActions.seedConversation(terminalId);
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.handleSend('hello machine');
+      });
+
+      await waitFor(() => expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1));
+      expect(chat.agentChat.sendMessage).not.toHaveBeenCalled();
+
+      const [message, options] = chat.defaultChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(message.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'hello machine' })]),
+      );
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: machineId, conversationId: terminalId }),
+      );
+    });
+  });
+
+  // ============================================
+  // Agent mode + mode switching
+  // ============================================
+
+  describe('agent mode and mode switching', () => {
+    it('selecting an agent swaps to the agent surface id and the agent\'s own conversation identity', async () => {
+      const { machineId, terminalId } = ids('agent-switch');
+      const agent = agentFixture('agent-switch-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-recent' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-recent'));
+      expect(result.current.selectedAgent?.id).toBe(agent.id);
+      expect(
+        chat.capturedConfigs.some((c) => c.id === `machine-pane-agent:${terminalId}`),
+      ).toBe(true);
+      await waitFor(() =>
+        expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(
+          agent.id,
+          'conv-agent-recent',
+        ),
+      );
+      // Agent-channel multiplayer follows the selection.
+      expect(
+        multiplayer.calls.some(
+          (c) => c.selectedAgent?.id === agent.id && c.agentConversationId === 'conv-agent-recent',
+        ),
+      ).toBe(true);
+    });
+
+    it('agent mode sends the AGENT\'s own ids through the AGENT chat instance — machine ids never bleed in', async () => {
+      const { machineId, terminalId } = ids('agent-send');
+      const agent = agentFixture('agent-send-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-send' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-send'));
+
+      await act(async () => {
+        await result.current.handleSend('hello agent');
+      });
+
+      await waitFor(() => expect(chat.agentChat.sendMessage).toHaveBeenCalledTimes(1));
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+
+      const [, options] = chat.agentChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: agent.id, conversationId: 'conv-agent-send' }),
+      );
+      expect(options.body).not.toEqual(
+        expect.objectContaining({ chatId: machineId }),
+      );
+    });
+
+    it('an agent with no conversations gets a client-minted one, persisted to the AGENT\'s page', async () => {
+      const { machineId, terminalId } = ids('agent-create');
+      const agent = agentFixture('agent-create-1');
+      routeFetches({ mostRecent: { [agent.id]: [] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).not.toBeNull();
+        expect(result.current.currentConversationId).not.toBe(terminalId);
+      });
+
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          `/api/ai/page-agents/${agent.id}/conversations`,
+          expect.objectContaining({ method: 'POST' }),
+        ),
+      );
+    });
+
+    it('returning to null RESUMES the machine conversation (row id) — never mints a new session row', async () => {
+      const { machineId, terminalId } = ids('resume-null');
+      const agent = agentFixture('agent-resume-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-resume' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-resume'));
+
+      act(() => {
+        result.current.selectAgent(null);
+      });
+
+      await waitFor(() => expect(result.current.currentConversationId).toBe(terminalId));
+      expect(result.current.selectedAgent).toBeNull();
+
+      // Never minted: no conversation row was ever created on the MACHINE page.
+      const machineCreates = mockFetchWithAuth.mock.calls.filter(
+        ([url, init]: [string, RequestInit | undefined]) =>
+          url === `/api/ai/page-agents/${machineId}/conversations` && init?.method === 'POST',
+      );
+      expect(machineCreates).toHaveLength(0);
+    });
+  });
+
+  // ============================================
+  // History — per-mode conversations
+  // ============================================
+
+  describe('history', () => {
+    it('default mode lists the MACHINE page\'s conversations', async () => {
+      const { machineId, terminalId } = ids('history-default');
+      routeFetches({
+        lists: { [machineId]: [conversationRow('machine-conv-1', 'Machine chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await waitFor(() =>
+        expect(result.current.conversations.map((c) => c.id)).toEqual(['machine-conv-1']),
+      );
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        `/api/ai/page-agents/${machineId}/conversations`,
+      );
+    });
+
+    it('agent mode lists the AGENT\'s conversations', async () => {
+      const { machineId, terminalId } = ids('history-agent');
+      const agent = agentFixture('agent-history-1');
+      routeFetches({
+        mostRecent: { [agent.id]: [{ id: 'agent-conv-1' }] },
+        lists: { [agent.id]: [conversationRow('agent-conv-1', 'Agent chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() =>
+        expect(result.current.conversations.map((c) => c.id)).toEqual(['agent-conv-1']),
+      );
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        `/api/ai/page-agents/${agent.id}/conversations`,
+      );
+    });
+
+    it('opening a history conversation loads it under the ACTIVE mode\'s page id and adopts it', async () => {
+      const { machineId, terminalId } = ids('history-open');
+      routeFetches({
+        lists: { [machineId]: [conversationRow('machine-conv-2', 'Older machine chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.openConversation('machine-conv-2');
+      });
+
+      expect(result.current.currentConversationId).toBe('machine-conv-2');
+      expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(
+        machineId,
+        'machine-conv-2',
+      );
+    });
+  });
+
+  // ============================================
+  // pendingPrompt — auto-send exactly once
+  // ============================================
+
+  describe('pendingPrompt', () => {
+    it('auto-sends into a fresh EMPTY default-mode conversation exactly once, then onPromptSent()', async () => {
+      const { machineId, terminalId } = ids('pending-fresh');
+      conversationMessagesActions.seedConversation(terminalId);
+      const onPromptSent = vi.fn();
+
+      const { rerender } = renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await waitFor(() => expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1));
+      const [message, options] = chat.defaultChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(message.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'run the tests' })]),
+      );
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: machineId, conversationId: terminalId }),
+      );
+      await waitFor(() => expect(onPromptSent).toHaveBeenCalledTimes(1));
+
+      rerender();
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1);
+      expect(onPromptSent).toHaveBeenCalledTimes(1);
+    });
+
+    it('never auto-sends into a RESUMED session (conversation already has messages)', async () => {
+      const { machineId, terminalId } = ids('pending-resumed');
+      const generation = conversationMessagesActions.startLoad(terminalId);
+      conversationMessagesActions.applyLoad(terminalId, generation, [
+        assistantMessage('m-existing', 'Already ran once.'),
+      ]);
+      const onPromptSent = vi.fn();
+
+      renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+      expect(onPromptSent).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-send while the conversation is still unloaded', async () => {
+      const { machineId, terminalId } = ids('pending-unloaded');
+      // No seed: the cache has no loaded entry for the terminal conversation.
+      const onPromptSent = vi.fn();
+
+      renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+      expect(onPromptSent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Stop — wired in both modes
+  // ============================================
+
+  describe('stop', () => {
+    it('default mode: handleStop stops the DEFAULT chat instance', async () => {
+      const { machineId, terminalId } = ids('stop-default');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(chat.defaultChat.stop).toHaveBeenCalled();
+      expect(chat.agentChat.stop).not.toHaveBeenCalled();
+    });
+
+    it('agent mode: handleStop stops the AGENT chat instance', async () => {
+      const { machineId, terminalId } = ids('stop-agent');
+      const agent = agentFixture('agent-stop-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-stop' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-stop'));
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(chat.agentChat.stop).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Rendering source
+  // ============================================
+
+  describe('rendered messages', () => {
+    it('renders from the shared conversation cache, per conversation', async () => {
+      const { machineId, terminalId } = ids('render-cache');
+      const generation = conversationMessagesActions.startLoad(terminalId);
+      conversationMessagesActions.applyLoad(terminalId, generation, [
+        assistantMessage('m-cache-1', 'From the cache.'),
+      ]);
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(['m-cache-1']));
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
@@ -412,6 +412,22 @@ describe('useMachinePaneChat', () => {
       );
     });
 
+    it('refuses to delete the machine-anchored session conversation', async () => {
+      const { machineId, terminalId } = ids('history-delete-guard');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.deleteConversation(terminalId);
+      });
+
+      const deletes = mockFetchWithAuth.mock.calls.filter(
+        (call) => (call[1] as RequestInit | undefined)?.method === 'DELETE',
+      );
+      expect(deletes).toHaveLength(0);
+      expect(result.current.currentConversationId).toBe(terminalId);
+    });
+
     it('opening a history conversation loads it under the ACTIVE mode\'s page id and adopts it', async () => {
       const { machineId, terminalId } = ids('history-open');
       routeFetches({

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
@@ -1,0 +1,609 @@
+/**
+ * useMachinePaneChat — the machine pane's dual-mode chat state (Phase 11, #2166).
+ *
+ * The third selector surface (after SidebarChatTab and GlobalAssistantView's
+ * dashboard): null selection = the assistant identity on the MACHINE-ANCHORED
+ * conversation — the terminal row's pre-created conversation (Phase 4), with
+ * `chatId = machineId` so the chat route derives the machine-pane binding
+ * (Phase 6) and sandbox tools run against this pane's checkout (Phase 7).
+ * Any page agent = that agent's own chat, exactly as the sidebar runs it —
+ * the machine binding does not apply (the route derives null for it).
+ *
+ * Identity model:
+ * - Surface ids are stable per pane: `machine-pane:${terminalId}` (default) /
+ *   `machine-pane-agent:${terminalId}` (agent mode) — one Chat instance per
+ *   mode for the pane's lifetime, so a mode switch swaps WHICH instance is on
+ *   screen instead of recreating either (no cross-mode bleed; see
+ *   useDualModeChat).
+ * - The default conversation starts as (and returns to) the terminal row id.
+ *   Returning to null selection RESUMES it — nothing here ever mints a new
+ *   session row for the machine; only an explicit "new conversation" in
+ *   History creates a machine-page conversation.
+ * - Both modes are agent-style surfaces: conversations live on a PAGE (the
+ *   machine page or the agent's page), so loaders, history and message
+ *   actions all key on `channelId` = machineId | agent.id.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import type { UIMessage } from 'ai';
+import { toast } from 'sonner';
+import { createId } from '@paralleldrive/cuid2';
+import type { AgentInfo } from '@/types/agent';
+import { useDualModeChat } from '@/hooks/useDualModeChat';
+import {
+  useChatTransport,
+  useConversations,
+  useCacheMessageActions,
+  useSendHandoff,
+  useConversationSendHandoff,
+  HANDOFF_REFUSED_MESSAGE,
+  useChatErrorCause,
+  buildChatConfig,
+  fetchMostRecentAgentConversation,
+  createAgentConversation,
+  type ConversationData,
+  type AIErrorCause,
+} from '@/lib/ai/shared';
+import { buildContextRef, type ContextRef } from '@/lib/ai/shared/buildContextRef';
+import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
+import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimisticSendOnFailure';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import {
+  loadAgentConversationMessages,
+  loadOlderAgentConversationMessages,
+} from '@/hooks/conversationMessagesLoaders';
+import {
+  useRenderedMessages,
+  useConversationLoadState,
+  useConversationOlderPageState,
+} from '@/hooks/useRenderedMessages';
+import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
+import { useActiveStream, useConversationActiveStream } from '@/hooks/useActiveStream';
+import { useOwnStreamMirror } from '@/hooks/useOwnStreamMirror';
+import { useStopStream } from '@/hooks/useStopStream';
+import { useAuth } from '@/hooks/useAuth';
+import { useDriveStore } from '@/hooks/useDrive';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+export interface UseMachinePaneChatOptions {
+  /** The machine page hosting this pane — the default mode's chatId + channel. */
+  machineId: string;
+  /** The terminal row id — the machine-anchored conversation's id (Phase 4). */
+  terminalId: string;
+  /** The picker's starting prompt — auto-sent once into a fresh empty default
+   *  conversation, never into a resumed one. */
+  pendingPrompt?: string;
+  /** Consumed-notification for pendingPrompt (clears the pane's one-shot intent). */
+  onPromptSent?: () => void;
+  /** Whether the conversation list should be fetched (e.g. only on relevant tabs). */
+  historyEnabled?: boolean;
+}
+
+export interface UseMachinePaneChatReturn {
+  /** null = default (machine) mode. */
+  selectedAgent: AgentInfo | null;
+  selectAgent: (agent: AgentInfo | null) => void;
+  /** The active mode's conversation. Default mode starts at (and resumes to) the terminal row id. */
+  currentConversationId: string | null;
+  /** The active mode's page channel: machineId or the agent's page id. */
+  channelId: string;
+  /** Rendered messages for the conversation on screen (shared cache + live streams). */
+  messages: UIMessage[];
+  /** Remote in-progress streams to render inline below the messages. */
+  remoteStreams: PendingStream[];
+  displayIsStreaming: boolean;
+  isMessagesLoading: boolean;
+  hasLoadError: boolean;
+  reloadConversation: () => Promise<void>;
+  /** Send a user message under the active mode's ids. Resolves false when
+   *  nothing was dispatched (empty text, no conversation, refused handoff) so
+   *  the composer can restore its draft. */
+  handleSend: (text: string) => Promise<boolean>;
+  handleStop: () => Promise<void>;
+  /** Store-first message actions (settled rows only). */
+  handleEdit: (messageId: string, newContent: string) => Promise<void>;
+  handleDelete: (messageId: string) => Promise<void>;
+  handleRetry: () => Promise<void>;
+  lastAssistantMessageId: string | undefined;
+  lastUserMessageId: string | undefined;
+  /** "Load older" wiring (scroll-near-top). */
+  handleScrollNearTop: () => void;
+  isLoadingOlder: boolean;
+  hasMoreOlder: boolean;
+  /** Per-mode history (machine-page conversations in default mode; the agent's in agent mode). */
+  conversations: ConversationData[];
+  isLoadingConversations: boolean;
+  openConversation: (conversationId: string) => Promise<void>;
+  createNewConversation: () => Promise<string | null>;
+  deleteConversation: (conversationId: string) => Promise<void>;
+  errorCause: AIErrorCause | null;
+  dismissError: () => void;
+}
+
+export function useMachinePaneChat({
+  machineId,
+  terminalId,
+  pendingPrompt,
+  onPromptSent,
+  historyEnabled = true,
+}: UseMachinePaneChatOptions): UseMachinePaneChatReturn {
+  const pathname = usePathname();
+  const { user } = useAuth();
+  const drives = useDriveStore((state) => state.drives);
+
+  // ============================================
+  // Mode + per-mode conversation identity
+  // ============================================
+  const [selectedAgent, setSelectedAgent] = useState<AgentInfo | null>(null);
+  // Starts as — and on return-to-null still is — the terminal row's
+  // conversation. Only History (open/new/delete) moves it.
+  const [defaultConversationId, setDefaultConversationId] = useState<string>(terminalId);
+  const [agentConversationId, setAgentConversationId] = useState<string | null>(null);
+
+  const channelId = selectedAgent ? selectedAgent.id : machineId;
+  const currentConversationId = selectedAgent ? agentConversationId : defaultConversationId;
+
+  const selectAgent = useCallback((agent: AgentInfo | null) => {
+    setSelectedAgent((previous) => {
+      if (agent?.id !== previous?.id) {
+        // A genuinely new subject — the resolve effect below re-resolves it.
+        // The DEFAULT identity is deliberately untouched: returning to null
+        // resumes the machine conversation as-is, it never mints a new row.
+        setAgentConversationId(null);
+      }
+      return agent;
+    });
+  }, []);
+
+  // Resolve the selected agent's conversation: most recent, or a client-minted
+  // new one (same shape as usePageAgentSidebarState, pane-local instead of the
+  // sidebar's shared store — each pane owns its selection).
+  const resolvingAgentIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedAgent) {
+      resolvingAgentIdRef.current = null;
+      return;
+    }
+    const agentId = selectedAgent.id;
+    resolvingAgentIdRef.current = agentId;
+
+    const resolve = async () => {
+      try {
+        const mostRecent = await fetchMostRecentAgentConversation(agentId);
+        if (resolvingAgentIdRef.current !== agentId) return;
+        if (mostRecent) {
+          setAgentConversationId(mostRecent.id);
+          await loadAgentConversationMessages(agentId, mostRecent.id);
+          return;
+        }
+      } catch (error) {
+        if (resolvingAgentIdRef.current !== agentId) return;
+        console.error('Failed to load recent agent conversation:', error);
+      }
+      if (resolvingAgentIdRef.current !== agentId) return;
+
+      const newConversationId = createId();
+      setAgentConversationId(newConversationId);
+      conversationMessagesActions.seedConversation(newConversationId);
+      try {
+        await createAgentConversation(agentId, newConversationId);
+      } catch (error) {
+        if (resolvingAgentIdRef.current !== agentId) return;
+        console.error('Failed to create agent conversation:', error);
+        toast.error('Failed to initialize agent conversation');
+      }
+    };
+    void resolve();
+  }, [selectedAgent]);
+
+  // Load the default (machine) conversation into the shared cache. The
+  // loader's generation gate makes re-runs safe.
+  useEffect(() => {
+    void loadAgentConversationMessages(machineId, defaultConversationId);
+  }, [machineId, defaultConversationId]);
+
+  // ============================================
+  // Chat instances — one per mode, stable surface ids per pane
+  // ============================================
+  const defaultTransport = useChatTransport(defaultConversationId, '/api/ai/chat', machineId);
+  const defaultChatConfig = useMemo(() => {
+    if (!defaultTransport) return null;
+    return buildChatConfig({
+      id: `machine-pane:${terminalId}`,
+      transport: defaultTransport,
+      onError: (error: Error) => {
+        console.error('Machine pane chat error:', error);
+        toast.error('Chat error. Please try again.');
+      },
+    });
+  }, [defaultTransport, terminalId]);
+
+  const agentTransport = useChatTransport(
+    agentConversationId,
+    '/api/ai/chat',
+    selectedAgent?.id ?? null,
+  );
+  const agentChatConfig = useMemo(() => {
+    if (!selectedAgent || !agentConversationId || !agentTransport) return null;
+    return buildChatConfig({
+      id: `machine-pane-agent:${terminalId}`,
+      transport: agentTransport,
+      onError: (error: Error) => {
+        console.error('Machine pane agent chat error:', error);
+        toast.error('Chat error. Please try again.');
+      },
+    });
+  }, [selectedAgent, agentConversationId, agentTransport, terminalId]);
+
+  const {
+    sendMessage,
+    status,
+    error,
+    clearError,
+    regenerate,
+    setMessages,
+    stop,
+    isStreaming,
+    globalStatus: defaultStatus,
+    globalStop: defaultStop,
+    globalMessages: defaultMessages,
+    agentStatus,
+    agentMessages,
+    agentStop,
+  } = useDualModeChat({
+    selectedAgent,
+    globalChatConfig: defaultChatConfig,
+    agentChatConfig,
+  });
+
+  // ============================================
+  // Multiplayer — both page channels are agent-style
+  // ============================================
+  // The machine channel stays wired in agent mode too: remote streams landing
+  // on the machine conversation keep committing to the shared cache, so a
+  // return to null shows them without a refetch (cache writes are idempotent).
+  const machineChannel = useMemo(() => ({ id: machineId }), [machineId]);
+  const loadDefaultConversation = useCallback(
+    (conversationId: string) => loadAgentConversationMessages(machineId, conversationId),
+    [machineId],
+  );
+  const { rejoinActiveStreams: rejoinDefaultStream } = useAgentChannelMultiplayer({
+    selectedAgent: machineChannel,
+    agentConversationId: defaultConversationId,
+    loadConversation: loadDefaultConversation,
+  });
+
+  const loadSelectedAgentConversation = useCallback(
+    (conversationId: string) => {
+      const agentId = selectedAgent?.id;
+      if (agentId) return loadAgentConversationMessages(agentId, conversationId);
+    },
+    [selectedAgent?.id],
+  );
+  const { rejoinActiveStreams: rejoinAgentStream } = useAgentChannelMultiplayer({
+    selectedAgent,
+    agentConversationId,
+    loadConversation: loadSelectedAgentConversation,
+  });
+
+  // ============================================
+  // Store-first rendering
+  // ============================================
+  const renderedMessages = useRenderedMessages(channelId, currentConversationId);
+  const messages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
+  const loadState = useConversationLoadState(currentConversationId);
+
+  const activeStream = useConversationActiveStream(channelId, currentConversationId);
+  const { streams: remoteStreams } = useActiveStream(channelId, currentConversationId);
+
+  const { wrapSend, pendingSendConversationId } = useSendHandoff(
+    currentConversationId,
+    status,
+    activeStream?.isOwn === true,
+  );
+
+  const displayIsStreaming =
+    activeStream?.isOwn === true ||
+    (pendingSendConversationId !== null && pendingSendConversationId === currentConversationId);
+
+  // Own-stream mirrors, MOUNTED PER CHAT (see useDualModeChat's interface
+  // docblock — a mode-selected mirror silently repoints on switch and deletes
+  // the live stream's store entry).
+  const mirrorTriggeredBy = useMemo(
+    () => ({ userId: user?.id ?? '', displayName: user?.name || user?.email || 'You' }),
+    [user?.id, user?.name, user?.email],
+  );
+  const { getLatchedConversationId: getDefaultLatched } = useOwnStreamMirror({
+    status: defaultStatus,
+    ownMessages: defaultMessages,
+    pageId: machineId,
+    conversationId: defaultConversationId,
+    triggeredBy: mirrorTriggeredBy,
+  });
+  const { getLatchedConversationId: getAgentLatched } = useOwnStreamMirror({
+    status: agentStatus,
+    ownMessages: agentMessages,
+    pageId: selectedAgent?.id ?? '',
+    conversationId: agentConversationId ?? '',
+    triggeredBy: mirrorTriggeredBy,
+  });
+
+  // Pre-send handoff, per chat like the mirrors (see useConversationSendHandoff).
+  const { prepareSend: prepareDefaultSend } = useConversationSendHandoff({
+    status: defaultStatus,
+    stop: defaultStop,
+    getLatchedConversationId: getDefaultLatched,
+    rejoin: rejoinDefaultStream,
+  });
+  const { prepareSend: prepareAgentSend } = useConversationSendHandoff({
+    status: agentStatus,
+    stop: agentStop,
+    getLatchedConversationId: getAgentLatched,
+    rejoin: rejoinAgentStream,
+  });
+  const prepareSendForMode = selectedAgent ? prepareAgentSend : prepareDefaultSend;
+
+  // ============================================
+  // Send
+  // ============================================
+  const writeMode = useAssistantSettingsStore((state) => state.writeMode);
+  const webSearchEnabled = useAssistantSettingsStore((state) => state.webSearchEnabled);
+  const imageGenEnabled = useAssistantSettingsStore((state) => state.imageGenEnabled);
+  const currentProvider = useAssistantSettingsStore((state) => state.currentProvider);
+  const currentModel = useAssistantSettingsStore((state) => state.currentModel);
+
+  const buildPaneChatRequestBody = useCallback(
+    (contextRef: ContextRef, isReadOnly: boolean) => {
+      return selectedAgent
+        ? {
+            chatId: selectedAgent.id,
+            conversationId: agentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: selectedAgent.aiProvider,
+            model: selectedAgent.aiModel,
+            systemPrompt: selectedAgent.systemPrompt,
+            contextRef,
+            enabledTools: selectedAgent.enabledTools,
+          }
+        : {
+            // The machine-pane binding contract (Phase 6): the machine page as
+            // chatId, the terminal-row conversation as conversationId.
+            chatId: machineId,
+            conversationId: defaultConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: currentProvider,
+            model: currentModel,
+            contextRef,
+          };
+    },
+    [
+      selectedAgent,
+      agentConversationId,
+      machineId,
+      defaultConversationId,
+      webSearchEnabled,
+      imageGenEnabled,
+      currentProvider,
+      currentModel,
+    ],
+  );
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || !currentConversationId) return false;
+
+      const contextRef = buildContextRef(pathname, drives);
+      // Hand off any in-flight stream this chat is consuming for ANOTHER
+      // conversation before sending (the Chat cannot consume two bodies at once).
+      if (!(await prepareSendForMode(currentConversationId))) {
+        toast.error(HANDOFF_REFUSED_MESSAGE);
+        return false;
+      }
+
+      // Client-minted id, parts-form send; optimistic cache write so the
+      // bubble appears the same tick (the sender never gets its own broadcast).
+      const userMessage = buildUserMessage({ id: createId(), text: trimmed }) as UIMessage;
+      conversationMessagesActions.addOptimisticSend(currentConversationId, userMessage);
+
+      rollbackOptimisticSendOnFailure(
+        () =>
+          wrapSend(() =>
+            sendMessage(userMessage, { body: buildPaneChatRequestBody(contextRef, !writeMode) }),
+          ),
+        currentConversationId,
+        userMessage.id,
+      );
+      return true;
+    },
+    [
+      currentConversationId,
+      pathname,
+      drives,
+      prepareSendForMode,
+      wrapSend,
+      sendMessage,
+      buildPaneChatRequestBody,
+      writeMode,
+    ],
+  );
+
+  // ============================================
+  // pendingPrompt — exactly once, fresh empty default conversation only
+  // ============================================
+  const pendingPromptSentRef = useRef(false);
+  useEffect(() => {
+    if (pendingPromptSentRef.current) return;
+    if (!pendingPrompt) return;
+    if (selectedAgent) return;
+    // Only the terminal row's own conversation — a history-opened machine
+    // conversation is by definition not the fresh spawn target.
+    if (defaultConversationId !== terminalId) return;
+    // Not before the cache answers: an unloaded conversation might be a
+    // resumed one whose history simply hasn't arrived yet.
+    if (loadState.status !== 'loaded') return;
+    // A resumed session has messages — never auto-send into it.
+    if (renderedMessages.length > 0) return;
+
+    pendingPromptSentRef.current = true;
+    void handleSend(pendingPrompt).then(() => onPromptSent?.());
+  }, [
+    pendingPrompt,
+    selectedAgent,
+    defaultConversationId,
+    terminalId,
+    loadState.status,
+    renderedMessages.length,
+    handleSend,
+    onPromptSent,
+  ]);
+
+  // ============================================
+  // Stop + message actions
+  // ============================================
+  const handleStop = useStopStream({
+    activeStream,
+    pendingSendConversationId,
+    rawStop: stop,
+    getLocalSendConversationId: selectedAgent ? getAgentLatched : getDefaultLatched,
+    targetConversationId: currentConversationId,
+  });
+
+  const isOwnSendLive = isStreaming || activeStream?.isOwn === true;
+  const isOwnSendLiveRef = useRef(isOwnSendLive);
+  isOwnSendLiveRef.current = isOwnSendLive;
+  const getIsOwnSendLive = useCallback(() => isOwnSendLiveRef.current, []);
+
+  const { handleEdit, handleDelete, handleRetry } = useCacheMessageActions({
+    // Both modes are agent-style (page-hosted conversations) — the machine
+    // page id serves as the "agent" for the default mode's endpoints.
+    agentId: channelId,
+    conversationId: currentConversationId,
+    renderedMessages,
+    isOwnSendLive,
+    setMessages,
+    regenerate,
+    prepareSend: prepareSendForMode,
+    getIsOwnSendLive,
+  });
+
+  const lastAssistantMessageId = useMemo(
+    () => [...messages].reverse().find((m) => m.role === 'assistant')?.id,
+    [messages],
+  );
+  const lastUserMessageId = useMemo(
+    () => [...messages].reverse().find((m) => m.role === 'user')?.id,
+    [messages],
+  );
+
+  const reloadConversation = useCallback(async () => {
+    if (!currentConversationId) return;
+    await loadAgentConversationMessages(channelId, currentConversationId);
+  }, [channelId, currentConversationId]);
+
+  const { isLoadingOlder, hasMoreOlder } = useConversationOlderPageState(currentConversationId);
+  const handleScrollNearTop = useCallback(() => {
+    if (!currentConversationId) return;
+    void loadOlderAgentConversationMessages(channelId, currentConversationId);
+  }, [channelId, currentConversationId]);
+
+  // ============================================
+  // History — per-mode conversations (page-agents endpoints for both modes)
+  // ============================================
+  const adoptConversation = useCallback(
+    (conversationId: string) => {
+      if (selectedAgent) {
+        setAgentConversationId(conversationId);
+      } else {
+        setDefaultConversationId(conversationId);
+      }
+    },
+    [selectedAgent],
+  );
+
+  const {
+    conversations,
+    isLoading: isLoadingConversations,
+    createConversation,
+    deleteConversation: deleteConversationBase,
+  } = useConversations({
+    agentId: channelId,
+    currentConversationId,
+    enabled: historyEnabled,
+    onConversationCreate: (conversationId) => {
+      conversationMessagesActions.seedConversation(conversationId);
+      adoptConversation(conversationId);
+    },
+    onConversationDelete: () => {
+      if (selectedAgent) {
+        // Same shape as create: a fresh client-minted id, seeded empty;
+        // persisted lazily by the first message save.
+        const nextId = createId();
+        conversationMessagesActions.seedConversation(nextId);
+        setAgentConversationId(nextId);
+      } else {
+        // Deleting the machine conversation on screen falls back to the
+        // terminal row's own conversation — resume, never mint.
+        setDefaultConversationId(terminalId);
+      }
+    },
+  });
+
+  const openConversation = useCallback(
+    async (conversationId: string) => {
+      adoptConversation(conversationId);
+      await loadAgentConversationMessages(channelId, conversationId);
+    },
+    [adoptConversation, channelId],
+  );
+
+  const deleteConversation = useCallback(
+    (conversationId: string) => deleteConversationBase(conversationId),
+    [deleteConversationBase],
+  );
+
+  // ============================================
+  // Error surface
+  // ============================================
+  const { cause: errorCause, dismiss: dismissError } = useChatErrorCause(
+    currentConversationId,
+    error,
+    clearError,
+    pendingSendConversationId ?? currentConversationId,
+  );
+
+  return {
+    selectedAgent,
+    selectAgent,
+    currentConversationId,
+    channelId,
+    messages,
+    remoteStreams,
+    displayIsStreaming,
+    isMessagesLoading: loadState.isLoading,
+    hasLoadError: loadState.hasError,
+    reloadConversation,
+    handleSend,
+    handleStop,
+    handleEdit,
+    handleDelete,
+    handleRetry,
+    lastAssistantMessageId,
+    lastUserMessageId,
+    handleScrollNearTop,
+    isLoadingOlder,
+    hasMoreOlder,
+    conversations,
+    isLoadingConversations,
+    openConversation,
+    createNewConversation: createConversation,
+    deleteConversation,
+    errorCause,
+    dismissError,
+  };
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
@@ -144,17 +144,32 @@ export function useMachinePaneChat({
   const channelId = selectedAgent ? selectedAgent.id : machineId;
   const currentConversationId = selectedAgent ? agentConversationId : defaultConversationId;
 
+  // Ref-read rather than a functional-updater compare: clearing the agent
+  // conversation is a second state write, and state updaters must stay pure.
+  const selectedAgentRef = useRef(selectedAgent);
+  selectedAgentRef.current = selectedAgent;
   const selectAgent = useCallback((agent: AgentInfo | null) => {
-    setSelectedAgent((previous) => {
-      if (agent?.id !== previous?.id) {
-        // A genuinely new subject — the resolve effect below re-resolves it.
-        // The DEFAULT identity is deliberately untouched: returning to null
-        // resumes the machine conversation as-is, it never mints a new row.
-        setAgentConversationId(null);
-      }
-      return agent;
-    });
+    if (agent?.id !== selectedAgentRef.current?.id) {
+      // A genuinely new subject — the resolve effect below re-resolves it.
+      // The DEFAULT identity is deliberately untouched: returning to null
+      // resumes the machine conversation as-is, it never mints a new row.
+      setAgentConversationId(null);
+    }
+    setSelectedAgent(agent);
   }, []);
+
+  // A pane re-bound to a different terminal row is a different chat surface.
+  // Phase 10 keys the mount by session, but the hook defends its own
+  // invariant: the default identity and the pendingPrompt latch belong to
+  // the terminal row, not the mount.
+  const boundTerminalIdRef = useRef(terminalId);
+  const pendingPromptSentRef = useRef(false);
+  useEffect(() => {
+    if (boundTerminalIdRef.current === terminalId) return;
+    boundTerminalIdRef.current = terminalId;
+    pendingPromptSentRef.current = false;
+    setDefaultConversationId(terminalId);
+  }, [terminalId]);
 
   // Resolve the selected agent's conversation: most recent, or a client-minted
   // new one (same shape as usePageAgentSidebarState, pane-local instead of the
@@ -436,7 +451,6 @@ export function useMachinePaneChat({
   // ============================================
   // pendingPrompt — exactly once, fresh empty default conversation only
   // ============================================
-  const pendingPromptSentRef = useRef(false);
   useEffect(() => {
     if (pendingPromptSentRef.current) return;
     if (!pendingPrompt) return;
@@ -563,8 +577,17 @@ export function useMachinePaneChat({
   );
 
   const deleteConversation = useCallback(
-    (conversationId: string) => deleteConversationBase(conversationId),
-    [deleteConversationBase],
+    async (conversationId: string) => {
+      // The machine-anchored session conversation IS the pane's identity —
+      // deleting it out from under the live terminal row would leave the
+      // default mode pointing at a dead id. Not deletable from this surface.
+      if (conversationId === terminalId) {
+        toast.error('The machine session conversation cannot be deleted from this pane');
+        return;
+      }
+      await deleteConversationBase(conversationId);
+    },
+    [terminalId, deleteConversationBase],
   );
 
   // ============================================

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -19,7 +19,8 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
 import { useGlobalChatConversation, useGlobalChatConfig } from '@/contexts/GlobalChatContext';
-import { usePageAgentSidebarState, usePageAgentSidebarChat, type SidebarAgentInfo } from '@/hooks/page-agents';
+import { usePageAgentSidebarState, type SidebarAgentInfo } from '@/hooks/page-agents';
+import { useDualModeChat } from '@/hooks/useDualModeChat';
 import { type PendingStream } from '@/stores/usePendingStreamsStore';
 import { useAuth } from '@/hooks/useAuth';
 import { dedupRemoteStreams } from '@/lib/ai/streams/dedupRemoteStreams';
@@ -277,7 +278,7 @@ const SidebarChatTab: React.FC = () => {
     agentStatus,
     agentMessages,
     agentStop,
-  } = usePageAgentSidebarChat({
+  } = useDualModeChat({
     selectedAgent,
     globalChatConfig,
     agentChatConfig,
@@ -424,7 +425,7 @@ const SidebarChatTab: React.FC = () => {
   // nothing is streaming, and emits removeStream for the id it was mirroring — deleting a live
   // stream's entry, and with it that stream's Stop button and its rendered content.
   //
-  // The sidebar's two chats happen to be mutually exclusive today (usePageAgentSidebarChat stops
+  // The sidebar's two chats happen to be mutually exclusive today (useDualModeChat stops
   // the other mode's LOCAL fetch on switch), which is exactly the kind of invariant that makes a
   // mode-selected mirror look fine until it isn't: those stop effects are themselves scheduled to
   // change (leaf 5.4, W6), and a local stop never stopped the SERVER stream anyway.

--- a/apps/web/src/hooks/__tests__/useDualModeChat.test.ts
+++ b/apps/web/src/hooks/__tests__/useDualModeChat.test.ts
@@ -1,12 +1,12 @@
 /**
- * usePageAgentSidebarChat Hook Tests
+ * useDualModeChat Hook Tests
  * Tests for unified chat interface supporting both global and agent modes
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { usePageAgentSidebarChat } from '../usePageAgentSidebarChat';
-import type { SidebarAgentInfo } from '../usePageAgentSidebarState';
+import { useDualModeChat } from '../useDualModeChat';
+import type { AgentInfo } from '@/types/agent';
 
 // Mock useChat from @ai-sdk/react
 const mockGlobalSendMessage = vi.fn();
@@ -50,9 +50,9 @@ vi.mock('@ai-sdk/react', () => ({
   }),
 }));
 
-describe('usePageAgentSidebarChat', () => {
+describe('useDualModeChat', () => {
   // Sample agent
-  const mockAgent: SidebarAgentInfo = {
+  const mockAgent: AgentInfo = {
     id: 'agent-123',
     title: 'Test Agent',
     driveId: 'drive-456',
@@ -83,7 +83,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('unified interface', () => {
     it('should return messages from global chat when no agent selected', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -98,7 +98,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return sendMessage function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -110,7 +110,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return stop function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -122,7 +122,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return regenerate function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -134,7 +134,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return setMessages function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -151,7 +151,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('global mode (no agent selected)', () => {
     it('should use global sendMessage when sending in global mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -169,7 +169,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should use global regenerate in global mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -186,7 +186,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose globalStatus for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -198,7 +198,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose globalMessages for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -210,7 +210,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose setGlobalMessages for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -227,7 +227,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('agent mode (agent selected)', () => {
     it('should use agent sendMessage when agent is selected', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: mockAgent,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: mockAgentChatConfig,
@@ -248,7 +248,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should use agent regenerate in agent mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: mockAgent,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: mockAgentChatConfig,
@@ -274,7 +274,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should be false when status is ready (default mock)', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -290,7 +290,7 @@ describe('usePageAgentSidebarChat', () => {
       // Test the isStreaming logic pattern:
       // isStreaming = status === 'submitted' || status === 'streaming'
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -309,7 +309,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('return type stability', () => {
     it('should include all required properties', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,

--- a/apps/web/src/hooks/page-agents/index.ts
+++ b/apps/web/src/hooks/page-agents/index.ts
@@ -12,7 +12,3 @@ export {
   type SidebarAgentInfo,
   type UseSidebarAgentStateReturn,
 } from './usePageAgentSidebarState';
-export {
-  usePageAgentSidebarChat,
-  type UseSidebarChatReturn,
-} from './usePageAgentSidebarChat';

--- a/apps/web/src/hooks/useDualModeChat.ts
+++ b/apps/web/src/hooks/useDualModeChat.ts
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useCallback } from 'react';
 import { useChat, UseChatOptions } from '@ai-sdk/react';
 import { UIMessage, type CreateUIMessage } from 'ai';
-import { SidebarAgentInfo } from './usePageAgentSidebarState';
+import type { AgentInfo } from '@/types/agent';
 
 /**
- * Return type for the unified sidebar chat interface.
+ * Return type for the unified dual-mode chat interface.
  */
-export interface UseSidebarChatReturn {
+export interface UseDualModeChatReturn {
   /** Current messages (from active mode) */
   messages: UIMessage[];
   /** Send a message — parts-form (client-minted id preserved end to end, PR 5B). */
@@ -56,28 +56,31 @@ export interface UseSidebarChatReturn {
   }) => void | PromiseLike<void>;
 }
 
-interface UseSidebarChatOptions {
-  /** Currently selected agent (null = global mode) */
-  selectedAgent: SidebarAgentInfo | null;
-  /** Chat config for global mode (from GlobalChatContext) */
+interface UseDualModeChatOptions {
+  /** Currently selected agent (null = default mode) */
+  selectedAgent: AgentInfo | null;
+  /** Chat config for default mode (the surface's null-selection identity) */
   globalChatConfig: UseChatOptions<UIMessage> | null;
   /** Chat config for agent mode */
   agentChatConfig: UseChatOptions<UIMessage> | null;
 }
 
 /**
- * Manages chat for the sidebar, handling both global and agent modes.
+ * Manages chat for a dual-mode surface (sidebar, machine pane), handling both
+ * the default (null-selection) and agent modes.
  *
- * - In Global mode: Uses globalChatConfig, syncs with GlobalChatContext
+ * - In default mode: Uses globalChatConfig (whatever identity the surface
+ *   gives its null selection — the global assistant in the sidebar, the
+ *   machine-anchored conversation in a machine pane)
  * - In Agent mode: Uses agentChatConfig, operates independently
  *
  * Handles mode switching gracefully (stops streams, clears stale messages).
  */
-export function usePageAgentSidebarChat({
+export function useDualModeChat({
   selectedAgent,
   globalChatConfig,
   agentChatConfig,
-}: UseSidebarChatOptions): UseSidebarChatReturn {
+}: UseDualModeChatOptions): UseDualModeChatReturn {
   // ============================================
   // Global Mode Chat Instance
   // ============================================

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ kind: 'eq', field, value })),
   and: vi.fn((...conds) => ({ kind: 'and', conds })),
+  inArray: vi.fn((field, values) => ({ kind: 'inArray', field, values })),
   sql: Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       kind: 'sql',
@@ -113,6 +114,42 @@ describe('conversationRepository.getConversation', () => {
     const result = await conversationRepository.getConversation('conv_missing');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('conversationRepository.getAiAgent', () => {
+  // vi.mocked(db) does not see through Drizzle's query-builder generics.
+  const findFirstMock = () =>
+    mockDb.query.pages.findFirst as unknown as ReturnType<typeof vi.fn>;
+
+  // #2166 Phase 11: MACHINE pages host machine-pane conversations (Phase 4
+  // pre-creates them), so the conversation routes' host-page lookup must
+  // accept both types. Agent-only routes do their own AI_CHAT checks.
+  it('queries for conversation-hosting page types: AI_CHAT and MACHINE', async () => {
+    findFirstMock().mockResolvedValue({
+      id: 'machine_1',
+      title: 'Build box',
+      type: 'MACHINE',
+      driveId: 'drive_1',
+    });
+
+    const result = await conversationRepository.getAiAgent('machine_1');
+
+    expect(result).toEqual(
+      expect.objectContaining({ id: 'machine_1', type: 'MACHINE' }),
+    );
+    const call = findFirstMock().mock.calls[0][0] as { where: { conds: unknown[] } };
+    expect(call.where.conds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'inArray', values: ['AI_CHAT', 'MACHINE'] }),
+      ]),
+    );
+  });
+
+  it('returns null when the page does not exist', async () => {
+    findFirstMock().mockResolvedValue(undefined);
+
+    expect(await conversationRepository.getAiAgent('missing')).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, sql } from '@pagespace/db/operators'
+import { eq, and, sql, inArray } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core'
 import { userActivities } from '@pagespace/db/schema/monitoring'
 import { conversations } from '@pagespace/db/schema/conversations';
@@ -180,10 +180,15 @@ export const conversationRepository = {
    * Get an AI_CHAT agent by ID
    */
   async getAiAgent(agentId: string): Promise<AiAgent | null> {
+    // Conversation-hosting pages: AI_CHAT agents, and MACHINE pages — machine
+    // panes anchor their terminal conversations to the machine page (Phase 4
+    // pre-creates them, Phase 11's pane lists/loads them, #2166). Agent-only
+    // routes (config, drives, consult) do their own AI_CHAT checks and are
+    // unaffected by this widening.
     const agent = await db.query.pages.findFirst({
       where: and(
         eq(pages.id, agentId),
-        eq(pages.type, 'AI_CHAT'),
+        inArray(pages.type, ['AI_CHAT', 'MACHINE']),
         eq(pages.isTrashed, false)
       ),
       columns: {


### PR DESCRIPTION
Phase 11 of #2166 (phase page \`h1jtxfqy280oavmbr1k5v1sz\`) — the "PageSpace Agent" pane's UI: the third selector surface. Null selection = the assistant identity on the **machine-anchored conversation** (the terminal row's pre-created conversation, \`chatId = machineId\` so the chat route derives the machine-pane binding from Phases 4/6/7); any page agent = that agent's own chat, machine binding not applied.

## Commits (TDD)

1. **refactor(ai)**: rename \`usePageAgentSidebarChat\` → location-agnostic \`useDualModeChat\` (\`src/hooks/useDualModeChat.ts\`); sidebar consumer updated mechanically, API shape unchanged.
2. **test(machine-panes): RED** — \`useMachinePaneChat\` behavior tests: mode switch swaps surface id + conversation identity with no cross-mode bleed; return-to-null **resumes** the machine conversation (never mints a session row); default mode sends \`{ chatId: machineId, conversationId: terminalId }\`, agent mode the agent's own ids; per-mode History; pendingPrompt auto-send exactly once (never for a resumed session); Stop wired in both modes.
3. **feat(machine-panes): GREEN** — \`useMachinePaneChat\` + \`MachinePaneChat\`: stable per-pane surface ids (\`machine-pane:<terminalId>\` / \`machine-pane-agent:<terminalId>\`), store-first rendering, per-chat own-stream mirrors + send handoffs, both page channels on \`useAgentChannelMultiplayer\`, in-pane Chat/History/Settings tabs (History reuses \`PageAgentHistoryTab\` minus share controls; Settings kept slim), compact terminal-leaning skin (\`Conversation\` + \`CompactMessageRenderer\` via shared \`SidebarMessagesContent\` + \`ChatInput variant="sidebar"\`).
4. **fix(machine-panes)**: \`/aidd-review\` follow-up — **blocker**: page-agents conversation endpoints gated on \`AI_CHAT\` and 404'd the machine page; host-page lookups now accept \`AI_CHAT | MACHINE\` (permission/MCP/audit checks unchanged). Plus: pure \`selectAgent\` (no setState-in-updater), terminalId rebind reset, terminal-conversation delete guard, prop cleanup. Findings + audit trail on the phase page.

Phase 10 owns the TerminalPanes render branch — this PR deliberately does not touch \`TerminalPanes.tsx\`.

## Verification

- 275 tests across the affected suites green (new: 16 hook + 5 component + 2 repository); \`tsc\` and \`eslint\` clean.
- Full \`vitest\` run: only pre-existing environment failures (Postgres \`test\` role, TZ-dependent grouping test) untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZfLCcN4f8GQRe5P4RBhcJ