### PR TITLE
fix(auth): stop desktop logout storm + native-shell recovery (wave 1)

### DIFF
--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_stream', resourceId: 'abort', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_stream', resourceId: 'abort', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/__tests__/route.test.ts
@@ -84,6 +84,7 @@ vi.mock('@/lib/ai/core/materialize-interrupted-stream', () => ({
 import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user-test-1';
 const mockChannelId = 'page-test-1';
@@ -97,8 +98,9 @@ const mockSessionAuth = (userId = mockUserId): SessionAuthResult => ({
   adminRoleVersion: 0,
 });
 
-const mockAuthFailure = (status = 401): AuthError => ({
+const mockAuthFailure = (status = 401, authFailureReason?: AuthError['authFailureReason']): AuthError => ({
   error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+  authFailureReason,
 });
 
 const makeRequest = (channelId = mockChannelId) =>
@@ -389,6 +391,22 @@ describe('GET /api/ai/chat/active-streams', () => {
     const response = await GET(makeRequest());
 
     expect(response.status).toBe(401);
+  });
+
+  // D5: the auth_failed audit must carry the machine-readable reason so an incident is provable
+  // (expired vs revoked vs ...) rather than a bare auth_failed.
+  it('given auth fails with a known reason, should populate details.authFailureReason in the audit', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthFailure(401, 'expired'));
+
+    await GET(makeRequest());
+
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({ reason: 'auth_failed', authFailureReason: 'expired' }),
+      }),
+    );
   });
 
   it('given the user cannot view the page, should return 403 without querying streams', async () => {

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: Request) {
         eventType: 'authz.access.denied',
         resourceType: 'ai_chat_stream',
         resourceId: 'active-streams',
-        details: { reason: 'auth_failed', method: 'GET' },
+        details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason },
         riskScore: 0.5,
       });
       return auth.error;

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -49,7 +49,7 @@ export async function PATCH(
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -205,7 +205,7 @@ export async function DELETE(
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -89,7 +89,7 @@ export async function GET(
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'preview', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'preview', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -154,7 +154,7 @@ export async function POST(
     // Authenticate with CSRF
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'execute', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'execute', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -224,7 +224,7 @@ export async function POST(request: Request) {
     const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(authResult)) {
       loggers.ai.warn('AI Chat API: Authentication failed');
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat', resourceId: 'post', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat', resourceId: 'post', details: { reason: 'auth_failed', method: 'POST', authFailureReason: authResult.authFailureReason }, riskScore: 0.5 });
       return authResult.error;
     }
     userId = authResult.userId;
@@ -1975,7 +1975,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -2083,7 +2083,7 @@ export async function PATCH(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -37,7 +37,7 @@ export async function GET(
       eventType: 'authz.access.denied',
       resourceType: 'ai_stream',
       resourceId: 'stream-join',
-      details: { reason: 'auth_failed', method: 'GET' },
+      details: { reason: 'auth_failed', method: 'GET', authFailureReason: authResult.authFailureReason },
       riskScore: 0.4,
     });
     return authResult.error;

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -166,7 +166,7 @@ export async function DELETE(
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -108,7 +108,7 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -278,7 +278,7 @@ export async function POST(
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
       loggers.api.debug('Global Assistant Chat API: Authentication failed', {});
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'send', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'send', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -17,7 +17,7 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -55,7 +55,7 @@ export async function PATCH(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -99,7 +99,7 @@ export async function DELETE(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -20,7 +20,7 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_usage', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_usage', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const { userId, role } = auth;

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'active', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'active', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -62,7 +62,7 @@ export async function PUT(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'config', details: { reason: 'auth_failed', method: 'PUT' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'config', details: { reason: 'auth_failed', method: 'PUT', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const { userId } = auth;

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -26,7 +26,7 @@ export async function PATCH(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -179,7 +179,7 @@ export async function DELETE(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -60,7 +60,7 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -23,7 +23,7 @@ export async function PATCH(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 
@@ -172,7 +172,7 @@ export async function DELETE(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -27,7 +27,7 @@ export async function GET(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 
@@ -145,7 +145,7 @@ export async function POST(
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
 

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -165,7 +165,7 @@ export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'consult', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'consult', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const { userId } = auth;

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'multi_drive_list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'multi_drive_list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const { userId } = auth;

--- a/apps/web/src/app/api/ai/settings/image-model/route.ts
+++ b/apps/web/src/app/api/ai/settings/image-model/route.ts
@@ -22,7 +22,7 @@ export async function PATCH(request: Request) {
         eventType: 'authz.access.denied',
         resourceType: 'ai_settings',
         resourceId: 'image_model',
-        details: { reason: 'auth_failed', method: 'PATCH' },
+        details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason },
         riskScore: 0.5,
       });
       return auth.error;

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -87,7 +87,7 @@ export async function PATCH(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
-      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'update_selection', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'update_selection', details: { reason: 'auth_failed', method: 'PATCH', authFailureReason: auth.authFailureReason }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request): Promise<Response> {
   // 1. Authenticate — MCP tokens only; no session, no CSRF, no browser session ID
   const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
   if (isAuthError(authResult)) {
-    auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'openai_inference', resourceId: 'post', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+    auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'openai_inference', resourceId: 'post', details: { reason: 'auth_failed', method: 'POST', authFailureReason: authResult.authFailureReason }, riskScore: 0.5 });
     return authResult.error;
   }
 

--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -16,7 +16,7 @@ const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
 export async function GET(request: Request): Promise<Response> {
   const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
   if (isAuthError(authResult)) {
-    auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'openai_models', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+    auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'openai_models', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET', authFailureReason: authResult.authFailureReason }, riskScore: 0.5 });
     return authResult.error;
   }
 

--- a/apps/web/src/app/auth/signin/__tests__/signin-recovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/signin-recovery.test.ts
@@ -10,9 +10,13 @@ import { decideSigninRecovery, type SigninRecoveryInput } from '../signin-recove
 // Regression context: middleware began redirecting cookieless navigations to /auth/signin
 // on 2026-07-07, which killed the app's own JS-level device-token recovery. This restores
 // it at the one page every bounced user now lands on.
+//
+// D1 (wave 1): native shells (desktop/Capacitor) now run this SAME machine — the old
+// `isNativeShell -> skip` short-circuit was the bug that stranded desktop users on the form
+// while safeStorage held a valid 90-day session. The authFailedPermanently guard (the desktop
+// loop-guard) is what prevents a native redirect loop, and it runs FIRST.
 
 const base: SigninRecoveryInput = {
-  isNativeShell: false,
   authFailedPermanently: false,
   meAuthenticated: undefined,
   hasDeviceToken: false,
@@ -20,23 +24,18 @@ const base: SigninRecoveryInput = {
 };
 
 describe('decideSigninRecovery', () => {
-  it('skips recovery entirely inside a native shell (desktop/Capacitor own their session)', () => {
-    // Native shells manage sessions via bearer tokens / keychain, not cookies — the store's
-    // loadSession already handles them, so the web recovery must stay out of the way.
-    expect(decideSigninRecovery({ ...base, isNativeShell: true })).toEqual({ type: 'skip' });
-    // Native wins even when other signals would otherwise drive recovery.
-    expect(
-      decideSigninRecovery({ ...base, isNativeShell: true, meAuthenticated: true }),
-    ).toEqual({ type: 'skip' });
-  });
-
   it('shows the form immediately when auth has permanently failed (never retry — that is the loop)', () => {
     expect(
       decideSigninRecovery({ ...base, authFailedPermanently: true }),
     ).toEqual({ type: 'show-form' });
-    // A dead-permanent flag must short-circuit even if a device token is present.
+    // A dead-permanent flag must short-circuit even if a device token is present — this is the
+    // desktop loop-guard: it must win before any check-me/refresh runs.
     expect(
       decideSigninRecovery({ ...base, authFailedPermanently: true, hasDeviceToken: true }),
+    ).toEqual({ type: 'show-form' });
+    // ...and even if check-me would otherwise say the session is live.
+    expect(
+      decideSigninRecovery({ ...base, authFailedPermanently: true, meAuthenticated: true }),
     ).toEqual({ type: 'show-form' });
   });
 

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -148,19 +148,18 @@ describe('useSigninRecovery', () => {
       expect(result.current.recovering).toBe(true); // stays recovering through the nav — no form
     });
 
-    it('check-me carries a Bearer token (via fetchWithAuth) and hasDeviceToken reads platform storage, not localStorage (acceptance #2)', async () => {
+    it('check-me carries a Bearer token (via fetchWithAuth) and hasDeviceToken reads platform storage (acceptance #2)', async () => {
       getStoredSession.mockResolvedValue({ deviceToken: 'safe_dt' });
       mockMe(true);
-      const lsSpy = vi.spyOn(Storage.prototype, 'getItem');
 
       renderHook(() => useSigninRecovery('/dashboard', true));
 
       await waitFor(() => expect(replace).toHaveBeenCalled());
       // Bearer path: goes through the auth-fetch wrapper, never raw fetch.
       expect(fetchWithAuth).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({ credentials: 'include' }));
-      // Device token read from safeStorage over IPC, not from localStorage.
+      // Device token read from PLATFORM storage (safeStorage over IPC on desktop) — the shell's
+      // only token source is getPlatformStorage().getStoredSession(), not a raw localStorage read.
       expect(getStoredSession).toHaveBeenCalled();
-      expect(lsSpy).not.toHaveBeenCalledWith('deviceToken');
     });
 
     it('a successful device refresh redirects to /dashboard (acceptance #3)', async () => {

--- a/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
+++ b/apps/web/src/app/auth/signin/__tests__/useSigninRecovery.test.ts
@@ -4,25 +4,31 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useSigninRecovery } from '../useSigninRecovery';
 
 // Shell-level coverage for the recovery effect. The DECISION branches live in
-// signin-recovery.test.ts; here we assert the effects are wired to the right actions:
-// a live /api/auth/me redirects, an expired cookie + device token refreshes then redirects,
-// and an unrecoverable state renders the form. We also cover the two subtleties the shell
-// alone carries: it must not start before the redirect destination is resolved (readiness),
-// and it must survive React StrictMode's dev mount probe.
+// signin-recovery.test.ts; here we assert the effects are wired to the right actions AND to the
+// right platform-routed primitives (D1): check-me goes through fetchWithAuth (Bearer-attaching,
+// refresh-on-401), and hasDeviceToken reads PLATFORM storage (safeStorage over IPC on desktop),
+// never localStorage directly. We also cover the two subtleties the shell alone carries: it must
+// not start before the redirect destination is resolved (readiness), and it must survive React
+// StrictMode's dev mount probe.
 
 const replace = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ replace }),
 }));
 
+const fetchWithAuth = vi.fn();
 const refreshAuthSession = vi.fn();
 vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuth(...args),
   refreshAuthSession: () => refreshAuthSession(),
 }));
 
-const isCapacitorApp = vi.fn(() => false);
-vi.mock('@/lib/capacitor-bridge', () => ({
-  isCapacitorApp: () => isCapacitorApp(),
+// The platform-storage seam: desktop returns a session read from safeStorage over IPC, web from
+// localStorage. The shell only ever touches it through getPlatformStorage().getStoredSession().
+const getStoredSession = vi.fn();
+let storagePlatform: 'web' | 'desktop' | 'ios' | 'android' = 'web';
+vi.mock('@/lib/auth/platform-storage', () => ({
+  getPlatformStorage: () => ({ platform: storagePlatform, getStoredSession }),
 }));
 
 let authFailedPermanently = false;
@@ -30,25 +36,24 @@ vi.mock('@/stores/useAuthStore', () => ({
   useAuthStore: { getState: () => ({ authFailedPermanently }) },
 }));
 
+// check-me result via fetchWithAuth('/api/auth/me').
 function mockMe(ok: boolean) {
-  vi.stubGlobal(
-    'fetch',
-    vi.fn(async () => ({ ok }) as Response),
-  );
+  fetchWithAuth.mockResolvedValue({ ok } as Response);
 }
 
 beforeEach(() => {
   replace.mockClear();
+  fetchWithAuth.mockReset();
   refreshAuthSession.mockReset();
-  isCapacitorApp.mockReturnValue(false);
+  getStoredSession.mockReset();
+  getStoredSession.mockResolvedValue(null); // default: no device token
+  storagePlatform = 'web';
   authFailedPermanently = false;
   localStorage.clear();
-  // Default: window.electron absent (pure web).
-  delete (window as unknown as { electron?: unknown }).electron;
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe('useSigninRecovery', () => {
@@ -70,9 +75,20 @@ describe('useSigninRecovery', () => {
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
   });
 
+  it('checks the session through fetchWithAuth (Bearer-attaching), not raw fetch', async () => {
+    mockMe(true);
+    const rawFetch = vi.spyOn(globalThis, 'fetch');
+
+    renderHook(() => useSigninRecovery('/dashboard', true));
+
+    await waitFor(() => expect(replace).toHaveBeenCalled());
+    expect(fetchWithAuth).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({ credentials: 'include' }));
+    expect(rawFetch).not.toHaveBeenCalled();
+  });
+
   it('refreshes via the device token then redirects when the cookie is expired', async () => {
     mockMe(false);
-    localStorage.setItem('deviceToken', 'dt_valid');
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
     refreshAuthSession.mockResolvedValue({ success: true, shouldLogout: false });
 
     renderHook(() => useSigninRecovery('/dashboard', true));
@@ -83,6 +99,7 @@ describe('useSigninRecovery', () => {
 
   it('renders the form (no redirect) when the cookie is expired and there is no device token', async () => {
     mockMe(false);
+    getStoredSession.mockResolvedValue(null);
 
     const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
@@ -93,7 +110,7 @@ describe('useSigninRecovery', () => {
 
   it('renders the form when the device-token refresh fails, without looping', async () => {
     mockMe(false);
-    localStorage.setItem('deviceToken', 'dt_revoked');
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_revoked' });
     refreshAuthSession.mockResolvedValue({ success: false, shouldLogout: true });
 
     const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
@@ -103,40 +120,107 @@ describe('useSigninRecovery', () => {
     expect(refreshAuthSession).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the form immediately when auth has permanently failed (no /api/auth/me, no loop)', async () => {
+  it('renders the form immediately when auth has permanently failed (no check-me, no loop)', async () => {
     authFailedPermanently = true;
-    localStorage.setItem('deviceToken', 'dt_valid');
-    const fetchSpy = vi.fn();
-    vi.stubGlobal('fetch', fetchSpy);
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
 
     const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
     await waitFor(() => expect(result.current.recovering).toBe(false));
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchWithAuth).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it('skips recovery in a native shell and renders the form', async () => {
-    isCapacitorApp.mockReturnValue(true);
-    const fetchSpy = vi.fn();
-    vi.stubGlobal('fetch', fetchSpy);
+  // ── D1 acceptance: native shells now run the SAME recovery machine ───────────────────────
+  describe('desktop (native shell)', () => {
+    beforeEach(() => {
+      storagePlatform = 'desktop';
+    });
 
-    const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+    it('an authenticated check-me redirects — no signin form shown (acceptance #1)', async () => {
+      // safeStorage holds a valid session; check-me succeeds so we never even need the token.
+      getStoredSession.mockResolvedValue({ deviceToken: 'safe_dt' });
+      mockMe(true);
 
-    await waitFor(() => expect(result.current.recovering).toBe(false));
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(replace).not.toHaveBeenCalled();
+      const { result } = renderHook(() => useSigninRecovery('/dashboard/deep', true));
+
+      await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard/deep'));
+      expect(result.current.recovering).toBe(true); // stays recovering through the nav — no form
+    });
+
+    it('check-me carries a Bearer token (via fetchWithAuth) and hasDeviceToken reads platform storage, not localStorage (acceptance #2)', async () => {
+      getStoredSession.mockResolvedValue({ deviceToken: 'safe_dt' });
+      mockMe(true);
+      const lsSpy = vi.spyOn(Storage.prototype, 'getItem');
+
+      renderHook(() => useSigninRecovery('/dashboard', true));
+
+      await waitFor(() => expect(replace).toHaveBeenCalled());
+      // Bearer path: goes through the auth-fetch wrapper, never raw fetch.
+      expect(fetchWithAuth).toHaveBeenCalledWith('/api/auth/me', expect.objectContaining({ credentials: 'include' }));
+      // Device token read from safeStorage over IPC, not from localStorage.
+      expect(getStoredSession).toHaveBeenCalled();
+      expect(lsSpy).not.toHaveBeenCalledWith('deviceToken');
+    });
+
+    it('a successful device refresh redirects to /dashboard (acceptance #3)', async () => {
+      getStoredSession.mockResolvedValue({ deviceToken: 'safe_dt' });
+      mockMe(false); // cookie/session gone
+      refreshAuthSession.mockResolvedValue({ success: true, shouldLogout: false });
+
+      renderHook(() => useSigninRecovery('/dashboard', true));
+
+      await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+      expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('NO redirect loop: when genuinely unauthenticated, authFailedPermanently wins and the form is shown (acceptance #4)', async () => {
+      // The loop-guard must short-circuit BEFORE any check-me/refresh — proving it, not the
+      // absence of a token, is what stops the check-me→refresh→bounce loop on desktop.
+      authFailedPermanently = true;
+      getStoredSession.mockResolvedValue({ deviceToken: 'safe_dt' });
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      await waitFor(() => expect(result.current.recovering).toBe(false));
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+      expect(refreshAuthSession).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    it('shows the form when unauthenticated with no recoverable token (terminates, no loop)', async () => {
+      mockMe(false);
+      getStoredSession.mockResolvedValue({ deviceToken: null });
+
+      const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
+
+      await waitFor(() => expect(result.current.recovering).toBe(false));
+      expect(replace).not.toHaveBeenCalled();
+      expect(refreshAuthSession).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not start recovery until ready — no /api/auth/me while the destination is unresolved', async () => {
-    const fetchSpy = vi.fn(async () => ({ ok: true }) as Response);
-    vi.stubGlobal('fetch', fetchSpy);
+  // ── Web regression: behavior is identical to before D1 ───────────────────────────────────
+  it('web: expired cookie + valid device token still refreshes and redirects (acceptance #5)', async () => {
+    storagePlatform = 'web';
+    mockMe(false);
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
+    refreshAuthSession.mockResolvedValue({ success: true, shouldLogout: false });
+
+    renderHook(() => useSigninRecovery('/dashboard', true));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/dashboard'));
+    expect(refreshAuthSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not start recovery until ready — no check-me while the destination is unresolved', async () => {
+    mockMe(true);
 
     renderHook(() => useSigninRecovery(undefined, false));
 
     // Give any (incorrectly-scheduled) effect a chance to run.
     await Promise.resolve();
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchWithAuth).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
   });
 
@@ -166,7 +250,7 @@ describe('useSigninRecovery', () => {
     // The driver is best-effort: a thrown rejection anywhere must fall back to the form
     // rather than leave the page stuck on the loading state forever.
     mockMe(false);
-    localStorage.setItem('deviceToken', 'dt_valid');
+    getStoredSession.mockResolvedValue({ deviceToken: 'dt_valid' });
     refreshAuthSession.mockRejectedValue(new Error('boom'));
 
     const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
@@ -175,13 +259,8 @@ describe('useSigninRecovery', () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it('fails open to the form if the /api/auth/me fetch itself rejects', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => {
-        throw new Error('network down');
-      }),
-    );
+  it('fails open to the form if the check-me fetch itself rejects', async () => {
+    fetchWithAuth.mockRejectedValue(new Error('network down'));
 
     const { result } = renderHook(() => useSigninRecovery('/dashboard', true));
 
@@ -190,8 +269,7 @@ describe('useSigninRecovery', () => {
   });
 
   it('runs recovery only once even if the component re-renders while ready stays true', async () => {
-    const fetchSpy = vi.fn(async () => ({ ok: false }) as Response);
-    vi.stubGlobal('fetch', fetchSpy);
+    mockMe(false);
 
     const { rerender, result } = renderHook(
       ({ n }: { n: number }) => useSigninRecovery(`/dashboard?r=${n}`, true),
@@ -203,7 +281,7 @@ describe('useSigninRecovery', () => {
     rerender({ n: 2 });
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchWithAuth).toHaveBeenCalledTimes(1);
   });
 
   it('completes recovery under React StrictMode (does not get stuck on loading)', async () => {

--- a/apps/web/src/app/auth/signin/signin-recovery.ts
+++ b/apps/web/src/app/auth/signin/signin-recovery.ts
@@ -5,13 +5,22 @@
  * arrives without a session cookie and redirecting it to /auth/signin, *before* the app's
  * own JavaScript can run. That JS used to silently recover the session — an expired 7-day
  * cookie was invisible, the page loaded, a 401 came back, and AuthFetch minted a fresh
- * session from the localStorage device token. The middleware redirect now lands those users
+ * session from the stored device token. The middleware redirect now lands those users
  * on the signin form instead, so they re-authenticate by hand (which then revokes their
  * other devices — a logout storm). This restores the recovery at the page every bounced
  * user now lands on: before showing the form, try to heal the session.
  *
+ * NATIVE SHELLS RUN THIS TOO (D1, wave 1). This machine used to short-circuit to `skip` on
+ * desktop/Capacitor, on the theory that native shells own their own session and web cookie
+ * recovery must stay out of the way. That was the bug: a desktop user middleware-bounced to
+ * /auth/signin would see the form even though safeStorage held a valid 90-day session, because
+ * nothing re-ran the recovery. Native shells now run the exact same check-me -> refresh ->
+ * redirect flow; the shell just routes the effects through platform storage (safeStorage over
+ * IPC) and Bearer-attaching fetch. The `authFailedPermanently` guard below is the native
+ * loop-guard — it runs FIRST so a genuinely-dead session shows the form instead of looping.
+ *
  * FUNCTIONAL CORE. This module holds only the decision. The shell (useSigninRecovery) owns
- * every effect — fetching /api/auth/me, reading localStorage, running the refresh, calling
+ * every effect — fetching /api/auth/me, reading the device token, running the refresh, calling
  * the router — and feeds the observations back here one at a time. `undefined` means "not
  * observed yet", which is how the shell drives the machine forward: it keeps calling this
  * with more filled-in fields until it gets a terminal action.
@@ -19,27 +28,20 @@
 
 export interface SigninRecoveryInput {
   /**
-   * Desktop (Electron) or Capacitor (iOS) shell. Those shells authenticate with bearer
-   * tokens / keychain, not the web session cookie, and the auth store already recovers
-   * them — web cookie recovery must never run there.
-   */
-  isNativeShell: boolean;
-  /**
    * The auth store's permanent-failure flag. When set, a session has already definitively
    * failed (revoked token, detected loop) and must not be retried — retrying is the loop.
+   * This is the loop-guard for every shell, native included.
    */
   authFailedPermanently: boolean;
   /** Result of GET /api/auth/me; undefined until the shell has checked. */
   meAuthenticated: boolean | undefined;
-  /** Whether a device token exists in localStorage to recover an expired cookie from. */
+  /** Whether a device token exists in platform storage to recover an expired session from. */
   hasDeviceToken: boolean;
   /** Result of the device-token refresh; undefined until the shell has attempted it. */
   refreshSucceeded: boolean | undefined;
 }
 
 export type SigninRecoveryAction =
-  /** Native shell: don't run web recovery at all — render the form as today. */
-  | { type: 'skip' }
   /** Observe the current session via GET /api/auth/me. */
   | { type: 'check-me' }
   /** Attempt the device-token refresh (reuses AuthFetch's refresh machinery). */
@@ -52,19 +54,18 @@ export type SigninRecoveryAction =
 /**
  * Given what the shell has observed so far, decide the next recovery action.
  *
- * The progression, once past the two guards, is: check the session → if live, redirect →
+ * The progression, once past the loop-guard, is: check the session → if live, redirect →
  * else if a device token exists, refresh → if the refresh succeeds, redirect, otherwise
  * show the form. A missing device token or a failed refresh both terminate at the form,
  * and nothing here ever loops back to an earlier step, so the shell (which runs each
  * action once) cannot spin.
  */
 export function decideSigninRecovery(input: SigninRecoveryInput): SigninRecoveryAction {
-  const { isNativeShell, authFailedPermanently, meAuthenticated, hasDeviceToken, refreshSucceeded } =
-    input;
-
-  if (isNativeShell) return { type: 'skip' };
+  const { authFailedPermanently, meAuthenticated, hasDeviceToken, refreshSucceeded } = input;
 
   // A definitively-dead session must not be retried; that retry IS the loop the store guards.
+  // Runs first — before any check-me/refresh — so it wins on every platform (this is the
+  // desktop loop-guard).
   if (authFailedPermanently) return { type: 'show-form' };
 
   // Step 1 — is the current session live?

--- a/apps/web/src/app/auth/signin/useSigninRecovery.ts
+++ b/apps/web/src/app/auth/signin/useSigninRecovery.ts
@@ -2,25 +2,38 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { refreshAuthSession } from '@/lib/auth/auth-fetch';
-import { isCapacitorApp } from '@/lib/capacitor-bridge';
+import { fetchWithAuth, refreshAuthSession } from '@/lib/auth/auth-fetch';
+import { getPlatformStorage } from '@/lib/auth/platform-storage';
 import { useAuthStore } from '@/stores/useAuthStore';
 import { decideSigninRecovery, type SigninRecoveryInput } from './signin-recovery';
 
 const DEFAULT_NEXT = '/dashboard';
 
-function detectNativeShell(): boolean {
-  if (typeof window === 'undefined') return false;
-  return !!window.electron?.isDesktop || isCapacitorApp();
+/**
+ * Whether a device token exists to recover an expired session from — read from PLATFORM storage
+ * (D1): desktop reads safeStorage over IPC (window.electron.auth) via DesktopStorage, web reads
+ * localStorage via WebStorage. The old localStorage-only check saw nothing on desktop, which is
+ * why native shells could never self-recover. Async because the desktop read is an IPC round-trip.
+ */
+async function hasDeviceToken(): Promise<boolean> {
+  try {
+    const session = await getPlatformStorage().getStoredSession();
+    return !!session?.deviceToken;
+  } catch {
+    // Storage unavailable (IPC failure / SSR) — treat as no token and fall through to the form.
+    return false;
+  }
 }
 
-function hasDeviceToken(): boolean {
-  return typeof localStorage !== 'undefined' && !!localStorage.getItem('deviceToken');
-}
-
+/**
+ * Observe the current session via GET /api/auth/me through `fetchWithAuth` (D1): it attaches the
+ * Bearer token on native shells and, crucially, its own refresh-on-401 IS the recovery — a 401
+ * here transparently mints a fresh session from the device token before we ever decide to show
+ * the form. A raw `fetch` would have skipped both.
+ */
 async function checkMeAuthenticated(): Promise<boolean> {
   try {
-    const response = await fetch('/api/auth/me', { credentials: 'include' });
+    const response = await fetchWithAuth('/api/auth/me', { credentials: 'include' });
     return response.ok;
   } catch {
     // Network error — treat as unauthenticated and fall through to the device-token path.
@@ -31,15 +44,16 @@ async function checkMeAuthenticated(): Promise<boolean> {
 /**
  * Imperative shell for silent session recovery on the signin page.
  *
- * Runs the effects — GET /api/auth/me, reading the device token, the AuthFetch refresh,
- * the router navigation — and defers every decision to the pure `decideSigninRecovery`
- * core. See ./signin-recovery.ts for why this exists (the 2026-07-07 middleware change
- * that started bouncing recoverable sessions to the signin form).
+ * Runs the effects — GET /api/auth/me (via fetchWithAuth), reading the device token from
+ * platform storage, the AuthFetch refresh, the router navigation — and defers every decision to
+ * the pure `decideSigninRecovery` core. See ./signin-recovery.ts for why this exists (the
+ * 2026-07-07 middleware change that started bouncing recoverable sessions to the signin form,
+ * and the D1 fix that lets native shells recover too).
  *
  * Returns `recovering`: while true, the page shows a minimal loading state instead of the
  * form, so a user who is about to be redirected never sees the form flash. It flips to
- * false only when recovery lands on the form (or is skipped in a native shell); on a
- * redirect it stays true through the navigation.
+ * false only when recovery lands on the form; on a redirect it stays true through the
+ * navigation.
  *
  * READINESS. Recovery must not begin until `ready` is true. The signin page resolves the
  * post-recovery destination (`nextPath`) from the browser URL in a mount effect, so on the
@@ -69,14 +83,14 @@ export function useSigninRecovery(
 
     const run = async () => {
       const observed: SigninRecoveryInput = {
-        isNativeShell: detectNativeShell(),
         // Read fresh from the store rather than subscribing: this effect runs once and must
         // see the flag's value when recovery starts, not restart when it later changes.
         authFailedPermanently: useAuthStore.getState().authFailedPermanently,
         meAuthenticated: undefined,
-        hasDeviceToken: hasDeviceToken(),
+        hasDeviceToken: await hasDeviceToken(),
         refreshSucceeded: undefined,
       };
+      if (cancelled) return;
 
       // Drive the pure machine: perform each action, feed the result back, repeat until
       // a terminal action. The machine never loops back to an earlier step, and every
@@ -86,7 +100,6 @@ export function useSigninRecovery(
         const action = decideSigninRecovery(observed);
 
         switch (action.type) {
-          case 'skip':
           case 'show-form':
             if (!cancelled) setRecovering(false);
             return;
@@ -111,8 +124,9 @@ export function useSigninRecovery(
 
     // Fail open: recovery is best-effort, so an unexpected rejection anywhere in the driver
     // must fall back to showing the form — never strand the page on the loading state (this
-    // is the app's primary auth entry point). `refreshAuthSession` resolves a result today,
-    // but its type makes no never-throw guarantee, and neither does a dynamic import inside it.
+    // is the app's primary auth entry point). `refreshAuthSession`/`fetchWithAuth` resolve a
+    // result today, but their types make no never-throw guarantee, and neither does a dynamic
+    // import inside them.
     void run().catch(() => {
       if (!cancelled) setRecovering(false);
     });

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
@@ -485,6 +485,49 @@ describe('startStreamJoinPollFallback', () => {
       expect(mockFetchWithAuth).not.toHaveBeenCalled();
     });
 
+    // Regression (Codex P2 / CodeRabbit Major): setInterval does not wait for a slow tick, so two
+    // ticks can be in flight at once. If BOTH see a 401, each suspends — and a naive
+    // implementation would leave two `auth:refreshed` listeners registered, so one resume would
+    // spin up two intervals and orphan one past abort. Exactly one listener must survive, so a
+    // single resume yields a single interval, and abort stops everything.
+    it('given two overlapping in-flight ticks that both 401, should keep only ONE resume listener (no orphaned interval)', async () => {
+      // Both in-flight ticks resolve 401 (the slow-fetch race), then everything else is healthy.
+      mockFetchWithAuth
+        .mockResolvedValueOnce(notOkResponse(401)) // tick A (interval-driven)
+        .mockResolvedValueOnce(notOkResponse(401)) // tick B (overlapping, manually driven)
+        .mockResolvedValue(okResponse([{ messageId: 'msg-1', parts: [] }]));
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      // First tick (A) resolves 401 → suspend #1.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      // Simulate a second, overlapping tick (B) that also 401s → suspend #2 overwrites the
+      // listener. Trigger it by dispatching a resume (which fires tick B) — tick B's 401 suspends
+      // again. If the first listener leaked, TWO would now be registered.
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(2); // tick B ran and re-suspended
+
+      // A single resume must now produce a SINGLE immediate tick (one listener), not two.
+      mockFetchWithAuth.mockClear();
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      // ...and a SINGLE interval, not two orphaned ones (would be 2 fetches per interval if leaked).
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      // Abort must silence everything — proof no orphaned interval survives.
+      controller.abort();
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 5);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
     it('given a second 401 after a resume, should suspend again (survives repeated auth failures)', async () => {
       mockFetchWithAuth
         .mockResolvedValueOnce(notOkResponse(401)) // tick 1 → suspend

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
@@ -528,6 +528,61 @@ describe('startStreamJoinPollFallback', () => {
       expect(mockFetchWithAuth).not.toHaveBeenCalled();
     });
 
+    // Regression (adversarial review): the terminal not-found path must not leave a resume
+    // listener behind. If a 401 armed one and a subsequently-resumed tick finds the row gone, the
+    // poll is terminally done — a later stray `auth:refreshed` must NOT resurrect polling.
+    it('given a resumed tick that finds the row gone, should clear the listener so a later auth:refreshed cannot resurrect polling', async () => {
+      mockFetchWithAuth
+        .mockResolvedValueOnce(notOkResponse(401)) // tick 1 → suspend, arms listener
+        .mockResolvedValueOnce(okResponse([])); // resumed tick → row gone → terminal
+      const controller = newController();
+      const onNotFound = vi.fn();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), onNotFound);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Resume → the resumed tick sees the row gone → onNotFound + terminal teardown.
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onNotFound).toHaveBeenCalledTimes(1);
+
+      // A stray auth:refreshed after the terminal state must do nothing (listener was cleared).
+      mockFetchWithAuth.mockClear();
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 3);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+      expect(onNotFound).toHaveBeenCalledTimes(1); // never fired again
+    });
+
+    it('given a terminal not-found while an overlapping tick is still in flight, that tick 401ing must NOT arm a resume listener', async () => {
+      // Simulate two overlapping in-flight ticks: tick A (first, slow) will 401; tick B (interval)
+      // resolves row-gone FIRST → terminal. When tick A finally resolves 401, the `terminated`
+      // guard must stop it from arming a resume listener that auth:refreshed could resurrect.
+      let resolveA: (v: unknown) => void = () => {};
+      const aPending = new Promise((r) => { resolveA = r; });
+      mockFetchWithAuth
+        .mockReturnValueOnce(aPending) // tick A — stays pending past the interval
+        .mockResolvedValueOnce(okResponse([])); // tick B — row gone → terminal
+      const controller = newController();
+      const onNotFound = vi.fn();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), onNotFound);
+      await vi.advanceTimersByTimeAsync(0); // tick A fired, awaiting
+      // Interval fires tick B, which resolves row-gone → terminal.
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS);
+      expect(onNotFound).toHaveBeenCalledTimes(1);
+
+      // Now tick A resolves 401 — post-terminal. It must not arm a listener.
+      resolveA(notOkResponse(401));
+      await vi.advanceTimersByTimeAsync(0);
+
+      mockFetchWithAuth.mockClear();
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 3);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled(); // no resurrection
+      expect(onNotFound).toHaveBeenCalledTimes(1);
+    });
+
     it('given a second 401 after a resume, should suspend again (survives repeated auth failures)', async () => {
       mockFetchWithAuth
         .mockResolvedValueOnce(notOkResponse(401)) // tick 1 → suspend

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-poll-fallback.test.ts
@@ -6,11 +6,46 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: mockFetchWithAuth,
 }));
 
-import { startStreamJoinPollFallback, STREAM_JOIN_POLL_INTERVAL_MS } from '../stream-join-poll-fallback';
+import {
+  startStreamJoinPollFallback,
+  decidePollTickOutcome,
+  STREAM_JOIN_POLL_INTERVAL_MS,
+} from '../stream-join-poll-fallback';
 
 const okResponse = (streams: unknown[]) => ({
   ok: true,
   json: async () => ({ streams }),
+});
+
+const notOkResponse = (status: number) => ({ ok: false, status, json: async () => ({}) });
+
+// The pure decision core for what a failed tick means: an auth failure (401/403) is a signal
+// to STOP the 1s interval (the storm) until a refresh lands; anything else is a transient miss
+// the interval should ride out and retry on its next tick.
+describe('decidePollTickOutcome (pure)', () => {
+  it('given a 401, should suspend (an auth failure would otherwise storm the refresh endpoint)', () => {
+    expect(decidePollTickOutcome(401)).toBe('suspend');
+  });
+
+  it('given a 403, should suspend (same auth-failure class as 401)', () => {
+    expect(decidePollTickOutcome(403)).toBe('suspend');
+  });
+
+  it('given a 500, should continue (server error — retry on the next tick)', () => {
+    expect(decidePollTickOutcome(500)).toBe('continue');
+  });
+
+  it('given a 429, should continue (rate limited — retry on the next tick)', () => {
+    expect(decidePollTickOutcome(429)).toBe('continue');
+  });
+
+  it('given a 400, should continue (not an auth failure)', () => {
+    expect(decidePollTickOutcome(400)).toBe('continue');
+  });
+
+  it('given a 404, should continue (not an auth failure)', () => {
+    expect(decidePollTickOutcome(404)).toBe('continue');
+  });
 });
 
 describe('startStreamJoinPollFallback', () => {
@@ -346,5 +381,133 @@ describe('startStreamJoinPollFallback', () => {
       `/api/ai/chat/active-streams?channelId=${encodeURIComponent('page/weird id')}`,
       expect.any(Object),
     );
+  });
+
+  // The storm (D2): before this, a 401 was swallowed like any other non-ok response and the 1s
+  // interval kept firing forever — hammering device-refresh ~1/sec until the rate limit locked
+  // the user out. Now a 401/403 SUSPENDS the interval until an `auth:refreshed` event says the
+  // session is healed.
+  describe('auth-failure suspend/resume (the D2 storm fix)', () => {
+    // A suspended poll registers a window `auth:refreshed` listener that only clears on abort or
+    // on the event firing. Tests that intentionally leave a poll suspended must abort at the end
+    // or their listener leaks onto the shared window and fires during a LATER test's dispatch.
+    // Track every controller and abort it in cleanup so each test is isolated.
+    const controllers: AbortController[] = [];
+    const newController = (): AbortController => {
+      const c = new AbortController();
+      controllers.push(c);
+      return c;
+    };
+    afterEach(() => {
+      controllers.forEach((c) => c.abort());
+      controllers.length = 0;
+    });
+
+    it('given a 401 tick, should stop the 1s interval — the storm cannot happen', async () => {
+      mockFetchWithAuth.mockResolvedValue(notOkResponse(401));
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 10);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given a 403 tick, should also stop the interval (same auth-failure class)', async () => {
+      mockFetchWithAuth.mockResolvedValue(notOkResponse(403));
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 10);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given an auth:refreshed event after a suspend, should resume with an immediate tick and restart the interval', async () => {
+      mockFetchWithAuth
+        .mockResolvedValueOnce(notOkResponse(401)) // first tick suspends
+        .mockResolvedValue(okResponse([{ messageId: 'msg-1', parts: [{ type: 'text', text: 'healed' }] }]));
+      const controller = newController();
+      const onSnapshot = vi.fn();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, onSnapshot, vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      // Refresh landed — the session is healed. Resuming fires an IMMEDIATE tick (not a full
+      // interval's wait).
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(2);
+      expect(onSnapshot).toHaveBeenCalledWith([{ type: 'text', text: 'healed' }]);
+
+      // ...and the interval is running again.
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(3);
+    });
+
+    it('given the signal aborts while suspended, should remove the auth:refreshed listener (no leak, no resume)', async () => {
+      mockFetchWithAuth.mockResolvedValue(notOkResponse(401));
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      controller.abort();
+      mockFetchWithAuth.mockClear();
+
+      // The listener must be gone — a stray auth:refreshed cannot resurrect a dead poll.
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 5);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given auth:refreshed fires but the signal aborted first, should not resume', async () => {
+      // Belt-and-suspenders: even if the listener somehow survived the abort cleanup, the resume
+      // handler itself must no-op on an aborted signal.
+      mockFetchWithAuth.mockResolvedValue(notOkResponse(401));
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+
+      controller.abort();
+      mockFetchWithAuth.mockClear();
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    it('given a second 401 after a resume, should suspend again (survives repeated auth failures)', async () => {
+      mockFetchWithAuth
+        .mockResolvedValueOnce(notOkResponse(401)) // tick 1 → suspend
+        .mockResolvedValueOnce(notOkResponse(401)); // resumed tick → suspend again
+      const controller = newController();
+
+      startStreamJoinPollFallback('page-a', 'msg-1', controller.signal, vi.fn(), vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(2);
+
+      // Suspended again — interval is stopped, no storm.
+      mockFetchWithAuth.mockClear();
+      await vi.advanceTimersByTimeAsync(STREAM_JOIN_POLL_INTERVAL_MS * 5);
+      expect(mockFetchWithAuth).not.toHaveBeenCalled();
+
+      // A fresh auth:refreshed still resumes it.
+      mockFetchWithAuth.mockResolvedValue(okResponse([{ messageId: 'msg-1', parts: [] }]));
+      window.dispatchEvent(new Event('auth:refreshed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
+++ b/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
@@ -68,6 +68,11 @@ export function startStreamJoinPollFallback(
   // The `auth:refreshed` resume listener, tracked so the abort cleanup can remove it if the caller
   // gives up mid-suspend (before any refresh lands) — otherwise it would leak past this poll.
   let resumeListener: (() => void) | null = null;
+  // Set once the poll reaches its terminal row-gone state (`onNotFound`). Guards against a second,
+  // still-in-flight tick re-arming a resume listener AFTER the poll is already done — otherwise a
+  // later `auth:refreshed` (the very event this feature waits on) would resurrect polling for a
+  // stream already declared gone. See the not-found branch and `suspendUntilAuthRefreshed`.
+  let terminated = false;
 
   const startInterval = (): void => {
     intervalId = setInterval(() => void tick(), STREAM_JOIN_POLL_INTERVAL_MS);
@@ -103,6 +108,9 @@ export function startStreamJoinPollFallback(
   // fire both, spinning up two intervals but only tracking the last handle — the other orphaned
   // past abort. Removing any prior listener before registering guarantees exactly one at a time.
   const suspendUntilAuthRefreshed = (): void => {
+    // A terminal not-found may have already ended this poll while this (overlapping) tick was in
+    // flight — never arm a resume listener after that, or `auth:refreshed` would resurrect it.
+    if (terminated) return;
     clearResumeListener();
     stopInterval();
     resumeListener = () => {
@@ -129,7 +137,12 @@ export function startStreamJoinPollFallback(
       if (signal.aborted) return;
       const row = (data.streams ?? []).find((s) => s.messageId === messageId);
       if (!row) {
+        // Terminal. Mark first, then tear down BOTH the interval and any resume listener an
+        // overlapping 401 tick may already have armed — a finished poll must leave nothing behind
+        // that a later `auth:refreshed` could use to resurrect it.
+        terminated = true;
         stopInterval();
+        clearResumeListener();
         onNotFound();
         return;
       }

--- a/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
+++ b/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
@@ -95,7 +95,15 @@ export function startStreamJoinPollFallback(
   // poll can never resume, and the `{ once: true }` listener never leaks. (No inner
   // `signal.aborted` re-check: an aborted signal removes this listener synchronously, so it
   // simply never fires afterward.)
+  //
+  // `clearResumeListener()` first — `setInterval` does NOT wait for a slow tick to resolve, so if
+  // a fetch outlives the 1s interval two ticks can be in flight at once; were both to see a
+  // 401/403 each would suspend, and without this a second suspend would overwrite `resumeListener`
+  // while leaving the FIRST listener registered on `window`. A later `auth:refreshed` would then
+  // fire both, spinning up two intervals but only tracking the last handle — the other orphaned
+  // past abort. Removing any prior listener before registering guarantees exactly one at a time.
   const suspendUntilAuthRefreshed = (): void => {
+    clearResumeListener();
     stopInterval();
     resumeListener = () => {
       resumeListener = null; // consumed — the browser already removed the once-listener

--- a/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
+++ b/apps/web/src/lib/ai/core/stream-join-poll-fallback.ts
@@ -13,6 +13,21 @@ interface ActiveStreamsPollResponse {
 }
 
 /**
+ * Pure decision core for what a failed (`!ok`) poll tick means.
+ *
+ * `'suspend'` — an auth failure (401/403). The 1s interval must STOP, not retry: the session
+ * cookie/bearer is dead, and re-polling every second just hammers the device-refresh endpoint
+ * ~1/sec until the rate limit locks the user out (the D2 "API-401 storm" that stranded desktop
+ * users). Polling resumes only once `auth-fetch` dispatches `auth:refreshed`.
+ *
+ * `'continue'` — any other non-ok status (network blip, 429, 5xx). Transient: swallow it and
+ * retry on the next interval, exactly as before.
+ */
+export function decidePollTickOutcome(status: number): 'continue' | 'suspend' {
+  return status === 401 || status === 403 ? 'suspend' : 'continue';
+}
+
+/**
  * Leaf 5.4 — cross-instance rejoin fallback. When an SSE stream-join 404s, the usual cause is
  * that the stream lives on another web instance: the multicast registry is per-process, so
  * this instance simply cannot see its live tokens (see `stream-join-client.ts`'s
@@ -46,6 +61,50 @@ export function startStreamJoinPollFallback(
 ): void {
   if (signal.aborted) return;
 
+  // The interval is stopped-and-restarted across auth-failure suspends, so it is a mutable
+  // handle rather than a `const`. `null` means "not currently polling" (suspended, or terminally
+  // stopped after a row-gone / abort).
+  let intervalId: ReturnType<typeof setInterval> | null = null;
+  // The `auth:refreshed` resume listener, tracked so the abort cleanup can remove it if the caller
+  // gives up mid-suspend (before any refresh lands) — otherwise it would leak past this poll.
+  let resumeListener: (() => void) | null = null;
+
+  const startInterval = (): void => {
+    intervalId = setInterval(() => void tick(), STREAM_JOIN_POLL_INTERVAL_MS);
+  };
+
+  const stopInterval = (): void => {
+    if (intervalId !== null) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+
+  const clearResumeListener = (): void => {
+    if (resumeListener) {
+      window.removeEventListener('auth:refreshed', resumeListener);
+      resumeListener = null;
+    }
+  };
+
+  // Auth failure: kill the 1s interval and wait — once, no polling in the meantime — for
+  // `auth-fetch` to announce a healed session via `auth:refreshed`. On that event, resume with an
+  // immediate tick (don't make the user wait a full interval for fresh content) plus a fresh
+  // interval. "Unless the signal is aborted, restart" is enforced by the abort cleanup below,
+  // which removes this listener the instant the caller gives up — so a suspended-then-aborted
+  // poll can never resume, and the `{ once: true }` listener never leaks. (No inner
+  // `signal.aborted` re-check: an aborted signal removes this listener synchronously, so it
+  // simply never fires afterward.)
+  const suspendUntilAuthRefreshed = (): void => {
+    stopInterval();
+    resumeListener = () => {
+      resumeListener = null; // consumed — the browser already removed the once-listener
+      startInterval();
+      void tick();
+    };
+    window.addEventListener('auth:refreshed', resumeListener, { once: true });
+  };
+
   const tick = async (): Promise<void> => {
     if (signal.aborted) return;
     try {
@@ -53,12 +112,16 @@ export function startStreamJoinPollFallback(
         `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
         { credentials: 'include', signal },
       );
-      if (signal.aborted || !res.ok) return;
+      if (signal.aborted) return;
+      if (!res.ok) {
+        if (decidePollTickOutcome(res.status) === 'suspend') suspendUntilAuthRefreshed();
+        return;
+      }
       const data = (await res.json()) as ActiveStreamsPollResponse;
       if (signal.aborted) return;
       const row = (data.streams ?? []).find((s) => s.messageId === messageId);
       if (!row) {
-        clearInterval(intervalId);
+        stopInterval();
         onNotFound();
         return;
       }
@@ -70,9 +133,12 @@ export function startStreamJoinPollFallback(
   };
 
   void tick();
-  // `tick`'s closure references `intervalId` (in the `!row` branch) before this line runs — safe
-  // because that branch only executes asynchronously, after `intervalId` is fully initialized:
-  // `void tick()` above suspends at its first `await` and returns control here synchronously.
-  const intervalId = setInterval(() => void tick(), STREAM_JOIN_POLL_INTERVAL_MS);
-  signal.addEventListener('abort', () => clearInterval(intervalId), { once: true });
+  // `tick`'s closure references `intervalId`/`resumeListener` before this line runs — safe because
+  // those branches only execute asynchronously, after both are initialized: `void tick()` above
+  // suspends at its first `await` and returns control here synchronously.
+  startInterval();
+  signal.addEventListener('abort', () => {
+    stopInterval();
+    clearResumeListener();
+  }, { once: true });
 }

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -17,11 +17,21 @@ import {
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
   hashToken: vi.fn().mockReturnValue('mocked-hash'),
 }));
-vi.mock('@pagespace/lib/auth/session-service', () => ({
-  sessionService: {
-    validateSession: vi.fn(),
-  },
-}));
+vi.mock('@pagespace/lib/auth/session-service', () => {
+  const validateSession = vi.fn();
+  return {
+    sessionService: {
+      validateSession,
+      // D5: authenticateSessionRequest now goes through validateSessionWithReason. Delegate to
+      // the same validateSession mock so every existing per-test setup drives both paths: claims
+      // -> { claims }, null -> { failureReason }.
+      validateSessionWithReason: vi.fn(async (token: string, opts?: unknown) => {
+        const claims = await validateSession(token, opts);
+        return claims ? { claims } : { failureReason: 'not_found' };
+      }),
+    },
+  };
+});
 vi.mock('@pagespace/lib/auth/token-lookup', () => ({
   findOAuthAccessTokenByValue: vi.fn(),
 }));

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -4,7 +4,7 @@ import { eq, and, isNull } from '@pagespace/db/operators'
 import { mcpTokens } from '@pagespace/db/schema/auth';
 import { oauthAccessTokens } from '@pagespace/db/schema/oauth';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
-import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { sessionService, type SessionClaims, type SessionFailureReason } from '@pagespace/lib/auth/session-service';
 import { findOAuthAccessTokenByValue } from '@pagespace/lib/auth/token-lookup';
 import { parseScopeList, scopeSetToDriveScopes, type ScopeSet, type DriveScopeRow } from '@pagespace/lib/auth/oauth/scopes';
 import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context';
@@ -66,6 +66,13 @@ export type AuthResult = MCPAuthResult | SessionAuthResult | OAuthAuthResult;
 
 export interface AuthError {
   error: NextResponse;
+  /**
+   * When the failure was a session-token validation failure, the machine-readable reason
+   * (D5): expired vs revoked vs not_found vs ... Additive — undefined for non-session failures
+   * (missing token, MCP/OAuth failures). Callers spread it into their `auth_failed` audit
+   * details so an incident is provable.
+   */
+  authFailureReason?: SessionFailureReason;
 }
 
 export type AuthenticationResult = AuthResult | AuthError;
@@ -290,6 +297,27 @@ export async function validateSessionToken(token: string): Promise<SessionClaims
   }
 }
 
+/**
+ * Session-token validation that also surfaces WHY it failed (D5), for the audit trail.
+ * Mirrors `validateSessionToken`'s error-swallowing contract: on success returns the claims;
+ * on any failure returns `{ failureReason }` and never throws (an unexpected error maps to
+ * `not_found`, preserving the historical 401 outcome).
+ */
+async function validateSessionTokenWithReason(
+  token: string,
+): Promise<{ claims: SessionClaims } | { claims?: undefined; failureReason: SessionFailureReason }> {
+  try {
+    if (!token) {
+      return { failureReason: 'bad_format' };
+    }
+    const result = await sessionService.validateSessionWithReason(token, { expectedType: 'user' });
+    return result.claims ? { claims: result.claims } : { failureReason: result.failureReason };
+  } catch (error) {
+    console.error('validateSessionTokenWithReason error', error);
+    return { failureReason: 'not_found' };
+  }
+}
+
 export async function authenticateMCPRequest(request: Request): Promise<AuthenticationResult> {
   const token = getBearerToken(request);
 
@@ -348,18 +376,18 @@ export async function authenticateSessionRequest(request: Request): Promise<Auth
 
     // Session token sent as Bearer (mobile/desktop)
     if (bearerToken.startsWith(SESSION_TOKEN_PREFIX)) {
-      const sessionResult = await validateSessionToken(bearerToken);
-      if (sessionResult) {
+      const sessionResult = await validateSessionTokenWithReason(bearerToken);
+      if (sessionResult.claims) {
         return {
-          userId: sessionResult.userId,
-          role: sessionResult.userRole,
-          tokenVersion: sessionResult.tokenVersion,
-          adminRoleVersion: sessionResult.adminRoleVersion,
-          sessionId: sessionResult.sessionId,
+          userId: sessionResult.claims.userId,
+          role: sessionResult.claims.userRole,
+          tokenVersion: sessionResult.claims.tokenVersion,
+          adminRoleVersion: sessionResult.claims.adminRoleVersion,
+          sessionId: sessionResult.claims.sessionId,
           tokenType: 'session',
         } satisfies SessionAuthResult;
       }
-      return { error: unauthorized('Invalid or expired session') };
+      return { error: unauthorized('Invalid or expired session'), authFailureReason: sessionResult.failureReason };
     }
 
     // Unknown Bearer token format
@@ -376,19 +404,20 @@ export async function authenticateSessionRequest(request: Request): Promise<Auth
     };
   }
 
-  const sessionClaims = await validateSessionToken(sessionToken);
-  if (!sessionClaims) {
+  const sessionResult = await validateSessionTokenWithReason(sessionToken);
+  if (!sessionResult.claims) {
     return {
       error: unauthorized('Invalid or expired session'),
+      authFailureReason: sessionResult.failureReason,
     };
   }
 
   return {
-    userId: sessionClaims.userId,
-    role: sessionClaims.userRole,
-    tokenVersion: sessionClaims.tokenVersion,
-    adminRoleVersion: sessionClaims.adminRoleVersion,
-    sessionId: sessionClaims.sessionId,
+    userId: sessionResult.claims.userId,
+    role: sessionResult.claims.userRole,
+    tokenVersion: sessionResult.claims.tokenVersion,
+    adminRoleVersion: sessionResult.claims.adminRoleVersion,
+    sessionId: sessionResult.claims.sessionId,
     tokenType: 'session',
   } satisfies SessionAuthResult;
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -97,6 +97,10 @@ export default defineConfig({
         // same as materialize-interrupted-stream above.
         'src/lib/ai/core/checkpoint-serialize.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/lib/ai/core/stream-join-poll-fallback.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
+        // Native-shell signin recovery (wave 1, D1): the pure decision core is gated at 100%
+        // branch. Per-file (not a dir glob) — useSigninRecovery.ts alongside it is the effectful
+        // shell.
+        'src/app/auth/signin/signin-recovery.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/useConversationMessagesStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/usePendingStreamsStore.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },
         'src/stores/conversationMessages/*.ts': { lines: 100, branches: 100, functions: 100, statements: 100 },

--- a/packages/lib/src/auth/__tests__/session-service-expire.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-expire.test.ts
@@ -30,6 +30,11 @@ vi.mock('../constants', () => ({
   IDLE_TIMEOUT_MS: 0,
 }));
 
+const { infoSpy } = vi.hoisted(() => ({ infoSpy: vi.fn() }));
+vi.mock('../../logging/logger-config', () => ({
+  loggers: { auth: { info: infoSpy, warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
 import { SessionService, clampExpiry } from '../session-service';
 import { sessionRepository } from '../session-repository';
 
@@ -75,6 +80,13 @@ describe('SessionService.expireSessionByHashSoon', () => {
     // Clamped to ~now+grace, never the original 1h expiry.
     expect(clamped.getTime()).toBeGreaterThanOrEqual(now + 60_000 - 1000);
     expect(clamped.getTime()).toBeLessThanOrEqual(now + 60_000 + 1000);
+    // D5: the clamp is logged so grace-expiries are visible in prod (and traceable to the
+    // later `expired` failure reason).
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith('Session grace-expiry clamped', expect.objectContaining({
+      sessionRef: 'hash-1',
+      graceMs: 60_000,
+    }));
   });
 
   it('never extends a session already expiring sooner than now+grace', async () => {
@@ -86,6 +98,8 @@ describe('SessionService.expireSessionByHashSoon', () => {
     await service.expireSessionByHashSoon('hash-1', 60_000);
 
     expect(sessionRepository.setExpiresAtByHash).not.toHaveBeenCalled();
+    // No clamp ⇒ no log.
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   it('is a no-op when there is no active session for the hash', async () => {
@@ -94,5 +108,6 @@ describe('SessionService.expireSessionByHashSoon', () => {
     await expect(service.expireSessionByHashSoon('hash-missing', 60_000)).resolves.toBeUndefined();
 
     expect(sessionRepository.setExpiresAtByHash).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/auth/__tests__/session-service-reason.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-reason.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// D5 — session-failure reasons. validateSessionWithReason explains WHY a session failed to
+// validate (expired vs revoked vs never-existed vs suspended vs ...), so an incident is
+// provable from the audit log instead of a bare `auth_failed`. validateSession stays a thin
+// claims|null wrapper over it (non-breaking).
+
+vi.mock('../session-repository', () => ({
+  sessionRepository: {
+    findUserById: vi.fn(),
+    findActiveSession: vi.fn(),
+    findSessionByHashAnyState: vi.fn(),
+    getActiveSessionExpiry: vi.fn(),
+    setExpiresAtByHash: vi.fn(),
+    insertSession: vi.fn(),
+    touchSession: vi.fn(),
+    revokeByHash: vi.fn(),
+    revokeAllForUser: vi.fn(),
+    revokeWebForUser: vi.fn(),
+    revokeAdminForUser: vi.fn(),
+    revokeForUserDevice: vi.fn(),
+    deleteExpired: vi.fn(),
+  },
+}));
+
+vi.mock('../opaque-tokens', () => ({
+  generateOpaqueToken: vi.fn(),
+  isValidTokenFormat: vi.fn(),
+}));
+
+vi.mock('../token-utils', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+}));
+
+// Idle timeout disabled by default; a dedicated test re-mocks it to exercise the branch.
+vi.mock('../constants', () => ({
+  IDLE_TIMEOUT_MS: 0,
+}));
+
+import { SessionService } from '../session-service';
+import { sessionRepository } from '../session-repository';
+import { isValidTokenFormat } from '../opaque-tokens';
+
+const activeSession = (overrides: Record<string, unknown> = {}) => ({
+  id: 'sess_abcdef123456',
+  userId: 'user-1',
+  tokenHash: 'hashed_tok',
+  tokenVersion: 3,
+  adminRoleVersion: 1,
+  type: 'user',
+  scopes: ['read'],
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+  lastUsedAt: new Date(),
+  createdAt: new Date(),
+  resourceType: null,
+  resourceId: null,
+  driveId: null,
+  user: {
+    id: 'user-1',
+    tokenVersion: 3,
+    role: 'user',
+    adminRoleVersion: 1,
+    suspendedAt: null,
+  },
+  ...overrides,
+});
+
+describe('validateSessionWithReason', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+    vi.mocked(isValidTokenFormat).mockReturnValue(true);
+  });
+
+  it('given a malformed token, yields failureReason bad_format (no DB lookup)', async () => {
+    vi.mocked(isValidTokenFormat).mockReturnValue(false);
+
+    const result = await service.validateSessionWithReason('garbage');
+
+    expect(result).toEqual({ failureReason: 'bad_format' });
+    expect(sessionRepository.findActiveSession).not.toHaveBeenCalled();
+  });
+
+  it('given no active session and no session at all for the hash, yields not_found', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(undefined);
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue(undefined);
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('not_found');
+  });
+
+  it('given no active session but a grace-expired one (revokedAt null, expiresAt past), yields expired with expiresAt', async () => {
+    // #2176's expireSessionByHashSoon clamps expiresAt into the past WITHOUT setting revokedAt.
+    const expiredAt = new Date(Date.now() - 5_000);
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(undefined);
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue({
+      id: 'sess_expired01',
+      type: 'user',
+      revokedAt: null,
+      revokedReason: null,
+      expiresAt: expiredAt,
+    } as never);
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('expired');
+    // Narrow to the failure branch (success has failureReason: undefined).
+    if (!result.failureReason) throw new Error('expected a failure result');
+    expect(result.expiresAt).toEqual(expiredAt);
+  });
+
+  it('given no active session but a revoked one, yields revoked with revokedReason', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(undefined);
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue({
+      id: 'sess_revoked01',
+      type: 'user',
+      revokedAt: new Date(Date.now() - 1000),
+      revokedReason: 'device_id_mismatch',
+      expiresAt: new Date(Date.now() + 60_000),
+    } as never);
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('revoked');
+    if (!result.failureReason) throw new Error('expected a failure result');
+    expect(result.revokedReason).toBe('device_id_mismatch');
+  });
+
+  it('given an active session of the wrong type, yields wrong_type (no revoke side effect)', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+      activeSession({ type: 'socket' }) as never,
+    );
+
+    const result = await service.validateSessionWithReason('sess_tok', { expectedType: 'user' });
+
+    expect(result.failureReason).toBe('wrong_type');
+    expect(sessionRepository.revokeByHash).not.toHaveBeenCalled();
+  });
+
+  it('given a suspended user, yields user_suspended and revokes the session', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+      activeSession({ user: { id: 'user-1', tokenVersion: 3, role: 'user', adminRoleVersion: 1, suspendedAt: new Date() } }) as never,
+    );
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('user_suspended');
+    expect(sessionRepository.revokeByHash).toHaveBeenCalledWith('hashed_sess_tok', 'user_suspended');
+  });
+
+  it('given a token-version mismatch, yields token_version_mismatch and revokes', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+      activeSession({ tokenVersion: 2 }) as never, // user.tokenVersion is 3
+    );
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('token_version_mismatch');
+    expect(sessionRepository.revokeByHash).toHaveBeenCalledWith('hashed_sess_tok', 'token_version_mismatch');
+  });
+
+  it('given a valid active session, yields claims and touches the session', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(activeSession() as never);
+
+    const result = await service.validateSessionWithReason('sess_tok', { expectedType: 'user' });
+
+    expect(result.claims).toMatchObject({ userId: 'user-1', sessionId: 'sess_abcdef123456', type: 'user' });
+    expect(result.failureReason).toBeUndefined();
+    expect(sessionRepository.touchSession).toHaveBeenCalledWith('hashed_sess_tok');
+  });
+
+  it('given no active session and no user on the joined active row, yields not_found', async () => {
+    // Active row exists but the user was deleted (join null) — cannot mint claims.
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+      activeSession({ user: null }) as never,
+    );
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue(undefined);
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('not_found');
+  });
+});
+
+describe('validateSessionWithReason — idle timeout branch', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('given an idle session (last activity older than the timeout), yields idle_timeout and revokes', async () => {
+    vi.doMock('../constants', () => ({ IDLE_TIMEOUT_MS: 15 * 60 * 1000 }));
+    vi.doMock('../opaque-tokens', () => ({
+      generateOpaqueToken: vi.fn(),
+      isValidTokenFormat: vi.fn(() => true),
+    }));
+    vi.doMock('../token-utils', () => ({ hashToken: vi.fn((t: string) => `hashed_${t}`) }));
+    const repo = {
+      findActiveSession: vi.fn().mockResolvedValue({
+        id: 'sess_idle01',
+        userId: 'user-1',
+        tokenHash: 'hashed_tok',
+        tokenVersion: 3,
+        adminRoleVersion: 1,
+        type: 'user',
+        scopes: ['read'],
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        lastUsedAt: new Date(Date.now() - 30 * 60 * 1000), // idle 30min > 15min timeout
+        createdAt: new Date(Date.now() - 60 * 60 * 1000),
+        resourceType: null,
+        resourceId: null,
+        driveId: null,
+        user: { id: 'user-1', tokenVersion: 3, role: 'user', adminRoleVersion: 1, suspendedAt: null },
+      }),
+      findSessionByHashAnyState: vi.fn(),
+      touchSession: vi.fn(),
+      revokeByHash: vi.fn(),
+    };
+    vi.doMock('../session-repository', () => ({ sessionRepository: repo }));
+
+    const { SessionService: FreshService } = await import('../session-service');
+    const service = new FreshService();
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('idle_timeout');
+    expect(repo.revokeByHash).toHaveBeenCalledWith('hashed_sess_tok', 'idle_timeout');
+  });
+});
+
+// The wrapper must return exactly what it did before: claims on success, null on any failure.
+describe('validateSession wrapper parity', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+    vi.mocked(isValidTokenFormat).mockReturnValue(true);
+  });
+
+  it('returns claims on a valid session (identical to the reason path claims)', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(activeSession() as never);
+
+    const claims = await service.validateSession('sess_tok', { expectedType: 'user' });
+
+    expect(claims).not.toBeNull();
+    expect(claims?.userId).toBe('user-1');
+    expect(claims?.sessionId).toBe('sess_abcdef123456');
+  });
+
+  it('returns null on a malformed token', async () => {
+    vi.mocked(isValidTokenFormat).mockReturnValue(false);
+    expect(await service.validateSession('garbage')).toBeNull();
+  });
+
+  it('returns null on a revoked session', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(undefined);
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue({
+      id: 'sess_x', type: 'user', revokedAt: new Date(), revokedReason: 'logout', expiresAt: new Date(),
+    } as never);
+
+    expect(await service.validateSession('sess_tok')).toBeNull();
+  });
+
+  it('returns null on a wrong-type token', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+      activeSession({ type: 'socket' }) as never,
+    );
+    expect(await service.validateSession('sess_tok', { expectedType: 'user' })).toBeNull();
+  });
+});

--- a/packages/lib/src/auth/__tests__/session-service-reason.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-reason.test.ts
@@ -172,11 +172,31 @@ describe('validateSessionWithReason', () => {
     expect(sessionRepository.touchSession).toHaveBeenCalledWith('hashed_sess_tok');
   });
 
-  it('given no active session and no user on the joined active row, yields not_found', async () => {
-    // Active row exists but the user was deleted (join null) — cannot mint claims.
+  it('given an orphaned active row (user deleted, session still non-revoked + future expiry), yields not_found — NOT expired', async () => {
+    // findActiveSession left-joins the user, so a userless row fails the `!session.user` guard and
+    // routes into the any-state path. The any-state lookup for the SAME hash returns that SAME
+    // still-active row (revokedAt null, expiresAt in the FUTURE). It must classify as not_found —
+    // an active row's future expiry is not an expiry at all. (Regression: CodeRabbit — orphaned
+    // session misclassified as `expired`.)
+    const futureExpiry = new Date(Date.now() + 60 * 60 * 1000);
     vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
-      activeSession({ user: null }) as never,
+      activeSession({ user: null, expiresAt: futureExpiry }) as never,
     );
+    vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue({
+      id: 'sess_orphan01',
+      type: 'user',
+      revokedAt: null,
+      revokedReason: null,
+      expiresAt: futureExpiry, // still in the future — the session itself hasn't expired
+    } as never);
+
+    const result = await service.validateSessionWithReason('sess_tok');
+
+    expect(result.failureReason).toBe('not_found');
+  });
+
+  it('given no active session and no any-state row at all, yields not_found', async () => {
+    vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(undefined);
     vi.mocked(sessionRepository.findSessionByHashAnyState).mockResolvedValue(undefined);
 
     const result = await service.validateSessionWithReason('sess_tok');

--- a/packages/lib/src/auth/__tests__/session-service-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-unit.test.ts
@@ -4,6 +4,9 @@ vi.mock('../session-repository', () => ({
   sessionRepository: {
     findUserById: vi.fn(),
     findActiveSession: vi.fn(),
+    // D5: the failure path now does a secondary any-state lookup to classify the reason.
+    // Defaults to undefined ⇒ 'not_found' ⇒ validateSession still returns null (parity).
+    findSessionByHashAnyState: vi.fn(),
     insertSession: vi.fn(),
     touchSession: vi.fn(),
     revokeByHash: vi.fn(),

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -39,6 +39,19 @@ export interface SessionRecord {
   } | null;
 }
 
+/**
+ * A session row read WITHOUT the active-only filter (any revoked/expired state), for
+ * explaining WHY there is no active session (D5). Deliberately minimal: just the columns the
+ * failure-reason classifier needs, no user join.
+ */
+export interface SessionAnyStateRecord {
+  id: string;
+  type: 'user' | 'service' | 'mcp' | 'device' | 'socket';
+  revokedAt: Date | null;
+  revokedReason: string | null;
+  expiresAt: Date;
+}
+
 export const sessionRepository = {
   findUserById: async (userId: string): Promise<SessionUserRecord | undefined> => {
     return db.query.users.findFirst({
@@ -60,6 +73,16 @@ export const sessionRepository = {
         },
       },
     }) as Promise<SessionRecord | undefined>;
+  },
+
+  // Look up a session by hash in ANY state (revoked, expired, or active). Used by the
+  // failure-reason classifier when findActiveSession finds nothing, to split "revoked" vs
+  // "grace-expired" vs "genuinely never existed". No revoked/expiry predicate, no user join.
+  findSessionByHashAnyState: async (tokenHash: string): Promise<SessionAnyStateRecord | undefined> => {
+    return db.query.sessions.findFirst({
+      where: eq(sessions.tokenHash, tokenHash),
+      columns: { id: true, type: true, revokedAt: true, revokedReason: true, expiresAt: true },
+    }) as Promise<SessionAnyStateRecord | undefined>;
   },
 
   insertSession: async (values: typeof sessions.$inferInsert): Promise<void> => {

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -154,10 +154,17 @@ export class SessionService {
           sessionIdPrefix,
         };
       }
-      // Not revoked but not active ⇒ its expiry is in the past. A grace-expiry
-      // (expireSessionByHashSoon) lands here: revokedAt null, expiresAt clamped to the retirement
-      // time.
-      return { failureReason: 'expired', expiresAt: anyState.expiresAt, sessionIdPrefix };
+      // Not revoked. Classify by expiry, NOT by "not active" — because we also reach here for a
+      // still-active row whose USER was deleted (findActiveSession left-joins the user, so a
+      // userless row fails the `!session.user` guard above while its own expiry is still in the
+      // future). Only an expiry actually in the past is `expired` (a grace-expiry from
+      // expireSessionByHashSoon: revokedAt null, expiresAt clamped into the past). A future expiry
+      // here means the session row exists but is unusable (orphaned by a deleted user) — that is
+      // `not_found`, not `expired`.
+      if (anyState.expiresAt.getTime() <= Date.now()) {
+        return { failureReason: 'expired', expiresAt: anyState.expiresAt, sessionIdPrefix };
+      }
+      return { failureReason: 'not_found', sessionIdPrefix };
     }
 
     const sessionIdPrefix = session.id.slice(0, 8);

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -2,6 +2,7 @@ import { generateOpaqueToken, isValidTokenFormat, type TokenType } from './opaqu
 import { hashToken } from './token-utils';
 import { IDLE_TIMEOUT_MS } from './constants';
 import { sessionRepository } from './session-repository';
+import { loggers } from '../logging/logger-config';
 
 const SESSION_CLEANUP_RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
@@ -27,6 +28,39 @@ export interface SessionClaims {
   resourceId?: string;
   driveId?: string;
 }
+
+/**
+ * Why a session token failed to validate. Additive diagnostics (D5) — surfaced in audit logs
+ * so an incident is provable (expired vs revoked vs grace-expired vs never-existed) instead of
+ * a bare `auth_failed`.
+ */
+export type SessionFailureReason =
+  | 'bad_format'
+  | 'not_found'
+  | 'expired'
+  | 'revoked'
+  | 'wrong_type'
+  | 'user_suspended'
+  | 'token_version_mismatch'
+  | 'idle_timeout';
+
+export interface SessionValidationSuccess {
+  claims: SessionClaims;
+  failureReason?: undefined;
+}
+
+export interface SessionValidationFailure {
+  claims?: undefined;
+  failureReason: SessionFailureReason;
+  /** For `revoked`: the reason recorded on the session row (e.g. `device_id_mismatch`). */
+  revokedReason?: string;
+  /** For `expired`/`revoked`: the session's expiry (≈ the retirement time for a grace-expiry). */
+  expiresAt?: Date;
+  /** First 8 chars of the session id — enough to correlate logs without exposing the full id. */
+  sessionIdPrefix?: string;
+}
+
+export type SessionValidationResult = SessionValidationSuccess | SessionValidationFailure;
 
 export interface CreateSessionOptions {
   userId: string;
@@ -81,43 +115,68 @@ export class SessionService {
   }
 
   /**
-   * Validate token and return claims - this is the ONLY way to get claims
+   * Validate token and return claims OR the reason it failed (D5).
    *
-   * `expectedType` scopes the token to one authentication surface: pass it at
-   * every boundary that only serves a single session type (e.g. 'user' for
-   * browser cookie/bearer auth, 'socket' for the Socket.IO handshake) so a
-   * token leaked from one surface cannot be replayed on another.
+   * Behaviourally identical to the historical `validateSession` — same reject conditions, same
+   * revoke/touch side effects — but instead of collapsing every failure to `null`, it names the
+   * reason. When no ACTIVE session is found, it does a secondary any-state lookup to split
+   * `revoked` vs `expired` (incl. #2176's grace-expiries: revokedAt null, expiresAt in the past)
+   * vs a genuinely unknown `not_found`.
+   *
+   * `expectedType` scopes the token to one authentication surface: pass it at every boundary that
+   * only serves a single session type (e.g. 'user' for browser cookie/bearer auth) so a token
+   * leaked from one surface cannot be replayed on another.
    */
-  async validateSession(
+  async validateSessionWithReason(
     token: string,
     options?: { expectedType?: SessionClaims['type'] }
-  ): Promise<SessionClaims | null> {
+  ): Promise<SessionValidationResult> {
     if (!isValidTokenFormat(token)) {
-      return null;
+      return { failureReason: 'bad_format' };
     }
 
     const tokenHash = hashToken(token);
 
     const session = await sessionRepository.findActiveSession(tokenHash);
 
-    if (!session) return null;
-    if (!session.user) return null;
+    if (!session || !session.user) {
+      // No usable active session — ask the any-state lookup WHY (revoked vs expired vs unknown).
+      const anyState = await sessionRepository.findSessionByHashAnyState(tokenHash);
+      if (!anyState) {
+        return { failureReason: 'not_found' };
+      }
+      const sessionIdPrefix = anyState.id.slice(0, 8);
+      if (anyState.revokedAt) {
+        return {
+          failureReason: 'revoked',
+          revokedReason: anyState.revokedReason ?? undefined,
+          expiresAt: anyState.expiresAt,
+          sessionIdPrefix,
+        };
+      }
+      // Not revoked but not active ⇒ its expiry is in the past. A grace-expiry
+      // (expireSessionByHashSoon) lands here: revokedAt null, expiresAt clamped to the retirement
+      // time.
+      return { failureReason: 'expired', expiresAt: anyState.expiresAt, sessionIdPrefix };
+    }
+
+    const sessionIdPrefix = session.id.slice(0, 8);
 
     // Wrong-surface token (e.g. a socket token presented as a session cookie):
     // reject without side effects — the token stays valid at its own surface.
     if (options?.expectedType && session.type !== options.expectedType) {
-      return null;
+      return { failureReason: 'wrong_type', sessionIdPrefix };
     }
 
     // Check if user is suspended (administrative action)
     if (session.user.suspendedAt) {
       await this.revokeSession(token, 'user_suspended');
-      return null;
+      return { failureReason: 'user_suspended', sessionIdPrefix };
     }
 
     if (session.tokenVersion !== session.user.tokenVersion) {
       await this.revokeSession(token, 'token_version_mismatch');
-      return null;
+      return { failureReason: 'token_version_mismatch', sessionIdPrefix };
     }
 
     // HIPAA idle timeout: revoke session if idle too long
@@ -128,7 +187,7 @@ export class SessionService {
       const idleDuration = Date.now() - lastUsed.getTime();
       if (idleDuration > IDLE_TIMEOUT_MS) {
         await this.revokeSession(token, 'idle_timeout');
-        return null;
+        return { failureReason: 'idle_timeout', sessionIdPrefix };
       }
     }
 
@@ -140,18 +199,35 @@ export class SessionService {
     sessionRepository.touchSession(tokenHash);
 
     return {
-      sessionId: session.id,
-      userId: session.userId,
-      userRole: session.user.role,
-      tokenVersion: session.tokenVersion,
-      adminRoleVersion: session.adminRoleVersion,
-      type: session.type,
-      scopes: session.scopes,
-      expiresAt: session.expiresAt,
-      resourceType: session.resourceType ?? undefined,
-      resourceId: session.resourceId ?? undefined,
-      driveId: session.driveId ?? undefined,
+      claims: {
+        sessionId: session.id,
+        userId: session.userId,
+        userRole: session.user.role,
+        tokenVersion: session.tokenVersion,
+        adminRoleVersion: session.adminRoleVersion,
+        type: session.type,
+        scopes: session.scopes,
+        expiresAt: session.expiresAt,
+        resourceType: session.resourceType ?? undefined,
+        resourceId: session.resourceId ?? undefined,
+        driveId: session.driveId ?? undefined,
+      },
     };
+  }
+
+  /**
+   * Validate token and return claims - this is the ONLY way to get claims.
+   *
+   * Thin, non-breaking wrapper over `validateSessionWithReason`: returns the claims on success or
+   * `null` on any failure, exactly as before. New callers that want the failure reason should use
+   * `validateSessionWithReason` directly.
+   */
+  async validateSession(
+    token: string,
+    options?: { expectedType?: SessionClaims['type'] }
+  ): Promise<SessionClaims | null> {
+    const result = await this.validateSessionWithReason(token, options);
+    return result.claims ?? null;
   }
 
   /**
@@ -172,6 +248,16 @@ export class SessionService {
     const clamped = clampExpiry(currentExpiresAt, notLaterThan);
     if (clamped.getTime() < currentExpiresAt.getTime()) {
       await sessionRepository.setExpiresAtByHash(tokenHash, clamped);
+      // Make grace-expiries visible in prod: this is the mechanism that later surfaces as an
+      // `expired` failure reason (D5), so logging the clamp lets an incident be traced end-to-end.
+      loggers.auth.info('Session grace-expiry clamped', {
+        // A short, non-reversible correlator (8 of 64 hex chars). Named to avoid the logger's
+        // `token`/`hash` redaction so it survives as a usable trace key.
+        sessionRef: tokenHash.slice(0, 8),
+        graceMs,
+        clampedTo: clamped.toISOString(),
+        previousExpiresAt: currentExpiresAt.toISOString(),
+      });
     }
   }
 


### PR DESCRIPTION
## Wave 1 — Stop desktop random logouts (D2 + D5 + D1)

Desktop (Electron) users were **still** randomly logged out after PR #2176 ("session-refresh hardening", live as web v455 + desktop 1.0.23). #2176 fixed narrow triggers (retirement instant-revoke, device-token clobber, deviceId flip) but missed the two mechanisms that actually strand the user. This is **Wave 1 of a 2-wave fix**. All changes live in `apps/web` + `packages/lib` — the desktop shell remote-loads the web app, so these ship with the **web** deploy, not a desktop binary.

Three commits, one per defect. RED-first TDD; pure decision cores gated at 100% branch coverage in `vitest.config`.

### D2 — Stop the 1s API-401 poll storm — `commit f1f2a9e`
The cross-instance stream-join poll swallowed a 401 and kept its 1s `setInterval` firing forever, hammering `/api/auth/device/refresh` ~1/sec until the rate limit locked the user out (90s+ of `auth_failed` → logout).

- Pure `decidePollTickOutcome(status)`: `401`/`403` → `'suspend'`, else `'continue'` (unit-tested per branch).
- On `'suspend'` the tick `clearInterval`s and registers a **once** `auth:refreshed` listener (dispatched by `auth-fetch` on refresh success) that resumes with an immediate tick + fresh interval. Listener removed via the existing signal-abort cleanup so it can't leak or resurrect an aborted poll.
- Preserved: network/5xx → retry next tick; row-missing → `onNotFound` once + stop; abort → stop everything.

**Acceptance**
- ✅ A 401 tick stops the 1s interval (no further requests) — storm cannot happen.
- ✅ Dispatching `auth:refreshed` after a suspend resumes polling (immediate tick + interval).
- ✅ Aborting while suspended removes the `auth:refreshed` listener (no leak, no resume).
- ✅ A 500 tick still retries on the next interval (not suspended).
- ✅ Row-missing still fires `onNotFound` exactly once and stops.
- ✅ Module held at 100% branch coverage.

### D5 — Provable session-failure reasons — `commit f1204b2`
We couldn't tell **why** a session failed, so an incident was unprovable from the logs.

- `validateSessionWithReason(token)` → `{ claims } | { failureReason }` over all 8 branches (`bad_format`, `not_found`, `expired`, `revoked`, `wrong_type`, `user_suspended`, `token_version_mismatch`, `idle_timeout`). No active session → secondary any-state lookup (`findSessionByHashAnyState`) splits revoked vs expired vs unknown; a grace-expired session (#2176's `expireSessionByHashSoon`: `revokedAt` null, `expiresAt` past) surfaces as `'expired'` with `expiresAt`.
- `validateSession` is now a thin `claims | null` wrapper — **non-breaking**, identical side effects (verified by a parity test).
- Additive `authFailureReason` on `AuthError`, threaded through `authenticateSessionRequest` (bearer + cookie) and thus `authenticateRequestWithOptions`.
- Spread `details.authFailureReason` into the `auth_failed` audit at `active-streams` and every sibling AI route sharing the `isAuthError` pattern (37 sites; `verifyAuth`-based routes excluded — no reason available there).
- `expireSessionByHashSoon` logs `loggers.auth.info` on an actual clamp, so grace-expiries are visible in prod and traceable to the later `'expired'` reason.

**Acceptance**
- ✅ Every failure branch of `validateSessionWithReason` covered with a fake repository.
- ✅ A grace-expired token yields `failureReason: 'expired'` with `expiresAt` ≈ the retirement time.
- ✅ `active-streams` route test: a failed-auth audit's `details.authFailureReason` is populated (`'expired'`).
- ✅ `validateSession` wrapper parity (claims on success, null on every failure).

### D1 — Native-shell silent recovery — `commit 2e966b1`
A desktop user middleware-bounced to `/auth/signin` saw the form even though safeStorage held a valid 90-day session: the recovery machine short-circuited to `skip` on native shells.

- `signin-recovery.ts` (pure core): removed the `isNativeShell → skip` short-circuit and dropped `skip` from the action union (TS now enforces switch exhaustiveness). The `authFailedPermanently` loop-guard runs **first** for every platform. Doc comment corrected (its "must never run on native" claim was the bug).
- `useSigninRecovery.ts` (shell): `hasDeviceToken()` is async + platform-aware via `getPlatformStorage().getStoredSession()` (desktop safeStorage over IPC, web localStorage); check-me uses `fetchWithAuth('/api/auth/me')` (attaches Bearer; its refresh-on-401 IS the recovery); refresh stays `refreshAuthSession()` (platform-routed — the desktop device-refresh response also re-sets the session cookie, healing the middleware bounce).

**Acceptance**
- ✅ On desktop, an authenticated check-me → redirect (no form shown).
- ✅ On desktop, check-me carries a Bearer token (via `fetchWithAuth`) and `hasDeviceToken` reads platform storage (safeStorage), not localStorage.
- ✅ On desktop, a successful refresh → redirect to `/dashboard`.
- ✅ NO redirect loop: when genuinely unauthenticated, `authFailedPermanently` short-circuits and the form is shown (guard wins before any check-me/refresh).
- ✅ Web behavior unchanged (regression test).
- ✅ 100% branch coverage on the `signin-recovery.ts` pure core (gated).

## Verification
- `bun run typecheck` — ✅ green (web + lib).
- All new/changed unit tests pass. The one regression surfaced by the full suite (`auth-middleware.test.ts` mock missing the new `validateSessionWithReason`) is fixed and folded into the D5 commit.
- Remaining full-suite failures are **pre-existing environmental** ones, untouched by this PR: DB-integration tests needing a live Postgres (`admin-role-version`, `activity-tools`, `version-sdk-contract` — all fail with `role "test" does not exist` / connection refused) and one TZ-sensitive test (`grouping` "cross midnight", hardcoded-UTC timestamps that don't cross midnight in a UTC-5 runner).

Prior context: #2176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WgVWHepptVgFnSp6DcFJb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in recovery consistency across web and desktop, reducing redirect loops and aligning session handling.
  * Stream-join polling now suspends only on auth failures (401/403) and reliably resumes after authentication is restored.
* **Security & Reliability**
  * Audit logs for authentication-denied requests now include machine-readable `authFailureReason` for clearer diagnosis.
* **Tests**
  * Expanded tests for sign-in recovery behavior, polling suspend/resume edge cases, and audit detail coverage.
  * Increased coverage thresholds for signin recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review round (post-open)

Addressed all automated-review feedback plus one bug found by an independent adversarial self-review:

- **Duplicate `auth:refreshed` resume listener / orphaned interval** on overlapping 401 ticks (Codex P2 + CodeRabbit Major) — `suspendUntilAuthRefreshed()` clears any prior listener before re-registering (`39f8155`).
- **Orphaned active session (deleted user) misclassified as `expired`** (CodeRabbit) — classify by actual expiry; a future-expiry orphaned row is `not_found` (`39f8155`).
- **Weak localStorage test assertion** (CodeRabbit) — removed; `getStoredSession` is the real proof (`39f8155`).
- **Terminal not-found could leave a resume listener armed → polling resurrected on the next `auth:refreshed`** (adversarial self-review; missed by both bots) — added a `terminated` flag guarding both interleavings (`975ab2e`).

Each came with a regression test; the two pure/core modules remain at 100% branch coverage. CI green on `975ab2e` (the CodeRabbit *check* showing failed is its own transient rate-limit, a non-required check — `mergeStateStatus` is `UNSTABLE`, not `BLOCKED`).
