### PR TITLE
feat(machine-panes): Phase 10 — renderer branch: PageSpace Agent panes in TerminalPanes

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -205,7 +205,7 @@ describe('NodeActionPalette', () => {
     });
   });
 
-  test('"New terminal" offers shell, claude, and codex — not pagespace-cli — with shell first/default', async () => {
+  test('"New terminal" offers shell, claude, codex, and the PageSpace Agent — not pagespace-cli — with shell first/default', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
 
     const user = await openPalette();
@@ -218,9 +218,10 @@ describe('NodeActionPalette', () => {
 
     assert({
       given: 'the "New terminal" agent-type picker, opened',
-      should: 'offer exactly shell, claude, and codex (never pagespace-cli), defaulting to shell',
+      should:
+        'offer the shared PICKABLE_AGENT_TYPES — shell first/default, then claude, codex, and the chat agent labeled "PageSpace Agent" (never pagespace-cli); a palette-local hardcoded list is exactly what silently dropped pagespace from this surface',
       actual: { optionTexts, defaultSelected },
-      expected: { optionTexts: ['shell', 'claude', 'codex'], defaultSelected: 'shell' },
+      expected: { optionTexts: ['shell', 'claude', 'codex', 'PageSpace Agent'], defaultSelected: 'shell' },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -205,6 +205,34 @@ describe('NodeActionPalette', () => {
     });
   });
 
+  test('a "PageSpace Agent" palette spawn binds a chat-kind scope', async () => {
+    vi.mocked(post).mockResolvedValueOnce({
+      agentTerminal: { name: 'pagespace-mocked', agentType: 'pagespace', resumed: false },
+    });
+    const onWorkspaceCreated = vi.fn();
+    renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await user.click(await screen.findByLabelText('Agent type'));
+    await user.click(await screen.findByRole('option', { name: 'PageSpace Agent' }));
+    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    await waitFor(() => {
+      const workspaceId = onWorkspaceCreated.mock.calls[0]?.[0];
+      const machine = selectMachine('m1')(store());
+      const workspace = workspaceId ? machine?.workspaces[workspaceId] : undefined;
+      const pane = workspace?.columns[0]?.panes[0];
+      assert({
+        given: 'the palette\'s "PageSpace Agent" choice, spawned on a branch node',
+        should:
+          'record kind "chat" on the bound pane scope — the pane grid renders MachinePaneChat from this tag, so a palette spawn that omitted it would open as a PTY',
+        actual: { name: pane?.scope?.name, kind: pane?.scope?.kind },
+        expected: { name: 'pagespace-mocked', kind: 'chat' },
+      });
+    });
+  });
+
   test('"New terminal" offers shell, claude, codex, and the PageSpace Agent — not pagespace-cli — with shell first/default', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -60,6 +60,7 @@ import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-nam
 import {
   PICKABLE_AGENT_TYPES,
   agentSurfaceOf,
+  isAgentRuntimeType,
   type AgentRuntimeType,
 } from '@pagespace/lib/services/machines/agent-terminal-types';
 import { useMachineWorkspaceStore, autoSessionName } from '@/stores/machine-workspace/useMachineWorkspaceStore';
@@ -283,9 +284,13 @@ function TerminalSpawnForm({
               branchName: scope.branchName,
               name: created.name,
               // Same rule as TerminalPanes' spawnIntoPane: record the surface
-              // at bind time; only `chat` is written, since an omitted kind
-              // already means `terminal` (see OpenTerminalScope).
-              ...(agentSurfaceOf(agentType) === 'chat' ? { kind: 'chat' as const } : {}),
+              // at bind time, judged by the API's answer (`created.agentType`
+              // — a resumed session's type can differ from the picked one);
+              // only `chat` is written, since an omitted kind already means
+              // `terminal` (see OpenTerminalScope).
+              ...(isAgentRuntimeType(created.agentType) && agentSurfaceOf(created.agentType) === 'chat'
+                ? { kind: 'chat' as const }
+                : {}),
             },
             created.resumed ? undefined : prompt.trim() || undefined,
           )

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -57,21 +57,16 @@ import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
 import { normalizeProjectName } from '@pagespace/lib/services/machines/project-name';
 import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-name';
-import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  PICKABLE_AGENT_TYPES,
+  agentSurfaceOf,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
 import { useMachineWorkspaceStore, autoSessionName } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { AddButton } from './RemoveButton';
 import { nodeScopeOf } from './WorkspaceLeaves';
+import { agentTypeLabelOf } from './pane-surface';
 import type { MachineTreeNode } from './MachineTree';
-
-/**
- * The "New terminal" agent choices — a fixed, local list rather than
- * `Object.keys(AGENT_LAUNCH_SPECS)`, for two reasons: `pagespace-cli` is
- * being removed as an agent type by a sibling change, and `shell` must be
- * offered and listed FIRST (a plain shell is a first-class choice here,
- * arguably the default — not an afterthought). Defined locally so this
- * palette can't silently inherit some other list that (buggily) excludes it.
- */
-const PICKABLE_AGENT_TYPES: AgentRuntimeType[] = ['shell', 'claude', 'codex'];
 
 /** Short project name from a GitHub `full_name` (e.g. "org/my-repo" -> "my-repo"), and the ready-to-clone URL. */
 export function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
@@ -283,7 +278,15 @@ function TerminalSpawnForm({
         ? bindPaneTerminal(
             workspaceId,
             workspace.activePaneId,
-            { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
+            {
+              projectName: scope.projectName,
+              branchName: scope.branchName,
+              name: created.name,
+              // Same rule as TerminalPanes' spawnIntoPane: record the surface
+              // at bind time; only `chat` is written, since an omitted kind
+              // already means `terminal` (see OpenTerminalScope).
+              ...(agentSurfaceOf(agentType) === 'chat' ? { kind: 'chat' as const } : {}),
+            },
             created.resumed ? undefined : prompt.trim() || undefined,
           )
         : false;
@@ -324,7 +327,7 @@ function TerminalSpawnForm({
           <SelectContent>
             {PICKABLE_AGENT_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
-                {type}
+                {agentTypeLabelOf(type)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -798,6 +798,48 @@ describe('TerminalPanes (PageSpace Agent panes)', () => {
     });
   });
 
+  test('a RESUMED spawn takes its kind from the API\'s agentType, not the picked one', async () => {
+    // The upsert handed back an EXISTING session that happens to wear a
+    // pagespace-shaped name but is actually a PTY agent. Labeling it chat
+    // from the PICKED type would mislabel it forever — an explicit kind
+    // beats the SWR fallback on every future mount.
+    addAgentTerminal.mockResolvedValueOnce({ name: 'pagespace-x', agentType: 'claude', resumed: true });
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByLabelText('Agent type'));
+    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    assert({
+      given: 'a pagespace pick the API served by resuming an existing claude session',
+      should:
+        'bind WITHOUT a chat kind — the surface is judged by the API\'s answer, the same standard the resumed-prompt guard applies',
+      actual: bindPaneTerminal.mock.calls[0]?.[3],
+      expected: { projectName: 'app', branchName: 'main', name: 'pagespace-x' },
+    });
+  });
+
+  test('a chat pane whose row is GONE from the loaded list says so — not an eternal spinner', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE });
+    // The list has answered and the session isn't in it: killed elsewhere.
+    agentTerminalRows = [];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a chat-kind pane whose session the loaded list no longer contains',
+      should:
+        'render a notice with close still reachable — an indefinite "Loading session…" over a dead session would read as a hang',
+      actual: {
+        notice: screen.queryByText('This session no longer exists') !== null,
+        loading: screen.queryByText('Loading session…') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+        canClose: screen.queryByTitle('Close pane') !== null,
+      },
+      expected: { notice: true, loading: false, chat: false, xterm: false, canClose: true },
+    });
+  });
+
   test('a chat-kind pane renders MachinePaneChat — addressed by row id, with the picker prompt — not xterm', async () => {
     workspace = soloPane({ scope: CHAT_SCOPE, pendingPrompt: 'audit the docs' });
     agentTerminalRows = [CHAT_ROW];

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -36,6 +36,28 @@ vi.mock('../XtermTerminal', () => ({
   ),
 }));
 
+// The chat pane is a whole AI-chat subtree (Phase 11) — stubbed for the same
+// reason as XtermTerminal: under test is WHICH surface the pane renders and
+// what it is handed, not the chat UI inside it.
+vi.mock('./MachinePaneChat', () => ({
+  default: ({
+    machineId,
+    terminalId,
+    pendingPrompt,
+  }: {
+    machineId: string;
+    terminalId: string;
+    pendingPrompt?: string;
+  }) => (
+    <div
+      data-testid="machine-pane-chat"
+      data-machine-id={machineId}
+      data-terminal-id={terminalId}
+      data-initial-input={pendingPrompt}
+    />
+  ),
+}));
+
 const selectPane = vi.fn();
 const splitRight = vi.fn();
 const splitDown = vi.fn();
@@ -57,14 +79,18 @@ const killAgentTerminal = vi.fn<
 >(async () => {});
 /** Records the scope the hook was asked for, so a spawn at the wrong checkout can't pass. */
 const useAgentTerminalsArgs = vi.fn<(machineId: string, projectName: string | null, branchName: string | null) => void>();
+/** The workspace-scoped SWR session list — what a kind-less pane's surface is
+ * resolved against, and where a chat pane finds its conversation row id. */
+let agentTerminalRows: { id: string; name: string; agentType: string; createdAt: string }[] = [];
+let agentTerminalsLoading = false;
 vi.mock('@/hooks/useAgentTerminals', () => ({
   killAgentTerminal: (machineId: string, scope: { projectName?: string; branchName?: string; name: string }) =>
     killAgentTerminal(machineId, scope),
   useAgentTerminals: (machineId: string, projectName: string | null, branchName: string | null) => {
     useAgentTerminalsArgs(machineId, projectName, branchName);
     return {
-      agentTerminals: [],
-      isLoading: false,
+      agentTerminals: agentTerminalRows,
+      isLoading: agentTerminalsLoading,
       error: undefined,
       mutate: vi.fn(),
       addAgentTerminal,
@@ -136,6 +162,8 @@ let machineEnsured = true;
 let extraWorkspaces: WorkspaceState[] = [];
 beforeEach(() => {
   extraWorkspaces = [];
+  agentTerminalRows = [];
+  agentTerminalsLoading = false;
 });
 
 // Only the store HOOK is faked; selectActiveWorkspace / panesOf / autoSessionName
@@ -552,7 +580,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and the PageSpace Agent — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +588,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and the chat agent labeled "PageSpace Agent" (agents and chats are one thing, so it presents as an agent, never as "chat") — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex', 'pagespace'],
+      expected: ['shell', 'claude', 'codex', 'PageSpace Agent'],
     });
   });
 
@@ -722,6 +750,177 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
       should: 'leave that session alone — the cleanup path kills terminals, and this spawn did not create this one',
       actual: removeAgentTerminal.mock.calls.length,
       expected: 0,
+    });
+  });
+});
+
+describe('TerminalPanes (PageSpace Agent panes)', () => {
+  /** A pane bound to the chat agent — kind on the SCOPE (Phase 9), so the
+   * surface decision survives every place a scope flows opaquely. */
+  const CHAT_SCOPE = { ...WORKSPACE_SCOPE, name: 'pagespace-a1', kind: 'chat' as const };
+  /** The chat session's own row — its id IS the conversation id (Phase 4). */
+  const CHAT_ROW = { id: 'row-ps1', name: 'pagespace-a1', agentType: 'pagespace', createdAt: '' };
+
+  const soloPane = (pane: { scope: OpenTerminalScope | null; pendingPrompt?: string }) =>
+    aWorkspace({
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', ...pane }] }],
+      activePaneId: 'pane-1',
+      pendingPickerPaneId: null,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDesktop();
+    machineEnsured = true;
+    workspace = EMPTY_WORKSPACE;
+  });
+
+  test('picking the PageSpace Agent spawns a pagespace session bound with a chat-kind scope', async () => {
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByLabelText('Agent type'));
+    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    const [spawnedName, spawnedType] = addAgentTerminal.mock.calls[0] ?? [];
+    assert({
+      given: 'the picker\'s "PageSpace Agent" choice, spawned',
+      should:
+        'create a pagespace session and bind it with kind "chat" on the scope — without the kind, the pane would have to guess its surface from the SWR list on every future mount',
+      actual: {
+        agentType: spawnedType,
+        boundScope: bindPaneTerminal.mock.calls[0]?.[3],
+      },
+      expected: {
+        agentType: 'pagespace',
+        boundScope: { projectName: 'app', branchName: 'main', name: spawnedName, kind: 'chat' },
+      },
+    });
+  });
+
+  test('a chat-kind pane renders MachinePaneChat — addressed by row id, with the picker prompt — not xterm', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE, pendingPrompt: 'audit the docs' });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    const chat = await screen.findByTestId('machine-pane-chat');
+
+    assert({
+      given: 'a pane whose scope carries kind "chat", its session row in the list',
+      should:
+        'render the chat surface addressed by the ROW id (the machine-anchored conversation) carrying the starting prompt — and never mount an xterm for it',
+      actual: {
+        terminalId: chat.getAttribute('data-terminal-id'),
+        machineId: chat.getAttribute('data-machine-id'),
+        pendingPrompt: chat.getAttribute('data-initial-input'),
+        xterm: screen.queryByTestId('xterm') !== null,
+      },
+      expected: {
+        terminalId: 'row-ps1',
+        machineId: 'm1',
+        pendingPrompt: 'audit the docs',
+        xterm: false,
+      },
+    });
+  });
+
+  test('no kind hint + SWR resolving the name to pagespace renders chat', async () => {
+    // A kind-less binding: made before the kind tag existed, or by a path that
+    // didn't set it. The session list is the only witness to what it is.
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'pagespace-a1' } });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane whose name the loaded list maps to agentType "pagespace"',
+      should: 'resolve to the chat surface',
+      actual: {
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+      },
+      expected: { chat: true, xterm: false },
+    });
+  });
+
+  test('no kind hint + SWR resolving the name to claude renders xterm', async () => {
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'claude-b2' } });
+    agentTerminalRows = [{ id: 'row-c1', name: 'claude-b2', agentType: 'claude', createdAt: '' }];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane whose name the loaded list maps to agentType "claude"',
+      should: 'resolve to the PTY surface',
+      actual: {
+        xterm: screen.queryByTestId('xterm') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+      },
+      expected: { xterm: true, chat: false },
+    });
+  });
+
+  test('no kind hint while the list is loading renders PaneLoading — NEVER xterm for a maybe-chat session', async () => {
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'pagespace-a1' } });
+    agentTerminalsLoading = true;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane before the session list has answered',
+      should:
+        'hold at a loading state — mounting Xterm now would cold-start a PTY (and register a viewer) for a session that may turn out to be a chat',
+      actual: {
+        loading: screen.queryByText('Loading session…') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+      },
+      expected: { loading: true, xterm: false, chat: false },
+    });
+  });
+
+  test('on mobile, a hidden chat pane stays MOUNTED — invisible, never unmounted', async () => {
+    onMobile();
+    workspace = aWorkspace({
+      columns: [
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: CHAT_SCOPE }] },
+        { id: 'col-2', panes: [{ id: 'pane-2', scope: { ...WORKSPACE_SCOPE, name: 'claude-b2', kind: 'terminal' } }] },
+      ],
+      activePaneId: 'pane-2',
+      pendingPickerPaneId: null,
+    });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    const chat = await screen.findByTestId('machine-pane-chat');
+    const wrapper = screen
+      .getAllByTestId('mobile-pane')
+      .find((pane) => pane.contains(chat));
+
+    assert({
+      given: 'a chat pane hidden by the narrow-viewport collapse',
+      should:
+        'keep it mounted but invisible, exactly like a hidden PTY pane — unmounting would drop the chat\'s in-flight state, and its streaming reply with it',
+      actual: {
+        mounted: chat !== null,
+        hidden: wrapper?.dataset.hidden,
+        invisible: wrapper?.classList.contains('invisible'),
+      },
+      expected: { mounted: true, hidden: 'true', invisible: true },
+    });
+  });
+
+  test('closing a chat pane kills its session row, exactly as a PTY close does', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findByTestId('machine-pane-chat');
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'the close control on a pane rendering the chat surface',
+      should:
+        'kill the session at the pane\'s own scope, same as any terminal — the row delete is cheap (Phase 2) and the conversation survives it',
+      actual: killAgentTerminal.mock.calls,
+      expected: [['m1', CHAT_SCOPE]],
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -19,7 +19,12 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/componen
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals, killAgentTerminal, type AgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
-import { PICKABLE_AGENT_TYPES, agentSurfaceOf, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  PICKABLE_AGENT_TYPES,
+  agentSurfaceOf,
+  isAgentRuntimeType,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
@@ -119,8 +124,14 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
           // rather than re-derived from the SWR list on every future mount.
           // Only `chat` is written — an omitted kind already means `terminal`
           // (see OpenTerminalScope), so PTY bindings stay byte-identical to
-          // every binding that predates the tag.
-          ...(agentSurfaceOf(agentType) === 'chat' ? { kind: 'chat' as const } : {}),
+          // every binding that predates the tag. Judged by the API's OWN
+          // answer, not the picked type: a `resumed` upsert hands back an
+          // existing session whose agentType can differ (same reasoning as
+          // the resumed-prompt guard below), and a retired type the registry
+          // no longer knows falls through to the terminal default.
+          ...(isAgentRuntimeType(created.agentType) && agentSurfaceOf(created.agentType) === 'chat'
+            ? { kind: 'chat' as const }
+            : {}),
         },
         // `spawnAgentTerminal` is an upsert: `resumed` means it handed back a session
         // that ALREADY EXISTED rather than creating one. An agent that was already
@@ -506,11 +517,20 @@ function TerminalPane({
             onFocused={onPickerFocused}
           />
         ) : resolved.surface === 'chat' ? (
-          // `terminalId` still null means the list hasn't turned the row up
-          // yet — hold, exactly like the kind-less loading branch below; the
-          // one thing a chat-bound pane must never do is mount an Xterm.
+          // `terminalId` still null means the list hasn't turned the row up:
+          // hold while it's still loading (the one thing a chat-bound pane
+          // must never do is mount an Xterm), but a LOADED list without the
+          // row means the session was killed — say so rather than spin
+          // forever; the close control above stays reachable either way.
           resolved.terminalId === null ? (
-            <PaneLoading message="Loading session…" />
+            agentTerminalsLoading ? (
+              <PaneLoading message="Loading session…" />
+            ) : (
+              <PaneNotice
+                title="This session no longer exists"
+                description="It may have been closed elsewhere. Close the pane to remove it."
+              />
+            )
           ) : (
             <MachinePaneChat
               // Re-keyed per conversation row, same reason TerminalPaneStream

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -17,9 +17,9 @@ import {
 } from '@/components/ui/select';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
-import { useAgentTerminals, killAgentTerminal } from '@/hooks/useAgentTerminals';
+import { useAgentTerminals, killAgentTerminal, type AgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
-import { PICKABLE_AGENT_TYPES, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { PICKABLE_AGENT_TYPES, agentSurfaceOf, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
@@ -34,8 +34,13 @@ import {
   type TerminalPaneState,
 } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { PaneLoading, PaneNotice } from '../tabs/tab-states';
+import { resolvePaneSurface, agentTypeLabelOf } from './pane-surface';
 
 const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
+// Split out like XtermTerminal and for the same reason in reverse: the chat
+// pane is a whole AI-chat subtree, and a workspace holding only PTY panes
+// should not pay to load it.
+const MachinePaneChat = dynamic(() => import('./MachinePaneChat'), { ssr: false });
 
 const AGENT_TYPES = PICKABLE_AGENT_TYPES;
 
@@ -85,7 +90,10 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
   // Every agent spawned here runs in the workspace's node scope — a branch
   // workspace's panes all share that branch's checkout.
   const scope = workspace?.scope ?? MACHINE_NODE_SCOPE;
-  const { addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
+  // `agentTerminals`/`isLoading` feed the per-pane surface decision
+  // (`resolvePaneSurface`): a kind-less pane's surface is resolved from this
+  // list, and a chat pane finds its conversation ROW id in it.
+  const { agentTerminals, isLoading: agentTerminalsLoading, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
     machineId,
     scope.projectName ?? null,
     scope.branchName ?? null,
@@ -103,7 +111,17 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
       const bound = bindPaneTerminal(
         workspaceId,
         paneId,
-        { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
+        {
+          projectName: scope.projectName,
+          branchName: scope.branchName,
+          name: created.name,
+          // The surface decision, recorded at the one moment it is KNOWN
+          // rather than re-derived from the SWR list on every future mount.
+          // Only `chat` is written — an omitted kind already means `terminal`
+          // (see OpenTerminalScope), so PTY bindings stay byte-identical to
+          // every binding that predates the tag.
+          ...(agentSurfaceOf(agentType) === 'chat' ? { kind: 'chat' as const } : {}),
+        },
         // `spawnAgentTerminal` is an upsert: `resumed` means it handed back a session
         // that ALREADY EXISTED rather than creating one. An agent that was already
         // running must never be typed at, and the API says so right here — relying on
@@ -222,6 +240,11 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     socket,
     machineId,
     pane,
+    // What the pane's surface decision resolves against — the workspace's own
+    // session list (see resolvePaneSurface's doc for the foreign-scope rule).
+    workspaceScope: scope,
+    agentTerminals,
+    agentTerminalsLoading,
     isActive: pane.id === activeId,
     // Every pane closes, always. The old rule (`panes.length > 1 || scope !==
     // null`) existed to stop a lone empty pane being closed, because the
@@ -370,6 +393,9 @@ function TerminalPane({
   socket,
   machineId,
   pane,
+  workspaceScope,
+  agentTerminals,
+  agentTerminalsLoading,
   isActive,
   canClose,
   canSplit,
@@ -386,6 +412,10 @@ function TerminalPane({
   socket: Socket | null | undefined;
   machineId: string;
   pane: TerminalPaneState;
+  /** The checkout `agentTerminals` was fetched at — the workspace's scope. */
+  workspaceScope: MachineNodeScope;
+  agentTerminals: AgentTerminal[];
+  agentTerminalsLoading: boolean;
   isActive: boolean;
   canClose: boolean;
   /** False on narrow viewports, where a split would produce two unusable slivers. */
@@ -403,6 +433,12 @@ function TerminalPane({
   onPromptSent(): void;
 }) {
   const sessionId = pane.scope ? paneSessionId(machineId, pane.scope) : null;
+  // Which surface this pane renders — decided by the pure helper, never by
+  // defaulting: an Xterm mounted for what turns out to be a chat session
+  // would open (and register a viewer on) a PTY stream that shouldn't exist.
+  const resolved = pane.scope
+    ? resolvePaneSurface({ scope: pane.scope, workspaceScope, agentTerminals, isLoading: agentTerminalsLoading })
+    : null;
   // With neither a split nor a close to offer (a lone pane on a phone), the
   // control chip has nothing in it — and since it is opacity-100 on touch, an
   // empty bordered box would just sit in the corner forever.
@@ -462,13 +498,33 @@ function TerminalPane({
       </div>
       )}
       <div className="relative min-h-0 flex-1">
-        {!pane.scope || !sessionId ? (
+        {!pane.scope || !sessionId || !resolved ? (
           <PaneAgentPicker
             focused={pickerFocused}
             scopeLabel={scopeLabel}
             onSpawn={onSpawn}
             onFocused={onPickerFocused}
           />
+        ) : resolved.surface === 'chat' ? (
+          // `terminalId` still null means the list hasn't turned the row up
+          // yet — hold, exactly like the kind-less loading branch below; the
+          // one thing a chat-bound pane must never do is mount an Xterm.
+          resolved.terminalId === null ? (
+            <PaneLoading message="Loading session…" />
+          ) : (
+            <MachinePaneChat
+              // Re-keyed per conversation row, same reason TerminalPaneStream
+              // keys by sessionId: switching sessions is a remount, not a
+              // state handoff.
+              key={resolved.terminalId}
+              machineId={machineId}
+              terminalId={resolved.terminalId}
+              pendingPrompt={pane.pendingPrompt}
+              onPromptSent={onPromptSent}
+            />
+          )
+        ) : resolved.surface === 'loading' ? (
+          <PaneLoading message="Loading session…" />
         ) : (
           <TerminalPaneStream
             key={sessionId}
@@ -546,7 +602,7 @@ function PaneAgentPicker({
           <SelectContent>
             {AGENT_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
-                {type}
+                {agentTypeLabelOf(type)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
@@ -122,7 +122,7 @@ describe('resolvePaneSurface', () => {
       actual: resolvePaneSurface({
         scope: { ...NODE, name: 'old-cli' },
         workspaceScope: NODE,
-        agentTerminals: [{ id: 'row-old', name: 'old-cli', agentType: 'pagespace-cli', createdAt: '' }],
+        agentTerminals: [{ id: 'row-old', name: 'old-cli', agentType: 'pagespace-cli' }],
         isLoading: false,
       }),
       expected: { surface: 'terminal' },

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
@@ -1,0 +1,167 @@
+/**
+ * What a bound pane renders is a DECISION, not a default: an explicit
+ * `kind` on the pane's scope wins outright, and only a kind-less (pre-#2166)
+ * binding falls back to resolving the session's agentType from the SWR list —
+ * where "the list hasn't answered yet" must yield `loading`, never a mounted
+ * Xterm that cold-starts a PTY for a session that turns out to be a chat.
+ */
+import { describe, test } from 'vitest';
+import { assert } from '@/stores/__tests__/riteway';
+import { resolvePaneSurface, agentTypeLabelOf } from './pane-surface';
+
+/** The workspace's checkout — the scope its SWR session list is fetched at. */
+const NODE = { projectName: 'app', branchName: 'main' };
+
+const chatRow = { id: 'row-chat', name: 'pagespace-a1', agentType: 'pagespace', createdAt: '' };
+const ptyRow = { id: 'row-pty', name: 'claude-b2', agentType: 'claude', createdAt: '' };
+
+describe('resolvePaneSurface', () => {
+  test('an explicit chat kind renders chat, carrying the row id the list resolved', () => {
+    assert({
+      given: 'a pane bound with kind "chat" whose session row is in the list',
+      should: 'be a chat surface addressing that row — the row id IS the conversation id (Phase 4)',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1', kind: 'chat' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'chat', terminalId: 'row-chat' },
+    });
+  });
+
+  test('a chat-kind pane whose row has not arrived yet is chat WITHOUT a row id — never a PTY', () => {
+    assert({
+      given: 'kind "chat" while the session list is still loading',
+      should: 'stay a chat surface with a null terminalId (the caller shows loading) rather than fall back to a terminal',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1', kind: 'chat' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'chat', terminalId: null },
+    });
+  });
+
+  test('an explicit terminal kind is a terminal, no list consulted', () => {
+    assert({
+      given: 'kind "terminal" while the list is still loading',
+      should: 'be a terminal immediately — an explicit binding never waits on the list',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'claude-b2', kind: 'terminal' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('no kind hint + the list resolving the name to a chat agent type renders chat', () => {
+    assert({
+      given: 'a kind-less scope whose name the loaded list maps to agentType "pagespace"',
+      should: 'resolve to the chat surface, with the row id',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'chat', terminalId: 'row-chat' },
+    });
+  });
+
+  test('no kind hint + the list resolving the name to a PTY agent type renders a terminal', () => {
+    assert({
+      given: 'a kind-less scope whose name the loaded list maps to agentType "claude"',
+      should: 'resolve to a terminal',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'claude-b2' },
+        workspaceScope: NODE,
+        agentTerminals: [ptyRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('no kind hint while the list is loading is LOADING — never mount Xterm for a maybe-chat session', () => {
+    assert({
+      given: 'a kind-less scope and a list that has not answered yet',
+      should:
+        'hold at loading — mounting Xterm now would cold-start a PTY (and register a viewer) for a session that may turn out to be a chat',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'loading' },
+    });
+  });
+
+  test('no kind hint, list loaded, name not found: a terminal — every pre-kind binding was a PTY', () => {
+    assert({
+      given: 'a kind-less scope the loaded list does not contain (a stale or killed session)',
+      should: 'fall back to a terminal — omitted kind predates chat panes, so the legacy reading is the safe one',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'gone' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('a retired agentType the registry no longer knows resolves to a terminal, not a crash', () => {
+    assert({
+      given: 'a row whose agentType is a since-removed AGENT_LAUNCH_SPECS entry',
+      should: 'treat it as a PTY — the DB can hold rows from retired types (see AgentTerminal.agentType\'s doc)',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'old-cli' },
+        workspaceScope: NODE,
+        agentTerminals: [{ id: 'row-old', name: 'old-cli', agentType: 'pagespace-cli', createdAt: '' }],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('a pane at a FOREIGN checkout never resolves against this workspace\'s list', () => {
+    assert({
+      given: 'a kind-less pane whose node scope differs from the workspace\'s (a restored server layout), sharing a name with a chat row in the list',
+      should:
+        'be a terminal immediately, even mid-load — the workspace-scoped list says nothing about another checkout\'s sessions, and a same-name match across scopes would be a different session',
+      actual: resolvePaneSurface({
+        scope: { name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: true,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+});
+
+describe('agentTypeLabelOf', () => {
+  test('the chat agent presents as "PageSpace Agent", PTY types as themselves', () => {
+    assert({
+      given: 'every pickable agent type',
+      should: 'label pagespace "PageSpace Agent" — agents and chats are one thing, so it presents as an agent, never as "chat" — and leave PTY binaries under their real names',
+      actual: {
+        pagespace: agentTypeLabelOf('pagespace'),
+        shell: agentTypeLabelOf('shell'),
+        claude: agentTypeLabelOf('claude'),
+        codex: agentTypeLabelOf('codex'),
+      },
+      expected: {
+        pagespace: 'PageSpace Agent',
+        shell: 'shell',
+        claude: 'claude',
+        codex: 'codex',
+      },
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
@@ -1,0 +1,90 @@
+/**
+ * Which surface a bound pane renders (#2166, Phase 10) — a pure decision,
+ * colocated-tested like `tab-states`, so the render branch in TerminalPanes
+ * stays a lookup rather than a policy.
+ *
+ * Precedence: an explicit `kind` on the pane's scope (Phase 9) wins outright —
+ * it was written at bind time by the path that KNEW what it was spawning. Only
+ * a kind-less binding (pre-#2166, or a path that didn't set it) falls back to
+ * resolving the session's agentType from the workspace's SWR session list, and
+ * there the unanswered list means `loading`, never a mounted Xterm: opening a
+ * PTY stream registers this pane as a viewer server-side, so guessing "pty"
+ * for what turns out to be a chat isn't a harmless flash, it's a connection.
+ *
+ * The list consulted is the WORKSPACE's (the one TerminalPanes already
+ * subscribes to for spawning). A pane bound at a foreign checkout (a restored
+ * server layout can hold one) is outside that list's world, so its name is
+ * never matched against it — a same-name row at the workspace's scope would
+ * be a different session — and a kind-less foreign pane reads as a terminal
+ * immediately: every binding that predates the kind tag was a PTY.
+ */
+import {
+  agentSurfaceOf,
+  isAgentRuntimeType,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  isSameNodeScope,
+  nodeOfTerminalScope,
+  type MachineNodeScope,
+  type OpenTerminalScope,
+} from '@/stores/machine-workspace/workspace-reducer';
+
+/** The slice of an `AgentTerminal` row this decision reads. */
+export interface PaneSessionRow {
+  /** The row's own id — for chat surfaces, the conversation id (Phase 4). */
+  id: string;
+  name: string;
+  /** Raw DB value; can name a retired AGENT_LAUNCH_SPECS entry. */
+  agentType: string;
+}
+
+export type PaneSurface =
+  /** The list hasn't answered and the binding carries no kind — hold. */
+  | { surface: 'loading' }
+  | { surface: 'terminal' }
+  /** `terminalId` is the session ROW id MachinePaneChat is addressed by —
+   * `null` until the list turns it up (the caller shows loading meanwhile). */
+  | { surface: 'chat'; terminalId: string | null };
+
+export function resolvePaneSurface(params: {
+  scope: OpenTerminalScope;
+  /** The checkout the session list below was fetched at. */
+  workspaceScope: MachineNodeScope;
+  agentTerminals: readonly PaneSessionRow[];
+  isLoading: boolean;
+}): PaneSurface {
+  const { scope, workspaceScope, agentTerminals, isLoading } = params;
+
+  if (scope.kind === 'terminal') return { surface: 'terminal' };
+
+  // A session's identity is (project, branch, name) — the list only speaks
+  // for the workspace's own checkout, so a foreign pane's name is never
+  // looked up in it (see module doc).
+  const resolvable = isSameNodeScope(nodeOfTerminalScope(scope), workspaceScope);
+  const row = resolvable ? agentTerminals.find((terminal) => terminal.name === scope.name) : undefined;
+
+  if (scope.kind === 'chat') return { surface: 'chat', terminalId: row?.id ?? null };
+
+  if (row) {
+    return isAgentRuntimeType(row.agentType) && agentSurfaceOf(row.agentType) === 'chat'
+      ? { surface: 'chat', terminalId: row.id }
+      : { surface: 'terminal' };
+  }
+  if (resolvable && isLoading) return { surface: 'loading' };
+  // Loaded (or unresolvable) and absent: a kind-less binding predates chat
+  // panes, so the legacy reading — a PTY — is the safe one.
+  return { surface: 'terminal' };
+}
+
+/** What the chat agent presents as everywhere a picker lists it — agents and
+ * chats are one thing, so it's an agent ("PageSpace Agent"), never a "chat". */
+const AGENT_TYPE_LABELS: Partial<Record<AgentRuntimeType, string>> = {
+  pagespace: 'PageSpace Agent',
+};
+
+/** Display label for an agent type — PTY binaries under their real names, the
+ * chat agent as "PageSpace Agent". */
+export function agentTypeLabelOf(type: AgentRuntimeType): string {
+  return AGENT_TYPE_LABELS[type] ?? type;
+}


### PR DESCRIPTION
Part of #2166 (step 10). Phase page: `m04thxfd2zbavbpab63cqoy6`.

The pane grid gains its render branch: chat-kind panes render `MachinePaneChat` (Phase 11), addressed by the session ROW id — the machine-anchored conversation (Phase 4). PTY panes are untouched.

## What

- **Pure surface resolution** (`pane-surface.ts`, colocated tests like `tab-states`): an explicit scope `kind` (Phase 9) wins; a kind-less binding resolves its agentType from the workspace's SWR session list — `pagespace` → chat, PTY types → xterm, unanswered list → `PaneLoading`. **Never mounts Xterm for a maybe-chat session** (opening the PTY stream registers a viewer server-side). Foreign-checkout panes never match against the workspace's list.
- **Spawn paths record the kind at bind time**: `spawnIntoPane` and `NodeActionPalette`'s `TerminalSpawnForm` write `kind: 'chat'` for chat-surface spawns, judged by the API's own answer (`created.agentType` — a resumed upsert can hand back a session whose type differs from the picked one). PTY bindings stay byte-identical (omitted kind already means terminal).
- **Picker copy**: both pickers label the chat type **"PageSpace Agent"** (never "chat").
- **NodeActionPalette reconcile**: drops its hardcoded `['shell','claude','codex']` for the lib `PICKABLE_AGENT_TYPES` — the local copy had diverged and silently kept pagespace out of that surface.
- **Mobile**: chat panes stay mounted-but-`invisible`, exactly like hidden PTY panes.
- **Close**: a chat pane's close calls `killAgentTerminal` as today (row delete is cheap after Phase 2; the conversation survives). `closePaneAndKill` / `WorkspaceLeaves` unchanged.
- A chat pane whose row is absent from the *loaded* list renders a "session no longer exists" notice instead of spinning forever.

## Process

RED → GREEN → `/aidd-review` (findings recorded + fixed on the phase page: 0 blockers / 0 majors / 3 minors fixed / 1 nit accepted). `typecheck`, `lint`, and the machine-workspace suites (165 tests) green; full-app vitest failures are pre-existing environment-dependent suites (DB-backed auth/activity tests, TZ-dependent grouping test) untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpesgsiFTMfmTvq3JiSnNJ