### PR TITLE
fix(machines): deleted-upstream data loss, storage accounting on Sprite revival, targeted path docs

### DIFF
--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -490,7 +490,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
 
     writeFile: tool({
       description:
-        'Write a file inside this conversation\'s sandbox. The path is relative to the sandbox root and cannot escape it. In a machine-bound conversation you may add target: { project?, branch? } to run against a project or branch beneath your node instead of your own; omit it to use your own node.',
+        'Write a file inside this conversation\'s sandbox. A relative path resolves from your node\'s working directory, and cannot escape the sandbox root. In a machine-bound conversation you may add target: { project?, branch? } to act on a project or branch beneath your node instead of your own — a relative path then resolves from THAT node\'s working directory; omit it to use your own node. Pass an absolute path to override this.',
       inputSchema: writeFileInputSchema,
       execute: async ({ path, content, target }, options) => {
         const opened = await open(options, target);
@@ -501,7 +501,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
 
     readFile: tool({
       description:
-        'Read a file from this conversation\'s sandbox. The path is relative to the sandbox root and cannot escape it. In a machine-bound conversation you may add target: { project?, branch? } to run against a project or branch beneath your node instead of your own; omit it to use your own node.',
+        'Read a file from this conversation\'s sandbox. A relative path resolves from your node\'s working directory, and cannot escape the sandbox root. In a machine-bound conversation you may add target: { project?, branch? } to act on a project or branch beneath your node instead of your own — a relative path then resolves from THAT node\'s working directory; omit it to use your own node. Pass an absolute path to override this.',
       inputSchema: readFileInputSchema,
       execute: async ({ path, target }, options) => {
         const opened = await open(options, target);
@@ -512,7 +512,7 @@ export function createSandboxTools({ runDeps, resolveContext, gate, machines }: 
 
     editFile: tool({
       description:
-        'Edit a file in this conversation\'s sandbox by replacing oldString with newString. oldString must be unique in the file unless replaceAll is set. Prefer this over writeFile for targeted changes — it does not rewrite the whole file. The path is relative to the sandbox root and cannot escape it. In a machine-bound conversation you may add target: { project?, branch? } to run against a project or branch beneath your node instead of your own; omit it to use your own node.',
+        'Edit a file in this conversation\'s sandbox by replacing oldString with newString. oldString must be unique in the file unless replaceAll is set. Prefer this over writeFile for targeted changes — it does not rewrite the whole file. A relative path resolves from your node\'s working directory, and cannot escape the sandbox root. In a machine-bound conversation you may add target: { project?, branch? } to act on a project or branch beneath your node instead of your own — a relative path then resolves from THAT node\'s working directory; omit it to use your own node. Pass an absolute path to override this.',
       inputSchema: editFileInputSchema,
       execute: async ({ path, oldString, newString, replaceAll, target }, options) => {
         const opened = await open(options, target);

--- a/packages/lib/src/services/machines/__tests__/machine-branches-store.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-branches-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { revivedBranchColumns } from '../machine-branches-store';
+
+/**
+ * Machines-feature audit, 2026-07-23. The F11 accounting fix landed on the
+ * project tier only; the branch tier has the same lifecycle and the same
+ * defect — and it is worse there, because a torn-down branch row is EXCLUDED
+ * from the reconcile (`listBranchSprites` filters `spriteTornDownAt IS NULL`),
+ * so its watermark freezes for the whole teardown and the next reconcile after
+ * revival bills that entire window at the dead generation's size.
+ */
+describe('revivedBranchColumns', () => {
+  const now = new Date('2026-07-23T12:00:00.000Z');
+  const base = { sandboxId: 'sbx-new', spriteInstanceId: 'inst-new', now };
+
+  it('given a revived branch, should restart the storage accounting period', () => {
+    const columns = revivedBranchColumns(base);
+    expect({
+      storageLastBilledAt: columns.storageLastBilledAt,
+      storageMeasuredBytes: columns.storageMeasuredBytes,
+      storageMeasuredAt: columns.storageMeasuredAt,
+    }).toEqual({
+      // Without this the teardown window itself gets billed on revival.
+      storageLastBilledAt: now,
+      storageMeasuredBytes: null,
+      storageMeasuredAt: null,
+    });
+  });
+
+  it('given a revived branch, should record the replacement Sprite identity', () => {
+    const columns = revivedBranchColumns(base);
+    expect({ sandboxId: columns.sandboxId, spriteInstanceId: columns.spriteInstanceId }).toEqual({
+      sandboxId: 'sbx-new',
+      spriteInstanceId: 'inst-new',
+    });
+  });
+
+  it('given a revived branch, should void BOTH teardown marks', () => {
+    const columns = revivedBranchColumns(base);
+    expect({
+      spriteTornDownAt: columns.spriteTornDownAt,
+      teardownRequestedAt: columns.teardownRequestedAt,
+    }).toEqual({ spriteTornDownAt: null, teardownRequestedAt: null });
+  });
+
+  it('given a driver that could not report an instance id, should persist null rather than omit it', () => {
+    expect(revivedBranchColumns({ ...base, spriteInstanceId: null }).spriteInstanceId).toBeNull();
+  });
+
+  it('given a revival, should stamp updatedAt from the injected clock', () => {
+    expect(revivedBranchColumns(base).updatedAt).toEqual(now);
+  });
+});

--- a/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
+++ b/packages/lib/src/services/machines/__tests__/machine-project-promotion.test.ts
@@ -588,6 +588,14 @@ describe('classifyCheckoutStatus', () => {
     expect(classifyCheckoutStatus('## main...origin/main [behind 3]\n')).toEqual({ kind: 'clean' });
   });
 
+  it('given a DELETED upstream ([gone]), should refuse — nothing on the remote can reproduce this branch', () => {
+    // Git reports no ahead/behind counts for a gone upstream, so the `...` in
+    // the header would otherwise read as tracked-and-in-sync.
+    const result = classifyCheckoutStatus('## main...origin/main [gone]\n');
+    expect(result.kind).toBe('unpushed');
+    expect(result.kind === 'unpushed' && result.detail).toContain('no longer exists');
+  });
+
   it('given a branch with NO upstream, should refuse — there is no remote ref to reproduce it from', () => {
     const result = classifyCheckoutStatus('## scratch\n');
     expect(result.kind).toBe('unpushed');

--- a/packages/lib/src/services/machines/machine-branches-store.ts
+++ b/packages/lib/src/services/machines/machine-branches-store.ts
@@ -47,6 +47,54 @@ export interface NewMachineBranchInput {
   now: Date;
 }
 
+/**
+ * What recording a live replacement Sprite writes onto a `machine_branches` row
+ * (pure) — the branch-tier twin of `promotedProjectColumns`.
+ *
+ * IDENTITY. The new Sprite's name and WHICH VM it is, plus the voiding of both
+ * teardown marks: `spriteTornDownAt` (it is not torn down) and
+ * `teardownRequestedAt` (that request was against the PREVIOUS VM). Leaving the
+ * request set would let the reconciler destroy this live VM, and would turn a
+ * later REVERSIBLE trash of the restored Machine into an irreversible kill.
+ *
+ * ACCOUNTING. A new Sprite generation is a NEW ACCOUNTING PERIOD, and this is
+ * the tier where getting it wrong costs the most. A torn-down branch row is
+ * EXCLUDED from the storage reconcile (`listBranchSprites` filters
+ * `spriteTornDownAt IS NULL`), so its watermark freezes for the whole teardown.
+ * Reviving it without resetting that watermark makes the next reconcile bill
+ * `now - storageLastBilledAt` — the entire period the branch did not exist —
+ * at the DEAD generation's measured size. The measurement is dropped for the
+ * same reason it is on promotion: it described a filesystem that is gone.
+ *
+ * (Issue #2204 follow-up F11 covered the project tier only; this is the same
+ * defect in the branch tier, found by the machines-feature audit.)
+ */
+export function revivedBranchColumns(input: {
+  sandboxId: string;
+  spriteInstanceId: string | null;
+  now: Date;
+}): {
+  sandboxId: string;
+  spriteInstanceId: string | null;
+  spriteTornDownAt: null;
+  teardownRequestedAt: null;
+  storageLastBilledAt: Date;
+  storageMeasuredBytes: null;
+  storageMeasuredAt: null;
+  updatedAt: Date;
+} {
+  return {
+    sandboxId: input.sandboxId,
+    spriteInstanceId: input.spriteInstanceId,
+    spriteTornDownAt: null,
+    teardownRequestedAt: null,
+    storageLastBilledAt: input.now,
+    storageMeasuredBytes: null,
+    storageMeasuredAt: null,
+    updatedAt: input.now,
+  };
+}
+
 export interface MachineBranchStore {
   list(machineId: string, projectName: string): Promise<MachineBranchRecord[]>;
   /** Every branch of the machine in one read — the machine-root cascade derivation's query (see `MachinePaneBindingBranchLookup.listAll`). */
@@ -167,18 +215,7 @@ export async function createDbMachineBranchStore(): Promise<MachineBranchStore> 
     async updateSandboxId({ id, previousSandboxId, sandboxId, spriteInstanceId, now }) {
       const updated = await db
         .update(machineBranches)
-        .set({
-          sandboxId,
-          spriteInstanceId,
-          // This row points at a LIVE Sprite again, so BOTH teardown marks are void:
-          // `spriteTornDownAt` (it is not torn down) and `teardownRequestedAt` (the
-          // request was against the PREVIOUS VM). Leaving the request set would let
-          // the reconciler destroy this live VM — and would turn a later REVERSIBLE
-          // trash of the restored Machine into an irreversible kill.
-          spriteTornDownAt: null,
-          teardownRequestedAt: null,
-          updatedAt: now,
-        })
+        .set(revivedBranchColumns({ sandboxId, spriteInstanceId, now }))
         .where(and(eq(machineBranches.id, id), eq(machineBranches.sandboxId, previousSandboxId)))
         .returning({ id: machineBranches.id });
       return updated.length > 0;

--- a/packages/lib/src/services/machines/machine-project-promotion.ts
+++ b/packages/lib/src/services/machines/machine-project-promotion.ts
@@ -294,6 +294,14 @@ export function classifyCheckoutStatus(stdout: string): CheckoutState {
   if (ahead) {
     return { kind: 'unpushed', detail: `${ahead[1]} commit(s) not on the remote (${branch})` };
   }
+  // `[gone]` — the branch still NAMES an upstream, but that ref no longer
+  // exists on the remote (deleted after a merge, or a force-pruned fork). Git
+  // then reports no ahead/behind counts at all, so the `...` below would read
+  // this as tracked-and-in-sync when in fact NOTHING on the remote can
+  // reproduce this branch. That is the same loss as having no upstream at all.
+  if (/\bgone\b/.test(divergence)) {
+    return { kind: 'unpushed', detail: `the upstream branch no longer exists on the remote (${branch})` };
+  }
   // `## name...upstream` is the only shape that names a remote ref. Anything
   // else — `## name`, `## HEAD (no branch)` — has nothing to be reproduced from.
   if (!branch.includes('...')) {

--- a/packages/lib/src/services/sandbox/machine-session-manager.ts
+++ b/packages/lib/src/services/sandbox/machine-session-manager.ts
@@ -643,7 +643,17 @@ export async function createDbMachineSessionStore(): Promise<MachineSessionStore
           // re-provision). Recording it also voids any teardown INTENT: that
           // request was against the previous VM, which is provably gone, and
           // leaving it set would let the reconciler destroy this live one.
-          ...(spriteInstanceId === undefined ? {} : { spriteInstanceId, teardownRequestedAt: null }),
+          //
+          // A changed instance id is a NEW VM with a FRESH disk, so the stored
+          // measurement — which describes the previous generation's filesystem
+          // — is dropped rather than inherited. Keeping it would bill the old
+          // size until some unrelated wake happened to re-measure. Unlike the
+          // branch/project tiers there is no watermark to reset: `machine_sessions`
+          // rows carry no `spriteTornDownAt` and are never excluded from the
+          // reconcile, so no billing window is ever skipped for them.
+          ...(spriteInstanceId === undefined
+            ? {}
+            : { spriteInstanceId, teardownRequestedAt: null, storageMeasuredBytes: null, storageMeasuredAt: null }),
         })
         .where(eq(machineSessions.sessionKey, sessionKey));
     },


### PR DESCRIPTION
Follow-up to #2209. CodeRabbit's review landed while that PR was mid-iteration and it merged before these two findings were applied. One of them is a data-loss path currently on `master`.

## 1. A deleted upstream is treated as clean — data loss (bug, not a missing test)

CodeRabbit filed this as "add a `[gone]` test case". It is not a missing test; it is a missing branch.

When a branch's upstream ref has been deleted — merged and pruned, or a force-pruned fork — git reports:

```
## main...origin/main [gone]
```

with **no ahead/behind counts at all**. `classifyCheckoutStatus` saw the `...`, concluded the branch was tracked and in sync, and returned `clean`. Promotion then proceeds, replaces the checkout with a fresh clone of `repoUrl`, and loses every local commit on that branch.

That is precisely the loss F1 was written to prevent, reached through a shape F1 did not cover: F1 handled *ahead of upstream* and *no upstream named*, but not *upstream named and gone*. `[gone]` now classifies as `unpushed` with its own message.

## 2. The file tools describe a path rule that stopped being true (docs)

`writeFile` / `readFile` / `editFile` still told the model:

> The path is relative to the sandbox root and cannot escape it.

That stopped being accurate in #2209, when `nodeScopedPath` (F9) began anchoring relative paths to the **resolved node's** cwd — so under `target: { project: 'foo' }` a relative path resolves from `/workspace/projects/foo`, not `/workspace`. A model trusting the old sentence targets the wrong file, which is the same class of mistake F9 fixed in the implementation.

All three descriptions now state the real rule: a relative path resolves from your node's working directory; a targeted call resolves from *that* node's; an absolute path overrides it. Behavior unchanged — this aligns the contract the model reads with the one the code implements.

## 3. Storage accounting is not reset when a branch or machine Sprite is revived (audit)

From a full audit of the machines feature. The F11 fix in #2209 landed on the **project** tier only; the same defect is present in the other two tiers of the same cascade. Found by checking the siblings of the tier the review comment happened to name.

**Branch tier (major).** A torn-down branch row is *excluded* from the storage reconcile — `listBranchSprites` filters `spriteTornDownAt IS NULL` (`machine-storage-billing.ts:75`) — so its watermark freezes for the whole teardown. `updateSandboxId` then revives the row (nulling `spriteTornDownAt`) without touching `storageLastBilledAt`, so the next reconcile computes `elapsedMs = now - storageLastBilledAt` (`machine-storage-reconcile.ts:318`) across **the entire period the branch did not exist**, priced at the dead generation's measured size.

Trace: orphan-reconcile CAS-stamps `spriteTornDownAt` after a confirmed kill → row leaves the billable set, watermark freezes → machine restored, branch re-spawned → `updateSandboxId` nulls the mark → row re-enters billing with the old watermark and the old measurement.

Fixed by `revivedBranchColumns`, the branch twin of `promotedProjectColumns`: restart the watermark, drop the measurement that described a filesystem which no longer exists.

**Machine tier (minor).** `touch` records a changed `spriteInstanceId` — a new VM with a fresh disk — but kept the previous generation's `storageMeasuredBytes`, billing the old size until some unrelated wake re-measured. Now dropped alongside the instance change. There is no watermark to reset here: `machine_sessions` rows carry no `spriteTornDownAt` and are never excluded from the reconcile, so no billing window is ever skipped for them.

Full audit (including the dimensions that came back clean — authorization, path confinement, deployment-mode gating, concurrency, billing attribution) is recorded at page `ziu55l7e1aujym5lgivynk7v` under the `Terminal — PageSpace Pane Agent` epic.

## Verification

- `bun run typecheck` — 17/17 pass
- `bun run lint` — pass (full web build green)
- `packages/lib` full suite — 8844 pass, 11 skipped
- `machine-project-promotion` suite — 46 pass, including the new `[gone]` case asserting `unpushed`
- `sandbox-tools` suite — 63 pass
- new `machine-branches-store` suite — 5 pass (accounting reset, Sprite identity, both teardown marks, null instance id, injected clock)

## Note on the three open threads on #2209

The three Codex threads on #2209 are still unresolved there. All three were fixed in `99607d34d` with replies explaining what changed; they were deliberately left open for reviewer verification and the PR merged before that happened. Nothing in this PR depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLHwcKfoF9nn9doCmJfN1v
