### PR TITLE
fix(ai): machine-pane conversations authorize as the user, not a phantom agent

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -481,6 +481,24 @@ describe('machine-pane conversations (agentPageId is a MACHINE page, not an agen
     expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
   });
 
+  // A consulted agent (ask_agent) inherits the PARENT's actor identity — the
+  // nested context spreads the caller's chatSource — so from a machine pane it
+  // resolves to the invoking user and can never exceed that user's own ACL.
+  it('a nested ask_agent run from a machine pane stays bounded by the invoking user', async () => {
+    const { getUserAccessLevel } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(getUserAccessLevel).mockResolvedValue(null);
+    const nestedCtx = {
+      ...machinePaneCtx,
+      agentCallDepth: 1,
+      parentAgentId: 'machine-1',
+      requestOrigin: 'agent',
+    } as ToolExecutionContext;
+
+    expect(await canActorViewPage(nestedCtx, 'page-the-user-cannot-see')).toBe(false);
+    expect(vi.mocked(getUserAccessLevel)).toHaveBeenCalledWith('user-1', 'page-the-user-cannot-see');
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
   it('an AI_CHAT page keeps the agent-scoped path (the gate only rejects non-agent pages)', async () => {
     mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
     mockGetAgentAccessLevel.mockResolvedValue(FULL);

--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -47,7 +47,9 @@ vi.mock('@pagespace/db/db', () => ({
   db: { select: () => ({ from: () => ({ where: mockDbWhere }) }) },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
-vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id', driveId: 'driveId' } }));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', type: 'type', userScopedAccess: 'userScopedAccess' },
+}));
 
 import {
   canActorManageDrive,
@@ -70,11 +72,16 @@ const agentCtx = {
   chatSource: { type: 'page', agentPageId: 'agent-1' },
 } as ToolExecutionContext;
 
+// The single row the actor gate reads for `chatSource.agentPageId`: a REAL
+// agent page (AI_CHAT) that has not opted into user-scoped reach. Only such a
+// page authorizes as an agent; anything else falls through to the user.
+const AGENT_PAGE_ROW = { type: 'AI_CHAT', userScopedAccess: false };
+
 describe('canActorManageDrive', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Agent actors look up their pages row for userScopedAccess; default: not found.
-    mockDbWhere.mockResolvedValue([]);
+    // Agent actors look up their pages row for type/userScopedAccess.
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
   });
 
   it('allows a drive owner', async () => {
@@ -114,8 +121,8 @@ describe('canActorManageDrive', () => {
 describe('MCP drive-scope enforcement', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Agent actors look up their pages row for userScopedAccess; default: not found.
-    mockDbWhere.mockResolvedValue([]);
+    // Agent actors look up their pages row for type/userScopedAccess.
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
   });
 
   // A scoped MCP token acting as an agent that DOES have access to the target.
@@ -138,7 +145,7 @@ describe('MCP drive-scope enforcement', () => {
   });
 
   it('canActorEditPage: denies when the page lives in a drive outside the token scope', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-B' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-B' }]);
     expect(await canActorEditPage(scopedAgentCtx, 'page-x')).toBe(false);
     expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
   });
@@ -151,7 +158,7 @@ describe('MCP drive-scope enforcement', () => {
 
   it('canActorEditPage: root-create path — an in-scope drive id with no page row is allowed', async () => {
     // create_page passes the DRIVE id to canActorEditPage for root-level creates.
-    mockDbWhere.mockResolvedValue([]); // no page row for a drive id
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]); // no page row for a drive id (so no driveId)
     mockGetAgentAccessLevel.mockResolvedValue({ canEdit: true });
     expect(await canActorEditPage(scopedAgentCtx, 'drive-A')).toBe(true);
     // The scope ceiling passed (drive-A is in scope), so the agent ACL was consulted.
@@ -159,7 +166,7 @@ describe('MCP drive-scope enforcement', () => {
   });
 
   it('canActorEditPage: allows an in-scope page (then defers to the agent ACL)', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAgentAccessLevel.mockResolvedValue({ canEdit: true });
     expect(await canActorEditPage(scopedAgentCtx, 'page-y')).toBe(true);
   });
@@ -195,7 +202,7 @@ describe('app-member RBAC ceiling (mcpTokenId set)', () => {
   } as ToolExecutionContext;
 
   it('canActorEditPage: explicit MEMBER token (view-only page) is denied even when the agent ACL allows edit', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAppDriveMembership.mockResolvedValue({ role: 'MEMBER', customRoleId: null, ownerUserId: 'user-1' });
     mockGetAppAccessLevel.mockResolvedValue(VIEW_ONLY);
     mockGetAgentAccessLevel.mockResolvedValue(FULL);
@@ -207,7 +214,7 @@ describe('app-member RBAC ceiling (mcpTokenId set)', () => {
   });
 
   it('canActorEditPage: INHERITED token (role null) applies no ceiling — agent ACL decides', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAppDriveMembership.mockResolvedValue({ role: null, customRoleId: null, ownerUserId: 'user-1' });
     mockGetAgentAccessLevel.mockResolvedValue(FULL);
 
@@ -217,7 +224,7 @@ describe('app-member RBAC ceiling (mcpTokenId set)', () => {
   });
 
   it('canActorEditPage: explicit ADMIN token falls through to the agent ACL (deny-only, never grants)', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAppDriveMembership.mockResolvedValue({ role: 'ADMIN', customRoleId: null, ownerUserId: 'user-1' });
     mockGetAppAccessLevel.mockResolvedValue(FULL);
     mockGetAgentAccessLevel.mockResolvedValue({ ...FULL, canEdit: false });
@@ -228,7 +235,7 @@ describe('app-member RBAC ceiling (mcpTokenId set)', () => {
   });
 
   it('canActorViewPage: explicit-role token outside its page access (null level) is denied', async () => {
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAppDriveMembership.mockResolvedValue({ role: 'MEMBER', customRoleId: null, ownerUserId: 'user-1' });
     mockGetAppAccessLevel.mockResolvedValue(null);
 
@@ -241,7 +248,7 @@ describe('app-member RBAC ceiling (mcpTokenId set)', () => {
       chatSource: { type: 'page', agentPageId: 'agent-1' },
       mcpAllowedDriveIds: ['drive-A'],
     } as ToolExecutionContext;
-    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockDbWhere.mockResolvedValue([{ ...AGENT_PAGE_ROW, driveId: 'drive-A' }]);
     mockGetAgentAccessLevel.mockResolvedValue(FULL);
 
     expect(await canActorEditPage(legacyScopedCtx, 'page-x')).toBe(true);
@@ -344,7 +351,7 @@ describe('user-scoped agents (userScopedAccess fallback to the invoking user)', 
   beforeEach(() => {
     vi.clearAllMocks();
     // The agent's pages-row lookup: user-scoped access enabled.
-    mockDbWhere.mockResolvedValue([{ userScopedAccess: true }]);
+    mockDbWhere.mockResolvedValue([{ type: 'AI_CHAT', userScopedAccess: true }]);
   });
 
   it('canActorViewPage authorizes as the invoking user, not the agent', async () => {
@@ -393,7 +400,7 @@ describe('user-scoped agents (userScopedAccess fallback to the invoking user)', 
   });
 
   it('keeps the agent-scoped path when the flag is off', async () => {
-    mockDbWhere.mockResolvedValue([{ userScopedAccess: false }]);
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
     mockGetAgentAccessLevel.mockResolvedValue(FULL);
 
     expect(await canActorViewPage(agentCtx, 'page-x')).toBe(true);
@@ -412,11 +419,82 @@ describe('user-scoped agents (userScopedAccess fallback to the invoking user)', 
   });
 });
 
+// Field bug (pagespace.ai prod): a machine-pane conversation carries the
+// MACHINE page as `chatSource.agentPageId` (chat/route.ts sets it for EVERY
+// page chat), so the acting-agent gate used to authorize as a page that is not
+// an agent at all — no driveAgentMembers row exists, so every canActor* check
+// denied. The honest actor is the user the chat route already authorized.
+describe('machine-pane conversations (agentPageId is a MACHINE page, not an agent)', () => {
+  const FULL = { canView: true, canEdit: true, canShare: true, canDelete: true };
+  const machinePaneCtx = {
+    userId: 'user-1',
+    chatSource: { type: 'page', agentPageId: 'machine-1' },
+  } as ToolExecutionContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWhere.mockResolvedValue([{ type: 'MACHINE', userScopedAccess: false }]);
+  });
+
+  it('canActorViewPage authorizes as the invoking user (the prod repro: bash/git_* denied by isMachineAccessible)', async () => {
+    const { getUserAccessLevel } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+
+    expect(await canActorViewPage(machinePaneCtx, 'machine-1')).toBe(true);
+    expect(vi.mocked(getUserAccessLevel)).toHaveBeenCalledWith('user-1', 'machine-1');
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('canActorViewPage still denies when the USER has no access to the page', async () => {
+    const { getUserAccessLevel } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(getUserAccessLevel).mockResolvedValue(null);
+
+    expect(await canActorViewPage(machinePaneCtx, 'machine-1')).toBe(false);
+  });
+
+  it('canActorEditPage / canActorAccessDrive authorize as the user too (page & drive tools, silently broken before)', async () => {
+    const { canUserEditPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+    mockGetUserDriveAccess.mockResolvedValue(true);
+
+    expect(await canActorEditPage(machinePaneCtx, 'page-x')).toBe(true);
+    expect(vi.mocked(canUserEditPage)).toHaveBeenCalledWith('user-1', 'page-x');
+    expect(await canActorAccessDrive(machinePaneCtx, DRIVE)).toBe(true);
+    expect(mockGetUserDriveAccess).toHaveBeenCalledWith('user-1', DRIVE);
+    expect(mockHasAgentDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it('reads the acting-page row exactly once per check (the type gate adds no query)', async () => {
+    const { getUserAccessLevel } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+
+    await canActorViewPage(machinePaneCtx, 'machine-1');
+    expect(mockDbWhere).toHaveBeenCalledTimes(1);
+  });
+
+  it('a MISSING page row also falls through to the user — a page that does not exist is not an agent', async () => {
+    mockDbWhere.mockResolvedValue([]);
+    const { getUserAccessLevel } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(getUserAccessLevel).mockResolvedValue(FULL);
+
+    expect(await canActorViewPage(machinePaneCtx, 'page-x')).toBe(true);
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('an AI_CHAT page keeps the agent-scoped path (the gate only rejects non-agent pages)', async () => {
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
+    mockGetAgentAccessLevel.mockResolvedValue(FULL);
+
+    expect(await canActorViewPage(agentCtx, 'page-x')).toBe(true);
+    expect(mockGetAgentAccessLevel).toHaveBeenCalledWith('agent-1', 'page-x');
+  });
+});
+
 describe('hasAgentUserScopedAccess', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns true when the agent page has userScopedAccess set', async () => {
-    mockDbWhere.mockResolvedValue([{ userScopedAccess: true }]);
+    mockDbWhere.mockResolvedValue([{ type: 'AI_CHAT', userScopedAccess: true }]);
     expect(await hasAgentUserScopedAccess('agent-1')).toBe(true);
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -158,7 +158,10 @@ describe('MCP drive-scope enforcement', () => {
 
   it('canActorEditPage: root-create path — an in-scope drive id with no page row is allowed', async () => {
     // create_page passes the DRIVE id to canActorEditPage for root-level creates.
-    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]); // no page row for a drive id (so no driveId)
+    // One mock serves both selects: the actor row resolves the agent, and the
+    // page-drive lookup finds no driveId (a drive id has no page row), so the
+    // scope check falls back to treating the id itself as the drive.
+    mockDbWhere.mockResolvedValue([AGENT_PAGE_ROW]);
     mockGetAgentAccessLevel.mockResolvedValue({ canEdit: true });
     expect(await canActorEditPage(scopedAgentCtx, 'drive-A')).toBe(true);
     // The scope ceiling passed (drive-A is in scope), so the agent ACL was consulted.

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -125,14 +125,18 @@ vi.mock('@/services/api/task-sync-service', () => ({
   ensureTaskListForPage: vi.fn().mockResolvedValue({ id: 'tasklist-1' }),
 }));
 
-// resolveActingAgentId (internal to actor-permissions.ts) queries pages.userScopedAccess
-// directly via db — mock that query boundary rather than the actor-permissions exports,
-// since same-module internal calls aren't interceptable by mocking the module's exports.
+// resolveActingAgentId (internal to actor-permissions.ts) queries the acting
+// page's type/userScopedAccess directly via db — mock that query boundary rather
+// than the actor-permissions exports, since same-module internal calls aren't
+// interceptable by mocking the module's exports. AI_CHAT: these agent fixtures
+// are real agent pages, so they keep the agent-scoped path.
 vi.mock('@pagespace/db/db', () => ({
-  db: { select: () => ({ from: () => ({ where: () => Promise.resolve([{ userScopedAccess: false }]) }) }) },
+  db: { select: () => ({ from: () => ({ where: () => Promise.resolve([{ type: 'AI_CHAT', userScopedAccess: false }]) }) }) },
 }));
 vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
-vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id', driveId: 'driveId' } }));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', type: 'type', userScopedAccess: 'userScopedAccess' },
+}));
 
 import { pageWriteTools } from '../page-write-tools';
 import { ensureTaskListForPage } from '@/services/api/task-sync-service';

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -1,10 +1,35 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Only the two IO seams the REAL canActorViewPage touches are faked (the
+// acting-page row lookup + the user ACL), so the machine-pane pin below runs
+// the actual actor-permissions chain end-to-end instead of a stubbed predicate.
+const { mockDbWhere, mockGetUserAccessLevel, mockGetAgentAccessLevel } = vi.hoisted(() => ({
+  mockDbWhere: vi.fn(),
+  mockGetUserAccessLevel: vi.fn(),
+  // A MACHINE page has no driveAgentMembers row — the agent path can only ever
+  // return null for it, which is exactly how the field bug denied every tool.
+  mockGetAgentAccessLevel: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@pagespace/db/db', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  db: { select: () => ({ from: () => ({ where: mockDbWhere }) }) },
+}));
+vi.mock('@pagespace/lib/permissions/permissions', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getUserAccessLevel: mockGetUserAccessLevel,
+}));
+vi.mock('@pagespace/lib/permissions/agent-permissions', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getAgentAccessLevel: mockGetAgentAccessLevel,
+}));
+
 import {
   createResolveSandboxActorContext,
   createMachineDirectory,
   type ResolveSandboxActorContextDeps,
   type MachineDirectoryRuntimeDeps,
 } from '../sandbox-tools-runtime';
+import { canActorViewPage } from '../actor-permissions';
 import type { ToolExecutionContext } from '../../core/types';
 import type { MachineRef } from '@/lib/repositories/page-agent-repository';
 
@@ -723,5 +748,89 @@ describe('createMachineDirectory', () => {
         directory.resolveTenantId?.(undefined, { kind: 'existing', machineId: 'gone' }, 'ambient-tenant'),
       ).resolves.toBe('ambient-tenant');
     });
+  });
+});
+
+// Field bug (pagespace.ai prod): every machine-pane PageSpace Agent was denied
+// by its own bash/git_* tools. chat/route.ts sets chatSource.agentPageId to the
+// MACHINE page id, so the acting-agent gate authorized as a page that is not an
+// agent and canActorViewPage denied before the binding exemption could apply.
+// Wired to the REAL canActorViewPage so the fix is pinned end-to-end.
+describe('machine-pane agents (agentPageId is the MACHINE page) — real canActorViewPage', () => {
+  const FULL = { canView: true, canEdit: true, canShare: true, canDelete: true };
+  const machinePaneContext: ToolExecutionContext = {
+    userId: 'u1',
+    chatSource: { type: 'page', agentPageId: 't1' },
+    machineBinding: { machineId: 't1', cwd: '/workspace' },
+  };
+  // The acting-page row the gate reads: the MACHINE page the pane is bound to.
+  const machinePageRow = [{ type: 'MACHINE', userScopedAccess: false }];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWhere.mockResolvedValue(machinePageRow);
+    mockGetUserAccessLevel.mockResolvedValue(FULL);
+    mockGetAgentAccessLevel.mockResolvedValue(null);
+  });
+
+  const directoryWithRealViewCheck = (overrides: Partial<MachineDirectoryRuntimeDeps> = {}) =>
+    createMachineDirectory(makeMachineDirectoryDeps({ canViewPage: canActorViewPage, ...overrides }));
+
+  it('given a bound machine and a user with page access, should allow — authorized as the USER, matching the PTY path', async () => {
+    await expect(
+      directoryWithRealViewCheck().isMachineAccessible(machinePaneContext, { kind: 'existing', machineId: 't1' }),
+    ).resolves.toEqual({ allowed: true });
+    expect(mockGetUserAccessLevel).toHaveBeenCalledWith('u1', 't1');
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('given a bound machine whose page is TRASHED, should still deny', async () => {
+    const directory = directoryWithRealViewCheck({
+      findPage: async () => ({
+        title: 'Trashed Machine',
+        type: 'MACHINE',
+        driveId: 'drive-1',
+        isTrashed: true,
+        allowPageAgents: true,
+        visibleToGlobalAssistant: true,
+      }),
+    });
+    await expect(
+      directory.isMachineAccessible(machinePaneContext, { kind: 'existing', machineId: 't1' }),
+    ).resolves.toEqual({ allowed: false });
+  });
+
+  it('given a bound machine whose page is MISSING, should still deny', async () => {
+    const directory = directoryWithRealViewCheck({ findPage: async () => undefined });
+    await expect(
+      directory.isMachineAccessible(machinePaneContext, { kind: 'existing', machineId: 't1' }),
+    ).resolves.toEqual({ allowed: false });
+  });
+
+  it('given a bound id that is not a MACHINE page, should still deny', async () => {
+    const directory = directoryWithRealViewCheck({
+      findPage: async () => ({
+        title: 'Not a machine',
+        type: 'DOCUMENT',
+        driveId: 'drive-1',
+        isTrashed: false,
+        allowPageAgents: true,
+        visibleToGlobalAssistant: true,
+      }),
+    });
+    await expect(
+      directory.isMachineAccessible(machinePaneContext, { kind: 'existing', machineId: 't1' }),
+    ).resolves.toEqual({ allowed: false });
+  });
+
+  it('given an UNBOUND existing machine the user genuinely cannot view, should deny — the type gate grants nothing on its own', async () => {
+    mockGetUserAccessLevel.mockResolvedValue(null);
+    const unboundContext: ToolExecutionContext = {
+      userId: 'u1',
+      chatSource: { type: 'page', agentPageId: 'machine-page-1' },
+    };
+    await expect(
+      directoryWithRealViewCheck().isMachineAccessible(unboundContext, { kind: 'existing', machineId: 't1' }),
+    ).resolves.toEqual({ allowed: false });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools-runtime.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Only the two IO seams the REAL canActorViewPage touches are faked (the
-// acting-page row lookup + the user ACL), so the machine-pane pin below runs
-// the actual actor-permissions chain end-to-end instead of a stubbed predicate.
+// Only the IO seams the REAL canActorViewPage touches are faked (the
+// acting-page row lookup, the user ACL, the agent ACL), so the machine-pane pin
+// at the bottom of this file runs the actual actor-permissions chain end-to-end
+// instead of a stubbed predicate. Every other describe here injects its own
+// `canViewPage` through makeMachineDirectoryDeps and never reaches these.
 const { mockDbWhere, mockGetUserAccessLevel, mockGetAgentAccessLevel } = vi.hoisted(() => ({
   mockDbWhere: vi.fn(),
   mockGetUserAccessLevel: vi.fn(),

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -46,9 +46,7 @@ export async function hasAgentUserScopedAccess(agentPageId: string): Promise<boo
  * (`userScopedAccess`)? Kept as a single select so the type gate below costs
  * zero additional queries on a path every tool call runs through.
  */
-async function fetchActingPageRow(
-  agentPageId: string,
-): Promise<{ type: string; userScopedAccess: boolean } | undefined> {
+async function fetchActingPageRow(agentPageId: string) {
   const [row] = await db
     .select({ type: pages.type, userScopedAccess: pages.userScopedAccess })
     .from(pages)

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -20,6 +20,7 @@ import {
   hasAppDriveMembership,
 } from '@pagespace/lib/permissions/app-permissions';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { PageType } from '@pagespace/lib/utils/enums';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
@@ -36,11 +37,23 @@ export function getAgentPageId(context: ToolExecutionContext): string | undefine
  * assistants that need the user's full reach rather than explicit membership.
  */
 export async function hasAgentUserScopedAccess(agentPageId: string): Promise<boolean> {
+  return (await fetchActingPageRow(agentPageId))?.userScopedAccess ?? false;
+}
+
+/**
+ * The ONE row both actor gates read for `chatSource.agentPageId`: is this page
+ * actually an agent (`type`), and has it opted into user-scoped reach
+ * (`userScopedAccess`)? Kept as a single select so the type gate below costs
+ * zero additional queries on a path every tool call runs through.
+ */
+async function fetchActingPageRow(
+  agentPageId: string,
+): Promise<{ type: string; userScopedAccess: boolean } | undefined> {
   const [row] = await db
-    .select({ userScopedAccess: pages.userScopedAccess })
+    .select({ type: pages.type, userScopedAccess: pages.userScopedAccess })
     .from(pages)
     .where(eq(pages.id, agentPageId));
-  return row?.userScopedAccess ?? false;
+  return row;
 }
 
 /**
@@ -50,6 +63,16 @@ export async function hasAgentUserScopedAccess(agentPageId: string): Promise<boo
  * Invoker-scoped by design: a user-scoped agent acts with the CURRENT
  * chatter's reach, never its owner's.
  *
+ * "Not a page-agent" is a claim about the PAGE, not just about whether a
+ * chatSource carries an id: a machine-pane conversation carries the MACHINE
+ * page as agentPageId (api/ai/chat/route.ts sets it for every page chat), and a
+ * non-agent page must not be treated as an acting agent — no driveAgentMembers
+ * row can ever exist for it, so every getAgentAccessLevel lookup returned null
+ * and denied. Falling through to the authenticated user is the honest actor and
+ * matches the PTY path; the chat route already authorized that user against the
+ * machine page. A missing page row is a non-agent for the same reason (and the
+ * user's own ACL still denies a page that does not exist).
+ *
  * Exported for tools that branch on the same "is this a membership-scoped
  * agent, or should it fall through to the user's own reach" question outside
  * these chokepoints (e.g. drive discovery/creation) — reuse this instead of
@@ -58,7 +81,9 @@ export async function hasAgentUserScopedAccess(agentPageId: string): Promise<boo
 export async function resolveActingAgentId(context: ToolExecutionContext): Promise<string | undefined> {
   const agentPageId = getAgentPageId(context);
   if (!agentPageId) return undefined;
-  return (await hasAgentUserScopedAccess(agentPageId)) ? undefined : agentPageId;
+  const row = await fetchActingPageRow(agentPageId);
+  if (row?.type !== PageType.AI_CHAT) return undefined;
+  return row.userScopedAccess ? undefined : agentPageId;
 }
 
 /**

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -35,6 +35,13 @@ export function getAgentPageId(context: ToolExecutionContext): string | undefine
  * would otherwise confine the agent to its own drive memberships should fall
  * back to the invoking user's own access instead — for personal/global-style
  * assistants that need the user's full reach rather than explicit membership.
+ *
+ * Deliberately a RAW flag read, unlike resolveActingAgentId's type-gated
+ * resolution: its only caller is the machine Settings-toggle exemption
+ * (sandbox-tools-runtime's isUserScopedAgent), which asks a different question
+ * — "did the owner widen this agent's reach?" — and the column is AI_CHAT-only
+ * by construction (packages/db/src/schema/core.ts), so a non-agent page reads
+ * the default `false` and is exempt from nothing.
  */
 export async function hasAgentUserScopedAccess(agentPageId: string): Promise<boolean> {
   return (await fetchActingPageRow(agentPageId))?.userScopedAccess ?? false;

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -73,6 +73,15 @@ async function fetchActingPageRow(
  * machine page. A missing page row is a non-agent for the same reason (and the
  * user's own ACL still denies a page that does not exist).
  *
+ * Nested (ask_agent) runs inherit the PARENT's actor identity by design —
+ * agent-communication-tools.ts spreads the caller's context, and
+ * sandbox-tools-runtime's activeMachineAgentPageId documents the same "the
+ * agent's own page or the parent's for a sub-agent" rule. So a consulted agent
+ * reached FROM a machine pane also resolves to the invoking user: bounded by
+ * that user's own ACL, never beyond it, and never wider than what the pane's
+ * own tools already reach. Before this gate that whole path was dead, not
+ * tighter — ask_agent's own canActorViewPage gate denied at the door.
+ *
  * Exported for tools that branch on the same "is this a membership-scoped
  * agent, or should it fall through to the user's own reach" question outside
  * these chokepoints (e.g. drive discovery/creation) — reuse this instead of


### PR DESCRIPTION
## The field bug

On pagespace.ai prod, every machine-pane PageSpace Agent (the chat panes shipped by #2200 — both machine-root and branch scope) is denied by its own tools: `bash`/`git_*` return *"You no longer have access to the active machine (…)"*. Shell PTYs on the same machines work, so the sandbox is fine. Page/task/drive tools in those panes are silently broken the same way.

## Root cause

`api/ai/chat/route.ts` sets `chatSource = { type: 'page', agentPageId: chatId }` for **every** page chat — including MACHINE pages, where `chatId` is the machine page id. `resolveActingAgentId` took that at face value, so every `canActor*` check ran `getAgentAccessLevel(machinePageId, target)` → `fetchAgentMembership` finds no `driveAgentMembers` row (a machine page is not an agent) → `null` → deny. All **43 `canActor*` call sites** were poisoned: `bash`/`git_*` denied loudly through `isMachineAccessible`, page/task/drive tools denied silently. The authorized user (`context.userId`) was never consulted — the honest `getUserAccessLevel` fallback was unreachable for machine panes.

## The fix

`resolveActingAgentId` (`apps/web/src/lib/ai/tools/actor-permissions.ts`) now returns `undefined` unless the `agentPageId` page is **actually an agent page** (`PageType.AI_CHAT`). Non-agent (and missing) pages fall through to `getUserAccessLevel(context.userId, …)` — the honest actor, matching the PTY path; the chat route has already authorized that user against the machine page.

- **Zero additional queries.** The existing single-row `pages` select is widened to read `type` alongside `userScopedAccess` in one private helper serving both gates — one DB round-trip on a path every tool call runs through.
- **Real agents unchanged.** AI_CHAT pages keep the agent-scoped path and `userScopedAccess` handling byte-identical.
- **`isMachineAccessible` untouched.** `canActorViewPage` now passes honestly and the existing `machineBinding` exemption stays where it is — verified by test, not by edit.
- Security-sensitive surface: the change only moves machine-pane actors from *"impossible agent"* to *"the authenticated user"*. Nothing else is loosened; a user without access is still denied.

## Tests (red first — 5 failing before the fix)

- `actor-permissions.test.ts` (+6): prod repro (MACHINE page → user ACL grants), user-without-access still denied, `canActorEditPage`/`canActorAccessDrive` also user-scoped, one-DB-call pin, missing row → user, AI_CHAT path pinned unchanged. Existing agent fixtures now carry `type: 'AI_CHAT'` (the row the gate reads).
- `sandbox-tools-runtime.test.ts` (+5): end-to-end through the **real** `canActorViewPage` (only the db-row and permission seams faked) — bound machine + user access → `{ allowed: true }`; trashed / missing / non-MACHINE page still denied; unbound machine without user access still denied.
- `page-write-tools.test.ts`: its db-boundary mock row updated to `type: 'AI_CHAT'`.

**Verification:** target pair 103/103 green; full `src/lib/ai/tools/__tests__/` 974 passed, 1 failed — `activity-tools > throws error when specified drive access denied`, which fails identically on a clean checkout (local test-DB env: `role "test…"`). `bunx tsc --noEmit -p apps/web/tsconfig.json` clean.

Fix 1 of the same plan (machine-workspace spawn sync) is a separate branch/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TebaKGKENRMStPXDU6GxJP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission checks for AI agents based on page type and user-scoped access settings.
  * Corrected access handling for machine-pane conversations, including missing, trashed, or incorrectly typed pages.
  * Ensured checks fall back to the invoking user when an agent cannot be used.
* **Tests**
  * Expanded authorization coverage for view, edit, drive access, and agent resolution scenarios.
  * Added regression tests for machine-pane access and user-scoped agent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up (`bebbae37e`)

Codex raised a P1 on consulted agents (`ask_agent`) inheriting this fallthrough. Verified and answered [in-thread](https://github.com/2witstudios/PageSpace/pull/2203#discussion_r3627434124): sub-agent runs inherit the **parent's** actor identity by pre-existing design (`agent-communication-tools.ts` spreads the caller's `chatSource`; `activeMachineAgentPageId` documents the same rule), so AI_CHAT parents are unaffected, and for a machine-pane parent the path was previously **denied outright** at `ask_agent`'s own `canActorViewPage` gate — it becomes user-scoped, never wider than the invoking user's own ACL or than the pane's own tools. `resolveActingAgentId`'s doc block now states that bound, and a regression test pins that a nested machine-pane run is denied when the user lacks access.
