### PR TITLE
feat(webhooks): in-place secret rotation — same URL, new secret (F6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ All notable user-facing changes to PageSpace are documented here. Format follows
 
 ### Added
 
+- **Rotate a webhook secret in place** — the Incoming Webhooks dialog (and
+  `POST /api/pages/[pageId]/webhooks/[id]/rotate`) now mints a fresh signing secret for the **same
+  webhook URL**, so replacing a lost or leaked secret no longer means deleting the webhook and
+  re-wiring the external sender to a new URL. The old secret stops verifying the moment the
+  rotation lands; the new one is shown exactly once, just like at creation. Owner/admin only,
+  audited, and concurrent rotations are serialized — the losing request gets a conflict instead of
+  silently minting a secret nobody can use.
 - **Incoming Webhooks** — mint a signed, page-scoped URL (owner/admin only, from the webhook icon
   on a Channel or AI Chat page) so an external system — CI, monitoring, a script — can push events
   into PageSpace without a full drive-scoped credential. A signed delivery to a Channel webhook

--- a/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/incoming-webhooks/page.tsx
@@ -17,8 +17,9 @@ Incoming Webhooks let an external system — CI, a monitoring tool, a cron job, 
 
 ## What you can do
 
-- Mint a named webhook on any non-trashed page — only the drive's **owner** or an **admin** can create, toggle, or delete one. The **Incoming Webhooks** dialog that does this from the UI is currently wired up on **Channel** and **AI Chat (agent)** pages; other page types can still mint one via the API.
+- Mint a named webhook on any non-trashed page — only the drive's **owner** or an **admin** can create, toggle, rotate, or delete one. The **Incoming Webhooks** dialog that does this from the UI is currently wired up on **Channel** and **AI Chat (agent)** pages; other page types can still mint one via the API.
 - Get back a URL (\`/api/webhooks/<token>\`) and a secret shown exactly once — save it, PageSpace never shows it again and can't recover it for you.
+- Rotate the secret in place (**Rotate secret** in the dialog, or \`POST /api/pages/<pageId>/webhooks/<id>/rotate\`) — the URL stays the same, so the external sender only swaps the secret. The old secret stops verifying the instant the rotation lands, and the new one is shown exactly once, just like at creation.
 - POST any JSON object to that URL, signed with the secret. A **Channel** webhook with no other wiring posts the payload's \`content\` into the channel verbatim, as if a bot had typed it.
 - Bind one or more **workflows** to a webhook (via the API — see below) so the same delivery also kicks off an agent run, with the full payload handed to it as context.
 - Disable a webhook without deleting it (its URL stops accepting deliveries but its history and bindings stay), or delete it outright.
@@ -113,7 +114,7 @@ Once bound, the workflow receives the full JSON payload as context (wrapped so t
 - **Least privilege by design.** A webhook secret only ever authenticates deliveries to the one page it was minted on — it can't read, list, or act on anything else in the drive, unlike a full API key or OAuth token.
 - **No dedupe, no event-type filtering (yet).** Every enabled trigger on a webhook fires on every accepted delivery; if you need "only fire on this kind of event," filter in the payload you send or in the workflow's own prompt.
 - **A page moved to a different drive after a trigger was bound** is re-checked at fire time — if the page's current drive no longer matches the workflow's drive, that trigger is skipped and recorded as a stale binding rather than silently executed.
-- **The secret is shown once.** If you lose it, delete the webhook and mint a new one — PageSpace stores it encrypted and can't display it again.
+- **The secret is shown once.** If you lose it (or suspect it leaked), rotate it — **Rotate secret** in the dialog mints a new one for the **same URL**, so your sender's configuration only changes the secret. PageSpace stores it encrypted and can't display it again; deleting and re-minting is never necessary just to replace a secret.
 
 ## Related
 

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
@@ -12,17 +12,19 @@ vi.mock('@/lib/auth', () => ({
 
 const mockFindFirst = vi.fn();
 const mockUpdateSet = vi.fn();
+const mockUpdateWhere = vi.fn();
 const mockUpdateReturning = vi.fn();
 vi.mock('@pagespace/db/db', () => ({
   db: {
     query: { pageWebhooks: { findFirst: (...args: unknown[]) => mockFindFirst(...args) } },
     update: () => ({
-      set: (...args: unknown[]) => {
-        mockUpdateSet(...args);
+      set: (...setArgs: unknown[]) => {
+        mockUpdateSet(...setArgs);
         return {
-          where: () => ({
-            returning: () => mockUpdateReturning(...args),
-          }),
+          where: (...whereArgs: unknown[]) => {
+            mockUpdateWhere(...whereArgs);
+            return { returning: () => mockUpdateReturning(...setArgs) };
+          },
         };
       },
     }),
@@ -33,7 +35,11 @@ vi.mock('@pagespace/db/operators', () => ({
   and: (...args: unknown[]) => ({ and: args }),
 }));
 vi.mock('@pagespace/db/schema/page-webhooks', () => ({
-  pageWebhooks: { id: 'pageWebhooks.id', pageId: 'pageWebhooks.pageId' },
+  pageWebhooks: {
+    id: 'pageWebhooks.id',
+    pageId: 'pageWebhooks.pageId',
+    webhookSecretEncrypted: 'pageWebhooks.webhookSecretEncrypted',
+  },
 }));
 
 const mockEncryptField = vi.fn(async (v: string) => `encrypted(${v})`);
@@ -141,6 +147,26 @@ describe('POST /api/pages/[pageId]/webhooks/[id]/rotate', () => {
     const signedWithNew = v0Scheme.sign(newSecret, timestampSeconds, rawBody);
     expect(verifyAgainstStored(signedWithOld)).toBe(false);
     expect(verifyAgainstStored(signedWithNew)).toBe(true);
+  });
+
+  it('guards the update on the previously stored ciphertext (optimistic concurrency)', async () => {
+    await POST(makeRequest(), PARAMS);
+    expect(mockUpdateWhere).toHaveBeenCalledWith({
+      and: [
+        { a: 'pageWebhooks.id', b: 'wh-1' },
+        { a: 'pageWebhooks.webhookSecretEncrypted', b: 'encrypted(old-secret)' },
+      ],
+    });
+  });
+
+  it('returns 409 without auditing or leaking a secret when a concurrent rotation wins', async () => {
+    mockUpdateReturning.mockReturnValue([]);
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.webhookSecret).toBeUndefined();
+    expect(body.webhook).toBeUndefined();
+    expect(mockAuditRequest).not.toHaveBeenCalled();
   });
 
   it('audits the rotation as a data.write with operation rotate', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { v0Scheme, DEFAULT_REPLAY_WINDOW_MS } from '@pagespace/lib/security/webhook-signature';
+
+const mockAuthenticateRequestWithOptions = vi.fn();
+const mockIsAuthError = vi.fn();
+const mockCanManagePageWebhooks = vi.fn();
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: (...args: unknown[]) => mockAuthenticateRequestWithOptions(...args),
+  isAuthError: (...args: unknown[]) => mockIsAuthError(...args),
+  canManagePageWebhooks: (...args: unknown[]) => mockCanManagePageWebhooks(...args),
+}));
+
+const mockFindFirst = vi.fn();
+const mockUpdateSet = vi.fn();
+const mockUpdateReturning = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: { pageWebhooks: { findFirst: (...args: unknown[]) => mockFindFirst(...args) } },
+    update: () => ({
+      set: (...args: unknown[]) => {
+        mockUpdateSet(...args);
+        return {
+          where: () => ({
+            returning: () => mockUpdateReturning(...args),
+          }),
+        };
+      },
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  and: (...args: unknown[]) => ({ and: args }),
+}));
+vi.mock('@pagespace/db/schema/page-webhooks', () => ({
+  pageWebhooks: { id: 'pageWebhooks.id', pageId: 'pageWebhooks.pageId' },
+}));
+
+const mockEncryptField = vi.fn(async (v: string) => `encrypted(${v})`);
+vi.mock('@pagespace/lib/encryption/field-crypto', () => ({
+  encryptField: (...args: [string]) => mockEncryptField(...args),
+}));
+
+const mockAuditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+import { POST } from '../route';
+
+const SESSION_AUTH = { userId: 'user-1', kind: 'session' };
+const PARAMS = { params: Promise.resolve({ pageId: 'page-1', id: 'wh-1' }) };
+const WEBHOOK_ROW = {
+  id: 'wh-1',
+  pageId: 'page-1',
+  name: 'Deploys',
+  webhookToken: 'tok-abc',
+  webhookSecretEncrypted: 'encrypted(old-secret)',
+  isEnabled: true,
+  createdBy: 'user-1',
+};
+
+function makeRequest(): Request {
+  return new Request('https://example.com/api/pages/page-1/webhooks/wh-1/rotate', { method: 'POST' });
+}
+
+/** What the mocked encryptField stored, inverted — stands in for intake's decryptField. */
+function storedPlaintext(): string {
+  const [setArg] = mockUpdateSet.mock.calls[0] as [{ webhookSecretEncrypted: string }];
+  const match = setArg.webhookSecretEncrypted.match(/^encrypted\((.+)\)$/);
+  if (!match) throw new Error('stored secret was not encrypted');
+  return match[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAuthenticateRequestWithOptions.mockResolvedValue(SESSION_AUTH);
+  mockIsAuthError.mockReturnValue(false);
+  mockCanManagePageWebhooks.mockResolvedValue(true);
+  mockFindFirst.mockResolvedValue(WEBHOOK_ROW);
+  mockUpdateReturning.mockImplementation((setArg: Partial<typeof WEBHOOK_ROW>) => [{ ...WEBHOOK_ROW, ...setArg }]);
+});
+
+describe('POST /api/pages/[pageId]/webhooks/[id]/rotate', () => {
+  it('mints a new 256-bit secret, encrypts it at rest, and returns the plaintext exactly once', async () => {
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+
+    // 32 random bytes as base64url — 43 chars, no padding.
+    expect(body.webhookSecret).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    expect(body.webhookSecret).not.toBe('old-secret');
+
+    // At rest: only the encrypted form of the new secret is written.
+    expect(mockEncryptField).toHaveBeenCalledWith(body.webhookSecret);
+    expect(mockUpdateSet).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSet).toHaveBeenCalledWith({ webhookSecretEncrypted: `encrypted(${body.webhookSecret})` });
+  });
+
+  it('keeps the webhookToken (and URL) unchanged and never writes it', async () => {
+    const response = await POST(makeRequest(), PARAMS);
+    const body = await response.json();
+    expect(body.webhook.webhookToken).toBe('tok-abc');
+    const [setArg] = mockUpdateSet.mock.calls[0] as [Record<string, unknown>];
+    expect(Object.keys(setArg)).toEqual(['webhookSecretEncrypted']);
+  });
+
+  it('strips the encrypted secret from the returned webhook row', async () => {
+    const response = await POST(makeRequest(), PARAMS);
+    const body = await response.json();
+    expect(body.webhook.webhookSecretEncrypted).toBeUndefined();
+    expect(JSON.stringify(body.webhook)).not.toContain('encrypted(');
+  });
+
+  it('after rotation the OLD secret no longer verifies and the NEW secret does', async () => {
+    const response = await POST(makeRequest(), PARAMS);
+    const { webhookSecret: newSecret } = await response.json();
+
+    // Intake decrypts the stored secret and verifies the delivery against it.
+    const storedSecret = storedPlaintext();
+    expect(storedSecret).toBe(newSecret);
+
+    const nowMs = 1_700_000_000_000;
+    const timestampSeconds = Math.floor(nowMs / 1000);
+    const rawBody = '{"text":"deploy finished"}';
+    const verifyAgainstStored = (signature: string) =>
+      v0Scheme.verify({
+        secret: storedSecret,
+        signature,
+        timestamp: String(timestampSeconds),
+        rawBody,
+        nowMs,
+        replayWindowMs: DEFAULT_REPLAY_WINDOW_MS,
+      });
+
+    const signedWithOld = v0Scheme.sign('old-secret', timestampSeconds, rawBody);
+    const signedWithNew = v0Scheme.sign(newSecret, timestampSeconds, rawBody);
+    expect(verifyAgainstStored(signedWithOld)).toBe(false);
+    expect(verifyAgainstStored(signedWithNew)).toBe(true);
+  });
+
+  it('audits the rotation as a data.write with operation rotate', async () => {
+    await POST(makeRequest(), PARAMS);
+    expect(mockAuditRequest).toHaveBeenCalledWith(expect.any(Request), {
+      eventType: 'data.write',
+      userId: 'user-1',
+      resourceType: 'page_webhook',
+      resourceId: 'wh-1',
+      details: { operation: 'rotate', pageId: 'page-1' },
+    });
+  });
+
+  it('rejects a non-owner/admin with 403 without reading or rotating', async () => {
+    mockCanManagePageWebhooks.mockResolvedValue(false);
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(403);
+    expect(mockFindFirst).not.toHaveBeenCalled();
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a webhook not owned by this page, without rotating', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(404);
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it('propagates an auth error unchanged', async () => {
+    const authError = { error: new Response(null, { status: 401 }) };
+    mockAuthenticateRequestWithOptions.mockResolvedValue(authError);
+    mockIsAuthError.mockReturnValue(true);
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(401);
+    expect(mockCanManagePageWebhooks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/__tests__/route.test.ts
@@ -169,6 +169,34 @@ describe('POST /api/pages/[pageId]/webhooks/[id]/rotate', () => {
     expect(mockAuditRequest).not.toHaveBeenCalled();
   });
 
+  it('returns 404 when the webhook was deleted concurrently (zero-row update, row gone)', async () => {
+    mockFindFirst.mockResolvedValueOnce(WEBHOOK_ROW).mockResolvedValueOnce(null);
+    mockUpdateReturning.mockReturnValue([]);
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.webhookSecret).toBeUndefined();
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
+  it('requires CSRF on the auth gate', async () => {
+    await POST(makeRequest(), PARAMS);
+    expect(mockAuthenticateRequestWithOptions).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({ requireCSRF: true }),
+    );
+  });
+
+  it('returns a generic 500 with no secret material when encryption fails', async () => {
+    mockEncryptField.mockRejectedValueOnce(new Error('kms unavailable'));
+    const response = await POST(makeRequest(), PARAMS);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Failed to rotate webhook secret' });
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+    expect(mockAuditRequest).not.toHaveBeenCalled();
+  });
+
   it('audits the rotation as a data.write with operation rotate', async () => {
     await POST(makeRequest(), PARAMS);
     expect(mockAuditRequest).toHaveBeenCalledWith(expect.any(Request), {

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
@@ -45,6 +45,15 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
     // means a concurrent rotation makes this update match zero rows instead of
     // silently overwriting (which would 200 both callers but leave one holding
     // a plaintext secret that never verifies).
+    //
+    // Scope, deliberately: this rejects READ-BEFORE-WRITE interleavings only.
+    // A request that reads AFTER another rotation committed is sequential
+    // re-rotation and wins last-writer — the same contract as re-running
+    // rotation on any provider. The API can't do better without a
+    // client-echoed version (the ciphertext never leaves at rest, and the row
+    // has no version column); same-client overlap is additionally refused
+    // outright in the dialog. If cross-admin rotation contention ever becomes
+    // real, add a rotationVersion column + If-Match — don't widen this guard.
     const [row] = await db
       .update(pageWebhooks)
       .set({ webhookSecretEncrypted })

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
@@ -40,11 +40,25 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
     const webhookSecretPlaintext = randomBytes(32).toString('base64url');
     const webhookSecretEncrypted = await encryptField(webhookSecretPlaintext);
 
+    // Optimistic-concurrency guard: encryption is randomized, so the stored
+    // ciphertext is unique per write — conditioning on the value we just read
+    // means a concurrent rotation makes this update match zero rows instead of
+    // silently overwriting (which would 200 both callers but leave one holding
+    // a plaintext secret that never verifies).
     const [row] = await db
       .update(pageWebhooks)
       .set({ webhookSecretEncrypted })
-      .where(eq(pageWebhooks.id, id))
+      .where(and(
+        eq(pageWebhooks.id, id),
+        eq(pageWebhooks.webhookSecretEncrypted, existing.webhookSecretEncrypted),
+      ))
       .returning();
+    if (!row) {
+      return NextResponse.json(
+        { error: 'The secret was rotated by a concurrent request — use that rotation\'s secret or rotate again' },
+        { status: 409 },
+      );
+    }
 
     auditRequest(request, {
       eventType: 'data.write',

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { randomBytes } from 'crypto';
+import { db } from '@pagespace/db/db';
+import { and, eq } from '@pagespace/db/operators';
+import { pageWebhooks } from '@pagespace/db/schema/page-webhooks';
+import { encryptField } from '@pagespace/lib/encryption/field-crypto';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { authenticateRequestWithOptions, isAuthError, canManagePageWebhooks } from '@/lib/auth';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+/** Strip the encrypted secret from every response — the new plaintext is returned exactly once, below. */
+function toPublicWebhook(row: typeof pageWebhooks.$inferSelect) {
+  const { webhookSecretEncrypted: _webhookSecretEncrypted, ...publicRow } = row;
+  return publicRow;
+}
+
+// POST /api/pages/[pageId]/webhooks/[id]/rotate — mint a new signing secret in
+// place. The webhookToken (and thus the URL) is untouched, so the external
+// sender only swaps the secret; deliveries signed with the old secret stop
+// verifying the moment the row is updated.
+export async function POST(request: Request, context: { params: Promise<{ pageId: string; id: string }> }) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+    const { pageId, id } = await context.params;
+
+    const canManage = await canManagePageWebhooks(auth, pageId);
+    if (!canManage) {
+      return NextResponse.json({ error: 'Only the drive owner or an admin can manage page webhooks' }, { status: 403 });
+    }
+
+    const existing = await db.query.pageWebhooks.findFirst({
+      where: and(eq(pageWebhooks.id, id), eq(pageWebhooks.pageId, pageId)),
+    });
+    if (!existing) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
+
+    const webhookSecretPlaintext = randomBytes(32).toString('base64url');
+    const webhookSecretEncrypted = await encryptField(webhookSecretPlaintext);
+
+    const [row] = await db
+      .update(pageWebhooks)
+      .set({ webhookSecretEncrypted })
+      .where(eq(pageWebhooks.id, id))
+      .returning();
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'page_webhook',
+      resourceId: id,
+      details: { operation: 'rotate', pageId },
+    });
+
+    return NextResponse.json({
+      webhook: toPublicWebhook(row),
+      // Returned exactly once — the plaintext secret is never persisted or re-derivable after this response.
+      webhookSecret: webhookSecretPlaintext,
+    });
+  } catch (error) {
+    loggers.api.error('Error rotating page webhook secret', error as Error);
+    return NextResponse.json({ error: 'Failed to rotate webhook secret' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/webhooks/[id]/rotate/route.ts
@@ -54,6 +54,12 @@ export async function POST(request: Request, context: { params: Promise<{ pageId
       ))
       .returning();
     if (!row) {
+      // Zero rows can also mean a concurrent DELETE won, not a rotation —
+      // re-check so the caller gets a truthful 404 instead of "rotate again".
+      const stillExists = await db.query.pageWebhooks.findFirst({
+        where: and(eq(pageWebhooks.id, id), eq(pageWebhooks.pageId, pageId)),
+      });
+      if (!stillExists) return NextResponse.json({ error: 'Webhook not found' }, { status: 404 });
       return NextResponse.json(
         { error: 'The secret was rotated by a concurrent request — use that rotation\'s secret or rotate again' },
         { status: 409 },

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { Check, Copy, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
@@ -89,6 +89,11 @@ const parkOrphan = (value: RevealedSecret) => {
 // (Other browsers/admins are covered by the server's 409 optimistic guard.)
 const rotatingWebhooks = new Set<string>();
 
+// Layout-effect timing on the client (passive effects leave a window between
+// commit and effect where a resolving mint would read stale refs), useEffect
+// on the server (Next SSRs client components; useLayoutEffect warns there).
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
   const res = await fetchWithAuth(url);
   const body = await res.json().catch(() => ({}));
@@ -118,8 +123,12 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const forbidden = errorStatus === 403;
   const loadFailed = errorStatus !== null && errorStatus !== 403;
 
+  // Both refs are stamped in LAYOUT effects: they run synchronously inside the
+  // commit, so no promise callback can observe a committed close/unmount while
+  // the refs still claim the dialog is live (a passive useEffect would leave
+  // exactly that window, and reveal() would write a secret into doomed state).
   const mountedRef = useRef(true);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     mountedRef.current = true;
     return () => { mountedRef.current = false; };
   }, []);
@@ -127,7 +136,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   // Handlers resolve long after the render that created them — they must see
   // the dialog's CURRENT visibility, not the closure's stale `open`.
   const openRef = useRef(open);
-  useEffect(() => { openRef.current = open; }, [open]);
+  useIsomorphicLayoutEffect(() => { openRef.current = open; }, [open]);
 
   const orphanSignal = useSyncExternalStore(subscribeOrphans, getOrphanVersion, getOrphanVersion);
 

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -106,6 +106,11 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     return () => { mountedRef.current = false; };
   }, []);
 
+  // Handlers resolve long after the render that created them — they must see
+  // the dialog's CURRENT visibility, not the closure's stale `open`.
+  const openRef = useRef(open);
+  useEffect(() => { openRef.current = open; }, [open]);
+
   const orphanSignal = useSyncExternalStore(subscribeOrphans, getOrphanVersion, getOrphanVersion);
 
   // Routes a fresh one-time secret to the live dialog, or parks it in the
@@ -119,7 +124,10 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       webhookUrl: `${window.location.origin}/api/webhooks/${webhook.webhookToken}`,
       secret,
     };
-    if (!mountedRef.current) {
+    // Park unless the dialog is mounted AND currently open — writing into a
+    // closed dialog's state would be wiped by the close-reset effect, losing
+    // the only plaintext copy. The pen delivers it at the next open instead.
+    if (!mountedRef.current || !openRef.current) {
       parkOrphan(value);
       return;
     }
@@ -138,11 +146,10 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
 
   useEffect(() => {
     if (!open) {
-      // Clears the secret from state on close — but deliberately does NOT
-      // cancel an in-flight create/rotate: its response holds the only copy of
-      // a one-time secret (rotate has already invalidated the old one), so a
-      // late resolution repopulates `revealed` and the reopened dialog shows
-      // the secret once instead of silently losing it.
+      // Clears an on-screen secret when the user closes the dialog — an
+      // in-flight create/rotate is NOT cancelled: its late response goes to
+      // the orphan pen (reveal() parks while closed) and is delivered at the
+      // next open instead of being lost.
       setRevealed(null);
       setNewName('');
       return;

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -70,12 +70,14 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
         `/api/pages/${pageId}/webhooks`,
         { name },
       );
-      await refetch();
       setNewName('');
+      // Reveal before refreshing the list: the secret exists only in this
+      // response, so a failed (cosmetic) revalidation must never discard it.
       setRevealed({
         webhookUrl: `${window.location.origin}/api/webhooks/${res.webhook.webhookToken}`,
         secret: res.webhookSecret,
       });
+      await refetch().catch(() => {});
     } catch {
       toast.error('Failed to create webhook');
     } finally {
@@ -101,11 +103,14 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       const res = await post<{ webhook: WebhookRow; webhookSecret: string }>(
         `/api/pages/${pageId}/webhooks/${id}/rotate`,
       );
-      await refetch();
+      // Reveal before refreshing the list: the old secret is already dead and
+      // this response holds the only copy of the new one — a failed (cosmetic)
+      // revalidation must never discard it.
       setRevealed({
         webhookUrl: `${window.location.origin}/api/webhooks/${res.webhook.webhookToken}`,
         secret: res.webhookSecret,
       });
+      await refetch().catch(() => {});
     } catch (error) {
       // The rotate route's error bodies are user-actionable (e.g. "rotated by a
       // concurrent request") — surface them instead of a generic failure.
@@ -197,7 +202,11 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                 placeholder="Webhook name (e.g. Deploys)"
                 maxLength={80}
               />
-              <Button type="submit" size="sm" disabled={creating || newName.trim().length === 0}>
+              <Button
+                type="submit"
+                size="sm"
+                disabled={creating || busyId !== null || newName.trim().length === 0}
+              >
                 {creating ? 'Creating…' : 'Create webhook'}
               </Button>
             </form>
@@ -226,11 +235,14 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                         disabled={busyId === webhook.id}
                         onCheckedChange={(checked) => toggleWebhook(webhook.id, checked)}
                       />
+                      {/* Any-busy, not row-busy: two in-flight rotations would race
+                          for the single reveal slot and one one-time secret would be
+                          lost — no new secret may start while one is being minted. */}
                       <Button
                         type="button"
                         variant="ghost"
                         size="sm"
-                        disabled={busyId === webhook.id}
+                        disabled={busyId !== null || creating}
                         onClick={() => rotateWebhook(webhook.id)}
                       >
                         Rotate secret

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -26,6 +26,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface WebhookRow {
   id: string;
@@ -43,8 +44,14 @@ interface PageWebhooksDialogProps {
   pageType: string;
 }
 
-/** pageId is the ORIGINATING page — the reveal panel only renders when it matches the dialog's current page. */
-type RevealedSecret = { pageId: string; webhookUrl: string; secret: string };
+/**
+ * ownerId/pageId are the ORIGINATING user and page — the reveal panel only
+ * renders when both match the dialog's current identity, so neither another
+ * page's dialog nor another signed-in account can ever be shown this secret.
+ */
+type RevealedSecret = { ownerId: string; pageId: string; webhookUrl: string; secret: string };
+
+const penKey = (ownerId: string, pageId: string) => `${ownerId}:${pageId}`;
 
 // Holding pen for one-time secrets whose create/rotate response landed after
 // this page's dialog unmounted (CenterPanel remounts views by page id on
@@ -64,12 +71,13 @@ const subscribeOrphans = (listener: () => void) => {
 const getOrphanVersion = () => orphanVersion;
 
 const parkOrphan = (value: RevealedSecret) => {
-  const queue = orphanedReveals.get(value.pageId) ?? [];
+  const key = penKey(value.ownerId, value.pageId);
+  const queue = orphanedReveals.get(key) ?? [];
   // Idempotent per secret (43-char random, unique per mint) — effects may
   // double-fire under StrictMode and must not queue duplicates.
   if (queue.some((parked) => parked.secret === value.secret)) return;
   queue.push(value);
-  orphanedReveals.set(value.pageId, queue);
+  orphanedReveals.set(key, queue);
   orphanVersion += 1;
   orphanListeners.forEach((listener) => listener());
 };
@@ -89,6 +97,9 @@ const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } 
 };
 
 function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWebhooksDialogProps) {
+  // Identity only — deliberately the store selector, not useAuth() (which
+  // wires refresh timers and routing this dialog must not own).
+  const userId = useAuthStore((state) => state.user?.id) ?? '';
   const key = open ? `/api/pages/${pageId}/webhooks` : null;
   const { data, isLoading, mutate: refetch } = useSWR(key, webhooksFetcher, { revalidateOnFocus: false });
 
@@ -123,6 +134,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   // page ids), which the render gate below handles.
   const reveal = (webhook: WebhookRow, secret: string) => {
     const value: RevealedSecret = {
+      ownerId: userId,
       pageId,
       webhookUrl: `${window.location.origin}/api/webhooks/${webhook.webhookToken}`,
       secret,
@@ -137,15 +149,17 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     setRevealed(value);
   };
 
-  // Never show a secret in another page's dialog: only a reveal minted for the
-  // current page renders; one that belongs elsewhere is parked for that page.
-  const activeReveal = revealed && revealed.pageId === pageId ? revealed : null;
+  // Never show a secret in another page's dialog or to another signed-in
+  // user: only a reveal minted for the current page AND account renders; one
+  // that belongs elsewhere is parked under its owner+page for later.
+  const activeReveal =
+    revealed && revealed.pageId === pageId && revealed.ownerId === userId ? revealed : null;
   useEffect(() => {
-    if (revealed && revealed.pageId !== pageId) {
+    if (revealed && (revealed.pageId !== pageId || revealed.ownerId !== userId)) {
       parkOrphan(revealed);
       setRevealed(null);
     }
-  }, [revealed, pageId]);
+  }, [revealed, pageId, userId]);
 
   useEffect(() => {
     if (!open) {
@@ -159,15 +173,16 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       setNewName('');
       return;
     }
-    // Open with no reveal showing: deliver the next parked secret, if any.
-    // Re-runs when a reveal is dismissed or a new orphan is parked
-    // (orphanSignal), so queued secrets surface one at a time.
+    // Open with no reveal showing: deliver the next parked secret for THIS
+    // user on THIS page, if any. Re-runs when a reveal is dismissed or a new
+    // orphan is parked (orphanSignal), so queued secrets surface one at a time.
     if (revealed) return;
-    const queue = orphanedReveals.get(pageId);
+    const pen = penKey(userId, pageId);
+    const queue = orphanedReveals.get(pen);
     const next = queue?.shift();
-    if (queue && queue.length === 0) orphanedReveals.delete(pageId);
+    if (queue && queue.length === 0) orphanedReveals.delete(pen);
     if (next) setRevealed(next);
-  }, [open, pageId, revealed, orphanSignal]);
+  }, [open, pageId, userId, revealed, orphanSignal]);
 
   const errorStatus = data && 'error' in data ? data.status : null;
   const forbidden = errorStatus === 403;
@@ -268,20 +283,10 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
           </DialogDescription>
         </DialogHeader>
 
-        {isLoading ? (
-          <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
-        ) : forbidden ? (
-          <p className="text-sm text-muted-foreground py-4">
-            Only this drive&apos;s owner or an admin can manage webhooks.
-          </p>
-        ) : loadFailed ? (
-          <div className="flex items-center justify-between gap-2 py-4">
-            <p className="text-sm text-muted-foreground">Failed to load webhooks.</p>
-            <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
-              Retry
-            </Button>
-          </div>
-        ) : activeReveal ? (
+        {/* The reveal panel outranks every list state: it holds the only copy
+            of a one-time secret, and a transient list failure (which resolves
+            to an error value, not a rejection) must never replace it. */}
+        {activeReveal ? (
           <div className="space-y-3 py-2">
             <p className="text-sm">
               Save this secret now — it won&apos;t be shown again. Configure your system to POST to the URL below,
@@ -299,6 +304,19 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                 <Check className="h-3.5 w-3.5 mr-1" /> Done, I&apos;ve saved it
               </Button>
             </div>
+          </div>
+        ) : isLoading ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
+        ) : forbidden ? (
+          <p className="text-sm text-muted-foreground py-4">
+            Only this drive&apos;s owner or an admin can manage webhooks.
+          </p>
+        ) : loadFailed ? (
+          <div className="flex items-center justify-between gap-2 py-4">
+            <p className="text-sm text-muted-foreground">Failed to load webhooks.</p>
+            <Button type="button" variant="outline" size="sm" onClick={() => refetch()}>
+              Retry
+            </Button>
           </div>
         ) : (
           <div className="min-h-0 flex-1 overflow-y-auto space-y-4 pr-1">

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -146,7 +146,17 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       parkOrphan(value);
       return;
     }
-    setRevealed(value);
+    // Never clobber a secret already on screen (another mint may have resolved
+    // first): queue behind it and the pickup effect delivers after dismissal.
+    // parkOrphan is idempotent per secret, so the functional updater is safe
+    // under StrictMode double-invocation.
+    setRevealed((current) => {
+      if (current) {
+        parkOrphan(value);
+        return current;
+      }
+      return value;
+    });
   };
 
   // Never show a secret in another page's dialog or to another signed-in

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -114,6 +114,12 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const [confirmRotateId, setConfirmRotateId] = useState<string | null>(null);
   const [revealed, setRevealed] = useState<RevealedSecret | null>(null);
 
+  const errorStatus = data && 'error' in data ? data.status : null;
+  const forbidden = errorStatus === 403;
+  const loadFailed = errorStatus !== null && errorStatus !== 403;
+  /** The list GET runs the same canManagePageWebhooks gate as rotation — a successful list IS the permission check. */
+  const managementConfirmed = Boolean(data && 'webhooks' in data);
+
   const mountedRef = useRef(true);
   useEffect(() => {
     mountedRef.current = true;
@@ -188,15 +194,21 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     // orphan is parked (orphanSignal), so queued secrets surface one at a time.
     if (revealed) return;
     const pen = penKey(userId, pageId);
+    // Pen delivery crosses a session boundary, so it must fail closed: a 403
+    // list means the owner/admin role was revoked since minting — purge the
+    // pen (a demoted manager must not recover a live credential), and don't
+    // deliver anything until a successful list re-confirms management.
+    if (forbidden) {
+      orphanedReveals.delete(pen);
+      return;
+    }
+    if (!managementConfirmed) return;
     const queue = orphanedReveals.get(pen);
     const next = queue?.shift();
     if (queue && queue.length === 0) orphanedReveals.delete(pen);
     if (next) setRevealed(next);
-  }, [open, pageId, userId, revealed, orphanSignal]);
+  }, [open, pageId, userId, revealed, orphanSignal, forbidden, managementConfirmed]);
 
-  const errorStatus = data && 'error' in data ? data.status : null;
-  const forbidden = errorStatus === 403;
-  const loadFailed = errorStatus !== null && errorStatus !== 403;
   const webhooks = data && 'webhooks' in data ? data.webhooks : [];
 
   const createWebhook = async () => {

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -117,8 +117,6 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const errorStatus = data && 'error' in data ? data.status : null;
   const forbidden = errorStatus === 403;
   const loadFailed = errorStatus !== null && errorStatus !== 403;
-  /** The list GET runs the same canManagePageWebhooks gate as rotation — a successful list IS the permission check. */
-  const managementConfirmed = Boolean(data && 'webhooks' in data);
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -194,20 +192,30 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     // orphan is parked (orphanSignal), so queued secrets surface one at a time.
     if (revealed) return;
     const pen = penKey(userId, pageId);
-    // Pen delivery crosses a session boundary, so it must fail closed: a 403
-    // list means the owner/admin role was revoked since minting — purge the
-    // pen (a demoted manager must not recover a live credential), and don't
-    // deliver anything until a successful list re-confirms management.
-    if (forbidden) {
-      orphanedReveals.delete(pen);
-      return;
-    }
-    if (!managementConfirmed) return;
-    const queue = orphanedReveals.get(pen);
-    const next = queue?.shift();
-    if (queue && queue.length === 0) orphanedReveals.delete(pen);
-    if (next) setRevealed(next);
-  }, [open, pageId, userId, revealed, orphanSignal, forbidden, managementConfirmed]);
+    if (!orphanedReveals.get(pen)?.length) return;
+    // Pen delivery crosses a session boundary, so it must fail closed on a
+    // FRESH authorization — `data` may be a stale cached 200 from before a
+    // role revocation. Revalidate (the list GET runs the same
+    // canManagePageWebhooks gate as rotation) and dequeue only from the fresh
+    // result: 403 purges the pen (a demoted manager must not recover a live
+    // credential), a transient failure keeps it parked for the next attempt.
+    let cancelled = false;
+    refetch()
+      .then((fresh) => {
+        if (cancelled) return;
+        if (fresh && 'error' in fresh && fresh.status === 403) {
+          orphanedReveals.delete(pen);
+          return;
+        }
+        if (!(fresh && 'webhooks' in fresh)) return;
+        const queue = orphanedReveals.get(pen);
+        const next = queue?.shift();
+        if (queue && queue.length === 0) orphanedReveals.delete(pen);
+        if (next) setRevealed(next);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [open, pageId, userId, revealed, orphanSignal, refetch]);
 
   const webhooks = data && 'webhooks' in data ? data.webhooks : [];
 

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { Check, Copy, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
@@ -33,6 +33,15 @@ interface PageWebhooksDialogProps {
   pageType: string;
 }
 
+type RevealedSecret = { webhookUrl: string; secret: string };
+
+// Holding pen for a one-time secret whose create/rotate response landed after
+// this page's dialog unmounted (CenterPanel remounts views by page id on
+// navigation). Rotate has already invalidated the predecessor server-side, so
+// the response is the only plaintext copy — parked here, keyed by page, and
+// consumed the next time that page's dialog opens.
+const orphanedReveals = new Map<string, RevealedSecret>();
+
 const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
   const res = await fetchWithAuth(url);
   const body = await res.json().catch(() => ({}));
@@ -47,10 +56,36 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const [newName, setNewName] = useState('');
   const [creating, setCreating] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [revealed, setRevealed] = useState<{ webhookUrl: string; secret: string } | null>(null);
+  const [revealed, setRevealed] = useState<RevealedSecret | null>(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  // Routes a fresh one-time secret to the live dialog, or parks it in the
+  // orphan pen when the response outlived this component instance.
+  const reveal = (webhook: WebhookRow, secret: string) => {
+    const value: RevealedSecret = {
+      webhookUrl: `${window.location.origin}/api/webhooks/${webhook.webhookToken}`,
+      secret,
+    };
+    if (!mountedRef.current) {
+      orphanedReveals.set(pageId, value);
+      return;
+    }
+    setRevealed(value);
+  };
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      const orphan = orphanedReveals.get(pageId);
+      if (orphan) {
+        orphanedReveals.delete(pageId);
+        setRevealed(orphan);
+      }
+    } else {
       // Clears the secret from state on close — but deliberately does NOT
       // cancel an in-flight create/rotate: its response holds the only copy of
       // a one-time secret (rotate has already invalidated the old one), so a
@@ -59,7 +94,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       setRevealed(null);
       setNewName('');
     }
-  }, [open]);
+  }, [open, pageId]);
 
   const errorStatus = data && 'error' in data ? data.status : null;
   const forbidden = errorStatus === 403;
@@ -78,10 +113,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       setNewName('');
       // Reveal before refreshing the list: the secret exists only in this
       // response, so a failed (cosmetic) revalidation must never discard it.
-      setRevealed({
-        webhookUrl: `${window.location.origin}/api/webhooks/${res.webhook.webhookToken}`,
-        secret: res.webhookSecret,
-      });
+      reveal(res.webhook, res.webhookSecret);
       await refetch().catch(() => {});
     } catch {
       toast.error('Failed to create webhook');
@@ -111,10 +143,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       // Reveal before refreshing the list: the old secret is already dead and
       // this response holds the only copy of the new one — a failed (cosmetic)
       // revalidation must never discard it.
-      setRevealed({
-        webhookUrl: `${window.location.origin}/api/webhooks/${res.webhook.webhookToken}`,
-        secret: res.webhookSecret,
-      });
+      reveal(res.webhook, res.webhookSecret);
       await refetch().catch(() => {});
     } catch (error) {
       // The rotate route's error bodies are user-actionable (e.g. "rotated by a

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -65,6 +65,9 @@ const getOrphanVersion = () => orphanVersion;
 
 const parkOrphan = (value: RevealedSecret) => {
   const queue = orphanedReveals.get(value.pageId) ?? [];
+  // Idempotent per secret (43-char random, unique per mint) — effects may
+  // double-fire under StrictMode and must not queue duplicates.
+  if (queue.some((parked) => parked.secret === value.secret)) return;
   queue.push(value);
   orphanedReveals.set(value.pageId, queue);
   orphanVersion += 1;
@@ -146,10 +149,12 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
 
   useEffect(() => {
     if (!open) {
-      // Clears an on-screen secret when the user closes the dialog — an
-      // in-flight create/rotate is NOT cancelled: its late response goes to
-      // the orphan pen (reveal() parks while closed) and is delivered at the
-      // next open instead of being lost.
+      // Closing does not discard: an UNACKNOWLEDGED on-screen secret is parked
+      // and redelivered at the next open (an accidental X/Escape/outside-click
+      // must not orphan the integration), and an in-flight create/rotate's
+      // late response also parks (reveal() checks openRef). The one true
+      // discard is the explicit "Done, I've saved it" acknowledgement.
+      if (revealed) parkOrphan(revealed);
       setRevealed(null);
       setNewName('');
       return;

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -95,6 +95,26 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     }
   };
 
+  const rotateWebhook = async (id: string) => {
+    setBusyId(id);
+    try {
+      const res = await post<{ webhook: WebhookRow; webhookSecret: string }>(
+        `/api/pages/${pageId}/webhooks/${id}/rotate`,
+      );
+      await refetch();
+      setRevealed({
+        webhookUrl: `${window.location.origin}/api/webhooks/${res.webhook.webhookToken}`,
+        secret: res.webhookSecret,
+      });
+    } catch (error) {
+      // The rotate route's error bodies are user-actionable (e.g. "rotated by a
+      // concurrent request") — surface them instead of a generic failure.
+      toast.error(error instanceof Error && error.message ? error.message : 'Failed to rotate secret');
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   const removeWebhook = async (id: string) => {
     setBusyId(id);
     try {
@@ -206,6 +226,15 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                         disabled={busyId === webhook.id}
                         onCheckedChange={(checked) => toggleWebhook(webhook.id, checked)}
                       />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={busyId === webhook.id}
+                        onClick={() => rotateWebhook(webhook.id)}
+                      >
+                        Rotate secret
+                      </Button>
                       <Button
                         type="button"
                         variant="ghost"

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -51,6 +51,11 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
 
   useEffect(() => {
     if (!open) {
+      // Clears the secret from state on close — but deliberately does NOT
+      // cancel an in-flight create/rotate: its response holds the only copy of
+      // a one-time secret (rotate has already invalidated the old one), so a
+      // late resolution repopulates `revealed` and the reopened dialog shows
+      // the secret once instead of silently losing it.
       setRevealed(null);
       setNewName('');
     }

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -89,6 +89,12 @@ const parkOrphan = (value: RevealedSecret) => {
 // (Other browsers/admins are covered by the server's 409 optimistic guard.)
 const rotatingWebhooks = new Set<string>();
 
+/** Test-only: wipe the module-level pen/lock state so cases stay isolated. */
+export const __resetPageWebhooksDialogModuleState = () => {
+  orphanedReveals.clear();
+  rotatingWebhooks.clear();
+};
+
 // Layout-effect timing on the client (passive effects leave a window between
 // commit and effect where a resolving mint would read stale refs), useEffect
 // on the server (Next SSRs client components; useLayoutEffect warns there).

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { Check, Copy, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
@@ -46,18 +46,37 @@ interface PageWebhooksDialogProps {
 /** pageId is the ORIGINATING page — the reveal panel only renders when it matches the dialog's current page. */
 type RevealedSecret = { pageId: string; webhookUrl: string; secret: string };
 
-// Holding pen for a one-time secret whose create/rotate response landed after
+// Holding pen for one-time secrets whose create/rotate response landed after
 // this page's dialog unmounted (CenterPanel remounts views by page id on
 // navigation). Rotate has already invalidated the predecessor server-side, so
-// the response is the only plaintext copy — parked here, keyed by page, and
-// consumed the next time that page's dialog opens.
-const orphanedReveals = new Map<string, RevealedSecret>();
+// each response is the only plaintext copy — parked here in arrival order,
+// keyed by page, and consumed one at a time by that page's dialog.
+const orphanedReveals = new Map<string, RevealedSecret[]>();
 
-// Latest rotation issued per webhook id. A response from a superseded rotation
-// (an older request resolving after a newer one already succeeded) is
-// discarded outright — its secret is already dead server-side, so revealing or
-// parking it would hand the user a credential that can never verify.
-const rotationGenerations = new Map<string, number>();
+// The pen is module state, so parking must notify any mounted dialog — a
+// version counter via useSyncExternalStore re-runs the pickup effect.
+let orphanVersion = 0;
+const orphanListeners = new Set<() => void>();
+const subscribeOrphans = (listener: () => void) => {
+  orphanListeners.add(listener);
+  return () => { orphanListeners.delete(listener); };
+};
+const getOrphanVersion = () => orphanVersion;
+
+const parkOrphan = (value: RevealedSecret) => {
+  const queue = orphanedReveals.get(value.pageId) ?? [];
+  queue.push(value);
+  orphanedReveals.set(value.pageId, queue);
+  orphanVersion += 1;
+  orphanListeners.forEach((listener) => listener());
+};
+
+// Webhook ids with a rotation in flight, across component instances. Client
+// issuance order cannot establish DB commit order, so a second concurrent
+// rotation of the same webhook would make it unknowable which response's
+// secret is live — a new rotation is refused until the pending one settles.
+// (Other browsers/admins are covered by the server's 409 optimistic guard.)
+const rotatingWebhooks = new Set<string>();
 
 const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
   const res = await fetchWithAuth(url);
@@ -72,7 +91,12 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
 
   const [newName, setNewName] = useState('');
   const [creating, setCreating] = useState(false);
+  // Two independent locks: busyId covers row edits (toggle/delete); mintingId
+  // covers the secret-producing rotation. They must not share state — a
+  // toggle/delete settling mid-rotation would otherwise clear the shared lock
+  // and let a second one-time secret race for the single reveal slot.
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [mintingId, setMintingId] = useState<string | null>(null);
   const [confirmRotateId, setConfirmRotateId] = useState<string | null>(null);
   const [revealed, setRevealed] = useState<RevealedSecret | null>(null);
 
@@ -81,6 +105,8 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     mountedRef.current = true;
     return () => { mountedRef.current = false; };
   }, []);
+
+  const orphanSignal = useSyncExternalStore(subscribeOrphans, getOrphanVersion, getOrphanVersion);
 
   // Routes a fresh one-time secret to the live dialog, or parks it in the
   // orphan pen when the response outlived this component instance. `pageId` in
@@ -94,7 +120,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       secret,
     };
     if (!mountedRef.current) {
-      orphanedReveals.set(pageId, value);
+      parkOrphan(value);
       return;
     }
     setRevealed(value);
@@ -105,19 +131,13 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const activeReveal = revealed && revealed.pageId === pageId ? revealed : null;
   useEffect(() => {
     if (revealed && revealed.pageId !== pageId) {
-      orphanedReveals.set(revealed.pageId, revealed);
+      parkOrphan(revealed);
       setRevealed(null);
     }
   }, [revealed, pageId]);
 
   useEffect(() => {
-    if (open) {
-      const orphan = orphanedReveals.get(pageId);
-      if (orphan) {
-        orphanedReveals.delete(pageId);
-        setRevealed(orphan);
-      }
-    } else {
+    if (!open) {
       // Clears the secret from state on close — but deliberately does NOT
       // cancel an in-flight create/rotate: its response holds the only copy of
       // a one-time secret (rotate has already invalidated the old one), so a
@@ -125,8 +145,17 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
       // the secret once instead of silently losing it.
       setRevealed(null);
       setNewName('');
+      return;
     }
-  }, [open, pageId]);
+    // Open with no reveal showing: deliver the next parked secret, if any.
+    // Re-runs when a reveal is dismissed or a new orphan is parked
+    // (orphanSignal), so queued secrets surface one at a time.
+    if (revealed) return;
+    const queue = orphanedReveals.get(pageId);
+    const next = queue?.shift();
+    if (queue && queue.length === 0) orphanedReveals.delete(pageId);
+    if (next) setRevealed(next);
+  }, [open, pageId, revealed, orphanSignal]);
 
   const errorStatus = data && 'error' in data ? data.status : null;
   const forbidden = errorStatus === 403;
@@ -167,30 +196,28 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   };
 
   const rotateWebhook = async (id: string) => {
-    setBusyId(id);
-    const generation = (rotationGenerations.get(id) ?? 0) + 1;
-    rotationGenerations.set(id, generation);
+    if (rotatingWebhooks.has(id)) {
+      toast.error('A rotation of this webhook is still in progress — wait for its secret before starting another');
+      return;
+    }
+    rotatingWebhooks.add(id);
+    setMintingId(id);
     try {
       const res = await post<{ webhook: WebhookRow; webhookSecret: string }>(
         `/api/pages/${pageId}/webhooks/${id}/rotate`,
       );
-      // Superseded while in flight (a newer rotation of this webhook already
-      // succeeded): this secret can never verify — drop it.
-      if (rotationGenerations.get(id) !== generation) return;
       // Reveal before refreshing the list: the old secret is already dead and
       // this response holds the only copy of the new one — a failed (cosmetic)
       // revalidation must never discard it.
       reveal(res.webhook, res.webhookSecret);
       await refetch().catch(() => {});
     } catch (error) {
-      // A failed rotation didn't mint anything — restore the previous
-      // generation so an older still-pending response may deliver its secret.
-      if (rotationGenerations.get(id) === generation) rotationGenerations.set(id, generation - 1);
       // The rotate route's error bodies are user-actionable (e.g. "rotated by a
       // concurrent request") — surface them instead of a generic failure.
       toast.error(error instanceof Error && error.message ? error.message : 'Failed to rotate secret');
     } finally {
-      setBusyId(null);
+      rotatingWebhooks.delete(id);
+      setMintingId(null);
     }
   };
 
@@ -279,7 +306,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
               <Button
                 type="submit"
                 size="sm"
-                disabled={creating || busyId !== null || newName.trim().length === 0}
+                disabled={creating || mintingId !== null || newName.trim().length === 0}
               >
                 {creating ? 'Creating…' : 'Create webhook'}
               </Button>
@@ -306,17 +333,18 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                     <div className="flex items-center gap-2 shrink-0">
                       <Switch
                         checked={webhook.isEnabled}
-                        disabled={busyId === webhook.id}
+                        disabled={busyId === webhook.id || mintingId === webhook.id}
                         onCheckedChange={(checked) => toggleWebhook(webhook.id, checked)}
                       />
-                      {/* Any-busy, not row-busy: two in-flight rotations would race
-                          for the single reveal slot and one one-time secret would be
-                          lost — no new secret may start while one is being minted. */}
+                      {/* Any-minting, not row-busy: two in-flight secret mints would
+                          race for the single reveal slot and one one-time secret
+                          would be lost — no new secret may start while one is being
+                          minted anywhere in this dialog. */}
                       <Button
                         type="button"
                         variant="ghost"
                         size="sm"
-                        disabled={busyId !== null || creating}
+                        disabled={mintingId !== null || creating}
                         onClick={() => setConfirmRotateId(webhook.id)}
                       >
                         Rotate secret
@@ -325,7 +353,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                         type="button"
                         variant="ghost"
                         size="sm"
-                        disabled={busyId === webhook.id}
+                        disabled={busyId === webhook.id || mintingId === webhook.id}
                         onClick={() => removeWebhook(webhook.id)}
                       >
                         Delete

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -33,7 +33,8 @@ interface PageWebhooksDialogProps {
   pageType: string;
 }
 
-type RevealedSecret = { webhookUrl: string; secret: string };
+/** pageId is the ORIGINATING page — the reveal panel only renders when it matches the dialog's current page. */
+type RevealedSecret = { pageId: string; webhookUrl: string; secret: string };
 
 // Holding pen for a one-time secret whose create/rotate response landed after
 // this page's dialog unmounted (CenterPanel remounts views by page id on
@@ -65,9 +66,13 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   }, []);
 
   // Routes a fresh one-time secret to the live dialog, or parks it in the
-  // orphan pen when the response outlived this component instance.
+  // orphan pen when the response outlived this component instance. `pageId` in
+  // the closure is the page the request was started on — the same instance may
+  // meanwhile be showing a different page (CenterPanel reuses views across
+  // page ids), which the render gate below handles.
   const reveal = (webhook: WebhookRow, secret: string) => {
     const value: RevealedSecret = {
+      pageId,
       webhookUrl: `${window.location.origin}/api/webhooks/${webhook.webhookToken}`,
       secret,
     };
@@ -77,6 +82,16 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
     }
     setRevealed(value);
   };
+
+  // Never show a secret in another page's dialog: only a reveal minted for the
+  // current page renders; one that belongs elsewhere is parked for that page.
+  const activeReveal = revealed && revealed.pageId === pageId ? revealed : null;
+  useEffect(() => {
+    if (revealed && revealed.pageId !== pageId) {
+      orphanedReveals.set(revealed.pageId, revealed);
+      setRevealed(null);
+    }
+  }, [revealed, pageId]);
 
   useEffect(() => {
     if (open) {
@@ -167,8 +182,8 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   };
 
   const copyRevealed = async () => {
-    if (!revealed) return;
-    await navigator.clipboard.writeText(`${revealed.webhookUrl}\n${revealed.secret}`);
+    if (!activeReveal) return;
+    await navigator.clipboard.writeText(`${activeReveal.webhookUrl}\n${activeReveal.secret}`);
     toast.success('Copied to clipboard');
   };
 
@@ -202,15 +217,15 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
               Retry
             </Button>
           </div>
-        ) : revealed ? (
+        ) : activeReveal ? (
           <div className="space-y-3 py-2">
             <p className="text-sm">
               Save this secret now — it won&apos;t be shown again. Configure your system to POST to the URL below,
               signed with the secret (see docs for the signature scheme).
             </p>
             <div className="rounded-md border bg-muted p-3 space-y-1 text-xs font-mono break-all">
-              <div>{revealed.webhookUrl}</div>
-              <div>{revealed.secret}</div>
+              <div>{activeReveal.webhookUrl}</div>
+              <div>{activeReveal.secret}</div>
             </div>
             <div className="flex items-center justify-end gap-2">
               <Button type="button" variant="outline" size="sm" onClick={copyRevealed}>

--- a/apps/web/src/components/shared/PageWebhooksDialog.tsx
+++ b/apps/web/src/components/shared/PageWebhooksDialog.tsx
@@ -5,6 +5,16 @@ import { Check, Copy, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -43,6 +53,12 @@ type RevealedSecret = { pageId: string; webhookUrl: string; secret: string };
 // consumed the next time that page's dialog opens.
 const orphanedReveals = new Map<string, RevealedSecret>();
 
+// Latest rotation issued per webhook id. A response from a superseded rotation
+// (an older request resolving after a newer one already succeeded) is
+// discarded outright — its secret is already dead server-side, so revealing or
+// parking it would hand the user a credential that can never verify.
+const rotationGenerations = new Map<string, number>();
+
 const webhooksFetcher = async (url: string): Promise<{ webhooks: WebhookRow[] } | { error: string; status: number }> => {
   const res = await fetchWithAuth(url);
   const body = await res.json().catch(() => ({}));
@@ -57,6 +73,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
   const [newName, setNewName] = useState('');
   const [creating, setCreating] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [confirmRotateId, setConfirmRotateId] = useState<string | null>(null);
   const [revealed, setRevealed] = useState<RevealedSecret | null>(null);
 
   const mountedRef = useRef(true);
@@ -151,16 +168,24 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
 
   const rotateWebhook = async (id: string) => {
     setBusyId(id);
+    const generation = (rotationGenerations.get(id) ?? 0) + 1;
+    rotationGenerations.set(id, generation);
     try {
       const res = await post<{ webhook: WebhookRow; webhookSecret: string }>(
         `/api/pages/${pageId}/webhooks/${id}/rotate`,
       );
+      // Superseded while in flight (a newer rotation of this webhook already
+      // succeeded): this secret can never verify — drop it.
+      if (rotationGenerations.get(id) !== generation) return;
       // Reveal before refreshing the list: the old secret is already dead and
       // this response holds the only copy of the new one — a failed (cosmetic)
       // revalidation must never discard it.
       reveal(res.webhook, res.webhookSecret);
       await refetch().catch(() => {});
     } catch (error) {
+      // A failed rotation didn't mint anything — restore the previous
+      // generation so an older still-pending response may deliver its secret.
+      if (rotationGenerations.get(id) === generation) rotationGenerations.set(id, generation - 1);
       // The rotate route's error bodies are user-actionable (e.g. "rotated by a
       // concurrent request") — surface them instead of a generic failure.
       toast.error(error instanceof Error && error.message ? error.message : 'Failed to rotate secret');
@@ -292,7 +317,7 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
                         variant="ghost"
                         size="sm"
                         disabled={busyId !== null || creating}
-                        onClick={() => rotateWebhook(webhook.id)}
+                        onClick={() => setConfirmRotateId(webhook.id)}
                       >
                         Rotate secret
                       </Button>
@@ -318,6 +343,31 @@ function PageWebhooksDialogImpl({ open, onOpenChange, pageId, pageType }: PageWe
             Done
           </Button>
         </DialogFooter>
+
+        <AlertDialog open={confirmRotateId !== null} onOpenChange={(o) => { if (!o) setConfirmRotateId(null); }}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Rotate this webhook&apos;s secret?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The current secret stops working immediately — deliveries signed with it are rejected
+                until your external sender is updated with the new secret. The webhook URL stays the
+                same, and the new secret is shown exactly once.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  const id = confirmRotateId;
+                  setConfirmRotateId(null);
+                  if (id) void rotateWebhook(id);
+                }}
+              >
+                Rotate
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </DialogContent>
     </Dialog>
   );

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
   del: vi.fn(),
 }));
 
+import { toast } from 'sonner';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { PageWebhooksDialog } from '../PageWebhooksDialog';
 
@@ -128,6 +129,66 @@ describe('PageWebhooksDialog', () => {
         permissionCopy: screen.queryByText(/Only this drive's owner or an admin/),
       },
       expected: { failure: true, retry: true, permissionCopy: null },
+    });
+  });
+
+  test('rotates a webhook secret in place and reveals the new secret exactly once', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_rotated_once',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await waitFor(() => screen.getByText('whsec_rotated_once'));
+
+    assert({
+      given: 'the user rotated an existing webhook secret',
+      should: 'POST to the rotate endpoint and show the new secret once, same URL',
+      actual: {
+        endpoint: vi.mocked(post).mock.calls[0]?.[0],
+        secret: screen.getByText('whsec_rotated_once') !== null,
+        sameUrl: screen.getByText(new RegExp('/api/webhooks/tok_abcdef12345678')) !== null,
+        dismiss: screen.getByRole('button', { name: /Done, I've saved it/ }) !== null,
+      },
+      expected: {
+        endpoint: `/api/pages/${PAGE_ID}/webhooks/wh-1/rotate`,
+        secret: true,
+        sameUrl: true,
+        dismiss: true,
+      },
+    });
+  });
+
+  test('surfaces the server explanation when rotation fails (e.g. concurrent rotation)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    const conflict =
+      'The secret was rotated by a concurrent request — use that rotation’s secret or rotate again';
+    vi.mocked(post).mockRejectedValue(new Error(conflict));
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await waitFor(() => {
+      if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('no toast yet');
+    });
+
+    assert({
+      given: 'the rotate request failed with a server-provided reason',
+      should: 'surface that reason in the error toast and never show a secret panel',
+      actual: {
+        toastMessage: vi.mocked(toast.error).mock.calls[0]?.[0],
+        revealPanel: screen.queryByText(/Save this secret now/),
+      },
+      expected: { toastMessage: conflict, revealPanel: null },
     });
   });
 

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -172,7 +172,7 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
-  test('a superseded rotation response is discarded, not parked for a later reveal', async () => {
+  test('a second rotation of the same webhook is refused while one is in flight across remounts', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
@@ -189,23 +189,100 @@ describe('PageWebhooksDialog', () => {
     const second = renderDialog();
     await waitFor(() => screen.getByText('Deploys'));
     await startRotation();
-    resolvers[1]({ webhook: remoteWebhook(), webhookSecret: 'whsec_newer' });
-    await waitFor(() => screen.getByText('whsec_newer'));
-    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+
+    const postsAfterRefusal = vi.mocked(post).mock.calls.length;
+    const refusalToast = vi.mocked(toast.error).mock.calls[0]?.[0];
+
+    resolvers[0]({ webhook: remoteWebhook(), webhookSecret: 'whsec_serialized' });
+    await waitFor(() => screen.getByText('whsec_serialized'));
     second.unmount();
+
+    assert({
+      given: 'a rotation still in flight from a previous mount of this dialog',
+      should: 'refuse a second rotation of the same webhook (commit order is unknowable) and deliver the in-flight secret',
+      actual: {
+        postsAfterRefusal,
+        refusalMentionsProgress: typeof refusalToast === 'string' && /in progress/i.test(refusalToast),
+        inFlightSecretDelivered: true,
+      },
+      expected: { postsAfterRefusal: 1, refusalMentionsProgress: true, inFlightSecretDelivered: true },
+    });
+  });
+
+  test('toggling or deleting another row does not unlock secret-producing actions mid-rotation', async () => {
+    const second = { ...remoteWebhook(), id: 'wh-2', name: 'Alerts', webhookToken: 'tok_second_999999' };
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook(), second] }),
+    );
+    let resolveRotation: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolveRotation = resolve as (value: unknown) => void; }),
+    );
+    const { del } = await import('@/lib/auth/auth-fetch');
+    vi.mocked(del).mockResolvedValue(undefined);
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+
+    const rotateButtons = screen.getAllByRole('button', { name: /Rotate secret/ });
+    await userEvent.click(rotateButtons[0]);
+    await confirmRotation();
+
+    // Delete the OTHER row while the rotation is still pending — its finally
+    // must not unlock the mint gate.
+    await userEvent.click(screen.getAllByRole('button', { name: /^Delete$/ })[1]);
     await new Promise((r) => { setTimeout(r, 0); });
 
-    resolvers[0]({ webhook: remoteWebhook(), webhookSecret: 'whsec_older_stale' });
+    assert({
+      given: 'a delete on another row settling while a rotation is still in flight',
+      should: 'keep every secret-producing action locked until the rotation settles',
+      actual: {
+        otherRotateDisabled: (screen.getAllByRole('button', { name: /Rotate secret/ })[1] as HTMLButtonElement).disabled,
+        createDisabled: (screen.getByRole('button', { name: /Create webhook/ }) as HTMLButtonElement).disabled,
+      },
+      expected: { otherRotateDisabled: true, createDisabled: true },
+    });
+
+    resolveRotation({ webhook: remoteWebhook(), webhookSecret: 'whsec_settled_late' });
+  });
+
+  test('two secrets parked while unmounted are both delivered, one reveal at a time', async () => {
+    const secondHook = { ...remoteWebhook(), id: 'wh-2', name: 'Alerts', webhookToken: 'tok_second_999999' };
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook(), secondHook] }),
+    );
+    const resolvers: Array<(value: unknown) => void> = [];
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvers.push(resolve as (value: unknown) => void); }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+    const rotateButtons = screen.getAllByRole('button', { name: /Rotate secret/ });
+    await userEvent.click(rotateButtons[0]);
+    await confirmRotation();
+    first.unmount();
+
+    const second = renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+    await userEvent.click(screen.getAllByRole('button', { name: /Rotate secret/ })[1]);
+    await confirmRotation();
+    second.unmount();
+
+    resolvers[0]({ webhook: remoteWebhook(), webhookSecret: 'whsec_first_parked' });
+    resolvers[1]({ webhook: secondHook, webhookSecret: 'whsec_second_parked' });
     await new Promise((r) => { setTimeout(r, 0); });
 
     renderDialog();
-    await waitFor(() => screen.getByText('Deploys'));
+    const firstShown = await screen.findByText('whsec_first_parked');
+    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+    const secondShown = await screen.findByText('whsec_second_parked');
 
     assert({
-      given: 'an older rotation response arriving after a newer rotation was revealed and saved',
-      should: 'discard the stale secret (already dead server-side) instead of parking it for the next open',
-      actual: screen.queryByText('whsec_older_stale'),
-      expected: null,
+      given: 'two rotations of different webhooks whose responses both landed while unmounted',
+      should: 'deliver both parked one-time secrets in order, one reveal at a time',
+      actual: { firstShown: firstShown !== null, secondShown: secondShown !== null },
+      expected: { firstShown: true, secondShown: true },
     });
   });
 

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -534,6 +534,50 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('closing without acknowledging parks the on-screen secret; acknowledging discards it', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_unacknowledged',
+    });
+
+    const dialogAt = (open: boolean) => (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <PageWebhooksDialog open={open} onOpenChange={() => {}} pageId={PAGE_ID} pageType="AI_CHAT" />
+      </SWRConfig>
+    );
+    const view = render(dialogAt(true));
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    await waitFor(() => screen.getByText('whsec_unacknowledged'));
+
+    // Accidental close (X / Escape / outside click / generic Done) — the
+    // unacknowledged secret must come back on reopen.
+    view.rerender(dialogAt(false));
+    await new Promise((r) => { setTimeout(r, 0); });
+    view.rerender(dialogAt(true));
+    const survivedClose = await screen.findByText('whsec_unacknowledged');
+
+    // Explicit acknowledgement is the one true discard.
+    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+    view.rerender(dialogAt(false));
+    await new Promise((r) => { setTimeout(r, 0); });
+    view.rerender(dialogAt(true));
+    await waitFor(() => screen.getByText('Deploys'));
+
+    assert({
+      given: 'a revealed secret across an unacknowledged close and then an acknowledged one',
+      should: 'redeliver after the accidental close and stay gone after "Done, I\'ve saved it"',
+      actual: {
+        survivedClose: survivedClose !== null,
+        goneAfterAck: screen.queryByText('whsec_unacknowledged'),
+      },
+      expected: { survivedClose: true, goneAfterAck: null },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -728,6 +728,56 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('a parked secret is not released from a stale cached 200 before fresh authorization', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    // One shared SWR cache across mounts — like the app's global cache, the
+    // reopened dialog sees the previous session's 200 before revalidation.
+    const cache = new Map();
+    const withCache = () =>
+      render(
+        <SWRConfig value={{ provider: () => cache, dedupingInterval: 0 }}>
+          <PageWebhooksDialog open onOpenChange={() => {}} pageId={PAGE_ID} pageType="AI_CHAT" />
+        </SWRConfig>,
+      );
+
+    const first = withCache();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    first.unmount();
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_stale_gate' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    // Role revoked — but the fresh 403 is slow, so the cached 200 arrives first.
+    let resolveList: (response: Response) => void = () => {};
+    vi.mocked(fetchWithAuth).mockImplementation(
+      () => new Promise<Response>((resolve) => { resolveList = resolve; }),
+    );
+
+    withCache();
+    await new Promise((r) => { setTimeout(r, 0); });
+    const leakedFromCache = screen.queryByText('whsec_stale_gate');
+
+    resolveList(listResponse(403, { error: 'Forbidden' }));
+    await waitFor(() => screen.getByText(/Only this drive's owner or an admin/));
+
+    assert({
+      given: 'a reopened dialog holding a stale cached 200 while the fresh list request will 403',
+      should: 'withhold the parked secret until fresh authorization, then discard it on the 403',
+      actual: {
+        leakedFromCache,
+        shownAfterFresh403: screen.queryByText('whsec_stale_gate'),
+      },
+      expected: { leakedFromCache: null, shownAfterFresh403: null },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () => listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 
 import { toast } from 'sonner';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { useAuthStore } from '@/stores/useAuthStore';
 import { PageWebhooksDialog } from '../PageWebhooksDialog';
 
 const PAGE_ID = 'page-1';
@@ -55,6 +56,7 @@ const renderDialog = (pageType = 'AI_CHAT') =>
 describe('PageWebhooksDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    useAuthStore.setState({ user: { id: 'user-a' } as never });
   });
 
   test('lists webhooks under the Incoming Webhooks title', async () => {
@@ -575,6 +577,71 @@ describe('PageWebhooksDialog', () => {
         goneAfterAck: screen.queryByText('whsec_unacknowledged'),
       },
       expected: { survivedClose: true, goneAfterAck: null },
+    });
+  });
+
+  test('the reveal panel outranks a failed list refresh', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(listResponse(200, { webhooks: [remoteWebhook()] }))
+      .mockImplementation(async () => listResponse(500, { error: 'transient list failure' }));
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_outranks_errors',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    await waitFor(() => screen.getByText('whsec_outranks_errors'));
+
+    assert({
+      given: 'a successful rotation whose follow-up list refresh resolves to a non-2xx error state',
+      should: 'render the one-time secret panel, never the list error screen, over the only copy',
+      actual: {
+        secret: screen.getByText('whsec_outranks_errors') !== null,
+        errorScreen: screen.queryByText('Failed to load webhooks.'),
+      },
+      expected: { secret: true, errorScreen: null },
+    });
+  });
+
+  test('a parked secret is never delivered to a different authenticated user', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    first.unmount();
+
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_user_scoped' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    // A different account on the same shared browser opens the same page's dialog.
+    useAuthStore.setState({ user: { id: 'user-b' } as never });
+    const second = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    const leakedToOtherUser = screen.queryByText('whsec_user_scoped');
+    second.unmount();
+
+    // The owner comes back — their secret is still deliverable.
+    useAuthStore.setState({ user: { id: 'user-a' } as never });
+    renderDialog();
+    const deliveredToOwner = await screen.findByText('whsec_user_scoped');
+
+    assert({
+      given: 'a parked one-time secret and a subsequent sign-in by a different user',
+      should: 'never deliver the parked secret to another account, but keep it for its owner',
+      actual: {
+        leakedToOtherUser,
+        deliveredToOwner: deliveredToOwner !== null,
+      },
+      expected: { leakedToOtherUser: null, deliveredToOwner: true },
     });
   });
 

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -308,6 +308,34 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('a rotation resolving after the component unmounts reveals on the next mount', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    first.unmount();
+
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_after_unmount' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('whsec_after_unmount'));
+
+    assert({
+      given: 'a rotation whose response landed after the page-scoped component unmounted (navigation)',
+      should: 'hold the one-time secret and reveal it on the next mount of this page’s dialog',
+      actual: screen.getByText('whsec_after_unmount') !== null,
+      expected: true,
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -36,6 +36,15 @@ const listResponse = (status: number, body: unknown) =>
     headers: { 'Content-Type': 'application/json' },
   });
 
+/** Click a row's "Rotate secret", then confirm in the alert dialog. */
+const confirmRotation = async () => {
+  await userEvent.click(await screen.findByRole('button', { name: /^Rotate$/ }));
+};
+const startRotation = async () => {
+  await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+  await confirmRotation();
+};
+
 const renderDialog = (pageType = 'AI_CHAT') =>
   render(
     <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
@@ -132,6 +141,74 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('rotation is gated behind an explicit confirmation that names the consequence', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_confirmed',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+
+    const postedBeforeConfirm = vi.mocked(post).mock.calls.length;
+    const warning = await screen.findByText(/current secret stops working immediately/i);
+
+    await confirmRotation();
+    await waitFor(() => screen.getByText('whsec_confirmed'));
+
+    assert({
+      given: 'a click on Rotate secret',
+      should: 'not call the API until the destructive consequence is confirmed',
+      actual: {
+        postedBeforeConfirm,
+        warningShown: warning !== null,
+        postedAfterConfirm: vi.mocked(post).mock.calls.length,
+      },
+      expected: { postedBeforeConfirm: 0, warningShown: true, postedAfterConfirm: 1 },
+    });
+  });
+
+  test('a superseded rotation response is discarded, not parked for a later reveal', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    const resolvers: Array<(value: unknown) => void> = [];
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvers.push(resolve as (value: unknown) => void); }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    first.unmount();
+
+    const second = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    resolvers[1]({ webhook: remoteWebhook(), webhookSecret: 'whsec_newer' });
+    await waitFor(() => screen.getByText('whsec_newer'));
+    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+    second.unmount();
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    resolvers[0]({ webhook: remoteWebhook(), webhookSecret: 'whsec_older_stale' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    assert({
+      given: 'an older rotation response arriving after a newer rotation was revealed and saved',
+      should: 'discard the stale secret (already dead server-side) instead of parking it for the next open',
+      actual: screen.queryByText('whsec_older_stale'),
+      expected: null,
+    });
+  });
+
   test('rotates a webhook secret in place and reveals the new secret exactly once', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(
       listResponse(200, { webhooks: [remoteWebhook()] }),
@@ -144,7 +221,7 @@ describe('PageWebhooksDialog', () => {
     renderDialog();
     await waitFor(() => screen.getByText('Deploys'));
 
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
     await waitFor(() => screen.getByText('whsec_rotated_once'));
 
     assert({
@@ -176,7 +253,7 @@ describe('PageWebhooksDialog', () => {
     renderDialog();
     await waitFor(() => screen.getByText('Deploys'));
 
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
     await waitFor(() => {
       if (vi.mocked(toast.error).mock.calls.length === 0) throw new Error('no toast yet');
     });
@@ -204,7 +281,7 @@ describe('PageWebhooksDialog', () => {
     renderDialog();
     await waitFor(() => screen.getByText('Deploys'));
 
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
     await waitFor(() => screen.getByText('whsec_survives_refetch'));
 
     assert({
@@ -260,6 +337,7 @@ describe('PageWebhooksDialog', () => {
 
     const rotateButtons = screen.getAllByRole('button', { name: /Rotate secret/ });
     await userEvent.click(rotateButtons[0]);
+    await confirmRotation();
     await waitFor(() => {
       if (!(rotateButtons[1] as HTMLButtonElement).disabled) throw new Error('not yet disabled');
     });
@@ -293,7 +371,7 @@ describe('PageWebhooksDialog', () => {
     );
     const view = render(dialogAt(true));
     await waitFor(() => screen.getByText('Deploys'));
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
 
     view.rerender(dialogAt(false));
     resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_late_arrival' });
@@ -319,7 +397,7 @@ describe('PageWebhooksDialog', () => {
 
     const first = renderDialog();
     await waitFor(() => screen.getByText('Deploys'));
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
     first.unmount();
 
     resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_after_unmount' });
@@ -352,7 +430,7 @@ describe('PageWebhooksDialog', () => {
     );
     const view = render(dialogFor(PAGE_ID));
     await waitFor(() => screen.getByText('Deploys'));
-    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await startRotation();
 
     // Same component instance survives navigation (CenterPanel reuses the
     // view across channel ids) — only the pageId prop changes.

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -60,7 +60,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('lists webhooks under the Incoming Webhooks title', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
 
@@ -79,7 +79,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('shows the owner/admin explanation on a 403 — disabled, not hidden', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(403, { error: 'Forbidden' }),
     );
 
@@ -101,7 +101,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('description copy states the channel default action only on channels', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
+    vi.mocked(fetchWithAuth).mockImplementation(async () => listResponse(200, { webhooks: [] }));
 
     const channelRender = renderDialog('CHANNEL');
     await waitFor(() => screen.getByText(/post messages into this channel/));
@@ -124,7 +124,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('distinguishes a server failure from missing permission', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(500, { error: 'Failed to list webhooks' }),
     );
 
@@ -144,7 +144,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('rotation is gated behind an explicit confirmation that names the consequence', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     vi.mocked(post).mockResolvedValue({
@@ -289,7 +289,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('rotates a webhook secret in place and reveals the new secret exactly once', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     vi.mocked(post).mockResolvedValue({
@@ -322,7 +322,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('surfaces the server explanation when rotation fails (e.g. concurrent rotation)', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     const conflict =
@@ -403,7 +403,7 @@ describe('PageWebhooksDialog', () => {
 
   test('a pending rotation disables every other secret-producing action', async () => {
     const second = { ...remoteWebhook(), id: 'wh-2', name: 'Alerts', webhookToken: 'tok_second_999999' };
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook(), second] }),
     );
     let resolvePost: (value: unknown) => void = () => {};
@@ -435,7 +435,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('a rotation resolving after the dialog closes still reveals its secret on reopen', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     let resolvePost: (value: unknown) => void = () => {};
@@ -469,7 +469,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('a rotation resolving after the component unmounts reveals on the next mount', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     let resolvePost: (value: unknown) => void = () => {};
@@ -497,7 +497,7 @@ describe('PageWebhooksDialog', () => {
   });
 
   test('a rotation from one page never reveals in another page’s dialog', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
       listResponse(200, { webhooks: [remoteWebhook()] }),
     );
     let resolvePost: (value: unknown) => void = () => {};
@@ -685,8 +685,51 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('a parked secret is discarded, never delivered, after management permission is revoked', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+    await startRotation();
+    first.unmount();
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_revoked_manager' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    // The user's owner/admin role is revoked before they reopen the dialog.
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(403, { error: 'Forbidden' }),
+    );
+    const second = renderDialog();
+    await waitFor(() => screen.getByText(/Only this drive's owner or an admin/));
+    const shownWhileRevoked = screen.queryByText('whsec_revoked_manager');
+    second.unmount();
+
+    // Even re-promoted later, the discarded secret must not resurface.
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    assert({
+      given: 'a parked one-time secret whose owner lost management permission before reopening',
+      should: 'never deliver the credential to the demoted user and discard it for good',
+      actual: {
+        shownWhileRevoked,
+        resurfacedAfterRepromotion: screen.queryByText('whsec_revoked_manager'),
+      },
+      expected: { shownWhileRevoked: null, resurfacedAfterRepromotion: null },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
+    vi.mocked(fetchWithAuth).mockImplementation(async () => listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({
       webhook: remoteWebhook(),
       webhookSecret: 'whsec_only_shown_once',

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -192,6 +192,91 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('reveals the rotated secret even when the list refresh fails', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(listResponse(200, { webhooks: [remoteWebhook()] }))
+      .mockRejectedValue(new Error('network down'));
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_survives_refetch',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Deploys'));
+
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+    await waitFor(() => screen.getByText('whsec_survives_refetch'));
+
+    assert({
+      given: 'a successful rotation whose follow-up list revalidation rejects',
+      should: 'still reveal the one-time secret (the old one is already dead) with no error toast',
+      actual: {
+        secret: screen.getByText('whsec_survives_refetch') !== null,
+        errorToasts: vi.mocked(toast.error).mock.calls.length,
+      },
+      expected: { secret: true, errorToasts: 0 },
+    });
+  });
+
+  test('reveals the created secret even when the list refresh fails', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(listResponse(200, { webhooks: [] }))
+      .mockRejectedValue(new Error('network down'));
+    vi.mocked(post).mockResolvedValue({
+      webhook: remoteWebhook(),
+      webhookSecret: 'whsec_created_survives',
+    });
+
+    renderDialog();
+    await waitFor(() => screen.getByPlaceholderText(/Webhook name/));
+
+    await userEvent.type(screen.getByPlaceholderText(/Webhook name/), 'Deploys');
+    await userEvent.click(screen.getByRole('button', { name: /Create webhook/ }));
+    await waitFor(() => screen.getByText('whsec_created_survives'));
+
+    assert({
+      given: 'a successful creation whose follow-up list revalidation rejects',
+      should: 'still reveal the one-time secret with no error toast',
+      actual: {
+        secret: screen.getByText('whsec_created_survives') !== null,
+        errorToasts: vi.mocked(toast.error).mock.calls.length,
+      },
+      expected: { secret: true, errorToasts: 0 },
+    });
+  });
+
+  test('a pending rotation disables every other secret-producing action', async () => {
+    const second = { ...remoteWebhook(), id: 'wh-2', name: 'Alerts', webhookToken: 'tok_second_999999' };
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook(), second] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+
+    const rotateButtons = screen.getAllByRole('button', { name: /Rotate secret/ });
+    await userEvent.click(rotateButtons[0]);
+    await waitFor(() => {
+      if (!(rotateButtons[1] as HTMLButtonElement).disabled) throw new Error('not yet disabled');
+    });
+
+    assert({
+      given: 'a rotation in flight on one webhook of several',
+      should: 'disable the other rotate and create actions so a second one-time secret cannot overwrite the first reveal',
+      actual: {
+        otherRotateDisabled: (rotateButtons[1] as HTMLButtonElement).disabled,
+        createDisabled: (screen.getByRole('button', { name: /Create webhook/ }) as HTMLButtonElement).disabled,
+      },
+      expected: { otherRotateDisabled: true, createDisabled: true },
+    });
+
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_settled' });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 import { toast } from 'sonner';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { PageWebhooksDialog } from '../PageWebhooksDialog';
+import { PageWebhooksDialog, __resetPageWebhooksDialogModuleState } from '../PageWebhooksDialog';
 
 const PAGE_ID = 'page-1';
 
@@ -56,6 +56,9 @@ const renderDialog = (pageType = 'AI_CHAT') =>
 describe('PageWebhooksDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Module-level pen/lock state survives vi.clearAllMocks — wipe it so a
+    // parked secret from one case can never leak into another.
+    __resetPageWebhooksDialogModuleState();
     useAuthStore.setState({ user: { id: 'user-a' } as never });
   });
 

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -645,6 +645,46 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('a second resolving mint queues behind an on-screen secret instead of overwriting it', async () => {
+    const hookB = { ...remoteWebhook(), id: 'wh-2', name: 'Alerts', webhookToken: 'tok_second_999999' };
+    vi.mocked(fetchWithAuth).mockImplementation(async () =>
+      listResponse(200, { webhooks: [remoteWebhook(), hookB] }),
+    );
+    const resolvers: Array<(value: unknown) => void> = [];
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvers.push(resolve as (value: unknown) => void); }),
+    );
+
+    const first = renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+    await userEvent.click(screen.getAllByRole('button', { name: /Rotate secret/ })[0]);
+    await confirmRotation();
+    first.unmount();
+
+    // Fresh instance after navigation: its mint gate is clear, so rotating B
+    // is allowed while A is still in flight from the previous mount.
+    renderDialog();
+    await waitFor(() => screen.getByText('Alerts'));
+    await userEvent.click(screen.getAllByRole('button', { name: /Rotate secret/ })[1]);
+    await confirmRotation();
+
+    resolvers[0]({ webhook: remoteWebhook(), webhookSecret: 'whsec_A_shown_first' });
+    await waitFor(() => screen.getByText('whsec_A_shown_first'));
+    resolvers[1]({ webhook: hookB, webhookSecret: 'whsec_B_queued' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    const aStillShown = screen.queryByText('whsec_A_shown_first');
+    await userEvent.click(screen.getByRole('button', { name: /Done, I've saved it/ }));
+    const bShownNext = await screen.findByText('whsec_B_queued');
+
+    assert({
+      given: 'a second mint resolving while another one-time secret is on screen',
+      should: 'keep the on-screen secret and queue the new one for the next reveal slot',
+      actual: { aStillShown: aStillShown !== null, bShownNext: bShownNext !== null },
+      expected: { aStillShown: true, bShownNext: true },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -452,6 +452,9 @@ describe('PageWebhooksDialog', () => {
 
     view.rerender(dialogAt(false));
     resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_late_arrival' });
+    // The response must be fully processed while the dialog is still closed —
+    // reopening first would mask a wipe of the closed-dialog reveal.
+    await new Promise((r) => { setTimeout(r, 0); });
     view.rerender(dialogAt(true));
     await waitFor(() => screen.getByText('whsec_late_arrival'));
 

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -336,6 +336,46 @@ describe('PageWebhooksDialog', () => {
     });
   });
 
+  test('a rotation from one page never reveals in another page’s dialog', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    const dialogFor = (pid: string) => (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <PageWebhooksDialog open onOpenChange={() => {}} pageId={pid} pageType="CHANNEL" />
+      </SWRConfig>
+    );
+    const view = render(dialogFor(PAGE_ID));
+    await waitFor(() => screen.getByText('Deploys'));
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+
+    // Same component instance survives navigation (CenterPanel reuses the
+    // view across channel ids) — only the pageId prop changes.
+    view.rerender(dialogFor('page-2'));
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_page_scoped' });
+    await new Promise((r) => { setTimeout(r, 0); });
+
+    const leakedIntoOtherPage = screen.queryByText('whsec_page_scoped');
+
+    view.rerender(dialogFor(PAGE_ID));
+    await waitFor(() => screen.getByText('whsec_page_scoped'));
+
+    assert({
+      given: 'a rotation started on page A whose response landed while the same dialog instance showed page B',
+      should: 'never reveal A’s secret in B’s dialog, but deliver it when A’s dialog is shown again',
+      actual: {
+        leakedIntoOtherPage,
+        revealedOnOwnPage: screen.getByText('whsec_page_scoped') !== null,
+      },
+      expected: { leakedIntoOtherPage: null, revealedOnOwnPage: true },
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({

--- a/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
+++ b/apps/web/src/components/shared/__tests__/PageWebhooksDialog.test.tsx
@@ -277,6 +277,37 @@ describe('PageWebhooksDialog', () => {
     resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_settled' });
   });
 
+  test('a rotation resolving after the dialog closes still reveals its secret on reopen', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(
+      listResponse(200, { webhooks: [remoteWebhook()] }),
+    );
+    let resolvePost: (value: unknown) => void = () => {};
+    vi.mocked(post).mockImplementation(
+      () => new Promise<never>((resolve) => { resolvePost = resolve as (value: unknown) => void; }),
+    );
+
+    const dialogAt = (open: boolean) => (
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <PageWebhooksDialog open={open} onOpenChange={() => {}} pageId={PAGE_ID} pageType="AI_CHAT" />
+      </SWRConfig>
+    );
+    const view = render(dialogAt(true));
+    await waitFor(() => screen.getByText('Deploys'));
+    await userEvent.click(screen.getByRole('button', { name: /Rotate secret/ }));
+
+    view.rerender(dialogAt(false));
+    resolvePost({ webhook: remoteWebhook(), webhookSecret: 'whsec_late_arrival' });
+    view.rerender(dialogAt(true));
+    await waitFor(() => screen.getByText('whsec_late_arrival'));
+
+    assert({
+      given: 'a rotation whose response arrived only after the dialog was closed',
+      should: 'reveal the one-time secret on reopen — the old secret is already dead and this is the only copy',
+      actual: screen.getByText('whsec_late_arrival') !== null,
+      expected: true,
+    });
+  });
+
   test('reveals the secret exactly once, dismissed only by explicit confirmation', async () => {
     vi.mocked(fetchWithAuth).mockResolvedValue(listResponse(200, { webhooks: [] }));
     vi.mocked(post).mockResolvedValue({


### PR DESCRIPTION
## Finding

**F6 (webhooks hardening audit):** there was no in-place secret rotation. Rotating a leaked webhook secret forced delete+recreate, which changes the `webhookToken` and therefore the URL — breaking the external integration. A bearer secret you can't rotate without breaking the integration is a bearer secret people won't rotate.

## Approach

New dedicated sub-route `POST /api/pages/[pageId]/webhooks/[id]/rotate` (cleaner than overloading PATCH):

- **Same trust model as the sibling webhook CRUD**: `authenticateRequestWithOptions` with CSRF required, `canManagePageWebhooks` (drive owner/admin only; scoped MCP/OAuth tokens rejected outright), 404 for a webhook not owned by the addressed page.
- **Mints a fresh 256-bit secret** — `randomBytes(32).toString('base64url')`, identical to creation — and `encryptField`-stores it into `webhookSecretEncrypted` on the **same row**. `webhookToken` (and thus the URL) is never written, so the external sender only swaps the secret.
- **Returned exactly once**: the plaintext secret appears only in the rotate response; the row is stripped via `toPublicWebhook` and the plaintext is never re-derivable.
- **Concurrent rotations serialized** (Codex review): the UPDATE is conditioned on the `webhookSecretEncrypted` ciphertext read by this request — randomized encryption makes the stored ciphertext unique per write, so it acts as an optimistic-concurrency token. The losing request gets a **409** (no secret, no audit); a zero-row update caused by a concurrent DELETE is re-checked and returns a truthful **404**.
- **Audited**: `auditRequest` `data.write` with `operation: 'rotate'` — which also satisfies the security-audit route-coverage gate the same way the sibling webhook routes do (pattern scan on `auditRequest(`, no exemption entry).
- **Old secret dies immediately**: intake does a fresh read + `decryptField` per delivery (no cache), so a request signed with the old secret fails verification the moment the row updates — proven at unit level with a real `v0Scheme` sign/verify round-trip against the stored value.
- **Reachable from the UI** (Codex review): `PageWebhooksDialog` gets a **Rotate secret** action per row — POSTs to the rotate endpoint, reuses the create-flow reveal-once panel (same URL, secret shown exactly once), and surfaces the route's user-actionable error bodies (e.g. the concurrent-rotation 409) in the error toast.
- **One-time secrets can't be lost in the UI** (Codex review): the secret is revealed *before* the SWR list revalidation and the refetch is non-fatal (in both create and rotate — the response holds the only copy); while any rotation/creation is in flight, all other secret-producing actions are disabled so two one-shot secrets can't race for the single reveal slot; and a response that lands after the page-scoped dialog unmounts (navigation mid-rotation) is parked in a pageId-keyed orphan pen and revealed on the dialog's next open instead of being discarded; every reveal is scoped to its originating page, so a reused view instance can never leak one page's secret into another page's dialog; rotations of the same webhook are hard-serialized client-side (a second one is refused until the pending one settles — issuance order can't establish commit order, so nothing valid is ever discarded); the secret-mint lock is independent of the row-action lock; the orphan pen is a reactive queue (multiple parked secrets all delivered, surfaced the moment they arrive); rotation sits behind an explicit AlertDialog confirmation spelling out that the current secret dies immediately; and an unacknowledged on-screen secret survives an accidental dialog close (parked and redelivered at next open) — the explicit "Done, I've saved it" acknowledgement is the only true discard. The reveal panel outranks every list state (a transient list error can't replace the only secret copy), and reveals/pen entries are scoped to the signed-in user (owner+page keys), so another account on a shared browser can never be shown a parked secret.
- **Docs + changelog** (Codex review): the Incoming Webhooks guide now documents same-URL rotation (management actions + lost/leaked-secret guidance no longer says delete+recreate), and CHANGELOG.md gains a "Rotate a webhook secret in place" entry.

## Test plan

13 tests in `rotate/__tests__/route.test.ts` (mirroring the sibling mock style):

- new secret is base64url/43-chars, returned once, encrypted form is the only thing written at rest
- `webhookToken` unchanged in the response and never present in the DB `set()`
- encrypted secret stripped from the returned row
- **rotate → old secret no longer verifies, new secret verifies** (`v0Scheme` round-trip)
- **optimistic-concurrency guard shape**; concurrent rotation → 409 with no secret/audit; concurrent delete → 404
- CSRF required on the auth gate; encryption failure → generic 500 with no secret material
- audit call shape (`data.write` / `rotate`)
- 403 for non-owner/admin (no read, no write), 404 cross-page, auth error propagated

Plus 18 dialog tests (`PageWebhooksDialog.test.tsx`): rotate → reveal-once panel with unchanged URL; rotate failure → server reason surfaced in toast, no secret panel; rotated/created secret still revealed when the list refresh fails (zero toasts); a pending rotation disables every other secret-producing action; a rotation resolving after close reveals on reopen; a rotation resolving after unmount reveals on the next mount; a rotation from one page never reveals in another page's dialog; rotation gated behind explicit confirmation (zero POSTs before confirm); a second rotation of the same webhook is refused while one is in flight; row actions settling mid-rotation never unlock the mint gate; two parked secrets are both delivered one reveal at a time; an unacknowledged close parks the secret while acknowledgement discards it; the reveal outranks a resolved list-refresh error; a parked secret is never delivered to a different authenticated user; a second resolving mint queues behind an on-screen secret instead of overwriting it; a parked secret is discarded, never delivered, after management permission is revoked (pen delivery revalidates and dequeues only on a FRESH successful canManagePageWebhooks-gated response — a stale cached 200 releases nothing, a fresh 403 purges the pen).

Gates: webhook API suite 53/53 + dialog suite 23/23 green, `security-audit-coverage` green, `bun run typecheck` green, `bun run lint` green, `knip:check` within baseline. `test:security` shows only the 7 documented pre-existing script-drift failures (Session Service / Device Auth / Permissions / Login / Signup / Mobile Login / Admin Role Versioning — DB-integration-only or renamed paths, verified pre-existing 2026-07-20); no failing suite touches files in this PR. Rebased on latest master (be9fda5de).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCwYBg4yMbWkvcGCx9JhMX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-place rotation for incoming webhook secrets while preserving the existing webhook URL.
  * New secrets are shown once, and the previous secret is invalidated after rotation.
  * Added confirmation prompts, loading states, and protection against duplicate rotations.
  * Limited rotation to authorized owners and administrators.

* **Documentation**
  * Updated incoming webhook guidance for rotating, securing, and recovering leaked secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->