### PR TITLE
Terminal panes: native PageSpace Agent surface (epic #2166)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test Suite
 
 on:
   push:
-    branches: [main, master, develop, pu/flash-sandbox]
+    branches: [main, master, develop, pu/flash-sandbox, pu/panes-agent]
   pull_request:
-    branches: [main, master, develop, pu/flash-sandbox]
+    branches: [main, master, develop, pu/flash-sandbox, pu/panes-agent]
   workflow_dispatch:
 
 jobs:

--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -203,6 +203,24 @@ describe('resolveMachineSandbox', () => {
     });
   });
 
+  it('refuses a pagespace (chat-surface) target WITHOUT reading the Sprite', async () => {
+    const getSprite = spyGetSprite();
+    const result = await resolveMachineSandbox(
+      { machineId: 'm-1', name: 'assistant' },
+      {
+        resolveAgentTerminal: async () => ({ ...resolvedOk, agentType: 'pagespace' }),
+        getSprite: getSprite.fn,
+      },
+    );
+
+    assert({
+      given: 'a resolved agent terminal whose agentType is pagespace (chat surface, not pty)',
+      should: 'deny with not_a_pty_agent without touching the Sprite',
+      actual: { result, spriteCalls: getSprite.calls.length },
+      expected: { result: { ok: false, reason: 'not_a_pty_agent' }, spriteCalls: 0 },
+    });
+  });
+
   it('denies with provision_failed (and the sandboxId) when the Sprite lookup throws', async () => {
     const result = await resolveMachineSandbox(
       { machineId: 'm-1', name: 'shell' },
@@ -440,7 +458,7 @@ function buildDeps(overrides: Partial<AgentTerminalCheckAuthDeps> = {}): {
     }),
     resolveMachineRow: async () => {
       calls.resolveMachineRow += 1;
-      return { ok: true };
+      return { ok: true, agentType: 'shell' };
     },
     writeAudit: () => {},
     buildSessionKey: () => 'session-key-1',
@@ -825,6 +843,43 @@ describe('buildAgentTerminalCheckAuth', () => {
       should: 'deny with not_found from the access half, touching no Sprite',
       actual: { result, spriteCalls: sandbox.getSpriteCalls.length },
       expected: { result: { ok: false, reason: 'not_found' }, spriteCalls: 0 },
+    });
+  });
+
+  it('DENIES a pagespace (chat-surface) row from the ACCESS half itself, before the lazy sandbox thunk could ever acquire/wake the machine\'s Sprite', async () => {
+    // This is the gap a machine/project-scope target has that a direct
+    // resolveMachineSandbox() call can't see: the real resolveAgentTerminal
+    // (agent-terminals.ts) resolves the Sprite's LOCATION via
+    // machineSandbox.acquire — which can resume or reprovision a hibernating
+    // Sprite — BEFORE it even reads the row's agentType. Gating only inside
+    // resolveMachineSandbox (which only runs from the lazy resolveSandbox
+    // thunk, i.e. AFTER resolveAgentTerminal has already resolved/acquired)
+    // is too late for that scope. resolveMachineRow uses resolveScopeKey
+    // instead, which never touches machineSandbox at all, so denying here is
+    // the earliest point that's both correct and Sprite-free.
+    const sandbox = sandboxSpy(async () => ({ ...resolvedOk, agentType: 'pagespace' }));
+    const denials: string[] = [];
+    const { deps } = buildDeps({
+      resolveSandbox: sandbox.fn,
+      resolveMachineRow: async () => ({ ok: true, agentType: 'pagespace' }),
+      logDenied: (reason) => {
+        denials.push(reason);
+      },
+    });
+    const checkAuth = buildAgentTerminalCheckAuth(deps);
+
+    const result = await checkAuth({ userId: 'u-1', machineId: 'm-1', name: 'assistant' });
+
+    assert({
+      given: 'a resolveMachineRow that reports a chat-surface (pagespace) agentType for a machine-scope target',
+      should: 'deny with not_a_pty_agent from the access half alone, never calling resolveSandbox or touching a Sprite',
+      actual: { result, denials, sandboxCalls: sandbox.calls, spriteCalls: sandbox.getSpriteCalls.length },
+      expected: {
+        result: { ok: false, reason: 'not_a_pty_agent' },
+        denials: ['not_a_pty_agent'],
+        sandboxCalls: 0,
+        spriteCalls: 0,
+      },
     });
   });
 

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -20,7 +20,7 @@
  * testable with none.
  */
 
-import { resolveAgentLaunchSpec } from '@pagespace/lib/services/machines/agent-terminal-types';
+import { isPtyAgentType, resolveAgentLaunchSpec, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import type { ResolveAgentTerminalResult } from '@pagespace/lib/services/machines/agent-terminals';
 import type { SpriteInstanceLike } from '@pagespace/lib/services/sandbox/sandbox-client/sprites';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
@@ -158,8 +158,9 @@ export type ResolveMachineSandboxResult =
 /**
  * Resolve the Sprite a FRESH PTY will attach to: resolve the agent-terminal row
  * to its sandbox, then read that Sprite once. A read-only resolve failure never
- * touches the Sprite; a vanished Sprite (getSprite throws) denies with
- * `provision_failed`.
+ * touches the Sprite; a chat-surface agentType (e.g. `pagespace`) denies with
+ * `not_a_pty_agent` before the Sprite is touched; a vanished Sprite (getSprite
+ * throws) denies with `provision_failed`.
  */
 export async function resolveMachineSandbox(
   target: ResolveMachineSandboxTarget,
@@ -167,6 +168,12 @@ export async function resolveMachineSandbox(
 ): Promise<ResolveMachineSandboxResult> {
   const resolved = await deps.resolveAgentTerminal(target);
   if (!resolved.ok) return { ok: false, reason: resolved.reason };
+
+  // Belt-and-suspenders over the socket layer's own `not_a_pty_agent` deny: a
+  // buggy client emitting `agent-terminal:connect` for a chat-surface
+  // (`pagespace`) session must be refused here too, before ever touching the
+  // Sprite — the socket deny path and this one share the same reason string.
+  if (!isPtyAgentType(resolved.agentType)) return { ok: false, reason: 'not_a_pty_agent' };
 
   const spec = resolveAgentLaunchSpec(resolved.agentType);
 
@@ -241,8 +248,16 @@ export interface AgentTerminalCheckAuthDeps {
    * Part of the ACCESS half precisely because it is cheap: authorization must
    * keep noticing that a terminal's project/branch/row was deleted, and the 60s
    * re-auth tick (which never resolves a sandbox) is the only thing that will.
+   *
+   * Surfaces `agentType` on success — unlike `resolveAgentTerminal`, resolving
+   * this row's SCOPE (`resolveScopeKey`) never touches `machineSandbox.acquire`
+   * even for machine/project scope, so this is the earliest point a chat-surface
+   * (`pagespace`) row can be denied `not_a_pty_agent` WITHOUT first waking or
+   * reprovisioning the Machine's Sprite — `resolveMachineSandbox`'s own guard
+   * runs too late for that (it only sees the row after `resolveAgentTerminal`
+   * has already resolved the Sprite's location via `machineSandbox.acquire`).
    */
-  resolveMachineRow: (target: ResolveMachineSandboxTarget) => Promise<{ ok: true } | { ok: false; reason: string }>;
+  resolveMachineRow: (target: ResolveMachineSandboxTarget) => Promise<{ ok: true; agentType: AgentRuntimeType } | { ok: false; reason: string }>;
   writeAudit: (input: { userId: string; actorEmail: string; driveId: string; command: string }) => void;
   buildSessionKey: (args: { machineId: string; projectName?: string; branchName?: string; name: string }) => string;
   logDenied: (reason: string, context: Record<string, unknown>) => void;
@@ -306,6 +321,17 @@ export function buildAgentTerminalCheckAuth(deps: AgentTerminalCheckAuthDeps): A
     if (!machineRow.ok) {
       deps.logDenied(machineRow.reason, { userId, machineId, projectName, branchName, name });
       return { ok: false, reason: machineRow.reason };
+    }
+
+    // Belt-and-suspenders over the socket layer's own `not_a_pty_agent` deny,
+    // enforced HERE (not only in `resolveMachineSandbox`) because this is the
+    // earliest point the row's agentType is known WITHOUT having already
+    // acquired (and possibly woken/reprovisioned) the machine/project scope's
+    // Sprite — that acquisition happens inside `resolveAgentTerminal`, which
+    // the lazy `resolveSandbox` thunk below only calls for pty-surface rows.
+    if (!isPtyAgentType(machineRow.agentType)) {
+      deps.logDenied('not_a_pty_agent', { userId, machineId, projectName, branchName, name });
+      return { ok: false, reason: 'not_a_pty_agent' };
     }
 
     // Decrypt the actor email BEFORE anything is reserved (a decrypt throw here

--- a/apps/realtime/src/terminal/agent-terminal-access.ts
+++ b/apps/realtime/src/terminal/agent-terminal-access.ts
@@ -185,8 +185,8 @@ export async function resolveMachineSandbox(
   }
 
   // Both `projectName` AND `branchName` must be set for true branch scope —
-  // matching `resolveScopeKey`/`resolveScopeLocation`'s own discriminator
-  // (`agent-terminals.ts`), rather than relying on the implicit invariant
+  // matching `resolveScopeKey`'s own discriminator (`agent-terminals.ts`),
+  // rather than relying on the implicit invariant
   // that a real `resolveAgentTerminal` already rejects `branchName` without
   // `projectName` as `invalid_target` before ever reaching here. Checking
   // both explicitly means this gate stays correct even if that upstream

--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -151,6 +151,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
 
 vi.mock('ai', () => ({
   streamText: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/machine-binding-route.test.ts
@@ -3,20 +3,21 @@ import { POST } from '../route';
 import type { SessionAuthResult } from '@/lib/auth';
 
 // ============================================================================
-// Route-level regression test for GitHub-integration/sandbox-tool suppression
-// in 'search' tool-exposure mode.
+// Machine Pane binding tests for POST /api/ai/chat (Phase 6, issue #2166)
 //
-// The bug this guards against: `resolvePageAgentIntegrationTools` needs the
-// PRE-exposure tool set to detect whether the sandbox git/gh CLI toolkit is
-// active (search mode moves non-core tools, including all sandbox tools,
-// behind execute_tool — hiding their names from a top-level key scan). A
-// prior implementation captured the tool set AFTER `applyToolExposureMode`
-// ran, so suppression silently never fired in search mode. `resolveThe
-// PageAgentIntegrationTools` is mocked here (its own suppression logic is
-// covered by integration-tool-resolver.test.ts) — this test only asserts on
-// what the ROUTE passes as `currentTools`, which is the part a resolver-level
-// unit test cannot observe.
+// Verifies the route's wiring of deriveMachinePaneBinding (Phase 5 pure core):
+//  - bound conversation -> machineBinding + activeMachine seeded into
+//    experimental_context, switch_machine/list_machines dropped from tools
+//  - row.machineId !== chatId -> 400 before streaming
+//  - non-bound conversation -> derivation null, passthrough unchanged
+//
+// Mirrors mcp-scope-tool-filtering.test.ts's idiom: mocks every module the
+// route imports, calls the real POST with a real Request, and spies on the
+// REAL filterToolsForMachineBinding (via importOriginal) to assert on its
+// actual isBound argument and return value.
 // ============================================================================
+
+const deriveMachinePaneBindingMock = vi.fn();
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
@@ -54,6 +55,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     },
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logPerformance: vi.fn(),
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
@@ -65,7 +67,6 @@ vi.mock('@pagespace/db/db', () => {
     title: 'Test Page',
     systemPrompt: null,
     enabledTools: null,
-    toolExposureMode: 'search',
     aiProvider: 'openai',
     aiModel: 'openai/gpt-5.3-chat',
     driveId: 'drive_A',
@@ -73,6 +74,7 @@ vi.mock('@pagespace/db/db', () => {
     includePageTree: false,
     pageTreeScope: null,
     revision: 0,
+    type: 'AI_CHAT',
   };
   return {
     db: {
@@ -88,17 +90,23 @@ vi.mock('@pagespace/db/db', () => {
         })),
       })),
     },
+    // Accessed by start-generation-exclusive's advisory lock (real, unmocked
+    // implementation) — its own error handling degrades to running unlocked
+    // when the pool/lock query fails, which a bare object triggers harmlessly.
+    getAdvisoryLockPool: vi.fn(() => ({})),
   };
 });
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  ne: vi.fn(),
+  desc: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'id' },
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt' },
+  chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt', status: 'status' },
   pages: { id: 'id' },
   drives: { id: 'id', drivePrompt: 'drivePrompt' },
 }));
@@ -126,14 +134,12 @@ vi.mock('@/lib/ai/core/provider-factory', () => ({
   createProviderErrorResponse: vi.fn(),
   isProviderError: vi.fn().mockReturnValue(false),
 }));
-// git_clone stands in for the sandbox git/gh CLI toolkit — a real sandbox
-// toolkit registers ~56 tool names, but only one is needed to prove
-// suppression sees it. list_pages is a non-sandbox, non-core tool so it gets
-// deferred behind execute_tool in search mode alongside git_clone.
+// pageSpaceTools includes switch_machine/list_machines so filtering behavior is observable.
 vi.mock('@/lib/ai/core/ai-tools', () => ({
   pageSpaceTools: {
-    git_clone: { description: 'git_clone' },
-    list_pages: { description: 'list_pages' },
+    switch_machine: { description: 'switch_machine' },
+    list_machines: { description: 'list_machines' },
+    read_page: { description: 'read_page' },
   },
 }));
 vi.mock('@/lib/ai/core/message-utils', () => ({
@@ -153,9 +159,16 @@ vi.mock('@/lib/ai/core/timestamp-utils', () => ({
 vi.mock('@/lib/ai/core/system-prompt', () => ({
   buildSystemPrompt: vi.fn().mockReturnValue(''),
   buildPersonalizationPrompt: vi.fn().mockReturnValue(''),
-  TOOL_DISCOVERY_PROMPT: 'discover tools',
-  buildNonCoreToolNamesPrompt: vi.fn().mockReturnValue(''),
 }));
+// Spy on the REAL implementation so we can assert on its actual behavior
+// (isBound argument + filtered return value), instead of stubbing it away.
+vi.mock('@/lib/ai/core/tool-filtering', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../../lib/ai/core/tool-filtering')>();
+  return {
+    ...actual,
+    filterToolsForMachineBinding: vi.fn(actual.filterToolsForMachineBinding),
+  };
+});
 vi.mock('@/lib/ai/core/page-tree-context', () => ({
   getPageTreeContext: vi.fn(),
 }));
@@ -167,30 +180,31 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
-// Phase 6 (#2166): the route now derives a Machine Pane binding for every
-// request. None of these requests carry a machine-bound conversationId, so
-// this resolves to null (not a machine-bound pane) — the real DB-backed
-// deps builder is stubbed out since the pure core itself is fully mocked.
-vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
-  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
-}));
-vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
-  buildMachinePaneBindingDeps: vi.fn(() => ({})),
-}));
 
+const streamTextMock = vi.fn();
 vi.mock('ai', () => ({
-  streamText: vi.fn(),
+  streamText: (...args: unknown[]) => streamTextMock(...args),
   convertToModelMessages: vi.fn().mockReturnValue([]),
   stepCountIs: vi.fn(),
   hasToolCall: vi.fn(() => () => false),
   tool: vi.fn((config) => config),
-  createUIMessageStream: vi.fn(),
-  createUIMessageStreamResponse: vi.fn(),
+  // Real createUIMessageStream runs `execute` as a detached producer (the
+  // route never awaits it — the returned stream is consumed by piping into
+  // the HTTP response). Mirror that: fire it without awaiting, so the route
+  // under test returns the same way it does in production, and this file's
+  // tests poll (vi.waitFor) for streamText to have been invoked once its
+  // microtasks settle.
+  createUIMessageStream: vi.fn((opts: { execute?: (args: { writer: { write: () => void } }) => Promise<void> }) => {
+    void opts.execute?.({ writer: { write: vi.fn() } })?.catch(() => {});
+    return {};
+  }),
+  createUIMessageStreamResponse: vi.fn(() => new Response(null, { status: 200 })),
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('generated_id'),
   init: vi.fn(() => vi.fn(() => 'test-cuid')),
+  isCuid: vi.fn(() => true),
 }));
 
 vi.mock('@/lib/logging/mask', () => ({
@@ -222,6 +236,7 @@ vi.mock('@/services/api/page-mutation-service', () => ({
 vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
   createStreamAbortController: vi.fn().mockReturnValue({ streamId: 'stream_123', signal: new AbortController().signal }),
   removeStream: vi.fn(),
+  attachStreamFinisher: vi.fn(),
   STREAM_ID_HEADER: 'x-stream-id',
 }));
 
@@ -233,20 +248,37 @@ vi.mock('@/lib/ai/core/validate-image-parts', () => ({
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   getModelCapabilities: vi.fn(),
   hasVisionCapability: vi.fn().mockReturnValue(true),
+  DEFAULT_IMAGE_MODEL: 'default-image-model',
 }));
-
-// The resolver itself (and its suppression logic) is unit-tested in
-// integration-tool-resolver.test.ts. This test only needs to observe what
-// the route passes as `currentTools`.
 vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
   resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    getConversation: vi.fn().mockResolvedValue(null),
+    hasConflictingMessageOwner: vi.fn().mockResolvedValue(false),
+    createConversation: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+// The module under test in this file: deriveMachinePaneBinding is the Phase 5
+// pure core the route must call. buildMachinePaneBindingDeps is its DB-backed
+// wiring (Phase 5 runtime shell) — stubbed to a no-op object since the pure
+// core itself is fully mocked below.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: (...args: unknown[]) => deriveMachinePaneBindingMock(...args),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
+
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { resolvePageAgentIntegrationTools } from '@/lib/ai/core/integration-tool-resolver';
+import { filterToolsForMachineBinding } from '@/lib/ai/core/tool-filtering';
 
 const mockUserId = 'user_123';
 const chatId = 'page_123'; // in drive_A per db mock above
+const conversationId = 'conversation_abc';
 
 const mockWebAuth = (userId: string): SessionAuthResult => ({
   userId,
@@ -266,29 +298,77 @@ const createChatRequest = () => {
         { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
       ],
       chatId,
+      conversationId,
       selectedProvider: 'openai',
       selectedModel: 'openai/gpt-5.3-chat',
     }),
   });
 };
 
-describe('POST /api/ai/chat - GitHub suppression sees sandbox tools in search mode', () => {
+describe('POST /api/ai/chat - machine-pane binding', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    streamTextMock.mockReturnValue({});
   });
 
-  it('passes the pre-exposure tool set (including sandbox tools) to resolvePageAgentIntegrationTools even in search mode', async () => {
-    const auth = mockWebAuth(mockUserId);
-    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(auth);
+  it('injects machineBinding + seeds activeMachine, and drops switch_machine/list_machines when bound', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue({
+      ok: true,
+      binding: { cwd: '/workspace' },
+    });
 
     await POST(createChatRequest());
 
-    expect(resolvePageAgentIntegrationTools).toHaveBeenCalledTimes(1);
-    const call = vi.mocked(resolvePageAgentIntegrationTools).mock.calls[0]![0];
-    // In search mode, git_clone/list_pages are moved behind execute_tool and
-    // vanish as top-level keys — this assertion only passes if the route
-    // captured currentTools BEFORE applyToolExposureMode ran.
-    expect(call.currentTools).toHaveProperty('git_clone');
-    expect(call.currentTools).toHaveProperty('list_pages');
+    expect(deriveMachinePaneBindingMock).toHaveBeenCalledWith(
+      { chatId, conversationId },
+      expect.anything(),
+    );
+
+    expect(filterToolsForMachineBinding).toHaveBeenCalledWith(expect.anything(), true);
+    const filtered = vi.mocked(filterToolsForMachineBinding).mock.results[0]?.value as Record<string, unknown>;
+    expect(filtered).not.toHaveProperty('switch_machine');
+    expect(filtered).not.toHaveProperty('list_machines');
+    expect(filtered).toHaveProperty('read_page');
+
+    await vi.waitFor(() => expect(streamTextMock).toHaveBeenCalled());
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
+    expect(streamTextArgs.experimental_context?.machineBinding).toEqual({
+      machineId: chatId,
+      cwd: '/workspace',
+      branchSandbox: undefined,
+    });
+    expect(streamTextArgs.experimental_context?.activeMachine).toEqual({
+      kind: 'existing',
+      machineId: chatId,
+    });
+  });
+
+  it('returns 400 before streaming when row.machineId !== chatId', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue({
+      ok: false,
+      reason: 'binding_page_mismatch',
+    });
+
+    const response = await POST(createChatRequest());
+
+    expect(response.status).toBe(400);
+    expect(streamTextMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves behavior unchanged for a non-bound conversation (derivation null)', async () => {
+    deriveMachinePaneBindingMock.mockResolvedValue(null);
+
+    await POST(createChatRequest());
+
+    expect(filterToolsForMachineBinding).toHaveBeenCalledWith(expect.anything(), false);
+    const filtered = vi.mocked(filterToolsForMachineBinding).mock.results[0]?.value as Record<string, unknown>;
+    expect(filtered).toHaveProperty('switch_machine');
+    expect(filtered).toHaveProperty('list_machines');
+
+    await vi.waitFor(() => expect(streamTextMock).toHaveBeenCalled());
+    const streamTextArgs = streamTextMock.mock.calls[0]?.[0] as { experimental_context?: Record<string, unknown> };
+    expect(streamTextArgs.experimental_context?.machineBinding).toBeUndefined();
+    expect(streamTextArgs.experimental_context?.activeMachine).toBeUndefined();
   });
 });

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope-tool-filtering.test.ts
@@ -165,6 +165,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
+}));
 
 vi.mock('ai', () => ({
   streamText: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -179,6 +179,7 @@ vi.mock('@/lib/ai/core/tool-filtering', () => ({
   filterToolsForReadOnly: vi.fn().mockReturnValue({}),
   filterToolsForWebSearch: vi.fn().mockReturnValue({}),
   filterToolsForMcpScope: vi.fn().mockReturnValue({}),
+  filterToolsForMachineBinding: vi.fn().mockReturnValue({}),
   buildPageAITools: vi.fn().mockReturnValue({}),
 }));
 vi.mock('@/lib/ai/core/page-tree-context', () => ({
@@ -191,6 +192,16 @@ vi.mock('@/lib/ai/core/mcp-tool-converter', () => ({
 }));
 vi.mock('@/lib/ai/core/personalization-utils', () => ({
   getUserPersonalization: vi.fn().mockResolvedValue(null),
+}));
+// Phase 6 (#2166): the route now derives a Machine Pane binding for every
+// request. None of these requests carry a machine-bound conversationId, so
+// this resolves to null (not a machine-bound pane) — the real DB-backed
+// deps builder is stubbed out since the pure core itself is fully mocked.
+vi.mock('@pagespace/lib/services/machines/machine-pane-binding', () => ({
+  deriveMachinePaneBinding: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/lib/ai/machine-pane/machine-pane-binding-runtime', () => ({
+  buildMachinePaneBindingDeps: vi.fn(() => ({})),
 }));
 
 vi.mock('ai', () => ({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -64,7 +64,9 @@ import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-
 import { getAgentContextDrives } from '@pagespace/lib/services/drive-agent-service';
 import { buildInlineInstructions } from '@/lib/ai/core/inline-instructions';
 import { buildLocationTurnPrompt } from '@/lib/ai/core/location-prompt';
-import { filterToolsForReadOnly, filterToolsForMcpScope } from '@/lib/ai/core/tool-filtering';
+import { filterToolsForReadOnly, filterToolsForMcpScope, filterToolsForMachineBinding } from '@/lib/ai/core/tool-filtering';
+import { deriveMachinePaneBinding } from '@pagespace/lib/services/machines/machine-pane-binding';
+import { buildMachinePaneBindingDeps } from '@/lib/ai/machine-pane/machine-pane-binding-runtime';
 import { shouldExposeImageGen } from '@/lib/ai/core/image-gen-access';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/core/model-capabilities';
 import { getPageTreeContext } from '@/lib/ai/core/page-tree-context';
@@ -556,6 +558,36 @@ export async function POST(request: Request) {
       isNewConversation: !requestConversationId
     });
 
+    // Machine Pane binding (Phase 5's deriveMachinePaneBinding pure core): a
+    // conversation whose id is a machine_agent_terminals row bound to THIS
+    // page is pinned to that machine for the rest of the request — tools,
+    // system prompt, and default active machine all follow from it below.
+    // No additional access check is needed here: canPrincipalViewPage /
+    // canPrincipalEditPage against chatId (above) already authorizes the
+    // acting user for this page, which is the precondition the pure core's
+    // own docstring requires of its caller. A non-bound conversation (a
+    // brand-new cuid, or any conversation not backed by a machine_agent_terminals
+    // row) derives to null and leaves everything below byte-identical to today.
+    const machinePaneBindingResult = await deriveMachinePaneBinding(
+      { chatId: chatId!, conversationId: conversationId! },
+      buildMachinePaneBindingDeps()
+    );
+    if (machinePaneBindingResult && !machinePaneBindingResult.ok) {
+      loggers.ai.warn('AI Chat API: machine-pane binding rejected', {
+        chatId: maskedChatId,
+        conversationId,
+        reason: machinePaneBindingResult.reason,
+      });
+      return NextResponse.json({ error: 'This conversation is not bound to this machine' }, { status: 400 });
+    }
+    const machineBinding = machinePaneBindingResult?.ok
+      ? {
+          machineId: chatId!,
+          cwd: machinePaneBindingResult.binding.cwd,
+          branchSandbox: machinePaneBindingResult.binding.branchSandbox,
+        }
+      : undefined;
+
     // Process @mentions in the user's message
     let mentionSystemPrompt = '';
     let mentionedPageIds: string[] = [];
@@ -855,11 +887,16 @@ export async function POST(request: Request) {
     const webSearchMode = webSearchEnabled === true;
     loggers.ai.debug('AI Page Chat API: Tool modes', { isReadOnly: readOnlyMode, webSearchEnabled: webSearchMode });
 
-    // Step 1: Apply isReadOnly filter, then hide account-level-only tools
-    // (e.g. create_drive) from drive-scoped MCP tokens' tool list.
-    const baseTools = filterToolsForMcpScope(
-      filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
-      isScopedMCPAuth(authResult)
+    // Step 1: Apply isReadOnly filter, hide account-level-only tools
+    // (e.g. create_drive) from drive-scoped MCP tokens' tool list, then drop
+    // switch_machine/list_machines when this conversation is bound to one
+    // machine (see machinePaneBindingResult above).
+    const baseTools = filterToolsForMachineBinding(
+      filterToolsForMcpScope(
+        filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
+        isScopedMCPAuth(authResult)
+      ),
+      machineBinding != null
     );
 
     // Step 2: Extract web_search + generate_image so they can be handled as
@@ -1151,6 +1188,14 @@ export async function POST(request: Request) {
     // a custom system prompt is set (unlike drivePromptPrefix above, which is
     // only prepended in the customSystemPrompt branch).
     systemPrompt = memberDriveContextPrefix + systemPrompt;
+
+    // Machine binding section — applies uniformly (custom or default system
+    // prompt) for the same reason as memberDriveContextPrefix above. Fixed
+    // for the conversation's lifetime, so it belongs in the STABLE section,
+    // not the per-turn locationPrompt below.
+    if (machineBinding) {
+      systemPrompt += `\n\nMACHINE BINDING (this conversation)\n• This conversation is bound to machine "${machineBinding.machineId}" — code-execution tools (bash, readFile, writeFile, editFile, git/gh) operate from working directory: ${machineBinding.cwd}\n• switch_machine and list_machines are unavailable — this conversation cannot leave its bound machine`;
+    }
 
     // Build timestamp system prompt for temporal awareness
     const userTimezone = user?.timezone ?? undefined;
@@ -1509,6 +1554,15 @@ export async function POST(request: Request) {
                 // exceed its own membership role — via the agent's broader ACL.
                 mcpAllowedDriveIds: getAllowedDriveIds(authResult),
                 mcpTokenId: isMCPAuthResult(authResult) ? authResult.tokenId : undefined,
+                // Computed once above from deriveMachinePaneBinding — undefined
+                // for every conversation that isn't a machine-bound pagespace
+                // pane. activeMachine seeds the default-mode sandbox tools'
+                // active machine so they operate on the bound machine from the
+                // first tool call, without waiting for a switch_machine call.
+                machineBinding,
+                activeMachine: machineBinding
+                  ? { kind: 'existing' as const, machineId: machineBinding.machineId }
+                  : undefined,
               }, // Pass userId, timezone, AI context, location context, model capabilities, and chat source to tools
               maxRetries: 20, // Increase from default 2 to 20 for better handling of rate limits
               onChunk: ({ chunk }) => {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/__tests__/route.test.ts
@@ -33,6 +33,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ kind: 'eq', a, b })),
   ne: vi.fn((a, b) => ({ kind: 'ne', a, b })),
   and: vi.fn((...c) => ({ kind: 'and', c })),
+  inArray: vi.fn((f, values) => ({ kind: 'inArray', f, values })),
   desc: vi.fn((f) => ({ kind: 'desc', f })),
   sql: Object.assign(vi.fn(), { as: vi.fn() }),
 }));

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, canPrincipalViewPage } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq, and, ne, desc, sql } from '@pagespace/db/operators'
+import { eq, and, ne, desc, sql, inArray } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -19,7 +19,7 @@ const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: fal
  * Messages are returned in UIMessage format compatible with the Vercel AI SDK,
  * including tool calls and tool results if present.
  *
- * @param agentId - The unique identifier of the AI agent (AI_CHAT page ID)
+ * @param agentId - The conversation-hosting page id (AI_CHAT agent or MACHINE page)
  * @param conversationId - The unique identifier of the conversation session
  *
  * Query Parameters:
@@ -66,11 +66,13 @@ export async function GET(
 
     const { agentId, conversationId } = await context.params;
 
-    // Verify agent exists and is AI_CHAT type
+    // Verify the conversation-hosting page exists: an AI_CHAT agent, or a
+    // MACHINE page (machine panes anchor terminal conversations there —
+    // same widening as conversationRepository.getAiAgent, #2166 Phase 11).
     const agent = await db.query.pages.findFirst({
       where: and(
         eq(pages.id, agentId),
-        eq(pages.type, 'AI_CHAT'),
+        inArray(pages.type, ['AI_CHAT', 'MACHINE']),
         eq(pages.isTrashed, false)
       ),
     });

--- a/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
@@ -11,9 +11,11 @@ const {
   mockBuildSpawnAgentTerminalDeps,
   mockBuildKillAgentTerminalDeps,
   mockBuildListAgentTerminalsDeps,
+  mockIsCodeExecutionEnabled,
   mockSpawnAgentTerminal,
   mockKillAgentTerminal,
   mockListAgentTerminals,
+  mockCreateConversation,
 } = vi.hoisted(() => ({
   mockAuthenticateRequest: vi.fn(),
   mockIsAuthError: vi.fn((result: unknown) => result != null && typeof result === 'object' && 'error' in result),
@@ -22,9 +24,11 @@ const {
   mockBuildSpawnAgentTerminalDeps: vi.fn(),
   mockBuildKillAgentTerminalDeps: vi.fn(),
   mockBuildListAgentTerminalsDeps: vi.fn(),
+  mockIsCodeExecutionEnabled: vi.fn(),
   mockSpawnAgentTerminal: vi.fn(),
   mockKillAgentTerminal: vi.fn(),
   mockListAgentTerminals: vi.fn(),
+  mockCreateConversation: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -38,12 +42,19 @@ vi.mock('@/lib/machines/agent-terminals-runtime', () => ({
   buildListAgentTerminalsDeps: (...args: unknown[]) => mockBuildListAgentTerminalsDeps(...args),
   canAccessMachine: (...args: unknown[]) => mockCanAccessMachine(...args),
   canViewMachine: (...args: unknown[]) => mockCanViewMachine(...args),
+  isCodeExecutionEnabled: (...args: unknown[]) => mockIsCodeExecutionEnabled(...args),
 }));
 
 vi.mock('@pagespace/lib/services/machines/agent-terminals', () => ({
   spawnAgentTerminal: (...args: unknown[]) => mockSpawnAgentTerminal(...args),
   killAgentTerminal: (...args: unknown[]) => mockKillAgentTerminal(...args),
   listAgentTerminals: (...args: unknown[]) => mockListAgentTerminals(...args),
+}));
+
+vi.mock('@/lib/repositories/conversation-repository', () => ({
+  conversationRepository: {
+    createConversation: (...args: unknown[]) => mockCreateConversation(...args),
+  },
 }));
 
 import { GET, POST, DELETE } from '../route';
@@ -58,6 +69,8 @@ beforeEach(() => {
   mockBuildSpawnAgentTerminalDeps.mockReturnValue(FAKE_DEPS);
   mockBuildKillAgentTerminalDeps.mockResolvedValue(FAKE_DEPS);
   mockBuildListAgentTerminalsDeps.mockReturnValue(FAKE_DEPS);
+  mockIsCodeExecutionEnabled.mockReturnValue(true);
+  mockCreateConversation.mockResolvedValue(undefined);
 });
 
 describe('GET /api/machines/agent-terminals', () => {
@@ -71,12 +84,13 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
+      terminals: [{ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.agentTerminals).toHaveLength(1);
+    expect(body.agentTerminals[0].id).toBe('agent-terminal-1');
     expect(mockCanViewMachine).toHaveBeenCalledWith('user-1', 't1');
     expect(mockListAgentTerminals).toHaveBeenCalledWith(
       expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main' }),
@@ -87,11 +101,16 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
+      terminals: [{ id: 'agent-terminal-legacy', name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     const body = await res.json();
-    expect(body.agentTerminals[0]).toEqual({ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-07-01T00:00:00.000Z' });
+    expect(body.agentTerminals[0]).toEqual({
+      id: 'agent-terminal-legacy',
+      name: 'legacy-cli',
+      agentType: 'pagespace-cli',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
   });
 
   it('given no view access, returns 403 without listing', async () => {
@@ -153,13 +172,13 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
 
-  it('given a fresh spawn of a claude terminal, returns 201', async () => {
+  it('given a fresh spawn of a claude terminal, returns 201 with the row id', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ name: 'cli', agentType: 'claude', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', resumed: false });
     expect(mockSpawnAgentTerminal).toHaveBeenCalledWith(
       expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' }),
     );
@@ -248,6 +267,66 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(res.status).toBe(400);
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
+
+  it('given a pagespace terminal with the code-execution flag off, returns 403 without spawning', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(false);
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(403);
+    expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
+  });
+
+  it('given a pagespace terminal with the code-execution flag on, spawns normally', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-5', agentType: 'pagespace', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    expect(mockSpawnAgentTerminal).toHaveBeenCalled();
+  });
+
+  it('given a non-pagespace terminal, spawns regardless of the code-execution flag', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockIsCodeExecutionEnabled.mockReturnValue(false);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-6', agentType: 'claude', resumed: false });
+    const res = await POST(req(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockSpawnAgentTerminal).toHaveBeenCalled();
+  });
+
+  it('given a fresh pagespace spawn, pre-creates the shared conversation keyed on the row id', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-7', agentType: 'pagespace', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    expect(mockCreateConversation).toHaveBeenCalledWith('agent-terminal-7', 'user-1', 't1', { isShared: true });
+  });
+
+  it('given a resumed pagespace spawn, does NOT pre-create the conversation', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-7', agentType: 'pagespace', resumed: true });
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(200);
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('given a fresh non-pagespace spawn, does NOT pre-create a conversation', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-8', agentType: 'claude', resumed: false });
+    const res = await POST(req(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+  });
+
+  it('given the pre-create conversation call fails, the spawn still succeeds (non-fatal)', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-9', agentType: 'pagespace', resumed: false });
+    mockCreateConversation.mockRejectedValue(new Error('db unavailable'));
+    const res = await POST(req({ ...VALID_BODY, agentType: 'pagespace' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-9', resumed: false });
+  });
 });
 
 describe('DELETE /api/machines/agent-terminals', () => {
@@ -300,5 +379,12 @@ describe('DELETE /api/machines/agent-terminals', () => {
     mockKillAgentTerminal.mockResolvedValue({ ok: false, reason: 'invalid_target' });
     const res = await DELETE(url('machineId=t1&branchName=main&name=cli'));
     expect(res.status).toBe(400);
+  });
+
+  it('given a chat-surface (not_a_pty_agent) row, returns a pinned status', async () => {
+    mockCanAccessMachine.mockResolvedValue(true);
+    mockKillAgentTerminal.mockResolvedValue({ ok: false, reason: 'not_a_pty_agent' });
+    const res = await DELETE(url('machineId=t1&projectName=repo&branchName=main&name=cli'));
+    expect(res.status).toBe(409);
   });
 });

--- a/apps/web/src/app/api/machines/agent-terminals/route.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/route.ts
@@ -26,7 +26,9 @@ import {
   buildListAgentTerminalsDeps,
   canAccessMachine,
   canViewMachine,
+  isCodeExecutionEnabled,
 } from '@/lib/machines/agent-terminals-runtime';
+import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -67,6 +69,7 @@ const SPAWN_DENIAL_STATUS: Record<string, number> = {
 const KILL_DENIAL_STATUS: Record<string, number> = {
   ...SCOPE_DENIAL_STATUS,
   not_found: 404,
+  not_a_pty_agent: 409,
   error: 500,
 };
 
@@ -96,7 +99,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: result.reason }, { status: SCOPE_DENIAL_STATUS[result.reason] ?? 500 });
   }
   return NextResponse.json({
-    agentTerminals: result.terminals.map((t) => ({ name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
+    agentTerminals: result.terminals.map((t) => ({ id: t.id, name: t.name, agentType: t.agentType, createdAt: t.createdAt })),
   });
 }
 
@@ -124,6 +127,12 @@ export async function POST(request: Request) {
   const command = optionalString(body.command, 'command');
   if (!command.ok) return command.error;
 
+  // `pagespace` renders the PageSpace AI chat UI rather than a real PTY — refuse it
+  // up front, before any DB access check, when the code-execution kill switch is off.
+  if (agentType.value === 'pagespace' && !isCodeExecutionEnabled()) {
+    return NextResponse.json({ error: 'code_execution_disabled', reason: 'code_execution_disabled' }, { status: 403 });
+  }
+
   if (!(await canAccessMachine(auth.userId, machineId.value))) {
     return NextResponse.json({ error: 'You do not have access to this machine' }, { status: 403 });
   }
@@ -141,8 +150,21 @@ export async function POST(request: Request) {
   if (!result.ok) {
     return NextResponse.json({ error: result.reason, reason: result.reason }, { status: SPAWN_DENIAL_STATUS[result.reason] ?? 500 });
   }
+
+  // A fresh `pagespace` row needs its shared conversation to exist before the client's
+  // first message so co-editors get multi-viewer parity from the start. A resumed
+  // spawn reattaches to whatever the original fresh spawn already created. Non-fatal:
+  // a failed pre-create just means the row gets created lazily on first message instead.
+  if (agentType.value === 'pagespace' && !result.resumed) {
+    try {
+      await conversationRepository.createConversation(result.id, auth.userId, machineId.value, { isShared: true });
+    } catch {
+      // Non-fatal — see comment above.
+    }
+  }
+
   return NextResponse.json(
-    { agentTerminal: { name: name.value, agentType: result.agentType, resumed: result.resumed } },
+    { agentTerminal: { id: result.id, name: name.value, agentType: result.agentType, resumed: result.resumed } },
     { status: result.resumed ? 200 : 201 },
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+/**
+ * MachinePaneChat — the "PageSpace Agent" pane's UI (Phase 11, #2166).
+ *
+ * The third selector surface: the header's agent picker chooses between the
+ * machine-anchored assistant (null selection — the terminal row's own
+ * conversation, machine-pane binding active) and any page agent. All chat
+ * state lives in useMachinePaneChat; this component is tabs + presentation.
+ *
+ * Presentation is a compact, chrome-free, terminal-leaning skin: Conversation
+ * + CompactMessageRenderer (via the shared SidebarMessagesContent) + ChatInput
+ * (variant="sidebar"). No floating card, no share buttons — History mirrors
+ * PageAgentHistoryTab minus its share controls (omitting onToggleShare hides
+ * them). Rendered inside a split grid, so everything stays min-w-0/min-h-0
+ * and the messages area contains its own layout.
+ */
+import React, { useCallback, useState } from 'react';
+import { MessageSquare, History, Settings, Plus, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+import { ChatInput } from '@/components/ai/chat/input';
+import { ProviderModelSelector } from '@/components/ai/chat/input/ProviderModelSelector';
+import { AISelector } from '@/components/ai/shared';
+import { UndoAiChangesDialog } from '@/components/ai/shared/chat';
+import { ChatErrorBanner } from '@/components/ai/shared/chat/ChatErrorBanner';
+import {
+  Conversation,
+  ConversationScrollButton,
+} from '@/components/ai/ui/conversation';
+import PageAgentHistoryTab from '@/components/ai/page-agents/PageAgentHistoryTab';
+import { SidebarMessagesContent } from '@/components/layout/right-sidebar/ai-assistant/SidebarChatTab';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
+import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { useMachinePaneChat } from './useMachinePaneChat';
+
+export interface MachinePaneChatProps {
+  /** The machine page this pane belongs to. */
+  machineId: string;
+  /** The terminal row id — the machine-anchored conversation (Phase 4). */
+  terminalId: string;
+  /** The picker's starting prompt, auto-sent once into a fresh conversation. */
+  pendingPrompt?: string;
+  /** Consumed-notification for pendingPrompt. */
+  onPromptSent?: () => void;
+}
+
+type PaneTab = 'chat' | 'history' | 'settings';
+
+export default function MachinePaneChat({
+  machineId,
+  terminalId,
+  pendingPrompt,
+  onPromptSent,
+}: MachinePaneChatProps) {
+  const [activeTab, setActiveTab] = useState<PaneTab>('chat');
+  const [input, setInput] = useState('');
+  const [showError, setShowError] = useState(true);
+  const [undoMessageId, setUndoMessageId] = useState<string | null>(null);
+
+  const pane = useMachinePaneChat({
+    machineId,
+    terminalId,
+    pendingPrompt,
+    onPromptSent,
+    historyEnabled: activeTab === 'history' || activeTab === 'chat',
+  });
+
+  const assistantName = pane.selectedAgent ? pane.selectedAgent.title : 'PageSpace Agent';
+
+  const handleSendClick = useCallback(async () => {
+    const text = input;
+    if (!text.trim()) return;
+    // Clear immediately (typing during the handoff wait must not merge into
+    // the old draft); restore only if the composer is still empty on refusal.
+    setInput('');
+    const dispatched = await pane.handleSend(text);
+    if (!dispatched) {
+      setInput((current) => (current === '' ? text : current));
+    }
+  }, [input, pane]);
+
+  const handleSelectHistoryConversation = useCallback(
+    (conversationId: string) => {
+      void pane.openConversation(conversationId);
+      setActiveTab('chat');
+    },
+    [pane],
+  );
+
+  const handleCreateConversation = useCallback(() => {
+    void pane.createNewConversation().then((created) => {
+      if (created) setActiveTab('chat');
+    });
+  }, [pane]);
+
+  const handleUndoFromHere = useCallback((messageId: string) => {
+    setUndoMessageId(messageId);
+  }, []);
+
+  const handleUndoSuccess = useCallback(async () => {
+    setUndoMessageId(null);
+    await pane.reloadConversation();
+  }, [pane]);
+
+  const remoteStreamingUser = !pane.displayIsStreaming
+    ? pane.remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
+    : null;
+
+  return (
+    <div data-testid="machine-pane-chat" className="flex h-full min-w-0 flex-col bg-background">
+      <Tabs
+        value={activeTab}
+        onValueChange={(value) => setActiveTab(value as PaneTab)}
+        className="flex h-full min-h-0 flex-col"
+      >
+        {/* Header: picker + tabs + new conversation — one compact row. */}
+        <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
+          <AISelector
+            selectedAgent={pane.selectedAgent}
+            onSelectAgent={pane.selectAgent}
+            disabled={pane.displayIsStreaming}
+            className="min-w-0 flex-1 text-xs font-medium"
+          />
+          <TabsList className="h-7 shrink-0 p-0.5">
+            <TabsTrigger value="chat" aria-label="Chat" className="h-6 px-1.5">
+              <MessageSquare className="size-3.5" />
+            </TabsTrigger>
+            <TabsTrigger value="history" aria-label="History" className="h-6 px-1.5">
+              <History className="size-3.5" />
+            </TabsTrigger>
+            <TabsTrigger value="settings" aria-label="Settings" className="h-6 px-1.5">
+              <Settings className="size-3.5" />
+            </TabsTrigger>
+          </TabsList>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleCreateConversation}
+            title="New conversation"
+            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <Plus className="size-3.5" />
+          </Button>
+        </div>
+
+        <TabsContent value="chat" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
+          {pane.hasLoadError && (
+            <div className="flex items-center justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+              <span className="truncate">Failed to load messages</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 shrink-0 px-2 text-xs text-destructive hover:bg-destructive/10 hover:text-destructive"
+                onClick={() => void pane.reloadConversation()}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden" style={{ contain: 'layout' }}>
+            {pane.isMessagesLoading && pane.messages.length === 0 && pane.remoteStreams.length === 0 ? (
+              <div data-testid="machine-pane-chat-loading" className="flex h-full items-center justify-center">
+                <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              </div>
+            ) : (
+              <Conversation className="h-full">
+                <SidebarMessagesContent
+                  messages={pane.messages}
+                  assistantName={assistantName}
+                  contextLabel={null}
+                  handleEdit={pane.handleEdit}
+                  handleDelete={pane.handleDelete}
+                  handleRetry={pane.handleRetry}
+                  handleUndoFromHere={handleUndoFromHere}
+                  lastAssistantMessageId={pane.lastAssistantMessageId}
+                  lastUserMessageId={pane.lastUserMessageId}
+                  displayIsStreaming={pane.displayIsStreaming}
+                  remoteStreams={pane.remoteStreams}
+                  onScrollNearTop={pane.handleScrollNearTop}
+                  isLoadingOlder={pane.isLoadingOlder}
+                  hasMoreOlder={pane.hasMoreOlder}
+                />
+                <ConversationScrollButton className="bottom-6 z-10" />
+              </Conversation>
+            )}
+          </div>
+
+          <div className="shrink-0 space-y-1.5 border-t border-border p-2">
+            <ChatErrorBanner
+              cause={pane.errorCause}
+              show={showError}
+              onClearError={() => {
+                setShowError(false);
+                pane.dismissError();
+              }}
+            />
+            <ChatInput
+              value={input}
+              onChange={setInput}
+              onSend={() => void handleSendClick()}
+              onStop={() => void pane.handleStop()}
+              isStreaming={pane.displayIsStreaming}
+              placeholder={
+                pane.selectedAgent
+                  ? `Message ${pane.selectedAgent.title}...`
+                  : 'Message the machine agent...'
+              }
+              hideModelSelector
+              variant="sidebar"
+              hasVision={hasVisionCapability(pane.selectedAgent?.aiModel || '')}
+              remoteStreamingUser={remoteStreamingUser}
+            />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="history" className="mt-0 min-h-0 flex-1 overflow-hidden">
+          {/* No onToggleShare — that is what removes the share controls. */}
+          <PageAgentHistoryTab
+            conversations={pane.conversations}
+            currentConversationId={pane.currentConversationId}
+            onSelectConversation={handleSelectHistoryConversation}
+            onCreateNew={handleCreateConversation}
+            onDeleteConversation={(conversationId) => void pane.deleteConversation(conversationId)}
+            isLoading={pane.isLoadingConversations}
+          />
+        </TabsContent>
+
+        <TabsContent value="settings" className="mt-0 min-h-0 flex-1 overflow-auto">
+          <PaneSettings agent={pane.selectedAgent} />
+        </TabsContent>
+      </Tabs>
+
+      <UndoAiChangesDialog
+        open={!!undoMessageId}
+        onOpenChange={(open) => !open && setUndoMessageId(null)}
+        messageId={undoMessageId}
+        onSuccess={handleUndoSuccess}
+      />
+    </div>
+  );
+}
+
+/**
+ * Slim settings, per mode (kept thin by design — the phase page's "Keep tabs
+ * thin"): default mode edits the shared assistant settings store; agent mode
+ * shows the agent's own configuration read-only — editing an agent belongs on
+ * its page, not in a terminal pane.
+ */
+function PaneSettings({
+  agent,
+}: {
+  agent: {
+    title: string;
+    driveName: string;
+    aiProvider?: string;
+    aiModel?: string;
+    systemPrompt?: string;
+  } | null;
+}) {
+  const currentProvider = useAssistantSettingsStore((state) => state.currentProvider);
+  const currentModel = useAssistantSettingsStore((state) => state.currentModel);
+  const setProviderSettings = useAssistantSettingsStore((state) => state.setProviderSettings);
+  const webSearchEnabled = useAssistantSettingsStore((state) => state.webSearchEnabled);
+  const toggleWebSearch = useAssistantSettingsStore((state) => state.toggleWebSearch);
+  const writeMode = useAssistantSettingsStore((state) => state.writeMode);
+  const toggleWriteMode = useAssistantSettingsStore((state) => state.toggleWriteMode);
+
+  if (agent) {
+    return (
+      <div data-testid="machine-pane-agent-settings" className="space-y-3 p-3 text-xs">
+        <div>
+          <p className="font-medium">{agent.title}</p>
+          <p className="text-muted-foreground">{agent.driveName}</p>
+        </div>
+        <dl className="space-y-1.5">
+          <SettingsRow label="Provider" value={agent.aiProvider ?? 'Default'} />
+          <SettingsRow label="Model" value={agent.aiModel ?? 'Default'} />
+          <SettingsRow label="System prompt" value={agent.systemPrompt ? 'Custom' : 'None'} />
+        </dl>
+        <p className="text-muted-foreground">
+          Configure {agent.title} on its own page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="machine-pane-assistant-settings" className="space-y-3 p-3">
+      <div className="space-y-1.5">
+        <p className="text-xs font-medium">Model</p>
+        <ProviderModelSelector
+          provider={currentProvider}
+          model={currentModel}
+          onChange={setProviderSettings}
+        />
+      </div>
+      <SettingsToggle label="Web search" checked={webSearchEnabled} onToggle={toggleWebSearch} />
+      <SettingsToggle label="Write mode" checked={writeMode} onToggle={toggleWriteMode} />
+    </div>
+  );
+}
+
+function SettingsRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <dt className="shrink-0 text-muted-foreground">{label}</dt>
+      <dd className="truncate">{value}</dd>
+    </div>
+  );
+}
+
+function SettingsToggle({
+  label,
+  checked,
+  onToggle,
+}: {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      role="switch"
+      aria-checked={checked}
+      onClick={onToggle}
+      className={cn('h-7 w-full justify-between px-2 text-xs', checked && 'border-primary')}
+    >
+      <span>{label}</span>
+      <span className="text-muted-foreground">{checked ? 'On' : 'Off'}</span>
+    </Button>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -205,7 +205,35 @@ describe('NodeActionPalette', () => {
     });
   });
 
-  test('"New terminal" offers shell, claude, and codex — not pagespace-cli — with shell first/default', async () => {
+  test('a "PageSpace Agent" palette spawn binds a chat-kind scope', async () => {
+    vi.mocked(post).mockResolvedValueOnce({
+      agentTerminal: { name: 'pagespace-mocked', agentType: 'pagespace', resumed: false },
+    });
+    const onWorkspaceCreated = vi.fn();
+    renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
+
+    const user = await openPalette();
+    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
+    await user.click(await screen.findByLabelText('Agent type'));
+    await user.click(await screen.findByRole('option', { name: 'PageSpace Agent' }));
+    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    await waitFor(() => {
+      const workspaceId = onWorkspaceCreated.mock.calls[0]?.[0];
+      const machine = selectMachine('m1')(store());
+      const workspace = workspaceId ? machine?.workspaces[workspaceId] : undefined;
+      const pane = workspace?.columns[0]?.panes[0];
+      assert({
+        given: 'the palette\'s "PageSpace Agent" choice, spawned on a branch node',
+        should:
+          'record kind "chat" on the bound pane scope — the pane grid renders MachinePaneChat from this tag, so a palette spawn that omitted it would open as a PTY',
+        actual: { name: pane?.scope?.name, kind: pane?.scope?.kind },
+        expected: { name: 'pagespace-mocked', kind: 'chat' },
+      });
+    });
+  });
+
+  test('"New terminal" offers shell, claude, codex, and the PageSpace Agent — not pagespace-cli — with shell first/default', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
 
     const user = await openPalette();
@@ -218,9 +246,10 @@ describe('NodeActionPalette', () => {
 
     assert({
       given: 'the "New terminal" agent-type picker, opened',
-      should: 'offer exactly shell, claude, and codex (never pagespace-cli), defaulting to shell',
+      should:
+        'offer the shared PICKABLE_AGENT_TYPES — shell first/default, then claude, codex, and the chat agent labeled "PageSpace Agent" (never pagespace-cli); a palette-local hardcoded list is exactly what silently dropped pagespace from this surface',
       actual: { optionTexts, defaultSelected },
-      expected: { optionTexts: ['shell', 'claude', 'codex'], defaultSelected: 'shell' },
+      expected: { optionTexts: ['shell', 'claude', 'codex', 'PageSpace Agent'], defaultSelected: 'shell' },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -57,21 +57,17 @@ import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
 import { ConnectIntegrationDialog } from '@/components/integrations/ConnectIntegrationDialog';
 import { normalizeProjectName } from '@pagespace/lib/services/machines/project-name';
 import { normalizeBranchName } from '@pagespace/lib/services/machines/branch-name';
-import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  PICKABLE_AGENT_TYPES,
+  agentSurfaceOf,
+  isAgentRuntimeType,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
 import { useMachineWorkspaceStore, autoSessionName } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { AddButton } from './RemoveButton';
 import { nodeScopeOf } from './WorkspaceLeaves';
+import { agentTypeLabelOf } from './pane-surface';
 import type { MachineTreeNode } from './MachineTree';
-
-/**
- * The "New terminal" agent choices — a fixed, local list rather than
- * `Object.keys(AGENT_LAUNCH_SPECS)`, for two reasons: `pagespace-cli` is
- * being removed as an agent type by a sibling change, and `shell` must be
- * offered and listed FIRST (a plain shell is a first-class choice here,
- * arguably the default — not an afterthought). Defined locally so this
- * palette can't silently inherit some other list that (buggily) excludes it.
- */
-const PICKABLE_AGENT_TYPES: AgentRuntimeType[] = ['shell', 'claude', 'codex'];
 
 /** Short project name from a GitHub `full_name` (e.g. "org/my-repo" -> "my-repo"), and the ready-to-clone URL. */
 export function deriveProjectFieldsFromRepo(repo: { full_name: string; clone_url: string }): { name: string; repoUrl: string } {
@@ -283,7 +279,19 @@ function TerminalSpawnForm({
         ? bindPaneTerminal(
             workspaceId,
             workspace.activePaneId,
-            { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
+            {
+              projectName: scope.projectName,
+              branchName: scope.branchName,
+              name: created.name,
+              // Same rule as TerminalPanes' spawnIntoPane: record the surface
+              // at bind time, judged by the API's answer (`created.agentType`
+              // — a resumed session's type can differ from the picked one);
+              // only `chat` is written, since an omitted kind already means
+              // `terminal` (see OpenTerminalScope).
+              ...(isAgentRuntimeType(created.agentType) && agentSurfaceOf(created.agentType) === 'chat'
+                ? { kind: 'chat' as const }
+                : {}),
+            },
             created.resumed ? undefined : prompt.trim() || undefined,
           )
         : false;
@@ -324,7 +332,7 @@ function TerminalSpawnForm({
           <SelectContent>
             {PICKABLE_AGENT_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
-                {type}
+                {agentTypeLabelOf(type)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -36,6 +36,28 @@ vi.mock('../XtermTerminal', () => ({
   ),
 }));
 
+// The chat pane is a whole AI-chat subtree (Phase 11) — stubbed for the same
+// reason as XtermTerminal: under test is WHICH surface the pane renders and
+// what it is handed, not the chat UI inside it.
+vi.mock('./MachinePaneChat', () => ({
+  default: ({
+    machineId,
+    terminalId,
+    pendingPrompt,
+  }: {
+    machineId: string;
+    terminalId: string;
+    pendingPrompt?: string;
+  }) => (
+    <div
+      data-testid="machine-pane-chat"
+      data-machine-id={machineId}
+      data-terminal-id={terminalId}
+      data-initial-input={pendingPrompt}
+    />
+  ),
+}));
+
 const selectPane = vi.fn();
 const splitRight = vi.fn();
 const splitDown = vi.fn();
@@ -57,14 +79,18 @@ const killAgentTerminal = vi.fn<
 >(async () => {});
 /** Records the scope the hook was asked for, so a spawn at the wrong checkout can't pass. */
 const useAgentTerminalsArgs = vi.fn<(machineId: string, projectName: string | null, branchName: string | null) => void>();
+/** The workspace-scoped SWR session list — what a kind-less pane's surface is
+ * resolved against, and where a chat pane finds its conversation row id. */
+let agentTerminalRows: { id: string; name: string; agentType: string; createdAt: string }[] = [];
+let agentTerminalsLoading = false;
 vi.mock('@/hooks/useAgentTerminals', () => ({
   killAgentTerminal: (machineId: string, scope: { projectName?: string; branchName?: string; name: string }) =>
     killAgentTerminal(machineId, scope),
   useAgentTerminals: (machineId: string, projectName: string | null, branchName: string | null) => {
     useAgentTerminalsArgs(machineId, projectName, branchName);
     return {
-      agentTerminals: [],
-      isLoading: false,
+      agentTerminals: agentTerminalRows,
+      isLoading: agentTerminalsLoading,
       error: undefined,
       mutate: vi.fn(),
       addAgentTerminal,
@@ -136,6 +162,8 @@ let machineEnsured = true;
 let extraWorkspaces: WorkspaceState[] = [];
 beforeEach(() => {
   extraWorkspaces = [];
+  agentTerminalRows = [];
+  agentTerminalsLoading = false;
 });
 
 // Only the store HOOK is faked; selectActiveWorkspace / panesOf / autoSessionName
@@ -552,7 +580,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and the PageSpace Agent — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +588,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and the chat agent labeled "PageSpace Agent" (agents and chats are one thing, so it presents as an agent, never as "chat") — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex', 'pagespace'],
+      expected: ['shell', 'claude', 'codex', 'PageSpace Agent'],
     });
   });
 
@@ -722,6 +750,219 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
       should: 'leave that session alone — the cleanup path kills terminals, and this spawn did not create this one',
       actual: removeAgentTerminal.mock.calls.length,
       expected: 0,
+    });
+  });
+});
+
+describe('TerminalPanes (PageSpace Agent panes)', () => {
+  /** A pane bound to the chat agent — kind on the SCOPE (Phase 9), so the
+   * surface decision survives every place a scope flows opaquely. */
+  const CHAT_SCOPE = { ...WORKSPACE_SCOPE, name: 'pagespace-a1', kind: 'chat' as const };
+  /** The chat session's own row — its id IS the conversation id (Phase 4). */
+  const CHAT_ROW = { id: 'row-ps1', name: 'pagespace-a1', agentType: 'pagespace', createdAt: '' };
+
+  const soloPane = (pane: { scope: OpenTerminalScope | null; pendingPrompt?: string }) =>
+    aWorkspace({
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', ...pane }] }],
+      activePaneId: 'pane-1',
+      pendingPickerPaneId: null,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onDesktop();
+    machineEnsured = true;
+    workspace = EMPTY_WORKSPACE;
+  });
+
+  test('picking the PageSpace Agent spawns a pagespace session bound with a chat-kind scope', async () => {
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByLabelText('Agent type'));
+    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    const [spawnedName, spawnedType] = addAgentTerminal.mock.calls[0] ?? [];
+    assert({
+      given: 'the picker\'s "PageSpace Agent" choice, spawned',
+      should:
+        'create a pagespace session and bind it with kind "chat" on the scope — without the kind, the pane would have to guess its surface from the SWR list on every future mount',
+      actual: {
+        agentType: spawnedType,
+        boundScope: bindPaneTerminal.mock.calls[0]?.[3],
+      },
+      expected: {
+        agentType: 'pagespace',
+        boundScope: { projectName: 'app', branchName: 'main', name: spawnedName, kind: 'chat' },
+      },
+    });
+  });
+
+  test('a RESUMED spawn takes its kind from the API\'s agentType, not the picked one', async () => {
+    // The upsert handed back an EXISTING session that happens to wear a
+    // pagespace-shaped name but is actually a PTY agent. Labeling it chat
+    // from the PICKED type would mislabel it forever — an explicit kind
+    // beats the SWR fallback on every future mount.
+    addAgentTerminal.mockResolvedValueOnce({ name: 'pagespace-x', agentType: 'claude', resumed: true });
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    await userEvent.click(screen.getByLabelText('Agent type'));
+    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+
+    assert({
+      given: 'a pagespace pick the API served by resuming an existing claude session',
+      should:
+        'bind WITHOUT a chat kind — the surface is judged by the API\'s answer, the same standard the resumed-prompt guard applies',
+      actual: bindPaneTerminal.mock.calls[0]?.[3],
+      expected: { projectName: 'app', branchName: 'main', name: 'pagespace-x' },
+    });
+  });
+
+  test('a chat pane whose row is GONE from the loaded list says so — not an eternal spinner', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE });
+    // The list has answered and the session isn't in it: killed elsewhere.
+    agentTerminalRows = [];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a chat-kind pane whose session the loaded list no longer contains',
+      should:
+        'render a notice with close still reachable — an indefinite "Loading session…" over a dead session would read as a hang',
+      actual: {
+        notice: screen.queryByText('This session no longer exists') !== null,
+        loading: screen.queryByText('Loading session…') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+        canClose: screen.queryByTitle('Close pane') !== null,
+      },
+      expected: { notice: true, loading: false, chat: false, xterm: false, canClose: true },
+    });
+  });
+
+  test('a chat-kind pane renders MachinePaneChat — addressed by row id, with the picker prompt — not xterm', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE, pendingPrompt: 'audit the docs' });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    const chat = await screen.findByTestId('machine-pane-chat');
+
+    assert({
+      given: 'a pane whose scope carries kind "chat", its session row in the list',
+      should:
+        'render the chat surface addressed by the ROW id (the machine-anchored conversation) carrying the starting prompt — and never mount an xterm for it',
+      actual: {
+        terminalId: chat.getAttribute('data-terminal-id'),
+        machineId: chat.getAttribute('data-machine-id'),
+        pendingPrompt: chat.getAttribute('data-initial-input'),
+        xterm: screen.queryByTestId('xterm') !== null,
+      },
+      expected: {
+        terminalId: 'row-ps1',
+        machineId: 'm1',
+        pendingPrompt: 'audit the docs',
+        xterm: false,
+      },
+    });
+  });
+
+  test('no kind hint + SWR resolving the name to pagespace renders chat', async () => {
+    // A kind-less binding: made before the kind tag existed, or by a path that
+    // didn't set it. The session list is the only witness to what it is.
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'pagespace-a1' } });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane whose name the loaded list maps to agentType "pagespace"',
+      should: 'resolve to the chat surface',
+      actual: {
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+      },
+      expected: { chat: true, xterm: false },
+    });
+  });
+
+  test('no kind hint + SWR resolving the name to claude renders xterm', async () => {
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'claude-b2' } });
+    agentTerminalRows = [{ id: 'row-c1', name: 'claude-b2', agentType: 'claude', createdAt: '' }];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane whose name the loaded list maps to agentType "claude"',
+      should: 'resolve to the PTY surface',
+      actual: {
+        xterm: screen.queryByTestId('xterm') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+      },
+      expected: { xterm: true, chat: false },
+    });
+  });
+
+  test('no kind hint while the list is loading renders PaneLoading — NEVER xterm for a maybe-chat session', async () => {
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'pagespace-a1' } });
+    agentTerminalsLoading = true;
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    assert({
+      given: 'a kind-less pane before the session list has answered',
+      should:
+        'hold at a loading state — mounting Xterm now would cold-start a PTY (and register a viewer) for a session that may turn out to be a chat',
+      actual: {
+        loading: screen.queryByText('Loading session…') !== null,
+        xterm: screen.queryByTestId('xterm') !== null,
+        chat: screen.queryByTestId('machine-pane-chat') !== null,
+      },
+      expected: { loading: true, xterm: false, chat: false },
+    });
+  });
+
+  test('on mobile, a hidden chat pane stays MOUNTED — invisible, never unmounted', async () => {
+    onMobile();
+    workspace = aWorkspace({
+      columns: [
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: CHAT_SCOPE }] },
+        { id: 'col-2', panes: [{ id: 'pane-2', scope: { ...WORKSPACE_SCOPE, name: 'claude-b2', kind: 'terminal' } }] },
+      ],
+      activePaneId: 'pane-2',
+      pendingPickerPaneId: null,
+    });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+
+    const chat = await screen.findByTestId('machine-pane-chat');
+    const wrapper = screen
+      .getAllByTestId('mobile-pane')
+      .find((pane) => pane.contains(chat));
+
+    assert({
+      given: 'a chat pane hidden by the narrow-viewport collapse',
+      should:
+        'keep it mounted but invisible, exactly like a hidden PTY pane — unmounting would drop the chat\'s in-flight state, and its streaming reply with it',
+      actual: {
+        mounted: chat !== null,
+        hidden: wrapper?.dataset.hidden,
+        invisible: wrapper?.classList.contains('invisible'),
+      },
+      expected: { mounted: true, hidden: 'true', invisible: true },
+    });
+  });
+
+  test('closing a chat pane kills its session row, exactly as a PTY close does', async () => {
+    workspace = soloPane({ scope: CHAT_SCOPE });
+    agentTerminalRows = [CHAT_ROW];
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findByTestId('machine-pane-chat');
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'the close control on a pane rendering the chat surface',
+      should:
+        'kill the session at the pane\'s own scope, same as any terminal — the row delete is cheap (Phase 2) and the conversation survives it',
+      actual: killAgentTerminal.mock.calls,
+      expected: [['m1', CHAT_SCOPE]],
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -552,7 +552,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('the agent picker offers shell (primary), claude, and codex — no retired pagespace-cli', async () => {
+  test('the agent picker offers shell (primary), claude, codex, and pagespace — no retired pagespace-cli', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     await userEvent.click(screen.getByLabelText('Agent type'));
@@ -560,9 +560,9 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude and codex as secondary AI agents — excluding only the retired pagespace-cli',
+      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and pagespace as secondary agents — excluding only the retired pagespace-cli',
       actual: options,
-      expected: ['shell', 'claude', 'codex'],
+      expected: ['shell', 'claude', 'codex', 'pagespace'],
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -17,9 +17,14 @@ import {
 } from '@/components/ui/select';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
-import { useAgentTerminals, killAgentTerminal } from '@/hooks/useAgentTerminals';
+import { useAgentTerminals, killAgentTerminal, type AgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
-import { PICKABLE_AGENT_TYPES, type AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  PICKABLE_AGENT_TYPES,
+  agentSurfaceOf,
+  isAgentRuntimeType,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   useMachineWorkspaceStore,
   selectActiveWorkspace,
@@ -34,8 +39,13 @@ import {
   type TerminalPaneState,
 } from '@/stores/machine-workspace/useMachineWorkspaceStore';
 import { PaneLoading, PaneNotice } from '../tabs/tab-states';
+import { resolvePaneSurface, agentTypeLabelOf } from './pane-surface';
 
 const XtermTerminal = dynamic(() => import('../XtermTerminal'), { ssr: false });
+// Split out like XtermTerminal and for the same reason in reverse: the chat
+// pane is a whole AI-chat subtree, and a workspace holding only PTY panes
+// should not pay to load it.
+const MachinePaneChat = dynamic(() => import('./MachinePaneChat'), { ssr: false });
 
 const AGENT_TYPES = PICKABLE_AGENT_TYPES;
 
@@ -85,7 +95,10 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
   // Every agent spawned here runs in the workspace's node scope — a branch
   // workspace's panes all share that branch's checkout.
   const scope = workspace?.scope ?? MACHINE_NODE_SCOPE;
-  const { addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
+  // `agentTerminals`/`isLoading` feed the per-pane surface decision
+  // (`resolvePaneSurface`): a kind-less pane's surface is resolved from this
+  // list, and a chat pane finds its conversation ROW id in it.
+  const { agentTerminals, isLoading: agentTerminalsLoading, addAgentTerminal, removeAgentTerminal } = useAgentTerminals(
     machineId,
     scope.projectName ?? null,
     scope.branchName ?? null,
@@ -103,7 +116,23 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
       const bound = bindPaneTerminal(
         workspaceId,
         paneId,
-        { projectName: scope.projectName, branchName: scope.branchName, name: created.name },
+        {
+          projectName: scope.projectName,
+          branchName: scope.branchName,
+          name: created.name,
+          // The surface decision, recorded at the one moment it is KNOWN
+          // rather than re-derived from the SWR list on every future mount.
+          // Only `chat` is written — an omitted kind already means `terminal`
+          // (see OpenTerminalScope), so PTY bindings stay byte-identical to
+          // every binding that predates the tag. Judged by the API's OWN
+          // answer, not the picked type: a `resumed` upsert hands back an
+          // existing session whose agentType can differ (same reasoning as
+          // the resumed-prompt guard below), and a retired type the registry
+          // no longer knows falls through to the terminal default.
+          ...(isAgentRuntimeType(created.agentType) && agentSurfaceOf(created.agentType) === 'chat'
+            ? { kind: 'chat' as const }
+            : {}),
+        },
         // `spawnAgentTerminal` is an upsert: `resumed` means it handed back a session
         // that ALREADY EXISTED rather than creating one. An agent that was already
         // running must never be typed at, and the API says so right here — relying on
@@ -222,6 +251,11 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     socket,
     machineId,
     pane,
+    // What the pane's surface decision resolves against — the workspace's own
+    // session list (see resolvePaneSurface's doc for the foreign-scope rule).
+    workspaceScope: scope,
+    agentTerminals,
+    agentTerminalsLoading,
     isActive: pane.id === activeId,
     // Every pane closes, always. The old rule (`panes.length > 1 || scope !==
     // null`) existed to stop a lone empty pane being closed, because the
@@ -370,6 +404,9 @@ function TerminalPane({
   socket,
   machineId,
   pane,
+  workspaceScope,
+  agentTerminals,
+  agentTerminalsLoading,
   isActive,
   canClose,
   canSplit,
@@ -386,6 +423,10 @@ function TerminalPane({
   socket: Socket | null | undefined;
   machineId: string;
   pane: TerminalPaneState;
+  /** The checkout `agentTerminals` was fetched at — the workspace's scope. */
+  workspaceScope: MachineNodeScope;
+  agentTerminals: AgentTerminal[];
+  agentTerminalsLoading: boolean;
   isActive: boolean;
   canClose: boolean;
   /** False on narrow viewports, where a split would produce two unusable slivers. */
@@ -403,6 +444,12 @@ function TerminalPane({
   onPromptSent(): void;
 }) {
   const sessionId = pane.scope ? paneSessionId(machineId, pane.scope) : null;
+  // Which surface this pane renders — decided by the pure helper, never by
+  // defaulting: an Xterm mounted for what turns out to be a chat session
+  // would open (and register a viewer on) a PTY stream that shouldn't exist.
+  const resolved = pane.scope
+    ? resolvePaneSurface({ scope: pane.scope, workspaceScope, agentTerminals, isLoading: agentTerminalsLoading })
+    : null;
   // With neither a split nor a close to offer (a lone pane on a phone), the
   // control chip has nothing in it — and since it is opacity-100 on touch, an
   // empty bordered box would just sit in the corner forever.
@@ -462,13 +509,42 @@ function TerminalPane({
       </div>
       )}
       <div className="relative min-h-0 flex-1">
-        {!pane.scope || !sessionId ? (
+        {!pane.scope || !sessionId || !resolved ? (
           <PaneAgentPicker
             focused={pickerFocused}
             scopeLabel={scopeLabel}
             onSpawn={onSpawn}
             onFocused={onPickerFocused}
           />
+        ) : resolved.surface === 'chat' ? (
+          // `terminalId` still null means the list hasn't turned the row up:
+          // hold while it's still loading (the one thing a chat-bound pane
+          // must never do is mount an Xterm), but a LOADED list without the
+          // row means the session was killed — say so rather than spin
+          // forever; the close control above stays reachable either way.
+          resolved.terminalId === null ? (
+            agentTerminalsLoading ? (
+              <PaneLoading message="Loading session…" />
+            ) : (
+              <PaneNotice
+                title="This session no longer exists"
+                description="It may have been closed elsewhere. Close the pane to remove it."
+              />
+            )
+          ) : (
+            <MachinePaneChat
+              // Re-keyed per conversation row, same reason TerminalPaneStream
+              // keys by sessionId: switching sessions is a remount, not a
+              // state handoff.
+              key={resolved.terminalId}
+              machineId={machineId}
+              terminalId={resolved.terminalId}
+              pendingPrompt={pane.pendingPrompt}
+              onPromptSent={onPromptSent}
+            />
+          )
+        ) : resolved.surface === 'loading' ? (
+          <PaneLoading message="Loading session…" />
         ) : (
           <TerminalPaneStream
             key={sessionId}
@@ -546,7 +622,7 @@ function PaneAgentPicker({
           <SelectContent>
             {AGENT_TYPES.map((type) => (
               <SelectItem key={type} value={type}>
-                {type}
+                {agentTypeLabelOf(type)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * MachinePaneChat Component Tests — Phase 11 (#2166)
+ *
+ * The behavior contract lives in useMachinePaneChat.test.ts; this suite
+ * covers the component shell: in-pane tabs, the share-control-free History
+ * tab, per-mode Settings, and the composer wiring. The state hook is mocked.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AgentInfo } from '@/types/agent';
+
+const paneState = vi.hoisted(() => ({
+  current: {} as Record<string, unknown>,
+}));
+
+vi.mock('../useMachinePaneChat', () => ({
+  useMachinePaneChat: vi.fn(() => paneState.current),
+}));
+
+// Presentation-only children with heavy dependency trees are stubbed — this
+// suite is about MachinePaneChat's own shell, not theirs.
+vi.mock('@/components/layout/right-sidebar/ai-assistant/SidebarChatTab', () => ({
+  SidebarMessagesContent: () => <div data-testid="messages-content" />,
+}));
+
+vi.mock('@/components/ai/chat/input', () => ({
+  ChatInput: ({ value, onChange, onSend }: {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+  }) => (
+    <div>
+      <input
+        data-testid="chat-input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button data-testid="chat-send" onClick={onSend}>
+        Send
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ai/chat/input/ProviderModelSelector', () => ({
+  ProviderModelSelector: () => <div data-testid="provider-model-selector" />,
+}));
+
+vi.mock('@/components/ai/shared', () => ({
+  AISelector: ({ onSelectAgent }: { onSelectAgent: (agent: AgentInfo | null) => void }) => (
+    <button data-testid="agent-picker" onClick={() => onSelectAgent(null)}>
+      Picker
+    </button>
+  ),
+}));
+
+vi.mock('@/components/ai/shared/chat', () => ({
+  UndoAiChangesDialog: () => null,
+}));
+
+import MachinePaneChat from '../MachinePaneChat';
+
+function conversationRow(id: string, title: string) {
+  const now = new Date();
+  return {
+    id,
+    title,
+    preview: 'preview',
+    isShared: false,
+    isOwner: true,
+    createdAt: now,
+    updatedAt: now,
+    messageCount: 1,
+    lastMessage: { role: 'user', timestamp: now },
+  };
+}
+
+function basePaneState(overrides: Record<string, unknown> = {}) {
+  return {
+    selectedAgent: null,
+    selectAgent: vi.fn(),
+    currentConversationId: 'terminal-1',
+    channelId: 'machine-1',
+    messages: [],
+    remoteStreams: [],
+    displayIsStreaming: false,
+    isMessagesLoading: false,
+    hasLoadError: false,
+    reloadConversation: vi.fn(),
+    handleSend: vi.fn(async () => true),
+    handleStop: vi.fn(async () => {}),
+    handleEdit: vi.fn(),
+    handleDelete: vi.fn(),
+    handleRetry: vi.fn(),
+    lastAssistantMessageId: undefined,
+    lastUserMessageId: undefined,
+    handleScrollNearTop: vi.fn(),
+    isLoadingOlder: false,
+    hasMoreOlder: false,
+    conversations: [],
+    isLoadingConversations: false,
+    openConversation: vi.fn(async () => {}),
+    createNewConversation: vi.fn(async () => 'new-conv'),
+    deleteConversation: vi.fn(async () => {}),
+    errorCause: null,
+    dismissError: vi.fn(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  paneState.current = basePaneState();
+});
+
+describe('MachinePaneChat', () => {
+  it('renders the chat tab by default and dispatches sends through the hook', async () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    expect(screen.getByTestId('machine-pane-chat')).toBeInTheDocument();
+    expect(screen.getByTestId('messages-content')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId('chat-input'), { target: { value: 'hello' } });
+    fireEvent.click(screen.getByTestId('chat-send'));
+
+    await waitFor(() =>
+      expect(paneState.current.handleSend).toHaveBeenCalledWith('hello'),
+    );
+  });
+
+  it('History tab lists conversations WITHOUT share controls and opens into the chat tab', async () => {
+    paneState.current = basePaneState({
+      conversations: [conversationRow('conv-1', 'Machine chat')],
+    });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'History' }));
+
+    const row = await screen.findByTestId('history-conversation-item');
+    expect(row).toHaveTextContent('Machine chat');
+    // Minus share: PageAgentHistoryTab renders its share toggle only when
+    // onToggleShare is passed — this surface never passes it.
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/share/i)).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(paneState.current.openConversation).toHaveBeenCalledWith('conv-1');
+    await waitFor(() =>
+      expect(screen.getByTestId('messages-content')).toBeInTheDocument(),
+    );
+  });
+
+  it('Settings tab shows slim assistant settings in default mode', async () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    expect(screen.getByTestId('machine-pane-assistant-settings')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-model-selector')).toBeInTheDocument();
+  });
+
+  it('Settings tab shows the agent\'s read-only configuration in agent mode', async () => {
+    paneState.current = basePaneState({
+      selectedAgent: {
+        id: 'agent-1',
+        title: 'Docs Agent',
+        driveId: 'drive-1',
+        driveName: 'Docs Drive',
+        aiProvider: 'anthropic',
+        aiModel: 'claude-sonnet-5',
+      } satisfies AgentInfo,
+      currentConversationId: 'conv-agent',
+      channelId: 'agent-1',
+    });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    const settings = screen.getByTestId('machine-pane-agent-settings');
+    expect(settings).toHaveTextContent('Docs Agent');
+    expect(settings).toHaveTextContent('anthropic');
+    expect(settings).toHaveTextContent('claude-sonnet-5');
+  });
+
+  it('shows the load-error banner with a retry wired to reloadConversation', () => {
+    paneState.current = basePaneState({ hasLoadError: true });
+
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(paneState.current.reloadConversation).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/useMachinePaneChat.test.ts
@@ -1,0 +1,586 @@
+/**
+ * useMachinePaneChat Hook Tests — Phase 11 (#2166)
+ *
+ * The machine pane's dual-mode chat state: null selection = the assistant
+ * identity on the machine-anchored conversation (the terminal row's id,
+ * chatId = machineId); any page agent = that agent's own chat. Behavior under
+ * test (phase page h1jtxfqy280oavmbr1k5v1sz):
+ *
+ * - mode switch swaps surface id + conversation identity, no cross-mode bleed
+ * - return to null RESUMES the machine conversation (row id) — never mints a
+ *   new session row
+ * - default mode sends { chatId: machineId, conversationId: terminalId };
+ *   agent mode sends the agent's own ids
+ * - History lists/opens per-mode conversations
+ * - a fresh empty default-mode conversation auto-sends pendingPrompt exactly
+ *   once, then onPromptSent(); never for a resumed (non-empty) session
+ * - Stop is wired in both modes
+ *
+ * Template: useMachineWorkspaceSync.test.ts (renderHook, auth-fetch mocked,
+ * real swr, real conversation-messages store).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import type { AgentInfo } from '@/types/agent';
+
+// ============================================
+// Mocks
+// ============================================
+
+const { mockFetchWithAuth } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+}));
+
+// Two controllable useChat instances. useDualModeChat calls useChat twice per
+// render, default (global slot) first, agent second — same order every render.
+const chat = vi.hoisted(() => {
+  const instance = () => ({
+    sendMessage: vi.fn(),
+    regenerate: vi.fn(),
+    setMessages: vi.fn(),
+    stop: vi.fn(),
+    clearError: vi.fn(),
+    addToolResult: vi.fn(),
+  });
+  return {
+    capturedConfigs: [] as Array<Record<string, unknown>>,
+    defaultChat: instance(),
+    agentChat: instance(),
+    counter: { n: 0 },
+  };
+});
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: vi.fn((config: Record<string, unknown> | undefined) => {
+    chat.counter.n += 1;
+    if (config && typeof config.id === 'string') chat.capturedConfigs.push(config);
+    const instance = chat.counter.n % 2 === 1 ? chat.defaultChat : chat.agentChat;
+    return {
+      messages: [] as UIMessage[],
+      status: 'ready' as const,
+      error: undefined,
+      ...instance,
+    };
+  }),
+}));
+
+// Cache loaders are spied — the tests seed the real conversation-messages
+// store directly instead of round-tripping through fetches.
+const loaders = vi.hoisted(() => ({
+  loadAgentConversationMessages: vi.fn(async () => {}),
+  loadOlderAgentConversationMessages: vi.fn(async () => {}),
+  loadGlobalConversationMessages: vi.fn(async () => {}),
+  loadOlderGlobalConversationMessages: vi.fn(async () => {}),
+  refreshConversationSnapshot: vi.fn(async () => {}),
+}));
+vi.mock('@/hooks/conversationMessagesLoaders', () => loaders);
+
+// Multiplayer wiring is asserted by its inputs, not exercised.
+const multiplayer = vi.hoisted(() => ({
+  calls: [] as Array<{ selectedAgent: { id: string } | null; agentConversationId: string | null }>,
+  rejoin: vi.fn(),
+}));
+vi.mock('@/hooks/useAgentChannelMultiplayer', () => ({
+  useAgentChannelMultiplayer: vi.fn(
+    (opts: { selectedAgent: { id: string } | null; agentConversationId: string | null }) => {
+      multiplayer.calls.push({
+        selectedAgent: opts.selectedAgent,
+        agentConversationId: opts.agentConversationId,
+      });
+      return { rejoinActiveStreams: multiplayer.rejoin };
+    },
+  ),
+}));
+
+vi.mock('@/hooks/useActiveStream', () => ({
+  useActiveStream: () => ({ streams: [] }),
+  useConversationActiveStream: () => undefined,
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard/drive-1/machine-page',
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', name: 'Test User', email: 'test@example.com' } }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { useConversationMessagesStore } from '@/stores/useConversationMessagesStore';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import { useMachinePaneChat } from '../useMachinePaneChat';
+
+// ============================================
+// Fixtures
+// ============================================
+
+function jsonResponse(body: unknown) {
+  return { ok: true, json: async () => body };
+}
+
+function conversationRow(id: string, title: string) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title,
+    preview: '',
+    isShared: false,
+    isOwner: true,
+    createdAt: now,
+    updatedAt: now,
+    messageCount: 1,
+    lastMessage: { role: 'user', timestamp: now },
+  };
+}
+
+function agentFixture(id: string): AgentInfo {
+  return {
+    id,
+    title: `Agent ${id}`,
+    driveId: 'drive-1',
+    driveName: 'Drive One',
+    aiProvider: 'anthropic',
+    aiModel: 'claude-sonnet-5',
+    systemPrompt: 'You are a page agent.',
+    enabledTools: ['search'],
+  };
+}
+
+function assistantMessage(id: string, text: string): UIMessage {
+  return { id, role: 'assistant', parts: [{ type: 'text', text }] } as UIMessage;
+}
+
+/** Unique ids per test — SWR's cache is keyed by URL and survives renderHook
+ * calls within the file, so a reused machine id would serve a previous test's
+ * cached conversation list. */
+function ids(slug: string) {
+  return { machineId: `machine-${slug}`, terminalId: `terminal-${slug}` };
+}
+
+/** fetchWithAuth routing: most-recent lookups (?limit=1) per agent, full
+ * conversation lists per page id. Anything unrouted resolves empty. */
+function routeFetches(routes: {
+  mostRecent?: Record<string, Array<{ id: string }>>;
+  lists?: Record<string, Array<ReturnType<typeof conversationRow>>>;
+}) {
+  mockFetchWithAuth.mockImplementation(async (url: string) => {
+    const match = /\/api\/ai\/page-agents\/([^/]+)\/conversations(\?limit=1)?$/.exec(url);
+    if (match) {
+      const [, pageId, isMostRecent] = match;
+      if (isMostRecent) {
+        return jsonResponse({ conversations: routes.mostRecent?.[pageId] ?? [] });
+      }
+      return jsonResponse({ conversations: routes.lists?.[pageId] ?? [] });
+    }
+    return jsonResponse({});
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chat.capturedConfigs.length = 0;
+  chat.counter.n = 0;
+  multiplayer.calls.length = 0;
+  useConversationMessagesStore.setState({ byConversationId: {} });
+  routeFetches({});
+});
+
+// ============================================
+// Default (machine) mode identity
+// ============================================
+
+describe('useMachinePaneChat', () => {
+  describe('default mode identity', () => {
+    it('mounts on the machine-anchored conversation: surface id machine-pane:<terminalId>, conversation = the terminal row id', async () => {
+      const { machineId, terminalId } = ids('default-identity');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      expect(result.current.selectedAgent).toBeNull();
+      expect(result.current.currentConversationId).toBe(terminalId);
+      expect(
+        chat.capturedConfigs.some((c) => c.id === `machine-pane:${terminalId}`),
+      ).toBe(true);
+
+      // The machine conversation loads through the AGENT loader keyed by the
+      // machine page id — the machine page hosts the conversation row.
+      await waitFor(() =>
+        expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(machineId, terminalId),
+      );
+
+      // Multiplayer is wired to the machine's page channel in default mode.
+      expect(
+        multiplayer.calls.some(
+          (c) => c.selectedAgent?.id === machineId && c.agentConversationId === terminalId,
+        ),
+      ).toBe(true);
+    });
+
+    it('sends { chatId: machineId, conversationId: terminalId } through the DEFAULT chat instance', async () => {
+      const { machineId, terminalId } = ids('default-send');
+      conversationMessagesActions.seedConversation(terminalId);
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.handleSend('hello machine');
+      });
+
+      await waitFor(() => expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1));
+      expect(chat.agentChat.sendMessage).not.toHaveBeenCalled();
+
+      const [message, options] = chat.defaultChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(message.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'hello machine' })]),
+      );
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: machineId, conversationId: terminalId }),
+      );
+    });
+  });
+
+  // ============================================
+  // Agent mode + mode switching
+  // ============================================
+
+  describe('agent mode and mode switching', () => {
+    it('selecting an agent swaps to the agent surface id and the agent\'s own conversation identity', async () => {
+      const { machineId, terminalId } = ids('agent-switch');
+      const agent = agentFixture('agent-switch-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-recent' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-recent'));
+      expect(result.current.selectedAgent?.id).toBe(agent.id);
+      expect(
+        chat.capturedConfigs.some((c) => c.id === `machine-pane-agent:${terminalId}`),
+      ).toBe(true);
+      await waitFor(() =>
+        expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(
+          agent.id,
+          'conv-agent-recent',
+        ),
+      );
+      // Agent-channel multiplayer follows the selection.
+      expect(
+        multiplayer.calls.some(
+          (c) => c.selectedAgent?.id === agent.id && c.agentConversationId === 'conv-agent-recent',
+        ),
+      ).toBe(true);
+    });
+
+    it('agent mode sends the AGENT\'s own ids through the AGENT chat instance — machine ids never bleed in', async () => {
+      const { machineId, terminalId } = ids('agent-send');
+      const agent = agentFixture('agent-send-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-send' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-send'));
+
+      await act(async () => {
+        await result.current.handleSend('hello agent');
+      });
+
+      await waitFor(() => expect(chat.agentChat.sendMessage).toHaveBeenCalledTimes(1));
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+
+      const [, options] = chat.agentChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: agent.id, conversationId: 'conv-agent-send' }),
+      );
+      expect(options.body).not.toEqual(
+        expect.objectContaining({ chatId: machineId }),
+      );
+    });
+
+    it('an agent with no conversations gets a client-minted one, persisted to the AGENT\'s page', async () => {
+      const { machineId, terminalId } = ids('agent-create');
+      const agent = agentFixture('agent-create-1');
+      routeFetches({ mostRecent: { [agent.id]: [] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() => {
+        expect(result.current.currentConversationId).not.toBeNull();
+        expect(result.current.currentConversationId).not.toBe(terminalId);
+      });
+
+      await waitFor(() =>
+        expect(mockFetchWithAuth).toHaveBeenCalledWith(
+          `/api/ai/page-agents/${agent.id}/conversations`,
+          expect.objectContaining({ method: 'POST' }),
+        ),
+      );
+    });
+
+    it('returning to null RESUMES the machine conversation (row id) — never mints a new session row', async () => {
+      const { machineId, terminalId } = ids('resume-null');
+      const agent = agentFixture('agent-resume-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-resume' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-resume'));
+
+      act(() => {
+        result.current.selectAgent(null);
+      });
+
+      await waitFor(() => expect(result.current.currentConversationId).toBe(terminalId));
+      expect(result.current.selectedAgent).toBeNull();
+
+      // Never minted: no conversation row was ever created on the MACHINE page.
+      const machineCreates = mockFetchWithAuth.mock.calls.filter(
+        (call) =>
+          call[0] === `/api/ai/page-agents/${machineId}/conversations` &&
+          (call[1] as RequestInit | undefined)?.method === 'POST',
+      );
+      expect(machineCreates).toHaveLength(0);
+    });
+  });
+
+  // ============================================
+  // History — per-mode conversations
+  // ============================================
+
+  describe('history', () => {
+    it('default mode lists the MACHINE page\'s conversations', async () => {
+      const { machineId, terminalId } = ids('history-default');
+      routeFetches({
+        lists: { [machineId]: [conversationRow('machine-conv-1', 'Machine chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await waitFor(() =>
+        expect(result.current.conversations.map((c) => c.id)).toEqual(['machine-conv-1']),
+      );
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        `/api/ai/page-agents/${machineId}/conversations`,
+      );
+    });
+
+    it('agent mode lists the AGENT\'s conversations', async () => {
+      const { machineId, terminalId } = ids('history-agent');
+      const agent = agentFixture('agent-history-1');
+      routeFetches({
+        mostRecent: { [agent.id]: [{ id: 'agent-conv-1' }] },
+        lists: { [agent.id]: [conversationRow('agent-conv-1', 'Agent chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+
+      await waitFor(() =>
+        expect(result.current.conversations.map((c) => c.id)).toEqual(['agent-conv-1']),
+      );
+      expect(mockFetchWithAuth).toHaveBeenCalledWith(
+        `/api/ai/page-agents/${agent.id}/conversations`,
+      );
+    });
+
+    it('refuses to delete the machine-anchored session conversation', async () => {
+      const { machineId, terminalId } = ids('history-delete-guard');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.deleteConversation(terminalId);
+      });
+
+      const deletes = mockFetchWithAuth.mock.calls.filter(
+        (call) => (call[1] as RequestInit | undefined)?.method === 'DELETE',
+      );
+      expect(deletes).toHaveLength(0);
+      expect(result.current.currentConversationId).toBe(terminalId);
+    });
+
+    it('opening a history conversation loads it under the ACTIVE mode\'s page id and adopts it', async () => {
+      const { machineId, terminalId } = ids('history-open');
+      routeFetches({
+        lists: { [machineId]: [conversationRow('machine-conv-2', 'Older machine chat')] },
+      });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.openConversation('machine-conv-2');
+      });
+
+      expect(result.current.currentConversationId).toBe('machine-conv-2');
+      expect(loaders.loadAgentConversationMessages).toHaveBeenCalledWith(
+        machineId,
+        'machine-conv-2',
+      );
+    });
+  });
+
+  // ============================================
+  // pendingPrompt — auto-send exactly once
+  // ============================================
+
+  describe('pendingPrompt', () => {
+    it('auto-sends into a fresh EMPTY default-mode conversation exactly once, then onPromptSent()', async () => {
+      const { machineId, terminalId } = ids('pending-fresh');
+      conversationMessagesActions.seedConversation(terminalId);
+      const onPromptSent = vi.fn();
+
+      const { rerender } = renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await waitFor(() => expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1));
+      const [message, options] = chat.defaultChat.sendMessage.mock.calls[0] as [
+        UIMessage,
+        { body?: Record<string, unknown> },
+      ];
+      expect(message.parts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'text', text: 'run the tests' })]),
+      );
+      expect(options.body).toEqual(
+        expect.objectContaining({ chatId: machineId, conversationId: terminalId }),
+      );
+      await waitFor(() => expect(onPromptSent).toHaveBeenCalledTimes(1));
+
+      rerender();
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).toHaveBeenCalledTimes(1);
+      expect(onPromptSent).toHaveBeenCalledTimes(1);
+    });
+
+    it('never auto-sends into a RESUMED session (conversation already has messages)', async () => {
+      const { machineId, terminalId } = ids('pending-resumed');
+      const generation = conversationMessagesActions.startLoad(terminalId);
+      conversationMessagesActions.applyLoad(terminalId, generation, [
+        assistantMessage('m-existing', 'Already ran once.'),
+      ]);
+      const onPromptSent = vi.fn();
+
+      renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+      expect(onPromptSent).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-send while the conversation is still unloaded', async () => {
+      const { machineId, terminalId } = ids('pending-unloaded');
+      // No seed: the cache has no loaded entry for the terminal conversation.
+      const onPromptSent = vi.fn();
+
+      renderHook(() =>
+        useMachinePaneChat({
+          machineId,
+          terminalId,
+          pendingPrompt: 'run the tests',
+          onPromptSent,
+        }),
+      );
+
+      await act(async () => {});
+      expect(chat.defaultChat.sendMessage).not.toHaveBeenCalled();
+      expect(onPromptSent).not.toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Stop — wired in both modes
+  // ============================================
+
+  describe('stop', () => {
+    it('default mode: handleStop stops the DEFAULT chat instance', async () => {
+      const { machineId, terminalId } = ids('stop-default');
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(chat.defaultChat.stop).toHaveBeenCalled();
+      expect(chat.agentChat.stop).not.toHaveBeenCalled();
+    });
+
+    it('agent mode: handleStop stops the AGENT chat instance', async () => {
+      const { machineId, terminalId } = ids('stop-agent');
+      const agent = agentFixture('agent-stop-1');
+      routeFetches({ mostRecent: { [agent.id]: [{ id: 'conv-agent-stop' }] } });
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      act(() => {
+        result.current.selectAgent(agent);
+      });
+      await waitFor(() => expect(result.current.currentConversationId).toBe('conv-agent-stop'));
+
+      await act(async () => {
+        await result.current.handleStop();
+      });
+
+      expect(chat.agentChat.stop).toHaveBeenCalled();
+    });
+  });
+
+  // ============================================
+  // Rendering source
+  // ============================================
+
+  describe('rendered messages', () => {
+    it('renders from the shared conversation cache, per conversation', async () => {
+      const { machineId, terminalId } = ids('render-cache');
+      const generation = conversationMessagesActions.startLoad(terminalId);
+      conversationMessagesActions.applyLoad(terminalId, generation, [
+        assistantMessage('m-cache-1', 'From the cache.'),
+      ]);
+
+      const { result } = renderHook(() => useMachinePaneChat({ machineId, terminalId }));
+
+      await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(['m-cache-1']));
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
@@ -1,0 +1,167 @@
+/**
+ * What a bound pane renders is a DECISION, not a default: an explicit
+ * `kind` on the pane's scope wins outright, and only a kind-less (pre-#2166)
+ * binding falls back to resolving the session's agentType from the SWR list —
+ * where "the list hasn't answered yet" must yield `loading`, never a mounted
+ * Xterm that cold-starts a PTY for a session that turns out to be a chat.
+ */
+import { describe, test } from 'vitest';
+import { assert } from '@/stores/__tests__/riteway';
+import { resolvePaneSurface, agentTypeLabelOf } from './pane-surface';
+
+/** The workspace's checkout — the scope its SWR session list is fetched at. */
+const NODE = { projectName: 'app', branchName: 'main' };
+
+const chatRow = { id: 'row-chat', name: 'pagespace-a1', agentType: 'pagespace', createdAt: '' };
+const ptyRow = { id: 'row-pty', name: 'claude-b2', agentType: 'claude', createdAt: '' };
+
+describe('resolvePaneSurface', () => {
+  test('an explicit chat kind renders chat, carrying the row id the list resolved', () => {
+    assert({
+      given: 'a pane bound with kind "chat" whose session row is in the list',
+      should: 'be a chat surface addressing that row — the row id IS the conversation id (Phase 4)',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1', kind: 'chat' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'chat', terminalId: 'row-chat' },
+    });
+  });
+
+  test('a chat-kind pane whose row has not arrived yet is chat WITHOUT a row id — never a PTY', () => {
+    assert({
+      given: 'kind "chat" while the session list is still loading',
+      should: 'stay a chat surface with a null terminalId (the caller shows loading) rather than fall back to a terminal',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1', kind: 'chat' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'chat', terminalId: null },
+    });
+  });
+
+  test('an explicit terminal kind is a terminal, no list consulted', () => {
+    assert({
+      given: 'kind "terminal" while the list is still loading',
+      should: 'be a terminal immediately — an explicit binding never waits on the list',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'claude-b2', kind: 'terminal' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('no kind hint + the list resolving the name to a chat agent type renders chat', () => {
+    assert({
+      given: 'a kind-less scope whose name the loaded list maps to agentType "pagespace"',
+      should: 'resolve to the chat surface, with the row id',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'chat', terminalId: 'row-chat' },
+    });
+  });
+
+  test('no kind hint + the list resolving the name to a PTY agent type renders a terminal', () => {
+    assert({
+      given: 'a kind-less scope whose name the loaded list maps to agentType "claude"',
+      should: 'resolve to a terminal',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'claude-b2' },
+        workspaceScope: NODE,
+        agentTerminals: [ptyRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('no kind hint while the list is loading is LOADING — never mount Xterm for a maybe-chat session', () => {
+    assert({
+      given: 'a kind-less scope and a list that has not answered yet',
+      should:
+        'hold at loading — mounting Xterm now would cold-start a PTY (and register a viewer) for a session that may turn out to be a chat',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [],
+        isLoading: true,
+      }),
+      expected: { surface: 'loading' },
+    });
+  });
+
+  test('no kind hint, list loaded, name not found: a terminal — every pre-kind binding was a PTY', () => {
+    assert({
+      given: 'a kind-less scope the loaded list does not contain (a stale or killed session)',
+      should: 'fall back to a terminal — omitted kind predates chat panes, so the legacy reading is the safe one',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'gone' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('a retired agentType the registry no longer knows resolves to a terminal, not a crash', () => {
+    assert({
+      given: 'a row whose agentType is a since-removed AGENT_LAUNCH_SPECS entry',
+      should: 'treat it as a PTY — the DB can hold rows from retired types (see AgentTerminal.agentType\'s doc)',
+      actual: resolvePaneSurface({
+        scope: { ...NODE, name: 'old-cli' },
+        workspaceScope: NODE,
+        agentTerminals: [{ id: 'row-old', name: 'old-cli', agentType: 'pagespace-cli' }],
+        isLoading: false,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+
+  test('a pane at a FOREIGN checkout never resolves against this workspace\'s list', () => {
+    assert({
+      given: 'a kind-less pane whose node scope differs from the workspace\'s (a restored server layout), sharing a name with a chat row in the list',
+      should:
+        'be a terminal immediately, even mid-load — the workspace-scoped list says nothing about another checkout\'s sessions, and a same-name match across scopes would be a different session',
+      actual: resolvePaneSurface({
+        scope: { name: 'pagespace-a1' },
+        workspaceScope: NODE,
+        agentTerminals: [chatRow],
+        isLoading: true,
+      }),
+      expected: { surface: 'terminal' },
+    });
+  });
+});
+
+describe('agentTypeLabelOf', () => {
+  test('the chat agent presents as "PageSpace Agent", PTY types as themselves', () => {
+    assert({
+      given: 'every pickable agent type',
+      should: 'label pagespace "PageSpace Agent" — agents and chats are one thing, so it presents as an agent, never as "chat" — and leave PTY binaries under their real names',
+      actual: {
+        pagespace: agentTypeLabelOf('pagespace'),
+        shell: agentTypeLabelOf('shell'),
+        claude: agentTypeLabelOf('claude'),
+        codex: agentTypeLabelOf('codex'),
+      },
+      expected: {
+        pagespace: 'PageSpace Agent',
+        shell: 'shell',
+        claude: 'claude',
+        codex: 'codex',
+      },
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
@@ -1,0 +1,90 @@
+/**
+ * Which surface a bound pane renders (#2166, Phase 10) — a pure decision,
+ * colocated-tested like `tab-states`, so the render branch in TerminalPanes
+ * stays a lookup rather than a policy.
+ *
+ * Precedence: an explicit `kind` on the pane's scope (Phase 9) wins outright —
+ * it was written at bind time by the path that KNEW what it was spawning. Only
+ * a kind-less binding (pre-#2166, or a path that didn't set it) falls back to
+ * resolving the session's agentType from the workspace's SWR session list, and
+ * there the unanswered list means `loading`, never a mounted Xterm: opening a
+ * PTY stream registers this pane as a viewer server-side, so guessing "pty"
+ * for what turns out to be a chat isn't a harmless flash, it's a connection.
+ *
+ * The list consulted is the WORKSPACE's (the one TerminalPanes already
+ * subscribes to for spawning). A pane bound at a foreign checkout (a restored
+ * server layout can hold one) is outside that list's world, so its name is
+ * never matched against it — a same-name row at the workspace's scope would
+ * be a different session — and a kind-less foreign pane reads as a terminal
+ * immediately: every binding that predates the kind tag was a PTY.
+ */
+import {
+  agentSurfaceOf,
+  isAgentRuntimeType,
+  type AgentRuntimeType,
+} from '@pagespace/lib/services/machines/agent-terminal-types';
+import {
+  isSameNodeScope,
+  nodeOfTerminalScope,
+  type MachineNodeScope,
+  type OpenTerminalScope,
+} from '@/stores/machine-workspace/workspace-reducer';
+
+/** The slice of an `AgentTerminal` row this decision reads. */
+export interface PaneSessionRow {
+  /** The row's own id — for chat surfaces, the conversation id (Phase 4). */
+  id: string;
+  name: string;
+  /** Raw DB value; can name a retired AGENT_LAUNCH_SPECS entry. */
+  agentType: string;
+}
+
+export type PaneSurface =
+  /** The list hasn't answered and the binding carries no kind — hold. */
+  | { surface: 'loading' }
+  | { surface: 'terminal' }
+  /** `terminalId` is the session ROW id MachinePaneChat is addressed by —
+   * `null` until the list turns it up (the caller shows loading meanwhile). */
+  | { surface: 'chat'; terminalId: string | null };
+
+export function resolvePaneSurface(params: {
+  scope: OpenTerminalScope;
+  /** The checkout the session list below was fetched at. */
+  workspaceScope: MachineNodeScope;
+  agentTerminals: readonly PaneSessionRow[];
+  isLoading: boolean;
+}): PaneSurface {
+  const { scope, workspaceScope, agentTerminals, isLoading } = params;
+
+  if (scope.kind === 'terminal') return { surface: 'terminal' };
+
+  // A session's identity is (project, branch, name) — the list only speaks
+  // for the workspace's own checkout, so a foreign pane's name is never
+  // looked up in it (see module doc).
+  const resolvable = isSameNodeScope(nodeOfTerminalScope(scope), workspaceScope);
+  const row = resolvable ? agentTerminals.find((terminal) => terminal.name === scope.name) : undefined;
+
+  if (scope.kind === 'chat') return { surface: 'chat', terminalId: row?.id ?? null };
+
+  if (row) {
+    return isAgentRuntimeType(row.agentType) && agentSurfaceOf(row.agentType) === 'chat'
+      ? { surface: 'chat', terminalId: row.id }
+      : { surface: 'terminal' };
+  }
+  if (resolvable && isLoading) return { surface: 'loading' };
+  // Loaded (or unresolvable) and absent: a kind-less binding predates chat
+  // panes, so the legacy reading — a PTY — is the safe one.
+  return { surface: 'terminal' };
+}
+
+/** What the chat agent presents as everywhere a picker lists it — agents and
+ * chats are one thing, so it's an agent ("PageSpace Agent"), never a "chat". */
+const AGENT_TYPE_LABELS: Partial<Record<AgentRuntimeType, string>> = {
+  pagespace: 'PageSpace Agent',
+};
+
+/** Display label for an agent type — PTY binaries under their real names, the
+ * chat agent as "PageSpace Agent". */
+export function agentTypeLabelOf(type: AgentRuntimeType): string {
+  return AGENT_TYPE_LABELS[type] ?? type;
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/useMachinePaneChat.ts
@@ -1,0 +1,632 @@
+/**
+ * useMachinePaneChat — the machine pane's dual-mode chat state (Phase 11, #2166).
+ *
+ * The third selector surface (after SidebarChatTab and GlobalAssistantView's
+ * dashboard): null selection = the assistant identity on the MACHINE-ANCHORED
+ * conversation — the terminal row's pre-created conversation (Phase 4), with
+ * `chatId = machineId` so the chat route derives the machine-pane binding
+ * (Phase 6) and sandbox tools run against this pane's checkout (Phase 7).
+ * Any page agent = that agent's own chat, exactly as the sidebar runs it —
+ * the machine binding does not apply (the route derives null for it).
+ *
+ * Identity model:
+ * - Surface ids are stable per pane: `machine-pane:${terminalId}` (default) /
+ *   `machine-pane-agent:${terminalId}` (agent mode) — one Chat instance per
+ *   mode for the pane's lifetime, so a mode switch swaps WHICH instance is on
+ *   screen instead of recreating either (no cross-mode bleed; see
+ *   useDualModeChat).
+ * - The default conversation starts as (and returns to) the terminal row id.
+ *   Returning to null selection RESUMES it — nothing here ever mints a new
+ *   session row for the machine; only an explicit "new conversation" in
+ *   History creates a machine-page conversation.
+ * - Both modes are agent-style surfaces: conversations live on a PAGE (the
+ *   machine page or the agent's page), so loaders, history and message
+ *   actions all key on `channelId` = machineId | agent.id.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePathname } from 'next/navigation';
+import type { UIMessage } from 'ai';
+import { toast } from 'sonner';
+import { createId } from '@paralleldrive/cuid2';
+import type { AgentInfo } from '@/types/agent';
+import { useDualModeChat } from '@/hooks/useDualModeChat';
+import {
+  useChatTransport,
+  useConversations,
+  useCacheMessageActions,
+  useSendHandoff,
+  useConversationSendHandoff,
+  HANDOFF_REFUSED_MESSAGE,
+  useChatErrorCause,
+  buildChatConfig,
+  fetchMostRecentAgentConversation,
+  createAgentConversation,
+  type ConversationData,
+  type AIErrorCause,
+} from '@/lib/ai/shared';
+import { buildContextRef, type ContextRef } from '@/lib/ai/shared/buildContextRef';
+import { buildUserMessage } from '@/lib/ai/streams/buildUserMessage';
+import { rollbackOptimisticSendOnFailure } from '@/lib/ai/streams/rollbackOptimisticSendOnFailure';
+import { conversationMessagesActions } from '@/hooks/conversationMessagesActions';
+import {
+  loadAgentConversationMessages,
+  loadOlderAgentConversationMessages,
+} from '@/hooks/conversationMessagesLoaders';
+import {
+  useRenderedMessages,
+  useConversationLoadState,
+  useConversationOlderPageState,
+} from '@/hooks/useRenderedMessages';
+import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
+import { useActiveStream, useConversationActiveStream } from '@/hooks/useActiveStream';
+import { useOwnStreamMirror } from '@/hooks/useOwnStreamMirror';
+import { useStopStream } from '@/hooks/useStopStream';
+import { useAuth } from '@/hooks/useAuth';
+import { useDriveStore } from '@/hooks/useDrive';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+export interface UseMachinePaneChatOptions {
+  /** The machine page hosting this pane — the default mode's chatId + channel. */
+  machineId: string;
+  /** The terminal row id — the machine-anchored conversation's id (Phase 4). */
+  terminalId: string;
+  /** The picker's starting prompt — auto-sent once into a fresh empty default
+   *  conversation, never into a resumed one. */
+  pendingPrompt?: string;
+  /** Consumed-notification for pendingPrompt (clears the pane's one-shot intent). */
+  onPromptSent?: () => void;
+  /** Whether the conversation list should be fetched (e.g. only on relevant tabs). */
+  historyEnabled?: boolean;
+}
+
+export interface UseMachinePaneChatReturn {
+  /** null = default (machine) mode. */
+  selectedAgent: AgentInfo | null;
+  selectAgent: (agent: AgentInfo | null) => void;
+  /** The active mode's conversation. Default mode starts at (and resumes to) the terminal row id. */
+  currentConversationId: string | null;
+  /** The active mode's page channel: machineId or the agent's page id. */
+  channelId: string;
+  /** Rendered messages for the conversation on screen (shared cache + live streams). */
+  messages: UIMessage[];
+  /** Remote in-progress streams to render inline below the messages. */
+  remoteStreams: PendingStream[];
+  displayIsStreaming: boolean;
+  isMessagesLoading: boolean;
+  hasLoadError: boolean;
+  reloadConversation: () => Promise<void>;
+  /** Send a user message under the active mode's ids. Resolves false when
+   *  nothing was dispatched (empty text, no conversation, refused handoff) so
+   *  the composer can restore its draft. */
+  handleSend: (text: string) => Promise<boolean>;
+  handleStop: () => Promise<void>;
+  /** Store-first message actions (settled rows only). */
+  handleEdit: (messageId: string, newContent: string) => Promise<void>;
+  handleDelete: (messageId: string) => Promise<void>;
+  handleRetry: () => Promise<void>;
+  lastAssistantMessageId: string | undefined;
+  lastUserMessageId: string | undefined;
+  /** "Load older" wiring (scroll-near-top). */
+  handleScrollNearTop: () => void;
+  isLoadingOlder: boolean;
+  hasMoreOlder: boolean;
+  /** Per-mode history (machine-page conversations in default mode; the agent's in agent mode). */
+  conversations: ConversationData[];
+  isLoadingConversations: boolean;
+  openConversation: (conversationId: string) => Promise<void>;
+  createNewConversation: () => Promise<string | null>;
+  deleteConversation: (conversationId: string) => Promise<void>;
+  errorCause: AIErrorCause | null;
+  dismissError: () => void;
+}
+
+export function useMachinePaneChat({
+  machineId,
+  terminalId,
+  pendingPrompt,
+  onPromptSent,
+  historyEnabled = true,
+}: UseMachinePaneChatOptions): UseMachinePaneChatReturn {
+  const pathname = usePathname();
+  const { user } = useAuth();
+  const drives = useDriveStore((state) => state.drives);
+
+  // ============================================
+  // Mode + per-mode conversation identity
+  // ============================================
+  const [selectedAgent, setSelectedAgent] = useState<AgentInfo | null>(null);
+  // Starts as — and on return-to-null still is — the terminal row's
+  // conversation. Only History (open/new/delete) moves it.
+  const [defaultConversationId, setDefaultConversationId] = useState<string>(terminalId);
+  const [agentConversationId, setAgentConversationId] = useState<string | null>(null);
+
+  const channelId = selectedAgent ? selectedAgent.id : machineId;
+  const currentConversationId = selectedAgent ? agentConversationId : defaultConversationId;
+
+  // Ref-read rather than a functional-updater compare: clearing the agent
+  // conversation is a second state write, and state updaters must stay pure.
+  const selectedAgentRef = useRef(selectedAgent);
+  selectedAgentRef.current = selectedAgent;
+  const selectAgent = useCallback((agent: AgentInfo | null) => {
+    if (agent?.id !== selectedAgentRef.current?.id) {
+      // A genuinely new subject — the resolve effect below re-resolves it.
+      // The DEFAULT identity is deliberately untouched: returning to null
+      // resumes the machine conversation as-is, it never mints a new row.
+      setAgentConversationId(null);
+    }
+    setSelectedAgent(agent);
+  }, []);
+
+  // A pane re-bound to a different terminal row is a different chat surface.
+  // Phase 10 keys the mount by session, but the hook defends its own
+  // invariant: the default identity and the pendingPrompt latch belong to
+  // the terminal row, not the mount.
+  const boundTerminalIdRef = useRef(terminalId);
+  const pendingPromptSentRef = useRef(false);
+  useEffect(() => {
+    if (boundTerminalIdRef.current === terminalId) return;
+    boundTerminalIdRef.current = terminalId;
+    pendingPromptSentRef.current = false;
+    setDefaultConversationId(terminalId);
+  }, [terminalId]);
+
+  // Resolve the selected agent's conversation: most recent, or a client-minted
+  // new one (same shape as usePageAgentSidebarState, pane-local instead of the
+  // sidebar's shared store — each pane owns its selection).
+  const resolvingAgentIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!selectedAgent) {
+      resolvingAgentIdRef.current = null;
+      return;
+    }
+    const agentId = selectedAgent.id;
+    resolvingAgentIdRef.current = agentId;
+
+    const resolve = async () => {
+      try {
+        const mostRecent = await fetchMostRecentAgentConversation(agentId);
+        if (resolvingAgentIdRef.current !== agentId) return;
+        if (mostRecent) {
+          setAgentConversationId(mostRecent.id);
+          await loadAgentConversationMessages(agentId, mostRecent.id);
+          return;
+        }
+      } catch (error) {
+        if (resolvingAgentIdRef.current !== agentId) return;
+        console.error('Failed to load recent agent conversation:', error);
+      }
+      if (resolvingAgentIdRef.current !== agentId) return;
+
+      const newConversationId = createId();
+      setAgentConversationId(newConversationId);
+      conversationMessagesActions.seedConversation(newConversationId);
+      try {
+        await createAgentConversation(agentId, newConversationId);
+      } catch (error) {
+        if (resolvingAgentIdRef.current !== agentId) return;
+        console.error('Failed to create agent conversation:', error);
+        toast.error('Failed to initialize agent conversation');
+      }
+    };
+    void resolve();
+  }, [selectedAgent]);
+
+  // Load the default (machine) conversation into the shared cache. The
+  // loader's generation gate makes re-runs safe.
+  useEffect(() => {
+    void loadAgentConversationMessages(machineId, defaultConversationId);
+  }, [machineId, defaultConversationId]);
+
+  // ============================================
+  // Chat instances — one per mode, stable surface ids per pane
+  // ============================================
+  const defaultTransport = useChatTransport(defaultConversationId, '/api/ai/chat', machineId);
+  const defaultChatConfig = useMemo(() => {
+    if (!defaultTransport) return null;
+    return buildChatConfig({
+      id: `machine-pane:${terminalId}`,
+      transport: defaultTransport,
+      onError: (error: Error) => {
+        console.error('Machine pane chat error:', error);
+        toast.error('Chat error. Please try again.');
+      },
+    });
+  }, [defaultTransport, terminalId]);
+
+  const agentTransport = useChatTransport(
+    agentConversationId,
+    '/api/ai/chat',
+    selectedAgent?.id ?? null,
+  );
+  const agentChatConfig = useMemo(() => {
+    if (!selectedAgent || !agentConversationId || !agentTransport) return null;
+    return buildChatConfig({
+      id: `machine-pane-agent:${terminalId}`,
+      transport: agentTransport,
+      onError: (error: Error) => {
+        console.error('Machine pane agent chat error:', error);
+        toast.error('Chat error. Please try again.');
+      },
+    });
+  }, [selectedAgent, agentConversationId, agentTransport, terminalId]);
+
+  const {
+    sendMessage,
+    status,
+    error,
+    clearError,
+    regenerate,
+    setMessages,
+    stop,
+    isStreaming,
+    globalStatus: defaultStatus,
+    globalStop: defaultStop,
+    globalMessages: defaultMessages,
+    agentStatus,
+    agentMessages,
+    agentStop,
+  } = useDualModeChat({
+    selectedAgent,
+    globalChatConfig: defaultChatConfig,
+    agentChatConfig,
+  });
+
+  // ============================================
+  // Multiplayer — both page channels are agent-style
+  // ============================================
+  // The machine channel stays wired in agent mode too: remote streams landing
+  // on the machine conversation keep committing to the shared cache, so a
+  // return to null shows them without a refetch (cache writes are idempotent).
+  const machineChannel = useMemo(() => ({ id: machineId }), [machineId]);
+  const loadDefaultConversation = useCallback(
+    (conversationId: string) => loadAgentConversationMessages(machineId, conversationId),
+    [machineId],
+  );
+  const { rejoinActiveStreams: rejoinDefaultStream } = useAgentChannelMultiplayer({
+    selectedAgent: machineChannel,
+    agentConversationId: defaultConversationId,
+    loadConversation: loadDefaultConversation,
+  });
+
+  const loadSelectedAgentConversation = useCallback(
+    (conversationId: string) => {
+      const agentId = selectedAgent?.id;
+      if (agentId) return loadAgentConversationMessages(agentId, conversationId);
+    },
+    [selectedAgent?.id],
+  );
+  const { rejoinActiveStreams: rejoinAgentStream } = useAgentChannelMultiplayer({
+    selectedAgent,
+    agentConversationId,
+    loadConversation: loadSelectedAgentConversation,
+  });
+
+  // ============================================
+  // Store-first rendering
+  // ============================================
+  const renderedMessages = useRenderedMessages(channelId, currentConversationId);
+  const messages = useMemo(() => renderedMessages.map((r) => r.message), [renderedMessages]);
+  const loadState = useConversationLoadState(currentConversationId);
+
+  const activeStream = useConversationActiveStream(channelId, currentConversationId);
+  const { streams: remoteStreams } = useActiveStream(channelId, currentConversationId);
+
+  const { wrapSend, pendingSendConversationId } = useSendHandoff(
+    currentConversationId,
+    status,
+    activeStream?.isOwn === true,
+  );
+
+  const displayIsStreaming =
+    activeStream?.isOwn === true ||
+    (pendingSendConversationId !== null && pendingSendConversationId === currentConversationId);
+
+  // Own-stream mirrors, MOUNTED PER CHAT (see useDualModeChat's interface
+  // docblock — a mode-selected mirror silently repoints on switch and deletes
+  // the live stream's store entry).
+  const mirrorTriggeredBy = useMemo(
+    () => ({ userId: user?.id ?? '', displayName: user?.name || user?.email || 'You' }),
+    [user?.id, user?.name, user?.email],
+  );
+  const { getLatchedConversationId: getDefaultLatched } = useOwnStreamMirror({
+    status: defaultStatus,
+    ownMessages: defaultMessages,
+    pageId: machineId,
+    conversationId: defaultConversationId,
+    triggeredBy: mirrorTriggeredBy,
+  });
+  const { getLatchedConversationId: getAgentLatched } = useOwnStreamMirror({
+    status: agentStatus,
+    ownMessages: agentMessages,
+    pageId: selectedAgent?.id ?? '',
+    conversationId: agentConversationId ?? '',
+    triggeredBy: mirrorTriggeredBy,
+  });
+
+  // Pre-send handoff, per chat like the mirrors (see useConversationSendHandoff).
+  const { prepareSend: prepareDefaultSend } = useConversationSendHandoff({
+    status: defaultStatus,
+    stop: defaultStop,
+    getLatchedConversationId: getDefaultLatched,
+    rejoin: rejoinDefaultStream,
+  });
+  const { prepareSend: prepareAgentSend } = useConversationSendHandoff({
+    status: agentStatus,
+    stop: agentStop,
+    getLatchedConversationId: getAgentLatched,
+    rejoin: rejoinAgentStream,
+  });
+  const prepareSendForMode = selectedAgent ? prepareAgentSend : prepareDefaultSend;
+
+  // ============================================
+  // Send
+  // ============================================
+  const writeMode = useAssistantSettingsStore((state) => state.writeMode);
+  const webSearchEnabled = useAssistantSettingsStore((state) => state.webSearchEnabled);
+  const imageGenEnabled = useAssistantSettingsStore((state) => state.imageGenEnabled);
+  const currentProvider = useAssistantSettingsStore((state) => state.currentProvider);
+  const currentModel = useAssistantSettingsStore((state) => state.currentModel);
+
+  const buildPaneChatRequestBody = useCallback(
+    (contextRef: ContextRef, isReadOnly: boolean) => {
+      return selectedAgent
+        ? {
+            chatId: selectedAgent.id,
+            conversationId: agentConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: selectedAgent.aiProvider,
+            model: selectedAgent.aiModel,
+            systemPrompt: selectedAgent.systemPrompt,
+            contextRef,
+            enabledTools: selectedAgent.enabledTools,
+          }
+        : {
+            // The machine-pane binding contract (Phase 6): the machine page as
+            // chatId, the terminal-row conversation as conversationId.
+            chatId: machineId,
+            conversationId: defaultConversationId,
+            isReadOnly,
+            webSearchEnabled,
+            imageGenEnabled,
+            provider: currentProvider,
+            model: currentModel,
+            contextRef,
+          };
+    },
+    [
+      selectedAgent,
+      agentConversationId,
+      machineId,
+      defaultConversationId,
+      webSearchEnabled,
+      imageGenEnabled,
+      currentProvider,
+      currentModel,
+    ],
+  );
+
+  const handleSend = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || !currentConversationId) return false;
+
+      const contextRef = buildContextRef(pathname, drives);
+      // Hand off any in-flight stream this chat is consuming for ANOTHER
+      // conversation before sending (the Chat cannot consume two bodies at once).
+      if (!(await prepareSendForMode(currentConversationId))) {
+        toast.error(HANDOFF_REFUSED_MESSAGE);
+        return false;
+      }
+
+      // Client-minted id, parts-form send; optimistic cache write so the
+      // bubble appears the same tick (the sender never gets its own broadcast).
+      const userMessage = buildUserMessage({ id: createId(), text: trimmed }) as UIMessage;
+      conversationMessagesActions.addOptimisticSend(currentConversationId, userMessage);
+
+      rollbackOptimisticSendOnFailure(
+        () =>
+          wrapSend(() =>
+            sendMessage(userMessage, { body: buildPaneChatRequestBody(contextRef, !writeMode) }),
+          ),
+        currentConversationId,
+        userMessage.id,
+      );
+      return true;
+    },
+    [
+      currentConversationId,
+      pathname,
+      drives,
+      prepareSendForMode,
+      wrapSend,
+      sendMessage,
+      buildPaneChatRequestBody,
+      writeMode,
+    ],
+  );
+
+  // ============================================
+  // pendingPrompt — exactly once, fresh empty default conversation only
+  // ============================================
+  useEffect(() => {
+    if (pendingPromptSentRef.current) return;
+    if (!pendingPrompt) return;
+    if (selectedAgent) return;
+    // Only the terminal row's own conversation — a history-opened machine
+    // conversation is by definition not the fresh spawn target.
+    if (defaultConversationId !== terminalId) return;
+    // Not before the cache answers: an unloaded conversation might be a
+    // resumed one whose history simply hasn't arrived yet.
+    if (loadState.status !== 'loaded') return;
+    // A resumed session has messages — never auto-send into it.
+    if (renderedMessages.length > 0) return;
+
+    pendingPromptSentRef.current = true;
+    void handleSend(pendingPrompt).then(() => onPromptSent?.());
+  }, [
+    pendingPrompt,
+    selectedAgent,
+    defaultConversationId,
+    terminalId,
+    loadState.status,
+    renderedMessages.length,
+    handleSend,
+    onPromptSent,
+  ]);
+
+  // ============================================
+  // Stop + message actions
+  // ============================================
+  const handleStop = useStopStream({
+    activeStream,
+    pendingSendConversationId,
+    rawStop: stop,
+    getLocalSendConversationId: selectedAgent ? getAgentLatched : getDefaultLatched,
+    targetConversationId: currentConversationId,
+  });
+
+  const isOwnSendLive = isStreaming || activeStream?.isOwn === true;
+  const isOwnSendLiveRef = useRef(isOwnSendLive);
+  isOwnSendLiveRef.current = isOwnSendLive;
+  const getIsOwnSendLive = useCallback(() => isOwnSendLiveRef.current, []);
+
+  const { handleEdit, handleDelete, handleRetry } = useCacheMessageActions({
+    // Both modes are agent-style (page-hosted conversations) — the machine
+    // page id serves as the "agent" for the default mode's endpoints.
+    agentId: channelId,
+    conversationId: currentConversationId,
+    renderedMessages,
+    isOwnSendLive,
+    setMessages,
+    regenerate,
+    prepareSend: prepareSendForMode,
+    getIsOwnSendLive,
+  });
+
+  const lastAssistantMessageId = useMemo(
+    () => [...messages].reverse().find((m) => m.role === 'assistant')?.id,
+    [messages],
+  );
+  const lastUserMessageId = useMemo(
+    () => [...messages].reverse().find((m) => m.role === 'user')?.id,
+    [messages],
+  );
+
+  const reloadConversation = useCallback(async () => {
+    if (!currentConversationId) return;
+    await loadAgentConversationMessages(channelId, currentConversationId);
+  }, [channelId, currentConversationId]);
+
+  const { isLoadingOlder, hasMoreOlder } = useConversationOlderPageState(currentConversationId);
+  const handleScrollNearTop = useCallback(() => {
+    if (!currentConversationId) return;
+    void loadOlderAgentConversationMessages(channelId, currentConversationId);
+  }, [channelId, currentConversationId]);
+
+  // ============================================
+  // History — per-mode conversations (page-agents endpoints for both modes)
+  // ============================================
+  const adoptConversation = useCallback(
+    (conversationId: string) => {
+      if (selectedAgent) {
+        setAgentConversationId(conversationId);
+      } else {
+        setDefaultConversationId(conversationId);
+      }
+    },
+    [selectedAgent],
+  );
+
+  const {
+    conversations,
+    isLoading: isLoadingConversations,
+    createConversation,
+    deleteConversation: deleteConversationBase,
+  } = useConversations({
+    agentId: channelId,
+    currentConversationId,
+    enabled: historyEnabled,
+    onConversationCreate: (conversationId) => {
+      conversationMessagesActions.seedConversation(conversationId);
+      adoptConversation(conversationId);
+    },
+    onConversationDelete: () => {
+      if (selectedAgent) {
+        // Same shape as create: a fresh client-minted id, seeded empty;
+        // persisted lazily by the first message save.
+        const nextId = createId();
+        conversationMessagesActions.seedConversation(nextId);
+        setAgentConversationId(nextId);
+      } else {
+        // Deleting the machine conversation on screen falls back to the
+        // terminal row's own conversation — resume, never mint.
+        setDefaultConversationId(terminalId);
+      }
+    },
+  });
+
+  const openConversation = useCallback(
+    async (conversationId: string) => {
+      adoptConversation(conversationId);
+      await loadAgentConversationMessages(channelId, conversationId);
+    },
+    [adoptConversation, channelId],
+  );
+
+  const deleteConversation = useCallback(
+    async (conversationId: string) => {
+      // The machine-anchored session conversation IS the pane's identity —
+      // deleting it out from under the live terminal row would leave the
+      // default mode pointing at a dead id. Not deletable from this surface.
+      if (conversationId === terminalId) {
+        toast.error('The machine session conversation cannot be deleted from this pane');
+        return;
+      }
+      await deleteConversationBase(conversationId);
+    },
+    [terminalId, deleteConversationBase],
+  );
+
+  // ============================================
+  // Error surface
+  // ============================================
+  const { cause: errorCause, dismiss: dismissError } = useChatErrorCause(
+    currentConversationId,
+    error,
+    clearError,
+    pendingSendConversationId ?? currentConversationId,
+  );
+
+  return {
+    selectedAgent,
+    selectAgent,
+    currentConversationId,
+    channelId,
+    messages,
+    remoteStreams,
+    displayIsStreaming,
+    isMessagesLoading: loadState.isLoading,
+    hasLoadError: loadState.hasError,
+    reloadConversation,
+    handleSend,
+    handleStop,
+    handleEdit,
+    handleDelete,
+    handleRetry,
+    lastAssistantMessageId,
+    lastUserMessageId,
+    handleScrollNearTop,
+    isLoadingOlder,
+    hasMoreOlder,
+    conversations,
+    isLoadingConversations,
+    openConversation,
+    createNewConversation: createConversation,
+    deleteConversation,
+    errorCause,
+    dismissError,
+  };
+}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -19,7 +19,8 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
 import { useGlobalChatConversation, useGlobalChatConfig } from '@/contexts/GlobalChatContext';
-import { usePageAgentSidebarState, usePageAgentSidebarChat, type SidebarAgentInfo } from '@/hooks/page-agents';
+import { usePageAgentSidebarState, type SidebarAgentInfo } from '@/hooks/page-agents';
+import { useDualModeChat } from '@/hooks/useDualModeChat';
 import { type PendingStream } from '@/stores/usePendingStreamsStore';
 import { useAuth } from '@/hooks/useAuth';
 import { dedupRemoteStreams } from '@/lib/ai/streams/dedupRemoteStreams';
@@ -277,7 +278,7 @@ const SidebarChatTab: React.FC = () => {
     agentStatus,
     agentMessages,
     agentStop,
-  } = usePageAgentSidebarChat({
+  } = useDualModeChat({
     selectedAgent,
     globalChatConfig,
     agentChatConfig,
@@ -424,7 +425,7 @@ const SidebarChatTab: React.FC = () => {
   // nothing is streaming, and emits removeStream for the id it was mirroring — deleting a live
   // stream's entry, and with it that stream's Stop button and its rendered content.
   //
-  // The sidebar's two chats happen to be mutually exclusive today (usePageAgentSidebarChat stops
+  // The sidebar's two chats happen to be mutually exclusive today (useDualModeChat stops
   // the other mode's LOCAL fetch on switch), which is exactly the kind of invariant that makes a
   // mode-selected mirror look fine until it isn't: those stop effects are themselves scheduled to
   // change (leaf 5.4, W6), and a local stop never stopped the SERVER stream anyway.

--- a/apps/web/src/hooks/__tests__/useDualModeChat.test.ts
+++ b/apps/web/src/hooks/__tests__/useDualModeChat.test.ts
@@ -1,12 +1,12 @@
 /**
- * usePageAgentSidebarChat Hook Tests
+ * useDualModeChat Hook Tests
  * Tests for unified chat interface supporting both global and agent modes
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { usePageAgentSidebarChat } from '../usePageAgentSidebarChat';
-import type { SidebarAgentInfo } from '../usePageAgentSidebarState';
+import { useDualModeChat } from '../useDualModeChat';
+import type { AgentInfo } from '@/types/agent';
 
 // Mock useChat from @ai-sdk/react
 const mockGlobalSendMessage = vi.fn();
@@ -50,9 +50,9 @@ vi.mock('@ai-sdk/react', () => ({
   }),
 }));
 
-describe('usePageAgentSidebarChat', () => {
+describe('useDualModeChat', () => {
   // Sample agent
-  const mockAgent: SidebarAgentInfo = {
+  const mockAgent: AgentInfo = {
     id: 'agent-123',
     title: 'Test Agent',
     driveId: 'drive-456',
@@ -83,7 +83,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('unified interface', () => {
     it('should return messages from global chat when no agent selected', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -98,7 +98,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return sendMessage function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -110,7 +110,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return stop function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -122,7 +122,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return regenerate function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -134,7 +134,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should return setMessages function', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -151,7 +151,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('global mode (no agent selected)', () => {
     it('should use global sendMessage when sending in global mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -169,7 +169,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should use global regenerate in global mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -186,7 +186,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose globalStatus for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -198,7 +198,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose globalMessages for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -210,7 +210,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should expose setGlobalMessages for context sync', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -227,7 +227,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('agent mode (agent selected)', () => {
     it('should use agent sendMessage when agent is selected', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: mockAgent,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: mockAgentChatConfig,
@@ -248,7 +248,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should use agent regenerate in agent mode', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: mockAgent,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: mockAgentChatConfig,
@@ -274,7 +274,7 @@ describe('usePageAgentSidebarChat', () => {
 
     it('should be false when status is ready (default mock)', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -290,7 +290,7 @@ describe('usePageAgentSidebarChat', () => {
       // Test the isStreaming logic pattern:
       // isStreaming = status === 'submitted' || status === 'streaming'
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,
@@ -309,7 +309,7 @@ describe('usePageAgentSidebarChat', () => {
   describe('return type stability', () => {
     it('should include all required properties', () => {
       const { result } = renderHook(() =>
-        usePageAgentSidebarChat({
+        useDualModeChat({
           selectedAgent: null,
           globalChatConfig: mockGlobalChatConfig,
           agentChatConfig: null,

--- a/apps/web/src/hooks/page-agents/index.ts
+++ b/apps/web/src/hooks/page-agents/index.ts
@@ -12,7 +12,3 @@ export {
   type SidebarAgentInfo,
   type UseSidebarAgentStateReturn,
 } from './usePageAgentSidebarState';
-export {
-  usePageAgentSidebarChat,
-  type UseSidebarChatReturn,
-} from './usePageAgentSidebarChat';

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -6,6 +6,9 @@ import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
 import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 
 export interface AgentTerminal {
+  // The row's own id — used client-side as the conversation id for
+  // chat-surface (`pagespace`) terminals.
+  id: string;
   name: string;
   // A raw DB value, not narrowed to AgentRuntimeType — a row can carry an
   // agentType from a since-retired AGENT_LAUNCH_SPECS entry (e.g. the removed
@@ -95,7 +98,7 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
   const addAgentTerminal = useCallback(
     async (name: string, agentType: AgentRuntimeType) => {
       if (!machineId) throw new Error('No active machine');
-      const result = await post<{ agentTerminal: { name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
+      const result = await post<{ agentTerminal: { id: string; name: string; agentType: AgentRuntimeType; resumed: boolean } }>(
         '/api/machines/agent-terminals',
         { machineId, projectName: projectName ?? undefined, branchName: branchName ?? undefined, name, agentType },
       );

--- a/apps/web/src/hooks/useDualModeChat.ts
+++ b/apps/web/src/hooks/useDualModeChat.ts
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useCallback } from 'react';
 import { useChat, UseChatOptions } from '@ai-sdk/react';
 import { UIMessage, type CreateUIMessage } from 'ai';
-import { SidebarAgentInfo } from './usePageAgentSidebarState';
+import type { AgentInfo } from '@/types/agent';
 
 /**
- * Return type for the unified sidebar chat interface.
+ * Return type for the unified dual-mode chat interface.
  */
-export interface UseSidebarChatReturn {
+export interface UseDualModeChatReturn {
   /** Current messages (from active mode) */
   messages: UIMessage[];
   /** Send a message — parts-form (client-minted id preserved end to end, PR 5B). */
@@ -56,28 +56,31 @@ export interface UseSidebarChatReturn {
   }) => void | PromiseLike<void>;
 }
 
-interface UseSidebarChatOptions {
-  /** Currently selected agent (null = global mode) */
-  selectedAgent: SidebarAgentInfo | null;
-  /** Chat config for global mode (from GlobalChatContext) */
+interface UseDualModeChatOptions {
+  /** Currently selected agent (null = default mode) */
+  selectedAgent: AgentInfo | null;
+  /** Chat config for default mode (the surface's null-selection identity) */
   globalChatConfig: UseChatOptions<UIMessage> | null;
   /** Chat config for agent mode */
   agentChatConfig: UseChatOptions<UIMessage> | null;
 }
 
 /**
- * Manages chat for the sidebar, handling both global and agent modes.
+ * Manages chat for a dual-mode surface (sidebar, machine pane), handling both
+ * the default (null-selection) and agent modes.
  *
- * - In Global mode: Uses globalChatConfig, syncs with GlobalChatContext
+ * - In default mode: Uses globalChatConfig (whatever identity the surface
+ *   gives its null selection — the global assistant in the sidebar, the
+ *   machine-anchored conversation in a machine pane)
  * - In Agent mode: Uses agentChatConfig, operates independently
  *
  * Handles mode switching gracefully (stops streams, clears stale messages).
  */
-export function usePageAgentSidebarChat({
+export function useDualModeChat({
   selectedAgent,
   globalChatConfig,
   agentChatConfig,
-}: UseSidebarChatOptions): UseSidebarChatReturn {
+}: UseDualModeChatOptions): UseDualModeChatReturn {
   // ============================================
   // Global Mode Chat Instance
   // ============================================

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -4,6 +4,7 @@ import {
   filterToolsForReadOnly,
   filterToolsForWebSearch,
   filterToolsForMcpScope,
+  filterToolsForMachineBinding,
   isWebSearchTool,
   isImageGenTool,
   filterToolsForImageGen,
@@ -125,6 +126,28 @@ describe('filterToolsForMcpScope', () => {
     const result = filterToolsForMcpScope(withDrive, true);
     expect(result.create_drive).toBeUndefined();
     expect(result.list_pages).toBe('list_pages');
+    expect(result.read_page).toBe('read_page');
+  });
+});
+
+describe('filterToolsForMachineBinding', () => {
+  const withMachineTools = {
+    switch_machine: 'switch_machine',
+    list_machines: 'list_machines',
+    read_page: 'read_page',
+  };
+
+  it('returns input unchanged when not bound', () => {
+    const result = filterToolsForMachineBinding(withMachineTools, false);
+    expect(result).toEqual(withMachineTools);
+    expect(result.switch_machine).toBe('switch_machine');
+    expect(result.list_machines).toBe('list_machines');
+  });
+
+  it('removes switch_machine and list_machines when bound to a machine pane', () => {
+    const result = filterToolsForMachineBinding(withMachineTools, true);
+    expect(result.switch_machine).toBeUndefined();
+    expect(result.list_machines).toBeUndefined();
     expect(result.read_page).toBe('read_page');
   });
 });

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -118,6 +118,13 @@ export const WRITE_TOOLS = new Set([
 // Web search tools (excluded when web search is disabled)
 const WEB_SEARCH_TOOLS = new Set(['web_search', 'web_fetch']);
 
+// Tools that let the agent discover or switch to a different machine —
+// dropped when the conversation is bound to one specific machine via a
+// Machine Pane binding (deriveMachinePaneBinding). The bound machine is the
+// only one this conversation may ever act on, so offering a way to leave it
+// is moot.
+const MACHINE_BINDING_LOCKED_TOOLS = new Set(['switch_machine', 'list_machines']);
+
 // Image-generation tools (a runtime composer toggle, like web search — filtered
 // independently of the saved per-agent allow-list).
 const IMAGE_GEN_TOOLS = new Set(['generate_image']);
@@ -233,6 +240,22 @@ export function filterToolsForMcpScope<T>(
 
   return Object.fromEntries(
     Object.entries(tools).filter(([name]) => !isAccountLevelOnlyTool(name))
+  );
+}
+
+/**
+ * Filter tools based on machine-pane binding.
+ * Returns all tools when not bound, or drops switch_machine/list_machines
+ * when the conversation is bound to a specific machine.
+ */
+export function filterToolsForMachineBinding<T>(
+  tools: Record<string, T>,
+  isBound: boolean
+): Record<string, T> {
+  if (!isBound) return tools;
+
+  return Object.fromEntries(
+    Object.entries(tools).filter(([name]) => !MACHINE_BINDING_LOCKED_TOOLS.has(name))
   );
 }
 

--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -102,4 +102,19 @@ export interface ToolExecutionContext {
   // pre-batch checkpoint's "at most once per turn" throttle
   // (`checkpoint-policy.ts`). Undefined until first stamped.
   turnId?: string;
+
+  // "PageSpace Agent" panes (Terminal epics, issue #2166): the server-derived
+  // binding that pins THIS run's default-mode code-exec tools (bash/readFile/
+  // writeFile/editFile) to the machine checkout the pane is bound to —
+  // computed once per request from `deriveMachinePaneBinding`
+  // (@pagespace/lib/services/machines/machine-pane-binding) and never
+  // mutated in place afterward (unlike `activeMachine`, a pagespace pane's
+  // binding is fixed for the conversation's lifetime, not switchable
+  // mid-turn). Undefined for every conversation that isn't a machine-bound
+  // pagespace pane.
+  machineBinding?: {
+    machineId: string;
+    cwd: string;
+    branchSandbox?: { machineBranchId: string; sandboxId: string };
+  };
 }

--- a/apps/web/src/lib/ai/machine-pane/machine-pane-binding-runtime.ts
+++ b/apps/web/src/lib/ai/machine-pane/machine-pane-binding-runtime.ts
@@ -1,0 +1,47 @@
+/**
+ * Production wiring for the Machine Pane binding pure core
+ * (`@pagespace/lib/services/machines/machine-pane-binding`).
+ *
+ * Memoizes the DB stores — same idiom as `agent-terminals-runtime.ts` /
+ * `machine-branches-runtime.ts` (`apps/web/src/lib/machines/`) — and holds NO
+ * decision logic: narrowing each store down to the minimal-slice interfaces
+ * `deriveMachinePaneBinding` expects is plumbing, not policy.
+ */
+
+import { createDbMachineAgentTerminalStore } from '@pagespace/lib/services/machines/agent-terminals-store';
+import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/machine-projects-store';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
+import type { DeriveMachinePaneBindingDeps } from '@pagespace/lib/services/machines/machine-pane-binding';
+
+let terminalStorePromise: ReturnType<typeof createDbMachineAgentTerminalStore> | null = null;
+function getMachineAgentTerminalStore() {
+  terminalStorePromise ??= createDbMachineAgentTerminalStore();
+  return terminalStorePromise;
+}
+
+let projectStorePromise: ReturnType<typeof createDbMachineProjectStore> | null = null;
+function getMachineProjectStore() {
+  projectStorePromise ??= createDbMachineProjectStore();
+  return projectStorePromise;
+}
+
+let branchStorePromise: ReturnType<typeof createDbMachineBranchStore> | null = null;
+function getMachineBranchStore() {
+  branchStorePromise ??= createDbMachineBranchStore();
+  return branchStorePromise;
+}
+
+/** Wires `deriveMachinePaneBinding`'s deps to the real DB-backed stores. */
+export function buildMachinePaneBindingDeps(): DeriveMachinePaneBindingDeps {
+  return {
+    terminalStore: {
+      findById: async (id) => (await getMachineAgentTerminalStore()).findById(id),
+    },
+    projectLookup: {
+      findByName: async (machineId, name) => (await getMachineProjectStore()).findByName(machineId, name),
+    },
+    branchLookup: {
+      findById: async (machineBranchId) => (await getMachineBranchStore()).findById(machineBranchId),
+    },
+  };
+}

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -328,6 +328,43 @@ describe('createMachineDirectory', () => {
       await directory.listMachines({ userId: 'u1', parentAgentId: 'parent-agent-1' });
       expect(seen).toEqual(['parent-agent-1']);
     });
+
+    describe('machine-bound "PageSpace Agent" panes (machineBinding)', () => {
+      it('given a machineBinding, should collapse to exactly the bound machine — ignoring the agent\'s own configured machine list entirely', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            getAgentConfig: async () => ({
+              machineAccess: true,
+              machines: [{ kind: 'own' }, { kind: 'existing', machineId: 'other-1' }],
+            }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        await expect(directory.listMachines(context)).resolves.toEqual([
+          { kind: 'existing', machineId: 'bound-1' },
+        ]);
+      });
+
+      it('given a machineBinding on the global assistant context, should still collapse to the bound machine (not resolve the global config at all)', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            getGlobalConfig: async () => ({ machineAccess: false, machines: [] }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'global' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        await expect(directory.listMachines(context)).resolves.toEqual([
+          { kind: 'existing', machineId: 'bound-1' },
+        ]);
+      });
+    });
   });
 
   describe('describeMachine', () => {
@@ -517,6 +554,81 @@ describe('createMachineDirectory', () => {
         );
         const decision = await directory.isMachineAccessible(pageContext, { kind: 'existing', machineId: 't1' });
         expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
+      });
+    });
+
+    describe('machine-bound "PageSpace Agent" panes (machineBinding)', () => {
+      const machineDenyingPageAgents = async () => ({
+        title: 'Locked Machine',
+        type: 'MACHINE',
+        driveId: 'drive-1',
+        isTrashed: false,
+        allowPageAgents: false,
+        visibleToGlobalAssistant: true,
+      });
+
+      it('given the BOUND machine, should allow even though its allowPageAgents toggle is off — the binding IS the entitlement', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: true });
+      });
+
+      it('given a DIFFERENT machine than the one bound, should keep the full toggle checks and deny', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 'bound-1', cwd: '/workspace' },
+        };
+        const decision = await directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' });
+        expect(decision).toMatchObject({ allowed: false, code: 'page_agents_disabled' });
+      });
+
+      it('given the BOUND machine but its page is trashed, should still deny — existence/trash checks are never bypassed', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({
+            findPage: async () => ({
+              title: 'Trashed Machine',
+              type: 'MACHINE',
+              driveId: 'drive-1',
+              isTrashed: true,
+              allowPageAgents: false,
+              visibleToGlobalAssistant: true,
+            }),
+          }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
+      });
+
+      it('given the BOUND machine but the actor cannot view its page, should still deny — canActorViewPage is never bypassed', async () => {
+        const directory = createMachineDirectory(
+          makeMachineDirectoryDeps({ findPage: machineDenyingPageAgents, canViewPage: async () => false }),
+        );
+        const context: ToolExecutionContext = {
+          userId: 'u1',
+          chatSource: { type: 'page', agentPageId: 'agent-1' },
+          machineBinding: { machineId: 't1', cwd: '/workspace' },
+        };
+        await expect(
+          directory.isMachineAccessible(context, { kind: 'existing', machineId: 't1' }),
+        ).resolves.toEqual({ allowed: false });
       });
     });
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -643,6 +643,121 @@ describe('createSandboxTools', () => {
     });
   });
 
+  describe('machine-pane binding (machineBinding)', () => {
+    function runDepsCapturingCwd() {
+      const seenCwds: Array<string | undefined> = [];
+      const runDeps = fakeRunDeps();
+      runDeps.reconnect = async () => ({
+        sandboxId: 'sbx',
+        spriteInstanceId: null,
+        runCommand: async (args: { cwd?: string }) => {
+          seenCwds.push(args.cwd);
+          return { exitCode: 0, stdout: 'hi', stderr: '' };
+        },
+        writeFiles: async () => {},
+        readFileToBuffer: async () => Buffer.from('data'),
+        createCheckpoint: async () => {},
+      });
+      return { runDeps, seenCwds };
+    }
+
+    it('bash: given a binding and no explicit cwd, should default the runner cwd to the binding\'s cwd', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: { machineId: 'm1', cwd: '/workspace/repo' },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace/repo']);
+    });
+
+    it('bash: given a binding AND an explicit cwd, the explicit cwd should win', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: { machineId: 'm1', cwd: '/workspace/repo' },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi', cwd: '/workspace/other' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace/other']);
+    });
+
+    it('bash: given no binding, should leave the default cwd behavior unchanged (the runner\'s own SANDBOX_ROOT default)', async () => {
+      const { runDeps, seenCwds } = runDepsCapturingCwd();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const result = await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+      expect(result).toMatchObject({ success: true });
+      expect(seenCwds).toEqual(['/workspace']);
+    });
+
+    it('bash: given a binding with a branchSandbox, acquireSandbox should carry the branch target', async () => {
+      const seenAcquisitions: unknown[] = [];
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async (input) => {
+        seenAcquisitions.push(input);
+        return { ok: true, sandboxId: 'sbx', resumed: false };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: {
+          machineId: 'm1',
+          cwd: '/workspace/repo',
+          branchSandbox: { machineBranchId: 'branch-1', sandboxId: 'sbx-1' },
+        },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: true });
+      expect(seenAcquisitions).toEqual([
+        expect.objectContaining({ branchSandbox: { machineId: 'm1', machineBranchId: 'branch-1' } }),
+      ]);
+    });
+
+    it('bash: given no binding, acquireSandbox should carry no branchSandbox', async () => {
+      const seenAcquisitions: unknown[] = [];
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async (input) => {
+        seenAcquisitions.push(input);
+        return { ok: true, sandboxId: 'sbx', resumed: false };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      await exec(tools.bash, { command: 'echo hi' }, { userId: 'u1' });
+      expect(seenAcquisitions).toEqual([expect.objectContaining({ branchSandbox: undefined })]);
+    });
+
+    it('bash: given the branch acquire fails, should surface a tool error and run no command', async () => {
+      let reconnected = false;
+      const runDeps = fakeRunDeps();
+      runDeps.acquireSandbox = async () => ({ ok: false, reason: 'branch_not_found' });
+      runDeps.reconnect = async () => {
+        reconnected = true;
+        return {
+          sandboxId: 'sbx',
+          spriteInstanceId: null,
+          runCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+          writeFiles: async () => {},
+          readFileToBuffer: async () => Buffer.from(''),
+          createCheckpoint: async () => {},
+        };
+      };
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      const rawContext: ToolExecutionContext = {
+        userId: 'u1',
+        machineBinding: {
+          machineId: 'm1',
+          cwd: '/workspace/repo',
+          branchSandbox: { machineBranchId: 'branch-1', sandboxId: 'sbx-1' },
+        },
+      };
+      const result = await exec(tools.bash, { command: 'echo hi' }, rawContext);
+      expect(result).toMatchObject({ success: false });
+      expect(reconnected).toBe(false);
+    });
+  });
+
   describe('terminal tools resolve the active machine before delegating', () => {
     it('bash/writeFile/readFile/editFile should each resolve the configured machines to determine the active one', async () => {
       const listMachines = vi.fn().mockResolvedValue([{ kind: 'own' }]);

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -32,6 +32,8 @@ import {
   createDbMachineSessionStore,
 } from '@pagespace/lib/services/sandbox/machine-session-manager';
 import { acquireMachineSandbox } from '@pagespace/lib/services/sandbox/machine-session';
+import { acquireBranchSandbox } from '@pagespace/lib/services/sandbox/branch-session';
+import { createDbMachineBranchStore } from '@pagespace/lib/services/machines/machine-branches-store';
 import { defaultSandboxBillingDeps } from '@pagespace/lib/services/sandbox/machine-billing';
 import { measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
 import { lookupPageOwnerId } from '@pagespace/lib/billing/machine-payer';
@@ -72,6 +74,13 @@ let sandboxClientPromise: Promise<ExecSandboxClient> | null = null;
 function getStore() {
   storePromise ??= createDbMachineSessionStore();
   return storePromise;
+}
+
+let branchStorePromise: ReturnType<typeof createDbMachineBranchStore> | null = null;
+
+function getBranchStore() {
+  branchStorePromise ??= createDbMachineBranchStore();
+  return branchStorePromise;
 }
 
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one.
@@ -120,28 +129,48 @@ function getSandboxClient(): Promise<ExecSandboxClient> {
 export function buildRealSandboxRunDeps(): SandboxRunDeps {
   return {
     isEnabled: isCodeExecutionEnabled,
-    acquireSandbox: async (input) =>
-      acquireMachineSandbox({
-        ...input,
-        deps: {
-          store: await getStore(),
-          client: await getSandboxClient(),
-          authorize: canRunCode,
-          now: () => new Date(),
-          secret: getSandboxSessionSecret(),
-          // Full-egress G-gate: the agent sandbox runs OPEN egress, so refuse to
-          // provision unless containment is verified for the live topology
-          // (SANDBOX_CONTAINMENT_VERIFIED=true after the G1 probes pass). Admin
-          // gate has precedence. Fail-closed when unset.
-          checkFullEgressEnablement: async () =>
-            decideFullEgressEnablement({
-              adminGateEnabled: isCodeExecutionEnabled(),
-              containment: isContainmentVerified() ? { contained: true } : null,
-            }),
-          checkMachineRuntimeGuardrail,
-          recordMachineActivity,
-        },
-      }),
+    // Branch-scoped "PageSpace Agent" panes (issue #2166 phase 8) route to the
+    // attach-only branch seam instead of the machine's own persistent
+    // session — a branch's Sprite is provisioned exclusively by the
+    // branch-spawn path, never lazily here.
+    acquireSandbox: async ({ branchSandbox, ...input }) =>
+      branchSandbox
+        ? acquireBranchSandbox({
+            driveId: input.driveId,
+            userId: input.userId,
+            requestOrigin: input.requestOrigin,
+            agentPageId: input.agentPageId,
+            machineId: branchSandbox.machineId,
+            machineBranchId: branchSandbox.machineBranchId,
+            deps: {
+              authorize: canRunCode,
+              now: () => new Date(),
+              checkMachineRuntimeGuardrail,
+              recordMachineActivity,
+              findBranch: async (machineBranchId) => (await getBranchStore()).findById(machineBranchId),
+            },
+          })
+        : acquireMachineSandbox({
+            ...input,
+            deps: {
+              store: await getStore(),
+              client: await getSandboxClient(),
+              authorize: canRunCode,
+              now: () => new Date(),
+              secret: getSandboxSessionSecret(),
+              // Full-egress G-gate: the agent sandbox runs OPEN egress, so refuse to
+              // provision unless containment is verified for the live topology
+              // (SANDBOX_CONTAINMENT_VERIFIED=true after the G1 probes pass). Admin
+              // gate has precedence. Fail-closed when unset.
+              checkFullEgressEnablement: async () =>
+                decideFullEgressEnablement({
+                  adminGateEnabled: isCodeExecutionEnabled(),
+                  containment: isContainmentVerified() ? { contained: true } : null,
+                }),
+              checkMachineRuntimeGuardrail,
+              recordMachineActivity,
+            },
+          }),
     reconnect: async (sandboxId) => (await getSandboxClient()).get({ sandboxId }),
     quota: {
       acquireSlot: acquireCodeExecutionSlot,

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -497,8 +497,17 @@ export function createMachineDirectory(
   deps: MachineDirectoryRuntimeDeps = defaultMachineDirectoryDeps,
 ): MachineDirectoryDeps {
   return {
-    listMachines: (rawContext) =>
-      resolveConfiguredMachines(activeMachineAgentPageId(rawContext), rawContext?.userId, deps),
+    listMachines: (rawContext) => {
+      // A machine-bound "PageSpace Agent" pane (issue #2166 phase 7): the
+      // binding IS the entitlement (established by the route's page-edit
+      // check before deriveMachinePaneBinding ran), so the agent's/global
+      // assistant's own configured machine list is never consulted — the
+      // bound machine is the ONLY machine this run may ever see or switch to.
+      if (rawContext?.machineBinding) {
+        return Promise.resolve([{ kind: 'existing' as const, machineId: rawContext.machineBinding.machineId }]);
+      }
+      return resolveConfiguredMachines(activeMachineAgentPageId(rawContext), rawContext?.userId, deps);
+    },
     describeMachine: async (_rawContext, machine) => {
       if (machine.kind === 'own') return { name: 'My Machine' };
       const page = await deps.findPage(machine.machineId);
@@ -516,6 +525,15 @@ export function createMachineDirectory(
       if (!page || page.isTrashed || !isMachinePage(page.type as PageType)) return { allowed: false };
       const canView = await deps.canViewPage(rawContext, machine.machineId);
       if (!canView) return { allowed: false };
+      // A machine-bound "PageSpace Agent" pane (issue #2166 phase 7): the
+      // pane's OWN bound machine is exempt from the Settings-toggle decision
+      // below — same rationale as the user-scoped-agent exemption just below
+      // (the binding IS the entitlement, established by the route's
+      // page-edit check before deriveMachinePaneBinding ran) — but existence/
+      // trash/type/canActorViewPage above are NEVER bypassed. A DIFFERENT
+      // machine (e.g. an attempted switch_machine away from the bound
+      // checkout) still gets the full toggle check below.
+      if (rawContext.machineBinding?.machineId === machine.machineId) return { allowed: true };
       // Machine access toggles (Settings tab): pure policy in @pagespace/lib
       // machines/machine-access.ts. An agentPageId — the agent's own page or
       // the parent's for a sub-agent — marks the actor page-scoped; without

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -45,6 +45,19 @@ export function machineRefEquals(a: MachineRef, b: MachineRef): boolean {
   return machineRefId(a) === machineRefId(b);
 }
 
+/**
+ * `bash`'s cwd-default policy for a machine-bound "PageSpace Agent" pane
+ * (issue #2166 phase 7): an explicit `cwd` argument always wins; absent one,
+ * the binding's own `cwd` (the pane's checkout) is used. Returns `undefined`
+ * when neither is present, preserving the runner's own SANDBOX_ROOT default.
+ */
+export function bindingCwdFor(
+  explicitCwd: string | undefined,
+  binding: { cwd: string } | undefined,
+): string | undefined {
+  return explicitCwd ?? binding?.cwd;
+}
+
 /** Resolves an agent-facing id (from switch_machine's input) back to a configured MachineRef. */
 export function machineRefFromId(id: string, configured: MachineRef[]): MachineRef | undefined {
   return configured.find((m) => machineRefId(m) === id);
@@ -346,7 +359,15 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
     const tenantId = machines.resolveTenantId
       ? await machines.resolveTenantId(rawContext, activeMachine, ctx.tenantId)
       : ctx.tenantId;
-    return { ok: true, ctx: { ...ctx, driveId, tenantId, activeMachine } };
+    // A machine-bound "PageSpace Agent" pane's branchSandbox (issue #2166
+    // phase 7) routes acquireSandbox through the attach-only branch seam
+    // (acquireRequest in tool-runners.ts already forwards ctx.branchSandbox) —
+    // this is the one place that binding is translated onto the actor ctx.
+    const binding = rawContext?.machineBinding;
+    const branchSandbox = binding?.branchSandbox
+      ? { machineId: binding.machineId, machineBranchId: binding.branchSandbox.machineBranchId }
+      : undefined;
+    return { ok: true, ctx: { ...ctx, driveId, tenantId, activeMachine, branchSandbox } };
   };
 
   return {
@@ -357,7 +378,14 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
       execute: async ({ command, cwd, timeoutMs }, options) => {
         const opened = await open(options);
         if (!opened.ok) return opened.error;
-        return runBashInSandbox({ command, cwd, timeoutMs, ctx: opened.ctx, deps: runDeps });
+        const rawContext = readContext(options);
+        return runBashInSandbox({
+          command,
+          cwd: bindingCwdFor(cwd, rawContext?.machineBinding),
+          timeoutMs,
+          ctx: opened.ctx,
+          deps: runDeps,
+        });
       },
     }),
 

--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -49,7 +49,7 @@ import type {
 } from '@pagespace/lib/services/machines/agent-terminals';
 import { canAccessMachine, canViewMachine, getMachineHostForBranches } from './machine-branches-runtime';
 
-export { canAccessMachine, canViewMachine };
+export { canAccessMachine, canViewMachine, isCodeExecutionEnabled };
 
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one —
 // @fly/sprites is ESM-only and @pagespace/lib compiles to CJS. Mirrors the

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -221,6 +221,47 @@ describe('conversationRepository.createConversation', () => {
       expect.objectContaining({ id: 'conv-mine', userId: 'user-1' })
     );
   });
+
+  it('given { isShared: true }, persists a shared row, keeping the squat-guard + onConflictDoNothing', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-shared', 'user-1', 'machine-1', { isShared: true });
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-shared', userId: 'user-1', contextId: 'machine-1', isShared: true })
+    );
+    expect(onConflictDoNothing).toHaveBeenCalled();
+  });
+
+  it('given no opts (or isShared omitted), still defaults to isShared: false', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([]));
+    const onConflictDoNothing = vi.fn().mockResolvedValue(undefined);
+    const valuesMock = vi.fn().mockReturnValue({ onConflictDoNothing });
+    mockDb.insert = vi.fn().mockReturnValue({ values: valuesMock });
+
+    await conversationRepository.createConversation('conv-default', 'user-1', 'agent-1', {});
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'conv-default', isShared: false })
+    );
+  });
+
+  it('given { isShared: true }, still refuses a conversationId owned by a different user (squat-guard applies regardless of isShared)', async () => {
+    mockSelectChain.from
+      .mockImplementationOnce(() => mockConversationsLookup([]))
+      .mockImplementationOnce(() => mockChatMessagesLookup([{ userId: 'victim-user' }]));
+
+    await conversationRepository.createConversation('conv-legacy', 'attacker-user', 'machine-1', { isShared: true });
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
 });
 
 describe('conversationRepository.setConversationShared', () => {

--- a/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/conversation-repository.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ kind: 'eq', field, value })),
   and: vi.fn((...conds) => ({ kind: 'and', conds })),
+  inArray: vi.fn((field, values) => ({ kind: 'inArray', field, values })),
   sql: Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       kind: 'sql',
@@ -113,6 +114,42 @@ describe('conversationRepository.getConversation', () => {
     const result = await conversationRepository.getConversation('conv_missing');
 
     expect(result).toBeNull();
+  });
+});
+
+describe('conversationRepository.getAiAgent', () => {
+  // vi.mocked(db) does not see through Drizzle's query-builder generics.
+  const findFirstMock = () =>
+    mockDb.query.pages.findFirst as unknown as ReturnType<typeof vi.fn>;
+
+  // #2166 Phase 11: MACHINE pages host machine-pane conversations (Phase 4
+  // pre-creates them), so the conversation routes' host-page lookup must
+  // accept both types. Agent-only routes do their own AI_CHAT checks.
+  it('queries for conversation-hosting page types: AI_CHAT and MACHINE', async () => {
+    findFirstMock().mockResolvedValue({
+      id: 'machine_1',
+      title: 'Build box',
+      type: 'MACHINE',
+      driveId: 'drive_1',
+    });
+
+    const result = await conversationRepository.getAiAgent('machine_1');
+
+    expect(result).toEqual(
+      expect.objectContaining({ id: 'machine_1', type: 'MACHINE' }),
+    );
+    const call = findFirstMock().mock.calls[0][0] as { where: { conds: unknown[] } };
+    expect(call.where.conds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: 'inArray', values: ['AI_CHAT', 'MACHINE'] }),
+      ]),
+    );
+  });
+
+  it('returns null when the page does not exist', async () => {
+    findFirstMock().mockResolvedValue(undefined);
+
+    expect(await conversationRepository.getAiAgent('missing')).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -152,7 +152,7 @@ export const conversationRepository = {
    * so every caller — including pre-existing ones — gets this guarantee.
    */
 
-  async createConversation(conversationId: string, userId: string, pageId: string): Promise<void> {
+  async createConversation(conversationId: string, userId: string, pageId: string, opts?: { isShared?: boolean }): Promise<void> {
     const [existing] = await db
       .select({ id: conversations.id })
       .from(conversations)
@@ -170,7 +170,7 @@ export const conversationRepository = {
         userId,
         type: 'page',
         contextId: pageId,
-        isShared: false,
+        isShared: opts?.isShared ?? false,
         updatedAt: new Date(),
       })
       .onConflictDoNothing();

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -5,7 +5,7 @@
  */
 
 import { db } from '@pagespace/db/db'
-import { eq, and, sql } from '@pagespace/db/operators'
+import { eq, and, sql, inArray } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core'
 import { userActivities } from '@pagespace/db/schema/monitoring'
 import { conversations } from '@pagespace/db/schema/conversations';
@@ -180,10 +180,15 @@ export const conversationRepository = {
    * Get an AI_CHAT agent by ID
    */
   async getAiAgent(agentId: string): Promise<AiAgent | null> {
+    // Conversation-hosting pages: AI_CHAT agents, and MACHINE pages — machine
+    // panes anchor their terminal conversations to the machine page (Phase 4
+    // pre-creates them, Phase 11's pane lists/loads them, #2166). Agent-only
+    // routes (config, drives, consult) do their own AI_CHAT checks and are
+    // unaffected by this widening.
     const agent = await db.query.pages.findFirst({
       where: and(
         eq(pages.id, agentId),
-        eq(pages.type, 'AI_CHAT'),
+        inArray(pages.type, ['AI_CHAT', 'MACHINE']),
         eq(pages.isTrashed, false)
       ),
       columns: {

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -580,6 +580,24 @@ describe('useMachineWorkspaceStore', () => {
     });
   });
 
+  it('given hydrateFromServer with a pane scope carrying the content kind, should round-trip it (#2166 phase 9)', () => {
+    store().hydrateFromServer('m1', [
+      {
+        id: 'ws-1',
+        name: 'Workspace 1',
+        scope: {},
+        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: "the sync hook's initial hydrate carrying a pane tagged kind: 'chat'",
+      should: 'round-trip the content kind into the store',
+      actual: panesOf(activeOf('m1')!)[0]?.scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
   it('given applyServerUpsert for an unseen workspace id, should add it', () => {
     seedMachine('m1');
     const existing = activeOf('m1')!;

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -206,6 +206,19 @@ describe('sessionWorkspaceId', () => {
     });
   });
 
+  it('given scopes that differ only by content kind, should resolve to the same workspace id', () => {
+    assert({
+      given: 'the same session scope tagged "chat", "terminal", and untagged',
+      should: 'produce the identical workspace id — the content kind is not part of session identity',
+      actual: new Set([
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3', kind: 'chat' }),
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3', kind: 'terminal' }),
+        sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3' }),
+      ]).size,
+      expected: 1,
+    });
+  });
+
   it('given any scope, should never contain a NUL byte', () => {
     const id = sessionWorkspaceId({ projectName: 'app', branchName: 'main', name: 'claude-a1b2c3' });
 
@@ -337,6 +350,28 @@ describe('assignPane (split-and-pick landing)', () => {
       should:
         'return the state untouched — the store reads that identity to know the session it just created is orphaned, and removes it',
       actual: assignPane(state, 'closed-pane', { name: 'claude-a1b2c3' }),
+      expected: state,
+    });
+  });
+});
+
+describe('assignPane — content kind round-trips on the bound scope (#2166 phase 9)', () => {
+  it('given a scope carrying the content kind, should round-trip it onto the pane', () => {
+    assert({
+      given: 'assignPane with a scope tagged kind: "chat"',
+      should: "round-trip the kind onto the pane's scope, unchanged",
+      actual: panesOf(assignPane(aWorkspace(), 'pane-1', { name: 'claude-a1b2c3', kind: 'chat' }))[0].scope,
+      expected: { name: 'claude-a1b2c3', kind: 'chat' },
+    });
+  });
+
+  it('given an unknown pane id, should be a no-op even when the scope carries a content kind', () => {
+    const state = aWorkspace();
+
+    assert({
+      given: 'a pane id that does not resolve, with a scope carrying a content kind',
+      should: 'be a no-op, same as any other assignPane call',
+      actual: assignPane(state, 'gone', { name: 'claude-a1b2c3', kind: 'chat' }),
       expected: state,
     });
   });
@@ -806,6 +841,48 @@ describe('mergeServerWorkspaces — reconciling the server\'s workspace list', (
   });
 });
 
+describe('mergeServerWorkspaces — round-trips the content kind (#2166 phase 9)', () => {
+  it('given a server workspace whose pane scope carries the content kind, should round-trip it', () => {
+    const merged = mergeServerWorkspaces(undefined, [
+      {
+        id: 'ws-1',
+        name: 'Workspace 1',
+        scope: {},
+        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: 'a server payload whose pane scope is tagged kind: "chat"',
+      should: 'round-trip the tag into local state — server isValidLayout is lenient, so this is not stripped in transit',
+      actual: panesOf(merged.workspaces['ws-1'])[0].scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
+  it("given a surviving pane with a local pendingPrompt, should preserve both the prompt and the server's content kind", () => {
+    const local = initialMachineWorkspaces(
+      assignPane(aWorkspace('ws-1', 'pane-1'), 'pane-1', { name: 'claude-a1' }, 'fix the build')
+    );
+
+    const merged = mergeServerWorkspaces(local, [
+      {
+        id: 'ws-1',
+        name: 'ws-1',
+        scope: BRANCH_SCOPE,
+        columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+      },
+    ]);
+
+    assert({
+      given: 'an incoming layout for a pane that survives locally with an undelivered prompt, whose server scope now carries a content kind',
+      should: 'keep the local pendingPrompt AND adopt the server content kind together — same merge, two fields',
+      actual: panesOf(merged.workspaces['ws-1'])[0],
+      expected: { id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' }, pendingPrompt: 'fix the build' },
+    });
+  });
+});
+
 describe('applyServerWorkspaceUpsert', () => {
   it('given a brand-new workspace id, should add it to the end of order', () => {
     const machine = initialMachineWorkspaces(aWorkspace('ws-a', 'a1'));
@@ -990,6 +1067,61 @@ describe('sanitizeMachines — what comes back from storage is untrusted', () =>
         'point active at a real pane — every grid transition no-ops on a pane it cannot resolve, so a split anchored on a phantom would silently do nothing',
       actual: sanitizeMachines(persisted).m1.workspaces['ws-1'].activePaneId,
       expected: 'pane-1',
+    });
+  });
+
+  it('given a persisted pane scope carrying the content kind, should preserve it (#2166 phase 9)', () => {
+    const persisted = {
+      m1: {
+        workspaces: {
+          'ws-1': {
+            id: 'ws-1',
+            name: 'ws-1',
+            scope: {},
+            columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+            activePaneId: 'pane-1',
+          },
+        },
+        order: ['ws-1'],
+        activeWorkspaceId: 'ws-1',
+      },
+    };
+
+    const actual = sanitizeMachines(persisted).m1.workspaces['ws-1'];
+
+    assert({
+      given: 'a rehydrated pane whose scope carries kind: "chat"',
+      should: 'preserve the content kind on the way through, not strip it as an unrecognized field',
+      actual: panesOf(actual)[0].scope,
+      expected: { name: 'claude-a1', kind: 'chat' },
+    });
+  });
+
+  it('given a persisted activePaneId that does not resolve, should still repoint it while preserving the content kind on surviving panes', () => {
+    const persisted = {
+      m1: {
+        workspaces: {
+          'ws-1': {
+            id: 'ws-1',
+            name: 'ws-1',
+            scope: {},
+            columns: [{ id: 'pane-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+            activePaneId: 'pane-that-was-closed',
+          },
+        },
+        order: ['ws-1'],
+        activeWorkspaceId: 'ws-1',
+      },
+    };
+
+    const actual = sanitizeMachines(persisted).m1.workspaces['ws-1'];
+
+    assert({
+      given: 'an activePaneId that no longer resolves, on a workspace whose surviving pane carries a content kind',
+      should:
+        'repoint active at the real pane and keep the content kind intact — same no-op-on-unknown-id contract as every other transition here',
+      actual: { activePaneId: actual.activePaneId, scope: panesOf(actual)[0].scope },
+      expected: { activePaneId: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } },
     });
   });
 });

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -28,6 +28,14 @@ export interface OpenTerminalScope {
   projectName?: string;
   branchName?: string;
   name: string;
+  /** What the pane renders once bound: an xterm PTY, or the PageSpace Agent
+   * chat UI (#2166). Omitted means `'terminal'` — every session bound before
+   * this tag existed is a PTY, so the renderer can treat a missing kind the
+   * same as an explicit one without a migration. Lives on the scope, not a
+   * loose `agentType` string, so it survives every place a scope already
+   * flows opaquely (assignPane, sanitizeMachines, mergeServerWorkspaces)
+   * without those transitions needing to know about it. */
+  kind?: 'terminal' | 'chat';
 }
 
 /**

--- a/knip.json
+++ b/knip.json
@@ -42,7 +42,8 @@
         "src/lib/auth/platform-storage/web-storage.ts",
         "src/test/next-server-stub.ts",
         "src/__fixtures__/eslint-unbounded-findmany/**",
-        "src/components/ai/ui/web-preview.tsx"
+        "src/components/ai/ui/web-preview.tsx",
+        "src/lib/ai/machine-pane/machine-pane-binding-runtime.ts"
       ],
       "ignoreDependencies": [
         "eslint-config-next",
@@ -428,6 +429,7 @@
         "src/services/machines/machine-branches.ts",
         "src/services/machines/machine-list.ts",
         "src/services/machines/machine-orphan-reconcile.ts",
+        "src/services/machines/machine-pane-binding.ts",
         "src/services/machines/machine-projects-store.ts",
         "src/services/machines/machine-projects.ts",
         "src/services/machines/machine-settings.ts",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -682,6 +682,11 @@
       "import": "./dist/services/machines/agent-terminals.js",
       "require": "./dist/services/machines/agent-terminals.js"
     },
+    "./services/machines/machine-pane-binding": {
+      "types": "./dist/services/machines/machine-pane-binding.d.ts",
+      "import": "./dist/services/machines/machine-pane-binding.js",
+      "require": "./dist/services/machines/machine-pane-binding.js"
+    },
     "./services/machines/machine-access": {
       "types": "./dist/services/machines/machine-access.d.ts",
       "import": "./dist/services/machines/machine-access.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -502,6 +502,11 @@
       "import": "./dist/services/sandbox/machine-session.js",
       "require": "./dist/services/sandbox/machine-session.js"
     },
+    "./services/sandbox/branch-session": {
+      "types": "./dist/services/sandbox/branch-session.d.ts",
+      "import": "./dist/services/sandbox/branch-session.js",
+      "require": "./dist/services/sandbox/branch-session.js"
+    },
     "./services/sandbox/machine-billing": {
       "types": "./dist/services/sandbox/machine-billing.d.ts",
       "import": "./dist/services/sandbox/machine-billing.js",
@@ -1846,6 +1851,9 @@
       ],
       "services/sandbox/machine-session": [
         "./dist/services/sandbox/machine-session.d.ts"
+      ],
+      "services/sandbox/branch-session": [
+        "./dist/services/sandbox/branch-session.d.ts"
       ],
       "services/sandbox/machine-billing": [
         "./dist/services/sandbox/machine-billing.d.ts"

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -6,6 +6,8 @@ import {
   resolveAgentLaunchSpec,
   isValidAgentTerminalName,
   isValidAgentTerminalCommand,
+  isPtyAgentType,
+  agentSurfaceOf,
 } from '../agent-terminal-types';
 
 describe('isAgentRuntimeType', () => {
@@ -23,6 +25,10 @@ describe('isAgentRuntimeType', () => {
 
   it('given the retired pagespace-cli agent type, should reject it as unrecognized (not crash)', () => {
     expect(isAgentRuntimeType('pagespace-cli')).toBe(false);
+  });
+
+  it('given the pagespace agent type, should recognize it', () => {
+    expect(isAgentRuntimeType('pagespace')).toBe(true);
   });
 });
 
@@ -47,7 +53,7 @@ describe('resolveAgentLaunchSpec', () => {
   });
 
   it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex']);
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex', 'pagespace']);
   });
 
   it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
@@ -56,12 +62,49 @@ describe('resolveAgentLaunchSpec', () => {
 });
 
 describe('PICKABLE_AGENT_TYPES', () => {
-  it('should include shell (primary) plus claude and codex (secondary) — only the retired pagespace-cli is excluded', () => {
-    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex']);
+  it('should include shell (primary) plus claude, codex, and pagespace (secondary) — only the retired pagespace-cli is excluded', () => {
+    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex', 'pagespace']);
   });
 
   it('should list shell FIRST — a plain interactive shell is the default, primary way to work on a Machine', () => {
     expect(PICKABLE_AGENT_TYPES[0]).toBe('shell');
+  });
+});
+
+describe('agentSurfaceOf', () => {
+  it('given pagespace, should return chat', () => {
+    expect(agentSurfaceOf('pagespace')).toBe('chat');
+  });
+
+  it('given shell, claude, or codex, should return pty', () => {
+    expect(agentSurfaceOf('shell')).toBe('pty');
+    expect(agentSurfaceOf('claude')).toBe('pty');
+    expect(agentSurfaceOf('codex')).toBe('pty');
+  });
+});
+
+describe('isPtyAgentType', () => {
+  it('given pagespace, should return false', () => {
+    expect(isPtyAgentType('pagespace')).toBe(false);
+  });
+
+  it('given shell, claude, or codex, should return true', () => {
+    expect(isPtyAgentType('shell')).toBe(true);
+    expect(isPtyAgentType('claude')).toBe(true);
+    expect(isPtyAgentType('codex')).toBe(true);
+  });
+});
+
+describe('agent type identifiers stay compatible with autoSessionName', () => {
+  // autoSessionName (apps/web/src/stores/machine-workspace/workspace-reducer.ts) builds
+  // `${agentType}-${suffix}` or bare `agentType` for the split-and-pick spawn name — this
+  // guards that every registry key, including the new `pagespace` type, still produces a
+  // name isValidAgentTerminalName accepts.
+  it('given every pickable agent type, should produce identifiers that satisfy isValidAgentTerminalName', () => {
+    for (const type of PICKABLE_AGENT_TYPES) {
+      expect(isValidAgentTerminalName(type)).toBe(true);
+      expect(isValidAgentTerminalName(`${type}-a1b2c3`)).toBe(true);
+    }
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -467,6 +467,70 @@ describe('spawnAgentTerminal — machine scope', () => {
   });
 });
 
+describe('spawnAgentTerminal — pagespace (chat-surface) has NO spawn-side type restriction', () => {
+  it('given a fresh pagespace spawn at branch scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, agentType: 'pagespace' });
+  });
+
+  it('given a fresh pagespace spawn at project scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null, agentType: 'pagespace' });
+  });
+
+  it('given a fresh pagespace spawn at machine scope, should reserve it exactly like a pty type', async () => {
+    const { store, rows } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const result = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+    expect(result).toMatchObject({ ok: true, agentType: 'pagespace', resumed: false });
+    expect([...rows.values()][0]).toMatchObject({ scope: 'machine', projectName: null, machineBranchId: null, agentType: 'pagespace' });
+  });
+
+  it('given a repeat pagespace spawn of the same name, should resume idempotently rather than duplicate', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const first = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    const second = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    expect(first.ok && second.ok && first.id === second.id).toBe(true);
+    expect(second).toMatchObject({ resumed: true });
+  });
+
+  it('given the same name reused under a DIFFERENT agent type (claude then pagespace), should reject as name_in_use', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'claude', actor, deps });
+    const conflicting = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+    expect(conflicting).toEqual({ ok: false, reason: 'name_in_use' });
+  });
+});
+
 describe('resolveAgentTerminalRow', () => {
   // The whole point of this resolver: it answers "does this target still exist?"
   // with DB reads alone. Passing `machineSandbox: undefined` throughout is the
@@ -534,6 +598,16 @@ describe('resolveAgentTerminalRow', () => {
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, branchName: BRANCH_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: false, reason: 'invalid_target' });
+  });
+
+  it('given a pagespace (chat-surface) row, should deny not_a_pty_agent WITHOUT any machineSandbox', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store, projectStore: makeProjectLookup(), machineSandbox: undefined });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
   });
 });
 
@@ -681,6 +755,51 @@ describe('resolveAgentTerminal', () => {
 
     expect(result).toEqual({ ok: false, reason: 'machine_unavailable' });
   });
+
+  it('given a pagespace (chat-surface) row at machine scope, should deny not_a_pty_agent WITHOUT acquiring the machine Sprite', async () => {
+    const { store } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+    expect(acquireCalls).toEqual([]);
+  });
+
+  it('given a pagespace (chat-surface) row at branch scope, should deny not_a_pty_agent', async () => {
+    const { store } = makeStore();
+    const deps = makeDeps({ store });
+    await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      agentType: 'pagespace',
+      actor,
+      deps,
+    });
+
+    const result = await resolveAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      branchName: BRANCH_NAME,
+      name: 'agent',
+      deps,
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+  });
 });
 
 describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} parity)', () => {
@@ -775,6 +894,27 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
 
     expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
   });
+
+  it('given a pagespace (chat-surface) row id, should deny not_a_pty_agent WITHOUT acquiring the machine Sprite', async () => {
+    const { store } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({ ok: false, reason: 'not_a_pty_agent' });
+    expect(acquireCalls).toEqual([]);
+  });
 });
 
 describe('listAgentTerminals', () => {
@@ -839,6 +979,74 @@ describe('killAgentTerminal', () => {
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
     expect(result).toEqual({ ok: true });
+    expect(attachCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a PROJECT-scoped agent terminal whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'claude', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a MACHINE-scoped agent terminal whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a pagespace (chat-surface) agent terminal (never has a streamSessionId), should drop the row WITHOUT touching the Sprite at all', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const attachCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+      host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
+    });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await killAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
     expect(attachCalls).toEqual([]);
     expect(rows.size).toBe(0);
   });
@@ -1119,14 +1327,50 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
     expect(rows.size).toBe(0);
   });
 
-  it('given a machine-scoped row id, should acquire the machine Sprite and drop the row', async () => {
+  it('given a machine-scoped row id whose PTY was never opened (no streamSessionId), should drop the row WITHOUT acquiring the machine Sprite', async () => {
     const { store, rows } = makeStore();
-    const deps = makeDeps({ store, projectStore: makeProjectLookup() });
+    const acquireCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+    });
     const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
 
     const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
     expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(rows.size).toBe(0);
+  });
+
+  it('given a pagespace (chat-surface) row id (never has a streamSessionId), should drop the row WITHOUT touching the Sprite at all', async () => {
+    const { store, rows } = makeStore();
+    const acquireCalls: string[] = [];
+    const attachCalls: string[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: makeProjectLookup(),
+      machineSandbox: makeMachineSandbox({
+        acquire: async (machineId) => {
+          acquireCalls.push(machineId);
+          return { ok: true, sandboxId: MACHINE_SANDBOX_ID };
+        },
+      }),
+      host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
+    });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
+
+    const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
+
+    expect(result).toEqual({ ok: true });
+    expect(acquireCalls).toEqual([]);
+    expect(attachCalls).toEqual([]);
     expect(rows.size).toBe(0);
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { deriveMachinePaneBinding, type DeriveMachinePaneBindingDeps } from '../machine-pane-binding';
+import type { MachineAgentTerminalRecord } from '../agent-terminals-store';
+import { SANDBOX_ROOT } from '../../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from '../machine-branches';
+
+const NOW = new Date('2026-07-20T12:00:00.000Z');
+const MACHINE_ID = 'machine-1';
+const CONVERSATION_ID = 'agent-terminal-1';
+const PROJECT_NAME = 'my-repo';
+const PROJECT_PATH = '/workspace/projects/my-repo';
+const BRANCH_ID = 'branch-1';
+const BRANCH_SANDBOX_ID = 'sprite-branch-1';
+
+function makeRow(overrides: Partial<MachineAgentTerminalRecord> = {}): MachineAgentTerminalRecord {
+  return {
+    id: CONVERSATION_ID,
+    ownerId: 'user-1',
+    machineId: MACHINE_ID,
+    scope: 'machine',
+    projectName: null,
+    machineBranchId: null,
+    name: 'pagespace-agent',
+    agentType: 'pagespace',
+    command: null,
+    streamSessionId: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeTerminalStore(row: MachineAgentTerminalRecord | null): DeriveMachinePaneBindingDeps['terminalStore'] {
+  return { findById: async (id) => (id === CONVERSATION_ID ? row : null) };
+}
+
+function makeProjectLookup(rows: Record<string, { path: string }> = {}): DeriveMachinePaneBindingDeps['projectLookup'] {
+  return { findByName: async (machineId, name) => rows[`${machineId}\0${name}`] ?? null };
+}
+
+function makeBranchLookup(
+  rows: Record<string, { sandboxId: string; spriteTornDownAt: Date | null }> = {},
+): DeriveMachinePaneBindingDeps['branchLookup'] {
+  return { findById: async (id) => rows[id] ?? null };
+}
+
+function makeDeps(overrides: Partial<DeriveMachinePaneBindingDeps> = {}): DeriveMachinePaneBindingDeps {
+  return {
+    terminalStore: makeTerminalStore(null),
+    projectLookup: makeProjectLookup(),
+    branchLookup: makeBranchLookup(),
+    ...overrides,
+  };
+}
+
+describe('deriveMachinePaneBinding', () => {
+  it('given no row, should return null', async () => {
+    const deps = makeDeps({ terminalStore: makeTerminalStore(null) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given a non-pagespace (pty-surface) row, should return null', async () => {
+    const row = makeRow({ agentType: 'claude' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given a row with an unrecognized/retired agentType (e.g. pagespace-cli), should return null', async () => {
+    const row = makeRow({ agentType: 'pagespace-cli' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toBeNull();
+  });
+
+  it('given row.machineId !== chatId, should fail closed with binding_page_mismatch', async () => {
+    const row = makeRow({ machineId: 'a-different-machine' });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'binding_page_mismatch' });
+  });
+
+  it('given machine scope, should bind cwd to SANDBOX_ROOT', async () => {
+    const row = makeRow({ scope: 'machine', projectName: null, machineBranchId: null });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: true, binding: { cwd: SANDBOX_ROOT } });
+  });
+
+  it('given project scope with a known project, should bind cwd to the project path', async () => {
+    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      projectLookup: makeProjectLookup({ [`${MACHINE_ID}\0${PROJECT_NAME}`]: { path: PROJECT_PATH } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: true, binding: { cwd: PROJECT_PATH } });
+  });
+
+  it('given project scope with a missing project, should fail closed with project_not_found', async () => {
+    const row = makeRow({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row), projectLookup: makeProjectLookup({}) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'project_not_found' });
+  });
+
+  it('given branch scope with a live branch, should bind cwd to BRANCH_REPO_PATH with the branchSandbox', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      branchLookup: makeBranchLookup({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: null } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({
+      ok: true,
+      binding: { cwd: BRANCH_REPO_PATH, branchSandbox: { machineBranchId: BRANCH_ID, sandboxId: BRANCH_SANDBOX_ID } },
+    });
+  });
+
+  it('given branch scope with a missing branch row, should fail closed with branch_not_found', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({ terminalStore: makeTerminalStore(row), branchLookup: makeBranchLookup({}) });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+  });
+
+  it('given branch scope with a destroyed branch (spriteTornDownAt set), should fail closed with branch_not_found', async () => {
+    const row = makeRow({ scope: 'branch', projectName: PROJECT_NAME, machineBranchId: BRANCH_ID });
+    const deps = makeDeps({
+      terminalStore: makeTerminalStore(row),
+      branchLookup: makeBranchLookup({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: NOW } }),
+    });
+    const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+  });
+});

--- a/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-workspaces.test.ts
@@ -10,6 +10,7 @@ import {
   isBootstrapped,
   bootstrapWorkspaces,
   type MachineWorkspacesDeps,
+  type WorkspaceLayoutInput,
 } from '../machine-workspaces';
 import type { MachineWorkspaceStore, MachineWorkspaceRecord, NewMachineWorkspaceInput } from '../machine-workspaces-store';
 
@@ -153,6 +154,19 @@ describe('isValidWorkspaceName / planWorkspacePayload', () => {
   it('accepts a well-shaped payload', () => {
     const plan = planWorkspacePayload({ name: 'Workspace 1', layout: VALID_COLUMNS });
     expect(plan).toEqual({ ok: true, name: 'Workspace 1', layout: VALID_COLUMNS });
+  });
+
+  // #2166 phase 9 — the client tags a pane's bound scope with a content kind
+  // ('terminal' | 'chat'); this mirror type and its lenient runtime check must
+  // tolerate it so a workspace layout carrying the tag round-trips through create/update.
+  it('accepts a pane scope carrying the content kind — mirrors the client\'s tagged bound scope, lenient by design', () => {
+    const layoutWithKind: WorkspaceLayoutInput = {
+      columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+    };
+
+    const plan = planWorkspacePayload({ name: 'Workspace 1', layout: layoutWithKind });
+
+    expect(plan).toEqual({ ok: true, name: 'Workspace 1', layout: layoutWithKind });
   });
 });
 

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -25,17 +25,28 @@
  * `pickable` gates the empty-pane "spawn an agent" picker (`TerminalPanes.tsx`
  * — see `PICKABLE_AGENT_TYPES` below). `shell` is PRIMARY here — a plain
  * interactive shell is the default, first-class way to work on a Machine —
- * with `claude`/`codex` as secondary, opt-in AI agents. Only the retired
- * `pagespace-cli` is excluded. Keeping the marker on the registry entry
- * itself (rather than a hardcoded list living in the UI file) is what keeps
- * the picker in sync when a new entry is added here: forgetting to set
+ * with `claude`/`codex`/`pagespace` as secondary, opt-in AI agents. Only the
+ * retired `pagespace-cli` is excluded. Keeping the marker on the registry
+ * entry itself (rather than a hardcoded list living in the UI file) is what
+ * keeps the picker in sync when a new entry is added here: forgetting to set
  * `pickable: true` fails safe (excluded, not silently spawnable).
+ *
+ * `surface` is the rendering discriminator every pane-hosting layer branches
+ * on: `'pty'` types spawn a real PTY process (`command`/`args` are launched
+ * for real); `'chat'` types render the PageSpace AI chat UI in the pane
+ * instead — `pagespace`'s `command` is a dead sentinel, never launched. See
+ * `agentSurfaceOf`/`isPtyAgentType` below for the pure accessors callers
+ * should use rather than reading `.surface` off the registry directly.
  */
 export const AGENT_LAUNCH_SPECS = {
-  shell: { command: 'shell', args: [], pickable: true },
-  claude: { command: 'claude', args: [], pickable: true },
-  codex: { command: 'codex', args: [], pickable: true },
-} as const satisfies Record<string, { command: string; args: readonly string[]; pickable: boolean }>;
+  shell: { command: 'shell', args: [], pickable: true, surface: 'pty' },
+  claude: { command: 'claude', args: [], pickable: true, surface: 'pty' },
+  codex: { command: 'codex', args: [], pickable: true, surface: 'pty' },
+  pagespace: { command: 'pagespace', args: [], pickable: true, surface: 'chat' },
+} as const satisfies Record<
+  string,
+  { command: string; args: readonly string[]; pickable: boolean; surface: 'pty' | 'chat' }
+>;
 
 export type AgentRuntimeType = keyof typeof AGENT_LAUNCH_SPECS;
 
@@ -57,6 +68,18 @@ export function isAgentRuntimeType(value: string): value is AgentRuntimeType {
 export function resolveAgentLaunchSpec(type: AgentRuntimeType): AgentLaunchSpec {
   const spec = AGENT_LAUNCH_SPECS[type];
   return { command: spec.command, args: [...spec.args] };
+}
+
+export type AgentSurface = 'pty' | 'chat';
+
+/** The pane surface a given agent type renders: a real PTY process, or the PageSpace AI chat UI. */
+export function agentSurfaceOf(type: AgentRuntimeType): AgentSurface {
+  return AGENT_LAUNCH_SPECS[type].surface;
+}
+
+/** Whether an agent type spawns a real PTY process (as opposed to a `'chat'`-surface type like `pagespace`). */
+export function isPtyAgentType(type: AgentRuntimeType): boolean {
+  return agentSurfaceOf(type) === 'pty';
 }
 
 const MAX_AGENT_TERMINAL_NAME_LENGTH = 100;

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -47,7 +47,13 @@ import {
   type AgentTerminalScope,
   deriveAgentTerminalScope,
 } from './agent-terminals-store';
-import { isValidAgentTerminalName, isValidAgentTerminalCommand, isAgentRuntimeType, type AgentRuntimeType } from './agent-terminal-types';
+import {
+  isValidAgentTerminalName,
+  isValidAgentTerminalCommand,
+  isAgentRuntimeType,
+  isPtyAgentType,
+  type AgentRuntimeType,
+} from './agent-terminal-types';
 
 export type { AgentTerminalScopeKey, AgentTerminalScope };
 export { deriveAgentTerminalScope };
@@ -176,45 +182,6 @@ async function resolveProjectOrMachineLocation({
   return { ok: true, sandboxId: acquired.sandboxId, cwd };
 }
 
-type ScopeLocationResolution =
-  | { ok: true; scopeKey: AgentTerminalScopeKey; sandboxId: string; cwd: string }
-  | { ok: false; reason: AgentTerminalScopeDenialReason };
-
-/** Resolve WHERE a scope target's Sprite + working directory live, by (project, branch) NAME — used by the by-name resolve/kill path. */
-async function resolveScopeLocation({
-  machineId,
-  projectName,
-  branchName,
-  deps,
-}: {
-  machineId: string;
-  projectName?: string;
-  branchName?: string;
-  deps: Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox'>;
-}): Promise<ScopeLocationResolution> {
-  if (branchName !== undefined) {
-    if (!projectName) return { ok: false, reason: 'invalid_target' };
-    const branch = await deps.branchStore.findByName(machineId, projectName, branchName);
-    if (!branch) return { ok: false, reason: 'branch_not_found' };
-    return {
-      ok: true,
-      scopeKey: { machineId, projectName, machineBranchId: branch.id },
-      sandboxId: branch.sandboxId,
-      cwd: BRANCH_REPO_PATH,
-    };
-  }
-
-  const resolvedProjectName = projectName ?? null;
-  const located = await resolveProjectOrMachineLocation({ machineId, projectName: resolvedProjectName, deps });
-  if (!located.ok) return located;
-  return {
-    ok: true,
-    scopeKey: { machineId, projectName: resolvedProjectName, machineBranchId: null },
-    sandboxId: located.sandboxId,
-    cwd: located.cwd,
-  };
-}
-
 /** Resolve WHERE an already-known ROW's Sprite + working directory live, by its OWN scope columns — the level-agnostic path (no name lookup at all). */
 async function resolveLocationForRow(
   row: Pick<MachineAgentTerminalRecord, 'machineId' | 'projectName' | 'machineBranchId'>,
@@ -321,16 +288,33 @@ export type ResolveAgentTerminalResult =
       command: string | null;
       streamSessionId: string | null;
     }
-  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' | 'not_a_pty_agent' };
 
-function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId: string; cwd: string }): ResolveAgentTerminalResult {
+/**
+ * Is this row's agentType valid AND does it actually spawn a PTY (as opposed
+ * to a `'chat'`-surface type like `pagespace`)? Every resolve/kill path that
+ * would otherwise wake or attach a Sprite must run this check FIRST — a row
+ * nothing can ever launch a PTY on has no business touching a Sprite at all.
+ */
+function checkPtyAgentRow(
+  row: Pick<MachineAgentTerminalRecord, 'agentType'>,
+): { ok: true; agentType: AgentRuntimeType } | { ok: false; reason: 'not_found' | 'not_a_pty_agent' } {
   if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
+  if (!isPtyAgentType(row.agentType)) return { ok: false, reason: 'not_a_pty_agent' };
+  return { ok: true, agentType: row.agentType };
+}
+
+function toResolveResult(
+  row: MachineAgentTerminalRecord,
+  agentType: AgentRuntimeType,
+  location: { sandboxId: string; cwd: string },
+): ResolveAgentTerminalResult {
   return {
     ok: true,
     agentTerminalId: row.id,
     sandboxId: location.sandboxId,
     cwd: location.cwd,
-    agentType: row.agentType,
+    agentType,
     command: row.command,
     streamSessionId: row.streamSessionId,
   };
@@ -338,7 +322,7 @@ function toResolveResult(row: MachineAgentTerminalRecord, location: { sandboxId:
 
 export type ResolveAgentTerminalRowResult =
   | { ok: true; agentTerminalId: string; agentType: AgentRuntimeType }
-  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' };
+  | { ok: false; reason: AgentTerminalScopeDenialReason | 'not_found' | 'not_a_pty_agent' };
 
 export type ResolveAgentTerminalRowDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store'>;
 
@@ -372,8 +356,9 @@ export async function resolveAgentTerminalRow({
 
   const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
-  if (!isAgentRuntimeType(row.agentType)) return { ok: false, reason: 'not_found' };
-  return { ok: true, agentTerminalId: row.id, agentType: row.agentType };
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
+  return { ok: true, agentTerminalId: row.id, agentType: check.agentType };
 }
 
 /**
@@ -392,12 +377,17 @@ export async function resolveAgentTerminal({
   name,
   deps,
 }: AgentTerminalTarget & { deps: ResolveAgentTerminalDeps }): Promise<ResolveAgentTerminalResult> {
-  const location = await resolveScopeLocation({ machineId, projectName, branchName, deps });
-  if (!location.ok) return location;
+  const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
 
-  const row = await deps.store.findByName(location.scopeKey, name);
+  const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
-  return toResolveResult(row, location);
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+  return toResolveResult(row, check.agentType, location);
 }
 
 /**
@@ -422,10 +412,12 @@ export async function resolveAgentTerminalById({
 }): Promise<ResolveAgentTerminalResult> {
   const row = await deps.store.findById(agentTerminalId);
   if (!row) return { ok: false, reason: 'not_found' };
+  const check = checkPtyAgentRow(row);
+  if (!check.ok) return check;
 
   const location = await resolveLocationForRow(row, deps);
   if (!location.ok) return location;
-  return toResolveResult(row, location);
+  return toResolveResult(row, check.agentType, location);
 }
 
 export async function listAgentTerminals({
@@ -501,6 +493,25 @@ async function killAtLocation(
 }
 
 /**
+ * A row with `streamSessionId === null` (a chat-surface row, which never has
+ * one, or a PTY row whose stream was never opened) has nothing running to
+ * kill — drop it with a DB-only write, no Sprite touch at all. Only a row
+ * whose PTY IS running needs its scope's Sprite resolved (which, for
+ * machine/project scope, may acquire/reconnect it) before `killAtLocation`
+ * can reach in and kill that specific session.
+ */
+async function killRow(row: MachineAgentTerminalRecord, deps: KillAgentTerminalDeps): Promise<KillAgentTerminalResult> {
+  if (row.streamSessionId === null) {
+    await deps.store.remove({ machineId: row.machineId, projectName: row.projectName, machineBranchId: row.machineBranchId }, row.name);
+    return { ok: true };
+  }
+
+  const location = await resolveLocationForRow(row, deps);
+  if (!location.ok) return location;
+  return killAtLocation(row, location, deps);
+}
+
+/**
  * Tear down a named agent terminal: if its process was ever actually
  * launched (`streamSessionId` set), attach the scope's Sprite through the
  * `MachineHost` seam and kill that specific PTY session, then drop the
@@ -515,13 +526,13 @@ export async function killAgentTerminal({
   name,
   deps,
 }: AgentTerminalTarget & { deps: KillAgentTerminalDeps }): Promise<KillAgentTerminalResult> {
-  const location = await resolveScopeLocation({ machineId, projectName, branchName, deps });
-  if (!location.ok) return location;
+  const scope = await resolveScopeKey({ machineId, projectName, branchName, deps });
+  if (!scope.ok) return scope;
 
-  const row = await deps.store.findByName(location.scopeKey, name);
+  const row = await deps.store.findByName(scope.scopeKey, name);
   if (!row) return { ok: false, reason: 'not_found' };
 
-  return killAtLocation(row, location, deps);
+  return killRow(row, deps);
 }
 
 /**
@@ -543,8 +554,5 @@ export async function killAgentTerminalById({
   const row = await deps.store.findById(agentTerminalId);
   if (!row) return { ok: false, reason: 'not_found' };
 
-  const location = await resolveLocationForRow(row, deps);
-  if (!location.ok) return location;
-
-  return killAtLocation(row, location, deps);
+  return killRow(row, deps);
 }

--- a/packages/lib/src/services/machines/machine-pane-binding.ts
+++ b/packages/lib/src/services/machines/machine-pane-binding.ts
@@ -1,0 +1,116 @@
+/**
+ * Machine Pane binding: pure core (IO injected, no DB, no clock).
+ *
+ * The "PageSpace Agent" pane type (issue #2166) reuses `POST /api/ai/chat` in
+ * DEFAULT mode with `conversationId := machine_agent_terminals.id` — a
+ * `pagespace`-typed agent-terminal row IS the pane's identity. This module
+ * derives that row into the server-authoritative binding that pins the run's
+ * default-mode code-exec tools (bash/readFile/writeFile/editFile) to the
+ * right machine checkout, mirroring `resolveLocationForRow` in
+ * `agent-terminals.ts` (same branch → project → machine dispatch, by the
+ * row's own nullable scope columns) but for the pane's tool-context seam
+ * instead of the realtime PTY bridge.
+ *
+ * `chatId` (the Machine page id the client claims to be talking to) is
+ * checked against the resolved row's OWN `machineId` — never trusted from the
+ * row alone — because `conversationId` is client-suppliable and a stale or
+ * forged pairing must not silently bind tools to a DIFFERENT machine than the
+ * pane the user is actually looking at.
+ */
+
+import type { MachineAgentTerminalStore } from './agent-terminals-store';
+import { SANDBOX_ROOT } from '../sandbox/sandbox-paths';
+import { BRANCH_REPO_PATH } from './machine-branches';
+import { isAgentRuntimeType, isPtyAgentType } from './agent-terminal-types';
+
+export type MachinePaneBindingFailureReason = 'binding_page_mismatch' | 'project_not_found' | 'branch_not_found';
+
+export interface MachinePaneBindingBranchSandbox {
+  machineBranchId: string;
+  sandboxId: string;
+}
+
+export interface MachinePaneBinding {
+  cwd: string;
+  branchSandbox?: MachinePaneBindingBranchSandbox;
+}
+
+export type MachinePaneBindingResult =
+  | null
+  | { ok: true; binding: MachinePaneBinding }
+  | { ok: false; reason: MachinePaneBindingFailureReason };
+
+export interface DeriveMachinePaneBindingInput {
+  /** The Machine page id the client claims this pane belongs to. */
+  chatId: string;
+  /** The agent-terminal row id (`machine_agent_terminals.id`) backing this pane. */
+  conversationId: string;
+}
+
+/** The minimal slice of the Projects store this module needs — just enough to resolve a project's clone path. */
+export interface MachinePaneBindingProjectLookup {
+  findByName(machineId: string, name: string): Promise<{ path: string } | null>;
+}
+
+/** The minimal slice of the Branches store this module needs — a branch's Sprite plus whether it's been confirmed destroyed. */
+export interface MachinePaneBindingBranchLookup {
+  findById(machineBranchId: string): Promise<{ sandboxId: string; spriteTornDownAt: Date | null } | null>;
+}
+
+export interface DeriveMachinePaneBindingDeps {
+  terminalStore: Pick<MachineAgentTerminalStore, 'findById'>;
+  projectLookup: MachinePaneBindingProjectLookup;
+  branchLookup: MachinePaneBindingBranchLookup;
+}
+
+/**
+ * Derive the machine-pane tool binding for a conversation, or `null` when
+ * this conversation isn't a machine-bound PageSpace Agent pane at all — no
+ * row, an unrecognized/retired `agentType` (e.g. `pagespace-cli`), or a
+ * `'pty'`-surface type (`shell`/`claude`/`codex`) whose own conversation is
+ * never machine-bound. Uses `isAgentRuntimeType`/`isPtyAgentType`
+ * (`agent-terminal-types.ts`) rather than comparing against a hardcoded
+ * `'pagespace'` literal, per that module's own doc comment — this stays
+ * correct if a future `'chat'`-surface type joins the registry. A resolved
+ * chat-surface row that fails page-identity or scope-existence checks fails
+ * CLOSED (`ok: false`) rather than falling back to an unbound run.
+ *
+ * PERFORMS NO ACCESS CHECK on `input.chatId` itself (mirrors the same
+ * explicit caveat on `resolveAgentTerminalById` in `agent-terminals.ts`) —
+ * the `binding_page_mismatch` check only verifies that the resolved row is
+ * INTERNALLY CONSISTENT with the `chatId` the caller supplied, not that the
+ * caller is entitled to that machine. Whoever wires the actual call site
+ * (issue #2166 phases 6/7) MUST authorize the acting user against `chatId`
+ * BEFORE calling this — the same way the chat route already authorizes page
+ * access for every request.
+ */
+export async function deriveMachinePaneBinding(
+  input: DeriveMachinePaneBindingInput,
+  deps: DeriveMachinePaneBindingDeps,
+): Promise<MachinePaneBindingResult> {
+  const row = await deps.terminalStore.findById(input.conversationId);
+  if (!row) return null;
+  if (!isAgentRuntimeType(row.agentType)) return null;
+  if (isPtyAgentType(row.agentType)) return null;
+  if (row.machineId !== input.chatId) return { ok: false, reason: 'binding_page_mismatch' };
+
+  if (row.machineBranchId) {
+    const branch = await deps.branchLookup.findById(row.machineBranchId);
+    if (!branch || branch.spriteTornDownAt !== null) return { ok: false, reason: 'branch_not_found' };
+    return {
+      ok: true,
+      binding: {
+        cwd: BRANCH_REPO_PATH,
+        branchSandbox: { machineBranchId: row.machineBranchId, sandboxId: branch.sandboxId },
+      },
+    };
+  }
+
+  if (row.projectName) {
+    const project = await deps.projectLookup.findByName(row.machineId, row.projectName);
+    if (!project) return { ok: false, reason: 'project_not_found' };
+    return { ok: true, binding: { cwd: project.path } };
+  }
+
+  return { ok: true, binding: { cwd: SANDBOX_ROOT } };
+}

--- a/packages/lib/src/services/machines/machine-workspaces.ts
+++ b/packages/lib/src/services/machines/machine-workspaces.ts
@@ -31,7 +31,7 @@ export interface WorkspaceScopeInput {
 /** Mirrors the client's `OpenTerminalScope`/pane shape — see machine-workspaces-store.ts's DTOs. */
 export interface WorkspaceLayoutPaneInput {
   id: string;
-  scope: { projectName?: string; branchName?: string; name: string } | null;
+  scope: { projectName?: string; branchName?: string; name: string; kind?: 'terminal' | 'chat' } | null;
 }
 export interface WorkspaceLayoutColumnInput {
   id: string;

--- a/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/branch-session.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { acquireBranchSandbox, type AcquireBranchSandboxDeps } from '../branch-session';
+import type { MachineRuntimeGuardrailDecision } from '../quota';
+
+const NOW = new Date('2026-07-20T12:00:00.000Z');
+const MACHINE_ID = 'machine-1';
+const BRANCH_ID = 'branch-1';
+const BRANCH_SANDBOX_ID = 'sprite-branch-1';
+
+function makeFindBranch(
+  rows: Record<string, { sandboxId: string; spriteTornDownAt: Date | null }> = {
+    [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: null },
+  },
+): AcquireBranchSandboxDeps['findBranch'] {
+  return async (id) => rows[id] ?? null;
+}
+
+function makeDeps(over: Partial<AcquireBranchSandboxDeps> = {}): AcquireBranchSandboxDeps {
+  return {
+    authorize: async () => ({ ok: true }),
+    now: () => NOW,
+    checkMachineRuntimeGuardrail: (): MachineRuntimeGuardrailDecision => ({ allowed: true }),
+    recordMachineActivity: () => {},
+    findBranch: makeFindBranch(),
+    ...over,
+  };
+}
+
+const base = { driveId: 'd1', userId: 'u1', machineId: MACHINE_ID, machineBranchId: BRANCH_ID };
+
+describe('acquireBranchSandbox', () => {
+  it('given an authorize denial, should propagate the denial reason without checking the branch', async () => {
+    const seenFindBranch: string[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        findBranch: async (id) => {
+          seenFindBranch.push(id);
+          return null;
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+    expect(seenFindBranch).toEqual([]);
+  });
+
+  it('given a guardrail denial, should return machine_runtime_exceeded without checking the branch', async () => {
+    const seenFindBranch: string[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+        findBranch: async (id) => {
+          seenFindBranch.push(id);
+          return null;
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'machine_runtime_exceeded' });
+    expect(seenFindBranch).toEqual([]);
+  });
+
+  it('given a guardrail denial for an UNAUTHORIZED actor, should surface the authz denial first', async () => {
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        checkMachineRuntimeGuardrail: () => ({ allowed: false, reason: 'machine_runtime_exceeded' }),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+  });
+
+  it('given the happy path, should return the branch row\'s sandboxId with no provision call and record activity keyed to the machine page', async () => {
+    const seenGuardrail: Array<{ machineKey: string; now: number }> = [];
+    const seenRecord: Array<{ machineKey: string; now: number }> = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        checkMachineRuntimeGuardrail: (input) => {
+          seenGuardrail.push(input);
+          return { allowed: true };
+        },
+        recordMachineActivity: (input) => {
+          seenRecord.push(input);
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: true, sandboxId: BRANCH_SANDBOX_ID });
+    // Keyed by the MACHINE page id, not the branch id — mirrors acquireMachineSandbox.
+    expect(seenGuardrail).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);
+    expect(seenRecord).toEqual([{ machineKey: MACHINE_ID, now: NOW.getTime() }]);
+  });
+
+  it('given a destroyed branch (spriteTornDownAt set), should fail closed and never record activity', async () => {
+    const seenRecord: unknown[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        findBranch: makeFindBranch({ [BRANCH_ID]: { sandboxId: BRANCH_SANDBOX_ID, spriteTornDownAt: NOW } }),
+        recordMachineActivity: (input) => seenRecord.push(input),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+    expect(seenRecord).toEqual([]);
+  });
+
+  it('given a missing branch row, should fail closed and never record activity', async () => {
+    const seenRecord: unknown[] = [];
+    const result = await acquireBranchSandbox({
+      ...base,
+      deps: makeDeps({
+        findBranch: makeFindBranch({}),
+        recordMachineActivity: (input) => seenRecord.push(input),
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'branch_not_found' });
+    expect(seenRecord).toEqual([]);
+  });
+});

--- a/packages/lib/src/services/sandbox/branch-session.ts
+++ b/packages/lib/src/services/sandbox/branch-session.ts
@@ -1,0 +1,87 @@
+/**
+ * Branch-scoped sandbox acquisition (IO, dependency-injected).
+ *
+ * "PageSpace Agent" panes bound to a branch-terminal (`machine_branches`,
+ * issue #2166 phase 5/9's `deriveMachinePaneBinding.branchSandbox`) run tools
+ * on that branch's OWN isolated Sprite — never the owning Machine's
+ * persistent one. Unlike `acquireMachineSandbox` (machine-session.ts), this
+ * is attach-only: the branch's Sprite is provisioned exclusively by the
+ * branch-spawn path (`machine-branches.ts`), so a missing or torn-down
+ * branch fails closed here rather than lazily provisioning a replacement.
+ *
+ * Same authorize → guardrail → resolve → record-activity ORDERING as
+ * `acquireMachineSandbox` (load-bearing there, load-bearing here too): an
+ * unauthorized actor is denied on its own merits before the runtime
+ * guardrail is even consulted, and activity is recorded only once the branch
+ * is confirmed live. The guardrail and activity are keyed by the branch's
+ * OWNING MACHINE page id (`machineId`), not the branch row's own id — the
+ * runtime budget and payer (`lookupPageOwnerId(machineId)`) are the
+ * Machine's, shared across its machine/project/branch scopes alike.
+ */
+
+import type { CanRunCodeInput, CanRunCodeResult, CodeExecutionDenialReason } from './can-run-code';
+import type { MachineRuntimeGuardrailDecision, MachineRuntimeGuardrailReason } from './quota';
+
+export interface AcquireBranchSandboxDeps {
+  /** Re-authorize the CURRENT actor. Fail-closed; must never throw (canRunCode). */
+  authorize: (input: CanRunCodeInput) => Promise<CanRunCodeResult>;
+  now: () => Date;
+  /** Same per-machine active-runtime cost backstop `acquireMachineSandbox` checks — see quota.ts. */
+  checkMachineRuntimeGuardrail: (input: { machineKey: string; now: number }) => MachineRuntimeGuardrailDecision;
+  /** Record that the machine was just active, extending (or starting) its continuous-activity window. */
+  recordMachineActivity: (input: { machineKey: string; now: number }) => void;
+  /** Fresh lookup of the branch's own Sprite — mirrors `MachinePaneBindingBranchLookup.findById` (machine-pane-binding.ts). */
+  findBranch: (machineBranchId: string) => Promise<{ sandboxId: string; spriteTornDownAt: Date | null } | null>;
+}
+
+export interface AcquireBranchSandboxInput {
+  /** Absent for global (non-drive) contexts. */
+  driveId?: string;
+  userId: string;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
+  /** The branch's owning Machine page id. */
+  machineId: string;
+  /** The `machine_branches` row id backing this branch-terminal. */
+  machineBranchId: string;
+  deps: AcquireBranchSandboxDeps;
+}
+
+export type AcquireBranchSandboxResult =
+  | {
+      ok: true;
+      sandboxId: string;
+      /**
+       * Deliberately omitted (always undefined), NOT the branch's owning
+       * `machineId`: `openSession` (tool-runners.ts) threads this straight
+       * into the opportunistic storage-measurement seam and the Terminal
+       * activity-feed notifier, both of which key off a MACHINE's own
+       * `machine_sessions` row. The awake sandbox here is the branch's OWN,
+       * separate Sprite — attributing its measured bytes (or activity) to
+       * the machine's row would silently corrupt that machine's storage
+       * billing. A dedicated branch-scoped seam for either is future work;
+       * until then, omitting `pageId` cleanly opts branch runs out of both
+       * (`openSession`'s `if (acquired.pageId && ...)` guards).
+       */
+      pageId?: undefined;
+    }
+  | { ok: false; reason: CodeExecutionDenialReason | MachineRuntimeGuardrailReason | 'branch_not_found' };
+
+export async function acquireBranchSandbox(
+  input: AcquireBranchSandboxInput,
+): Promise<AcquireBranchSandboxResult> {
+  const { deps, machineId, machineBranchId, userId, driveId, requestOrigin, agentPageId } = input;
+
+  const authorization = await deps.authorize({ userId, driveId, requestOrigin, agentPageId });
+  if (!authorization.ok) return { ok: false, reason: authorization.reason };
+
+  const nowMs = deps.now().getTime();
+  const guardrail = deps.checkMachineRuntimeGuardrail({ machineKey: machineId, now: nowMs });
+  if (!guardrail.allowed) return { ok: false, reason: guardrail.reason };
+
+  const branch = await deps.findBranch(machineBranchId);
+  if (!branch || branch.spriteTornDownAt !== null) return { ok: false, reason: 'branch_not_found' };
+
+  deps.recordMachineActivity({ machineKey: machineId, now: nowMs });
+  return { ok: true, sandboxId: branch.sandboxId };
+}

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -44,6 +44,7 @@ import {
   type AcquireMachineSandboxResult,
   type MachineRefLike,
 } from './machine-session';
+import type { AcquireBranchSandboxResult } from './branch-session';
 import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 
@@ -75,6 +76,15 @@ export interface SandboxActorContext {
    * for that call rather than guessed at.
    */
   turnId?: string;
+  /**
+   * Present when this run is bound to a "PageSpace Agent" branch pane (issue
+   * #2166 phases 5/9's `deriveMachinePaneBinding.branchSandbox`) — the
+   * branch's owning Machine page id plus the `machine_branches` row backing
+   * it. Routes `acquireSandbox` through the attach-only branch seam
+   * (`acquireBranchSandbox`, branch-session.ts) instead of the machine's own
+   * persistent session. Undefined for every other run.
+   */
+  branchSandbox?: { machineId: string; machineBranchId: string };
 }
 
 export interface SandboxQuotaDeps {
@@ -155,10 +165,20 @@ export interface SandboxCheckpointDeps {
   createCheckpoint: (input: { sandbox: ExecutableSandbox; comment: string }) => Promise<void>;
 }
 
+/**
+ * `acquireSandbox`'s request: the machine-session shape plus the optional
+ * branch routing key. `branchSandbox` present → the caller routes to
+ * `acquireBranchSandbox` (attach-only); absent → `acquireMachineSandbox` as
+ * before.
+ */
+export type AcquireSandboxRequest = Omit<AcquireMachineSandboxInput, 'deps'> & {
+  branchSandbox?: { machineId: string; machineBranchId: string };
+};
+
 export interface SandboxRunDeps {
   isEnabled: () => boolean;
-  /** Pre-bound `acquireMachineSandbox` (lifecycle deps already injected). */
-  acquireSandbox: (input: Omit<AcquireMachineSandboxInput, 'deps'>) => Promise<AcquireMachineSandboxResult>;
+  /** Pre-bound `acquireMachineSandbox` / `acquireBranchSandbox` (lifecycle deps already injected). */
+  acquireSandbox: (input: AcquireSandboxRequest) => Promise<AcquireMachineSandboxResult | AcquireBranchSandboxResult>;
   /** Reconnect to the executable handle for an acquired sandbox id. */
   reconnect: (sandboxId: string) => Promise<ExecutableSandbox | null>;
   quota: SandboxQuotaDeps;
@@ -231,7 +251,7 @@ function safeLogWarn(
 // vs infra failures that are genuinely unexpected (error-level).
 const AUTHZ_DENY_REASONS = new Set([
   'no_drive_access', 'insufficient_role', 'no_agent_access', 'app_admin_required', 'kill_switch_off', 'no_machine',
-  'machine_runtime_exceeded',
+  'machine_runtime_exceeded', 'branch_not_found',
 ]);
 
 
@@ -306,9 +326,7 @@ function fail(
   return { success: false, error: DENIAL_MESSAGES[reason], reason };
 }
 
-function acquireRequest(
-  ctx: SandboxActorContext,
-): Omit<AcquireMachineSandboxInput, 'deps'> {
+function acquireRequest(ctx: SandboxActorContext): AcquireSandboxRequest {
   return {
     tenantId: ctx.tenantId,
     driveId: ctx.driveId,
@@ -316,6 +334,7 @@ function acquireRequest(
     requestOrigin: ctx.requestOrigin,
     agentPageId: ctx.agentPageId,
     activeMachine: ctx.activeMachine,
+    branchSandbox: ctx.branchSandbox,
   };
 }
 
@@ -366,7 +385,11 @@ async function safeNotifyTerminalActivity(
 }
 
 // Map a denial from the lifecycle acquire onto the tool-facing reason set.
-function reasonFromAcquire(result: Extract<AcquireMachineSandboxResult, { ok: false }>): SandboxToolDenialReason {
+// `branch_not_found` (acquireBranchSandbox's own fail-closed reason, no
+// tool-facing equivalent) falls through to 'error' with the rest.
+function reasonFromAcquire(
+  result: Extract<AcquireMachineSandboxResult | AcquireBranchSandboxResult, { ok: false }>,
+): SandboxToolDenialReason {
   switch (result.reason) {
     case 'app_admin_required':
     case 'no_drive_access':


### PR DESCRIPTION
## Terminal panes: native `pagespace` chat agent surface — full epic

Implements #2166. Adds a fourth machine-pane session type, **"PageSpace Agent"**, that renders the first-party PageSpace AI chat UI in a workspace pane instead of an xterm PTY, with its default-mode code-exec tools server-bound to that machine's checkout.

This PR is the integration of **11 phases** developed test-first on the `pu/panes-agent` trunk, each merged individually with full CI (lint + typecheck + unit + security) green.

### What it delivers
- New `pagespace` session type in the pane picker (labeled **"PageSpace Agent"**), alongside Shell / Claude / Codex — at machine, project, and branch scope.
- The pane renders the existing chat components (`CompactMessageRenderer`, `Conversation`, `ChatInput`); an in-pane `AISelector` switches between the machine-anchored assistant (default) and any page agent.
- Default mode's tools (`bash`/read/write/edit/git) are pinned to the machine's checkout via a **server-derived binding** that is never trusted from the client and removes `switch_machine`/`list_machines`. Branch panes attach to the branch's own Sprite (attach-only).
- Full pane parity: `machine_agent_terminals` row, cross-browser sync, sidebar listing, reload-survival, shared multi-viewer conversations. Closing a pane deletes the row cheaply; the conversation survives.

### Architecture (as specced)
- **Reuses `POST /api/ai/chat`** — no new AI backend. Default mode: `chatId = machineId`, `conversationId = terminal row id` (pre-created `isShared` on spawn).
- **Zero database schema changes** — no migrations.
- Agent loop stays **server-side**; the binding is derived server-side (`deriveMachinePaneBinding`, pure core in `packages/lib`, 100% branch).
- Gated on `isCodeExecutionEnabled()`; billed through the existing credit gate/holds + sandbox metering.

### Phases (all merged to trunk, CI-green)
1. Registry: `pagespace` type + `surface` discriminator
2. Lib service: PTY paths refuse chat rows; cheap kill
3. Realtime: defensive refusal
4. Spawn API: row ids, code-exec gate, shared-conversation pre-create
5. Binding module: pure core + runtime shell (`ToolExecutionContext.machineBinding`)
6. Chat route integration: bind, pin, filter (route stays a thin host)
7. Sandbox tools: honor the binding
8. Branch acquire seam (attach-only)
9. Pane state: session content kind
10. Renderer branch in `TerminalPanes` (+ NodeActionPalette picker reconcile)
11. `MachinePaneChat`: third selector surface, dual-mode hook, in-pane tabs

### Testing
- Test-first throughout (RED → GREEN → review per phase). New logic is pure functions with injected deps; the binding core carries a 100%-branch expectation.
- Every phase PR passed full CI against the trunk; no schema migrations; existing coverage ratchets held.

### Remaining human gate
- **Manual acceptance** (flag-on, admin): spawn PageSpace Agent panes in machine/project/branch workspaces, verify tool execution in the correct checkout, agent-switch/resume, history, reload, multi-viewer, socket-deny of `agent-terminal:connect` on a chat session, and 2×2 live-stream performance. This hands-on QA in a live environment is the one step not covered by automated CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PageSpace Agent chat panes with chat, history, and settings tabs.
  * Added support for machine-bound conversations, keeping tools and execution on the selected machine and working directory.
  * Added branch-aware sandbox support for machine-bound chats.
  * Agent terminal listings now include session IDs.
  * Machine conversation messages can be accessed from both AI chat and machine pages.

* **Bug Fixes**
  * Prevented chat-only agents from being treated as interactive terminals.
  * Added clearer handling when terminal operations are unavailable or code execution is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->