### PR TITLE
fix(machines): close all 15 open review findings from #2204

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -9,7 +9,8 @@ import {
   type TextUIPart,
   type ToolSet,
 } from 'ai';
-import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, ADMIN_ONLY_PROVIDERS, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
+import { ONPREM_ALLOWED_PROVIDERS, DEFAULT_PROVIDER, DEFAULT_MODEL, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
+import { resolveGenerationAdmission } from '@/lib/ai/core/generation-admission';
 import { ALL_PROVIDER_NAMES } from '@/lib/ai/core/ai-utils';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
@@ -798,12 +799,19 @@ export async function POST(request: Request) {
 
     const isAdminUser = user?.role === 'admin';
 
-    if (ADMIN_ONLY_PROVIDERS.has(currentProvider) && !isAdminUser) {
-      return createAdminRestrictedResponse();
-    }
-
-    // Check if the selected model requires a paid plan
-    if (requiresProSubscription(currentProvider, currentModel, user?.subscriptionTier, isAdminUser)) {
+    // The SHARED entitlement decision (generation-admission.ts) — the same one
+    // the headless dispatch path applies, so a provider restriction cannot hold
+    // on one transport and evaporate on the other. This route only translates
+    // the answer into its HTTP shape.
+    const admission = resolveGenerationAdmission({
+      provider: currentProvider,
+      model: currentModel,
+      subscriptionTier: user?.subscriptionTier ?? undefined,
+      isAdmin: isAdminUser,
+      requiresProSubscription,
+    });
+    if (!admission.allowed) {
+      if (admission.reason === 'provider_admin_only') return createAdminRestrictedResponse();
       loggers.ai.warn('AI Chat API: paid plan required for model', {
         userId,
         provider: currentProvider,
@@ -905,16 +913,23 @@ export async function POST(request: Request) {
     // this branch: it reaches the agent-terminal and workspace stores (and,
     // through them, the Sprites driver seam), none of which an unbound
     // request has any business pulling into its module graph.
-    const baseTools = withSessionFamilyTools(
-      filterToolsForMachineBinding(
-        filterToolsForMcpScope(
-          filterToolsForReadOnly(pageSpaceTools, readOnlyMode),
-          isScopedMCPAuth(authResult)
+    //
+    // The read-only filter is applied LAST, to the COMPOSED set (issue #2204
+    // follow-up, F3). The session family is registered by ADDITION, so a filter
+    // applied to the baseline alone never saw it — and add/move/kill/send all
+    // mutate state, with send_session running a full agent loop in the target.
+    // Filtering the final set is the only placement a later addition cannot
+    // slip past.
+    const baseTools = filterToolsForReadOnly(
+      withSessionFamilyTools(
+        filterToolsForMachineBinding(
+          filterToolsForMcpScope(pageSpaceTools, isScopedMCPAuth(authResult)),
+          machineBinding != null
         ),
+        machineBinding != null ? (await import('@/lib/ai/tools/session-tools-runtime')).buildSessionTools() : {},
         machineBinding != null
       ),
-      machineBinding != null ? (await import('@/lib/ai/tools/session-tools-runtime')).buildSessionTools() : {},
-      machineBinding != null
+      readOnlyMode
     );
 
     // Step 2: Extract web_search + generate_image so they can be handled as
@@ -2067,13 +2082,20 @@ async function validateProviderModel(
   try {
     const [user] = await db.select().from(users).where(eq(users.id, userId));
     const isAdminUser = user?.role === 'admin';
-    if (ADMIN_ONLY_PROVIDERS.has(provider) && !isAdminUser) {
-      return { valid: false, reason: 'This provider is restricted to administrators.' };
-    }
-    if (requiresProSubscription(provider, model, user?.subscriptionTier, isAdminUser)) {
+    const admission = resolveGenerationAdmission({
+      provider,
+      model,
+      subscriptionTier: user?.subscriptionTier ?? undefined,
+      isAdmin: isAdminUser,
+      requiresProSubscription,
+    });
+    if (!admission.allowed) {
       return {
         valid: false,
-        reason: 'A paid plan is required for this model'
+        reason:
+          admission.reason === 'provider_admin_only'
+            ? 'This provider is restricted to administrators.'
+            : 'A paid plan is required for this model',
       };
     }
   } catch (error) {

--- a/apps/web/src/hooks/useMachineWorkspaceSync.ts
+++ b/apps/web/src/hooks/useMachineWorkspaceSync.ts
@@ -51,6 +51,7 @@ import {
   workspaceShowing,
   sessionWorkspaceId,
   nodeScopeNames,
+  paneScopeForWire,
   type MachineNodeScope,
   type OpenTerminalScope,
   type ServerColumnDTO,
@@ -93,13 +94,20 @@ const fetcher = (url: string) =>
  */
 const declinedBootstraps = new Set<string>();
 
-/** Strips local-only pane state (`pendingPrompt`) before a layout crosses the
+/**
+ * Strips local-only pane state (`pendingPrompt`) before a layout crosses the
  * wire — the server's layout DTO has no such field, and a starting prompt not
- * yet typed into its PTY must never be persisted or broadcast to other browsers. */
-function toWireColumns(columns: TerminalColumnState[]) {
+ * yet typed into its PTY must never be persisted or broadcast to other browsers.
+ *
+ * Also WIDENS each pane scope back to a full session address
+ * ({@link paneScopeForWire}), which is why the workspace's node scope is a
+ * parameter: local state keeps the narrow pane, the wire keeps the address a
+ * pre-narrowing client needs to resolve it correctly.
+ */
+function toWireColumns(node: MachineNodeScope, columns: TerminalColumnState[]) {
   return columns.map((column) => ({
     id: column.id,
-    panes: column.panes.map((pane) => ({ id: pane.id, scope: pane.scope })),
+    panes: column.panes.map((pane) => ({ id: pane.id, scope: paneScopeForWire(node, pane.scope) })),
   }));
 }
 
@@ -178,7 +186,7 @@ export function useMachineWorkspaceSync(machineId: string | null): void {
       id: workspace.id,
       name: workspace.name,
       scope: nodeScopeNames(workspace.scope),
-      columns: toWireColumns(workspace.columns),
+      columns: toWireColumns(workspace.scope, workspace.columns),
     }));
 
     // Nothing local to seed — so claim nothing. Bootstrap is first-writer-wins
@@ -324,7 +332,7 @@ async function pushNewWorkspace(machineId: string, workspaceId: string): Promise
     id: workspace.id,
     name: workspace.name,
     scope: nodeScopeNames(workspace.scope),
-    columns: toWireColumns(workspace.columns),
+    columns: toWireColumns(workspace.scope, workspace.columns),
   })
     .then((res) => {
       // Lost the first-writer-wins race (another browser materialized the
@@ -367,7 +375,7 @@ type ChangedFields = { name?: true; columns?: true };
 async function pushWorkspaceUpdate(machineId: string, workspaceId: string, changed: ChangedFields): Promise<void> {
   const workspace = useMachineWorkspaceStore.getState().machines[machineId]?.workspaces[workspaceId];
   if (!workspace) return;
-  const columns = toWireColumns(workspace.columns);
+  const columns = toWireColumns(workspace.scope, workspace.columns);
 
   try {
     const response = await fetchWithAuth('/api/machines/workspaces', {

--- a/apps/web/src/lib/ai/core/__tests__/generation-admission.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/generation-admission.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from 'vitest';
+import { assert } from '@/lib/ai/tools/__tests__/riteway';
+
+import { resolveGenerationAdmission } from '../generation-admission';
+
+/** `glm` is the sole ADMIN_ONLY_PROVIDERS member; the rest of the catalog is role-free. */
+const ADMIN_ONLY = 'glm';
+const ORDINARY = 'openai';
+
+const never = () => false;
+const always = () => true;
+
+describe('resolveGenerationAdmission', () => {
+  it('given an ordinary provider and an in-tier model, should allow', () => {
+    assert({
+      given: 'a free user on a free-tier model',
+      should: 'allow the generation',
+      actual: resolveGenerationAdmission({
+        provider: ORDINARY,
+        model: 'openai/gpt-5.4-mini',
+        subscriptionTier: 'free',
+        isAdmin: false,
+        requiresProSubscription: never,
+      }),
+      expected: { allowed: true },
+    });
+  });
+
+  it('given an admin-only provider and a non-admin, should deny on ROLE — not as a subscription problem', () => {
+    assert({
+      given: 'a paying non-admin user on an admin-only provider',
+      should: 'deny with the role reason, which no upgrade lifts',
+      actual: resolveGenerationAdmission({
+        provider: ADMIN_ONLY,
+        model: 'glm-4',
+        subscriptionTier: 'pro',
+        isAdmin: false,
+        requiresProSubscription: never,
+      }),
+      expected: { allowed: false, reason: 'provider_admin_only' },
+    });
+  });
+
+  it('given an admin-only provider and an admin, should allow', () => {
+    assert({
+      given: 'an admin on an admin-only provider',
+      should: 'allow the generation',
+      actual: resolveGenerationAdmission({
+        provider: ADMIN_ONLY,
+        model: 'glm-4',
+        subscriptionTier: 'free',
+        isAdmin: true,
+        requiresProSubscription: never,
+      }),
+      expected: { allowed: true },
+    });
+  });
+
+  it('given an out-of-tier model, should deny with the upgradeable reason', () => {
+    assert({
+      given: 'a free user on a paid-tier model',
+      should: 'deny with the subscription reason',
+      actual: resolveGenerationAdmission({
+        provider: ORDINARY,
+        model: 'anthropic/claude-opus-4.8',
+        subscriptionTier: 'free',
+        isAdmin: false,
+        requiresProSubscription: always,
+      }),
+      expected: { allowed: false, reason: 'subscription_required' },
+    });
+  });
+
+  it('given BOTH gates failing, should report the ROLE denial — the one an upgrade cannot fix', () => {
+    assert({
+      given: 'a free non-admin user on an admin-only provider with an out-of-tier model',
+      should: 'deny on role rather than send them to a checkout that would not help',
+      actual: resolveGenerationAdmission({
+        provider: ADMIN_ONLY,
+        model: 'glm-4',
+        subscriptionTier: 'free',
+        isAdmin: false,
+        requiresProSubscription: always,
+      }),
+      expected: { allowed: false, reason: 'provider_admin_only' },
+    });
+  });
+
+  it('given no model at all, should defer entirely to the tier predicate', () => {
+    assert({
+      given: 'an unset model',
+      should: 'allow when the tier predicate allows it',
+      actual: resolveGenerationAdmission({
+        provider: ORDINARY,
+        model: undefined,
+        subscriptionTier: 'free',
+        isAdmin: false,
+        requiresProSubscription: never,
+      }),
+      expected: { allowed: true },
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -459,3 +459,46 @@ describe('filterToolsForAgentAllowlist', () => {
     });
   });
 });
+
+/**
+ * Issue #2204 follow-up, F3. The session family is registered by ADDITION
+ * after the read-only filter ran, and its mutating members were not in
+ * WRITE_TOOLS at all — so a read-only machine-bound conversation kept
+ * add/move/kill/send_session, and send_session runs a full agent loop in the
+ * target that can execute arbitrary shell commands.
+ */
+describe('read-only mode vs the session family', () => {
+  const sessionFamily = {
+    list_sessions: 'list_sessions',
+    read_session: 'read_session',
+    add_session: 'add_session',
+    move_session: 'move_session',
+    kill_session: 'kill_session',
+    send_session: 'send_session',
+  };
+
+  it('given the COMPOSED bound tool set, read-only should drop every mutating session tool', () => {
+    const composed = withSessionFamilyTools({}, sessionFamily, true);
+    expect(Object.keys(filterToolsForReadOnly(composed, true)).sort()).toEqual([
+      'list_sessions',
+      'read_session',
+    ]);
+  });
+
+  it('given read-only OFF, should keep the whole family', () => {
+    const composed = withSessionFamilyTools({}, sessionFamily, true);
+    expect(Object.keys(filterToolsForReadOnly(composed, false)).sort()).toEqual(
+      Object.keys(sessionFamily).sort(),
+    );
+  });
+
+  it('given the allowlist exemption runs after read-only, it should not resurrect a dropped write tool', () => {
+    const readOnly = filterToolsForReadOnly(withSessionFamilyTools({}, sessionFamily, true), true);
+    // The family is exempt from the allowlist by name, but exemption only KEEPS
+    // keys that are present — it cannot add back what read-only removed.
+    expect(Object.keys(filterToolsForAgentAllowlist(readOnly, [])).sort()).toEqual([
+      'list_sessions',
+      'read_session',
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai/core/generation-admission.ts
+++ b/apps/web/src/lib/ai/core/generation-admission.ts
@@ -1,0 +1,65 @@
+/**
+ * Provider/model ENTITLEMENT, as one pure decision (issue #2204 follow-up, F4).
+ *
+ * Two independent gates, and they are not interchangeable:
+ *
+ *  • ADMIN-ONLY PROVIDERS — a block on ROLE. No upgrade helps, so the denial
+ *    must never be phrased as one.
+ *  • PAID-TIER MODELS — a block on TIER, which an upgrade does lift.
+ *
+ * Both used to live inline in `chat/route.ts` (and again in the /v1 route, and
+ * again at the settings PATCH boundary), which is precisely why the headless
+ * dispatch path shipped without either: a free, non-admin collaborator could
+ * invoke a machine page configured with a paid or admin-only provider through
+ * `send_session` and be billed at that rate. Entitlement is a property of
+ * (provider, model, who is asking), not of which transport asked, so it is
+ * decided HERE and the transports only translate the answer into their own
+ * response shape.
+ */
+
+import { ADMIN_ONLY_PROVIDERS } from './ai-providers-config';
+
+export type GenerationAdmissionDenial =
+  /** The provider is administrator-only. Role, not tier — do not offer an upgrade. */
+  | 'provider_admin_only'
+  /** The model is outside the actor's subscription tier. An upgrade lifts this. */
+  | 'subscription_required';
+
+export type GenerationAdmission =
+  | { allowed: true }
+  | { allowed: false; reason: GenerationAdmissionDenial };
+
+/**
+ * May this actor run this (provider, model)?
+ *
+ * `requiresProSubscription` is injected rather than imported because it reads
+ * deployment mode (`isBillingEnabled`) — an effect. Callers pass the real one;
+ * tests pass a function.
+ */
+export function resolveGenerationAdmission(input: {
+  provider: string;
+  model: string | undefined;
+  subscriptionTier: string | undefined;
+  isAdmin: boolean;
+  requiresProSubscription: (
+    provider: string,
+    model: string | undefined,
+    subscriptionTier: string | undefined,
+    isAdmin: boolean,
+  ) => boolean;
+}): GenerationAdmission {
+  const { provider, model, subscriptionTier, isAdmin } = input;
+
+  // Role first: an admin-only provider is refused for a non-admin whatever
+  // their tier, and reporting it as a subscription problem would send a paying
+  // user to a checkout page that cannot fix it.
+  if (ADMIN_ONLY_PROVIDERS.has(provider) && !isAdmin) {
+    return { allowed: false, reason: 'provider_admin_only' };
+  }
+
+  if (input.requiresProSubscription(provider, model, subscriptionTier, isAdmin)) {
+    return { allowed: false, reason: 'subscription_required' };
+  }
+
+  return { allowed: true };
+}

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -113,6 +113,15 @@ export const WRITE_TOOLS = new Set([
   'gh_issue_reopen',
   'gh_repo_fork',
   'gh_repo_create',
+  // Session-family MUTATIONS (issue #2204 follow-up, F3). list_sessions and
+  // read_session are reads and stay available; these four create, move, kill
+  // and drive sessions — and send_session runs a full agent loop in the target,
+  // which can execute arbitrary shell commands. A read-only conversation that
+  // could still call them would be read-only in name only.
+  'add_session',
+  'move_session',
+  'kill_session',
+  'send_session',
 ]);
 
 // Web search tools (excluded when web search is disabled)

--- a/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
@@ -4,6 +4,7 @@ import { assert } from '@/lib/ai/tools/__tests__/riteway';
 import {
   dispatchHeadlessSessionTurn,
   isClaimContested,
+  buildHeadlessToolContext,
   MAX_AGENT_DEPTH,
   type HeadlessSessionRunDeps,
   type HeadlessSessionTarget,
@@ -464,6 +465,74 @@ describe('dispatchHeadlessSessionTurn', () => {
       should: 'report the failure and free the claim',
       actual: { ok: result.ok, released: recorded.released },
       expected: { ok: false, released: [{ aborted: true }] },
+    });
+  });
+});
+
+/**
+ * Issue #2204 follow-up, F8. A dispatched turn built a context with neither a
+ * drive nor a `chatSource`, so `resolveSandboxActorContext` failed closed and
+ * every bash/file/git tool in the run returned "Code execution requires an
+ * active drive" — the machine binding was valid and the tools were unusable.
+ */
+describe('buildHeadlessToolContext', () => {
+  const machinePage = { id: 'machine-page-1', title: 'Dev Machine', type: 'AI_CHAT' };
+
+  it('given a machine page, should identify the run as that page\'s agent so the sandbox resolver can find its drive', () => {
+    const context = buildHeadlessToolContext({ target: target(), machinePage, userId: 'u1', depth: 0 });
+
+    assert({
+      given: 'a dispatched turn on a machine page',
+      should: 'carry a page chatSource naming that page',
+      actual: context.chatSource,
+      expected: { type: 'page', agentPageId: 'machine-page-1', agentTitle: 'Dev Machine' },
+    });
+  });
+
+  it('given a machine page, should still carry the page location context', () => {
+    const context = buildHeadlessToolContext({ target: target(), machinePage, userId: 'u1', depth: 0 });
+
+    assert({
+      given: 'a dispatched turn on a machine page',
+      should: 'describe the current page as the interactive route does',
+      actual: context.locationContext,
+      expected: {
+        currentPage: { id: 'machine-page-1', title: 'Dev Machine', type: 'AI_CHAT', path: '/Dev Machine' },
+      },
+    });
+  });
+
+  it('given the target, should bind tools to the TARGET\'s node, not the dispatcher\'s', () => {
+    const context = buildHeadlessToolContext({ target: target(), machinePage, userId: 'u1', depth: 1 });
+
+    assert({
+      given: 'a dispatched turn at depth 1',
+      should: 'carry the target binding, the agent origin, and its own depth',
+      actual: {
+        machineBinding: context.machineBinding,
+        requestOrigin: context.requestOrigin,
+        agentCallDepth: context.agentCallDepth,
+        conversationId: context.conversationId,
+        userId: context.userId,
+      },
+      expected: {
+        machineBinding: branchBinding(),
+        requestOrigin: 'agent',
+        agentCallDepth: 1,
+        conversationId: 'terminal-row-1',
+        userId: 'u1',
+      },
+    });
+  });
+
+  it('given no machine page row, should omit the page fields rather than invent them', () => {
+    const context = buildHeadlessToolContext({ target: target(), machinePage: undefined, userId: 'u1', depth: 0 });
+
+    assert({
+      given: 'a dispatched turn whose machine page row is missing',
+      should: 'carry neither a chatSource nor a location context',
+      actual: { chatSource: context.chatSource, locationContext: context.locationContext },
+      expected: { chatSource: undefined, locationContext: undefined },
     });
   });
 });

--- a/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
@@ -57,7 +57,7 @@ interface Recorded {
   appended: { content: string; conversationId: string }[];
   generated: { depth: number; cwd: string; sandboxId?: string; message: string }[];
   replies: { content: string; aborted: boolean }[];
-  billed: { pageId: string; userId: string; success: boolean; provider?: string; model?: string }[];
+  billed: { pageId: string; userId: string; success: boolean; provider?: string; model?: string; usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } }[];
   historyLoads: { excludeMessageId: string }[];
   released: { aborted: boolean }[];
   /** Set at ACK time, so "did the loop run before the ACK?" is directly assertable. */
@@ -129,8 +129,8 @@ function deps(
     persistReply: async ({ content, aborted }) => {
       recorded.replies.push({ content, aborted });
     },
-    trackUsage: async ({ pageId, userId, success, provider, model }) => {
-      recorded.billed.push({ pageId, userId, success, provider, model });
+    trackUsage: async ({ pageId, userId, success, provider, model, usage }) => {
+      recorded.billed.push({ pageId, userId, success, provider, model, usage });
     },
     newId: () => `id${++ids}`,
     defer: (run) => {
@@ -212,6 +212,7 @@ describe('dispatchHeadlessSessionTurn — billing identity', () => {
         success: true,
         provider: 'openrouter',
         model: 'anthropic/claude-sonnet-5',
+        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
       },
     ]);
   });
@@ -401,6 +402,7 @@ describe('dispatchHeadlessSessionTurn', () => {
           success: true,
           provider: 'openrouter',
           model: 'anthropic/claude-sonnet-5',
+          usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
         },
       ],
     });
@@ -639,6 +641,114 @@ describe('dispatchHeadlessSessionTurn — hold release and abort threading', () 
       should: 'pass an explicit null',
       actual: seen,
       expected: null,
+    });
+  });
+});
+
+/**
+ * Codex P1 on PR #2209. A run stopped by takeover, by the credit guard, or by
+ * the lifetime backstop rejects out of `generateText` AFTER the provider has
+ * charged for completed steps — and `trackAIUsage` skips an unsuccessful
+ * zero-token call (`success || totalTokens > 0`), so those tokens went unbilled.
+ */
+describe('dispatchHeadlessSessionTurn — usage survives an aborted run', () => {
+  it('given a generation that aborts after completing steps, should still bill what those steps spent', async () => {
+    const { deps: d, recorded, drain } = deps({
+      generate: async ({ onStepUsage }) => {
+        onStepUsage?.({ inputTokens: 100, outputTokens: 40, totalTokens: 140 });
+        onStepUsage?.({ inputTokens: 60, outputTokens: 20, totalTokens: 80 });
+        throw new Error('AbortError: takeover');
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'an aborted run that completed two charged steps',
+      should: 'report the accumulated tokens so the charge is not absorbed',
+      actual: recorded.billed[0],
+      expected: {
+        pageId: 'machine-page-1',
+        userId: 'u1',
+        success: false,
+        usage: { inputTokens: 160, outputTokens: 60, totalTokens: 220 },
+        provider: undefined,
+        model: undefined,
+      },
+    });
+  });
+
+  it('given a run that aborts before ANY step completes, should report no usage rather than a zero row', async () => {
+    const { deps: d, recorded, drain } = deps({
+      generate: async () => {
+        throw new Error('AbortError: immediate');
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'an abort with nothing charged',
+      should: 'leave usage undefined',
+      actual: recorded.billed[0]?.usage,
+      expected: undefined,
+    });
+  });
+
+  it('given a SUCCESSFUL run, should bill the generation\'s own total, not the step sum', async () => {
+    const { deps: d, recorded, drain } = deps({
+      generate: async ({ onStepUsage }) => {
+        onStepUsage?.({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+        return {
+          text: 'done',
+          usage: { inputTokens: 999, outputTokens: 888, totalTokens: 1887 },
+          provider: 'openrouter',
+          model: 'm',
+        };
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'a completed run that also reported step usage',
+      should: 'prefer the run total — the step sum is only a fallback',
+      actual: recorded.billed[0]?.usage,
+      expected: { inputTokens: 999, outputTokens: 888, totalTokens: 1887 },
+    });
+  });
+
+  it('given steps reporting no totalTokens, should derive the total from input+output', async () => {
+    const { deps: d, recorded, drain } = deps({
+      generate: async ({ onStepUsage }) => {
+        onStepUsage?.({ inputTokens: 7, outputTokens: 3 });
+        throw new Error('AbortError');
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'a provider that omits totalTokens per step',
+      should: 'still produce a non-zero total so the charge is billed',
+      actual: recorded.billed[0]?.usage,
+      expected: { inputTokens: 7, outputTokens: 3, totalTokens: 10 },
     });
   });
 });

--- a/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
@@ -752,3 +752,53 @@ describe('dispatchHeadlessSessionTurn — usage survives an aborted run', () => 
     });
   });
 });
+
+describe('dispatchHeadlessSessionTurn — usage accumulator edge cases', () => {
+  it('given steps that report nothing measurable, should leave usage undefined rather than a zero row', async () => {
+    // An all-zero total reads as "measured and free"; undefined reads as
+    // "never measured". Only the second is true here.
+    const { deps: d, recorded, drain } = deps({
+      generate: async ({ onStepUsage }) => {
+        onStepUsage?.({});
+        onStepUsage?.({ inputTokens: 0, outputTokens: 0 });
+        throw new Error('AbortError');
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'an aborted run whose steps reported no measurable tokens',
+      should: 'report no usage at all',
+      actual: recorded.billed[0]?.usage,
+      expected: undefined,
+    });
+  });
+
+  it('given a mix of empty and charged steps, should bill only what was actually charged', async () => {
+    const { deps: d, recorded, drain } = deps({
+      generate: async ({ onStepUsage }) => {
+        onStepUsage?.({});
+        onStepUsage?.({ inputTokens: 12, outputTokens: 4, totalTokens: 16 });
+        throw new Error('AbortError');
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'one empty step and one charged step',
+      should: 'bill the charged step only',
+      actual: recorded.billed[0]?.usage,
+      expected: { inputTokens: 12, outputTokens: 4, totalTokens: 16 },
+    });
+  });
+});

--- a/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
+++ b/apps/web/src/lib/ai/machines/__tests__/headless-session-run.test.ts
@@ -536,3 +536,109 @@ describe('buildHeadlessToolContext', () => {
     });
   });
 });
+
+/**
+ * Issue #2204 follow-up, F15 and F5/F7/F14 threading. The hold is created
+ * before the claim, so every exit after that point must release it — and the
+ * claim's cancellation channel must actually reach the generation.
+ */
+describe('dispatchHeadlessSessionTurn — hold release and abort threading', () => {
+  it('given a claim acquisition that THROWS, should release the hold rather than strand the reservation', async () => {
+    const { deps: d, recorded } = deps({
+      claimRun: async () => {
+        throw new Error('connection reset');
+      },
+    });
+
+    const result = await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+
+    assert({
+      given: 'a dispatch whose claim insert rejects on a database blip',
+      should: 'report the failure and free the credit hold',
+      actual: { ok: result.ok, holdsReleased: recorded.holdsReleased },
+      expected: { ok: false, holdsReleased: ['hold-1'] },
+    });
+  });
+
+  it('given a claim carrying an abort signal, should hand that signal to the generation', async () => {
+    const controller = new AbortController();
+    let seen: AbortSignal | undefined;
+    const { deps: d, drain } = deps({
+      claimRun: async () => ({
+        ok: true,
+        claim: {
+          messageId: 'assistant-1',
+          abortSignal: controller.signal,
+          release: async () => {},
+        },
+      }),
+      generate: async ({ abortSignal }) => {
+        seen = abortSignal;
+        return { text: 'done', provider: 'openrouter', model: 'm' };
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'a claim that can be cancelled',
+      should: 'give the generation the same signal, so a takeover actually ends the loop',
+      actual: seen === controller.signal,
+      expected: true,
+    });
+  });
+
+  it('given a credit gate that reported a balance snapshot, should thread it to the generation', async () => {
+    let seen: number | null | undefined;
+    const { deps: d, drain } = deps({
+      checkCredit: async () => ({ allowed: true, holdId: 'hold-1', balanceSnapshotCents: 250 }),
+      generate: async ({ balanceSnapshotCents }) => {
+        seen = balanceSnapshotCents;
+        return { text: 'done', provider: 'openrouter', model: 'm' };
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'a reservation with a known spendable balance',
+      should: 'give the run its own slice to guard against',
+      actual: seen,
+      expected: 250,
+    });
+  });
+
+  it('given a gate with no balance snapshot, should pass null rather than leave it undefined', async () => {
+    let seen: number | null | undefined = 1;
+    const { deps: d, drain } = deps({
+      generate: async ({ balanceSnapshotCents }) => {
+        seen = balanceSnapshotCents;
+        return { text: 'done', provider: 'openrouter', model: 'm' };
+      },
+    });
+
+    await dispatchHeadlessSessionTurn(
+      { identity: identity(), actor: { userId: 'u1' }, message: 'hi', depth: 0 },
+      d,
+    );
+    await drain();
+
+    assert({
+      given: 'an unmetered deployment where the gate reports no snapshot',
+      should: 'pass an explicit null',
+      actual: seen,
+      expected: null,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
@@ -403,6 +403,7 @@ async function generate(input: {
   depth: number;
   abortSignal?: AbortSignal;
   balanceSnapshotCents?: number | null;
+  onStepUsage?: (usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number }) => void;
 }): Promise<{ text: string; usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }; toolCallCount?: number; provider: string; model: string }> {
   const { target, userId, depth } = input;
 
@@ -481,11 +482,19 @@ async function generate(input: {
   // a single reservation, so without this a low-balance user keeps spending
   // well past what was reserved for them.
   const creditAbortController = new AbortController();
-  const onStepFinish =
+  const guardBalance =
     input.balanceSnapshotCents != null
       ? makeOnStepFinishHandler(creditAbortController, input.balanceSnapshotCents, providerResult.modelName)
       : null;
   const abortSignal = mergeAbortSignals(input.abortSignal, creditAbortController.signal);
+
+  // ALWAYS registered, not only when a balance guard exists: this is also how
+  // the engine learns what the provider already charged for, so an aborted run
+  // still bills its completed steps (see HeadlessGenerateInput.onStepUsage).
+  const onStepFinish = ({ usage }: { usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } }) => {
+    input.onStepUsage?.(usage);
+    guardBalance?.(usage);
+  };
 
   const result = await generateText({
     model: providerResult.model,
@@ -496,7 +505,7 @@ async function generate(input: {
     maxRetries: 3,
     experimental_context: context,
     abortSignal,
-    ...(onStepFinish ? { onStepFinish: ({ usage }: { usage: { inputTokens?: number; outputTokens?: number } }) => onStepFinish(usage) } : {}),
+    onStepFinish,
     stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(MAX_STEPS)],
   });
 

--- a/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
@@ -491,9 +491,12 @@ async function generate(input: {
   // ALWAYS registered, not only when a balance guard exists: this is also how
   // the engine learns what the provider already charged for, so an aborted run
   // still bills its completed steps (see HeadlessGenerateInput.onStepUsage).
-  const onStepFinish = ({ usage }: { usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number } }) => {
-    input.onStepUsage?.(usage);
-    guardBalance?.(usage);
+  const onStepFinish = ({ usage }: { usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number } }) => {
+    // Defensive default: a provider that reports no usage for a step must not
+    // throw inside the step callback and take the whole generation down.
+    const step = usage ?? {};
+    input.onStepUsage?.(step);
+    guardBalance?.(step);
   };
 
   const result = await generateText({

--- a/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
@@ -48,6 +48,7 @@ import { and, eq, desc, ne, or } from '@pagespace/db/operators';
 import { chatMessages, pages } from '@pagespace/db/schema/core';
 import { users } from '@pagespace/db/schema/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { MAX_CHAT_INFLIGHT } from '@pagespace/lib/billing/credit-pricing';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { releaseHold } from '@pagespace/lib/billing/credit-consume';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
@@ -57,7 +58,11 @@ import { deriveMachinePaneBinding } from '@pagespace/lib/services/machines/machi
 import { agentSurfaceOf, isAgentRuntimeType } from '@pagespace/lib/services/machines/agent-terminal-types';
 import { buildMachinePaneBindingDeps } from '@/lib/ai/machine-pane/machine-pane-binding-runtime';
 import { createAIProvider, isProviderError } from '@/lib/ai/core/provider-factory';
-import { DEFAULT_PROVIDER, DEFAULT_MODEL } from '@/lib/ai/core/ai-providers-config';
+import { DEFAULT_PROVIDER, DEFAULT_MODEL, resolveProviderModel } from '@/lib/ai/core/ai-providers-config';
+import { resolveGenerationAdmission } from '@/lib/ai/core/generation-admission';
+import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
+import { makeOnStepFinishHandler } from '@/app/api/ai/chat/step-finish-handler';
+import { STREAM_MAX_LIFETIME_MS } from '@/lib/ai/core/stream-horizons';
 import { pageSpaceTools } from '@/lib/ai/core/ai-tools';
 import {
   filterToolsForMachineBinding,
@@ -87,6 +92,15 @@ const MAX_STEPS = 60;
 
 /** Heartbeat cadence for a held claim, matching `stream-lifecycle.ts`'s. */
 const HEARTBEAT_INTERVAL_MS = 20 * 1000;
+
+/**
+ * The two independent reasons a dispatched run must stop — the CLAIM's (a human
+ * took the pane over, or the lifetime backstop fired) and the CREDIT
+ * accumulator's — as one signal. Either alone ends the generation.
+ */
+function mergeAbortSignals(claimSignal: AbortSignal | undefined, creditSignal: AbortSignal): AbortSignal {
+  return claimSignal ? AbortSignal.any([claimSignal, creditSignal]) : creditSignal;
+}
 
 /** The claim key for one session's conversation — unique per conversation, by construction. */
 export function sessionRunClaimId(conversationId: string): string {
@@ -123,6 +137,23 @@ async function releaseStaleClaim(claimId: string): Promise<void> {
     .update(aiStreamSessions)
     .set({ status: 'aborted', completedAt: new Date(), streamId: null })
     .where(and(eq(aiStreamSessions.streamId, claimId), eq(aiStreamSessions.status, 'streaming')));
+}
+
+/**
+ * Has a human asked this conversation's generation to stop?
+ *
+ * `stream-abort-mark.ts` records takeover and Stop DURABLY, as
+ * `abortRequestedAt` on the streaming row — a mark, not a message, precisely so
+ * a run in another process can see it. The interactive path consumes it through
+ * the abort registry; a dispatched run has no registry entry, so it reads its
+ * own row on the heartbeat it is already running.
+ */
+async function isAbortRequested(messageId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ abortRequestedAt: aiStreamSessions.abortRequestedAt })
+    .from(aiStreamSessions)
+    .where(eq(aiStreamSessions.messageId, messageId));
+  return row?.abortRequestedAt != null;
 }
 
 async function claimRun({
@@ -182,15 +213,36 @@ async function claimRun({
     return { ok: false, reason: 'busy' };
   }
 
+  // The claim's cancellation channel. Tripped by a human taking the pane over,
+  // and by the lifetime backstop below; handed to the generation so either fact
+  // actually ends the loop instead of being recorded beside a run that keeps
+  // spending. (Issue #2204 follow-up, F7/F14.)
+  const abortController = new AbortController();
+  const startedAtMs = now.getTime();
+
   // A dispatched run can sit inside a single long tool call for minutes, so the
   // beat is a real timer — the same reason `stream-lifecycle.ts` refuses to ride
   // its parts checkpoint. `unref` so a held claim never keeps the process alive.
   const heartbeat = setInterval(() => {
-    void db
-      .update(aiStreamSessions)
-      .set({ lastHeartbeatAt: new Date() })
-      .where(eq(aiStreamSessions.messageId, messageId))
-      .catch(() => {});
+    void (async () => {
+      // The SAME horizon the normal stream lifecycle enforces. Without it a
+      // provider request or tool call that never settles keeps this claim — and
+      // its unique key — alive forever, which reads to every future dispatch as
+      // "that session is permanently busy".
+      if (Date.now() - startedAtMs >= STREAM_MAX_LIFETIME_MS) {
+        abortController.abort();
+        return;
+      }
+      if (await isAbortRequested(messageId).catch(() => false)) {
+        abortController.abort();
+        return;
+      }
+      await db
+        .update(aiStreamSessions)
+        .set({ lastHeartbeatAt: new Date() })
+        .where(eq(aiStreamSessions.messageId, messageId))
+        .catch(() => {});
+    })();
   }, HEARTBEAT_INTERVAL_MS);
   heartbeat.unref?.();
 
@@ -206,6 +258,7 @@ async function claimRun({
     ok: true,
     claim: {
       messageId,
+      abortSignal: abortController.signal,
       release: async ({ aborted }) => {
         clearInterval(heartbeat);
         // `streamId: null` is what actually frees the claim — NULLs are distinct
@@ -348,6 +401,8 @@ async function generate(input: {
   history: HeadlessTranscriptMessage[];
   userId: string;
   depth: number;
+  abortSignal?: AbortSignal;
+  balanceSnapshotCents?: number | null;
 }): Promise<{ text: string; usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number }; toolCallCount?: number; provider: string; model: string }> {
   const { target, userId, depth } = input;
 
@@ -355,6 +410,36 @@ async function generate(input: {
     .select({ id: pages.id, title: pages.title, type: pages.type, systemPrompt: pages.systemPrompt, aiProvider: pages.aiProvider, aiModel: pages.aiModel, enabledTools: pages.enabledTools })
     .from(pages)
     .where(eq(pages.id, target.machineId));
+
+  // ENTITLEMENT, before a token is spent (issue #2204 follow-up, F4). The
+  // machine page's configured provider/model is not the dispatcher's own
+  // selection, so a free or non-admin collaborator could otherwise reach a
+  // paid or admin-only provider through send_session that the chat route would
+  // have refused them. Same shared decision, same answer, different transport.
+  const [actor] = await db
+    .select({ role: users.role, subscriptionTier: users.subscriptionTier })
+    .from(users)
+    .where(eq(users.id, userId));
+  const requested = resolveProviderModel(
+    machinePage?.aiProvider || DEFAULT_PROVIDER,
+    machinePage?.aiModel || DEFAULT_MODEL,
+    undefined,
+    undefined,
+  );
+  const admission = resolveGenerationAdmission({
+    provider: requested.provider,
+    model: requested.model,
+    subscriptionTier: actor?.subscriptionTier ?? undefined,
+    isAdmin: actor?.role === 'admin',
+    requiresProSubscription,
+  });
+  if (!admission.allowed) {
+    throw new Error(
+      admission.reason === 'provider_admin_only'
+        ? 'This machine is configured with an administrator-only AI provider.'
+        : 'This machine is configured with a model that requires a paid plan.',
+    );
+  }
 
   const providerResult = await createAIProvider(userId, {
     selectedProvider: machinePage?.aiProvider || DEFAULT_PROVIDER,
@@ -391,6 +476,17 @@ async function generate(input: {
     { role: 'user' as const, content: input.message },
   ];
 
+  // The interactive route's balance-aware step accumulator, on the dispatched
+  // path (issue #2204 follow-up, F5). Up to MAX_STEPS of model work can follow
+  // a single reservation, so without this a low-balance user keeps spending
+  // well past what was reserved for them.
+  const creditAbortController = new AbortController();
+  const onStepFinish =
+    input.balanceSnapshotCents != null
+      ? makeOnStepFinishHandler(creditAbortController, input.balanceSnapshotCents, providerResult.modelName)
+      : null;
+  const abortSignal = mergeAbortSignals(input.abortSignal, creditAbortController.signal);
+
   const result = await generateText({
     model: providerResult.model,
     system: buildSystemPrompt(target, machinePage?.systemPrompt ?? null),
@@ -399,6 +495,8 @@ async function generate(input: {
     toolChoice: 'auto',
     maxRetries: 3,
     experimental_context: context,
+    abortSignal,
+    ...(onStepFinish ? { onStepFinish: ({ usage }: { usage: { inputTokens?: number; outputTokens?: number } }) => onStepFinish(usage) } : {}),
     stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(MAX_STEPS)],
   });
 
@@ -438,9 +536,23 @@ export function buildHeadlessSessionRunDeps(): HeadlessSessionRunDeps {
         .select({ subscriptionTier: users.subscriptionTier })
         .from(users)
         .where(eq(users.id, userId));
-      const gate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier);
+      const gate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier, {
+        // The interactive route's CONFIGURED cap, not the gate's default
+        // (issue #2204 follow-up, F6). Each session's claim is independent, so
+        // without this a paid user dispatching to many different sessions at
+        // once faced no concurrency ceiling at all — an unbounded headless
+        // fan-out of reservations the chat composer could never produce.
+        maxInFlight: MAX_CHAT_INFLIGHT,
+      });
       if (!gate.allowed) return { allowed: false, reason: gate.reason ?? 'denied' };
-      return { allowed: true, holdId: gate.holdId ?? null };
+      return {
+        allowed: true,
+        holdId: gate.holdId ?? null,
+        // The run's OWN slice of the balance — what its per-step accumulator
+        // guards against, so concurrent runs cannot collectively overshoot.
+        balanceSnapshotCents:
+          gate.holdId && gate.balanceSnapshot ? gate.balanceSnapshot.netSpendableCents : null,
+      };
     },
     releaseHold: async (holdId) => {
       await releaseHold(holdId);

--- a/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run-runtime.ts
@@ -71,7 +71,7 @@ import { broadcastChatUserMessage, broadcastAiStreamStart, broadcastAiStreamComp
 import { STREAM_HEARTBEAT_STALE_MS } from '@/lib/ai/core/stream-liveness';
 import type { ToolExecutionContext } from '@/lib/ai/core/types';
 import { buildMachineBindingPrompt } from './machine-binding-prompt';
-import { isClaimContested } from './headless-session-run';
+import { isClaimContested, buildHeadlessToolContext } from './headless-session-run';
 import type {
   HeadlessClaimResult,
   HeadlessSessionRunDeps,
@@ -379,25 +379,12 @@ async function generate(input: {
     (machinePage?.enabledTools as string[] | null) ?? null,
   ) as ToolSet;
 
-  const context: ToolExecutionContext = {
+  const context = buildHeadlessToolContext({
+    target,
+    machinePage: machinePage ? { id: machinePage.id, title: machinePage.title, type: machinePage.type } : undefined,
     userId,
-    conversationId: target.conversationId,
-    machineBinding: target.binding,
-    // Its own dispatches are one level deeper than this run — the cap in
-    // `headless-session-run.ts` reads this counter back off the context.
-    agentCallDepth: depth,
-    requestOrigin: 'agent',
-    locationContext: machinePage
-      ? {
-          currentPage: {
-            id: machinePage.id,
-            title: machinePage.title,
-            type: machinePage.type,
-            path: `/${machinePage.title}`,
-          },
-        }
-      : undefined,
-  } as ToolExecutionContext;
+    depth,
+  }) as ToolExecutionContext;
 
   const messages = [
     ...input.history.map((entry) => ({ role: entry.role, content: entry.content })),

--- a/apps/web/src/lib/ai/machines/headless-session-run.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run.ts
@@ -81,6 +81,16 @@ export interface HeadlessSessionTarget {
 export interface HeadlessRunClaim {
   /** The assistant message id this run will write into. */
   messageId: string;
+  /**
+   * The claim's cancellation channel (issue #2204 follow-up, F7/F14).
+   *
+   * The claim is what watches the conversation, so the claim is what learns
+   * that the run must stop — a human taking the pane over (a durable
+   * `abortRequestedAt` mark), or the run outliving its lifetime backstop. The
+   * generation is handed this signal so those facts actually end the loop
+   * rather than merely being recorded next to a loop that keeps billing.
+   */
+  abortSignal?: AbortSignal;
   /** Release the claim, exactly once, whatever the outcome. */
   release: (outcome: { aborted: boolean; error?: string }) => Promise<void>;
 }
@@ -105,6 +115,10 @@ export interface HeadlessGenerateInput {
   userId: string;
   /** The depth THIS run executes at — what its own tools see as `agentCallDepth`. */
   depth: number;
+  /** The claim's cancellation channel — see {@link HeadlessRunClaim.abortSignal}. */
+  abortSignal?: AbortSignal;
+  /** Net spendable cents behind this run's reservation, or null when unmetered. */
+  balanceSnapshotCents?: number | null;
 }
 
 export interface HeadlessGenerateResult {
@@ -221,7 +235,20 @@ export interface HeadlessSessionRunDeps {
    */
   checkCredit: (input: {
     userId: string;
-  }) => Promise<{ allowed: true; holdId: string | null } | { allowed: false; reason: string }>;
+  }) => Promise<
+    | {
+        allowed: true;
+        holdId: string | null;
+        /**
+         * Net spendable cents behind this reservation, when the gate computed
+         * one. Threaded to `generate` so the run's per-step accumulator guards
+         * against ITS OWN slice of the balance rather than the gross figure —
+         * the same discipline the interactive route applies. (F5.)
+         */
+        balanceSnapshotCents?: number | null;
+      }
+    | { allowed: false; reason: string }
+  >;
   /** Release the gate's hold once the run settles — actual consumption flows through `trackUsage`. */
   releaseHold: (holdId: string) => Promise<void>;
   /** Atomic claim on the conversation — the workflow_runs discipline, contended by live streams too. */
@@ -341,13 +368,26 @@ export async function dispatchHeadlessSessionTurn(
     return { ok: false, reason: 'credit_denied', detail: credit.reason };
   }
   const holdId = credit.holdId;
+  const balanceSnapshotCents = credit.balanceSnapshotCents ?? null;
 
   const releaseHold = async () => {
     if (holdId) await deps.releaseHold(holdId).catch(() => {});
   };
 
   const messageId = deps.newId();
-  const claimed = await deps.claimRun({ target, userId: input.actor.userId, messageId });
+  // THROWS release the hold too (issue #2204 follow-up, F15). A `busy` result
+  // and an append failure both released it; a claimRun that rejected on a
+  // database or network blip exited before any cleanup, stranding spendable
+  // balance until the hold's TTL expired. Every exit after the hold exists is
+  // now a releasing exit.
+  let claimed: HeadlessClaimResult;
+  try {
+    claimed = await deps.claimRun({ target, userId: input.actor.userId, messageId });
+  } catch (error) {
+    deps.onError?.('headless-session-run: claim failed', error);
+    await releaseHold();
+    return { ok: false, reason: 'failed', detail: errorText(error) };
+  }
   if (!claimed.ok) {
     // No run will happen — a hold left behind would strand spendable balance
     // until it expires.
@@ -373,7 +413,7 @@ export async function dispatchHeadlessSessionTurn(
     return { ok: false, reason: 'failed', detail: errorText(error) };
   }
 
-  deps.defer(() => runClaimedTurn({ input, target, claim, holdId, userMessageId, deps }));
+  deps.defer(() => runClaimedTurn({ input, target, claim, holdId, balanceSnapshotCents, userMessageId, deps }));
 
   return { ok: true, accepted: true, messageId: claim.messageId };
 }
@@ -388,6 +428,7 @@ async function runClaimedTurn({
   target,
   claim,
   holdId,
+  balanceSnapshotCents,
   userMessageId,
   deps,
 }: {
@@ -395,6 +436,7 @@ async function runClaimedTurn({
   target: HeadlessSessionTarget;
   claim: HeadlessRunClaim;
   holdId: string | null;
+  balanceSnapshotCents: number | null;
   userMessageId: string;
   deps: HeadlessSessionRunDeps;
 }): Promise<void> {
@@ -411,6 +453,8 @@ async function runClaimedTurn({
       // The run executes one level deeper than the dispatcher, so a session it
       // dispatches to in turn sees the chain it is actually part of.
       depth: input.depth + 1,
+      ...(claim.abortSignal ? { abortSignal: claim.abortSignal } : {}),
+      balanceSnapshotCents,
     });
     await deps.persistReply({
       target,

--- a/apps/web/src/lib/ai/machines/headless-session-run.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run.ts
@@ -141,6 +141,75 @@ export function isClaimContested(
   );
 }
 
+/** The machine page a dispatched run executes as — the slice the tool context needs. */
+export interface HeadlessMachinePage {
+  id: string;
+  title: string;
+  type: string;
+}
+
+/**
+ * The tool-execution context a dispatched turn runs under (issue #2204
+ * follow-up, F8).
+ *
+ * THE PART THAT IS EASY TO GET WRONG, and was: `chatSource`.
+ * `resolveSandboxActorContext` fails CLOSED — "Code execution requires an
+ * active drive" — for any context whose `chatSource.type` is not `'global'`
+ * and that carries no drive. It reaches a page agent's drive through
+ * `chatSource.agentPageId`, so a context with `locationContext.currentPage`
+ * alone looks driveless and every bash/file/git tool in the run is refused.
+ * A dispatched session is a page agent on the machine page, exactly as the
+ * interactive route describes it, so it must say so the same way.
+ *
+ * Pure, and separated from the runtime's `generate` for that reason: this is
+ * the whole difference between a dispatched session that can execute code and
+ * one that cannot, and it should never again be provable only by dispatching.
+ */
+export interface HeadlessToolContext {
+  userId: string;
+  conversationId: string;
+  machineBinding: MachineNodeHandleSet;
+  agentCallDepth: number;
+  requestOrigin: 'agent';
+  chatSource?: { type: 'page'; agentPageId: string; agentTitle: string };
+  locationContext?: { currentPage: { id: string; title: string; type: string; path: string } };
+}
+
+export function buildHeadlessToolContext(input: {
+  target: HeadlessSessionTarget;
+  machinePage: HeadlessMachinePage | undefined;
+  userId: string;
+  depth: number;
+}): HeadlessToolContext {
+  const { target, machinePage, userId, depth } = input;
+  return {
+    userId,
+    conversationId: target.conversationId,
+    machineBinding: target.binding,
+    // Its own dispatches are one level deeper than this run — the cap in
+    // `dispatchHeadlessSessionTurn` reads this counter back off the context.
+    agentCallDepth: depth,
+    requestOrigin: 'agent',
+    ...(machinePage
+      ? {
+          chatSource: {
+            type: 'page' as const,
+            agentPageId: machinePage.id,
+            agentTitle: machinePage.title,
+          },
+          locationContext: {
+            currentPage: {
+              id: machinePage.id,
+              title: machinePage.title,
+              type: machinePage.type,
+              path: `/${machinePage.title}`,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
 export interface HeadlessSessionRunDeps {
   /** Resolve the addressed session into a runnable target, or null if it is not an agent session. */
   resolveTarget: (identity: SessionTerminalIdentity) => Promise<HeadlessSessionTarget | null>;

--- a/apps/web/src/lib/ai/machines/headless-session-run.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run.ts
@@ -475,10 +475,17 @@ async function runClaimedTurn({
       ...(claim.abortSignal ? { abortSignal: claim.abortSignal } : {}),
       balanceSnapshotCents,
       onStepUsage: (usage) => {
+        const input = usage?.inputTokens ?? 0;
+        const output = usage?.outputTokens ?? 0;
+        const total = usage?.totalTokens ?? input + output;
+        // A step that reports nothing measurable must not flip this: it would
+        // turn `undefined` usage into an all-zero row, which reads as "measured
+        // and free" rather than "never measured".
+        if (input === 0 && output === 0 && total === 0) return;
         spentAnything = true;
-        spent.inputTokens += usage.inputTokens ?? 0;
-        spent.outputTokens += usage.outputTokens ?? 0;
-        spent.totalTokens += usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+        spent.inputTokens += input;
+        spent.outputTokens += output;
+        spent.totalTokens += total;
       },
     });
     await deps.persistReply({

--- a/apps/web/src/lib/ai/machines/headless-session-run.ts
+++ b/apps/web/src/lib/ai/machines/headless-session-run.ts
@@ -119,6 +119,19 @@ export interface HeadlessGenerateInput {
   abortSignal?: AbortSignal;
   /** Net spendable cents behind this run's reservation, or null when unmetered. */
   balanceSnapshotCents?: number | null;
+  /**
+   * Cumulative usage after each completed model step (issue #2204 follow-up
+   * review, Codex P1).
+   *
+   * The final `HeadlessGenerateResult` is the only usage report a SUCCESSFUL
+   * run needs — but an aborted or failed one never produces it. A run stopped
+   * by takeover, by the credit guard, or by the lifetime backstop rejects out
+   * of `generateText` after the provider has already charged for the steps it
+   * completed, and `trackAIUsage` skips an unsuccessful zero-token call
+   * entirely (`success || totalTokens > 0`), so those tokens went unbilled.
+   * Reporting per step makes the charge survive any exit.
+   */
+  onStepUsage?: (usage: { inputTokens?: number; outputTokens?: number; totalTokens?: number }) => void;
 }
 
 export interface HeadlessGenerateResult {
@@ -443,6 +456,12 @@ async function runClaimedTurn({
   let result: HeadlessGenerateResult | undefined;
   let failure: string | undefined;
 
+  // What the provider has ALREADY charged for, accumulated as the run goes, so
+  // an abort or a mid-loop failure still bills what it spent. See
+  // `HeadlessGenerateInput.onStepUsage`.
+  const spent = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  let spentAnything = false;
+
   try {
     const history = await deps.loadHistory(target, { excludeMessageId: userMessageId });
     result = await deps.generate({
@@ -455,6 +474,12 @@ async function runClaimedTurn({
       depth: input.depth + 1,
       ...(claim.abortSignal ? { abortSignal: claim.abortSignal } : {}),
       balanceSnapshotCents,
+      onStepUsage: (usage) => {
+        spentAnything = true;
+        spent.inputTokens += usage.inputTokens ?? 0;
+        spent.outputTokens += usage.outputTokens ?? 0;
+        spent.totalTokens += usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+      },
     });
     await deps.persistReply({
       target,
@@ -486,7 +511,10 @@ async function runClaimedTurn({
       userId: input.actor.userId,
       pageId: target.machineId,
       conversationId: target.conversationId,
-      usage: result?.usage,
+      // The completed run's own total when there is one; otherwise what the
+      // steps reported before the abort/failure — never nothing, or the
+      // provider's charge for those steps is silently absorbed.
+      usage: result?.usage ?? (spentAnything ? spent : undefined),
       success: failure === undefined,
       provider: result?.provider,
       model: result?.model,

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 // The factory is provider-agnostic and imports no DB or backing-provider SDK, so
 // it is exercised directly with injected fakes (the production wiring + the Fly
 // Sprites driver live in sandbox-tools-runtime.ts).
-import { createSandboxTools, type MachineDirectoryDeps, type ResolveSandboxContext, type SandboxGate } from '../sandbox-tools';
+import { createSandboxTools, nodeScopedPath, type MachineDirectoryDeps, type ResolveSandboxContext, type SandboxGate } from '../sandbox-tools';
 import type { SandboxRunDeps, SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 import type { ToolExecutionContext } from '../../core/types';
 import type { MachineNodeHandle, MachineNodeHandleSet } from '@pagespace/lib/services/machines/machine-pane-binding';
@@ -75,6 +75,38 @@ function exec(tool: { execute?: unknown }, args: unknown, context: unknown) {
   const fn = tool.execute as (a: unknown, o: unknown) => Promise<unknown>;
   return fn(args, { experimental_context: context });
 }
+
+/**
+ * The file tools' cwd policy (issue #2204 follow-up, F9). `bash` has always
+ * defaulted to the resolved node's cwd; the file tools rooted every relative
+ * path at SANDBOX_ROOT instead, so a targeted read/write hit a different file
+ * than a targeted `bash` in the same node.
+ */
+describe('nodeScopedPath', () => {
+  it('given a relative path and a node cwd, should anchor the path to that cwd', () => {
+    expect(nodeScopedPath('a.txt', { cwd: '/workspace/projects/foo' })).toBe('/workspace/projects/foo/a.txt');
+  });
+
+  it('given a nested relative path, should preserve the remainder under the node cwd', () => {
+    expect(nodeScopedPath('src/index.ts', { cwd: '/workspace/repo' })).toBe('/workspace/repo/src/index.ts');
+  });
+
+  it('given no node, should return the path untouched — an unbound call keeps the runner\'s SANDBOX_ROOT default', () => {
+    expect(nodeScopedPath('a.txt', undefined)).toBe('a.txt');
+  });
+
+  it('given an ABSOLUTE path, should leave it alone — the file-tool analogue of bash\'s explicit cwd', () => {
+    expect(nodeScopedPath('/workspace/other/a.txt', { cwd: '/workspace/repo' })).toBe('/workspace/other/a.txt');
+  });
+
+  it('given a node cwd with a trailing slash, should not emit a doubled separator', () => {
+    expect(nodeScopedPath('a.txt', { cwd: '/workspace/repo/' })).toBe('/workspace/repo/a.txt');
+  });
+
+  it('given a machine-root node, should be a no-op in effect — /workspace is the runner default anyway', () => {
+    expect(nodeScopedPath('a.txt', { cwd: '/workspace' })).toBe('/workspace/a.txt');
+  });
+});
 
 describe('createSandboxTools', () => {
   it('bash: given a resolvable context, should delegate to the runner and return its result', async () => {
@@ -798,6 +830,10 @@ describe('createSandboxTools', () => {
     function capturingRunDeps() {
       const seenCwds: Array<string | undefined> = [];
       const seenAcquisitions: Array<{ branchSandbox?: unknown }> = [];
+      // Where the file tools actually landed — the runner resolves the path it
+      // is handed against SANDBOX_ROOT, so this is the end of the path story.
+      const seenWritePaths: string[] = [];
+      const seenReadPaths: string[] = [];
       const runDeps = fakeRunDeps();
       runDeps.acquireSandbox = async (input) => {
         seenAcquisitions.push(input);
@@ -810,11 +846,16 @@ describe('createSandboxTools', () => {
           seenCwds.push(args.cwd);
           return { exitCode: 0, stdout: 'hi', stderr: '' };
         },
-        writeFiles: async () => {},
-        readFileToBuffer: async () => Buffer.from('data'),
+        writeFiles: async (files: Array<{ path: string }>) => {
+          for (const file of files) seenWritePaths.push(file.path);
+        },
+        readFileToBuffer: async (args: { path: string }) => {
+          seenReadPaths.push(args.path);
+          return Buffer.from('data');
+        },
         createCheckpoint: async () => {},
       });
-      return { runDeps, seenCwds, seenAcquisitions };
+      return { runDeps, seenCwds, seenAcquisitions, seenWritePaths, seenReadPaths };
     }
 
     it('bash: given target { project }, should run at the project\'s cwd on the MACHINE\'s own Sprite', async () => {
@@ -890,6 +931,40 @@ describe('createSandboxTools', () => {
         expect.objectContaining({ branchSandbox: { machineId: 'm1', machineBranchId: 'branch-1' } }),
         expect.objectContaining({ branchSandbox: { machineId: 'm1', machineBranchId: 'branch-1' } }),
       ]);
+    });
+
+    it('writeFile: given target { project }, should write UNDER the project cwd, not at the sandbox root', async () => {
+      const { runDeps, seenWritePaths } = capturingRunDeps();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      await exec(
+        tools.writeFile,
+        { path: 'a.txt', content: 'x', target: { project: 'repo' } },
+        { userId: 'u1', machineBinding: machineRootBinding },
+      );
+      expect(seenWritePaths).toEqual(['/workspace/projects/repo/a.txt']);
+    });
+
+    it('readFile: given target { branch }, should read UNDER the branch cwd — the same file bash would see', async () => {
+      const { runDeps, seenReadPaths } = capturingRunDeps();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      await exec(
+        tools.readFile,
+        { path: 'a.txt', target: { project: 'repo', branch: 'feature' } },
+        { userId: 'u1', machineBinding: machineRootBinding },
+      );
+      expect(seenReadPaths).toEqual(['/workspace/repo/a.txt']);
+    });
+
+    it('editFile: given target { project }, should edit the file under the project cwd', async () => {
+      const { runDeps, seenReadPaths, seenWritePaths } = capturingRunDeps();
+      const tools = createSandboxTools({ runDeps, resolveContext: okResolve, gate: okGate, machines: okMachines() });
+      await exec(
+        tools.editFile,
+        { path: 'a.txt', oldString: 'data', newString: 'X', target: { project: 'repo' } },
+        { userId: 'u1', machineBinding: machineRootBinding },
+      );
+      expect(seenReadPaths).toEqual(['/workspace/projects/repo/a.txt']);
+      expect(seenWritePaths).toEqual(['/workspace/projects/repo/a.txt']);
     });
 
     it('bash: given a branch-targeted run, the billing/guardrail key should stay the owning machine page id', async () => {

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -65,6 +65,27 @@ export function bindingCwdFor(
 }
 
 /**
+ * The FILE tools' counterpart to {@link bindingCwdFor}.
+ *
+ * `writeFile`/`readFile`/`editFile` take a path, not a cwd, and the runner
+ * resolves it against SANDBOX_ROOT (`resolveSandboxPath`). Without this, a
+ * relative path is rooted at `/workspace` no matter which node the call
+ * resolved to — so `target: { project: 'foo' }` would read and write
+ * `/workspace/a.txt` while `bash` in the same target ran in
+ * `/workspace/projects/foo`. Two tools, one addressed node, different files.
+ *
+ * Relative paths are therefore anchored to the RESOLVED NODE's cwd, which is
+ * exactly the default `bash` already applies. An ABSOLUTE path is left alone —
+ * it is the file-tool analogue of `bash`'s explicit `cwd` argument, and the
+ * runner still confines it to the sandbox root, so this can widen no reach.
+ */
+export function nodeScopedPath(path: string, node: { cwd: string } | undefined): string {
+  const cwd = node?.cwd;
+  if (!cwd || path.startsWith('/')) return path;
+  return `${cwd.replace(/\/+$/, '')}/${path}`;
+}
+
+/**
  * Direct child addressing (node epic): every code-execution tool may aim at a
  * node BENEATH the conversation's own — a project, or a branch — instead of
  * the node it is bound to. Resolution runs against the derived handle set
@@ -474,7 +495,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
       execute: async ({ path, content, target }, options) => {
         const opened = await open(options, target);
         if (!opened.ok) return opened.error;
-        return writeSandboxFile({ path, content, ctx: opened.ctx, deps: runDeps });
+        return writeSandboxFile({ path: nodeScopedPath(path, opened.node), content, ctx: opened.ctx, deps: runDeps });
       },
     }),
 
@@ -485,7 +506,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
       execute: async ({ path, target }, options) => {
         const opened = await open(options, target);
         if (!opened.ok) return opened.error;
-        return readSandboxFile({ path, ctx: opened.ctx, deps: runDeps });
+        return readSandboxFile({ path: nodeScopedPath(path, opened.node), ctx: opened.ctx, deps: runDeps });
       },
     }),
 
@@ -496,7 +517,14 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
       execute: async ({ path, oldString, newString, replaceAll, target }, options) => {
         const opened = await open(options, target);
         if (!opened.ok) return opened.error;
-        return editSandboxFile({ path, oldString, newString, replaceAll, ctx: opened.ctx, deps: runDeps });
+        return editSandboxFile({
+          path: nodeScopedPath(path, opened.node),
+          oldString,
+          newString,
+          replaceAll,
+          ctx: opened.ctx,
+          deps: runDeps,
+        });
       },
     }),
 

--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -46,6 +46,7 @@ import type {
   KillAgentTerminalDeps,
   AgentTerminalProjectLookup,
   AgentTerminalMachineSandbox,
+  AgentTerminalLiveSessions,
 } from '@pagespace/lib/services/machines/agent-terminals';
 import { promoteProject } from '@pagespace/lib/services/machines/machine-project-promotion';
 import { canAccessMachine, canViewMachine, getMachineHostForBranches } from './machine-branches-runtime';
@@ -195,10 +196,39 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
  * inside the seam — a machine- or branch-scope spawn never promotes and must
  * not pay for the lookup.
  */
+/**
+ * The machine Sprite's currently-running PTY session ids, or `null` when we
+ * could not find out (issue #2204 follow-up review, Codex P2).
+ *
+ * ATTACH-ONLY, deliberately: this asks whether a promotion would strand a live
+ * process, and waking a hibernating Sprite to answer that would both cost money
+ * and make the answer trivially "nothing is running" anyway. A machine with no
+ * live Sprite has no live PTY, which is the empty list — not an unknown.
+ */
+function buildLiveSessions(actorUserId: string): AgentTerminalLiveSessions {
+  return {
+    list: async (machineId) => {
+      try {
+        const acquired = await buildMachineSandbox(actorUserId).acquire(machineId);
+        if (!acquired.ok) return null;
+        const host = await getMachineHostForBranches();
+        const handle = await host.attach({ machineId: acquired.sandboxId });
+        // No Sprite to attach to means nothing is running on it.
+        if (!handle) return [];
+        return (await handle.listStreams()).map((session) => session.id);
+      } catch {
+        // Control plane unreachable — we learned nothing. The caller fails closed.
+        return null;
+      }
+    },
+  };
+}
+
 export function buildSpawnAgentTerminalDeps(actorUserId: string): SpawnAgentTerminalDeps {
   return {
     ...buildBaseDeps(),
     projectStore: buildProjectStoreLookup(),
+    liveSessions: buildLiveSessions(actorUserId),
     now: () => new Date(),
     projectPromotion: {
       promote: async ({ machineId, projectName }) => {

--- a/apps/web/src/lib/machines/agent-terminals-runtime.ts
+++ b/apps/web/src/lib/machines/agent-terminals-runtime.ts
@@ -49,7 +49,7 @@ import type {
   AgentTerminalLiveSessions,
 } from '@pagespace/lib/services/machines/agent-terminals';
 import { promoteProject } from '@pagespace/lib/services/machines/machine-project-promotion';
-import { canAccessMachine, canViewMachine, getMachineHostForBranches } from './machine-branches-runtime';
+import { canAccessMachine, canViewMachine, getMachineHostForBranches, resolveRootMachineHandle } from './machine-branches-runtime';
 import { buildPromoteProjectDeps, resolveMachineActorContext } from './machine-projects-runtime';
 
 export { canAccessMachine, canViewMachine, isCodeExecutionEnabled };
@@ -205,15 +205,19 @@ function buildMachineSandbox(actorUserId: string): AgentTerminalMachineSandbox {
  * and make the answer trivially "nothing is running" anyway. A machine with no
  * live Sprite has no live PTY, which is the empty list — not an unknown.
  */
-function buildLiveSessions(actorUserId: string): AgentTerminalLiveSessions {
+function buildLiveSessions(): AgentTerminalLiveSessions {
   return {
     list: async (machineId) => {
       try {
-        const acquired = await buildMachineSandbox(actorUserId).acquire(machineId);
-        if (!acquired.ok) return null;
-        const host = await getMachineHostForBranches();
-        const handle = await host.attach({ machineId: acquired.sandboxId });
-        // No Sprite to attach to means nothing is running on it.
+        // `resolveRootMachineHandle`, NOT `acquire`: the acquire path goes
+        // through `getOrCreate`, which wakes a hibernating VM and re-provisions
+        // a destroyed one. Paying that to ask "is anything running?" would be
+        // absurd — and the answer for a machine we had to create is trivially
+        // "no". This resolver looks up a LIVE session id and attaches, or
+        // returns null when there is none.
+        const handle = await resolveRootMachineHandle(machineId);
+        // No live Sprite means no live PTY. That is an empty list, not an
+        // unknown — the caller must not fail closed on it.
         if (!handle) return [];
         return (await handle.listStreams()).map((session) => session.id);
       } catch {
@@ -228,7 +232,7 @@ export function buildSpawnAgentTerminalDeps(actorUserId: string): SpawnAgentTerm
   return {
     ...buildBaseDeps(),
     projectStore: buildProjectStoreLookup(),
-    liveSessions: buildLiveSessions(actorUserId),
+    liveSessions: buildLiveSessions(),
     now: () => new Date(),
     projectPromotion: {
       promote: async ({ machineId, projectName }) => {

--- a/apps/web/src/lib/machines/machine-projects-runtime.ts
+++ b/apps/web/src/lib/machines/machine-projects-runtime.ts
@@ -48,7 +48,7 @@ import { createDbMachineProjectStore } from '@pagespace/lib/services/machines/ma
 import type { MachineActorContext, MachineProjectsDeps, MachineAcquireResult } from '@pagespace/lib/services/machines/machine-projects';
 import type { PromoteProjectDeps } from '@pagespace/lib/services/machines/machine-project-promotion';
 import { buildMachineBranchesDeps } from './machine-branches-runtime';
-import { measureProjectStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
+import { measureProjectStorageOpportunistically, measureMachineStorageOpportunistically } from '@pagespace/lib/services/sandbox/machine-storage-billing';
 
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one —
 // @fly/sprites is ESM-only and @pagespace/lib compiles to CJS. Mirrors the
@@ -268,5 +268,16 @@ export function buildPromoteProjectDeps({ actorUserId }: { actorUserId: string }
     // stop being metered anywhere.
     measureProjectStorage: ({ machineProjectId, machinePageId, handle }) =>
       measureProjectStorageOpportunistically({ machineProjectId, machinePageId, handle }),
+    // The other half of the same move (issue #2204 follow-up, F12): the bytes
+    // left the ROOT when its checkout was reclaimed, so the root's stale
+    // measurement must be refreshed or the reconcile bills them twice. Lazy
+    // handle — the root Sprite may be hibernating, and `resolveHandle` is only
+    // called once the measurement is known to be due.
+    remeasureMachineStorage: ({ machinePageId }) =>
+      measureMachineStorageOpportunistically({
+        pageId: machinePageId,
+        resolveHandle: () => branches.resolveRootMachineHandle(machinePageId),
+        force: true,
+      }),
   };
 }

--- a/apps/web/src/lib/machines/machine-projects-runtime.ts
+++ b/apps/web/src/lib/machines/machine-projects-runtime.ts
@@ -247,6 +247,7 @@ export function buildPromoteProjectDeps({ actorUserId }: { actorUserId: string }
     },
     isEnabled: projects.isEnabled,
     now: projects.now,
+    wait: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
     host: branches.host,
     substrate: branches.substrate,
     options: branches.options,

--- a/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
+++ b/apps/web/src/stores/machine-workspace/__tests__/workspace-reducer.test.ts
@@ -3,6 +3,9 @@ import { assert } from '@/stores/__tests__/riteway';
 import { isValidAgentTerminalName, AGENT_LAUNCH_SPECS } from '@pagespace/lib/services/machines/agent-terminal-types';
 import {
   newWorkspace,
+  paneScopeForWire,
+  paneTerminalScope,
+  projectStoredPaneScope,
   addWorkspace,
   setActiveWorkspace,
   updateWorkspace,
@@ -1123,6 +1126,76 @@ describe('sanitizeMachines — what comes back from storage is untrusted', () =>
         'repoint active at the real pane and keep the content kind intact — same no-op-on-unknown-id contract as every other transition here',
       actual: { activePaneId: actual.activePaneId, scope: panesOf(actual)[0].scope },
       expected: { activePaneId: 'pane-1', scope: { name: 'claude-a1', kind: 'chat' } },
+    });
+  });
+});
+
+/**
+ * Issue #2204 follow-up, F13. Narrowing the pane shape also narrowed the WIRE
+ * shape, and pane scopes are persisted and broadcast. A pre-narrowing client —
+ * mid rolling-deploy, or a stale tab — reads a name-only pane as a MACHINE-ROOT
+ * session, so a project pane named `worker` resolves to the root's `worker` and
+ * can be connected to or killed instead.
+ */
+describe('paneScopeForWire — pre-narrowing client compatibility', () => {
+  it('given a PROJECT workspace, should put the project name on the wire', () => {
+    assert({
+      given: 'a pane in a project-scoped workspace',
+      should: 'send the full address, not just the name',
+      actual: paneScopeForWire({ level: 'project', projectName: 'repo' }, { name: 'worker' }),
+      expected: { name: 'worker', projectName: 'repo' },
+    });
+  });
+
+  it('given a BRANCH workspace, should put both checkout names on the wire', () => {
+    assert({
+      given: 'a chat pane in a branch-scoped workspace',
+      should: 'send project and branch alongside the name and kind',
+      actual: paneScopeForWire(
+        { level: 'branch', projectName: 'repo', branchName: 'feature' },
+        { name: 'worker', kind: 'chat' },
+      ),
+      expected: { name: 'worker', kind: 'chat', projectName: 'repo', branchName: 'feature' },
+    });
+  });
+
+  it('given a MACHINE-ROOT workspace, should stay name-only — there is no checkout to name', () => {
+    assert({
+      given: 'a pane in a root workspace',
+      should: 'send only the name',
+      actual: paneScopeForWire({ level: 'machine' }, { name: 'worker' }),
+      expected: { name: 'worker' },
+    });
+  });
+
+  it('given an UNBOUND pane, should stay null', () => {
+    assert({
+      given: 'an empty pane',
+      should: 'send null rather than a scope with no session',
+      actual: paneScopeForWire({ level: 'project', projectName: 'repo' }, null),
+      expected: null,
+    });
+  });
+
+  it('given a wire pane carrying the compat fields, this version should ignore them on the way in', () => {
+    assert({
+      given: 'a stored pane with a duplicated checkout',
+      should: 'project down to the narrowed shape, so the copy can never be believed here',
+      actual: projectStoredPaneScope({ name: 'worker', projectName: 'repo', branchName: 'feature' }),
+      expected: { name: 'worker' },
+    });
+  });
+
+  it('given a stale duplicated checkout, the READ path should still trust the WORKSPACE', () => {
+    // The compat fields are write-only; paneTerminalScope is the single join point.
+    assert({
+      given: 'a project workspace and a pane whose compat fields say otherwise',
+      should: "address the session at the workspace's checkout",
+      actual: paneTerminalScope(
+        { level: 'project', projectName: 'real-repo' },
+        projectStoredPaneScope({ name: 'worker', projectName: 'stale-repo' })!,
+      ),
+      expected: { projectName: 'real-repo', name: 'worker' },
     });
   });
 });

--- a/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
+++ b/apps/web/src/stores/machine-workspace/useMachineWorkspaceStore.ts
@@ -47,6 +47,7 @@ import {
   nodeScopeNames,
   machineNodeScope,
   paneScopeOf,
+  paneScopeForWire,
   paneTerminalScope,
   panesOf,
   workspacesOf,
@@ -80,6 +81,7 @@ export type {
 export {
   autoSessionName,
   paneTerminalScope,
+  paneScopeForWire,
   nodeScopeNames,
   machineNodeScope,
   panesOf,

--- a/apps/web/src/stores/machine-workspace/workspace-reducer.ts
+++ b/apps/web/src/stores/machine-workspace/workspace-reducer.ts
@@ -173,6 +173,36 @@ export function paneScopeOf(scope: OpenTerminalScope): PaneSessionScope {
 }
 
 /**
+ * The pane scope as it goes ON THE WIRE — the narrowed shape PLUS the
+ * workspace's checkout names (issue #2204 follow-up, F13).
+ *
+ * Narrowing the pane deleted a real class of bug in THIS client, but a pane
+ * scope is also persisted and broadcast, and the wire has older readers on it:
+ * mid rolling-deploy, or a browser tab left open across one. A pre-narrowing
+ * client reads a name-only pane as a MACHINE-ROOT session — so a project pane
+ * named `worker` resolves to the ROOT's `worker`, and that client will connect
+ * to, or KILL, the wrong session.
+ *
+ * So the wire keeps the full address while local state keeps the narrow one.
+ * The duplication cannot rot here because it exists only in transit: nothing in
+ * this version reads these fields back ({@link projectStoredPaneScope} drops
+ * them on the way in, and {@link paneTerminalScope} is the single join point
+ * for a pane's checkout). Delete once no pre-narrowing client can still run.
+ */
+export function paneScopeForWire(
+  node: MachineNodeScope,
+  pane: PaneSessionScope | null,
+): (PaneSessionScope & { projectName?: string; branchName?: string }) | null {
+  if (!pane) return null;
+  const names = nodeScopeNames(node);
+  return {
+    ...pane,
+    ...(names.projectName ? { projectName: names.projectName } : {}),
+    ...(names.branchName ? { branchName: names.branchName } : {}),
+  };
+}
+
+/**
  * Read-time projection of a STORED node scope, from either shape: the union
  * this version writes, or the bare `{projectName, branchName}` an older client
  * (or a not-yet-redeployed server) sends. The discriminant is re-derived from

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -9,6 +9,7 @@ import {
   killAgentTerminalById,
   listAgentTerminals,
   deriveAgentTerminalScope,
+  findStrandedLiveSessions,
   type AgentTerminalsDeps,
   type AgentTerminalBranchLookup,
   type AgentTerminalProjectLookup,
@@ -1631,5 +1632,127 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
     expect(acquireCalls).toEqual([]);
     expect(attachCalls).toEqual([]);
     expect(rows.size).toBe(0);
+  });
+});
+
+/**
+ * Issue #2204 follow-up, F10. Promotion deletes the root checkout and points
+ * every project row at the new Sprite — but a PTY's process lives in the old
+ * Sprite and cannot follow, so a pre-existing live session would be left
+ * running somewhere no reconnect can reach.
+ */
+describe('findStrandedLiveSessions', () => {
+  it('given rows with launched PTYs, should name them', () => {
+    expect(
+      findStrandedLiveSessions([
+        { name: 'build', streamSessionId: 'stream-1' },
+        { name: 'notes', streamSessionId: null },
+        { name: 'watch', streamSessionId: 'stream-2' },
+      ]),
+    ).toEqual(['build', 'watch']);
+  });
+
+  it('given only reserved-but-never-launched rows, should find nothing to strand', () => {
+    expect(findStrandedLiveSessions([{ name: 'cli', streamSessionId: null }])).toEqual([]);
+  });
+
+  it('given no rows at all, should find nothing', () => {
+    expect(findStrandedLiveSessions([])).toEqual([]);
+  });
+});
+
+describe('spawnAgentTerminal — live sessions block promotion (F10)', () => {
+  function promotableProject() {
+    const row: { path: string; sandboxId: string | null; spriteTornDownAt: Date | null } = {
+      path: PROJECT_PATH,
+      sandboxId: null,
+      spriteTornDownAt: null,
+    };
+    const lookup: AgentTerminalProjectLookup = {
+      findByName: async (machineId, name) => (machineId === TERMINAL_ID && name === PROJECT_NAME ? row : null),
+    };
+    return { row, lookup };
+  }
+
+  it('given an unpromoted project with a LIVE PTY, should refuse and promote nothing', async () => {
+    const { lookup } = promotableProject();
+    const { store } = makeStore();
+    // A session reserved and launched BEFORE this rollout, on the machine's own Sprite.
+    const existing = await store.create({
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'project',
+      projectName: PROJECT_NAME,
+      machineBranchId: null,
+      name: 'build',
+      agentType: 'shell',
+      command: null,
+      now: new Date('2026-01-01'),
+    });
+    await store.updateStreamSessionId({ id: existing.id, streamSessionId: 'stream-1', now: new Date('2026-01-01') });
+
+    const promotionCalls: unknown[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: lookup,
+      projectPromotion: {
+        promote: async (input) => {
+          promotionCalls.push(input);
+          return { ok: true };
+        },
+      },
+    });
+
+    const spawned = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+
+    expect(spawned).toMatchObject({ ok: false, reason: 'live_sessions_block_promotion' });
+    expect(spawned.ok === false && spawned.detail).toContain('build');
+    expect(promotionCalls).toEqual([]);
+  });
+
+  it('given an unpromoted project whose rows never launched a PTY, should promote as before', async () => {
+    const { row, lookup } = promotableProject();
+    const { store } = makeStore();
+    await store.create({
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'project',
+      projectName: PROJECT_NAME,
+      machineBranchId: null,
+      name: 'notes',
+      agentType: 'claude',
+      command: null,
+      now: new Date('2026-01-01'),
+    });
+
+    const deps = makeDeps({
+      store,
+      projectStore: lookup,
+      projectPromotion: {
+        promote: async () => {
+          row.sandboxId = 'sprite-project-1';
+          return { ok: true };
+        },
+      },
+    });
+
+    const spawned = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+
+    expect(spawned).toMatchObject({ ok: true });
+    expect(row.sandboxId).toBe('sprite-project-1');
   });
 });

--- a/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
+++ b/packages/lib/src/services/machines/__tests__/agent-terminals.test.ts
@@ -1642,22 +1642,37 @@ describe('killAgentTerminalById — level-agnostic (PurePoint Attach{agent_id} p
  * running somewhere no reconnect can reach.
  */
 describe('findStrandedLiveSessions', () => {
-  it('given rows with launched PTYs, should name them', () => {
+  it('given rows whose PTYs are in the Sprite listing, should name them', () => {
     expect(
-      findStrandedLiveSessions([
-        { name: 'build', streamSessionId: 'stream-1' },
-        { name: 'notes', streamSessionId: null },
-        { name: 'watch', streamSessionId: 'stream-2' },
-      ]),
+      findStrandedLiveSessions(
+        [
+          { name: 'build', streamSessionId: 'stream-1' },
+          { name: 'notes', streamSessionId: null },
+          { name: 'watch', streamSessionId: 'stream-2' },
+        ],
+        new Set(['stream-1', 'stream-2']),
+      ),
     ).toEqual(['build', 'watch']);
   });
 
+  it('given a row whose PTY has EXITED, should not treat the historical id as live', () => {
+    // streamSessionId is never cleared, so this is the case that would
+    // otherwise block every later project-scoped spawn permanently.
+    expect(
+      findStrandedLiveSessions([{ name: 'build', streamSessionId: 'stream-old' }], new Set(['stream-other'])),
+    ).toEqual([]);
+  });
+
+  it('given an empty Sprite listing, should find nothing live', () => {
+    expect(findStrandedLiveSessions([{ name: 'build', streamSessionId: 'stream-1' }], new Set())).toEqual([]);
+  });
+
   it('given only reserved-but-never-launched rows, should find nothing to strand', () => {
-    expect(findStrandedLiveSessions([{ name: 'cli', streamSessionId: null }])).toEqual([]);
+    expect(findStrandedLiveSessions([{ name: 'cli', streamSessionId: null }], new Set(['x']))).toEqual([]);
   });
 
   it('given no rows at all, should find nothing', () => {
-    expect(findStrandedLiveSessions([])).toEqual([]);
+    expect(findStrandedLiveSessions([], new Set(['x']))).toEqual([]);
   });
 });
 
@@ -1695,6 +1710,7 @@ describe('spawnAgentTerminal — live sessions block promotion (F10)', () => {
     const deps = makeDeps({
       store,
       projectStore: lookup,
+      liveSessions: { list: async () => ['stream-1'] },
       projectPromotion: {
         promote: async (input) => {
           promotionCalls.push(input);
@@ -1735,6 +1751,8 @@ describe('spawnAgentTerminal — live sessions block promotion (F10)', () => {
     const deps = makeDeps({
       store,
       projectStore: lookup,
+      // Never consulted: no row here ever launched a PTY.
+      liveSessions: { list: async () => { throw new Error('probe must not be paid for'); } },
       projectPromotion: {
         promote: async () => {
           row.sandboxId = 'sprite-project-1';
@@ -1754,5 +1772,114 @@ describe('spawnAgentTerminal — live sessions block promotion (F10)', () => {
 
     expect(spawned).toMatchObject({ ok: true });
     expect(row.sandboxId).toBe('sprite-project-1');
+  });
+});
+
+/**
+ * Codex P2 on PR #2209: `streamSessionId` records a session that existed at
+ * some point and is never cleared, so the promotion gate must ask the Sprite
+ * what is running rather than trust the column.
+ */
+describe('spawnAgentTerminal — promotion gate consults real PTY liveness', () => {
+  async function projectWithLaunchedRow(streamSessionId: string) {
+    const row: { path: string; sandboxId: string | null; spriteTornDownAt: Date | null } = {
+      path: PROJECT_PATH,
+      sandboxId: null,
+      spriteTornDownAt: null,
+    };
+    const lookup: AgentTerminalProjectLookup = {
+      findByName: async (machineId, name) => (machineId === TERMINAL_ID && name === PROJECT_NAME ? row : null),
+    };
+    const { store } = makeStore();
+    const existing = await store.create({
+      ownerId: actor.userId,
+      machineId: TERMINAL_ID,
+      scope: 'project',
+      projectName: PROJECT_NAME,
+      machineBranchId: null,
+      name: 'build',
+      agentType: 'shell',
+      command: null,
+      now: new Date('2026-01-01'),
+    });
+    await store.updateStreamSessionId({ id: existing.id, streamSessionId, now: new Date('2026-01-01') });
+    return { row, lookup, store };
+  }
+
+  it('given a row whose PTY has EXITED, should promote rather than block forever', async () => {
+    const { row, lookup, store } = await projectWithLaunchedRow('stream-dead');
+    const deps = makeDeps({
+      store,
+      projectStore: lookup,
+      // The Sprite is running something else entirely — our session is gone.
+      liveSessions: { list: async () => ['stream-unrelated'] },
+      projectPromotion: {
+        promote: async () => {
+          row.sandboxId = 'sprite-project-1';
+          return { ok: true };
+        },
+      },
+    });
+
+    const spawned = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+
+    expect(spawned).toMatchObject({ ok: true });
+    expect(row.sandboxId).toBe('sprite-project-1');
+  });
+
+  it('given a Sprite that cannot be probed, should refuse rather than risk stranding a live process', async () => {
+    const { lookup, store } = await projectWithLaunchedRow('stream-1');
+    const promotionCalls: unknown[] = [];
+    const deps = makeDeps({
+      store,
+      projectStore: lookup,
+      liveSessions: { list: async () => null },
+      projectPromotion: {
+        promote: async (input) => {
+          promotionCalls.push(input);
+          return { ok: true };
+        },
+      },
+    });
+
+    const spawned = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+
+    expect(spawned).toMatchObject({ ok: false, reason: 'live_sessions_block_promotion' });
+    expect(spawned.ok === false && spawned.detail).toContain('Could not verify');
+    expect(promotionCalls).toEqual([]);
+  });
+
+  it('given NO liveness probe wired at all, should also refuse — an unverifiable answer is not a negative one', async () => {
+    const { lookup, store } = await projectWithLaunchedRow('stream-1');
+    const deps = makeDeps({
+      store,
+      projectStore: lookup,
+      projectPromotion: { promote: async () => ({ ok: true }) },
+    });
+
+    const spawned = await spawnAgentTerminal({
+      machineId: TERMINAL_ID,
+      projectName: PROJECT_NAME,
+      name: 'cli',
+      agentType: 'shell',
+      actor,
+      deps,
+    });
+
+    expect(spawned).toMatchObject({ ok: false, reason: 'live_sessions_block_promotion' });
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -735,3 +735,38 @@ describe('promoteProject — root re-measurement after reclaim (F12)', () => {
     expect(remeasured).toEqual([]);
   });
 });
+
+/**
+ * ReDoS regressions (CodeQL alerts 267/268 on PR #2209). Both inputs are
+ * attacker-influencable — a branch NAME reaches the porcelain header, and a
+ * repo URL/path reaches git's stderr — so neither classifier may scan with a
+ * backtracking `.*`.
+ */
+describe('checkout classifiers — linear on hostile input', () => {
+  it('given a branch name full of [, should classify without superlinear scanning', () => {
+    const hostile = `## ${'['.repeat(20000)}...origin/main\n`;
+    const startedAt = Date.now();
+    const result = classifyCheckoutStatus(hostile);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+    // No `]`, so no divergence payload and no upstream marker it can trust.
+    expect(result.kind).toBe('clean');
+  });
+
+  it('given a bracket-heavy branch name that IS ahead, should still find the divergence', () => {
+    const result = classifyCheckoutStatus('## we[i]rd[[[...origin/weird [ahead 3]\n');
+    expect(result.kind).toBe('unpushed');
+    expect(result.kind === 'unpushed' && result.detail).toContain('3 commit(s)');
+  });
+
+  it('given clone output repeating "destination path", should test without superlinear scanning', () => {
+    const hostile = `${'destination path '.repeat(20000)}fatal: nope`;
+    const startedAt = Date.now();
+    const result = isCloneBlockedByExistingCheckout(hostile);
+    expect(Date.now() - startedAt).toBeLessThan(1000);
+    expect(result).toBe(false);
+  });
+
+  it('given mixed-case git output, should still recognise the shared-Sprite signal', () => {
+    expect(isCloneBlockedByExistingCheckout("fatal: destination path 'X' ALREADY EXISTS.")).toBe(true);
+  });
+});

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -3,6 +3,8 @@ import {
   promoteProject,
   isPromotedProject,
   PROJECT_REPO_PATH,
+  classifyCheckoutStatus,
+  isCloneBlockedByExistingCheckout,
   type PromoteProjectDeps,
   type ProjectStorageMeasurement,
 } from '../machine-project-promotion';
@@ -150,13 +152,18 @@ function makeFakeHost() {
   return { host, byId, provisionCalls, killCalls, makeHandle };
 }
 
+/** `git status --porcelain -b` output for a checkout that is clean AND fully pushed. */
+const CLEAN_STATUS = '## main...origin/main\n';
+
 /**
  * The OWNING Machine's Sprite: `test -e` reports the checkout present, and
- * `git status --porcelain` reports it clean, unless a test says otherwise.
+ * `git status --porcelain -b` reports it clean and pushed, unless a test says
+ * otherwise. The branch header is part of the fixture because it is part of the
+ * command — a clean tree alone no longer licenses promotion (F1).
  */
 function makeMachineSandbox({
   checkoutExists = true,
-  status = { exitCode: 0, stdout: '', stderr: '' },
+  status = { exitCode: 0, stdout: CLEAN_STATUS, stderr: '' },
 }: {
   checkoutExists?: boolean;
   /** One result for every `git status`, or a sequence consumed per call (last one repeats). */
@@ -316,7 +323,7 @@ describe('promoteProject — first promotion', () => {
 
 describe('promoteProject — dirty-tree refusal', () => {
   it('given a dirty machine checkout, should REFUSE with an actionable error and provision nothing', async () => {
-    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: ' M src/index.ts\n?? notes.md\n', stderr: '' } });
+    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n?? notes.md\n`, stderr: '' } });
     const { deps, provisionCalls, rows } = makeDeps({}, { machine });
 
     const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
@@ -369,8 +376,8 @@ describe('promoteProject — post-promotion checkout reclaim', () => {
     // where deleted work is a loss.
     const machine = makeMachineSandbox({
       status: [
-        { exitCode: 0, stdout: '', stderr: '' }, // the gate: clean
-        { exitCode: 0, stdout: '?? new-work.ts\n', stderr: '' }, // the recheck: dirty now
+        { exitCode: 0, stdout: CLEAN_STATUS, stderr: '' }, // the gate: clean
+        { exitCode: 0, stdout: `${CLEAN_STATUS}?? new-work.ts\n`, stderr: '' }, // the recheck: dirty now
       ],
     });
     const { deps, machineSandbox } = makeDeps({}, { machine });
@@ -382,7 +389,7 @@ describe('promoteProject — post-promotion checkout reclaim', () => {
   });
 
   it('given a refused promotion, should NOT touch the machine checkout', async () => {
-    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: ' M src/index.ts\n', stderr: '' } });
+    const machine = makeMachineSandbox({ status: { exitCode: 0, stdout: `${CLEAN_STATUS} M src/index.ts\n`, stderr: '' } });
     const { deps, machineSandbox } = makeDeps({}, { machine });
 
     await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
@@ -544,5 +551,187 @@ describe('isPromotedProject', () => {
     expect(isPromotedProject({ sandboxId: 'sbx-1', spriteTornDownAt: null })).toBe(true);
     expect(isPromotedProject({ sandboxId: 'sbx-1', spriteTornDownAt: NOW })).toBe(false);
     expect(isPromotedProject({ sandboxId: null, spriteTornDownAt: null })).toBe(false);
+  });
+});
+
+/**
+ * Issue #2204 follow-up, F1. `git status --porcelain` reports a checkout with
+ * unpushed commits as pristine, so promotion deleted the only copy of that work
+ * on its way to a fresh clone. Cleanliness was never the right question —
+ * REPRODUCIBILITY FROM THE REMOTE is.
+ */
+describe('classifyCheckoutStatus', () => {
+  it('given a clean tree tracking an upstream, should report clean', () => {
+    expect(classifyCheckoutStatus('## main...origin/main\n')).toEqual({ kind: 'clean' });
+  });
+
+  it('given working-tree changes, should report dirty with just the changes', () => {
+    expect(classifyCheckoutStatus('## main...origin/main\n M src/a.ts\n?? b.md\n')).toEqual({
+      kind: 'dirty',
+      detail: ' M src/a.ts\n?? b.md',
+    });
+  });
+
+  it('given a CLEAN tree that is ahead of its upstream, should refuse as unpushed', () => {
+    const result = classifyCheckoutStatus('## main...origin/main [ahead 2]\n');
+    expect(result.kind).toBe('unpushed');
+    expect(result.kind === 'unpushed' && result.detail).toContain('2 commit(s)');
+  });
+
+  it('given a branch both ahead AND behind, should still refuse — the ahead commits are the loss', () => {
+    expect(classifyCheckoutStatus('## main...origin/main [ahead 1, behind 3]\n').kind).toBe('unpushed');
+  });
+
+  it('given a branch merely BEHIND its upstream, should report clean — nothing local is at risk', () => {
+    expect(classifyCheckoutStatus('## main...origin/main [behind 3]\n')).toEqual({ kind: 'clean' });
+  });
+
+  it('given a branch with NO upstream, should refuse — there is no remote ref to reproduce it from', () => {
+    const result = classifyCheckoutStatus('## scratch\n');
+    expect(result.kind).toBe('unpushed');
+    expect(result.kind === 'unpushed' && result.detail).toContain('no upstream');
+  });
+
+  it('given a detached HEAD, should refuse for the same reason', () => {
+    expect(classifyCheckoutStatus('## HEAD (no branch)\n').kind).toBe('unpushed');
+  });
+
+  it('given dirty changes AND unpushed commits, should report dirty — the nearer, more actionable fix', () => {
+    expect(classifyCheckoutStatus('## main...origin/main [ahead 1]\n M a.ts\n').kind).toBe('dirty');
+  });
+
+  it('given output with NO branch header, should be unknown rather than assumed clean', () => {
+    // `-b` always emits one, so its absence means we are not reading what we think.
+    expect(classifyCheckoutStatus('').kind).toBe('unknown');
+  });
+});
+
+/**
+ * Issue #2204 follow-up, F2. Two promotions of one project derive the same
+ * deterministic session key, so a name-keyed provision can hand both racers the
+ * SAME physical Sprite — and the loser's clone fails precisely because the
+ * winner already populated the destination.
+ */
+describe('isCloneBlockedByExistingCheckout', () => {
+  it('given git\'s "already exists and is not an empty directory", should recognise a shared Sprite', () => {
+    expect(
+      isCloneBlockedByExistingCheckout(
+        "fatal: destination path '/workspace/repo' already exists and is not an empty directory.",
+      ),
+    ).toBe(true);
+  });
+
+  it('given an authentication failure, should NOT — that Sprite is ours alone and must be torn down', () => {
+    expect(isCloneBlockedByExistingCheckout('fatal: Authentication failed for https://github.com/o/r.git')).toBe(false);
+  });
+
+  it('given a missing repository, should NOT', () => {
+    expect(isCloneBlockedByExistingCheckout('fatal: repository not found')).toBe(false);
+  });
+
+  it('given empty output, should NOT — an unexplained failure is not evidence of a racer', () => {
+    expect(isCloneBlockedByExistingCheckout('')).toBe(false);
+  });
+});
+
+describe('promoteProject — unpushed-commit refusal (F1)', () => {
+  it('given a clean checkout holding unpushed commits, should REFUSE and provision nothing', async () => {
+    const machine = makeMachineSandbox({
+      status: { exitCode: 0, stdout: '## main...origin/main [ahead 2]\n', stderr: '' },
+    });
+    const { deps, provisionCalls } = makeDeps({}, { machine });
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('unpushed_commits');
+    expect(result.detail).toContain('push');
+    expect(provisionCalls).toEqual([]);
+  });
+});
+
+describe('promoteProject — shared-Sprite protection on clone failure (F2)', () => {
+  it('given a clone blocked by an existing checkout, should NOT kill the Sprite a racer may be promoting on', async () => {
+    const { deps, killCalls } = makeDeps({}, {});
+    const blocked: PromoteProjectDeps = {
+      ...deps,
+      host: {
+        ...deps.host,
+        provision: async (args) => {
+          const handle = await deps.host.provision(args);
+          return {
+            ...handle,
+            exec: async () => ({
+              exitCode: 128,
+              stdout: '',
+              stderr: "fatal: destination path '/workspace/repo' already exists and is not an empty directory.",
+            }),
+          };
+        },
+      },
+    };
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps: blocked });
+
+    expect(result.ok).toBe(false);
+    expect(killCalls).toEqual([]);
+  });
+
+  it('given a clone that failed for our OWN reason, should still tear the unrecorded Sprite down', async () => {
+    const { deps, killCalls } = makeDeps({}, {});
+    const failing: PromoteProjectDeps = {
+      ...deps,
+      host: {
+        ...deps.host,
+        provision: async (args) => {
+          const handle = await deps.host.provision(args);
+          return {
+            ...handle,
+            exec: async () => ({ exitCode: 128, stdout: '', stderr: 'fatal: repository not found' }),
+          };
+        },
+      },
+    };
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps: failing });
+
+    expect(result.ok).toBe(false);
+    expect(killCalls.length).toBe(1);
+  });
+});
+
+describe('promoteProject — root re-measurement after reclaim (F12)', () => {
+  it('given a successful reclaim, should refresh the ROOT measurement so the removed bytes stop being billed', async () => {
+    const remeasured: string[] = [];
+    const { deps } = makeDeps({
+      remeasureMachineStorage: async ({ machinePageId }) => {
+        remeasured.push(machinePageId);
+      },
+    });
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.ok).toBe(true);
+    expect(remeasured).toEqual([MACHINE_ID]);
+  });
+
+  it('given a checkout that was ABSENT, should not re-measure — nothing was removed', async () => {
+    const remeasured: string[] = [];
+    const machine = makeMachineSandbox({ checkoutExists: false });
+    const { deps } = makeDeps(
+      {
+        remeasureMachineStorage: async ({ machinePageId }) => {
+          remeasured.push(machinePageId);
+        },
+      },
+      { machine },
+    );
+
+    await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(remeasured).toEqual([]);
   });
 });

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -202,6 +202,8 @@ function makeDeps(
     store,
     isEnabled: () => true,
     now: () => NOW,
+    // No real clock in tests: the promotion-race poll resolves immediately.
+    wait: async () => {},
     host,
     substrate: { kind: 'sprite' },
     options: {},
@@ -652,10 +654,24 @@ describe('promoteProject — unpushed-commit refusal (F1)', () => {
 });
 
 describe('promoteProject — shared-Sprite protection on clone failure (F2)', () => {
-  it('given a clone blocked by an existing checkout, should NOT kill the Sprite a racer may be promoting on', async () => {
-    const { deps, killCalls } = makeDeps({}, {});
+  it('given a clone blocked by a checkout a racer is promoting into, should adopt the winner and NOT kill the shared Sprite', async () => {
+    const { deps, killCalls, rows } = makeDeps({}, {});
+    let polls = 0;
     const blocked: PromoteProjectDeps = {
       ...deps,
+      store: {
+        ...deps.store,
+        // The winner's CAS lands while we are waiting, exactly as a real racer's would.
+        findById: async (id) => {
+          polls += 1;
+          if (polls > 1) {
+            const row = rows.get(id)!;
+            row.sandboxId = 'sbx-winner';
+            row.sessionKey = 'winner-key';
+          }
+          return rows.get(id) ?? null;
+        },
+      },
       host: {
         ...deps.host,
         provision: async (args) => {
@@ -674,8 +690,38 @@ describe('promoteProject — shared-Sprite protection on clone failure (F2)', ()
 
     const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps: blocked });
 
-    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ ok: true, sandboxId: 'sbx-winner', promoted: false, resumed: true });
     expect(killCalls).toEqual([]);
+  });
+
+  it('given a populated destination but NO winner ever appearing, should reclaim the derelict Sprite rather than leak it', async () => {
+    // A previous promotion whose persist failed and whose best-effort kill also
+    // failed leaves the same populated Sprite behind with the row unpromoted.
+    // Trusting git's message alone would make every retry resume it, fail the
+    // same clone, and leave it billing forever.
+    const { deps, killCalls } = makeDeps({}, {});
+    const derelict: PromoteProjectDeps = {
+      ...deps,
+      host: {
+        ...deps.host,
+        provision: async (args) => {
+          const handle = await deps.host.provision(args);
+          return {
+            ...handle,
+            exec: async () => ({
+              exitCode: 128,
+              stdout: '',
+              stderr: "fatal: destination path '/workspace/repo' already exists and is not an empty directory.",
+            }),
+          };
+        },
+      },
+    };
+
+    const result = await promoteProject({ machineId: MACHINE_ID, projectName: PROJECT_NAME, actor, deps: derelict });
+
+    expect(result).toMatchObject({ ok: false, reason: 'clone_failed' });
+    expect(killCalls.length).toBe(1);
   });
 
   it('given a clone that failed for our OWN reason, should still tear the unrecorded Sprite down', async () => {

--- a/packages/lib/src/services/machines/__tests__/machine-projects-store.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-projects-store.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { promotedProjectColumns } from '../machine-projects-store';
+
+/**
+ * Issue #2204 follow-up, F11. The promotion CAS retained the creation-time
+ * storage watermark, so a project promoted long after its row was created had
+ * its first measured clone bytes billed across a period when no project Sprite
+ * existed — and a re-provision after teardown inherited the previous
+ * generation's measurement across the downtime.
+ */
+describe('promotedProjectColumns', () => {
+  const now = new Date('2026-07-22T12:00:00.000Z');
+  const base = { sessionKey: 'key-1', sandboxId: 'sbx-1', spriteInstanceId: 'inst-1', now };
+
+  it('given a promotion, should restart the storage accounting period at this Sprite\'s birth', () => {
+    const columns = promotedProjectColumns(base);
+    expect({
+      storageLastBilledAt: columns.storageLastBilledAt,
+      storageMeasuredBytes: columns.storageMeasuredBytes,
+      storageMeasuredAt: columns.storageMeasuredAt,
+    }).toEqual({
+      storageLastBilledAt: now,
+      // The previous generation's measurement described a filesystem that no
+      // longer exists — inheriting it bills its bytes across the downtime.
+      storageMeasuredBytes: null,
+      storageMeasuredAt: null,
+    });
+  });
+
+  it('given a promotion, should record the Sprite identity', () => {
+    const columns = promotedProjectColumns(base);
+    expect({
+      sessionKey: columns.sessionKey,
+      sandboxId: columns.sandboxId,
+      spriteInstanceId: columns.spriteInstanceId,
+    }).toEqual({ sessionKey: 'key-1', sandboxId: 'sbx-1', spriteInstanceId: 'inst-1' });
+  });
+
+  it('given a promotion, should void BOTH teardown marks — this row points at a live Sprite', () => {
+    const columns = promotedProjectColumns(base);
+    expect({
+      spriteTornDownAt: columns.spriteTornDownAt,
+      teardownRequestedAt: columns.teardownRequestedAt,
+    }).toEqual({ spriteTornDownAt: null, teardownRequestedAt: null });
+  });
+
+  it('given a driver that could not report an instance id, should persist null rather than omit it', () => {
+    expect(promotedProjectColumns({ ...base, spriteInstanceId: null }).spriteInstanceId).toBeNull();
+  });
+
+  it('given a promotion, should stamp updatedAt from the injected clock', () => {
+    expect(promotedProjectColumns(base).updatedAt).toEqual(now);
+  });
+});

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -109,6 +109,17 @@ export interface AgentTerminalMachineSandbox {
   acquire(machineId: string): Promise<AgentTerminalMachineSandboxResult>;
 }
 
+/**
+ * The machine Sprite's CURRENTLY RUNNING PTY session ids.
+ *
+ * `null` means "could not tell" — the Sprite was unreachable or the listing
+ * failed. Callers must not read that as "nothing is running": see
+ * `findStrandedLiveSessions` for why an unverifiable answer fails closed.
+ */
+export interface AgentTerminalLiveSessions {
+  list(machineId: string): Promise<string[] | null>;
+}
+
 export interface AgentTerminalsDeps {
   branchStore: AgentTerminalBranchLookup;
   /** Required only for project/machine-scope targets — a branch-only caller (today's only wired consumer) never needs it. */
@@ -117,6 +128,8 @@ export interface AgentTerminalsDeps {
   machineSandbox?: AgentTerminalMachineSandbox;
   /** Lazy project-Sprite promotion, fired by a project-scoped spawn — see `AgentTerminalProjectPromotion`. */
   projectPromotion?: AgentTerminalProjectPromotion;
+  /** Live-PTY probe consulted before a promotion — required wherever `projectPromotion` is wired. */
+  liveSessions?: AgentTerminalLiveSessions;
   store: MachineAgentTerminalStore;
   host: MachineHost;
   now: () => Date;
@@ -125,7 +138,7 @@ export interface AgentTerminalsDeps {
 /** Each function below asks for exactly the slice of `AgentTerminalsDeps` it touches — e.g. a read-only resolver never needs `host`, so a caller (like the realtime PTY bridge) doesn't have to fabricate one just to satisfy the type. */
 export type SpawnAgentTerminalDeps = Pick<
   AgentTerminalsDeps,
-  'branchStore' | 'projectStore' | 'store' | 'now' | 'projectPromotion'
+  'branchStore' | 'projectStore' | 'store' | 'now' | 'projectPromotion' | 'liveSessions'
 >;
 export type ResolveAgentTerminalDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'machineSandbox' | 'store'>;
 export type ListAgentTerminalsDeps = Pick<AgentTerminalsDeps, 'branchStore' | 'projectStore' | 'store'>;
@@ -285,23 +298,31 @@ export type SpawnAgentTerminalDenialReason =
  * Which existing project-scoped rows would a promotion STRAND? (Pure.)
  *
  * A promotion moves the project's home to a new Sprite and deletes the old
- * checkout. A row whose PTY was launched before that (`streamSessionId` set)
- * names a process living in the OLD Sprite: promotion cannot carry it across —
- * the process is not data — and the row is redirected to the new Sprite, so
- * every reconnect then asks a Sprite where that session has never existed. The
- * process is left running, unreachable, and billing.
+ * checkout. A row whose PTY is running names a process living in the OLD
+ * Sprite: promotion cannot carry it across — the process is not data — and the
+ * row is redirected to the new Sprite, so every reconnect then asks a Sprite
+ * where that session has never existed. The process is left running,
+ * unreachable, and billing. Migration is impossible, so promotion is REFUSED
+ * while any such row is live.
  *
- * Migration is impossible, so promotion is REFUSED while any such row is live,
- * naming them so the user can kill or let them finish. Same shape as the
- * dirty-tree refusal, and for the same reason: the alternative is silent loss
- * of something the user did not ask us to destroy.
+ * MEMBERSHIP IS THE TEST, not `streamSessionId !== null`. That column records a
+ * session that existed at SOME point and is never cleared (nothing writes null
+ * back — see `MachineAgentTerminalStore.updateStreamSessionId`, whose parameter
+ * is not nullable), so treating every non-null id as live would block every
+ * later project-scoped spawn — including an idempotent re-spawn of the same
+ * name — permanently, with no user action able to clear it. `liveSessionIds` is
+ * the Sprite's ACTUAL session listing, so a row whose PTY has exited stops
+ * blocking as soon as it exits.
  *
  * Chat-surface rows never hold a `streamSessionId` and so never block.
  */
 export function findStrandedLiveSessions(
   rows: ReadonlyArray<{ name: string; streamSessionId: string | null }>,
+  liveSessionIds: ReadonlySet<string>,
 ): string[] {
-  return rows.filter((row) => row.streamSessionId !== null).map((row) => row.name);
+  return rows
+    .filter((row) => row.streamSessionId !== null && liveSessionIds.has(row.streamSessionId))
+    .map((row) => row.name);
 }
 
 /** Pure decision: is this (name, agentType, command?) safe to reserve as an agent terminal? */
@@ -340,7 +361,7 @@ async function ensureProjectPromoted({
   machineId: string;
   projectName: string;
   scopeKey: AgentTerminalScopeKey;
-  deps: Pick<AgentTerminalsDeps, 'projectStore' | 'projectPromotion' | 'store'>;
+  deps: Pick<AgentTerminalsDeps, 'projectStore' | 'projectPromotion' | 'store' | 'liveSessions'>;
 }): Promise<
   | { ok: true }
   | { ok: false; reason: 'promotion_failed' | 'live_sessions_block_promotion'; detail?: string }
@@ -358,16 +379,38 @@ async function ensureProjectPromoted({
   // Inspect existing rows BEFORE promoting — promotion deletes the root
   // checkout these sessions are running in, and their processes cannot follow.
   // (Issue #2204 follow-up, F10.)
-  const stranded = findStrandedLiveSessions(await deps.store.list(scopeKey));
-  if (stranded.length > 0) {
-    return {
-      ok: false,
-      reason: 'live_sessions_block_promotion',
-      detail:
-        `Project "${projectName}" still has live terminal session(s) — ${stranded.join(', ')} — running on the ` +
-        `machine's own sandbox. Giving this project its own sandbox would leave them running somewhere ` +
-        `nothing can reach. Close them (or let them finish) and retry.`,
-    };
+  //
+  // The probe is paid for ONLY when some row has ever launched a PTY. The
+  // common case — a fresh project, or one whose rows are all chat surfaces —
+  // reaches promotion without touching the Sprite at all.
+  const everLaunched = (await deps.store.list(scopeKey)).filter((row) => row.streamSessionId !== null);
+  if (everLaunched.length > 0) {
+    const listed = await deps.liveSessions?.list(machineId);
+    if (!listed) {
+      // Could not tell. Fail closed, exactly as the dirty-tree check does: the
+      // two mistakes are not symmetric — a refused promotion is retried, a
+      // stranded process cannot be recovered. Unlike a never-cleared DB column,
+      // this clears itself the moment the Sprite answers again.
+      return {
+        ok: false,
+        reason: 'live_sessions_block_promotion',
+        detail:
+          `Could not verify whether project "${projectName}"'s existing terminal session(s) are still running, ` +
+          `so promotion was refused rather than risk leaving a live process somewhere nothing can reach. ` +
+          `Retry once the machine's sandbox is reachable.`,
+      };
+    }
+    const stranded = findStrandedLiveSessions(everLaunched, new Set(listed));
+    if (stranded.length > 0) {
+      return {
+        ok: false,
+        reason: 'live_sessions_block_promotion',
+        detail:
+          `Project "${projectName}" still has live terminal session(s) — ${stranded.join(', ')} — running on the ` +
+          `machine's own sandbox. Giving this project its own sandbox would leave them running somewhere ` +
+          `nothing can reach. Close them (or let them finish) and retry.`,
+      };
+    }
   }
 
   const promoted = await deps.projectPromotion.promote({ machineId, projectName });

--- a/packages/lib/src/services/machines/agent-terminals.ts
+++ b/packages/lib/src/services/machines/agent-terminals.ts
@@ -272,8 +272,37 @@ export type SpawnAgentTerminalDenialReason =
    * directory the next successful promotion deletes.
    */
   | 'promotion_failed'
+  /**
+   * The project cannot be promoted because it still has LIVE PTY sessions on
+   * the machine's own Sprite (issue #2204 follow-up, F10). See
+   * `findStrandedLiveSessions`.
+   */
+  | 'live_sessions_block_promotion'
   | 'name_in_use'
   | 'error';
+
+/**
+ * Which existing project-scoped rows would a promotion STRAND? (Pure.)
+ *
+ * A promotion moves the project's home to a new Sprite and deletes the old
+ * checkout. A row whose PTY was launched before that (`streamSessionId` set)
+ * names a process living in the OLD Sprite: promotion cannot carry it across —
+ * the process is not data — and the row is redirected to the new Sprite, so
+ * every reconnect then asks a Sprite where that session has never existed. The
+ * process is left running, unreachable, and billing.
+ *
+ * Migration is impossible, so promotion is REFUSED while any such row is live,
+ * naming them so the user can kill or let them finish. Same shape as the
+ * dirty-tree refusal, and for the same reason: the alternative is silent loss
+ * of something the user did not ask us to destroy.
+ *
+ * Chat-surface rows never hold a `streamSessionId` and so never block.
+ */
+export function findStrandedLiveSessions(
+  rows: ReadonlyArray<{ name: string; streamSessionId: string | null }>,
+): string[] {
+  return rows.filter((row) => row.streamSessionId !== null).map((row) => row.name);
+}
 
 /** Pure decision: is this (name, agentType, command?) safe to reserve as an agent terminal? */
 export function planSpawnAgentTerminal(input: { name: string; agentType: string; command?: string }):
@@ -305,12 +334,17 @@ export type SpawnAgentTerminalResult =
 async function ensureProjectPromoted({
   machineId,
   projectName,
+  scopeKey,
   deps,
 }: {
   machineId: string;
   projectName: string;
-  deps: Pick<AgentTerminalsDeps, 'projectStore' | 'projectPromotion'>;
-}): Promise<{ ok: true } | { ok: false; reason: 'promotion_failed'; detail?: string }> {
+  scopeKey: AgentTerminalScopeKey;
+  deps: Pick<AgentTerminalsDeps, 'projectStore' | 'projectPromotion' | 'store'>;
+}): Promise<
+  | { ok: true }
+  | { ok: false; reason: 'promotion_failed' | 'live_sessions_block_promotion'; detail?: string }
+> {
   if (!deps.projectPromotion || !deps.projectStore) return { ok: true };
 
   const project = await deps.projectStore.findByName(machineId, projectName);
@@ -319,6 +353,21 @@ async function ensureProjectPromoted({
   if (!project) return { ok: true };
   if (isPromotedProject({ sandboxId: project.sandboxId ?? null, spriteTornDownAt: project.spriteTornDownAt ?? null })) {
     return { ok: true };
+  }
+
+  // Inspect existing rows BEFORE promoting — promotion deletes the root
+  // checkout these sessions are running in, and their processes cannot follow.
+  // (Issue #2204 follow-up, F10.)
+  const stranded = findStrandedLiveSessions(await deps.store.list(scopeKey));
+  if (stranded.length > 0) {
+    return {
+      ok: false,
+      reason: 'live_sessions_block_promotion',
+      detail:
+        `Project "${projectName}" still has live terminal session(s) — ${stranded.join(', ')} — running on the ` +
+        `machine's own sandbox. Giving this project its own sandbox would leave them running somewhere ` +
+        `nothing can reach. Close them (or let them finish) and retry.`,
+    };
   }
 
   const promoted = await deps.projectPromotion.promote({ machineId, projectName });
@@ -362,6 +411,7 @@ export async function spawnAgentTerminal({
     const promoted = await ensureProjectPromoted({
       machineId: scope.scopeKey.machineId,
       projectName: scope.scopeKey.projectName,
+      scopeKey: scope.scopeKey,
       deps,
     });
     if (!promoted.ok) return promoted;

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -63,6 +63,12 @@ export type PromoteProjectDenialReason =
   | 'project_not_found'
   /** The machine-side checkout has uncommitted work — promoting would destroy it. */
   | 'dirty_checkout'
+  /**
+   * The machine-side checkout is CLEAN but holds commits that exist nowhere
+   * else. A fresh clone from `repoUrl` cannot reproduce them. (Issue #2204
+   * follow-up, F1.)
+   */
+  | 'unpushed_commits'
   /** We could not determine whether the machine-side checkout is clean. Fail-closed. */
   | 'dirty_check_failed'
   | 'provision_failed'
@@ -127,6 +133,16 @@ export interface PromoteProjectDeps {
    * affect the promotion.
    */
   measureProjectStorage?: (input: ProjectStorageMeasurement) => Promise<void>;
+  /**
+   * Re-measure the OWNING Machine's own Sprite after its copy of the project
+   * checkout is reclaimed (issue #2204 follow-up, F12). The root's last
+   * persisted measurement still counts the bytes we removed, so without this
+   * the reconcile bills them on the machine AND on the new project Sprite until
+   * some unrelated root operation happens to refresh it. Best-effort, and
+   * FORCED past the ordinary measurement throttle — the caller is reporting a
+   * known shrink, not an opportunistic wake.
+   */
+  remeasureMachineStorage?: (input: { machinePageId: string }) => Promise<void>;
 }
 
 export type PromoteProjectResult =
@@ -158,6 +174,14 @@ function noteProjectStorage(
   if (!measure) return;
   void measure(input).catch(() => {
     /* Best-effort: the seam already logs; a promotion must never fail on it. */
+  });
+}
+
+/** See `noteProjectStorage`: a billing refresh must never be awaited by, or fail, the promotion. */
+function noteRootStorageAfterReclaim(machineId: string, deps: PromoteProjectDeps): void {
+  if (!deps.remeasureMachineStorage) return;
+  void deps.remeasureMachineStorage({ machinePageId: machineId }).catch(() => {
+    /* Best-effort: the seam already logs. */
   });
 }
 
@@ -201,8 +225,54 @@ type CheckoutState =
   | { kind: 'absent' }
   | { kind: 'clean' }
   | { kind: 'dirty'; detail: string }
+  /** Clean tree, but commits a fresh clone could not reproduce. */
+  | { kind: 'unpushed'; detail: string }
   /** We could not tell. Treated exactly like dirty (fail-closed), with its own reason. */
   | { kind: 'unknown'; detail: string };
+
+/**
+ * Classify `git status --porcelain -b` output (pure).
+ *
+ * A CLEAN WORKING TREE IS NOT THE SAME AS "NOTHING TO LOSE" — the gap this
+ * closes (issue #2204 follow-up, F1). Promotion replaces the old checkout with
+ * a fresh clone from `repoUrl`, so the question is not "are there uncommitted
+ * edits" but "can a clone reproduce this checkout". A branch sitting two
+ * commits ahead of its upstream answers no, and `--porcelain` alone reports it
+ * as pristine — so promotion deleted the only copy of that work.
+ *
+ * The branch header (`-b`) answers it. Both fail-closed cases are deliberate:
+ *
+ *  • `[ahead N]` — commits exist here and nowhere else.
+ *  • NO upstream at all (a locally-created branch, or a detached HEAD) — there
+ *    is no remote ref this checkout is reproducible from, which is the same
+ *    loss with less information.
+ *
+ * A missing header is `unknown`, not `clean`: `-b` always emits one, so its
+ * absence means we are not reading what we think we are.
+ */
+export function classifyCheckoutStatus(stdout: string): CheckoutState {
+  const lines = stdout.split('\n').filter((line) => line.trim().length > 0);
+  const branchLine = lines.find((line) => line.startsWith('## '));
+  // Porcelain output covers untracked files too, and that is intended: an
+  // untracked file in the old checkout is exactly the kind of work a fresh
+  // clone on a new Sprite would silently drop.
+  const changes = lines.filter((line) => !line.startsWith('## '));
+
+  if (changes.length > 0) return { kind: 'dirty', detail: changes.join('\n') };
+  if (!branchLine) return { kind: 'unknown', detail: 'git status reported no branch header' };
+
+  const branch = branchLine.slice(3).trim();
+  const ahead = /\[.*\bahead (\d+)\b.*\]/.exec(branch);
+  if (ahead) {
+    return { kind: 'unpushed', detail: `${ahead[1]} commit(s) not on the remote (${branch})` };
+  }
+  // `## name...upstream` is the only shape that names a remote ref. Anything
+  // else — `## name`, `## HEAD (no branch)` — has nothing to be reproduced from.
+  if (!branch.includes('...')) {
+    return { kind: 'unpushed', detail: `no upstream branch to reproduce this checkout from (${branch})` };
+  }
+  return { kind: 'clean' };
+}
 
 /**
  * Inspect the project's OLD home on the machine Sprite. Promotion is only safe
@@ -244,9 +314,11 @@ async function inspectMachineCheckout({
   }
   if (!exists) return { kind: 'absent' };
 
+  // `-b` for the branch header: a clean tree still loses work if its commits
+  // are not on a remote (see classifyCheckoutStatus).
   const status = await runGitInSandbox({
     cmd: 'git',
-    args: ['status', '--porcelain'],
+    args: ['status', '--porcelain', '-b'],
     cwd: project.path,
     ctx: buildActorCtx(`${machineId}:${project.name}`, actor),
     deps: buildGitDepsForMachine(machineId, deps),
@@ -254,11 +326,7 @@ async function inspectMachineCheckout({
   if (!status.success) return { kind: 'unknown', detail: status.error ?? 'git status did not complete' };
   if (status.exitCode !== 0) return { kind: 'unknown', detail: status.stderr || status.stdout };
 
-  // Porcelain output covers untracked files too, and that is intended: an
-  // untracked file in the old checkout is exactly the kind of work a fresh
-  // clone on a new Sprite would silently drop.
-  const dirty = status.stdout.trim();
-  return dirty.length === 0 ? { kind: 'clean' } : { kind: 'dirty', detail: dirty };
+  return classifyCheckoutStatus(status.stdout);
 }
 
 /**
@@ -266,6 +334,27 @@ async function inspectMachineCheckout({
  * a name-keyed kill can never destroy a replacement a concurrent promotion put
  * under the same name. See the identical helper in `machine-branches.ts`.
  */
+/**
+ * Did this clone fail because SOMETHING ELSE had already cloned into the
+ * destination? (Pure.)
+ *
+ * `MachineHost.provision` is name-keyed and auto-resumes, and both racers of a
+ * concurrent promotion derive the SAME deterministic `sessionKey` — so the two
+ * calls can be holding handles to ONE physical Sprite, and the loser's clone
+ * fails precisely because the winner already populated `PROJECT_REPO_PATH`.
+ * That git message is the direct evidence of a shared Sprite; anything else
+ * (auth failure, network, bad repo url) is our own clone failing on a Sprite
+ * only we are using.
+ *
+ * It matters because the two mistakes are not symmetric. Killing a Sprite the
+ * winner is mid-promotion on interrupts them, or leaves their row pointing at a
+ * dead instance. Leaving a genuinely orphaned Sprite alive costs money until
+ * `machine-orphan-reconcile` sweeps it. So this errs toward leaving it.
+ */
+export function isCloneBlockedByExistingCheckout(output: string): boolean {
+  return /already exists and is not an empty directory|destination path .* already exists/i.test(output);
+}
+
 async function safeKillSprite(host: MachineHost, handle: MachineHandle): Promise<void> {
   try {
     await host.kill({ machineId: handle.machineId, expectedInstanceId: handle.spriteInstanceId });
@@ -298,9 +387,13 @@ async function reconcilePromotionCollision({
     // The INSTANCE, not just the name: a name is reused across re-creates, so
     // two concurrent provisions can hold two DIFFERENT VMs answering to the
     // same sandboxId. If ours is not the exact instance the winner persisted,
-    // it is unrecorded and must die — and the kill is identity-guarded, so if
-    // the two handles turn out to be one physical VM the attempt is a no-op
-    // rather than a friendly-fire kill of the winner's Sprite.
+    // it is unrecorded and must die.
+    //
+    // This comparison is what makes that safe — NOT the kill's identity guard,
+    // which only rejects a REPLACEMENT under the same name. A shared physical
+    // VM carries the very instance id the guard checks for, so a kill of a
+    // shared Sprite would succeed. The winner's Sprite survives here because
+    // `isPersistedInstance` is true for it and we never call the kill.
     const isPersistedInstance =
       row.sandboxId === handle.machineId &&
       (row.spriteInstanceId ?? null) === (handle.spriteInstanceId ?? null);
@@ -326,20 +419,22 @@ async function reconcilePromotionCollision({
  * from the already-promoted early return, whose checkout state was never
  * inspected.
  */
-async function reclaimMachineCheckout(machineId: string, path: string, deps: PromoteProjectDeps): Promise<void> {
+async function reclaimMachineCheckout(machineId: string, path: string, deps: PromoteProjectDeps): Promise<boolean> {
   try {
     const acquired = await deps.acquireMachineSandbox(machineId);
-    if (!acquired.ok) return;
+    if (!acquired.ok) return false;
     const sandbox = await deps.reconnect(acquired.sandboxId);
-    if (!sandbox) return;
-    await sandbox.runCommand({
+    if (!sandbox) return false;
+    const removed = await sandbox.runCommand({
       cmd: 'rm',
       args: ['-rf', path],
       timeoutMs: SANDBOX_TIMEOUT_MS,
       maxBytes: SANDBOX_MAX_OUTPUT_BYTES,
     });
+    return removed.exitCode === 0;
   } catch {
     // best-effort — see above.
+    return false;
   }
 }
 
@@ -398,6 +493,16 @@ export async function promoteProject({
         `changes (git -C ${project.path} status) and retry.\n${checkout.detail}`,
     };
   }
+  if (checkout.kind === 'unpushed') {
+    return {
+      ok: false,
+      reason: 'unpushed_commits',
+      detail:
+        `The checkout at ${project.path} holds commits that are not on the remote, and promoting this ` +
+        `project would replace it with a fresh clone of ${project.repoUrl} — losing them. Push the ` +
+        `branch (git -C ${project.path} push) and retry.\n${checkout.detail}`,
+    };
+  }
   if (checkout.kind === 'unknown') {
     return {
       ok: false,
@@ -436,8 +541,18 @@ export async function promoteProject({
     if (row?.sandboxId === handle.machineId && row.sessionKey) {
       return { ok: true, sandboxId: row.sandboxId, sessionKey: row.sessionKey, promoted: false, resumed: true };
     }
-    await safeKillSprite(deps.host, handle);
-    return { ok: false, reason: 'clone_failed', detail: clone.success ? clone.stderr || clone.stdout : clone.error };
+    const detail = clone.success ? clone.stderr || clone.stdout : clone.error;
+    // The winner may not have PERSISTED yet — provision is name-keyed, so the
+    // Sprite we hold can be the very one their in-flight promotion is cloning
+    // into while the row still reads unpromoted. Killing it here interrupts
+    // them, or leaves their row pointing at a dead instance. The identity guard
+    // does NOT save us: a SHARED Sprite has exactly the instance id we would
+    // pass as `expectedInstanceId`, so the kill succeeds. Only a genuinely
+    // different Sprite is protected by it. (Issue #2204 follow-up, F2.)
+    if (!isCloneBlockedByExistingCheckout(detail ?? '')) {
+      await safeKillSprite(deps.host, handle);
+    }
+    return { ok: false, reason: 'clone_failed', detail };
   }
 
   let persisted: boolean;
@@ -478,7 +593,17 @@ export async function promoteProject({
     // just wrote is a loss. (The window between this recheck and the rm is
     // milliseconds; the one it closes was the whole clone.)
     const recheck = await inspectMachineCheckout({ machineId, project, actor, deps });
-    if (recheck.kind === 'clean') await reclaimMachineCheckout(machineId, project.path, deps);
+    if (recheck.kind === 'clean') {
+      const reclaimed = await reclaimMachineCheckout(machineId, project.path, deps);
+      // The ROOT just got smaller, and its last persisted measurement still
+      // includes the bytes we removed. Until some unrelated root operation
+      // refreshes it, storage reconciliation bills those bytes on the machine
+      // AND on the new project Sprite — indefinitely, if nothing else touches
+      // the root. Re-measure it here, on the one path that knows it shrank.
+      // (Issue #2204 follow-up, F12.) Best-effort, like every other follow-up
+      // step below the CAS.
+      if (reclaimed) noteRootStorageAfterReclaim(machineId, deps);
+    }
   }
   // Measured right after the clone that wrote the bulk of this Sprite's
   // footprint — the one moment its bytes are guaranteed non-trivial.

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -250,6 +250,19 @@ type CheckoutState =
  * A missing header is `unknown`, not `clean`: `-b` always emits one, so its
  * absence means we are not reading what we think we are.
  */
+/**
+ * The `[ahead 1, behind 2]` payload of a porcelain branch header, or `''`.
+ *
+ * Index arithmetic rather than a pattern, so no amount of `[` in a branch name
+ * can make this superlinear — see the call site.
+ */
+function trackingDivergence(branchLine: string): string {
+  const open = branchLine.lastIndexOf('[');
+  if (open === -1) return '';
+  const close = branchLine.indexOf(']', open + 1);
+  return close === -1 ? '' : branchLine.slice(open + 1, close);
+}
+
 export function classifyCheckoutStatus(stdout: string): CheckoutState {
   const lines = stdout.split('\n').filter((line) => line.trim().length > 0);
   const branchLine = lines.find((line) => line.startsWith('## '));
@@ -262,7 +275,13 @@ export function classifyCheckoutStatus(stdout: string): CheckoutState {
   if (!branchLine) return { kind: 'unknown', detail: 'git status reported no branch header' };
 
   const branch = branchLine.slice(3).trim();
-  const ahead = /\[.*\bahead (\d+)\b.*\]/.exec(branch);
+  // Sliced, not matched with a `.*`-wrapped pattern: `git status` output is
+  // attacker-influencable (a branch name is user input), and a regex that scans
+  // the whole line for a bracketed group backtracks polynomially on a line full
+  // of `[`. Taking the divergence hint by index bounds the regex to the short
+  // `ahead N, behind M` payload, where the pattern is linear.
+  const divergence = trackingDivergence(branch);
+  const ahead = /\bahead (\d+)/.exec(divergence);
   if (ahead) {
     return { kind: 'unpushed', detail: `${ahead[1]} commit(s) not on the remote (${branch})` };
   }
@@ -352,7 +371,14 @@ async function inspectMachineCheckout({
  * `machine-orphan-reconcile` sweeps it. So this errs toward leaving it.
  */
 export function isCloneBlockedByExistingCheckout(output: string): boolean {
-  return /already exists and is not an empty directory|destination path .* already exists/i.test(output);
+  // Substring tests, not a `.*`-bridged alternation: git's stderr carries a
+  // repo URL and path, both attacker-influencable, and `destination path .*
+  // already exists` backtracks polynomially on repeated `destination path `.
+  const text = output.toLowerCase();
+  return (
+    text.includes('already exists and is not an empty directory') ||
+    (text.includes('destination path') && text.includes('already exists'))
+  );
 }
 
 async function safeKillSprite(host: MachineHost, handle: MachineHandle): Promise<void> {

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -616,6 +616,19 @@ export async function promoteProject({
     // unreferenced Sprite, fail the same clone, and leave it billing forever.
     // So the message only buys a BOUNDED WAIT for the supposed winner to
     // persist; if the row never claims a Sprite, ours is unreferenced and dies.
+    //
+    // WHY KILLING IS THE SAFE SIDE OF THIS BET. The two mistakes are not
+    // symmetric, and not in the direction one might assume:
+    //
+    //  • Killing a Sprite a slow winner then CASes onto is RECOVERABLE. Their
+    //    row points at a dead instance, and the next promotion attempt attaches,
+    //    gets null, and re-provisions under the same deterministic session key
+    //    (the `Vanished — fall through` path above). The system self-heals.
+    //  • Leaving an unreferenced Sprite alive is PERMANENT. Nothing reclaims it:
+    //    `machine-orphan-reconcile` works from the delete outbox (which needs a
+    //    row to have existed and been deleted) and from rows stamped
+    //    `teardownRequestedAt` — a Sprite that was provisioned but never
+    //    persisted has neither, so no sweep will ever find it. It bills forever.
     const winner = isCloneBlockedByExistingCheckout(detail ?? '')
       ? await awaitPromotionWinner(project.id, deps)
       : null;

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -58,6 +58,10 @@ export type { MachineActorContext };
 import { PROJECT_REPO_PATH } from '../sandbox/sandbox-paths';
 export { PROJECT_REPO_PATH };
 
+/** How many extra reads `awaitPromotionWinner` makes after its first, and how long it pauses between them. */
+const PROMOTION_RACE_POLLS = 3;
+const PROMOTION_RACE_POLL_MS = 250;
+
 export type PromoteProjectDenialReason =
   | 'kill_switch_off'
   | 'project_not_found'
@@ -102,6 +106,11 @@ export interface PromoteProjectDeps {
   store: MachineProjectPromotionStore;
   isEnabled: () => boolean;
   now: () => Date;
+  /**
+   * Pause, injected so the promotion-race reconciliation is testable without a
+   * real clock (see `awaitPromotionWinner`).
+   */
+  wait: (ms: number) => Promise<void>;
   /** The provider-neutral Sprite lifecycle seam — the promoted project's own Sprite is provisioned through it. */
   host: MachineHost;
   substrate: MachineSubstrateSpec;
@@ -381,6 +390,30 @@ export function isCloneBlockedByExistingCheckout(output: string): boolean {
   );
 }
 
+/**
+ * Wait, briefly, for a concurrent promotion of this project to persist.
+ *
+ * Called only when our clone failed on an already-populated destination — the
+ * one failure a racer sharing our name-keyed Sprite actually produces. If a
+ * winner exists it is milliseconds from its CAS, so a short bounded poll
+ * separates "someone is winning right now" from "this Sprite is a derelict from
+ * an earlier failed attempt". Returns the winning row, or null if none appears.
+ *
+ * Bounded on purpose: waiting longer would hold a user-facing spawn open for a
+ * winner that, by then, almost certainly does not exist.
+ */
+async function awaitPromotionWinner(
+  projectId: string,
+  deps: PromoteProjectDeps,
+): Promise<MachineProjectRecord | null> {
+  for (let attempt = 0; attempt <= PROMOTION_RACE_POLLS; attempt += 1) {
+    const row = await deps.store.findById(projectId).catch(() => null);
+    if (row?.sandboxId && row.sessionKey) return row;
+    if (attempt < PROMOTION_RACE_POLLS) await deps.wait(PROMOTION_RACE_POLL_MS);
+  }
+  return null;
+}
+
 async function safeKillSprite(host: MachineHost, handle: MachineHandle): Promise<void> {
   try {
     await host.kill({ machineId: handle.machineId, expectedInstanceId: handle.spriteInstanceId });
@@ -575,9 +608,21 @@ export async function promoteProject({
     // does NOT save us: a SHARED Sprite has exactly the instance id we would
     // pass as `expectedInstanceId`, so the kill succeeds. Only a genuinely
     // different Sprite is protected by it. (Issue #2204 follow-up, F2.)
-    if (!isCloneBlockedByExistingCheckout(detail ?? '')) {
-      await safeKillSprite(deps.host, handle);
+    //
+    // But "the destination already exists" does NOT prove a live racer: a
+    // previous promotion whose persist failed and whose best-effort kill also
+    // failed leaves the same populated Sprite behind, with the row still
+    // unpromoted. Trusting the message alone would make every retry resume that
+    // unreferenced Sprite, fail the same clone, and leave it billing forever.
+    // So the message only buys a BOUNDED WAIT for the supposed winner to
+    // persist; if the row never claims a Sprite, ours is unreferenced and dies.
+    const winner = isCloneBlockedByExistingCheckout(detail ?? '')
+      ? await awaitPromotionWinner(project.id, deps)
+      : null;
+    if (winner?.sandboxId && winner.sessionKey) {
+      return { ok: true, sandboxId: winner.sandboxId, sessionKey: winner.sessionKey, promoted: false, resumed: true };
     }
+    await safeKillSprite(deps.host, handle);
     return { ok: false, reason: 'clone_failed', detail };
   }
 

--- a/packages/lib/src/services/machines/machine-projects-store.ts
+++ b/packages/lib/src/services/machines/machine-projects-store.ts
@@ -155,6 +155,17 @@ export async function createDbMachineProjectStore(): Promise<MachineProjectStore
           // see the interface doc.
           spriteTornDownAt: null,
           teardownRequestedAt: null,
+          // STORAGE ACCOUNTING STARTS AT THIS SPRITE'S BIRTH (issue #2204
+          // follow-up, F11). The watermark defaulted to row-CREATION time, so a
+          // project promoted months later had its first measured clone bytes
+          // billed across the whole period when no project Sprite existed — and
+          // re-provisioning after a teardown carried the previous generation's
+          // measurement across the downtime. A new Sprite generation is a new
+          // accounting period: reset the watermark, and drop the measurement
+          // that described a filesystem that no longer exists.
+          storageLastBilledAt: now,
+          storageMeasuredBytes: null,
+          storageMeasuredAt: null,
           updatedAt: now,
         })
         // `eqOrIsNull`, not `eq`: a FIRST promotion compares against SQL NULL,

--- a/packages/lib/src/services/machines/machine-projects-store.ts
+++ b/packages/lib/src/services/machines/machine-projects-store.ts
@@ -71,6 +71,54 @@ export interface PromoteMachineProjectInput {
   now: Date;
 }
 
+/**
+ * What a successful promotion CAS writes onto a `machine_projects` row (pure).
+ *
+ * Extracted from the update so the accounting rules are assertable without a
+ * database — the reason F11 shipped in the first place was that this field set
+ * lived only inside an IO call, where no test could see it.
+ *
+ * Two groups, and the second is the one that was missing:
+ *
+ *  • IDENTITY — the Sprite's name, WHICH VM it is, and the voiding of both
+ *    teardown marks (this row points at a LIVE Sprite; see the interface doc).
+ *  • ACCOUNTING — a new Sprite generation is a NEW ACCOUNTING PERIOD. The
+ *    watermark defaulted to row-CREATION time, so a project promoted months
+ *    later had its first measured clone bytes billed across the entire period
+ *    when no project Sprite existed; and re-provisioning after a teardown
+ *    carried the previous generation's measurement across the downtime. So the
+ *    watermark restarts here, and the measurement — which described a
+ *    filesystem that no longer exists — is dropped rather than inherited.
+ */
+export function promotedProjectColumns(input: {
+  sessionKey: string;
+  sandboxId: string;
+  spriteInstanceId: string | null;
+  now: Date;
+}): {
+  sessionKey: string;
+  sandboxId: string;
+  spriteInstanceId: string | null;
+  spriteTornDownAt: null;
+  teardownRequestedAt: null;
+  storageLastBilledAt: Date;
+  storageMeasuredBytes: null;
+  storageMeasuredAt: null;
+  updatedAt: Date;
+} {
+  return {
+    sessionKey: input.sessionKey,
+    sandboxId: input.sandboxId,
+    spriteInstanceId: input.spriteInstanceId,
+    spriteTornDownAt: null,
+    teardownRequestedAt: null,
+    storageLastBilledAt: input.now,
+    storageMeasuredBytes: null,
+    storageMeasuredAt: null,
+    updatedAt: input.now,
+  };
+}
+
 export interface MachineProjectStore {
   list(machineId: string): Promise<MachineProjectRecord[]>;
   findByName(machineId: string, name: string): Promise<MachineProjectRecord | null>;
@@ -147,27 +195,7 @@ export async function createDbMachineProjectStore(): Promise<MachineProjectStore
     async promote({ id, previousSandboxId, sessionKey, sandboxId, spriteInstanceId, now }) {
       const updated = await db
         .update(machineProjects)
-        .set({
-          sessionKey,
-          sandboxId,
-          spriteInstanceId,
-          // This row points at a LIVE Sprite, so BOTH teardown marks are void —
-          // see the interface doc.
-          spriteTornDownAt: null,
-          teardownRequestedAt: null,
-          // STORAGE ACCOUNTING STARTS AT THIS SPRITE'S BIRTH (issue #2204
-          // follow-up, F11). The watermark defaulted to row-CREATION time, so a
-          // project promoted months later had its first measured clone bytes
-          // billed across the whole period when no project Sprite existed — and
-          // re-provisioning after a teardown carried the previous generation's
-          // measurement across the downtime. A new Sprite generation is a new
-          // accounting period: reset the watermark, and drop the measurement
-          // that described a filesystem that no longer exists.
-          storageLastBilledAt: now,
-          storageMeasuredBytes: null,
-          storageMeasuredAt: null,
-          updatedAt: now,
-        })
+        .set(promotedProjectColumns({ sessionKey, sandboxId, spriteInstanceId, now }))
         // `eqOrIsNull`, not `eq`: a FIRST promotion compares against SQL NULL,
         // where `= NULL` is never true and would silently make every first
         // promotion a no-op loser.

--- a/packages/lib/src/services/sandbox/machine-storage-billing.ts
+++ b/packages/lib/src/services/sandbox/machine-storage-billing.ts
@@ -385,6 +385,18 @@ async function measureStorageOpportunistically(input: {
   subject: StorageSubject;
   handle?: Pick<MachineHandle, 'exec'>;
   resolveHandle?: () => Promise<Pick<MachineHandle, 'exec'> | null>;
+  /**
+   * Bypass BOTH throttles for a caller that KNOWS the filesystem just changed
+   * size — today, a project promotion reclaiming its checkout off the root
+   * (issue #2204 follow-up, F12). The throttles exist to stop opportunistic
+   * wakes re-measuring an unchanged Sprite; a caller reporting a known shrink
+   * is the opposite case, and leaving it throttled means billing the removed
+   * bytes until something unrelated happens to touch the root.
+   *
+   * Does NOT bypass the in-flight dedup: two concurrent measurements of one
+   * subject are still one measurement.
+   */
+  force?: boolean;
 }): Promise<void> {
   const key = storageSubjectKey(input.subject);
   const nowMs = Date.now();
@@ -392,7 +404,7 @@ async function measureStorageOpportunistically(input: {
   // instance reached a DEFINITIVE outcome for this subject within the window. NOT
   // stamped yet — a transient failure below must leave the subject retryable.
   const lastAttempt = lastMeasureAttemptAtMs.get(key);
-  if (lastAttempt !== undefined && nowMs - lastAttempt < STORAGE_MEASUREMENT_THROTTLE_MS) {
+  if (!input.force && lastAttempt !== undefined && nowMs - lastAttempt < STORAGE_MEASUREMENT_THROTTLE_MS) {
     return;
   }
   // Synchronous concurrent-dedup: a burst of parallel ops for the same subject in
@@ -416,6 +428,7 @@ async function measureStorageOpportunistically(input: {
     // node) never pays a wasted network attach. refreshStorageMeasurement
     // re-checks this too — this is purely to gate the attach. Definitive: cache.
     if (
+      !input.force &&
       !shouldRefreshMeasurement({
         lastMeasuredAt: state.lastMeasuredAt,
         now: new Date(nowMs),
@@ -436,7 +449,8 @@ async function measureStorageOpportunistically(input: {
     const result = await refreshStorageMeasurement({
       handle,
       subject: input.subject,
-      lastMeasuredAt: state.lastMeasuredAt,
+      // A forced measurement must not be re-throttled one layer down.
+      lastMeasuredAt: input.force ? null : state.lastMeasuredAt,
       now: new Date(nowMs),
       persist: persistStorageMeasurement,
     });
@@ -470,11 +484,14 @@ export async function measureMachineStorageOpportunistically(input: {
   pageId: string;
   handle?: Pick<MachineHandle, 'exec'>;
   resolveHandle?: () => Promise<Pick<MachineHandle, 'exec'> | null>;
+  /** See the `force` note on the shared implementation — for callers that know the filesystem just shrank. */
+  force?: boolean;
 }): Promise<void> {
   await measureStorageOpportunistically({
     subject: { kind: 'machine', pageId: input.pageId },
     handle: input.handle,
     resolveHandle: input.resolveHandle,
+    ...(input.force ? { force: true } : {}),
   });
 }
 


### PR DESCRIPTION
Closes the 15 review findings (13 P1, 2 P2) that PR #2204 merged with. All 15 were re-verified against the merged code on `master` (`c83a04b00`) before any change was written — **all 15 reproduced**; nothing had been silently fixed by the merge commits.

Two of them were not risks but **live breakage on master**:

- **F8** — every dispatched headless turn failed closed on `bash`/file/git tools with *"Code execution requires an active drive"*. `send_session` did not work for its primary use case.
- **F9** — `writeFile`/`readFile`/`editFile` with `target: {project|branch}` resolved relative paths against `SANDBOX_ROOT` instead of the addressed node's cwd, so a targeted read/write touched a different file than a targeted `bash` in the same node.

Review record: page `jvb3682z935h40qualj7bh33` under the `Terminal — PageSpace Pane Agent` epic, with all 15 tracked to closure.

## Commits

Five — three staged by finding group, then two rounds of review feedback on this branch:

| Commit | Findings | What |
|---|---|---|
| `1d3b25271` | F8, F9 | Restore headless code execution and node-scoped file ops |
| `4224b66bb` | F3–F7, F14, F15 | Close headless dispatch billing and authorization gaps |
| `3850498fe` | F1, F2, F10–F13 | Promotion safety, storage accounting, pane wire compatibility |
| `4f7e3371a` | CodeQL 267/268 | Remove polynomial backtracking from the checkout classifiers |
| `99607d34d` | Codex P1 + 2×P2 | Bill aborted runs, probe real PTY liveness, reclaim derelict Sprites |
| `9edd4d5ca` | self-review | Make the PTY liveness probe genuinely attach-only |
| `51e12e1b2` | self-review | Harden the usage accumulator against empty steps |
| `1a4ff1d2b` | self-review | Record why an unreferenced promotion Sprite must be killed |
| _(latest)_ | F11 gap | Make the promotion CAS field set provable |

### Review feedback addressed on this PR

Five threads were raised against this branch and all five were real defects in the new code:

- **Codex P1** — usage was lost whenever a headless run did not complete. An abort rejects out of `generateText` *after* the provider charged for completed steps, and `trackAIUsage` skips an unsuccessful zero-token call (`success || totalTokens > 0`), absorbing the charge. Usage is now reported per step (`onStepUsage`) and accumulated by the engine, so it survives any exit.
- **Codex P2** — the promotion gate read `streamSessionId !== null` as "live", but that column is never cleared, so an exited PTY blocked every later project-scoped spawn permanently. The gate now asks the Sprite which sessions are actually running (`MachineHandle.listStreams()`), attach-only, and paid for only when some row has ever launched a PTY.
- **Codex P2** — "destination path already exists" does not prove a live racer; a derelict Sprite from an earlier failed promotion produces the same message and would be resumed-and-leaked on every retry. The message now buys only a bounded wait for a winner to persist; an unreferenced Sprite is still torn down.
- **CodeQL 267/268** — both checkout classifiers scanned attacker-influencable text (a branch *name*; a repo URL in git stderr) with `.*`-bridged patterns that backtrack polynomially. Both are now linear, with regression tests asserting sub-second handling of 20k-repetition hostile input.

## The shape of the bug class

Nearly every finding is an **imperative-shell defect**: a decision — *kill this Sprite? abort this run? is this checkout safe to delete?* — was inlined into an IO function, so it was never expressible as a test. That is why 15 findings survived a merge.

So the fix is not 15 patches at 15 call sites. Each decision came out as a pure function with a RED test first:

`nodeScopedPath` · `buildHeadlessToolContext` · `resolveGenerationAdmission` · `classifyCheckoutStatus` · `isCloneBlockedByExistingCheckout` · `findStrandedLiveSessions` · `paneScopeForWire`

Second lesson, worth stating because it recurs: **the docblock is not the proof.** `machine-project-promotion.ts` asserted its identity-guarded kill "is a no-op rather than a friendly-fire kill of the winner's Sprite" — but a *shared* physical Sprite carries the exact instance id the guard checks, so that kill succeeds. The comment was camouflaging F2. It has been corrected, and the invariant it claimed is now a test.

## Findings closed

**Authorization and billing on the headless path** — the dispatched path was built as a peer of the interactive one but skipped its admission control, abort plumbing, and concurrency ceiling.

- **F4** — entitlement is now one shared pure decision (`resolveGenerationAdmission`) called by *both* the chat route and the headless runtime, replacing two inline copies and one omission. A free or non-admin collaborator can no longer reach a machine page's paid or admin-only provider through `send_session`. Role denial stays distinguishable from tier denial — no upgrade prompt for a block an upgrade cannot lift.
- **F6** — the headless credit gate now passes `MAX_CHAT_INFLIGHT`. Session claims are independent, so paid tiers previously had no ceiling on concurrent dispatches.
- **F5** — the gate's balance snapshot is threaded to the run and drives the same per-step accumulator the interactive route uses, so a 60-step turn cannot spend far past its reservation.
- **F7 / F14** — the claim now owns a cancellation channel and the heartbeat trips it: on a durable `abortRequestedAt` mark (human takeover or Stop), and on the same `STREAM_MAX_LIFETIME_MS` horizon the normal lifecycle enforces. A hung run no longer holds its unique claim forever, which read as "session permanently busy" to every later dispatch.
- **F15** — a `claimRun` that *rejects* now releases the credit hold. The busy and append-failure paths already did; a database blip exited before any cleanup.
- **F3** — `add/move/kill/send_session` join `WRITE_TOOLS`, and the read-only filter now runs on the **composed** tool set rather than the baseline the session family is added to afterwards. Read-only conversations kept all four, and `send_session` runs a full agent loop in the target that can execute arbitrary shell commands.

**Promotion safety**

- **F1** — a clean working tree is not the same as "nothing to lose". Promotion replaces the checkout with a fresh clone from `repoUrl`, so the real question is whether a clone can *reproduce* it. `git status --porcelain` alone reported a branch two commits ahead as pristine, and promotion deleted the only copy of that work. `classifyCheckoutStatus` reads the `-b` branch header and refuses on unpushed commits — and on a branch with no upstream at all.
- **F2** — the clone-failure path killed the Sprite whenever the row still read unpromoted, which is exactly the state a winner mid-promotion leaves it in. Git's "destination path already exists" now buys a *bounded wait* for that winner to persist (revised after review — the message alone would also have spared a derelict Sprite forever); an unreferenced Sprite is still torn down.
- **F10** — a PTY's process lives in the old Sprite and cannot follow a promotion. Migration is impossible, so promotion is refused while project-scoped sessions are *actually running*, checked against the Sprite's live session listing (revised after review — the original check trusted a DB column that is never cleared).

**Storage accounting**

- **F11** — the promotion CAS retained the creation-time watermark, so a project promoted long after its row was created had its first measured clone bytes billed across a period when no project Sprite existed. A new Sprite generation is a new accounting period.
- **F12** — reclaiming the root's copy of the checkout left the root's measurement counting the removed bytes, billing them on the machine *and* the project Sprite until something unrelated refreshed it. The root is now re-measured on the one path that knows it shrank, forced past the throttle that exists for opportunistic wakes rather than known shrinks.

**Wire compatibility**

- **F13** — narrowing the pane shape also narrowed the wire, and pane scopes are persisted and broadcast. A pre-narrowing client (rolling deploy, stale tab) reads a name-only pane as a machine-**root** session, so a project pane named `worker` resolves to the root's `worker` and can be connected to or killed instead. The wire now carries the full address while local state keeps the narrow one — the duplication exists only in transit, so it cannot rot.

## Two departures from the original plan

Both after the code disagreed with the plan:

- **F2** — the plan was to reuse the `spriteInstanceId` check from `reconcilePromotionCollision`. That does not work for a shared Sprite (see above), so the predicate keys on git's own error instead — direct evidence rather than an inference.
- **F13** — the compat fields first went into `PaneSessionScope`, which broke 4 existing tests guarding against re-duplicating the checkout in state. Those tests were right; the fields now live only at the serialization boundary (`paneScopeForWire`, applied in `toWireColumns`).

## Verification

- `bun run typecheck` — 17/17 tasks pass
- `bun run lint` — pass (full web build green)
- `packages/lib` — 8838 passed, 11 skipped
- `apps/web` — 15479 passed, **16 failed**

Those 16 failures are **pre-existing**, not regressions: I stashed to `master` and confirmed the same 16 fail across the same 3 files (`activity-tools`, `admin-role-version` — missing test DB role `"test"`; `messages/grouping` — TZ-dependent).

Manual checks worth running before merge, since they need a real Sprite:

- dispatch a `send_session` at a machine page and confirm `bash` returns output rather than the drive error
- write with `target: { project }` and confirm the path lands under the project cwd, not `/workspace`
- promote a project holding a local unpushed commit and confirm the refusal
- promote twice concurrently and confirm neither Sprite is killed

## On the failing `CodeQL` check

Red on three **pre-existing** alerts, not on anything this branch introduced. The two alerts this PR did introduce (267/268, polynomial regex) were fixed in `4f7e3371a` and auto-resolved; `CodeQL Security Analysis` passes.

The aggregate check reports `#228/#229/#230` (`js/user-controlled-bypass`) on the `!messages` / `!chatId` request-validation guards in `route.ts`. They were created `2026-07-03`, carry `ref = refs/heads/master`, and `master` currently has 8 such alerts. They surface here only because CodeQL attributes alerts by changed *file* and this PR touches `route.ts`. Merge is not blocked: the `Master Protection` ruleset enforces only `deletion` and `non_fast_forward`, with no required status checks. See the PR comment for full provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLHwcKfoF9nn9doCmJfN1v
