### PR TITLE
fix(auth): stop desktop logout at the source — main-process token cache + native-shell nav gate

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -34,6 +34,7 @@ vi.mock('../store', () => ({ store: { set: vi.fn() } }));
 vi.mock('../app-url', () => ({ getAppUrl: vi.fn(() => 'https://pagespace.ai/dashboard') }));
 vi.mock('../state', () => ({
   mainWindow: null,
+  setCachedSession: vi.fn(),
 }));
 vi.mock('../window', () => ({ reloadMainWindow: vi.fn() }));
 vi.mock('../mcp-manager', () => ({ getMCPManager: vi.fn(() => ({ setOnToolsReady: vi.fn() })) }));

--- a/apps/desktop/src/main/__tests__/store-session-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/store-session-cache.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Unlike ipc-handlers.test.ts (which mocks ../state and ../auth-session away),
+// this suite runs the REAL main-process session cache: real ./state module
+// state, real getOrLoadSession, real IPC handlers. The bug under test is the
+// interplay between them — auth:store-session persisted a refreshed token to
+// disk + cookie jar but never updated the in-memory cachedSession, so every
+// subsequent getOrLoadSession()/auth:get-session-token kept serving the STALE
+// startup token until sleep/wake or app restart (the desktop "random logout").
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.0.0'),
+    getPath: vi.fn(() => '/tmp/userData'),
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  session: {
+    defaultSession: {
+      cookies: {
+        set: vi.fn(),
+      },
+      clearStorageData: vi.fn(),
+    },
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+vi.mock('node:os', () => ({
+  default: {
+    hostname: vi.fn(() => 'test-host'),
+    type: vi.fn(() => 'Darwin'),
+    release: vi.fn(() => '25.0'),
+  },
+  hostname: vi.fn(() => 'test-host'),
+  type: vi.fn(() => 'Darwin'),
+  release: vi.fn(() => '25.0'),
+}));
+
+vi.mock('node-machine-id', () => ({
+  default: { machineIdSync: vi.fn(() => 'machine-id') },
+}));
+
+vi.mock('../store', () => ({ store: { set: vi.fn() } }));
+vi.mock('../app-url', () => ({ getAppUrl: vi.fn(() => 'https://pagespace.ai/dashboard') }));
+vi.mock('../window', () => ({ reloadMainWindow: vi.fn() }));
+vi.mock('../mcp-manager', () => ({ getMCPManager: vi.fn(() => ({ setOnToolsReady: vi.fn() })) }));
+vi.mock('../ws-client', () => ({ getWSClient: vi.fn() }));
+vi.mock('../logger', () => ({ logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('../error-utils', () => ({
+  getErrorMessage: vi.fn((e: unknown) => String(e)),
+  hasErrorCode: vi.fn(() => false),
+}));
+vi.mock('../auth-storage', () => ({
+  saveAuthSession: vi.fn(),
+  clearAuthSession: vi.fn(),
+  loadAuthSession: vi.fn(),
+}));
+vi.mock('../power-monitor', () => ({ getPowerState: vi.fn() }));
+vi.mock('../mcp-status', () => ({ triggerMCPStatusBroadcast: vi.fn() }));
+
+import { ipcMain } from 'electron';
+import { saveAuthSession, loadAuthSession, type StoredAuthSession } from '../auth-storage';
+import { setCachedSession } from '../state';
+import { getOrLoadSession } from '../auth-session';
+import { registerIPCHandlers } from '../ipc-handlers';
+
+const trustedEvent = { senderFrame: { url: 'https://pagespace.ai/dashboard' } };
+const untrustedEvent = { senderFrame: { url: 'https://evil.com/x' } };
+
+function getRegisteredHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  const calls = vi.mocked(ipcMain.handle).mock.calls;
+  const match = calls.find(([ch]) => ch === channel);
+  if (!match) throw new Error(`No handler registered for channel: ${channel}`);
+  return match[1] as (...args: unknown[]) => Promise<unknown>;
+}
+
+const OLD_SESSION: StoredAuthSession = {
+  sessionToken: 'ps_sess_OLD_startup_token',
+  csrfToken: 'csrf_old',
+  deviceToken: 'ps_dev_old',
+};
+
+const NEW_SESSION: StoredAuthSession = {
+  sessionToken: 'ps_sess_NEW_refreshed_token',
+  csrfToken: 'csrf_new',
+  deviceToken: 'ps_dev_new',
+};
+
+describe('main-process session cache stays fresh across auth:store-session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the real module-level cache to its process-startup state.
+    setCachedSession(undefined);
+    registerIPCHandlers();
+    vi.mocked(saveAuthSession).mockResolvedValue(undefined);
+    vi.mocked(loadAuthSession).mockResolvedValue(OLD_SESSION);
+  });
+
+  it('getOrLoadSession() returns the NEW token immediately after auth:store-session (not the cached startup token)', async () => {
+    // Startup: cache primes itself from disk with the OLD token.
+    expect((await getOrLoadSession())?.sessionToken).toBe(OLD_SESSION.sessionToken);
+
+    // The renderer refreshes and stores the NEW session via IPC.
+    const storeHandler = getRegisteredHandler('auth:store-session');
+    await storeHandler(trustedEvent, NEW_SESSION);
+
+    // The cache must serve the refreshed token — no restart/sleep-wake needed.
+    expect((await getOrLoadSession())?.sessionToken).toBe(NEW_SESSION.sessionToken);
+  });
+
+  it('auth:get-session-token reflects the new token immediately after a store', async () => {
+    await getOrLoadSession(); // prime cache with OLD
+
+    const storeHandler = getRegisteredHandler('auth:store-session');
+    await storeHandler(trustedEvent, NEW_SESSION);
+
+    const tokenHandler = getRegisteredHandler('auth:get-session-token');
+    expect(await tokenHandler(trustedEvent)).toBe(NEW_SESSION.sessionToken);
+  });
+
+  it('auth:get-session reflects the full new session immediately after a store', async () => {
+    await getOrLoadSession(); // prime cache with OLD
+
+    const storeHandler = getRegisteredHandler('auth:store-session');
+    await storeHandler(trustedEvent, NEW_SESSION);
+
+    const sessionHandler = getRegisteredHandler('auth:get-session');
+    expect(await sessionHandler(trustedEvent)).toEqual(NEW_SESSION);
+  });
+
+  it('regression: startup behavior unchanged — first read loads from disk, later reads hit the cache', async () => {
+    const first = await getOrLoadSession();
+    const second = await getOrLoadSession();
+
+    expect(first?.sessionToken).toBe(OLD_SESSION.sessionToken);
+    expect(second?.sessionToken).toBe(OLD_SESSION.sessionToken);
+    // Only the first call touches disk; the cache answers afterwards.
+    expect(loadAuthSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('regression: a resume-style cache reset (setCachedSession(undefined)) still re-reads from disk', async () => {
+    await getOrLoadSession();
+    setCachedSession(undefined); // what the power-monitor resume path does
+
+    vi.mocked(loadAuthSession).mockResolvedValue(NEW_SESSION);
+    expect((await getOrLoadSession())?.sessionToken).toBe(NEW_SESSION.sessionToken);
+    expect(loadAuthSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('security regression: an untrusted sender cannot poison the cache via auth:store-session', async () => {
+    await getOrLoadSession(); // prime cache with OLD
+
+    const storeHandler = getRegisteredHandler('auth:store-session');
+    const result = await storeHandler(untrustedEvent, {
+      sessionToken: 'ps_sess_ATTACKER',
+      csrfToken: 'x',
+      deviceToken: 'y',
+    });
+
+    expect(result).toEqual({ success: false });
+    expect((await getOrLoadSession())?.sessionToken).toBe(OLD_SESSION.sessionToken);
+  });
+
+  it('does not cache a session whose persistence failed (cache only updates after a successful save)', async () => {
+    await getOrLoadSession(); // prime cache with OLD
+    vi.mocked(saveAuthSession).mockRejectedValue(new Error('disk full'));
+
+    const storeHandler = getRegisteredHandler('auth:store-session');
+    await expect(storeHandler(trustedEvent, NEW_SESSION)).rejects.toThrow('disk full');
+
+    expect((await getOrLoadSession())?.sessionToken).toBe(OLD_SESSION.sessionToken);
+  });
+
+  it('auth:clear-auth invalidates the in-memory cache so a known-bad token cannot persist', async () => {
+    await getOrLoadSession(); // prime cache with OLD
+
+    const clearHandler = getRegisteredHandler('auth:clear-auth');
+    await clearHandler(trustedEvent);
+
+    // After a clear, the session file is gone — the cache must not keep
+    // serving the retired token.
+    vi.mocked(loadAuthSession).mockResolvedValue(null);
+    expect(await getOrLoadSession()).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -2,7 +2,7 @@ import * as os from 'node:os';
 import { app, ipcMain, session, shell } from 'electron';
 import { store } from './store';
 import { getAppUrl } from './app-url';
-import { mainWindow } from './state';
+import { mainWindow, setCachedSession } from './state';
 import { reloadMainWindow } from './window';
 import { getMCPManager } from './mcp-manager';
 import { getWSClient } from './ws-client';
@@ -120,6 +120,12 @@ export function registerIPCHandlers(): void {
       return { success: false };
     }
     await saveAuthSession(sessionData);
+    // Keep the in-memory cache in sync with what was just persisted. Without
+    // this, getOrLoadSession() keeps serving the STALE startup token after a
+    // refresh (it only re-reads disk when the cache is empty), so every API
+    // call starts failing ~when the old token expires — the desktop
+    // "random logout" — until a sleep/wake or restart repopulates the cache.
+    setCachedSession(sessionData);
 
     // Also set the session cookie on the BrowserWindow's session
     // so subsequent page loads/fetches include the cookie
@@ -149,6 +155,9 @@ export function registerIPCHandlers(): void {
     }
     try {
       await clearAuthSession();
+      // clearAuthSession only unlinks the file — invalidate the in-memory
+      // cache too so a known-bad token can't keep being served from memory.
+      setCachedSession(null);
       await session.defaultSession.clearStorageData({
         storages: ['cookies'],
       });

--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -347,6 +347,89 @@ describe('middleware — unauthenticated /dashboard rewrites instead of redirect
   });
 });
 
+// The Electron desktop shell navigates with COOKIES, not its Bearer token —
+// the renderer's real credential lives in the main process and is attached per
+// API call by authFetch. When the session cookie is missing or stale, the
+// middleware's page-navigation gate used to bounce the shell to the signin
+// form ("randomly logged out") even though the Bearer was perfectly valid.
+// For the Electron shell the gate must let the page load and let the client
+// recover via its Bearer; this relaxes only the navigation UX gate, never an
+// auth boundary — every API route still validates normally.
+describe('middleware — Electron shell page navigations are never bounced to signin', () => {
+  const ELECTRON_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) PageSpace/1.0.23 Chrome/130.0.6723.137 Electron/33.3.1 Safari/537.36';
+  const BROWSER_UA =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.137 Safari/537.36';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSessionFromCookies.mockReturnValue(undefined);
+    mockValidateOriginForMiddleware.mockReturnValue({ valid: true, origin: null, skipped: true, reason: 'no origin' });
+    mockIsOriginValidationBlocking.mockReturnValue(true);
+  });
+
+  it.each([['/dashboard'], ['/dashboard/drv_abc/pg_xyz']])(
+    'lets the Electron shell load %s with no session cookie — no redirect, no signin rewrite',
+    async (pathname) => {
+      const response = await middleware(buildRequest(pathname, { 'user-agent': ELECTRON_UA }));
+
+      // Neither bounce mechanism may fire: not the 307 redirect, not the
+      // /dashboard signin rewrite (which renders the signin form in place —
+      // the exact "logged out" the desktop user reports).
+      expect(response.status).not.toBe(307);
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    },
+  );
+
+  it('lets the Electron shell load a non-dashboard page with no session cookie', async () => {
+    const response = await middleware(buildRequest('/activate?user_code=ABCD', { 'user-agent': ELECTRON_UA }));
+
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('still redirects a BROWSER page navigation with no session cookie to signin, exactly as before', async () => {
+    const response = await middleware(buildRequest('/activate?user_code=ABCD-EFGH', { 'user-agent': BROWSER_UA }));
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location') as string);
+    expect(location.pathname).toBe('/auth/signin');
+    expect(location.searchParams.get('next')).toBe('/activate?user_code=ABCD-EFGH');
+  });
+
+  it('leaves the iOS/Capacitor /dashboard signin REWRITE untouched for non-Electron UAs', async () => {
+    // The iOS shell is a WKWebView with no Electron/ token — it must keep the
+    // rewrite-in-place behavior (redirecting it black-screens the shell).
+    const response = await middleware(buildRequest('/dashboard/drv_abc', { 'user-agent': BROWSER_UA }));
+
+    const target = response.headers.get('x-middleware-rewrite');
+    expect(target).not.toBeNull();
+    expect(new URL(target as string).pathname).toBe('/auth/signin');
+    expect(response.status).not.toBe(307);
+  });
+
+  it.each([
+    ['Electron shell', 'Mozilla/5.0 PageSpace/1.0.23 Electron/33.3.1 Safari/537.36'],
+    ['browser', 'Mozilla/5.0 Chrome/130.0.6723.137 Safari/537.36'],
+  ])('keeps API routes fully gated for a %s request with no credentials — still 401', async (_kind, ua) => {
+    const response = await middleware(buildRequest('/api/ai/chat/active-streams', { 'user-agent': ua }));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('changes nothing for the Electron shell when a session cookie IS present (pass-through, as for everyone)', async () => {
+    mockGetSessionFromCookies.mockReturnValue('ps_sess_valid');
+
+    const response = await middleware(buildRequest('/dashboard/drv_abc', { 'user-agent': ELECTRON_UA }));
+
+    expect(response.status).not.toBe(307);
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+});
+
 // The desktop/native OAuth callbacks return their own styled HTML "handoff
 // bridge" with a bespoke CSP that allows an inline <style> block. Middleware
 // must tell createSecureResponse to skip its own CSP for these paths, so the two

--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -420,6 +420,33 @@ describe('middleware — Electron shell page navigations are never bounced to si
     expect(response.headers.get('x-middleware-rewrite')).toBeNull();
   });
 
+  it('does NOT log a security "unauthorized" event for an accepted Electron shell page navigation', async () => {
+    // The navigation is deliberately accepted — logging it as unauthorized
+    // would flood the security drain on every client-side route change of a
+    // cookie-less desktop session and obscure real failures.
+    await middleware(buildRequest('/dashboard/drv_abc', { 'user-agent': ELECTRON_UA }));
+
+    expect(mockLogSecurityEvent).not.toHaveBeenCalled();
+  });
+
+  it('still logs the unauthorized event for an Electron API request with no credentials', async () => {
+    await middleware(buildRequest('/api/ai/chat/active-streams', { 'user-agent': ELECTRON_UA }));
+
+    expect(mockLogSecurityEvent).toHaveBeenCalledWith(
+      'unauthorized',
+      expect.objectContaining({ reason: 'No session token' }),
+    );
+  });
+
+  it('still logs the unauthorized event for a browser page navigation with no session cookie', async () => {
+    await middleware(buildRequest('/activate', { 'user-agent': BROWSER_UA }));
+
+    expect(mockLogSecurityEvent).toHaveBeenCalledWith(
+      'unauthorized',
+      expect.objectContaining({ reason: 'No session token' }),
+    );
+  });
+
   it('changes nothing for the Electron shell when a session cookie IS present (pass-through, as for everyone)', async () => {
     mockGetSessionFromCookies.mockReturnValue('ps_sess_valid');
 

--- a/apps/web/src/lib/auth/__tests__/native-shell.test.ts
+++ b/apps/web/src/lib/auth/__tests__/native-shell.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isElectronShell } from '../native-shell';
+
+// The Electron desktop shell's real User-Agent: Chromium's UA with the app
+// name and an `Electron/<version>` product token appended.
+const ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) PageSpace/1.0.23 Chrome/130.0.6723.137 Electron/33.3.1 Safari/537.36';
+
+const BROWSER_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.137 Safari/537.36';
+
+// The iOS shell is a WKWebView — no Electron token. It must never be detected
+// as the Electron shell, or it would lose its own /dashboard rewrite handling.
+const IOS_SHELL_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
+
+describe('isElectronShell', () => {
+  it('detects the Electron desktop shell by its Electron/ product token', () => {
+    expect(isElectronShell(ELECTRON_UA)).toBe(true);
+  });
+
+  it('returns false for a regular browser UA', () => {
+    expect(isElectronShell(BROWSER_UA)).toBe(false);
+  });
+
+  it('returns false for the iOS/Capacitor shell UA', () => {
+    expect(isElectronShell(IOS_SHELL_UA)).toBe(false);
+  });
+
+  it('returns false for an empty UA', () => {
+    expect(isElectronShell('')).toBe(false);
+  });
+
+  it('returns false for a missing UA (null)', () => {
+    expect(isElectronShell(null)).toBe(false);
+  });
+
+  it('returns false for a missing UA (undefined)', () => {
+    expect(isElectronShell(undefined)).toBe(false);
+  });
+
+  it('does not match the bare word Electron without the product-token slash', () => {
+    expect(isElectronShell('Mozilla/5.0 ElectronFanClub')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/native-shell.test.ts
+++ b/apps/web/src/lib/auth/__tests__/native-shell.test.ts
@@ -14,9 +14,32 @@ const BROWSER_UA =
 const IOS_SHELL_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148';
 
+// Dev mode: no electron-builder productName injection, so app.getName()
+// falls back to package.json name — the UA token is desktop/<version>.
+const DEV_SHELL_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) desktop/1.0.3 Chrome/130.0.6723.137 Electron/33.3.1 Safari/537.36';
+
+// A third-party Electron-based browser or app webview visiting pagespace.ai:
+// carries Electron/ but not our app token. It must keep the normal signin
+// redirect rather than being handed the empty dashboard shell.
+const FOREIGN_ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) SomeBrowser/2.4.1 Chrome/130.0.6723.137 Electron/33.3.1 Safari/537.36';
+
 describe('isElectronShell', () => {
-  it('detects the Electron desktop shell by its Electron/ product token', () => {
+  it('detects the packaged shell by Electron/ plus the PageSpace/ productName token', () => {
     expect(isElectronShell(ELECTRON_UA)).toBe(true);
+  });
+
+  it('detects the dev shell by Electron/ plus the desktop/ package-name token', () => {
+    expect(isElectronShell(DEV_SHELL_UA)).toBe(true);
+  });
+
+  it('returns false for a third-party Electron app without the PageSpace app token', () => {
+    expect(isElectronShell(FOREIGN_ELECTRON_UA)).toBe(false);
+  });
+
+  it('returns false for an app token without the Electron/ token', () => {
+    expect(isElectronShell('Mozilla/5.0 PageSpace/1.0.23 Chrome/130.0.0.0 Safari/537.36')).toBe(false);
   });
 
   it('returns false for a regular browser UA', () => {

--- a/apps/web/src/lib/auth/native-shell.ts
+++ b/apps/web/src/lib/auth/native-shell.ts
@@ -2,8 +2,16 @@
 // pull in the Node-only '@/lib/auth' barrel.
 
 /**
- * True when the request comes from the Electron desktop shell, detected by the
- * `Electron/<version>` product token Chromium appends to the shell's UA.
+ * True when the request comes from the PageSpace Electron desktop shell,
+ * detected by the `Electron/<version>` product token Chromium appends to the
+ * shell's UA PLUS the app's own name token — `PageSpace/<version>` in packaged
+ * builds (electron-builder `productName`) or `desktop/<version>` in dev
+ * (package.json `name`); both are what `app.getName()` yields, and the desktop
+ * app never overrides its UA. Requiring the app token keeps third-party
+ * Electron browsers on the normal signin redirect; accepting either spelling
+ * keeps every shipped AND dev shell covered — a false negative here would
+ * reintroduce the desktop logout bounce, so the app-token check is
+ * deliberately the OR of both known spellings.
  *
  * Used only to relax the middleware's page-navigation signin bounce — never an
  * auth boundary. The shell navigates with cookies while its real credential
@@ -13,5 +21,6 @@
  * public, and every API route still validates its own credentials.
  */
 export function isElectronShell(userAgent: string | null | undefined): boolean {
-  return !!userAgent && userAgent.includes('Electron/');
+  if (!userAgent || !userAgent.includes('Electron/')) return false;
+  return userAgent.includes('PageSpace/') || userAgent.includes('desktop/');
 }

--- a/apps/web/src/lib/auth/native-shell.ts
+++ b/apps/web/src/lib/auth/native-shell.ts
@@ -1,0 +1,17 @@
+// Edge-safe leaf (no imports): consumed by middleware.ts, which must never
+// pull in the Node-only '@/lib/auth' barrel.
+
+/**
+ * True when the request comes from the Electron desktop shell, detected by the
+ * `Electron/<version>` product token Chromium appends to the shell's UA.
+ *
+ * Used only to relax the middleware's page-navigation signin bounce — never an
+ * auth boundary. The shell navigates with cookies while its real credential
+ * (the Bearer token) lives in the main process and is attached per API call,
+ * so a missing session cookie says nothing about whether the desktop user is
+ * authenticated. A spoofed UA therefore gains nothing: the shell pages are
+ * public, and every API route still validates its own credentials.
+ */
+export function isElectronShell(userAgent: string | null | undefined): boolean {
+  return !!userAgent && userAgent.includes('Electron/');
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -24,6 +24,7 @@ import {
   OAUTH_ACCESS_TOKEN_PREFIX,
 } from '@/lib/auth/token-prefixes';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
+import { isElectronShell } from '@/lib/auth/native-shell';
 import { WELL_KNOWN_REWRITES } from '@/lib/well-known/rewrites';
 import { getClientIP } from '@/lib/security/edge-client-ip';
 
@@ -341,6 +342,25 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
 
       if (isAPIRoute) {
         return createSecureErrorResponse('Authentication required', 401, isProduction, isSecureRequest(req));
+      }
+
+      // Electron desktop shell: its page navigations carry COOKIES while the
+      // real credential (the Bearer token) lives in the Electron main process
+      // and is attached per API call — so a missing/stale session cookie says
+      // nothing about whether the desktop user is authenticated. Bouncing the
+      // shell to the signin form here IS the desktop "random logout". Let the
+      // page load and let the shell recover client-side via its Bearer. This
+      // relaxes only the navigation UX gate, never an auth boundary: the page
+      // shell is public and all data still comes from Bearer-validated API
+      // routes (the isAPIRoute 401 above is untouched). The iOS/Capacitor
+      // /dashboard rewrite below is a different shell (no Electron/ UA token)
+      // and keeps its own handling.
+      if (isElectronShell(req.headers.get('user-agent'))) {
+        const { response } = createSecureResponse(isProduction, req, {
+          isAPIRoute,
+          disableCOEP: shouldDisableCOEP(pathname),
+        });
+        return response;
       }
 
       if (isShellEntryPath(pathname)) {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -350,7 +350,6 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
       // session, drowning out real unauthorized events.
       if (!isAPIRoute && isElectronShell(req.headers.get('user-agent'))) {
         const { response } = createSecureResponse(isProduction, req, {
-          isAPIRoute,
           disableCOEP: shouldDisableCOEP(pathname),
         });
         return response;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -334,16 +334,6 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
     const sessionToken = getSessionFromCookies(cookieHeader);
 
     if (!sessionToken) {
-      logSecurityEvent('unauthorized', {
-        pathname,
-        reason: 'No session token',
-        ip,
-      });
-
-      if (isAPIRoute) {
-        return createSecureErrorResponse('Authentication required', 401, isProduction, isSecureRequest(req));
-      }
-
       // Electron desktop shell: its page navigations carry COOKIES while the
       // real credential (the Bearer token) lives in the Electron main process
       // and is attached per API call — so a missing/stale session cookie says
@@ -352,15 +342,28 @@ export async function middleware(req: NextRequest, event?: NextFetchEvent) {
       // page load and let the shell recover client-side via its Bearer. This
       // relaxes only the navigation UX gate, never an auth boundary: the page
       // shell is public and all data still comes from Bearer-validated API
-      // routes (the isAPIRoute 401 above is untouched). The iOS/Capacitor
+      // routes (the isAPIRoute 401 below is untouched). The iOS/Capacitor
       // /dashboard rewrite below is a different shell (no Electron/ UA token)
-      // and keeps its own handling.
-      if (isElectronShell(req.headers.get('user-agent'))) {
+      // and keeps its own handling. Sits above the 'unauthorized' security
+      // event: this navigation is deliberately accepted, and logging it would
+      // fire on every client-side route change of a cookie-less desktop
+      // session, drowning out real unauthorized events.
+      if (!isAPIRoute && isElectronShell(req.headers.get('user-agent'))) {
         const { response } = createSecureResponse(isProduction, req, {
           isAPIRoute,
           disableCOEP: shouldDisableCOEP(pathname),
         });
         return response;
+      }
+
+      logSecurityEvent('unauthorized', {
+        pathname,
+        reason: 'No session token',
+        ip,
+      });
+
+      if (isAPIRoute) {
+        return createSecureErrorResponse('Authentication required', 401, isProduction, isSecureRequest(req));
       }
 
       if (isShellEntryPath(pathname)) {


### PR DESCRIPTION
## Round 3 — the corrected root cause

Desktop users kept getting "randomly logged out" after two prior fixes (#2176, #2196). Those addressed real but secondary issues. Three independent code traces plus the git timeline converge on **two defects that together produce the logout** — and confirm the app owner's observation that nothing was wrong until middleware was enabled (2026-07-07, #1932):

1. **Middleware navigation gate (the 07-07 regression).** `apps/web/src/middleware.ts` gates page navigations on session-**cookie** presence and redirects to `/auth/signin` (or rewrites, for `/dashboard`). The Electron shell navigates with cookies, but its real credential — the Bearer token — lives in the Electron main process and is attached per API call. A missing/stale session cookie therefore says nothing about desktop auth state, yet it bounced the shell to the signin form: the visible "logged out."
2. **Stale desktop token cache (old latent bug, made fatal by the above).** The Electron main process serves the Bearer from an in-memory `cachedSession` (`apps/desktop/src/main/state.ts`) that the refresh path never updated: `auth:store-session` wrote the refreshed token to disk + cookie jar but never called `setCachedSession`, and `getOrLoadSession` only re-reads disk when the cache is empty (startup/login/sleep-wake). After the first proactive refresh the desktop kept sending the OLD token; once it expired, every API call failed until sleep/wake or restart. This same stale token is what defeated the D1 signin recovery shipped in #2196.

Timeline note: session retirement (#2084, 9 days later) is **not** the cause, and the `authFailureReason: "expired"` in logs is downstream of our own grace-expiry code — a red herring. Retirement is untouched by this PR.

## Changes

### 1. Desktop: main-process cache updates on refresh (THE root fix) — commit `dd4bcaa87`
`auth:store-session` now calls `setCachedSession(sessionData)` after a successful `saveAuthSession`, so `getOrLoadSession()`/`auth:get-session-token` serve the refreshed token immediately. Defense-in-depth: `auth:clear-auth` now calls `setCachedSession(null)` — `clearAuthSession` only unlinks the file, so a known-bad token could otherwise keep being served from memory.

> **⚠️ Ships in the DESKTOP BINARY — requires a desktop 1.0.24 release** (version is stamped from the git tag by `.github/workflows/build-desktop.yml`). Users are not fixed by a web deploy alone.

### 2. Web middleware: don't bounce the Electron shell to signin — commit `6a7c9c61a`
For a **page navigation** from the PageSpace Electron shell (detected via the new pure `isElectronShell` helper, `apps/web/src/lib/auth/native-shell.ts` — requires the `Electron/` UA product token **plus** the app's own name token, `PageSpace/` in packaged builds / `desktop/` in dev, so third-party Electron browsers keep the normal signin redirect) with no session cookie, middleware now passes the request through (`createSecureResponse`, same as the session-present path) instead of redirecting/rewriting to signin. The shell loads and recovers client-side via its Bearer (#2196's D1 recovery — which Change 1 makes actually succeed). Deploys with web.

This relaxes only the navigation UX gate, never an auth boundary: the page shell is public; all data comes from Bearer-validated API routes; API routes still 401 identically for every UA. A spoofed UA gains nothing.

### 3. D1 native-shell signin recovery — no code change
Already shipped in #2196. Change 1 is what lets it succeed (it previously read back the same stale token).

## Acceptance criteria

**Change 1** (`apps/desktop/src/main/__tests__/store-session-cache.test.ts`, RED-first — runs the REAL `state` + `auth-session` modules against the real IPC handlers):
- ✅ After `auth:store-session` with a new token, `getOrLoadSession()` returns the NEW token, not the previously-cached one *(failed RED before the fix)*
- ✅ `auth:get-session-token` (and `auth:get-session`) reflect the new token immediately after a store — no restart/sleep needed *(failed RED)*
- ✅ Existing startup/login/resume cache behavior unchanged (first read hits disk, later reads hit cache; resume-style cache reset re-reads disk) *(passed before and after — regression pins)*
- ✅ Extra: untrusted sender cannot poison the cache; a failed save does not update the cache; `auth:clear-auth` invalidates the cache *(clear-invalidation failed RED)*

**Change 2** (`apps/web/src/__tests__/middleware.test.ts` + `apps/web/src/lib/auth/__tests__/native-shell.test.ts`, RED-first):
- ✅ Electron UA + no session cookie on a page navigation → pass-through: no 307, no `Location`, no signin rewrite *(failed RED)*
- ✅ Browser UA + no session cookie on a page navigation → redirect to signin exactly as today (307, `next=` preserved)
- ✅ API routes (`/api/ai/chat/active-streams`) unaffected for both UAs → still 401
- ✅ iOS/Capacitor `/dashboard` signin **rewrite** unchanged for non-Electron UAs (black-screen fix untouched)
- ✅ `isElectronShell`: full branch coverage — packaged (`PageSpace/`+`Electron/`) and dev (`desktop/`+`Electron/`) shells true; browser/iOS UA false; third-party Electron app without our app token false; app token without `Electron/` false; empty/null/undefined false; bare word "Electron" false

## Verification
- `apps/desktop`: vitest 16 files / 209 tests passed; `tsc --noEmit` clean; eslint clean on changed files
- `apps/web`: vitest full suite green (env-known exceptions only, none related); `tsc --noEmit` clean; eslint clean on changed files
- Branch based on `origin/master` tip (a3856e3e2); no open PR overlaps this scope

## Review follow-through
- Codex P2 (security-event noise) — fixed in `86b37c49c`: the Electron pass-through now sits above `logSecurityEvent('unauthorized')`; API and browser logging pinned unchanged by tests.
- Self-review (4-agent reuse/simplification/efficiency/altitude pass) — applied in `64e21c634`: app-token-scoped detection + dropped a constant option. Noted as **follow-ups, deliberately out of this point-release's scope**: (a) unify the three Electron-UA predicates (`isElectronShell`, `detectPlatform` in `packages/lib` fingerprinting, client `isElectron`) into one edge-safe leaf; (b) move the save+cache / clear+cache pairing into `auth-session.ts` wrappers so no future IPC/deep-link call site can forget it (deep-links.ts already hand-pairs it today); (c) `apps/desktop` has no `test:coverage` script, so `ci / Unit Tests` (`turbo run test:coverage`) never executes the desktop suite — this PR's Change-1 tests (and all 209 desktop tests) are verified locally only; desktop should be wired into CI in its own change.

## Rollout
1. Merge → web deploy picks up Change 2 (stops the signin bounce for existing desktop builds).
2. **Cut desktop release 1.0.24** → ships Change 1 (stops the stale-token API failures at the source).

Prior rounds: #2176 (round 1), #2196 (round 2 — wave 1 + D1 recovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xGQtpYoShMusENqiTZLpr
