### PR TITLE
Machine pane chrome: reliable pane close, instant-spawn palette, universal pane bar

### DIFF
--- a/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
+++ b/apps/realtime/src/terminal/__tests__/agent-terminal-access.test.ts
@@ -175,7 +175,7 @@ describe('resolveMachineSandbox', () => {
     const result = await resolveMachineSandbox(
       { machineId: 'm-1', name: 'runner' },
       {
-        resolveAgentTerminal: async () => ({ ...resolvedOk, agentType: 'claude', command: 'claude --dangerously' }),
+        resolveAgentTerminal: async () => ({ ...resolvedOk, agentType: 'shell', command: 'htop --tree' }),
         getSprite: spyGetSprite().fn,
       },
     );
@@ -184,7 +184,7 @@ describe('resolveMachineSandbox', () => {
       given: 'a resolved row with a command override',
       should: 'expose the override plus the agentType launch command',
       actual: result.ok ? { command: result.command, commandOverride: result.commandOverride } : result,
-      expected: { command: 'claude', commandOverride: 'claude --dangerously' },
+      expected: { command: 'shell', commandOverride: 'htop --tree' },
     });
   });
 

--- a/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
+++ b/apps/web/src/app/api/machines/agent-terminals/__tests__/route.test.ts
@@ -84,7 +84,7 @@ describe('GET /api/machines/agent-terminals', () => {
     mockCanViewMachine.mockResolvedValue(true);
     mockListAgentTerminals.mockResolvedValue({
       ok: true,
-      terminals: [{ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', createdAt: new Date('2026-07-01') }],
+      terminals: [{ id: 'agent-terminal-1', name: 'cli', agentType: 'shell', createdAt: new Date('2026-07-01') }],
     });
     const res = await GET(new Request('https://x.test/api/machines/agent-terminals?machineId=t1&projectName=repo&branchName=main'));
     expect(res.status).toBe(200);
@@ -163,7 +163,7 @@ describe('POST /api/machines/agent-terminals', () => {
       headers: { 'content-type': 'application/json' },
     });
   }
-  const VALID_BODY = { machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' };
+  const VALID_BODY = { machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'shell' };
 
   it('given no edit access, returns 403 without spawning', async () => {
     mockCanAccessMachine.mockResolvedValue(false);
@@ -172,30 +172,30 @@ describe('POST /api/machines/agent-terminals', () => {
     expect(mockSpawnAgentTerminal).not.toHaveBeenCalled();
   });
 
-  it('given a fresh spawn of a claude terminal, returns 201 with the row id', async () => {
+  it('given a fresh spawn of a shell terminal, returns 201 with the row id', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: false });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'shell', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-1', name: 'cli', agentType: 'claude', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ id: 'agent-terminal-1', name: 'cli', agentType: 'shell', resumed: false });
     expect(mockSpawnAgentTerminal).toHaveBeenCalledWith(
-      expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'claude' }),
+      expect.objectContaining({ machineId: 't1', projectName: 'repo', branchName: 'main', name: 'cli', agentType: 'shell' }),
     );
   });
 
-  it('given a fresh spawn of a codex terminal, returns 201', async () => {
+  it('given a fresh spawn of a pagespace terminal, returns 201', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-2', agentType: 'codex', resumed: false });
-    const res = await POST(req({ ...VALID_BODY, name: 'reviewer', agentType: 'codex' }));
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-2', agentType: 'pagespace', resumed: false });
+    const res = await POST(req({ ...VALID_BODY, name: 'reviewer', agentType: 'pagespace' }));
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.agentTerminal).toMatchObject({ name: 'reviewer', agentType: 'codex', resumed: false });
+    expect(body.agentTerminal).toMatchObject({ name: 'reviewer', agentType: 'pagespace', resumed: false });
   });
 
   it('given a resumed spawn, returns 200', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'claude', resumed: true });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-1', agentType: 'shell', resumed: true });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(200);
   });
@@ -288,7 +288,7 @@ describe('POST /api/machines/agent-terminals', () => {
   it('given a non-pagespace terminal, spawns regardless of the code-execution flag', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
     mockIsCodeExecutionEnabled.mockReturnValue(false);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-6', agentType: 'claude', resumed: false });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-6', agentType: 'shell', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     expect(mockSpawnAgentTerminal).toHaveBeenCalled();
@@ -312,7 +312,7 @@ describe('POST /api/machines/agent-terminals', () => {
 
   it('given a fresh non-pagespace spawn, does NOT pre-create a conversation', async () => {
     mockCanAccessMachine.mockResolvedValue(true);
-    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-8', agentType: 'claude', resumed: false });
+    mockSpawnAgentTerminal.mockResolvedValue({ ok: true, id: 'agent-terminal-8', agentType: 'shell', resumed: false });
     const res = await POST(req(VALID_BODY));
     expect(res.status).toBe(201);
     expect(mockCreateConversation).not.toHaveBeenCalled();

--- a/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
+++ b/apps/web/src/components/layout/left-sidebar/__tests__/DevelopmentSidebar.test.tsx
@@ -98,7 +98,7 @@ vi.mock('@/hooks/useMachineWorkspaceSync', async (importOriginal) => {
 
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
-  post: vi.fn(async () => ({ agentTerminal: { name: 'claude-a1b2c3', agentType: 'claude', resumed: false } })),
+  post: vi.fn(async () => ({ agentTerminal: { name: 'shell-a1b2c3', agentType: 'shell', resumed: false } })),
   del: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 
@@ -329,8 +329,7 @@ describe('DevelopmentSidebar', () => {
     render(<DevelopmentSidebar />);
 
     await user.click(await screen.findByTitle('Add…'));
-    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
-    await user.click(await screen.findByRole('button', { name: 'Spawn agent' }));
+    await user.click(await screen.findByRole('option', { name: 'Shell' }));
 
     await waitFor(() => {
       const machine = selectMachine('machine-1')(useMachineWorkspaceStore.getState())!;

--- a/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/XtermTerminal.test.tsx
@@ -105,7 +105,7 @@ function fakeSocket() {
   };
 }
 
-const CONNECT = { machineId: 'm1', name: 'claude-a1b2c3' };
+const CONNECT = { machineId: 'm1', name: 'shell-a1b2c3' };
 
 const inputs = (emitted: Array<{ event: string; payload: Record<string, unknown> }>) =>
   emitted.filter((entry) => entry.event === 'agent-terminal:input').map((entry) => entry.payload.data);
@@ -141,7 +141,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     const beforeOutput = inputs(fake.emitted);
 
     // The agent prints its banner: it is alive and reading.
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId });
 
     assert({
       given: 'a cold agent that has just been exec’d, then starts drawing',
@@ -221,7 +221,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     // so treating every reattach as unsafe would mean the prompt never worked
     // while developing the feature.
     fake.server('agent-terminal:ready', { scrollback: '', resumed: false, connectionId });
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId });
 
     assert({
       given: 'a re-mount that reattaches to an agent which has printed nothing yet',
@@ -309,7 +309,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     await waitFor(() => expect(fake.hasHandlers()).toBe(true));
 
     fake.server('agent-terminal:ready', { connectionId: fake.connectionId() });
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId: fake.connectionId() });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId: fake.connectionId() });
     await vi.advanceTimersByTimeAsync(5000);
 
     assert({
@@ -381,7 +381,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     await waitFor(() => expect(fake.hasHandlers()).toBe(true));
     const connectionId = fake.connectionId();
 
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId });
     fake.server('agent-terminal:ready', { resumed: false, connectionId });
 
     assert({
@@ -400,18 +400,18 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     const paneA = render(
       <XtermTerminal socket={fake.socket} sessionId="a" connectPayload={CONNECT} initialInput="fix the build" />
     );
-    render(<XtermTerminal socket={fake.socket} sessionId="b" connectPayload={{ ...CONNECT, name: 'codex-b2' }} />);
+    render(<XtermTerminal socket={fake.socket} sessionId="b" connectPayload={{ ...CONNECT, name: 'other-b2' }} />);
     await waitFor(() => expect(fake.connectionIds().length).toBe(2));
     const [idA, idB] = fake.connectionIds();
 
     // B boots and draws. A must not read that as its own agent waking up.
     fake.server('agent-terminal:ready', { connectionId: idB });
-    fake.server('agent-terminal:output', { data: 'codex> ', connectionId: idB });
+    fake.server('agent-terminal:output', { data: 'other> ', connectionId: idB });
     const afterBOnly = inputs(fake.emitted);
 
     // Now A's own agent comes up.
     fake.server('agent-terminal:ready', { connectionId: idA });
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId: idA });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId: idA });
 
     paneA.unmount();
     const listenersAfterAClosed = fake.listenerCount('agent-terminal:output');
@@ -479,7 +479,7 @@ describe('XtermTerminal — starting-prompt delivery', () => {
     await waitFor(() => expect(fake.hasHandlers()).toBe(true));
 
     fake.server('agent-terminal:ready', { connectionId: fake.connectionId() });
-    fake.server('agent-terminal:output', { data: 'claude> ', connectionId: fake.connectionId() });
+    fake.server('agent-terminal:output', { data: 'shell> ', connectionId: fake.connectionId() });
     await vi.advanceTimersByTimeAsync(5000);
 
     assert({

--- a/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/tabs/TerminalTab.test.tsx
@@ -26,7 +26,7 @@ vi.mock('@/hooks/useGithubRepos', () => ({
 vi.mock('@/hooks/useIntegrations', () => ({ useProviders: () => ({ providers: [] }) }));
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: vi.fn(async () => new Response(JSON.stringify({ agentTerminals: [] }), { status: 200 })),
-  post: vi.fn(async () => ({ agentTerminal: { name: 'claude-a1b2c3', agentType: 'claude', resumed: false } })),
+  post: vi.fn(async () => ({ agentTerminal: { name: 'shell-a1b2c3', agentType: 'shell', resumed: false } })),
   del: vi.fn(async () => new Response(null, { status: 204 })),
 }));
 
@@ -87,8 +87,7 @@ describe('TerminalTab', () => {
 
     await screen.findByText('Machine');
     await userEvent.click(screen.getByTitle('Add…'));
-    await userEvent.click(await screen.findByRole('option', { name: 'New terminal' }));
-    await userEvent.click(await screen.findByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(await screen.findByRole('option', { name: 'Shell' }));
 
     await waitFor(() => {
       const machine = selectMachine('machine-1')(store())!;

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
@@ -202,15 +202,24 @@ export default function MachinePaneChat({
                       <MoreHorizontal className="size-3.5" />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onSelect={() => handleCreateConversation()}>
-                      <Plus className="size-3.5" /> New conversation
+                  {/* Menu clicks bubble through the Radix portal back into
+                      TerminalPane's onClick={onSelect} — for a split action
+                      that would immediately re-select the SOURCE pane,
+                      undoing the new pane's activation. Same guard as
+                      PaneSplitCloseActions' buttons. */}
+                  <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+                    <DropdownMenuItem onSelect={() => setActiveTab('chat')}>
+                      <MessageSquare className="size-3.5" /> Chat
                     </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => setActiveTab('history')}>
                       <History className="size-3.5" /> History
                     </DropdownMenuItem>
                     <DropdownMenuItem onSelect={() => setActiveTab('settings')}>
                       <Settings className="size-3.5" /> Settings
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem onSelect={() => handleCreateConversation()}>
+                      <Plus className="size-3.5" /> New conversation
                     </DropdownMenuItem>
                     {paneControls?.canSplit && (
                       <>

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachinePaneChat.tsx
@@ -16,8 +16,24 @@
  * and the messages area contains its own layout.
  */
 import React, { useCallback, useState } from 'react';
-import { MessageSquare, History, Settings, Plus, Loader2 } from 'lucide-react';
+import {
+  MessageSquare,
+  History,
+  Settings,
+  Plus,
+  Loader2,
+  MoreHorizontal,
+  SquareSplitHorizontal,
+  SquareSplitVertical,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { ChatInput } from '@/components/ai/chat/input';
@@ -33,6 +49,7 @@ import PageAgentHistoryTab from '@/components/ai/page-agents/PageAgentHistoryTab
 import { SidebarMessagesContent } from '@/components/layout/right-sidebar/ai-assistant/SidebarChatTab';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import PaneBar, { PaneSplitCloseActions, type PaneControlProps } from './PaneBar';
 import { useMachinePaneChat } from './useMachinePaneChat';
 
 export interface MachinePaneChatProps {
@@ -44,6 +61,12 @@ export interface MachinePaneChatProps {
   pendingPrompt?: string;
   /** Consumed-notification for pendingPrompt. */
   onPromptSent?: () => void;
+  /** Drives the pane bar's focus tint — same grammar as every PTY pane. */
+  isActive?: boolean;
+  /** The pane-level split/close controls, merged into THIS component's bar —
+   * a chat pane renders exactly one bar, so TerminalPane hands its controls
+   * down instead of drawing a second bar (or floating chrome) above this one. */
+  paneControls?: PaneControlProps;
 }
 
 type PaneTab = 'chat' | 'history' | 'settings';
@@ -53,6 +76,8 @@ export default function MachinePaneChat({
   terminalId,
   pendingPrompt,
   onPromptSent,
+  isActive = false,
+  paneControls,
 }: MachinePaneChatProps) {
   const [activeTab, setActiveTab] = useState<PaneTab>('chat');
   const [input, setInput] = useState('');
@@ -67,7 +92,7 @@ export default function MachinePaneChat({
     historyEnabled: activeTab === 'history' || activeTab === 'chat',
   });
 
-  const assistantName = pane.selectedAgent ? pane.selectedAgent.title : 'PageSpace Agent';
+  const assistantName = pane.selectedAgent ? pane.selectedAgent.title : 'Agent';
 
   const handleSendClick = useCallback(async () => {
     const text = input;
@@ -109,41 +134,104 @@ export default function MachinePaneChat({
     : null;
 
   return (
-    <div data-testid="machine-pane-chat" className="flex h-full min-w-0 flex-col bg-background">
+    // `@container` sizes the bar's fold to the PANE, not the viewport — a
+    // 3-way split on a wide screen is exactly where the chat bar overflows.
+    <div data-testid="machine-pane-chat" className="@container flex h-full min-w-0 flex-col bg-background">
       <Tabs
         value={activeTab}
         onValueChange={(value) => setActiveTab(value as PaneTab)}
         className="flex h-full min-h-0 flex-col"
       >
-        {/* Header: picker + tabs + new conversation — one compact row. */}
-        <div className="flex shrink-0 items-center gap-1 border-b border-border px-2 py-1">
-          <AISelector
-            selectedAgent={pane.selectedAgent}
-            onSelectAgent={pane.selectAgent}
-            disabled={pane.displayIsStreaming}
-            className="min-w-0 flex-1 text-xs font-medium"
-          />
-          <TabsList className="h-7 shrink-0 p-0.5">
-            <TabsTrigger value="chat" aria-label="Chat" className="h-6 px-1.5">
-              <MessageSquare className="size-3.5" />
-            </TabsTrigger>
-            <TabsTrigger value="history" aria-label="History" className="h-6 px-1.5">
-              <History className="size-3.5" />
-            </TabsTrigger>
-            <TabsTrigger value="settings" aria-label="Settings" className="h-6 px-1.5">
-              <Settings className="size-3.5" />
-            </TabsTrigger>
-          </TabsList>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleCreateConversation}
-            title="New conversation"
-            className="size-7 shrink-0 text-muted-foreground hover:text-foreground"
-          >
-            <Plus className="size-3.5" />
-          </Button>
-        </div>
+        {/* The pane's ONE bar (pane-chrome redesign): agent picker as
+            identity; tabs + new-conversation + the pane-level split/close
+            controls merged as actions. Nothing floats over this header
+            anymore — the old chip sat exactly on top of these tabs. */}
+        <PaneBar
+          isActive={isActive}
+          identity={
+            <AISelector
+              selectedAgent={pane.selectedAgent}
+              onSelectAgent={pane.selectAgent}
+              disabled={pane.displayIsStreaming}
+              className="min-w-0 flex-1 text-xs font-medium"
+            />
+          }
+          actions={
+            <>
+              {/* Full-width run of controls — folds away under the container
+                  threshold, replaced by the ⋯ menu below. Close never folds:
+                  a control that destroys the pane must never be two clicks
+                  deep or hidden behind a layout state. */}
+              <span className="flex items-center gap-0.5 @max-[360px]:hidden">
+                <TabsList className="h-6 shrink-0 p-0.5">
+                  <TabsTrigger value="chat" aria-label="Chat" className="h-5 px-1.5">
+                    <MessageSquare className="size-3.5" />
+                  </TabsTrigger>
+                  <TabsTrigger value="history" aria-label="History" className="h-5 px-1.5">
+                    <History className="size-3.5" />
+                  </TabsTrigger>
+                  <TabsTrigger value="settings" aria-label="Settings" className="h-5 px-1.5">
+                    <Settings className="size-3.5" />
+                  </TabsTrigger>
+                </TabsList>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleCreateConversation}
+                  title="New conversation"
+                  className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
+                >
+                  <Plus className="size-3.5" />
+                </Button>
+                {paneControls?.canSplit && (
+                  <>
+                    <div aria-hidden className="mx-0.5 h-3.5 w-px shrink-0 bg-border" />
+                    <PaneSplitCloseActions {...paneControls} canClose={false} />
+                  </>
+                )}
+              </span>
+              <span className="hidden @max-[360px]:flex">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      title="More"
+                      className="size-6 shrink-0 text-muted-foreground hover:text-foreground"
+                    >
+                      <MoreHorizontal className="size-3.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={() => handleCreateConversation()}>
+                      <Plus className="size-3.5" /> New conversation
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setActiveTab('history')}>
+                      <History className="size-3.5" /> History
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onSelect={() => setActiveTab('settings')}>
+                      <Settings className="size-3.5" /> Settings
+                    </DropdownMenuItem>
+                    {paneControls?.canSplit && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem onSelect={() => paneControls.onSplitRight()}>
+                          <SquareSplitHorizontal className="size-3.5" /> Split right
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onSelect={() => paneControls.onSplitDown()}>
+                          <SquareSplitVertical className="size-3.5" /> Split down
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </span>
+              {paneControls?.canClose && (
+                <PaneSplitCloseActions {...paneControls} canSplit={false} />
+              )}
+            </>
+          }
+        />
 
         <TabsContent value="chat" className="mt-0 flex min-h-0 flex-1 flex-col overflow-hidden">
           {pane.hasLoadError && (

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/MachineTree.test.tsx
@@ -445,7 +445,7 @@ describe('MachineTree', () => {
     });
   });
 
-  test('the project node\'s palette does not offer "New terminal" when the tree is BARE (no onWorkspaceCreated)', async () => {
+  test('the project node\'s palette offers no spawn options when the tree is BARE (no onWorkspaceCreated)', async () => {
     const user = userEvent.setup();
     renderTree();
 
@@ -454,12 +454,13 @@ describe('MachineTree', () => {
 
     assert({
       given: 'a bare tree (Diff/Files-tab shape: no onWorkspaceCreated passed) with a project node\'s palette opened',
-      should: 'offer "Add branch" but not "New terminal" — no workspace concept to spawn into',
+      should: 'offer "Add branch" but neither Agent nor Shell — no workspace concept to spawn into',
       actual: {
         addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
-        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        agent: screen.queryByRole('option', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('option', { name: 'Shell' }) !== null,
       },
-      expected: { addBranch: true, newTerminal: false },
+      expected: { addBranch: true, agent: false, shell: false },
     });
   });
 
@@ -477,13 +478,14 @@ describe('MachineTree', () => {
 
     assert({
       given: 'a branch row with onWorkspaceCreated wired in',
-      should: 'offer "New terminal" only — a branch has no structural add-child action',
+      should: 'offer the Agent + Shell spawns only — a branch has no structural add-child action',
       actual: {
-        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        agent: screen.queryByRole('option', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('option', { name: 'Shell' }) !== null,
         addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
         addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
       },
-      expected: { newTerminal: true, addProject: false, addBranch: false },
+      expected: { agent: true, shell: true, addProject: false, addBranch: false },
     });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/hooks/useIntegrations', () => ({
   useProviders: () => ({ providers: [] }),
 }));
 
+import { toast } from 'sonner';
 import { post } from '@/lib/auth/auth-fetch';
 
 const MACHINE_NODE: MachineTreeNode = { level: 'machine' };
@@ -71,51 +72,54 @@ describe('NodeActionPalette', () => {
     });
   });
 
-  test('the machine node offers New terminal + Add project, not Add branch', async () => {
+  test('the machine node offers Agent + Shell + Add project, not Add branch', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onAddProject={vi.fn()} onWorkspaceCreated={vi.fn()} />);
     await openPalette();
 
     assert({
       given: 'a machine node\'s palette, with onWorkspaceCreated wired in',
-      should: 'offer New terminal and Add project, but not Add branch',
+      should: 'offer the instant spawns plus Add project, but not Add branch',
       actual: {
-        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        agent: screen.queryByRole('option', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('option', { name: 'Shell' }) !== null,
         addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
         addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
       },
-      expected: { newTerminal: true, addProject: true, addBranch: false },
+      expected: { agent: true, shell: true, addProject: true, addBranch: false },
     });
   });
 
-  test('the project node offers New terminal + Add branch, not Add project', async () => {
+  test('the project node offers Agent + Shell + Add branch, not Add project', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={vi.fn()} onWorkspaceCreated={vi.fn()} />);
     await openPalette();
 
     assert({
       given: 'a project node\'s palette, with onWorkspaceCreated wired in',
-      should: 'offer New terminal and Add branch, but not Add project',
+      should: 'offer the instant spawns plus Add branch, but not Add project',
       actual: {
-        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        agent: screen.queryByRole('option', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('option', { name: 'Shell' }) !== null,
         addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
         addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
       },
-      expected: { newTerminal: true, addBranch: true, addProject: false },
+      expected: { agent: true, shell: true, addBranch: true, addProject: false },
     });
   });
 
-  test('the branch node offers New terminal only', async () => {
+  test('the branch node offers Agent + Shell only', async () => {
     renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={vi.fn()} />);
     await openPalette();
 
     assert({
       given: 'a branch node\'s palette, with onWorkspaceCreated wired in',
-      should: 'offer New terminal only — a branch has no structural add-child action',
+      should: 'offer the instant spawns only — a branch has no structural add-child action',
       actual: {
-        newTerminal: screen.queryByRole('option', { name: 'New terminal' }) !== null,
+        agent: screen.queryByRole('option', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('option', { name: 'Shell' }) !== null,
         addProject: screen.queryByRole('option', { name: 'Add project' }) !== null,
         addBranch: screen.queryByRole('option', { name: 'Add branch' }) !== null,
       },
-      expected: { newTerminal: true, addProject: false, addBranch: false },
+      expected: { agent: true, shell: true, addProject: false, addBranch: false },
     });
   });
 
@@ -130,17 +134,40 @@ describe('NodeActionPalette', () => {
     });
   });
 
-  test('"New terminal" creates a workspace at the node\'s scope, spawns the picked agent into it with the typed prompt, and reports the new workspace id', async () => {
+  test('the spawn options derive from the registry: exactly Agent then Shell', async () => {
+    renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={vi.fn()} />);
+    await openPalette();
+
+    const optionTexts = (await screen.findAllByRole('option')).map((o) => o.textContent);
+    assert({
+      given: 'the palette\'s spawn group, on a node with no structural actions',
+      should:
+        'list exactly the PICKABLE_AGENT_TYPES in registry order — Agent (pagespace) first, then Shell; a palette-local hardcoded list is exactly what silently dropped pagespace from this surface once',
+      actual: optionTexts,
+      expected: ['Agent', 'Shell'],
+    });
+  });
+
+  test('clicking Shell closes the palette immediately and spawns into a fresh workspace at the node\'s scope', async () => {
     vi.mocked(post).mockResolvedValueOnce({
-      agentTerminal: { name: 'claude-mocked', agentType: 'pagespace-cli', resumed: false },
+      agentTerminal: { name: 'shell-mocked', agentType: 'shell', resumed: false },
     });
     const onWorkspaceCreated = vi.fn();
     renderPalette(<NodeActionPalette machineId="m1" node={PROJECT_NODE} onAddBranch={vi.fn()} onWorkspaceCreated={onWorkspaceCreated} />);
 
     const user = await openPalette();
-    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
-    await user.type(await screen.findByLabelText('Starting prompt'), 'hello agent');
-    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await user.click(await screen.findByRole('option', { name: 'Shell' }));
+
+    // The click is the commitment: no second phase, no form — the palette is
+    // gone before the network resolves.
+    await waitFor(() => {
+      assert({
+        given: 'Shell clicked in the palette',
+        should: 'close the palette immediately (instant spawn, no form phase)',
+        actual: screen.queryByRole('dialog'),
+        expected: null,
+      });
+    });
 
     await waitFor(() => {
       const workspaceId = onWorkspaceCreated.mock.calls[0]?.[0];
@@ -148,64 +175,28 @@ describe('NodeActionPalette', () => {
       const workspace = workspaceId ? machine?.workspaces[workspaceId] : undefined;
       const pane = workspace?.columns[0]?.panes[0];
       assert({
-        given: '"New terminal" submitted with a starting prompt, on a project node',
-        should: 'create a workspace scoped to that project, bind the spawned agent into its first pane with the prompt pending, and report the workspace id',
+        given: 'the spawn resolving, on a project node',
+        should:
+          'create a workspace scoped to that project, bind the spawned shell into its first pane with NO pending prompt (the prompt is typed in the pane), and report the workspace id',
         actual: {
           reported: workspaceId !== undefined,
           scope: workspace?.scope,
           paneAgentName: pane?.scope?.name,
+          kind: pane?.scope?.kind,
           pendingPrompt: pane?.pendingPrompt,
         },
         expected: {
           reported: true,
           scope: { projectName: 'app' },
-          paneAgentName: 'claude-mocked',
-          pendingPrompt: 'hello agent',
+          paneAgentName: 'shell-mocked',
+          kind: undefined,
+          pendingPrompt: undefined,
         },
       });
     });
   });
 
-  // Regression: submit() used to call onSpawned(workspaceId) unconditionally,
-  // even if the user backed out (Escape/backdrop) while the addAgentTerminal
-  // network call was still in flight. A late-resolving spawn would then still
-  // report "success" to a caller no longer listening — in DevelopmentSidebar
-  // that meant navigating the user to a workspace they explicitly cancelled.
-  test('cancelling "New terminal" (Escape) while the spawn is in flight never reports success once it resolves', async () => {
-    let resolveSpawn: (value: unknown) => void = () => {};
-    vi.mocked(post).mockImplementationOnce(() => new Promise((resolve) => { resolveSpawn = resolve; }));
-    const onWorkspaceCreated = vi.fn();
-    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
-
-    const user = await openPalette();
-    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
-    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
-
-    // Still awaiting the network — back out before it resolves.
-    await user.keyboard('{Escape}');
-    await waitFor(() => {
-      assert({
-        given: 'Escape pressed while a "New terminal" spawn is awaiting the network',
-        should: 'close the palette immediately rather than wait for the in-flight spawn',
-        actual: screen.queryByRole('dialog'),
-        expected: null,
-      });
-    });
-
-    resolveSpawn({ agentTerminal: { name: 'claude-late', agentType: 'claude', resumed: false } });
-    // Let the now-resolved promise chain (addAgentTerminal -> cancelledRef
-    // check -> removeAgentTerminal cleanup) finish draining.
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    assert({
-      given: 'the spawn resolving AFTER the user cancelled it',
-      should: 'never call onWorkspaceCreated for a spawn the user backed out of',
-      actual: onWorkspaceCreated.mock.calls.length,
-      expected: 0,
-    });
-  });
-
-  test('a "PageSpace Agent" palette spawn binds a chat-kind scope', async () => {
+  test('clicking Agent binds a chat-kind scope', async () => {
     vi.mocked(post).mockResolvedValueOnce({
       agentTerminal: { name: 'pagespace-mocked', agentType: 'pagespace', resumed: false },
     });
@@ -213,10 +204,7 @@ describe('NodeActionPalette', () => {
     renderPalette(<NodeActionPalette machineId="m1" node={BRANCH_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
 
     const user = await openPalette();
-    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
-    await user.click(await screen.findByLabelText('Agent type'));
-    await user.click(await screen.findByRole('option', { name: 'PageSpace Agent' }));
-    await user.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await user.click(await screen.findByRole('option', { name: 'Agent' }));
 
     await waitFor(() => {
       const workspaceId = onWorkspaceCreated.mock.calls[0]?.[0];
@@ -224,7 +212,7 @@ describe('NodeActionPalette', () => {
       const workspace = workspaceId ? machine?.workspaces[workspaceId] : undefined;
       const pane = workspace?.columns[0]?.panes[0];
       assert({
-        given: 'the palette\'s "PageSpace Agent" choice, spawned on a branch node',
+        given: 'the palette\'s Agent choice, spawned on a branch node',
         should:
           'record kind "chat" on the bound pane scope — the pane grid renders MachinePaneChat from this tag, so a palette spawn that omitted it would open as a PTY',
         actual: { name: pane?.scope?.name, kind: pane?.scope?.kind },
@@ -233,23 +221,36 @@ describe('NodeActionPalette', () => {
     });
   });
 
-  test('"New terminal" offers shell, claude, codex, and the PageSpace Agent — not pagespace-cli — with shell first/default', async () => {
-    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={vi.fn()} />);
+  test('a spawn that fails after the palette closed toasts the error and never navigates', async () => {
+    let rejectSpawn: (reason: Error) => void = () => {};
+    vi.mocked(post).mockImplementationOnce(() => new Promise((resolve, reject) => { rejectSpawn = reject; }));
+    const onWorkspaceCreated = vi.fn();
+    renderPalette(<NodeActionPalette machineId="m1" node={MACHINE_NODE} onWorkspaceCreated={onWorkspaceCreated} />);
 
     const user = await openPalette();
-    await user.click(await screen.findByRole('option', { name: 'New terminal' }));
-    const agentTypeTrigger = await screen.findByLabelText('Agent type');
-    const defaultSelected = agentTypeTrigger.textContent;
+    await user.click(await screen.findByRole('option', { name: 'Agent' }));
 
-    await user.click(agentTypeTrigger);
-    const optionTexts = (await screen.findAllByRole('option')).map((o) => o.textContent);
+    // Palette already closed, spawn still in flight.
+    await waitFor(() => {
+      assert({
+        given: 'Agent clicked, spawn in flight',
+        should: 'have closed the palette already',
+        actual: screen.queryByRole('dialog'),
+        expected: null,
+      });
+    });
 
-    assert({
-      given: 'the "New terminal" agent-type picker, opened',
-      should:
-        'offer the shared PICKABLE_AGENT_TYPES — shell first/default, then claude, codex, and the chat agent labeled "PageSpace Agent" (never pagespace-cli); a palette-local hardcoded list is exactly what silently dropped pagespace from this surface',
-      actual: { optionTexts, defaultSelected },
-      expected: { optionTexts: ['shell', 'claude', 'codex', 'PageSpace Agent'], defaultSelected: 'shell' },
+    rejectSpawn(new Error('code_execution_disabled'));
+    await waitFor(() => {
+      assert({
+        given: 'the spawn rejecting after the palette closed',
+        should: 'surface the error via toast and never call onWorkspaceCreated',
+        actual: {
+          toasts: vi.mocked(toast.error).mock.calls.length,
+          navigations: onWorkspaceCreated.mock.calls.length,
+        },
+        expected: { toasts: 1, navigations: 0 },
+      });
     });
   });
 
@@ -322,7 +323,7 @@ describe('NodeActionPalette', () => {
 
     assert({
       given: 'the palette reopened right after a successful "Add branch" submit',
-      should: 'show the action list (New terminal / Add branch), not the branch-name form left over from last time',
+      should: 'show the action list (Agent / Shell / Add branch), not the branch-name form left over from last time',
       actual: {
         actionList: screen.queryByRole('option', { name: 'Add branch' }) !== null,
         staleForm: screen.queryByPlaceholderText('Branch name') !== null,

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/NodeActionPalette.tsx
@@ -2,44 +2,37 @@
 
 /**
  * The single "+" per Machine/Project/Branch row (Terminal UX redesign,
- * add-palette consolidation). Before this, a row could carry up to TWO plus
- * icons that did different things — the structural "Add project"/"Add branch"
- * dialog trigger (this file's predecessor lived in MachineTree.tsx) and the
- * separate "New workspace" trigger injected via `renderNodeExtra`
- * (WorkspaceLeaves.tsx's `WorkspaceNodeExtras`). One `+` per row, one
- * Raycast-style palette, actions scoped to what that node can actually do:
+ * add-palette consolidation). One `+` per row, one Raycast-style palette,
+ * actions scoped to what that node can actually do:
  *
- * - Machine node: New terminal + Add project.
- * - Project node: New terminal + Add branch.
- * - Branch node: New terminal only.
+ * - Machine node: Agent + Shell + Add project.
+ * - Project node: Agent + Shell + Add branch.
+ * - Branch node: Agent + Shell only.
  *
- * "New terminal" only appears when `onWorkspaceCreated` is passed — the
+ * The spawn options are INSTANT: picking Agent or Shell closes the palette on
+ * the spot and spawns that agent type into a fresh workspace at the node's
+ * scope — no "New terminal" phase, no agent-type dropdown, no prompt form
+ * (the prompt is typed in the pane the agent opens in). The options come from
+ * `PICKABLE_AGENT_TYPES`, so the palette is registry-driven: a hardcoded list
+ * here is what silently dropped `pagespace` from a picker once. Only the
+ * structural actions (Add project/Add branch) keep a second form phase,
+ * mirroring {@link QuickCreatePalette}'s CommandDialog/back-button shape.
+ *
+ * The spawn options only appear when `onWorkspaceCreated` is passed — the
  * Diff/Files tabs render the shared {@link MachineTree} BARE, with no
- * workspace concept at all, and must not pay for one. Its spawn step
- * (`TerminalSpawnForm`) is its own component, mounted only once the user
- * actually opens that phase, so `useAgentTerminals`/the workspace store are
- * never subscribed to for a row that only ever shows Add project/Add branch.
- *
- * Two-phase flow mirrors {@link QuickCreatePalette}: pick the action, then
- * fill in its details. Follows that file's CommandDialog/back-button/phase
- * shape closely rather than inventing a new palette pattern.
+ * workspace concept at all, and must not pay for one. Their hooks live in
+ * {@link InstantSpawnGroup}, mounted only inside the OPEN dialog (Radix
+ * unmounts closed dialog content), so `useAgentTerminals`/the workspace store
+ * are never subscribed to for a row whose palette isn't showing.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { toast } from 'sonner';
-import { ArrowLeft, ChevronDown, FolderGit2, Github, GitBranch, Plus, TerminalSquare } from 'lucide-react';
+import { ArrowLeft, Bot, ChevronDown, FolderGit2, Github, GitBranch, Plus, TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   Command,
@@ -80,18 +73,17 @@ function freshNameSuffix(): string {
   return crypto.randomUUID().replace(/-/g, '');
 }
 
-type PaletteAction = 'new-terminal' | 'add-project' | 'add-branch';
-type Phase = 'select' | PaletteAction;
+/** The actions that still need a form phase — spawns are instant, not phases. */
+type StructuralAction = 'add-project' | 'add-branch';
+type Phase = 'select' | StructuralAction;
 
-const ACTION_LABEL: Record<PaletteAction, string> = {
-  'new-terminal': 'New terminal',
+const ACTION_LABEL: Record<StructuralAction, string> = {
   'add-project': 'Add project',
   'add-branch': 'Add branch',
 };
 
-function actionsFor(node: MachineTreeNode, hasTerminalSupport: boolean): PaletteAction[] {
-  const actions: PaletteAction[] = [];
-  if (hasTerminalSupport) actions.push('new-terminal');
+function structuralActionsFor(node: MachineTreeNode): StructuralAction[] {
+  const actions: StructuralAction[] = [];
   if (node.level === 'machine') actions.push('add-project');
   if (node.level === 'project') actions.push('add-branch');
   return actions;
@@ -146,8 +138,8 @@ export default function NodeActionPalette({ machineId, node, onAddProject, onAdd
   const [open, setOpen] = useState(false);
   const [phase, setPhase] = useState<Phase>('select');
 
-  const actions = actionsFor(node, onWorkspaceCreated !== undefined);
-  if (actions.length === 0) return null;
+  const structuralActions = structuralActionsFor(node);
+  if (structuralActions.length === 0 && onWorkspaceCreated === undefined) return null;
 
   const reset = () => setPhase('select');
   // Also resets the phase: this is called on SUCCESS (a spawn/add completing),
@@ -172,31 +164,26 @@ export default function NodeActionPalette({ machineId, node, onAddProject, onAdd
           <CommandInput placeholder="Search actions…" autoFocus />
           <CommandList>
             <CommandEmpty>No matching actions.</CommandEmpty>
-            <CommandGroup>
-              {actions.map((action) => (
-                <CommandItem key={action} value={ACTION_LABEL[action]} onSelect={() => setPhase(action)}>
-                  {action === 'new-terminal' && <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />}
-                  {action === 'add-project' && <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />}
-                  {action === 'add-branch' && <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />}
-                  {ACTION_LABEL[action]}
-                </CommandItem>
-              ))}
-            </CommandGroup>
+            {onWorkspaceCreated !== undefined && (
+              <InstantSpawnGroup
+                machineId={machineId}
+                node={node}
+                onClose={close}
+                onSpawned={onWorkspaceCreated}
+              />
+            )}
+            {structuralActions.length > 0 && (
+              <CommandGroup>
+                {structuralActions.map((action) => (
+                  <CommandItem key={action} value={ACTION_LABEL[action]} onSelect={() => setPhase(action)}>
+                    {action === 'add-project' && <FolderGit2 className="size-3.5 shrink-0 text-muted-foreground" />}
+                    {action === 'add-branch' && <GitBranch className="size-3.5 shrink-0 text-muted-foreground" />}
+                    {ACTION_LABEL[action]}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
           </CommandList>
-        </CommandDialog>
-      )}
-
-      {phase === 'new-terminal' && onWorkspaceCreated && (
-        <CommandDialog open={open} onOpenChange={(o) => { setOpen(o); if (!o) reset(); }} title="New terminal" description="Spawn an agent" showCloseButton={false} className="max-w-[380px]">
-          <TerminalSpawnForm
-            machineId={machineId}
-            node={node}
-            onBack={reset}
-            onSpawned={(workspaceId) => {
-              close();
-              onWorkspaceCreated(workspaceId);
-            }}
-          />
         </CommandDialog>
       )}
 
@@ -216,24 +203,36 @@ export default function NodeActionPalette({ machineId, node, onAddProject, onAdd
 }
 
 /**
- * Split-and-pick, retargeted at a fresh workspace instead of an existing
- * empty pane: create the session AND place it, in one act. Mirrors
- * TerminalPanes' `spawnIntoPane` closely — same upsert/`resumed` handling,
- * same "only clean up what we created" guard — but binds into the new
- * workspace's first pane rather than a pane the user picked by clicking into
- * it, since there is no pane yet: the palette action IS the "give me an
- * agent" click.
+ * The palette's instant-spawn options — split-and-pick retargeted at a fresh
+ * workspace, with the pick collapsed into the palette itself: clicking Agent
+ * or Shell closes the palette on the spot and spawns that type into a new
+ * workspace at the node's scope. Mirrors TerminalPanes' `spawnIntoPane`
+ * closely — same upsert/`resumed` handling, same "only clean up what we
+ * created" guard — but binds into the new workspace's first pane, since
+ * there is no pane yet: the palette click IS the "give me an agent" click.
+ *
+ * This component (not the palette) owns the SWR/workspace hooks so the bare
+ * Diff/Files trees never subscribe: it renders only when `onWorkspaceCreated`
+ * exists, inside dialog content Radix unmounts while closed.
+ *
+ * The palette closes BEFORE the network resolves — the click is the
+ * commitment, and the pane the caller navigates to on `onSpawned` is where
+ * the result lands. The async continuation is unmount-safe: everything it
+ * touches is closure-captured (store writes go through `getState`, the SWR
+ * mutations are cache-addressed, `onSpawned` closes over the caller's stable
+ * store actions). There is no cancel affordance mid-flight anymore, so the
+ * old `cancelledRef` back-out went with the form it guarded.
  */
-function TerminalSpawnForm({
+function InstantSpawnGroup({
   machineId,
   node,
+  onClose,
   onSpawned,
-  onBack,
 }: {
   machineId: string;
   node: MachineTreeNode;
+  onClose(): void;
   onSpawned(workspaceId: string): void;
-  onBack(): void;
 }) {
   const scope = nodeScopeOf(node);
   const { addAgentTerminal, removeAgentTerminal } = useAgentTerminals(machineId, scope.projectName ?? null, scope.branchName ?? null);
@@ -241,37 +240,14 @@ function TerminalSpawnForm({
   // server like every other create/bind path, not just materialize locally.
   const { createWorkspace, bindPaneTerminal } = useSyncedWorkspaceActions(machineId);
 
-  const [agentType, setAgentType] = useState<AgentRuntimeType>(PICKABLE_AGENT_TYPES[0]);
-  const [prompt, setPrompt] = useState('');
-  const [spawning, setSpawning] = useState(false);
-  const promptRef = useRef<HTMLTextAreaElement>(null);
-  // Backs out of an in-flight spawn cleanly: the palette can close (Escape,
-  // backdrop click) while `submit` is still awaiting the network. Without
-  // this, a spawn that resolves after the user backed out would still call
-  // `onSpawned` — reporting success to a caller that isn't listening for it
-  // anymore (e.g. DevelopmentSidebar would still navigate to the Terminal tab
-  // for a spawn the user explicitly cancelled).
-  const cancelledRef = useRef(false);
-  useEffect(() => () => { cancelledRef.current = true; }, []);
-
-  useEffect(() => {
-    const timer = setTimeout(() => promptRef.current?.focus(), 50);
-    return () => clearTimeout(timer);
-  }, []);
-
-  const submit = async () => {
-    setSpawning(true);
+  const spawn = async (agentType: AgentRuntimeType) => {
+    onClose();
     // May end up set even on a path that throws before assignment finishes —
     // tracked outside the try so the catch below knows whether there's a
     // session to clean up, regardless of which step failed.
     let created: Awaited<ReturnType<typeof addAgentTerminal>> | undefined;
     try {
       created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
-
-      if (cancelledRef.current) {
-        if (!created.resumed) await removeAgentTerminal(created.name).catch(() => {});
-        return;
-      }
 
       const workspaceId = createWorkspace(scope);
       const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
@@ -292,7 +268,9 @@ function TerminalSpawnForm({
                 ? { kind: 'chat' as const }
                 : {}),
             },
-            created.resumed ? undefined : prompt.trim() || undefined,
+            // No starting prompt — instant spawn means the prompt is typed in
+            // the pane itself, so there is nothing to auto-send.
+            undefined,
           )
         : false;
 
@@ -302,7 +280,6 @@ function TerminalSpawnForm({
         // open in someone else's pane — and report failure, not success.
         if (!created.resumed) await removeAgentTerminal(created.name).catch(() => {});
         toast.error('Failed to spawn agent');
-        setSpawning(false);
         return;
       }
 
@@ -314,51 +291,23 @@ function TerminalSpawnForm({
       if (created && !created.resumed) {
         await removeAgentTerminal(created.name).catch(() => {});
       }
-      if (!cancelledRef.current) {
-        toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
-        setSpawning(false);
-      }
+      toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
     }
   };
 
   return (
-    <>
-      <PhaseHeader title="New terminal" onBack={onBack} />
-      <div className="flex flex-col gap-3 px-4 py-4">
-        <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentRuntimeType)}>
-          <SelectTrigger aria-label="Agent type" className="h-9">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {PICKABLE_AGENT_TYPES.map((type) => (
-              <SelectItem key={type} value={type}>
-                {agentTypeLabelOf(type)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Textarea
-          ref={promptRef}
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Starting prompt (optional)"
-          aria-label="Starting prompt"
-          rows={2}
-          className="resize-none text-sm"
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              if (!spawning) void submit();
-            }
-          }}
-        />
-        <div className="flex justify-end">
-          <Button size="sm" disabled={spawning} onClick={() => void submit()} className="h-7 px-3 text-xs">
-            {spawning ? 'Spawning…' : 'Spawn agent'}
-          </Button>
-        </div>
-      </div>
-    </>
+    <CommandGroup>
+      {PICKABLE_AGENT_TYPES.map((type) => (
+        <CommandItem key={type} value={agentTypeLabelOf(type)} onSelect={() => void spawn(type)}>
+          {agentSurfaceOf(type) === 'chat' ? (
+            <Bot className="size-3.5 shrink-0 text-muted-foreground" />
+          ) : (
+            <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
+          )}
+          {agentTypeLabelOf(type)}
+        </CommandItem>
+      ))}
+    </CommandGroup>
   );
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/PaneBar.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/PaneBar.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * PaneBar — the universal pane title bar (pane-chrome redesign, variant B).
+ * Pure presentational: identity left, actions right, bar tint AS the focus
+ * state. These tests pin the contract every pane surface (PTY, picker, chat)
+ * relies on, without any store or hook in sight.
+ */
+import { describe, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { assert } from '@/stores/__tests__/riteway';
+import PaneBar, { PaneSplitCloseActions, PaneSessionIdentity } from './PaneBar';
+
+describe('PaneBar', () => {
+  test('renders identity and actions, and marks the active state on the bar itself', () => {
+    render(
+      <PaneBar isActive identity={<span>shell-a1</span>} actions={<button type="button">act</button>} />,
+    );
+
+    const bar = screen.getByTestId('pane-bar');
+    assert({
+      given: 'an active pane\'s bar with identity and actions',
+      should: 'render both and carry data-active — the bar tint IS the focus state, replacing the old 2px accent line',
+      actual: {
+        active: bar.getAttribute('data-active'),
+        identity: screen.queryByText('shell-a1') !== null,
+        action: screen.queryByRole('button', { name: 'act' }) !== null,
+      },
+      expected: { active: 'true', identity: true, action: true },
+    });
+  });
+
+  test('an inactive bar carries no active marker', () => {
+    render(<PaneBar isActive={false} identity={<span>shell-a1</span>} />);
+
+    assert({
+      given: 'an inactive pane\'s bar',
+      should: 'carry no data-active — inactive is the unmarked default, not a second style',
+      actual: screen.getByTestId('pane-bar').getAttribute('data-active'),
+      expected: null,
+    });
+  });
+
+  test('actions sit in a reveal container that never fully hides', () => {
+    render(<PaneBar isActive={false} identity={<span>x</span>} actions={<button type="button">act</button>} />);
+
+    const container = screen.getByRole('button', { name: 'act' }).parentElement as HTMLElement;
+    assert({
+      given: 'the actions container',
+      should:
+        'dim rather than hide (opacity, not display) — controls stay clickable on every pointer type without the coarse-pointer escape hatch the floating chip needed',
+      actual: {
+        dimmed: container.className.includes('opacity-60'),
+        hidden: container.className.includes('opacity-0'),
+      },
+      expected: { dimmed: true, hidden: false },
+    });
+  });
+});
+
+describe('PaneSplitCloseActions', () => {
+  test('renders split and close controls wired to their handlers', async () => {
+    const onSplitRight = vi.fn();
+    const onSplitDown = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <PaneSplitCloseActions canSplit canClose onSplitRight={onSplitRight} onSplitDown={onSplitDown} onClose={onClose} />,
+    );
+
+    await userEvent.click(screen.getByTitle('Split right'));
+    await userEvent.click(screen.getByTitle('Split down'));
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'all three pane controls clicked',
+      should: 'call each handler exactly once',
+      actual: {
+        splitRight: onSplitRight.mock.calls.length,
+        splitDown: onSplitDown.mock.calls.length,
+        close: onClose.mock.calls.length,
+      },
+      expected: { splitRight: 1, splitDown: 1, close: 1 },
+    });
+  });
+
+  test('canSplit=false renders close only — a phone cannot hold a split grid', () => {
+    render(
+      <PaneSplitCloseActions canSplit={false} canClose onSplitRight={vi.fn()} onSplitDown={vi.fn()} onClose={vi.fn()} />,
+    );
+
+    assert({
+      given: 'a pane that cannot split (narrow viewport)',
+      should: 'offer close but neither split control',
+      actual: {
+        close: screen.queryByTitle('Close pane') !== null,
+        splitRight: screen.queryByTitle('Split right'),
+        splitDown: screen.queryByTitle('Split down'),
+      },
+      expected: { close: true, splitRight: null, splitDown: null },
+    });
+  });
+
+  test('clicks do not bubble into the pane\'s own click handler', async () => {
+    const onPaneClick = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <div onClick={onPaneClick}>
+        <PaneSplitCloseActions canSplit={false} canClose onSplitRight={vi.fn()} onSplitDown={vi.fn()} onClose={onClose} />
+      </div>,
+    );
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    assert({
+      given: 'a close click inside a pane whose root selects-on-click',
+      should: 'stop propagation — closing a pane must not first re-select it (the old floating chip had the same guard)',
+      actual: { closed: onClose.mock.calls.length, paneClicked: onPaneClick.mock.calls.length },
+      expected: { closed: 1, paneClicked: 0 },
+    });
+  });
+});
+
+describe('PaneSessionIdentity', () => {
+  test('shows the session name and its checkout scope', () => {
+    render(<PaneSessionIdentity name="shell-b2c3d4" scopeLabel="app / main" />);
+
+    assert({
+      given: 'a bound pane\'s identity',
+      should: 'name the session and the checkout it runs in — the sidebar/pane relationship becomes legible per pane',
+      actual: {
+        name: screen.queryByText('shell-b2c3d4') !== null,
+        scope: screen.queryByText('app / main') !== null,
+      },
+      expected: { name: true, scope: true },
+    });
+  });
+
+  test('omits the scope chip when no label is given', () => {
+    render(<PaneSessionIdentity name="shell-b2c3d4" />);
+
+    assert({
+      given: 'an identity without a scope label',
+      should: 'render the name alone, no empty chip',
+      actual: screen.getByText('shell-b2c3d4').parentElement?.childElementCount,
+      expected: 2, // dot + name
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/PaneBar.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/PaneBar.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * PaneBar — the universal pane title bar (pane-chrome redesign, variant B).
+ *
+ * Every pane in the machine workspace grid — PTY, empty picker, chat — wears
+ * one slim bar: identity on the left, actions on the right. It replaces BOTH
+ * pieces of floating chrome the grid used to carry:
+ *
+ * - the hover-revealed split/close chip (`absolute top-right`), which on chat
+ *   panes physically covered the chat header's own tabs; and
+ * - the 2px top accent line — the bar's tint IS the focus state now.
+ *
+ * Actions dim instead of hiding (opacity, never display/visibility), so they
+ * stay clickable on every pointer type without the `[data-pointer='coarse']`
+ * escape hatch the opacity-0 chip needed.
+ *
+ * Pure presentational by design: no store, no hooks, no network — the caller
+ * decides what identity and actions mean. `TerminalPane` renders it for PTY
+ * and picker panes; `MachinePaneChat` renders it for chat panes with the
+ * pane-level controls merged in after its own (one bar per pane, always).
+ */
+
+import type { MouseEvent, ReactNode } from 'react';
+import { SquareSplitHorizontal, SquareSplitVertical, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+export default function PaneBar({
+  isActive,
+  identity,
+  actions,
+}: {
+  /** The bar tint is the pane's focus indicator — no separate accent line. */
+  isActive: boolean;
+  /** Left side: who this pane is (session name + scope, or the agent picker). */
+  identity: ReactNode;
+  /** Right side: the pane's controls, dimmed until hover/focus. */
+  actions?: ReactNode;
+}) {
+  return (
+    <div
+      data-testid="pane-bar"
+      data-active={isActive ? 'true' : undefined}
+      className={cn(
+        'flex h-[30px] min-w-0 shrink-0 items-center gap-1 border-b border-border/60 pl-2 pr-1 transition-colors',
+        isActive && 'border-primary/40 bg-primary/10',
+      )}
+    >
+      <div
+        className={cn(
+          'flex min-w-0 flex-1 items-center gap-1.5 text-xs font-medium',
+          isActive ? 'text-foreground' : 'text-muted-foreground',
+        )}
+      >
+        {identity}
+      </div>
+      {actions !== undefined && (
+        <div className="flex shrink-0 items-center gap-0.5 opacity-60 transition-opacity focus-within:opacity-100 group-hover/pane:opacity-100 touch:opacity-100">
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Swallows the bubble so a control click never re-selects the pane first —
+ * the same guard the floating chip's buttons carried. */
+function guarded(handler: () => void) {
+  return (event: MouseEvent) => {
+    event.stopPropagation();
+    handler();
+  };
+}
+
+/**
+ * The pane-level control handlers every surface shares. Passed as DATA (not a
+ * pre-rendered node) so a surface can render them however its bar needs —
+ * inline buttons at full width, or folded into an overflow menu when the pane
+ * is narrow.
+ */
+export interface PaneControlProps {
+  /** False on narrow viewports — two columns at phone width are unusable slivers. */
+  canSplit: boolean;
+  /** Close is universal — a view you cannot destroy is not a view. */
+  canClose: boolean;
+  onSplitRight(): void;
+  onSplitDown(): void;
+  onClose(): void;
+}
+
+/** The shared inline rendering of {@link PaneControlProps}: split right/down + close. */
+export function PaneSplitCloseActions({
+  canSplit,
+  canClose,
+  onSplitRight,
+  onSplitDown,
+  onClose,
+}: PaneControlProps) {
+  return (
+    <>
+      {canSplit && (
+        <>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={guarded(onSplitRight)}
+            className="size-6 text-muted-foreground hover:text-foreground"
+            title="Split right"
+          >
+            <SquareSplitHorizontal className="size-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={guarded(onSplitDown)}
+            className="size-6 text-muted-foreground hover:text-foreground"
+            title="Split down"
+          >
+            <SquareSplitVertical className="size-3.5" />
+          </Button>
+        </>
+      )}
+      {canClose && (
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={guarded(onClose)}
+          className="size-6 text-muted-foreground hover:text-destructive"
+          title="Close pane"
+        >
+          <X className="size-3.5" />
+        </Button>
+      )}
+    </>
+  );
+}
+
+/**
+ * A bound pane's identity: running dot + mono session name + checkout chip.
+ * The dot means "a live session is bound here" — this surface only lists
+ * sessions that exist server-side, so bound is the running state it has.
+ */
+export function PaneSessionIdentity({ name, scopeLabel }: { name: string; scopeLabel?: string }) {
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <span aria-hidden className="size-1.5 shrink-0 rounded-full bg-emerald-500" />
+      <span className="truncate font-mono text-[11px]">{name}</span>
+      {scopeLabel !== undefined && (
+        <span className="shrink-0 rounded border border-border px-1 py-px text-[10px] font-normal text-muted-foreground">
+          {scopeLabel}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { assert } from '@/stores/__tests__/riteway';
 import type { Socket } from 'socket.io-client';
@@ -8,6 +8,8 @@ import type { OpenTerminalScope, WorkspaceState } from '@/stores/machine-workspa
 
 const mockUseMobile = vi.fn<() => boolean>();
 vi.mock('@/hooks/useMobile', () => ({ useMobile: () => mockUseMobile() }));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 // `useSyncedWorkspaceActions` (#2048) pushes layout changes to the server via
 // these — fire-and-forget from the component's point of view, but each must
@@ -317,6 +319,28 @@ describe('TerminalPanes (close means close)', () => {
         kills: [['m1', { name: 'solo' }]],
         viaWorkspaceHook: 0,
       },
+    });
+  });
+
+  test('a failed close-kill TELLS the user the agent is still running — the pane is already gone', async () => {
+    // The pane closes optimistically, so a failed kill has no surface left to
+    // report through except a toast: the agent is still running (and billing),
+    // reachable only via the rolled-back sidebar row the user must go find.
+    workspace = SOLO_WORKSPACE;
+    killAgentTerminal.mockRejectedValueOnce(new Error('sprite unreachable'));
+    render(<TerminalPanes machineId="m1" socket={socket} />);
+    await screen.findByTestId('xterm');
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+
+    const { toast } = await import('sonner');
+    await waitFor(() => {
+      assert({
+        given: 'a close whose kill request failed after the pane was already removed',
+        should: 'toast that the named agent is still running rather than fail silently',
+        actual: vi.mocked(toast.error).mock.calls[0]?.[0],
+        expected: 'Failed to stop solo — it is still running, listed in the sidebar',
+      });
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -38,23 +38,37 @@ vi.mock('../XtermTerminal', () => ({
 
 // The chat pane is a whole AI-chat subtree (Phase 11) — stubbed for the same
 // reason as XtermTerminal: under test is WHICH surface the pane renders and
-// what it is handed, not the chat UI inside it.
+// what it is handed, not the chat UI inside it. The stub renders a close
+// control from the threaded paneControls because that IS the contract under
+// test: a chat pane's split/close live in ITS bar (one bar per pane), so
+// TerminalPane must hand them down rather than draw its own.
 vi.mock('./MachinePaneChat', () => ({
   default: ({
     machineId,
     terminalId,
     pendingPrompt,
+    isActive,
+    paneControls,
   }: {
     machineId: string;
     terminalId: string;
     pendingPrompt?: string;
+    isActive?: boolean;
+    paneControls?: { canSplit: boolean; canClose: boolean; onSplitRight(): void; onSplitDown(): void; onClose(): void };
   }) => (
     <div
       data-testid="machine-pane-chat"
       data-machine-id={machineId}
       data-terminal-id={terminalId}
       data-initial-input={pendingPrompt}
-    />
+      data-pane-active={isActive ? 'true' : undefined}
+    >
+      {paneControls?.canClose && (
+        <button type="button" title="Close pane" onClick={() => paneControls.onClose()}>
+          Close pane
+        </button>
+      )}
+    </div>
   ),
 }));
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.test.tsx
@@ -328,8 +328,8 @@ describe('TerminalPanes (close means close)', () => {
     // branch is a DIFFERENT terminal and must not be mistaken for this one.
     workspace = aWorkspace({
       columns: [
-        { id: 'col-1', panes: [{ id: 'pane-1', scope: { ...WORKSPACE_SCOPE, name: 'claude-x' } }] },
-        { id: 'col-2', panes: [{ id: 'pane-2', scope: { projectName: 'app', branchName: 'other', name: 'claude-x' } }] },
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: { ...WORKSPACE_SCOPE, name: 'shell-x' } }] },
+        { id: 'col-2', panes: [{ id: 'pane-2', scope: { projectName: 'app', branchName: 'other', name: 'shell-x' } }] },
       ],
       activePaneId: 'pane-1',
       pendingPickerPaneId: null,
@@ -343,7 +343,7 @@ describe('TerminalPanes (close means close)', () => {
       given: 'two panes whose sessions share a name but sit in different branches',
       should: 'still kill the closed one, at ITS checkout — comparing on name alone would silently skip it',
       actual: killAgentTerminal.mock.calls,
-      expected: [['m1', { ...WORKSPACE_SCOPE, name: 'claude-x' }]],
+      expected: [['m1', { ...WORKSPACE_SCOPE, name: 'shell-x' }]],
     });
   });
 
@@ -548,17 +548,16 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     workspace = EMPTY_WORKSPACE;
   });
 
-  test('an empty pane picks an agent and gets it running — ONE action, no modal, no name step', async () => {
+  test('an empty pane picks an agent and gets it running — ONE action, no modal, no name step, no prompt form', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.type(screen.getByLabelText('Starting prompt'), 'fix the build');
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     const [spawnedName, spawnedType] = addAgentTerminal.mock.calls[0] ?? [];
     assert({
-      given: 'an empty pane, an agent type (the default) and an optional starting prompt',
+      given: 'an empty pane and one click on Shell',
       should:
-        'spawn the session — auto-named, never prompted for — at the ACTIVE NODE\'s scope and bind it to that pane, in one action',
+        'spawn the session — auto-named, never prompted for — at the ACTIVE NODE\'s scope and bind it to that pane with NO starting prompt (the prompt is typed in the pane), in one action',
       actual: {
         spawns: addAgentTerminal.mock.calls.length,
         agentType: spawnedType,
@@ -574,52 +573,39 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
           WORKSPACE_ID,
           'pane-1',
           { projectName: 'app', branchName: 'main', name: spawnedName },
-          'fix the build',
+          undefined,
         ],
       },
     });
   });
 
-  test('the agent picker offers shell (primary), claude, codex, and the PageSpace Agent — no retired pagespace-cli', async () => {
+  test('the agent picker offers Agent then Shell — registry-driven, no retired types', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
-
-    await userEvent.click(screen.getByLabelText('Agent type'));
-    const options = screen.getAllByRole('option').map((el) => el.textContent);
 
     assert({
       given: 'the empty pane\'s agent picker',
-      should: 'list every user-spawnable agent type — shell as the default primary option, claude, codex, and the chat agent labeled "PageSpace Agent" (agents and chats are one thing, so it presents as an agent, never as "chat") — excluding only the retired pagespace-cli',
-      actual: options,
-      expected: ['shell', 'claude', 'codex', 'PageSpace Agent'],
-    });
-  });
-
-  test('the starting prompt is optional — picking an agent alone is enough', async () => {
-    render(<TerminalPanes machineId="m1" socket={socket} />);
-
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
-
-    assert({
-      given: 'a pick with no starting prompt typed',
-      should: 'still spawn and bind, carrying no prompt — the agent just boots to its own',
+      should:
+        'render one instant-spawn button per PICKABLE_AGENT_TYPES entry, in registry order — Agent (pagespace) first, then Shell; claude/codex/pagespace-cli are retired and must not resurface here',
       actual: {
-        spawns: addAgentTerminal.mock.calls.length,
-        prompt: bindPaneTerminal.mock.calls[0]?.[4],
+        agent: screen.queryByRole('button', { name: 'Agent' }) !== null,
+        shell: screen.queryByRole('button', { name: 'Shell' }) !== null,
+        claude: screen.queryByRole('button', { name: 'claude' }),
+        codex: screen.queryByRole('button', { name: 'codex' }),
       },
-      expected: { spawns: 1, prompt: undefined },
+      expected: { agent: true, shell: true, claude: null, codex: null },
     });
   });
 
-  test('a pane made by a split opens its picker FOCUSED', async () => {
+  test('a pane made by a split opens its picker FOCUSED on the Agent button', async () => {
     workspace = JUST_SPLIT_WORKSPACE;
 
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     assert({
       given: 'the empty pane a split just created',
-      should: 'focus its picker (and consume the pending-picker flag) rather than leave the user facing a blank pane',
+      should: 'focus its first spawn choice (and consume the pending-picker flag) rather than leave the user facing a blank pane',
       actual: {
-        focused: document.activeElement === screen.getByLabelText('Starting prompt'),
+        focused: document.activeElement === screen.getByRole('button', { name: 'Agent' }),
         consumed: dismissPicker.mock.calls[0],
       },
       expected: { focused: true, consumed: ['m1', WORKSPACE_ID, 'pane-1'] },
@@ -632,7 +618,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     assert({
       given: 'an empty pane the user did not just create (a restored grid, say)',
       should: 'leave focus alone — auto-focus is the split\'s intent, not every empty pane\'s',
-      actual: document.activeElement === screen.getByLabelText('Starting prompt'),
+      actual: document.activeElement === screen.getByRole('button', { name: 'Agent' }),
       expected: false,
     });
   });
@@ -641,14 +627,14 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     addAgentTerminal.mockRejectedValueOnce(new Error('name_in_use'));
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     assert({
       given: 'a spawn the API rejected',
       should: 'bind nothing and re-offer the picker — a pane bound to a session that does not exist would connect to nothing',
       actual: {
         bound: bindPaneTerminal.mock.calls.length,
-        canRetry: screen.queryByRole('button', { name: 'Spawn agent' }) !== null,
+        canRetry: !screen.getByRole('button', { name: 'Shell' }).hasAttribute('disabled'),
       },
       expected: { bound: 0, canRetry: true },
     });
@@ -657,7 +643,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
   test('the spawn is scoped to the WORKSPACE\'s checkout, not the machine root', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     assert({
       given: 'a workspace whose scope is the branch app/main',
@@ -681,7 +667,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     bindPaneTerminal.mockReturnValueOnce(false);
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     assert({
       given: 'a spawn whose pane is gone by the time it resolves',
@@ -696,7 +682,7 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     // The pane the picker just spawned into: bound, with its prompt not yet typed.
     workspace = aWorkspace({
       columns: [
-        { id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1' }, pendingPrompt: 'fix the build' }] },
+        { id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'shell-a1' }, pendingPrompt: 'fix the build' }] },
       ],
       activePaneId: 'pane-1',
       pendingPickerPaneId: null,
@@ -714,20 +700,19 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     });
   });
 
-  test('a session the API says ALREADY EXISTED is never handed a starting prompt', async () => {
+  test('a session the API says ALREADY EXISTED still binds with no prompt', async () => {
     // `spawnAgentTerminal` is an upsert: `resumed` means it gave back a session that
     // was already there (and whose agent may have been running for hours), rather
-    // than creating one. Typing a prompt into that is the hazard the whole flow
-    // guards against — and the API tells us right here.
-    addAgentTerminal.mockResolvedValueOnce({ name: 'claude-a1', agentType: 'claude', resumed: true });
+    // than creating one. Instant spawn never carries a prompt anyway, but this
+    // pins that a resumed bind stays promptless even if a prompt source returns.
+    addAgentTerminal.mockResolvedValueOnce({ name: 'shell-a1', agentType: 'shell', resumed: true });
 
     render(<TerminalPanes machineId="m1" socket={socket} />);
-    await userEvent.type(screen.getByLabelText('Starting prompt'), 'fix the build');
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     assert({
       given: 'a spawn the API served by handing back an EXISTING session',
-      should: 'bind it to the pane but carry NO prompt — the invariant must not rest on the auto-name never colliding',
+      should: 'bind it to the pane but carry NO prompt — an already-running agent must never be typed at',
       actual: { bound: bindPaneTerminal.mock.calls.length, prompt: bindPaneTerminal.mock.calls[0]?.[4] },
       expected: { bound: 1, prompt: undefined },
     });
@@ -739,11 +724,11 @@ describe('TerminalPanes (split-and-pick spawn)', () => {
     // terminal — so cleaning up here destroys an agent that may be mid-task in
     // someone else's pane. Only a session this spawn actually brought into the world
     // is ours to take back out.
-    addAgentTerminal.mockResolvedValueOnce({ name: 'claude-a1', agentType: 'claude', resumed: true });
+    addAgentTerminal.mockResolvedValueOnce({ name: 'shell-a1', agentType: 'shell', resumed: true });
     bindPaneTerminal.mockReturnValueOnce(false);
 
     render(<TerminalPanes machineId="m1" socket={socket} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Shell' }));
 
     assert({
       given: 'an unbindable spawn the API served from an EXISTING session',
@@ -775,16 +760,14 @@ describe('TerminalPanes (PageSpace Agent panes)', () => {
     workspace = EMPTY_WORKSPACE;
   });
 
-  test('picking the PageSpace Agent spawns a pagespace session bound with a chat-kind scope', async () => {
+  test('picking Agent spawns a pagespace session bound with a chat-kind scope', async () => {
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.click(screen.getByLabelText('Agent type'));
-    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Agent' }));
 
     const [spawnedName, spawnedType] = addAgentTerminal.mock.calls[0] ?? [];
     assert({
-      given: 'the picker\'s "PageSpace Agent" choice, spawned',
+      given: 'the picker\'s "Agent" choice, spawned',
       should:
         'create a pagespace session and bind it with kind "chat" on the scope — without the kind, the pane would have to guess its surface from the SWR list on every future mount',
       actual: {
@@ -803,15 +786,13 @@ describe('TerminalPanes (PageSpace Agent panes)', () => {
     // pagespace-shaped name but is actually a PTY agent. Labeling it chat
     // from the PICKED type would mislabel it forever — an explicit kind
     // beats the SWR fallback on every future mount.
-    addAgentTerminal.mockResolvedValueOnce({ name: 'pagespace-x', agentType: 'claude', resumed: true });
+    addAgentTerminal.mockResolvedValueOnce({ name: 'pagespace-x', agentType: 'shell', resumed: true });
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
-    await userEvent.click(screen.getByLabelText('Agent type'));
-    await userEvent.click(screen.getByRole('option', { name: 'PageSpace Agent' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Spawn agent' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Agent' }));
 
     assert({
-      given: 'a pagespace pick the API served by resuming an existing claude session',
+      given: 'an Agent pick the API served by resuming an existing shell session',
       should:
         'bind WITHOUT a chat kind — the surface is judged by the API\'s answer, the same standard the resumed-prompt guard applies',
       actual: bindPaneTerminal.mock.calls[0]?.[3],
@@ -884,13 +865,13 @@ describe('TerminalPanes (PageSpace Agent panes)', () => {
     });
   });
 
-  test('no kind hint + SWR resolving the name to claude renders xterm', async () => {
-    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'claude-b2' } });
-    agentTerminalRows = [{ id: 'row-c1', name: 'claude-b2', agentType: 'claude', createdAt: '' }];
+  test('no kind hint + SWR resolving the name to shell renders xterm', async () => {
+    workspace = soloPane({ scope: { ...WORKSPACE_SCOPE, name: 'shell-b2' } });
+    agentTerminalRows = [{ id: 'row-c1', name: 'shell-b2', agentType: 'shell', createdAt: '' }];
     render(<TerminalPanes machineId="m1" socket={socket} />);
 
     assert({
-      given: 'a kind-less pane whose name the loaded list maps to agentType "claude"',
+      given: 'a kind-less pane whose name the loaded list maps to agentType "shell"',
       should: 'resolve to the PTY surface',
       actual: {
         xterm: screen.queryByTestId('xterm') !== null,
@@ -923,7 +904,7 @@ describe('TerminalPanes (PageSpace Agent panes)', () => {
     workspace = aWorkspace({
       columns: [
         { id: 'col-1', panes: [{ id: 'pane-1', scope: CHAT_SCOPE }] },
-        { id: 'col-2', panes: [{ id: 'pane-2', scope: { ...WORKSPACE_SCOPE, name: 'claude-b2', kind: 'terminal' } }] },
+        { id: 'col-2', panes: [{ id: 'pane-2', scope: { ...WORKSPACE_SCOPE, name: 'shell-b2', kind: 'terminal' } }] },
       ],
       activePaneId: 'pane-2',
       pendingPickerPaneId: null,

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -202,9 +202,14 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
         // above — so the sidebar never flashes the closing session as an
         // unclaimed row. On a genuine kill failure the mutation ROLLS the row
         // BACK as the unclaimed fallback (still reachable, still removable,
-        // with its own remove button), so this must not throw into the click
-        // handler.
-        void killAgentTerminal(machineId, closing).catch(() => {});
+        // with its own remove button) — but the pane is already gone, so the
+        // user must be TOLD the agent is still running (and billing) rather
+        // than left to notice the sidebar row: toast instead of throwing into
+        // the click handler.
+        const closingName = closing.name;
+        void killAgentTerminal(machineId, closing).catch(() => {
+          toast.error(`Failed to stop ${closingName} — it is still running, listed in the sidebar`);
+        });
       }
     },
     [machineId, workspaceId, closePane],

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -4,10 +4,11 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
 import type { Socket } from 'socket.io-client';
-import { Bot, SquareSplitHorizontal, SquareSplitVertical, TerminalSquare, X } from 'lucide-react';
+import { Bot, TerminalSquare } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import PaneBar, { PaneSplitCloseActions, PaneSessionIdentity, type PaneControlProps } from './PaneBar';
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals, killAgentTerminal, type AgentTerminal } from '@/hooks/useAgentTerminals';
 import { useSyncedWorkspaceActions } from '@/hooks/useMachineWorkspaceSync';
@@ -385,12 +386,15 @@ function PaneStrip({
 }
 
 /**
- * Chrome-free by design (no per-pane header, ever, verified against
- * PurePoint's real chrome-free pane design) — a top accent bar shows focus
- * and hover-revealed controls handle splitting/closing without permanent
- * chrome. Known tradeoff: with 2+ panes open the Machine tree sidebar does not
- * yet indicate which open terminal is showing in which pane — that's tree
- * sidebar work, out of scope for this theming-foundation round.
+ * Every pane wears a {@link PaneBar}: identity left (session name + checkout),
+ * split/close right, bar tint as the focus state. This retired the chrome-free
+ * design's floating control chip and 2px accent line — the chip physically
+ * covered the chat surface's own header, hover-reveal needed a coarse-pointer
+ * escape hatch, and anonymous panes left "which terminal is showing where"
+ * unanswerable. A CHAT pane's bar is rendered by {@link MachinePaneChat}
+ * instead (its agent picker and tabs merge into the same bar — one bar per
+ * pane, never two), so this component only draws the bar for the surfaces
+ * that have no header of their own: PTY, picker, loading, and notice panes.
  */
 function TerminalPane({
   socket,
@@ -442,63 +446,34 @@ function TerminalPane({
   const resolved = pane.scope
     ? resolvePaneSurface({ scope: pane.scope, workspaceScope, agentTerminals, isLoading: agentTerminalsLoading })
     : null;
-  // With neither a split nor a close to offer (a lone pane on a phone), the
-  // control chip has nothing in it — and since it is opacity-100 on touch, an
-  // empty bordered box would just sit in the corner forever.
   const hasControls = canSplit || canClose;
+  const paneControls: PaneControlProps | undefined = hasControls
+    ? { canSplit, canClose, onSplitRight, onSplitDown, onClose }
+    : undefined;
+  // MachinePaneChat draws the pane's ONE bar itself (agent picker + tabs +
+  // these same controls, merged) — every other surface gets the bar here.
+  const chatMounted = pane.scope !== null && resolved?.surface === 'chat' && resolved.terminalId !== null;
 
   return (
     <div className="group/pane relative flex h-full flex-col" onClick={onSelect}>
-      <div className={`absolute inset-x-0 top-0 z-10 h-0.5 ${isActive ? 'bg-primary' : 'bg-transparent'}`} />
-      {/* Hover-revealed from `md:` up. On a coarse pointer there is nothing to
-          hover with, so the global `[data-pointer='coarse']` rule in globals.css
-          keeps this exact opacity-0/group-hover shape visible — the controls must
-          not be unreachable on a device that cannot hover. */}
-      {hasControls && (
-      <div className="absolute right-1.5 top-1.5 z-10 flex items-center gap-0.5 rounded-md border border-border bg-card/90 p-0.5 opacity-100 shadow-sm backdrop-blur-sm transition-opacity focus-within:opacity-100 md:opacity-0 md:group-hover/pane:opacity-100">
-        {canSplit && (
-          <>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => {
-                e.stopPropagation();
-                onSplitRight();
-              }}
-              className="size-6 text-muted-foreground hover:text-foreground"
-              title="Split right"
-            >
-              <SquareSplitHorizontal className="size-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={(e) => {
-                e.stopPropagation();
-                onSplitDown();
-              }}
-              className="size-6 text-muted-foreground hover:text-foreground"
-              title="Split down"
-            >
-              <SquareSplitVertical className="size-3.5" />
-            </Button>
-          </>
-        )}
-        {canClose && (
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClose();
-            }}
-            className="size-6 text-muted-foreground hover:text-destructive"
-            title="Close pane"
-          >
-            <X className="size-3.5" />
-          </Button>
-        )}
-      </div>
+      {!chatMounted && (
+        <PaneBar
+          isActive={isActive}
+          identity={
+            pane.scope ? (
+              <PaneSessionIdentity
+                name={pane.scope.name}
+                // The PANE's own checkout, not the workspace's — a restored
+                // server layout can hold panes bound at other checkouts, and
+                // the chip exists to make exactly that visible.
+                scopeLabel={scopeLabelOf({ projectName: pane.scope.projectName, branchName: pane.scope.branchName })}
+              />
+            ) : (
+              <span className="truncate">New pane</span>
+            )
+          }
+          actions={paneControls && <PaneSplitCloseActions {...paneControls} />}
+        />
       )}
       <div className="relative min-h-0 flex-1">
         {!pane.scope || !sessionId || !resolved ? (
@@ -513,7 +488,7 @@ function TerminalPane({
           // hold while it's still loading (the one thing a chat-bound pane
           // must never do is mount an Xterm), but a LOADED list without the
           // row means the session was killed — say so rather than spin
-          // forever; the close control above stays reachable either way.
+          // forever; the close control in the bar stays reachable either way.
           resolved.terminalId === null ? (
             agentTerminalsLoading ? (
               <PaneLoading message="Loading session…" />
@@ -533,6 +508,8 @@ function TerminalPane({
               terminalId={resolved.terminalId}
               pendingPrompt={pane.pendingPrompt}
               onPromptSent={onPromptSent}
+              isActive={isActive}
+              paneControls={paneControls}
             />
           )
         ) : resolved.surface === 'loading' ? (

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -207,11 +207,14 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
 
       closePane(workspaceId, paneId);
       if (closing !== null && !boundElsewhere) {
-        void killAgentTerminal(machineId, closing).catch(() => {
-          // The pane is already gone locally; a failed kill leaves the session
-          // discoverable as an unclaimed row (which now carries its own remove
-          // button), so this must not throw into the click handler.
-        });
+        // `killAgentTerminal` drops the session from the SWR cache
+        // synchronously (optimistic mutation) — the same tick as `closePane`
+        // above — so the sidebar never flashes the closing session as an
+        // unclaimed row. On a genuine kill failure the mutation ROLLS the row
+        // BACK as the unclaimed fallback (still reachable, still removable,
+        // with its own remove button), so this must not throw into the click
+        // handler.
+        void killAgentTerminal(machineId, closing).catch(() => {});
       }
     },
     [machineId, workspaceId, closePane],

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/TerminalPanes.tsx
@@ -4,17 +4,9 @@ import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { toast } from 'sonner';
 import type { Socket } from 'socket.io-client';
-import { SquareSplitHorizontal, SquareSplitVertical, X } from 'lucide-react';
+import { Bot, SquareSplitHorizontal, SquareSplitVertical, TerminalSquare, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useMobile } from '@/hooks/useMobile';
 import { useAgentTerminals, killAgentTerminal, type AgentTerminal } from '@/hooks/useAgentTerminals';
@@ -111,7 +103,7 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
    * resolves, so the agent belongs to a pane from the first frame it exists.
    */
   const spawnIntoPane = useCallback(
-    async (paneId: string, agentType: AgentRuntimeType, prompt?: string) => {
+    async (paneId: string, agentType: AgentRuntimeType) => {
       const created = await addAgentTerminal(autoSessionName(agentType, freshNameSuffix()), agentType);
       const bound = bindPaneTerminal(
         workspaceId,
@@ -133,12 +125,9 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
             ? { kind: 'chat' as const }
             : {}),
         },
-        // `spawnAgentTerminal` is an upsert: `resumed` means it handed back a session
-        // that ALREADY EXISTED rather than creating one. An agent that was already
-        // running must never be typed at, and the API says so right here — relying on
-        // the auto-name's entropy to make this unreachable would leave the invariant
-        // resting on luck instead of on the answer we were given.
-        created.resumed ? undefined : prompt,
+        // No starting prompt — instant spawn means the prompt is typed in the
+        // pane itself, so there is nothing to auto-send.
+        undefined,
       );
       if (!bound && !created.resumed) {
         // The pane went away while the Sprite booted (closed, or the page
@@ -277,7 +266,7 @@ export default function TerminalPanes({ machineId, socket }: TerminalPanesProps)
     onSplitRight: () => splitRight(workspaceId, pane.id),
     onSplitDown: () => splitDown(workspaceId, pane.id),
     onClose: () => closePaneAndKill(pane.id),
-    onSpawn: (agentType: AgentRuntimeType, prompt?: string) => spawnIntoPane(pane.id, agentType, prompt),
+    onSpawn: (agentType: AgentRuntimeType) => spawnIntoPane(pane.id, agentType),
     onPickerFocused: () => dismissPicker(machineId, workspaceId, pane.id),
     onPromptSent: () => clearPanePrompt(machineId, workspaceId, pane.id),
   });
@@ -442,7 +431,7 @@ function TerminalPane({
   onSplitRight(): void;
   onSplitDown(): void;
   onClose(): void;
-  onSpawn(agentType: AgentRuntimeType, prompt?: string): Promise<void>;
+  onSpawn(agentType: AgentRuntimeType): Promise<void>;
   onPickerFocused(): void;
   onPromptSent(): void;
 }) {
@@ -565,14 +554,12 @@ function TerminalPane({
 }
 
 /**
- * An empty pane's inline agent picker — the whole spawn flow, in the pane the
- * agent will run in. Pick a type, optionally say what it should start on, and
- * the agent is created AND placed here in one action: no modal, no name step,
- * no separate "now assign it to a pane" click.
- *
- * The starting prompt is optional on purpose — Enter on the type is the fast
- * path (the agent boots to its own prompt), and the textarea is there for when
- * the user already knows the first thing to say.
+ * An empty pane's inline agent picker — two instant-spawn buttons, in the pane
+ * the agent will run in. Click Agent or Shell and the agent is created AND
+ * placed here in one action: no modal, no name step, no type dropdown, no
+ * prompt form — the prompt is typed in the pane once it opens (same instant
+ * grammar as NodeActionPalette's spawn options). The buttons come from
+ * `PICKABLE_AGENT_TYPES`, so this stays registry-driven.
  */
 function PaneAgentPicker({
   focused,
@@ -582,29 +569,28 @@ function PaneAgentPicker({
 }: {
   focused: boolean;
   scopeLabel: string;
-  onSpawn(agentType: AgentRuntimeType, prompt?: string): Promise<void>;
+  onSpawn(agentType: AgentRuntimeType): Promise<void>;
   onFocused(): void;
 }) {
-  const [agentType, setAgentType] = useState<AgentRuntimeType>(AGENT_TYPES[0]);
-  const [prompt, setPrompt] = useState('');
   const [spawning, setSpawning] = useState(false);
-  const promptRef = useRef<HTMLTextAreaElement>(null);
+  const firstChoiceRef = useRef<HTMLButtonElement>(null);
 
   // Consume the focus intent once. Clearing it in the store (onFocused) is what
-  // stops a later unrelated re-render from yanking the caret back here while
-  // the user is typing in a sibling pane.
+  // stops a later unrelated re-render from yanking the focus back here while
+  // the user is typing in a sibling pane. Focus lands on the FIRST choice
+  // (Agent) — the split asked for a new agent, so Enter spawns the default.
   useEffect(() => {
     if (!focused) return;
-    promptRef.current?.focus();
+    firstChoiceRef.current?.focus();
     onFocused();
   }, [focused, onFocused]);
 
-  const submit = async () => {
+  const spawn = async (agentType: AgentRuntimeType) => {
     setSpawning(true);
     try {
       // A spawned pane re-renders with a terminal in it, unmounting this picker
       // — so `spawning` is only ever cleared on the failure path.
-      await onSpawn(agentType, prompt.trim() || undefined);
+      await onSpawn(agentType);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to spawn agent');
       setSpawning(false);
@@ -617,40 +603,21 @@ function PaneAgentPicker({
         <p className="text-sm font-medium">Spawn an agent</p>
         <p className="text-xs text-muted-foreground">Runs in {scopeLabel}.</p>
       </div>
-      <div className="flex w-full max-w-xs flex-col gap-2">
-        <Select value={agentType} onValueChange={(value) => setAgentType(value as AgentRuntimeType)}>
-          <SelectTrigger aria-label="Agent type" className="h-8">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {AGENT_TYPES.map((type) => (
-              <SelectItem key={type} value={type}>
-                {agentTypeLabelOf(type)}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Textarea
-          ref={promptRef}
-          value={prompt}
-          onChange={(e) => setPrompt(e.target.value)}
-          placeholder="Starting prompt (optional)"
-          aria-label="Starting prompt"
-          rows={2}
-          className="resize-none text-sm"
-          // Enter submits; Shift+Enter is a newline — the prompt is usually one
-          // line, and reaching for the button to spawn would put the click back
-          // into a flow whose whole point is not having one.
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              if (!spawning) void submit();
-            }
-          }}
-        />
-        <Button size="sm" disabled={spawning} onClick={() => void submit()}>
-          {spawning ? 'Spawning…' : 'Spawn agent'}
-        </Button>
+      <div className="flex gap-2">
+        {AGENT_TYPES.map((type, index) => (
+          <Button
+            key={type}
+            ref={index === 0 ? firstChoiceRef : undefined}
+            size="sm"
+            variant="outline"
+            disabled={spawning}
+            onClick={() => void spawn(type)}
+            className="gap-2"
+          >
+            {agentSurfaceOf(type) === 'chat' ? <Bot className="size-3.5" /> : <TerminalSquare className="size-3.5" />}
+            {agentTypeLabelOf(type)}
+          </Button>
+        ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 }));
 
 import { toast } from 'sonner';
-import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 // `pushWorkspaceUpdate` (useMachineWorkspaceSync) PATCHes via `fetchWithAuth`
 // directly rather than the `patch()` helper, to read the real HTTP status
@@ -38,10 +38,11 @@ const patchCallsTo = (url: string) =>
     ([calledUrl, options]) => calledUrl === url && (options as RequestInit | undefined)?.method === 'PATCH',
   );
 
-// `killAgentTerminal` DELETEs via `fetchWithAuth` directly (not the `del()`
-// helper) so it can read the real HTTP status — a 404 is its success state.
-// Workspace-removal kills therefore show up here; unclaimed-row removal still
-// goes through the hook's `removeAgentTerminal`, i.e. the `del` mock.
+// Every session removal — `killAgentTerminal` AND the hook's
+// `removeAgentTerminal` — DELETEs via `fetchWithAuth` directly so it can read
+// the real HTTP status (a 404 is the success state), wrapped in an optimistic
+// SWR mutation that drops the row synchronously and rolls it back on genuine
+// failure. All removal calls therefore show up here, not on the `del` mock.
 const killCalls = () =>
   vi.mocked(fetchWithAuth).mock.calls.filter(
     ([, options]) => (options as RequestInit | undefined)?.method === 'DELETE',
@@ -633,9 +634,56 @@ describe('WorkspaceLeaves', () => {
       assert({
         given: 'the remove button on an unlaunchable session',
         should: 'DELETE it by name server-side, exactly like a normal running agent',
-        actual: vi.mocked(del).mock.calls.some(([url]) => String(url).includes('name=legacy-cli')),
+        actual: killCalls().some(([url]) => String(url).includes('name=legacy-cli')),
         expected: true,
       });
+    });
+  });
+
+  // The pane-close orphan fix's DOM-level contract: the row leaves the list in
+  // the same render as the removal click — not after a DELETE round-trip whose
+  // revalidation might silently fail and strand the row.
+  test('removing an unclaimed session drops the row BEFORE the DELETE resolves', async () => {
+    let resolveDelete!: (response: Response) => void;
+    let deleted = false;
+    vi.mocked(fetchWithAuth).mockImplementation((url, init) => {
+      if ((init as RequestInit | undefined)?.method === 'DELETE') {
+        deleted = true;
+        return new Promise<Response>((resolve) => {
+          resolveDelete = resolve;
+        });
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            agentTerminals: deleted
+              ? []
+              : [{ name: 'shell-orphan', agentType: 'shell', createdAt: '2026-01-01' }],
+          }),
+          { status: 200 },
+        ),
+      );
+    });
+    renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
+
+    const row = (await screen.findByText('shell-orphan')).closest('.group') as HTMLElement;
+    await userEvent.click(within(row).getByRole('button', { name: /Remove session shell-orphan/ }));
+
+    assert({
+      given: 'a removal whose DELETE is still in flight',
+      should: 'have already dropped the row from the DOM (optimistic, same render)',
+      actual: screen.queryByText('shell-orphan'),
+      expected: null,
+    });
+
+    await act(async () => {
+      resolveDelete(new Response(null, { status: 204 }));
+    });
+    assert({
+      given: 'the DELETE then succeeding',
+      should: 'keep the row gone',
+      actual: screen.queryByText('shell-orphan'),
+      expected: null,
     });
   });
 
@@ -643,16 +691,17 @@ describe('WorkspaceLeaves', () => {
   // through ConfirmRemoveDialog, which reports a thrown error via toast), a
   // fire-and-forget remove call with nothing observing the rejection would
   // silently no-op on failure — the row stays, but the user gets no signal why.
-  test('a failed removal of an unlaunchable session is reported via toast, not swallowed silently', async () => {
-    vi.mocked(fetchWithAuth).mockImplementation(async () =>
-      new Response(
-        JSON.stringify({
-          agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01' }],
-        }),
-        { status: 200 },
-      ),
+  test('a failed removal is reported via toast AND the row rolls back into the list', async () => {
+    vi.mocked(fetchWithAuth).mockImplementation(async (url, init) =>
+      (init as RequestInit | undefined)?.method === 'DELETE'
+        ? new Response(JSON.stringify({ error: 'Failed to remove' }), { status: 500 })
+        : new Response(
+            JSON.stringify({
+              agentTerminals: [{ name: 'legacy-cli', agentType: 'pagespace-cli', createdAt: '2026-01-01' }],
+            }),
+            { status: 200 },
+          ),
     );
-    vi.mocked(del).mockRejectedValueOnce(new Error('Failed to remove'));
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
     const row = (await screen.findByText('legacy-cli')).closest('.group') as HTMLElement;
@@ -660,10 +709,20 @@ describe('WorkspaceLeaves', () => {
 
     await waitFor(() => {
       assert({
-        given: 'a DELETE that rejects for an unlaunchable session\'s remove button',
+        given: 'a DELETE that fails 5xx for an unclaimed session\'s remove button',
         should: 'surface the failure via toast.error rather than swallowing it',
         actual: vi.mocked(toast.error).mock.calls.length,
         expected: 1,
+      });
+    });
+    // Rollback: the agent may genuinely still be running (and billing) — the
+    // row is the only way left to reach it, so it must come back.
+    await waitFor(() => {
+      assert({
+        given: 'the failed removal',
+        should: 'restore the row to the list — still reachable, still removable',
+        actual: screen.queryByText('legacy-cli') !== null,
+        expected: true,
       });
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/WorkspaceLeaves.test.tsx
@@ -175,7 +175,7 @@ describe('WorkspaceLeaves', () => {
     store().splitRight('m1', workspace.id, workspace.activePaneId);
     const withPane = selectMachine('m1')(store())!.workspaces[workspace.id];
     const newPaneId = withPane.columns[1].panes[0].id;
-    store().bindPaneTerminal('m1', workspace.id, newPaneId, { name: 'claude-a1b2c3' });
+    store().bindPaneTerminal('m1', workspace.id, newPaneId, { name: 'shell-a1b2c3' });
 
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
@@ -185,7 +185,7 @@ describe('WorkspaceLeaves', () => {
       should: 'render only the owning workspace as a row — the child pane is not a separate row',
       actual: {
         rows: screen.getAllByRole('button', { name: /^Workspace \d+$/ }).length,
-        childRowRendered: screen.queryByText('claude-a1b2c3') !== null,
+        childRowRendered: screen.queryByText('shell-a1b2c3') !== null,
       },
       expected: { rows: 1, childRowRendered: false },
     });
@@ -235,7 +235,7 @@ describe('WorkspaceLeaves', () => {
   test('removing a workspace WITH a running pane stops that agent server-side before dropping the workspace', async () => {
     seedMachine('m1');
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
-    store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'claude-a1b2c3' });
+    store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'shell-a1b2c3' });
     // A SECOND (empty) workspace, so removing the first one actually exercises
     // the removeWorkspace path — not the "last workspace" no-op path, which
     // has its own dedicated test below.
@@ -254,7 +254,7 @@ describe('WorkspaceLeaves', () => {
         given: 'a workspace holding one running pane, with a sibling workspace also present, remove confirmed',
         should: 'DELETE that agent_terminal server-side, then drop the local workspace entirely (its sibling survives)',
         actual: {
-          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=claude-a1b2c3')),
+          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=shell-a1b2c3')),
           remainingWorkspaces: Object.keys(selectMachine('m1')(store())!.workspaces).length,
         },
         expected: { deletedRunningAgent: true, remainingWorkspaces: rows.length - 1 },
@@ -270,7 +270,7 @@ describe('WorkspaceLeaves', () => {
     seedMachine('m1');
     const workspaceId = selectMachine('m1')(store())!.activeWorkspaceId;
     const workspace = selectMachine('m1')(store())!.workspaces[workspaceId];
-    store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, { name: 'claude-solo' });
+    store().bindPaneTerminal('m1', workspaceId, workspace.activePaneId, { name: 'shell-solo' });
 
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
@@ -285,7 +285,7 @@ describe('WorkspaceLeaves', () => {
         should:
           'stop the agent server-side and drop the workspace — this used to EMPTY it in place instead, which left an un-removable row that New terminal then duplicated',
         actual: {
-          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=claude-solo')),
+          deletedRunningAgent: killCalls().some(([url]) => String(url).includes('name=shell-solo')),
           workspaceCount: Object.keys(machine.workspaces).length,
           active: machine.activeWorkspaceId,
         },
@@ -424,7 +424,7 @@ describe('WorkspaceLeaves', () => {
   test('a server-backed session with no local workspace is reachable — clicking adopts it into a real workspace', async () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
-        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'claude', createdAt: '2026-01-01' }] }),
+        JSON.stringify({ agentTerminals: [{ name: 'orphan-1', agentType: 'shell', createdAt: '2026-01-01' }] }),
         { status: 200 },
       ),
     );
@@ -591,7 +591,7 @@ describe('WorkspaceLeaves', () => {
     });
   });
 
-  // The OTHER un-removable listing: a `shell`/`claude`/`codex` orphan rendered
+  // The OTHER un-removable listing: a supported-type orphan rendered
   // its remove button only when `!launchable`, so a supported unclaimed session
   // had no remove affordance at all. The only stop path was "remove the
   // workspace holding it" — which is precisely what an unclaimed session lacks.
@@ -599,19 +599,19 @@ describe('WorkspaceLeaves', () => {
     vi.mocked(fetchWithAuth).mockImplementation(async () =>
       new Response(
         JSON.stringify({
-          agentTerminals: [{ name: 'claude-orphan', agentType: 'claude', createdAt: '2026-01-01' }],
+          agentTerminals: [{ name: 'shell-runner', agentType: 'shell', createdAt: '2026-01-01' }],
         }),
         { status: 200 },
       ),
     );
     renderLeaves(<WorkspaceLeaves machineId="m1" node={MACHINE_NODE} onSelectWorkspace={vi.fn()} />);
 
-    const row = (await screen.findByText('claude-orphan')).closest('.group') as HTMLElement;
+    const row = (await screen.findByText('shell-runner')).closest('.group') as HTMLElement;
 
     assert({
       given: 'an unclaimed session whose agent type IS supported',
       should: 'still offer a remove button — it has no workspace to remove instead',
-      actual: within(row).queryByRole('button', { name: /Remove session claude-orphan/ }) !== null,
+      actual: within(row).queryByRole('button', { name: /Remove session shell-runner/ }) !== null,
       expected: true,
     });
   });
@@ -749,7 +749,7 @@ describe('WorkspaceNodeExtras', () => {
   test('shows a running-count badge scoped to the node', () => {
     seedMachine('m1');
     const workspace = selectMachine('m1')(store())!.workspaces[selectMachine('m1')(store())!.activeWorkspaceId];
-    store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'claude-a1b2c3' });
+    store().bindPaneTerminal('m1', workspace.id, workspace.activePaneId, { name: 'shell-a1b2c3' });
 
     renderLeaves(<WorkspaceNodeExtras machineId="m1" node={MACHINE_NODE} />);
 

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
@@ -241,7 +241,7 @@ describe('MachinePaneChat (pane bar)', () => {
     expect(screen.queryByTitle('Split right')).not.toBeInTheDocument();
   });
 
-  it('the overflow menu lists the folded actions and drives them', async () => {
+  it('the overflow menu lists the folded actions — INCLUDING Chat — and drives them', async () => {
     const paneControls = controls();
     render(
       <MachinePaneChat machineId="machine-1" terminalId="terminal-1" isActive paneControls={paneControls} />,
@@ -249,8 +249,12 @@ describe('MachinePaneChat (pane bar)', () => {
 
     await userEvent.click(screen.getByTitle('More'));
 
-    // Everything foldable is here; close is NOT — it never leaves the bar.
-    expect(await screen.findByRole('menuitem', { name: /New conversation/ })).toBeInTheDocument();
+    // Everything foldable is here. Chat matters most: below the fold width the
+    // TabsList is hidden, so this menu is the ONLY way back to the
+    // conversation after opening History or Settings. Close is NOT here — it
+    // never leaves the bar.
+    expect(await screen.findByRole('menuitem', { name: /Chat/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /New conversation/ })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /History/ })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /Settings/ })).toBeInTheDocument();
     expect(screen.getByRole('menuitem', { name: /Split down/ })).toBeInTheDocument();
@@ -258,6 +262,40 @@ describe('MachinePaneChat (pane bar)', () => {
 
     await userEvent.click(screen.getByRole('menuitem', { name: /Split right/ }));
     expect(paneControls.onSplitRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('overflow-menu Chat returns to the conversation from another tab', async () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" paneControls={controls()} />);
+
+    // Leave the chat tab first (Settings), then come back via the menu alone —
+    // the narrow-pane path where the TabsList is unavailable.
+    await userEvent.click(screen.getByRole('tab', { name: 'Settings' }));
+    expect(screen.getByTestId('machine-pane-assistant-settings')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTitle('More'));
+    await userEvent.click(await screen.findByRole('menuitem', { name: /Chat/ }));
+
+    expect(await screen.findByTestId('messages-content')).toBeInTheDocument();
+  });
+
+  it('overflow-menu clicks do not bubble into the pane\'s own click handler', async () => {
+    // The menu is portaled, but React portals bubble through the REACT tree —
+    // straight into TerminalPane's onClick={onSelect}. A split action that
+    // re-selects the SOURCE pane undoes the new pane's activation.
+    const onPaneClick = vi.fn();
+    const paneControls = controls();
+    render(
+      <div onClick={onPaneClick}>
+        <MachinePaneChat machineId="machine-1" terminalId="terminal-1" paneControls={paneControls} />
+      </div>,
+    );
+
+    await userEvent.click(screen.getByTitle('More'));
+    onPaneClick.mockClear(); // opening the menu may bubble; only the ACTION must not
+    await userEvent.click(await screen.findByRole('menuitem', { name: /Split right/ }));
+
+    expect(paneControls.onSplitRight).toHaveBeenCalledTimes(1);
+    expect(onPaneClick).not.toHaveBeenCalled();
   });
 
   it('selecting History from the overflow menu switches to the history tab', async () => {

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/__tests__/MachinePaneChat.test.tsx
@@ -59,6 +59,14 @@ vi.mock('@/components/ai/shared/chat', () => ({
   UndoAiChangesDialog: () => null,
 }));
 
+// jsdom lacks the pointer-capture APIs and scrollIntoView Radix's DropdownMenu
+// uses when opening — without these stubs, clicking the overflow trigger
+// throws instead of rendering its items (same stubs as TerminalPanes.test).
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => {};
+Element.prototype.releasePointerCapture ??= () => {};
+Element.prototype.scrollIntoView ??= () => {};
+
 import MachinePaneChat from '../MachinePaneChat';
 
 function conversationRow(id: string, title: string) {
@@ -192,5 +200,77 @@ describe('MachinePaneChat', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
     expect(paneState.current.reloadConversation).toHaveBeenCalled();
+  });
+});
+
+describe('MachinePaneChat (pane bar)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    paneState.current = basePaneState();
+  });
+
+  const controls = () => ({
+    canSplit: true,
+    canClose: true,
+    onSplitRight: vi.fn(),
+    onSplitDown: vi.fn(),
+    onClose: vi.fn(),
+  });
+
+  it('renders the pane controls in its ONE bar, tinted when the pane is active', async () => {
+    const paneControls = controls();
+    render(
+      <MachinePaneChat machineId="machine-1" terminalId="terminal-1" isActive paneControls={paneControls} />,
+    );
+
+    const bar = screen.getByTestId('pane-bar');
+    expect(bar.getAttribute('data-active')).toBe('true');
+    // The controls live IN the bar — nothing floats over the tabs anymore.
+    expect(screen.getByTitle('Split right')).toBeInTheDocument();
+    expect(screen.getByTitle('Close pane')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTitle('Close pane'));
+    expect(paneControls.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('without paneControls (or focus), the bar is plain and control-free', () => {
+    render(<MachinePaneChat machineId="machine-1" terminalId="terminal-1" />);
+
+    expect(screen.getByTestId('pane-bar').getAttribute('data-active')).toBeNull();
+    expect(screen.queryByTitle('Close pane')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Split right')).not.toBeInTheDocument();
+  });
+
+  it('the overflow menu lists the folded actions and drives them', async () => {
+    const paneControls = controls();
+    render(
+      <MachinePaneChat machineId="machine-1" terminalId="terminal-1" isActive paneControls={paneControls} />,
+    );
+
+    await userEvent.click(screen.getByTitle('More'));
+
+    // Everything foldable is here; close is NOT — it never leaves the bar.
+    expect(await screen.findByRole('menuitem', { name: /New conversation/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /History/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Settings/ })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Split down/ })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Close/ })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: /Split right/ }));
+    expect(paneControls.onSplitRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('selecting History from the overflow menu switches to the history tab', async () => {
+    paneState.current = basePaneState({
+      conversations: [conversationRow('conv-1', 'Machine chat')],
+    });
+    render(
+      <MachinePaneChat machineId="machine-1" terminalId="terminal-1" paneControls={controls()} />,
+    );
+
+    await userEvent.click(screen.getByTitle('More'));
+    await userEvent.click(await screen.findByRole('menuitem', { name: /History/ }));
+
+    expect(await screen.findByTestId('history-conversation-item')).toHaveTextContent('Machine chat');
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.test.ts
@@ -13,7 +13,7 @@ import { resolvePaneSurface, agentTypeLabelOf } from './pane-surface';
 const NODE = { projectName: 'app', branchName: 'main' };
 
 const chatRow = { id: 'row-chat', name: 'pagespace-a1', agentType: 'pagespace', createdAt: '' };
-const ptyRow = { id: 'row-pty', name: 'claude-b2', agentType: 'claude', createdAt: '' };
+const ptyRow = { id: 'row-pty', name: 'shell-b2', agentType: 'shell', createdAt: '' };
 
 describe('resolvePaneSurface', () => {
   test('an explicit chat kind renders chat, carrying the row id the list resolved', () => {
@@ -49,7 +49,7 @@ describe('resolvePaneSurface', () => {
       given: 'kind "terminal" while the list is still loading',
       should: 'be a terminal immediately — an explicit binding never waits on the list',
       actual: resolvePaneSurface({
-        scope: { ...NODE, name: 'claude-b2', kind: 'terminal' },
+        scope: { ...NODE, name: 'shell-b2', kind: 'terminal' },
         workspaceScope: NODE,
         agentTerminals: [],
         isLoading: true,
@@ -74,10 +74,10 @@ describe('resolvePaneSurface', () => {
 
   test('no kind hint + the list resolving the name to a PTY agent type renders a terminal', () => {
     assert({
-      given: 'a kind-less scope whose name the loaded list maps to agentType "claude"',
+      given: 'a kind-less scope whose name the loaded list maps to agentType "shell"',
       should: 'resolve to a terminal',
       actual: resolvePaneSurface({
-        scope: { ...NODE, name: 'claude-b2' },
+        scope: { ...NODE, name: 'shell-b2' },
         workspaceScope: NODE,
         agentTerminals: [ptyRow],
         isLoading: false,
@@ -146,21 +146,17 @@ describe('resolvePaneSurface', () => {
 });
 
 describe('agentTypeLabelOf', () => {
-  test('the chat agent presents as "PageSpace Agent", PTY types as themselves', () => {
+  test('the chat agent presents as "Agent", the PTY type as "Shell"', () => {
     assert({
       given: 'every pickable agent type',
-      should: 'label pagespace "PageSpace Agent" — agents and chats are one thing, so it presents as an agent, never as "chat" — and leave PTY binaries under their real names',
+      should: 'label pagespace "Agent" — agents and chats are one thing, and PageSpace is the assumed context — and shell "Shell"',
       actual: {
         pagespace: agentTypeLabelOf('pagespace'),
         shell: agentTypeLabelOf('shell'),
-        claude: agentTypeLabelOf('claude'),
-        codex: agentTypeLabelOf('codex'),
       },
       expected: {
-        pagespace: 'PageSpace Agent',
-        shell: 'shell',
-        claude: 'claude',
-        codex: 'codex',
+        pagespace: 'Agent',
+        shell: 'Shell',
       },
     });
   });

--- a/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/machine/workspace/pane-surface.ts
@@ -77,14 +77,17 @@ export function resolvePaneSurface(params: {
   return { surface: 'terminal' };
 }
 
-/** What the chat agent presents as everywhere a picker lists it — agents and
- * chats are one thing, so it's an agent ("PageSpace Agent"), never a "chat". */
-const AGENT_TYPE_LABELS: Partial<Record<AgentRuntimeType, string>> = {
-  pagespace: 'PageSpace Agent',
+/** What each agent type presents as everywhere a picker lists it. TOTAL by
+ * design — a new registry entry fails compilation here until it declares its
+ * label, instead of silently leaking its raw key into the UI. `pagespace` is
+ * just "Agent": agents and chats are one thing, and PageSpace is the assumed
+ * context — we are pushing people toward it, not branding it as an add-on. */
+const AGENT_TYPE_LABELS: Record<AgentRuntimeType, string> = {
+  pagespace: 'Agent',
+  shell: 'Shell',
 };
 
-/** Display label for an agent type — PTY binaries under their real names, the
- * chat agent as "PageSpace Agent". */
+/** Display label for an agent type — "Agent" for the chat agent, "Shell" for the PTY. */
 export function agentTypeLabelOf(type: AgentRuntimeType): string {
-  return AGENT_TYPE_LABELS[type] ?? type;
+  return AGENT_TYPE_LABELS[type];
 }

--- a/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
+++ b/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
@@ -297,6 +297,148 @@ describe('removeAgentTerminal', () => {
 });
 
 describe('concurrent kills on one key', () => {
+  it('a LATER kill failing does not resurrect an already-killed sibling (rollback bypasses populateCache)', async () => {
+    // SWR's rollbackOnError writes the ORIGINAL committed snapshot back
+    // without consulting populateCache — so kill B failing would restore
+    // kill A's already-deleted row. The failed release must issue a
+    // compensating write that re-drops succeeded siblings.
+    const machineId = 'm-kill-late-fail';
+    const first = deferredDelete();
+    const second = deferredDelete();
+    const deletes = [first, second];
+    let loaded = false;
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return deletes.shift()!.promise as Promise<never>;
+      if (!loaded) {
+        loaded = true;
+        return Promise.resolve(jsonResponse({ agentTerminals: [row('shell-a'), row('shell-b')] }));
+      }
+      return new Promise(() => {}); // revalidation hung — cache must be right on its own
+    });
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let killA!: Promise<void>;
+    let killB!: Promise<void>;
+    act(() => {
+      killA = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+      killB = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-b' });
+    });
+
+    await act(async () => {
+      first.resolve(jsonResponse(null)); // A dies for real
+      await killA;
+    });
+    await act(async () => {
+      second.resolve(jsonResponse({ error: 'sprite unreachable' }, 500)); // B's kill fails
+      await killB.catch(() => {});
+    });
+
+    assert({
+      given: 'kill A succeeded, then the later-started kill B failed (rollback restored the pre-kill snapshot)',
+      should: 'show only B — the failed kill rolls ITS row back, never the sibling the server already deleted',
+      actual: result.current.agentTerminals.map((t) => t.name),
+      expected: ['shell-b'],
+    });
+  });
+
+  it('an EARLIER kill failing after a sibling settled still restores its row (SWR skips its rollback)', async () => {
+    // SWR's timestamp guard makes a non-latest mutation skip BOTH rollback
+    // and revalidation — a genuinely failed kill (agent still running and
+    // billing) would stay invisible everywhere. The failed release's
+    // compensating write forces a reconciling revalidation.
+    const machineId = 'm-kill-early-fail';
+    const first = deferredDelete();
+    const second = deferredDelete();
+    const deletes = [first, second];
+    let deletesStarted = 0;
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        deletesStarted += 1;
+        return deletes.shift()!.promise as Promise<never>;
+      }
+      // Server truth after the dust settles: A survived (its kill failed), B died.
+      return Promise.resolve(
+        jsonResponse({ agentTerminals: deletesStarted === 0 ? [row('shell-a'), row('shell-b')] : [row('shell-a')] }),
+      );
+    });
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let killA!: Promise<void>;
+    let killB!: Promise<void>;
+    act(() => {
+      killA = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+      killB = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-b' });
+    });
+
+    await act(async () => {
+      second.resolve(jsonResponse(null)); // B (latest) settles first, commits
+      await killB;
+    });
+    await act(async () => {
+      first.resolve(jsonResponse({ error: 'sprite unreachable' }, 500)); // A then fails
+      await killA.catch(() => {});
+    });
+
+    await waitFor(() => {
+      assert({
+        given: 'the earlier-started kill failing after its sibling already settled',
+        should:
+          'surface A again — its agent is still running (and billing), and a row SWR forgot to roll back must come back via the forced reconciliation',
+        actual: result.current.agentTerminals.map((t) => t.name),
+        expected: ['shell-a'],
+      });
+    });
+  });
+
+  it('two concurrent kills of the SAME name settle to the row being gone when either succeeds', async () => {
+    // names-as-a-Set undercounts duplicates: the first duplicate failing must
+    // not deregister the name while the second duplicate is still in flight —
+    // its later success would commit the snapshot WITH the row.
+    const machineId = 'm-kill-same-name';
+    const first = deferredDelete();
+    const second = deferredDelete();
+    const deletes = [first, second];
+    let loaded = false;
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return deletes.shift()!.promise as Promise<never>;
+      if (!loaded) {
+        loaded = true;
+        return Promise.resolve(jsonResponse({ agentTerminals: [row('shell-a'), row('shell-x')] }));
+      }
+      return new Promise(() => {}); // revalidation hung
+    });
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let kill1!: Promise<void>;
+    let kill2!: Promise<void>;
+    act(() => {
+      kill1 = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+      kill2 = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+    });
+
+    await act(async () => {
+      first.resolve(jsonResponse({ error: 'sprite unreachable' }, 500)); // duplicate 1 fails
+      await kill1.catch(() => {});
+    });
+    await act(async () => {
+      second.resolve(jsonResponse(null)); // duplicate 2 succeeds — the session IS dead
+      await kill2;
+    });
+
+    assert({
+      given: 'two concurrent kills of one name, the first failing and the second succeeding',
+      should: 'keep the row gone (the session is dead server-side) and the unrelated row intact',
+      actual: result.current.agentTerminals.map((t) => t.name),
+      expected: ['shell-x'],
+    });
+  });
+
   it('never resurrects an already-killed sibling row when settles arrive out of order and revalidation is delayed', async () => {
     // The Codex-flagged race: SWR hands each settle the ORIGINAL committed
     // snapshot (`_c`, captured before any optimistic update), so the

--- a/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
+++ b/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
@@ -108,7 +108,7 @@ describe('killMutateOptions (pure)', () => {
     assert({
       given: 'a concurrent kill already hid another row from displayed data',
       should: 'filter the displayed data, not resurrect the committed snapshot',
-      actual: killMutateOptions('shell-a').optimisticData(committed, displayed),
+      actual: killMutateOptions('key-pure', 'shell-a').optimisticData(committed, displayed),
       expected: { agentTerminals: [] },
     });
   });
@@ -119,13 +119,13 @@ describe('killMutateOptions (pure)', () => {
     assert({
       given: 'a settled DELETE and the committed snapshot',
       should: 'commit the snapshot minus the killed row',
-      actual: killMutateOptions('shell-a').populateCache(undefined, committed),
+      actual: killMutateOptions('key-pure', 'shell-a').populateCache(undefined, committed),
       expected: { agentTerminals: [row('shell-b')] },
     });
   });
 
   it('rolls back on error and reconciles via detached revalidation', () => {
-    const options = killMutateOptions('shell-a');
+    const options = killMutateOptions('key-pure', 'shell-a');
 
     assert({
       given: 'a kill mutation',
@@ -297,6 +297,57 @@ describe('removeAgentTerminal', () => {
 });
 
 describe('concurrent kills on one key', () => {
+  it('never resurrects an already-killed sibling row when settles arrive out of order and revalidation is delayed', async () => {
+    // The Codex-flagged race: SWR hands each settle the ORIGINAL committed
+    // snapshot (`_c`, captured before any optimistic update), so the
+    // latest-started kill's populateCache would write the FIRST kill's row
+    // back into the cache. With revalidation delayed (here: hung), that
+    // resurrected row is not a flash — it's an orphan listing again.
+    const machineId = 'm-kill-out-of-order';
+    const first = deferredDelete();
+    const second = deferredDelete();
+    const deletes = [first, second];
+    let loaded = false;
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return deletes.shift()!.promise as Promise<never>;
+      if (!loaded) {
+        loaded = true;
+        return Promise.resolve(jsonResponse({ agentTerminals: [row('shell-a'), row('shell-b')] }));
+      }
+      // Every revalidation after the initial load HANGS — the cache's own
+      // committed state must be correct without the detached repair.
+      return new Promise(() => {});
+    });
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let killA!: Promise<void>;
+    let killB!: Promise<void>;
+    act(() => {
+      killA = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+      killB = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-b' });
+    });
+
+    // B (the latest-started mutation, the one whose populateCache SWR will
+    // honor) settles FIRST; A settles after.
+    await act(async () => {
+      second.resolve(jsonResponse(null));
+      await killB;
+    });
+    await act(async () => {
+      first.resolve(jsonResponse(null));
+      await killA;
+    });
+
+    assert({
+      given: 'two concurrent kills whose DELETEs settle out of order, with revalidation hung',
+      should: 'commit a cache containing NEITHER row — no settle may resurrect the other kill from its stale committed snapshot',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+  });
+
   it('hides both rows in flight and keeps both gone after settling', async () => {
     const machineId = 'm-kill-concurrent';
     const first = deferredDelete();

--- a/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
+++ b/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
@@ -216,7 +216,7 @@ describe('killAgentTerminal', () => {
     assert({
       given: 'a DELETE failing 5xx',
       should: 'rethrow the server error (agent may still be running and billing)',
-      actual: error?.message,
+      actual: (error as Error | null)?.message,
       expected: 'sprite unreachable',
     });
     await waitFor(() => {
@@ -282,7 +282,7 @@ describe('removeAgentTerminal', () => {
     assert({
       given: 'a DELETE failing 5xx',
       should: 'rethrow so the caller can toast',
-      actual: error?.message,
+      actual: (error as Error | null)?.message,
       expected: 'kill failed',
     });
     await waitFor(() => {

--- a/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
+++ b/apps/web/src/hooks/__tests__/useAgentTerminals.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * useAgentTerminals — optimistic kill/remove tests (pane-close orphan fix).
+ *
+ * The sidebar's "unclaimed session" rows are a set-difference between the
+ * server session list (this hook's SWR cache) and the workspace store's panes.
+ * A pane close mutates the store synchronously, so the session row must leave
+ * this cache in the SAME tick — anything slower resurfaces the session as an
+ * orphan row for at least a frame, and forever if the round-trip fails
+ * silently. These tests pin the whole contract: synchronous optimistic
+ * removal, 404-as-success, and rollback (the row IS the fallback) on genuine
+ * failure.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { assert } from './riteway';
+
+const { mockFetchWithAuth, mockPost } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockPost: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+  post: mockPost,
+  del: vi.fn(),
+}));
+
+import {
+  useAgentTerminals,
+  killAgentTerminal,
+  withoutSession,
+  killMutateOptions,
+  type AgentTerminal,
+} from '../useAgentTerminals';
+
+const row = (name: string): AgentTerminal => ({
+  id: `id-${name}`,
+  name,
+  agentType: 'shell',
+  createdAt: '2026-07-21T00:00:00.000Z',
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+/** GET list responses resolve immediately; DELETE is routed to `onDelete`. */
+function routeFetch(list: AgentTerminal[], onDelete: () => Promise<unknown>) {
+  mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+    if (init?.method === 'DELETE') return onDelete();
+    return Promise.resolve(jsonResponse({ agentTerminals: list }));
+  });
+}
+
+/** A DELETE the test resolves by hand, to freeze the in-flight window. */
+function deferredDelete() {
+  let resolve!: (value: unknown) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('withoutSession (pure)', () => {
+  it('filters the named row and keeps the rest, without mutating its input', () => {
+    const list = { agentTerminals: [row('shell-a'), row('shell-b')] };
+    const result = withoutSession('shell-a')(list);
+
+    assert({
+      given: 'a cached list holding the named row',
+      should: 'return a list without it, other rows untouched',
+      actual: result,
+      expected: { agentTerminals: [row('shell-b')] },
+    });
+    assert({
+      given: 'the same input list after the call',
+      should: 'be unmodified (pure — no in-place mutation)',
+      actual: list,
+      expected: { agentTerminals: [row('shell-a'), row('shell-b')] },
+    });
+  });
+
+  it('passes undefined cache data through unchanged', () => {
+    assert({
+      given: 'an unpopulated cache (undefined)',
+      should: 'return it unchanged rather than fabricate a list',
+      actual: withoutSession('shell-a')(undefined),
+      expected: undefined,
+    });
+  });
+});
+
+describe('killMutateOptions (pure)', () => {
+  it('filters DISPLAYED data optimistically, so concurrent kills stay hidden', () => {
+    // Two concurrent kills on one key: kill A's committedData snapshot still
+    // holds row B (taken before B's optimistic update landed). Filtering the
+    // DISPLAYED data — which already lost B — is what keeps B from
+    // resurfacing for a frame while A settles.
+    const committed = { agentTerminals: [row('shell-a'), row('shell-b')] };
+    const displayed = { agentTerminals: [row('shell-a')] }; // B already optimistically gone
+
+    assert({
+      given: 'a concurrent kill already hid another row from displayed data',
+      should: 'filter the displayed data, not resurrect the committed snapshot',
+      actual: killMutateOptions('shell-a').optimisticData(committed, displayed),
+      expected: { agentTerminals: [] },
+    });
+  });
+
+  it('commits the filtered committed snapshot via populateCache', () => {
+    const committed = { agentTerminals: [row('shell-a'), row('shell-b')] };
+
+    assert({
+      given: 'a settled DELETE and the committed snapshot',
+      should: 'commit the snapshot minus the killed row',
+      actual: killMutateOptions('shell-a').populateCache(undefined, committed),
+      expected: { agentTerminals: [row('shell-b')] },
+    });
+  });
+
+  it('rolls back on error and reconciles via detached revalidation', () => {
+    const options = killMutateOptions('shell-a');
+
+    assert({
+      given: 'a kill mutation',
+      should: 'restore the row on failure — the unclaimed row IS the fallback',
+      actual: options.rollbackOnError,
+      expected: true,
+    });
+    assert({
+      given: 'a kill mutation',
+      should: 'revalidate after settling (detached — cannot reject the call)',
+      actual: options.revalidate,
+      expected: true,
+    });
+  });
+});
+
+describe('killAgentTerminal', () => {
+  it('removes the row from the cache before the DELETE resolves', async () => {
+    const machineId = 'm-kill-optimistic';
+    const deferred = deferredDelete();
+    routeFetch([row('shell-a'), row('shell-b')], () => deferred.promise as Promise<never>);
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let killed!: Promise<void>;
+    act(() => {
+      killed = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+    });
+
+    assert({
+      given: 'a kill whose DELETE is still in flight',
+      should: 'have already dropped the row (same tick as the pane close)',
+      actual: result.current.agentTerminals.map((t) => t.name),
+      expected: ['shell-b'],
+    });
+
+    // Settle: DELETE succeeds, row stays gone.
+    routeFetch([row('shell-b')], () => Promise.resolve(jsonResponse(null)));
+    await act(async () => {
+      deferred.resolve(jsonResponse(null));
+      await killed;
+    });
+    assert({
+      given: 'the DELETE succeeding',
+      should: 'keep the row gone',
+      actual: result.current.agentTerminals.map((t) => t.name),
+      expected: ['shell-b'],
+    });
+  });
+
+  it('treats 404 as success — the session is already gone server-side', async () => {
+    const machineId = 'm-kill-404';
+    routeFetch([row('shell-a')], () => Promise.resolve(jsonResponse({ error: 'not_found' }, 404)));
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(1));
+
+    routeFetch([], () => Promise.resolve(jsonResponse({ error: 'not_found' }, 404)));
+    await act(async () => {
+      await killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+    });
+
+    assert({
+      given: 'a DELETE answering 404',
+      should: 'resolve and keep the row removed (goal state reached)',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+  });
+
+  it('rolls the row back and rethrows when the DELETE genuinely fails', async () => {
+    const machineId = 'm-kill-rollback';
+    routeFetch([row('shell-a')], () => Promise.resolve(jsonResponse({ error: 'sprite unreachable' }, 500)));
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(1));
+
+    let error: Error | null = null;
+    await act(async () => {
+      await killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' }).catch(
+        (err: Error) => {
+          error = err;
+        },
+      );
+    });
+
+    assert({
+      given: 'a DELETE failing 5xx',
+      should: 'rethrow the server error (agent may still be running and billing)',
+      actual: error?.message,
+      expected: 'sprite unreachable',
+    });
+    await waitFor(() => {
+      assert({
+        given: 'the failed kill',
+        should: 'restore the row — still reachable, still removable',
+        actual: result.current.agentTerminals.map((t) => t.name),
+        expected: ['shell-a'],
+      });
+    });
+  });
+});
+
+describe('removeAgentTerminal', () => {
+  it('removes optimistically and stays removed on 404', async () => {
+    const machineId = 'm-remove-404';
+    const deferred = deferredDelete();
+    routeFetch([row('shell-a')], () => deferred.promise as Promise<never>);
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(1));
+
+    let removed!: Promise<void>;
+    act(() => {
+      removed = result.current.removeAgentTerminal('shell-a');
+    });
+    assert({
+      given: 'a removal whose DELETE is still in flight',
+      should: 'have already dropped the row from this hook instance',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+
+    // A row already dead server-side must still be removable — del()'s old
+    // throw-on-404 made these rows permanently stuck with an error toast.
+    routeFetch([], () => Promise.resolve(jsonResponse({ error: 'not_found' }, 404)));
+    await act(async () => {
+      deferred.resolve(jsonResponse({ error: 'not_found' }, 404));
+      await removed;
+    });
+    assert({
+      given: 'the DELETE answering 404',
+      should: 'resolve with the row still gone',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+  });
+
+  it('rolls back and rethrows on genuine failure', async () => {
+    const machineId = 'm-remove-rollback';
+    routeFetch([row('shell-a')], () => Promise.resolve(jsonResponse({ error: 'kill failed' }, 500)));
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(1));
+
+    let error: Error | null = null;
+    await act(async () => {
+      await result.current.removeAgentTerminal('shell-a').catch((err: Error) => {
+        error = err;
+      });
+    });
+
+    assert({
+      given: 'a DELETE failing 5xx',
+      should: 'rethrow so the caller can toast',
+      actual: error?.message,
+      expected: 'kill failed',
+    });
+    await waitFor(() => {
+      assert({
+        given: 'the failed removal',
+        should: 'restore the row',
+        actual: result.current.agentTerminals.map((t) => t.name),
+        expected: ['shell-a'],
+      });
+    });
+  });
+});
+
+describe('concurrent kills on one key', () => {
+  it('hides both rows in flight and keeps both gone after settling', async () => {
+    const machineId = 'm-kill-concurrent';
+    const first = deferredDelete();
+    const second = deferredDelete();
+    const deletes = [first, second];
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return deletes.shift()!.promise as Promise<never>;
+      return Promise.resolve(jsonResponse({ agentTerminals: [row('shell-a'), row('shell-b')] }));
+    });
+
+    const { result } = renderHook(() => useAgentTerminals(machineId, 'proj', 'main'));
+    await waitFor(() => expect(result.current.agentTerminals).toHaveLength(2));
+
+    let killA!: Promise<void>;
+    let killB!: Promise<void>;
+    act(() => {
+      killA = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-a' });
+      killB = killAgentTerminal(machineId, { projectName: 'proj', branchName: 'main', name: 'shell-b' });
+    });
+
+    assert({
+      given: 'two kills in flight on the same key (workspace removal)',
+      should: 'hide both rows — neither kill resurrects the other',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+
+    mockFetchWithAuth.mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return Promise.resolve(jsonResponse(null));
+      return Promise.resolve(jsonResponse({ agentTerminals: [] }));
+    });
+    await act(async () => {
+      first.resolve(jsonResponse(null));
+      second.resolve(jsonResponse(null));
+      await Promise.all([killA, killB]);
+    });
+    assert({
+      given: 'both DELETEs succeeding',
+      should: 'keep both rows gone',
+      actual: result.current.agentTerminals,
+      expected: [],
+    });
+  });
+});

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -84,31 +84,71 @@ export const withoutSession = (name: string) => withoutSessions(new Set([name]))
  * the committed snapshot through this registry keeps every sibling kill's row
  * out of whatever any settle commits.
  *
- * Lifecycle: a name is registered before its mutation starts, dropped on
- * FAILURE (rollback means that row is supposed to come back), kept on success,
- * and the whole entry is cleared once the key has zero kills in flight —
- * successful names must outlive their own settle because a sibling that
- * started earlier settles later with a snapshot that still contains them.
+ * Bookkeeping details, each covering a verified failure mode:
+ *
+ * - `perName` holds COUNTS, not a set: two concurrent kills of one name (a
+ *   pane close racing the sidebar's remove of the same session) register
+ *   twice, and the first duplicate failing must not deregister the name while
+ *   the second is still in flight — its later success would commit a snapshot
+ *   WITH the row.
+ * - `succeeded` names outlive their own settle: a sibling that started
+ *   earlier settles later with a snapshot that still contains them.
+ * - A FAILED kill deregisters its name (rollback means that row is supposed
+ *   to come back) — but SWR's own repair is not enough: `rollbackOnError`
+ *   writes the pre-kill snapshot back WITHOUT consulting `populateCache`
+ *   (resurrecting succeeded siblings), and a non-latest mutation's rollback
+ *   and revalidation are BOTH skipped by SWR's timestamp guard (leaving a
+ *   genuinely-failed kill's row invisible while its agent runs and bills).
+ *   So the failed release hands the caller a compensating filter set — see
+ *   {@link withKillRegistered} — to re-drop succeeded siblings and force one
+ *   reconciling revalidation.
+ * - The entry is cleared once the key has zero kills in flight; the detached
+ *   revalidation reconciles any longer-term drift with server truth.
  */
-const killsInFlight = new Map<string, { inflight: number; names: Set<string> }>();
+const killsInFlight = new Map<string, { inflight: number; perName: Map<string, number>; succeeded: Set<string> }>();
 
-function registerKill(key: string, name: string): (failed: boolean) => void {
+/** Every name any settle's commit must keep filtering: still-in-flight kills plus already-succeeded ones. */
+function activeKillNames(key: string): ReadonlySet<string> | null {
+  const entry = killsInFlight.get(key);
+  if (!entry) return null;
+  return new Set([...entry.perName.keys(), ...entry.succeeded]);
+}
+
+function registerKill(key: string, name: string): (failed: boolean) => ReadonlySet<string> {
   let entry = killsInFlight.get(key);
   if (!entry) {
-    entry = { inflight: 0, names: new Set() };
+    entry = { inflight: 0, perName: new Map(), succeeded: new Set() };
     killsInFlight.set(key, entry);
   }
   entry.inflight += 1;
-  entry.names.add(name);
+  entry.perName.set(name, (entry.perName.get(name) ?? 0) + 1);
   return (failed: boolean) => {
     entry.inflight -= 1;
-    if (failed) entry.names.delete(name);
+    const remaining = (entry.perName.get(name) ?? 1) - 1;
+    if (remaining <= 0) entry.perName.delete(name);
+    else entry.perName.set(name, remaining);
+    if (!failed) entry.succeeded.add(name);
+    const filterNames = new Set([...entry.perName.keys(), ...entry.succeeded]);
     if (entry.inflight === 0) killsInFlight.delete(key);
+    return filterNames;
   };
 }
 
-/** Runs `mutation` with its kill registered for the key's populateCache filter. */
-async function withKillRegistered(key: string, name: string, mutation: () => Promise<unknown>): Promise<void> {
+/**
+ * Runs `mutation` with its kill registered for the key's populateCache
+ * filter. On FAILURE, calls `compensate` with the post-release filter set —
+ * the caller issues a cache write that re-drops every still-relevant kill's
+ * row (undoing SWR's snapshot rollback resurrecting succeeded siblings)
+ * while leaving the failed row alone, and forces a reconciling revalidation
+ * (covering the non-latest-mutation case where SWR skips both its rollback
+ * and its revalidation).
+ */
+async function withKillRegistered(
+  key: string,
+  name: string,
+  mutation: () => Promise<unknown>,
+  compensate: (filterNames: ReadonlySet<string>) => void,
+): Promise<void> {
   const release = registerKill(key, name);
   let failed = false;
   try {
@@ -117,7 +157,8 @@ async function withKillRegistered(key: string, name: string, mutation: () => Pro
     failed = true;
     throw error;
   } finally {
-    release(failed);
+    const filterNames = release(failed);
+    if (failed) compensate(filterNames);
   }
 }
 
@@ -159,7 +200,7 @@ export const killMutateOptions = (key: string, name: string) => ({
   // from the promise) and a hook's bound one (no per-call generic in SWR
   // 2.4's KeyedMutator) — must accept this options object as-is.
   populateCache: (_result: unknown, committed: TerminalList) =>
-    withoutSessions(killsInFlight.get(key)?.names ?? new Set([name]))(committed) ?? { agentTerminals: [] },
+    withoutSessions(activeKillNames(key) ?? new Set([name]))(committed) ?? { agentTerminals: [] },
   rollbackOnError: true,
   revalidate: true,
 });
@@ -185,8 +226,16 @@ export async function killAgentTerminal(
   scope: { projectName?: string | null; branchName?: string | null; name: string },
 ): Promise<void> {
   const key = `/api/machines/agent-terminals?${buildQuery(machineId, scope.projectName, scope.branchName)}`;
-  await withKillRegistered(key, scope.name, () =>
-    mutate(key, deleteAgentTerminalRequest(machineId, scope), killMutateOptions(key, scope.name)),
+  await withKillRegistered(
+    key,
+    scope.name,
+    () => mutate(key, deleteAgentTerminalRequest(machineId, scope), killMutateOptions(key, scope.name)),
+    (filterNames) =>
+      void mutate(
+        key,
+        (current: TerminalList) => withoutSessions(filterNames)(current) ?? { agentTerminals: [] },
+        { revalidate: true },
+      ).catch(() => {}),
   );
 }
 
@@ -227,11 +276,19 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
       // `.then(() => undefined)` shapes the DELETE into the Promise<Data |
       // undefined> the bound mutate accepts; `populateCache` supplies the real
       // next cache value, so the undefined result is never written as data.
-      await withKillRegistered(key, name, () =>
-        mutate(
-          deleteAgentTerminalRequest(machineId, { projectName, branchName, name }).then(() => undefined),
-          killMutateOptions(key, name),
-        ),
+      await withKillRegistered(
+        key,
+        name,
+        () =>
+          mutate(
+            deleteAgentTerminalRequest(machineId, { projectName, branchName, name }).then(() => undefined),
+            killMutateOptions(key, name),
+          ),
+        (filterNames) =>
+          void mutate(
+            (current) => withoutSessions(filterNames)(current) ?? { agentTerminals: [] },
+            { revalidate: true },
+          ).catch(() => {}),
       );
     },
     [machineId, key, projectName, branchName, mutate],

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -65,11 +65,61 @@ async function deleteAgentTerminalRequest(
   }
 }
 
-/** Pure: the cached list minus the named row; `undefined` cache passes through. */
-export const withoutSession =
-  (name: string) =>
+/** Pure: the cached list minus the named row(s); `undefined` cache passes through. */
+export const withoutSessions =
+  (names: ReadonlySet<string>) =>
   (list: TerminalList): TerminalList =>
-    list ? { agentTerminals: list.agentTerminals.filter((terminal) => terminal.name !== name) } : list;
+    list ? { agentTerminals: list.agentTerminals.filter((terminal) => !names.has(terminal.name)) } : list;
+
+/** Pure: the cached list minus the named row; `undefined` cache passes through. */
+export const withoutSession = (name: string) => withoutSessions(new Set([name]));
+
+/**
+ * Per-key bookkeeping for kills currently in flight (or settled while a
+ * same-key sibling is still in flight). SWR hands every settle's
+ * `populateCache` the ORIGINAL committed snapshot (`_c`, captured before any
+ * optimistic update on the key) — so with two concurrent kills, the
+ * latest-started one's commit would write the OTHER kill's row straight back
+ * into the cache, and only the detached revalidation would repair it. Filtering
+ * the committed snapshot through this registry keeps every sibling kill's row
+ * out of whatever any settle commits.
+ *
+ * Lifecycle: a name is registered before its mutation starts, dropped on
+ * FAILURE (rollback means that row is supposed to come back), kept on success,
+ * and the whole entry is cleared once the key has zero kills in flight —
+ * successful names must outlive their own settle because a sibling that
+ * started earlier settles later with a snapshot that still contains them.
+ */
+const killsInFlight = new Map<string, { inflight: number; names: Set<string> }>();
+
+function registerKill(key: string, name: string): (failed: boolean) => void {
+  let entry = killsInFlight.get(key);
+  if (!entry) {
+    entry = { inflight: 0, names: new Set() };
+    killsInFlight.set(key, entry);
+  }
+  entry.inflight += 1;
+  entry.names.add(name);
+  return (failed: boolean) => {
+    entry.inflight -= 1;
+    if (failed) entry.names.delete(name);
+    if (entry.inflight === 0) killsInFlight.delete(key);
+  };
+}
+
+/** Runs `mutation` with its kill registered for the key's populateCache filter. */
+async function withKillRegistered(key: string, name: string, mutation: () => Promise<unknown>): Promise<void> {
+  const release = registerKill(key, name);
+  let failed = false;
+  try {
+    await mutation();
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    release(failed);
+  }
+}
 
 /**
  * The optimistic-mutation contract every session removal runs under. The
@@ -85,7 +135,12 @@ export const withoutSession =
  *   with two concurrent kills on one key (a workspace removal killing several
  *   same-scope sessions), the second kill's committed snapshot still holds
  *   the first kill's row — filtering displayed data keeps it hidden.
- * - `populateCache` commits the filtered committed snapshot on success.
+ * - `populateCache` commits the committed snapshot filtered through the
+ *   {@link killsInFlight} registry, not just this kill's own name: the
+ *   snapshot SWR hands every settle predates ALL optimistic updates on the
+ *   key, so filtering one name would resurrect a concurrently-killed sibling
+ *   (leaving the detached revalidation as the only — possibly delayed,
+ *   possibly failing — repair).
  * - `rollbackOnError` restores the row when the DELETE genuinely fails — the
  *   unclaimed fallback row IS the recovery path (still reachable, still
  *   removable), and the error still throws to the caller.
@@ -93,7 +148,7 @@ export const withoutSession =
  *   in SWR 2.x, so a transient refetch failure can never turn a completed
  *   teardown into a rejection.
  */
-export const killMutateOptions = (name: string) => ({
+export const killMutateOptions = (key: string, name: string) => ({
   // SWR's MutatorOptions require a non-undefined cache value from these — an
   // unpopulated cache filters to an empty list (the row wasn't shown anyway),
   // and the detached revalidation reconciles it with server truth.
@@ -104,7 +159,7 @@ export const killMutateOptions = (name: string) => ({
   // from the promise) and a hook's bound one (no per-call generic in SWR
   // 2.4's KeyedMutator) — must accept this options object as-is.
   populateCache: (_result: unknown, committed: TerminalList) =>
-    withoutSession(name)(committed) ?? { agentTerminals: [] },
+    withoutSessions(killsInFlight.get(key)?.names ?? new Set([name]))(committed) ?? { agentTerminals: [] },
   rollbackOnError: true,
   revalidate: true,
 });
@@ -130,7 +185,9 @@ export async function killAgentTerminal(
   scope: { projectName?: string | null; branchName?: string | null; name: string },
 ): Promise<void> {
   const key = `/api/machines/agent-terminals?${buildQuery(machineId, scope.projectName, scope.branchName)}`;
-  await mutate(key, deleteAgentTerminalRequest(machineId, scope), killMutateOptions(scope.name));
+  await withKillRegistered(key, scope.name, () =>
+    mutate(key, deleteAgentTerminalRequest(machineId, scope), killMutateOptions(key, scope.name)),
+  );
 }
 
 /**
@@ -166,16 +223,18 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
   // a row already dead server-side must still be removable.
   const removeAgentTerminal = useCallback(
     async (name: string) => {
-      if (!machineId) throw new Error('No active machine');
+      if (!machineId || !key) throw new Error('No active machine');
       // `.then(() => undefined)` shapes the DELETE into the Promise<Data |
       // undefined> the bound mutate accepts; `populateCache` supplies the real
       // next cache value, so the undefined result is never written as data.
-      await mutate(
-        deleteAgentTerminalRequest(machineId, { projectName, branchName, name }).then(() => undefined),
-        killMutateOptions(name),
+      await withKillRegistered(key, name, () =>
+        mutate(
+          deleteAgentTerminalRequest(machineId, { projectName, branchName, name }).then(() => undefined),
+          killMutateOptions(key, name),
+        ),
       );
     },
-    [machineId, projectName, branchName, mutate],
+    [machineId, key, projectName, branchName, mutate],
   );
 
   return {

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -99,7 +99,11 @@ export const killMutateOptions = (name: string) => ({
   // and the detached revalidation reconciles it with server truth.
   optimisticData: (_committed: TerminalList, displayed: TerminalList) =>
     withoutSession(name)(displayed) ?? { agentTerminals: [] },
-  populateCache: (_result: void, committed: TerminalList) =>
+  // `_result` is `unknown` (not `void`): the DELETE resolves to nothing, but
+  // both mutate flavors this feeds — the global one (MutationData inferred
+  // from the promise) and a hook's bound one (no per-call generic in SWR
+  // 2.4's KeyedMutator) — must accept this options object as-is.
+  populateCache: (_result: unknown, committed: TerminalList) =>
     withoutSession(name)(committed) ?? { agentTerminals: [] },
   rollbackOnError: true,
   revalidate: true,
@@ -163,8 +167,11 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
   const removeAgentTerminal = useCallback(
     async (name: string) => {
       if (!machineId) throw new Error('No active machine');
+      // `.then(() => undefined)` shapes the DELETE into the Promise<Data |
+      // undefined> the bound mutate accepts; `populateCache` supplies the real
+      // next cache value, so the undefined result is never written as data.
       await mutate(
-        deleteAgentTerminalRequest(machineId, { projectName, branchName, name }),
+        deleteAgentTerminalRequest(machineId, { projectName, branchName, name }).then(() => undefined),
         killMutateOptions(name),
       );
     },

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -94,8 +94,13 @@ export const withoutSession =
  *   teardown into a rejection.
  */
 export const killMutateOptions = (name: string) => ({
-  optimisticData: (_committed: TerminalList, displayed: TerminalList) => withoutSession(name)(displayed),
-  populateCache: (_result: void, committed: TerminalList) => withoutSession(name)(committed),
+  // SWR's MutatorOptions require a non-undefined cache value from these — an
+  // unpopulated cache filters to an empty list (the row wasn't shown anyway),
+  // and the detached revalidation reconciles it with server truth.
+  optimisticData: (_committed: TerminalList, displayed: TerminalList) =>
+    withoutSession(name)(displayed) ?? { agentTerminals: [] },
+  populateCache: (_result: void, committed: TerminalList) =>
+    withoutSession(name)(committed) ?? { agentTerminals: [] },
   rollbackOnError: true,
   revalidate: true,
 });

--- a/apps/web/src/hooks/useAgentTerminals.ts
+++ b/apps/web/src/hooks/useAgentTerminals.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react';
 import useSWR, { mutate } from 'swr';
-import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import type { AgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 
 export interface AgentTerminal {
@@ -34,19 +34,11 @@ function buildQuery(machineId: string, projectName?: string | null, branchName?:
   return params.toString();
 }
 
+/** The hook's SWR cache value — `undefined` until the first GET lands. */
+type TerminalList = { agentTerminals: AgentTerminal[] } | undefined;
+
 /**
- * Kills a session addressed by its OWN (project, branch, name) scope — the
- * session's real identity (`machine_agent_terminals`' unique index).
- *
- * The hook's `removeAgentTerminal` below DELETEs under whatever scope the hook
- * instance was mounted with — right for undoing a spawn that same instance
- * just made, wrong for killing an arbitrary pane's session: a pane's scope can
- * differ from its workspace's (a restored server layout can hold panes bound
- * at other checkouts), and DELETEing that pane's `name` under the WORKSPACE's
- * scope would kill a different terminal that happens to share the name — or
- * nothing — while the intended one lives on as an unclaimed session.
- *
- * A 404 is SUCCESS here, not a failure: it means the session — or the
+ * The shared DELETE, with 404-as-success: a 404 means the session — or the
  * project/branch checkout that held it — is already gone server-side, which is
  * this call's goal state. Treating it as an error made a workspace holding a
  * stale pane permanently unremovable: the kill rejected, the confirm dialog
@@ -57,11 +49,8 @@ function buildQuery(machineId: string, projectName?: string | null, branchName?:
  * status needs `fetchWithAuth` directly — the `del()` helper throws a plain
  * `Error` with no status attached (see `pushWorkspaceUpdate`'s doc in
  * useMachineWorkspaceSync for the same choice).
- *
- * Revalidates the killed scope's list afterwards so any mounted hook on that
- * scope (e.g. the sidebar's session rows) drops the dead row.
  */
-export async function killAgentTerminal(
+async function deleteAgentTerminalRequest(
   machineId: string,
   scope: { projectName?: string | null; branchName?: string | null; name: string },
 ): Promise<void> {
@@ -74,11 +63,65 @@ export async function killAgentTerminal(
     const body: { error?: unknown } | null = await response.json().catch(() => null);
     throw new Error(typeof body?.error === 'string' ? body.error : 'Failed to remove terminal');
   }
-  // Fire-and-forget: the kill has already succeeded by this point, and a
-  // transient failure of the list REFETCH must not turn a completed teardown
-  // into a rejection — that would keep the remove-workspace dialog open (and
-  // fail closePaneAndKill's catch path) over a session that is already dead.
-  void mutate(`/api/machines/agent-terminals?${query}`).catch(() => {});
+}
+
+/** Pure: the cached list minus the named row; `undefined` cache passes through. */
+export const withoutSession =
+  (name: string) =>
+  (list: TerminalList): TerminalList =>
+    list ? { agentTerminals: list.agentTerminals.filter((terminal) => terminal.name !== name) } : list;
+
+/**
+ * The optimistic-mutation contract every session removal runs under. The
+ * sidebar's "unclaimed session" rows are a set-difference between this cache
+ * and the workspace store's panes — a pane close mutates the store
+ * synchronously, so the row must leave this cache in the SAME tick, or the
+ * session resurfaces as an orphan row for at least a frame (and forever if
+ * the round-trip fails silently). Mutate applies `optimisticData`
+ * synchronously within the call, which is what makes close-and-kill one
+ * batched render.
+ *
+ * - `optimisticData` filters the DISPLAYED data, not the committed snapshot:
+ *   with two concurrent kills on one key (a workspace removal killing several
+ *   same-scope sessions), the second kill's committed snapshot still holds
+ *   the first kill's row — filtering displayed data keeps it hidden.
+ * - `populateCache` commits the filtered committed snapshot on success.
+ * - `rollbackOnError` restores the row when the DELETE genuinely fails — the
+ *   unclaimed fallback row IS the recovery path (still reachable, still
+ *   removable), and the error still throws to the caller.
+ * - `revalidate` reconciles with server truth after settling; it is detached
+ *   in SWR 2.x, so a transient refetch failure can never turn a completed
+ *   teardown into a rejection.
+ */
+export const killMutateOptions = (name: string) => ({
+  optimisticData: (_committed: TerminalList, displayed: TerminalList) => withoutSession(name)(displayed),
+  populateCache: (_result: void, committed: TerminalList) => withoutSession(name)(committed),
+  rollbackOnError: true,
+  revalidate: true,
+});
+
+/**
+ * Kills a session addressed by its OWN (project, branch, name) scope — the
+ * session's real identity (`machine_agent_terminals`' unique index).
+ *
+ * The hook's `removeAgentTerminal` below DELETEs under whatever scope the hook
+ * instance was mounted with — right for undoing a spawn that same instance
+ * just made, wrong for killing an arbitrary pane's session: a pane's scope can
+ * differ from its workspace's (a restored server layout can hold panes bound
+ * at other checkouts), and DELETEing that pane's `name` under the WORKSPACE's
+ * scope would kill a different terminal that happens to share the name — or
+ * nothing — while the intended one lives on as an unclaimed session.
+ *
+ * The DELETE runs inside an optimistic mutation (see {@link killMutateOptions})
+ * so the row leaves the killed scope's list synchronously — the same tick as
+ * the caller's `closePane` — and rolls back only on genuine failure.
+ */
+export async function killAgentTerminal(
+  machineId: string,
+  scope: { projectName?: string | null; branchName?: string | null; name: string },
+): Promise<void> {
+  const key = `/api/machines/agent-terminals?${buildQuery(machineId, scope.projectName, scope.branchName)}`;
+  await mutate(key, deleteAgentTerminalRequest(machineId, scope), killMutateOptions(scope.name));
 }
 
 /**
@@ -108,11 +151,17 @@ export function useAgentTerminals(machineId: string | null, projectName?: string
     [machineId, projectName, branchName, mutate],
   );
 
+  // The hook's BOUND mutate (not the global one): it targets this instance's
+  // cache through whatever SWR provider is active, and shares the exact
+  // optimistic/rollback/404-as-success contract as `killAgentTerminal` —
+  // a row already dead server-side must still be removable.
   const removeAgentTerminal = useCallback(
     async (name: string) => {
       if (!machineId) throw new Error('No active machine');
-      await del(`/api/machines/agent-terminals?${buildQuery(machineId, projectName, branchName)}&name=${encodeURIComponent(name)}`);
-      await mutate();
+      await mutate(
+        deleteAgentTerminalRequest(machineId, { projectName, branchName, name }),
+        killMutateOptions(name),
+      );
     },
     [machineId, projectName, branchName, mutate],
   );

--- a/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/useMachineWorkspaceStore.test.ts
@@ -26,7 +26,7 @@ const seedMachine = (machineId: string) => {
 };
 
 const BRANCH_SCOPE = { projectName: 'app', branchName: 'main' };
-const SESSION = { ...BRANCH_SCOPE, name: 'claude-a1b2c3' };
+const SESSION = { ...BRANCH_SCOPE, name: 'shell-a1b2c3' };
 
 describe('useMachineWorkspaceStore', () => {
   beforeEach(() => {
@@ -422,7 +422,7 @@ describe('useMachineWorkspaceStore', () => {
   it('given a persisted blob this version CAN render, should restore the grid', () => {
     const workspace = {
       id: 'ws-1',
-      name: 'claude-a1b2c3',
+      name: 'shell-a1b2c3',
       scope: BRANCH_SCOPE,
       columns: [
         { id: 'c1', panes: [{ id: 'p1', scope: SESSION, pendingPrompt: 'stale prompt' }] },
@@ -484,7 +484,7 @@ describe('useMachineWorkspaceStore', () => {
     // One session opened from the sidebar (its own workspace), one spawned into it.
     store().openTerminal('m1', SESSION);
     const sessionWorkspace = activeOf('m1')!;
-    const spawned = { ...BRANCH_SCOPE, name: 'codex-b2c3d4' };
+    const spawned = { ...BRANCH_SCOPE, name: 'shell-b2c3d4' };
     store().splitRight('m1', sessionWorkspace.id, sessionWorkspace.activePaneId);
     store().bindPaneTerminal(
       'm1',
@@ -586,7 +586,7 @@ describe('useMachineWorkspaceStore', () => {
         id: 'ws-1',
         name: 'Workspace 1',
         scope: {},
-        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } }] }],
+        columns: [{ id: 'col-1', panes: [{ id: 'pane-1', scope: { name: 'pagespace-a1', kind: 'chat' } }] }],
       },
     ]);
 
@@ -594,7 +594,7 @@ describe('useMachineWorkspaceStore', () => {
       given: "the sync hook's initial hydrate carrying a pane tagged kind: 'chat'",
       should: 'round-trip the content kind into the store',
       actual: panesOf(activeOf('m1')!)[0]?.scope,
-      expected: { name: 'claude-a1', kind: 'chat' },
+      expected: { name: 'pagespace-a1', kind: 'chat' },
     });
   });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminal-types.test.ts
@@ -12,8 +12,7 @@ import {
 
 describe('isAgentRuntimeType', () => {
   it('given each first-party agent type, should recognize it', () => {
-    expect(isAgentRuntimeType('claude')).toBe(true);
-    expect(isAgentRuntimeType('codex')).toBe(true);
+    expect(isAgentRuntimeType('pagespace')).toBe(true);
     expect(isAgentRuntimeType('shell')).toBe(true);
   });
 
@@ -23,51 +22,45 @@ describe('isAgentRuntimeType', () => {
     expect(isAgentRuntimeType('constructor')).toBe(false);
   });
 
-  it('given the retired pagespace-cli agent type, should reject it as unrecognized (not crash)', () => {
+  it('given a retired agent type, should reject it as unrecognized (not crash)', () => {
+    // Retired types' DB rows degrade to remove-only sidebar listings — the
+    // registry must NOT resurrect them as launchable.
     expect(isAgentRuntimeType('pagespace-cli')).toBe(false);
-  });
-
-  it('given the pagespace agent type, should recognize it', () => {
-    expect(isAgentRuntimeType('pagespace')).toBe(true);
+    expect(isAgentRuntimeType('claude')).toBe(false);
+    expect(isAgentRuntimeType('codex')).toBe(false);
   });
 });
 
 describe('resolveAgentLaunchSpec', () => {
-  it('given claude, should resolve the claude binary', () => {
-    expect(resolveAgentLaunchSpec('claude')).toEqual({ command: 'claude', args: [] });
-  });
-
-  it('given codex, should resolve the codex binary', () => {
-    expect(resolveAgentLaunchSpec('codex')).toEqual({ command: 'codex', args: [] });
-  });
-
   it('given shell, should resolve the "shell" sentinel command (resolved to $SHELL by the launching layer)', () => {
     expect(resolveAgentLaunchSpec('shell')).toEqual({ command: 'shell', args: [] });
   });
 
   it('given two resolutions, should return independent arrays (no shared mutable state)', () => {
-    const a = resolveAgentLaunchSpec('claude');
+    const a = resolveAgentLaunchSpec('shell');
     a.args.push('--danger');
-    const b = resolveAgentLaunchSpec('claude');
+    const b = resolveAgentLaunchSpec('shell');
     expect(b.args).toEqual([]);
   });
 
-  it('should expose a registry entry for every AgentRuntimeType', () => {
-    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['shell', 'claude', 'codex', 'pagespace']);
+  it('should expose a registry entry for every AgentRuntimeType, Agent first', () => {
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).toEqual(['pagespace', 'shell']);
   });
 
-  it('should not expose a registry entry for the retired pagespace-cli agent type', () => {
+  it('should not expose registry entries for retired agent types', () => {
     expect(Object.keys(AGENT_LAUNCH_SPECS)).not.toContain('pagespace-cli');
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).not.toContain('claude');
+    expect(Object.keys(AGENT_LAUNCH_SPECS)).not.toContain('codex');
   });
 });
 
 describe('PICKABLE_AGENT_TYPES', () => {
-  it('should include shell (primary) plus claude, codex, and pagespace (secondary) — only the retired pagespace-cli is excluded', () => {
-    expect(PICKABLE_AGENT_TYPES).toEqual(['shell', 'claude', 'codex', 'pagespace']);
+  it('should be exactly pagespace and shell — claude/codex are retired alongside pagespace-cli', () => {
+    expect(PICKABLE_AGENT_TYPES).toEqual(['pagespace', 'shell']);
   });
 
-  it('should list shell FIRST — a plain interactive shell is the default, primary way to work on a Machine', () => {
-    expect(PICKABLE_AGENT_TYPES[0]).toBe('shell');
+  it('should list pagespace FIRST — the Agent is the default, primary way to work on a Machine', () => {
+    expect(PICKABLE_AGENT_TYPES[0]).toBe('pagespace');
   });
 });
 
@@ -76,10 +69,8 @@ describe('agentSurfaceOf', () => {
     expect(agentSurfaceOf('pagespace')).toBe('chat');
   });
 
-  it('given shell, claude, or codex, should return pty', () => {
+  it('given shell, should return pty', () => {
     expect(agentSurfaceOf('shell')).toBe('pty');
-    expect(agentSurfaceOf('claude')).toBe('pty');
-    expect(agentSurfaceOf('codex')).toBe('pty');
   });
 });
 
@@ -88,10 +79,8 @@ describe('isPtyAgentType', () => {
     expect(isPtyAgentType('pagespace')).toBe(false);
   });
 
-  it('given shell, claude, or codex, should return true', () => {
+  it('given shell, should return true', () => {
     expect(isPtyAgentType('shell')).toBe(true);
-    expect(isPtyAgentType('claude')).toBe(true);
-    expect(isPtyAgentType('codex')).toBe(true);
   });
 });
 

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -199,11 +199,11 @@ describe('deriveAgentTerminalScope', () => {
 
 describe('planSpawnAgentTerminal', () => {
   it('given a valid name and known agent type, should allow it', () => {
-    expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'claude' })).toEqual({ ok: true });
+    expect(planSpawnAgentTerminal({ name: 'reviewer', agentType: 'shell' })).toEqual({ ok: true });
   });
 
   it('given an invalid name, should reject it', () => {
-    expect(planSpawnAgentTerminal({ name: '../etc', agentType: 'claude' })).toEqual({
+    expect(planSpawnAgentTerminal({ name: '../etc', agentType: 'shell' })).toEqual({
       ok: false,
       reason: 'invalid_name',
     });
@@ -243,7 +243,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -256,14 +256,14 @@ describe('spawnAgentTerminal — branch scope', () => {
       machineId: TERMINAL_ID,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
     expect(result).toEqual({ ok: false, reason: 'invalid_target' });
   });
 
-  it('given a fresh name, should reserve a claude agent terminal keyed to the branch with scope="branch"', async () => {
+  it('given a fresh name, should reserve a shell agent terminal keyed to the branch with scope="branch"', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
     const result = await spawnAgentTerminal({
@@ -271,13 +271,13 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'shell', resumed: false });
     const row = [...rows.values()][0];
-    expect(row).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, projectName: PROJECT_NAME, agentType: 'claude', command: null });
+    expect(row).toMatchObject({ scope: 'branch', machineBranchId: BRANCH_ID, projectName: PROJECT_NAME, agentType: 'shell', command: null });
   });
 
   it('given a command override, should persist it on the row', async () => {
@@ -297,7 +297,7 @@ describe('spawnAgentTerminal — branch scope', () => {
     expect(row.command).toBe('htop');
   });
 
-  it('given a second, differently-named spawn in the SAME branch, should let a claude terminal coexist with a codex one', async () => {
+  it('given a second, differently-named spawn in the SAME branch, should let a shell terminal coexist with a pagespace one', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
 
@@ -306,23 +306,23 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'codex',
+      agentType: 'pagespace',
       actor,
       deps,
     });
-    const claudeResult = await spawnAgentTerminal({
+    const shellResult = await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'reviewer',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
 
-    expect(claudeResult).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
+    expect(shellResult).toMatchObject({ ok: true, agentType: 'shell', resumed: false });
     expect(rows.size).toBe(2);
-    expect([...rows.values()].map((r) => r.agentType).sort()).toEqual(['claude', 'codex']);
+    expect([...rows.values()].map((r) => r.agentType).sort()).toEqual(['pagespace', 'shell']);
   });
 
   it('given a repeat spawn of the same (name, agentType), should resume idempotently rather than duplicate', async () => {
@@ -334,7 +334,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -343,7 +343,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -361,7 +361,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'agent',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -370,7 +370,7 @@ describe('spawnAgentTerminal — branch scope', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'agent',
-      agentType: 'codex',
+      agentType: 'pagespace',
       actor,
       deps,
     });
@@ -386,7 +386,7 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -399,7 +399,7 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -413,11 +413,11 @@ describe('spawnAgentTerminal — project scope', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'shell', resumed: false });
     const row = [...rows.values()][0];
     expect(row).toMatchObject({ scope: 'project', projectName: PROJECT_NAME, machineBranchId: null });
   });
@@ -430,11 +430,11 @@ describe('spawnAgentTerminal — machine scope', () => {
     const result = await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
-    expect(result).toMatchObject({ ok: true, agentType: 'claude', resumed: false });
+    expect(result).toMatchObject({ ok: true, agentType: 'shell', resumed: false });
     const row = [...rows.values()][0];
     expect(row).toMatchObject({ scope: 'machine', machineId: TERMINAL_ID, projectName: null, machineBranchId: null });
   });
@@ -459,7 +459,7 @@ describe('spawnAgentTerminal — machine scope', () => {
     const result = await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -522,10 +522,10 @@ describe('spawnAgentTerminal — pagespace (chat-surface) has NO spawn-side type
     expect(second).toMatchObject({ resumed: true });
   });
 
-  it('given the same name reused under a DIFFERENT agent type (claude then pagespace), should reject as name_in_use', async () => {
+  it('given the same name reused under a DIFFERENT agent type (shell then pagespace), should reject as name_in_use', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'shell', actor, deps });
     const conflicting = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'agent', agentType: 'pagespace', actor, deps });
     expect(conflicting).toEqual({ ok: false, reason: 'name_in_use' });
   });
@@ -540,11 +540,11 @@ describe('resolveAgentTerminalRow', () => {
   it('given a machine-scoped terminal, should resolve the row WITHOUT any machineSandbox', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, machineSandbox: undefined });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await resolveAgentTerminalRow({ machineId: TERMINAL_ID, name: 'cli', deps });
 
-    expect(result).toEqual({ ok: true, agentTerminalId: expect.any(String), agentType: 'claude' });
+    expect(result).toEqual({ ok: true, agentTerminalId: expect.any(String), agentType: 'shell' });
   });
 
   it('given a project-scoped terminal whose project row is GONE, should deny project_not_found without a Sprite', async () => {
@@ -653,7 +653,7 @@ describe('resolveAgentTerminal', () => {
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -671,7 +671,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: BRANCH_SANDBOX_ID,
       cwd: BRANCH_REPO_PATH,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -693,7 +693,7 @@ describe('resolveAgentTerminal', () => {
       machineId: TERMINAL_ID,
       projectName: PROJECT_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -710,7 +710,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: PROJECT_PATH,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -723,7 +723,7 @@ describe('resolveAgentTerminal', () => {
     await spawnAgentTerminal({
       machineId: TERMINAL_ID,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -739,7 +739,7 @@ describe('resolveAgentTerminal', () => {
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: SANDBOX_ROOT,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -748,7 +748,7 @@ describe('resolveAgentTerminal', () => {
   it('given the machine Sprite fails to acquire, should deny as machine_unavailable', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const failingDeps = { ...deps, machineSandbox: makeMachineSandbox({ acquire: async () => ({ ok: false, reason: 'provision_failed' }) }) };
     const result = await resolveAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', deps: failingDeps });
@@ -827,7 +827,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       projectName: PROJECT_NAME,
       branchName: BRANCH_NAME,
       name: 'cli',
-      agentType: 'claude',
+      agentType: 'shell',
       actor,
       deps,
     });
@@ -841,7 +841,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: BRANCH_SANDBOX_ID,
       cwd: BRANCH_REPO_PATH,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -851,7 +851,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a project-scoped row id, should resolve the SAME machine Sprite with cwd=project.path', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
@@ -860,7 +860,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: PROJECT_PATH,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -869,7 +869,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a machine-scoped row id, should resolve the machine Sprite with cwd=SANDBOX_ROOT', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store, projectStore: makeProjectLookup() });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 
@@ -878,7 +878,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
       agentTerminalId: 'agent-terminal-1',
       sandboxId: MACHINE_SANDBOX_ID,
       cwd: SANDBOX_ROOT,
-      agentType: 'claude',
+      agentType: 'shell',
       command: null,
       streamSessionId: null,
     });
@@ -887,7 +887,7 @@ describe('resolveAgentTerminalById — level-agnostic (PurePoint Attach{agent_id
   it('given a row whose branch has vanished, should deny as branch_not_found', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'shell', actor, deps });
 
     const goneDeps = { ...deps, branchStore: makeBranchLookup() };
     const result = await resolveAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps: goneDeps });
@@ -921,10 +921,10 @@ describe('listAgentTerminals', () => {
   it('given two agent terminals spawned in one branch, should list both without leaking the project/machine-scoped ones', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'reviewer', agentType: 'claude', actor, deps });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'project-cli', agentType: 'claude', actor, deps });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'machine-cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'shell', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'reviewer', agentType: 'shell', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'project-cli', agentType: 'shell', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'machine-cli', agentType: 'shell', actor, deps });
 
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, deps });
 
@@ -935,7 +935,7 @@ describe('listAgentTerminals', () => {
   it('given a machine scope with zero spawned terminals, should list empty rather than surfacing project/branch ones', async () => {
     const { store } = makeStore();
     const deps = makeDeps({ store });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, deps });
 
@@ -945,7 +945,7 @@ describe('listAgentTerminals', () => {
   it('given a legacy row whose agentType is the retired pagespace-cli, should STILL list it — dropping it would strand it with no way to clean it up', async () => {
     const { store } = makeStore([makeLegacyRow()]);
     const deps = makeDeps({ store });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await listAgentTerminals({ machineId: TERMINAL_ID, deps });
 
@@ -974,7 +974,7 @@ describe('killAgentTerminal', () => {
       store,
       host: makeHost({ attach: async ({ machineId }) => { attachCalls.push(machineId); return makeHandle(); } }),
     });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', deps });
 
@@ -995,7 +995,7 @@ describe('killAgentTerminal', () => {
         },
       }),
     });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, name: 'cli', deps });
 
@@ -1017,7 +1017,7 @@ describe('killAgentTerminal', () => {
         },
       }),
     });
-    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await killAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', deps });
 
@@ -1061,7 +1061,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1100,7 +1100,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: null,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-proj',
         createdAt: NOW,
@@ -1137,7 +1137,7 @@ describe('killAgentTerminal', () => {
         projectName: null,
         machineBranchId: null,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-machine',
         createdAt: NOW,
@@ -1175,7 +1175,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1205,7 +1205,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-dangling',
         createdAt: NOW,
@@ -1235,7 +1235,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1272,7 +1272,7 @@ describe('killAgentTerminal', () => {
         projectName: PROJECT_NAME,
         machineBranchId: BRANCH_ID,
         name: 'cli',
-        agentType: 'claude',
+        agentType: 'shell',
         command: null,
         streamSessionId: 'sess-abc',
         createdAt: NOW,
@@ -1305,7 +1305,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
   it('given a branch-scoped row id whose PTY IS running, should kill it purely by id (no project/branch name needed)', async () => {
     const { store, rows } = makeStore();
     const deps = makeDeps({ store });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'claude', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, projectName: PROJECT_NAME, branchName: BRANCH_NAME, name: 'cli', agentType: 'shell', actor, deps });
     const id = spawned.ok ? spawned.id : '';
     await store.updateStreamSessionId({ id, streamSessionId: 'sess-abc', now: NOW });
 
@@ -1340,7 +1340,7 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
         },
       }),
     });
-    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'claude', actor, deps });
+    const spawned = await spawnAgentTerminal({ machineId: TERMINAL_ID, name: 'cli', agentType: 'shell', actor, deps });
 
     const result = await killAgentTerminalById({ agentTerminalId: spawned.ok ? spawned.id : '', deps });
 

--- a/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-pane-binding.test.ts
@@ -61,7 +61,7 @@ describe('deriveMachinePaneBinding', () => {
   });
 
   it('given a non-pagespace (pty-surface) row, should return null', async () => {
-    const row = makeRow({ agentType: 'claude' });
+    const row = makeRow({ agentType: 'shell' });
     const deps = makeDeps({ terminalStore: makeTerminalStore(row) });
     const result = await deriveMachinePaneBinding({ chatId: MACHINE_ID, conversationId: CONVERSATION_ID }, deps);
     expect(result).toBeNull();

--- a/packages/lib/src/services/machines/agent-terminal-types.ts
+++ b/packages/lib/src/services/machines/agent-terminal-types.ts
@@ -22,14 +22,18 @@
  * `process.env.SHELL`) that belongs to whichever layer actually spawns the
  * PTY (the realtime bridge), not this pure module.
  *
- * `pickable` gates the empty-pane "spawn an agent" picker (`TerminalPanes.tsx`
- * — see `PICKABLE_AGENT_TYPES` below). `shell` is PRIMARY here — a plain
- * interactive shell is the default, first-class way to work on a Machine —
- * with `claude`/`codex`/`pagespace` as secondary, opt-in AI agents. Only the
- * retired `pagespace-cli` is excluded. Keeping the marker on the registry
- * entry itself (rather than a hardcoded list living in the UI file) is what
- * keeps the picker in sync when a new entry is added here: forgetting to set
- * `pickable: true` fails safe (excluded, not silently spawnable).
+ * `pickable` gates the spawn pickers (`TerminalPanes.tsx`'s empty-pane picker
+ * and `NodeActionPalette`'s "+" palette — see `PICKABLE_AGENT_TYPES` below).
+ * `pagespace` (the Agent) is PRIMARY — listed first, the default way to work
+ * on a Machine — with `shell` as the plain-PTY secondary. `claude`/`codex`
+ * are RETIRED alongside `pagespace-cli`: their existing DB rows degrade to
+ * unlaunchable, remove-only sidebar listings (the list endpoint is
+ * deliberately unfiltered — see `listAgentTerminals`), and new spawns of a
+ * retired type are rejected as `invalid_agent_type`. Keeping the marker on
+ * the registry entry itself (rather than a hardcoded list living in the UI
+ * file) is what keeps the pickers in sync when a new entry is added here:
+ * forgetting to set `pickable: true` fails safe (excluded, not silently
+ * spawnable), and the object's key ORDER is the pickers' display order.
  *
  * `surface` is the rendering discriminator every pane-hosting layer branches
  * on: `'pty'` types spawn a real PTY process (`command`/`args` are launched
@@ -39,10 +43,8 @@
  * should use rather than reading `.surface` off the registry directly.
  */
 export const AGENT_LAUNCH_SPECS = {
-  shell: { command: 'shell', args: [], pickable: true, surface: 'pty' },
-  claude: { command: 'claude', args: [], pickable: true, surface: 'pty' },
-  codex: { command: 'codex', args: [], pickable: true, surface: 'pty' },
   pagespace: { command: 'pagespace', args: [], pickable: true, surface: 'chat' },
+  shell: { command: 'shell', args: [], pickable: true, surface: 'pty' },
 } as const satisfies Record<
   string,
   { command: string; args: readonly string[]; pickable: boolean; surface: 'pty' | 'chat' }


### PR DESCRIPTION
## Summary

Three coordinated fixes to the Machine terminal workspace (follow-up to epic #2166), built incrementally with TDD and pure functions:

### 1. Pane close never orphans its sidebar listing
Closing a pane mutated the workspace store synchronously while the session kill revalidated on a fire-and-forget round-trip — the killed session resurfaced in the sidebar as an "unclaimed" row (forever, when the refetch failed silently). `killAgentTerminal`/`removeAgentTerminal` now run their DELETE inside an **optimistic SWR mutation**: the row leaves the cache in the same tick as `closePane` (one batched render), commits on success, and **rolls back** — restoring the unclaimed fallback row — only when the kill genuinely fails. 404 is success on both paths, which also makes already-dead rows removable (`del()` used to throw on 404). New `useAgentTerminals` test suite covers optimistic removal, 404-as-success, rollback, and concurrent kills on one key.

### 2. Raycast palette: Agent · Shell · Add project/branch — instant spawn
The nested "New terminal" phase (agent-type dropdown + prompt form) is gone. The "+" palette lists **Agent** (pagespace, relabeled from "PageSpace Agent") and **Shell** as instant spawns — click closes the palette, spawns into a fresh workspace at that node's scope, navigates on resolve — plus the contextual structural action. The empty-pane picker gets the same two instant buttons. **claude/codex are retired from `AGENT_LAUNCH_SPECS`** (registry reordered Agent-first; key order is picker display order): existing DB rows degrade to unlaunchable remove-only listings (pagespace-cli precedent), new spawns reject as `invalid_agent_type` with zero server edits.

### 3. Universal pane bar replaces floating chrome
Every pane wears one slim `PaneBar` — identity left (session name + checkout chip, or agent picker), split/close right, **bar tint as the focus state**. This retires the hover-revealed floating chip (which physically covered the chat pane's header tabs) and the 2px accent line. Chat panes render exactly one bar: `MachinePaneChat` merges the pane controls (threaded down as data) after its picker/tabs, and folds everything but close into a ⋯ overflow menu below 360px container width. Actions dim instead of hiding — no coarse-pointer escape hatch needed.

Design canvas (approved): https://claude.ai/code/artifact/5fe8279c-64e4-4d8a-a929-0278deef5e13

## Verification
- `bun run typecheck` ✅ (16/16) · `bun run lint` ✅ · `bun run knip:check` ✅ (5/5 baseline)
- Machine-surface suites green: 337 apps/web + 580 packages/lib machines + 884 apps/realtime
- Full apps/web run: only pre-existing env failures in untouched files (DB-dependent auth tests without the test container; a TZ-sensitive `grouping` midnight test; a parallelism-flaky `MachineFileTree` case that passes in isolation). `apps/processor` magika failures are environmental (model asset) — zero lines of this branch touch processor.
- Note: `bun run changelog:generate` points at `scripts/changelog/`, which was removed in #1044 — stale script entry, nothing to regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lfi3ckdwDHPzKPGFriJik

## Review response (aa0282824)
All three Codex findings addressed (threads left open for verification):
1. **Concurrent-kill commit resurrection (P1)** — real; reproduced with an out-of-order-settle test under hung revalidation, fixed with a per-key `killsInFlight` registry so every settle's `populateCache` filters ALL sibling kills' rows (failed kills deregister so their rollback row returns).
2. **Chat missing from the narrow-pane overflow menu (P1)** — Chat now leads the menu; test drives Settings → menu → Chat without the TabsList.
3. **Menu clicks re-selecting the source pane through the portal (P2)** — `DropdownMenuContent` carries the same `stopPropagation` guard as the bar's buttons; pinned by a bubbling test.
