### PR TITLE
fix(cli): report the credential whoami would actually use; add --device to every key ceremony

### DIFF
--- a/apps/web/src/app/activate/ActivateFlow.tsx
+++ b/apps/web/src/app/activate/ActivateFlow.tsx
@@ -104,6 +104,15 @@ export function ActivateFlow({ initialUserCode }: ActivateFlowProps) {
       });
       setStep({ name: 'done', action });
     } catch {
+      // A step-up grant is single-use and time-limited, so the most likely
+      // reason an approval request fails is that the one we hold was expired
+      // or bound to a different action. Keeping it would make every retry
+      // resubmit the same dead token and skip the ceremony that could mint a
+      // fresh one (the `!token` guard above) — a permanent, silent dead end,
+      // most easily hit by following a magic link that has since expired.
+      // Dropping it means the next attempt runs a genuinely fresh ceremony.
+      setStepUpToken(null);
+      setStepUpStatus('idle');
       setError('Something went wrong. Please try again.');
     } finally {
       setIsSubmitting(false);

--- a/apps/web/src/app/activate/ActivateFlow.tsx
+++ b/apps/web/src/app/activate/ActivateFlow.tsx
@@ -1,19 +1,25 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { post } from '@/lib/auth/auth-fetch';
+import { attemptStepUp, readStepUpTokenFromHash, stripStepUpTokenFromHash } from '@/lib/auth/step-up-ceremony';
 
 interface VerifyResponse {
   userCode: string;
   clientName: string;
   firstParty: boolean;
   scopeDescriptions: string[];
+  /** True for key-shaped grants (mint / re-scope / activate) — see the decision route. */
+  requiresStepUp: boolean;
+  stepUpActionBinding: Record<string, string> | null;
 }
 
 type Step =
   | { name: 'entry' }
   | { name: 'consent'; data: VerifyResponse }
   | { name: 'done'; action: 'approve' | 'deny' };
+
+type StepUpStatus = 'idle' | 'in_progress' | 'awaiting_email' | 'ready';
 
 interface ActivateFlowProps {
   initialUserCode: string;
@@ -30,6 +36,21 @@ export function ActivateFlow({ initialUserCode }: ActivateFlowProps) {
   const [step, setStep] = useState<Step>({ name: 'entry' });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [stepUpStatus, setStepUpStatus] = useState<StepUpStatus>('idle');
+  const [stepUpToken, setStepUpToken] = useState<string | null>(null);
+
+  // A step-up magic link redirects back to /activate?user_code=... with the
+  // grant attached in the fragment (never the query string, which would hit
+  // server logs) — pick it up on load and scrub it from the visible URL.
+  // Mirrors ConsentActions.tsx.
+  useEffect(() => {
+    const tokenFromEmail = readStepUpTokenFromHash(window.location.hash);
+    if (!tokenFromEmail) return;
+    setStepUpToken(tokenFromEmail);
+    setStepUpStatus('ready');
+    const cleanedHash = stripStepUpTokenFromHash(window.location.hash);
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}${cleanedHash}`);
+  }, []);
 
   async function verify() {
     setIsSubmitting(true);
@@ -44,17 +65,59 @@ export function ActivateFlow({ initialUserCode }: ActivateFlowProps) {
     }
   }
 
-  async function decide(action: 'approve' | 'deny', verifiedUserCode: string) {
+  async function decide(action: 'approve' | 'deny', data: VerifyResponse) {
     setIsSubmitting(true);
     setError(null);
     try {
-      await post('/api/oauth/device_authorization/decision', { userCode: verifiedUserCode, action });
+      let token = stepUpToken;
+
+      // Minting a key, re-scoping one, or making one a device's ambient
+      // default is a credential escalation and carries the same second factor
+      // the browser consent screen demands. A plain login approval skips this
+      // entirely, so `login --device` is unchanged.
+      if (action === 'approve' && data.requiresStepUp && data.stepUpActionBinding && !token) {
+        setStepUpStatus('in_progress');
+        try {
+          const next = `${window.location.pathname}${window.location.search}`;
+          const result = await attemptStepUp(data.stepUpActionBinding, next);
+          if (result.status === 'awaiting_email') {
+            setStepUpStatus('awaiting_email');
+            setIsSubmitting(false);
+            return;
+          }
+          token = result.stepUpToken;
+        } catch (ceremonyError) {
+          // Never leave the button stuck on "Confirming…" — drop back to idle
+          // and clear any token so a retry starts a genuinely fresh ceremony.
+          setStepUpStatus('idle');
+          setStepUpToken(null);
+          throw ceremonyError;
+        }
+        setStepUpToken(token);
+        setStepUpStatus('ready');
+      }
+
+      await post('/api/oauth/device_authorization/decision', {
+        userCode: data.userCode,
+        action,
+        ...(action === 'approve' && token ? { stepUpToken: token } : {}),
+      });
       setStep({ name: 'done', action });
     } catch {
       setError('Something went wrong. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
+  }
+
+  if (stepUpStatus === 'awaiting_email') {
+    return (
+      <div className="mt-8">
+        <p className="text-sm text-muted-foreground">
+          Check your email for a confirmation link to finish approving this request.
+        </p>
+      </div>
+    );
   }
 
   if (step.name === 'done') {
@@ -93,15 +156,15 @@ export function ActivateFlow({ initialUserCode }: ActivateFlowProps) {
           <button
             type="button"
             disabled={isSubmitting}
-            onClick={() => decide('approve', data.userCode)}
+            onClick={() => decide('approve', data)}
             className="flex-1 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >
-            Allow
+            {stepUpStatus === 'in_progress' ? 'Confirming…' : 'Allow'}
           </button>
           <button
             type="button"
             disabled={isSubmitting}
-            onClick={() => decide('deny', data.userCode)}
+            onClick={() => decide('deny', data)}
             className="flex-1 rounded border px-4 py-2 text-sm font-medium disabled:opacity-50"
           >
             Deny

--- a/apps/web/src/app/activate/__tests__/ActivateFlow.test.tsx
+++ b/apps/web/src/app/activate/__tests__/ActivateFlow.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * The /activate screen's step-up behaviour. A step-up grant is single-use and
+ * short-lived, so the interesting cases are all about what happens when the
+ * one we hold turns out to be dead — the screen must never trap the user in a
+ * loop that can only re-submit it.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+const postMock = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  post: (...args: unknown[]) => postMock(...args),
+}));
+
+import { ActivateFlow } from '../ActivateFlow';
+import { startAuthentication } from '@simplewebauthn/browser';
+
+const MINT_VERIFY = {
+  userCode: 'ABCDEFGH',
+  clientName: 'PageSpace CLI',
+  firstParty: true,
+  scopeDescriptions: ['Create a key named "remote-key"'],
+  requiresStepUp: true,
+  stepUpActionBinding: { userCode: 'ABCDEFGH', scope: 'drive:drv1:member name:remote-key offline_access' },
+};
+
+const LOGIN_VERIFY = {
+  userCode: 'ABCDEFGH',
+  clientName: 'PageSpace CLI',
+  firstParty: true,
+  scopeDescriptions: ['Manage your access keys'],
+  requiresStepUp: false,
+  stepUpActionBinding: null,
+};
+
+/** Drives the screen from the code entry box to the consent step. */
+async function reachConsent() {
+  render(<ActivateFlow initialUserCode="ABCD-EFGH" />);
+  await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+  await screen.findByRole('button', { name: /allow/i });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ActivateFlow — step-up on credential-escalating grants', () => {
+  /**
+   * Regression guard. The approval request is the first place a stale grant
+   * is detected (the decision route answers `step_up_required`). If the screen
+   * keeps the token after that failure, the `!token` guard skips the ceremony
+   * on every retry and re-submits the same dead token forever — a silent dead
+   * end, most easily reached by following a magic link that has since expired.
+   */
+  it('drops a rejected step-up token so the next attempt runs a fresh ceremony', async () => {
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'cred' } as never);
+    let decisionCalls = 0;
+    postMock.mockImplementation((url: string) => {
+      if (url === '/api/oauth/device_authorization/verify') return Promise.resolve(MINT_VERIFY);
+      if (url === '/api/auth/step-up/webauthn/options') {
+        return Promise.resolve({ options: { challenge: 'srv-challenge' }, challengeId: 'chal-1' });
+      }
+      if (url === '/api/auth/step-up/webauthn/verify') {
+        return Promise.resolve({ stepUpToken: `grant-${decisionCalls + 1}` });
+      }
+      if (url === '/api/oauth/device_authorization/decision') {
+        decisionCalls += 1;
+        // The server rejects the first grant as stale.
+        if (decisionCalls === 1) return Promise.reject(new Error('step_up_required'));
+        return Promise.resolve({ ok: true, action: 'approve' });
+      }
+      throw new Error(`unexpected post to ${url}`);
+    });
+
+    await reachConsent();
+    await userEvent.click(screen.getByRole('button', { name: /allow/i }));
+    await screen.findByText(/something went wrong/i);
+
+    // Second attempt: a NEW ceremony must run and a NEW grant be submitted.
+    await userEvent.click(screen.getByRole('button', { name: /^allow$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/device connected/i)).toBeInTheDocument();
+    });
+
+    expect(startAuthentication).toHaveBeenCalledTimes(2);
+    const submitted = postMock.mock.calls
+      .filter(([url]) => url === '/api/oauth/device_authorization/decision')
+      .map(([, body]) => (body as { stepUpToken?: string }).stepUpToken);
+    expect(submitted).toEqual(['grant-1', 'grant-2']);
+  });
+
+  it('runs the ceremony and submits the grant for an escalating grant', async () => {
+    vi.mocked(startAuthentication).mockResolvedValue({ id: 'cred' } as never);
+    postMock.mockImplementation((url: string) => {
+      if (url === '/api/oauth/device_authorization/verify') return Promise.resolve(MINT_VERIFY);
+      if (url === '/api/auth/step-up/webauthn/options') {
+        return Promise.resolve({ options: { challenge: 'srv-challenge' }, challengeId: 'chal-1' });
+      }
+      if (url === '/api/auth/step-up/webauthn/verify') return Promise.resolve({ stepUpToken: 'fresh-grant' });
+      if (url === '/api/oauth/device_authorization/decision') return Promise.resolve({ ok: true, action: 'approve' });
+      throw new Error(`unexpected post to ${url}`);
+    });
+
+    await reachConsent();
+    await userEvent.click(screen.getByRole('button', { name: /allow/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/device connected/i)).toBeInTheDocument();
+    });
+
+    // Bound to the tuple the decision route recomputes server-side.
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/auth/step-up/webauthn/options',
+      expect.objectContaining({ actionBinding: MINT_VERIFY.stepUpActionBinding }),
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oauth/device_authorization/decision',
+      expect.objectContaining({ stepUpToken: 'fresh-grant' }),
+    );
+  });
+
+  // `login --device` must be unchanged by the step-up work.
+  it('never runs a ceremony for a plain login grant', async () => {
+    postMock.mockImplementation((url: string) => {
+      if (url === '/api/oauth/device_authorization/verify') return Promise.resolve(LOGIN_VERIFY);
+      if (url === '/api/oauth/device_authorization/decision') return Promise.resolve({ ok: true, action: 'approve' });
+      throw new Error(`unexpected post to ${url}`);
+    });
+
+    await reachConsent();
+    await userEvent.click(screen.getByRole('button', { name: /allow/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/device connected/i)).toBeInTheDocument();
+    });
+
+    expect(startAuthentication).not.toHaveBeenCalled();
+    expect(postMock).toHaveBeenCalledWith(
+      '/api/oauth/device_authorization/decision',
+      expect.not.objectContaining({ stepUpToken: expect.anything() }),
+    );
+  });
+
+  it('never runs a ceremony to DENY, however escalating the grant', async () => {
+    postMock.mockImplementation((url: string) => {
+      if (url === '/api/oauth/device_authorization/verify') return Promise.resolve(MINT_VERIFY);
+      if (url === '/api/oauth/device_authorization/decision') return Promise.resolve({ ok: true, action: 'deny' });
+      throw new Error(`unexpected post to ${url}`);
+    });
+
+    await reachConsent();
+    await userEvent.click(screen.getByRole('button', { name: /deny/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+    });
+
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/__tests__/route.test.ts
@@ -138,16 +138,44 @@ describe('POST /api/oauth/device_authorization — scope validation', () => {
     );
   });
 
-  it('rejects an update_key scope outright — key re-scoping is loopback-consent-only, the device grant has no path for it', async () => {
+  it('accepts an update_key scope — key re-scoping now redeems over the device grant, so a remote machine can edit a key without a local browser', async () => {
     const res = await POST(
       deviceAuthRequest({ client_id: CLIENT_ID, scope: 'update_key:tok123 drive:drv1:member' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(createDeviceAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: expect.arrayContaining(['update_key:tok123']) }),
+    );
+  });
+
+  it('accepts an activate_key scope — the `keys use` approval ceremony also works headlessly', async () => {
+    const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID, scope: 'activate_key:tok123' }) as never);
+    expect(res.status).toBe(200);
+    expect(createDeviceAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: expect.arrayContaining(['activate_key:tok123']) }),
+    );
+  });
+
+  it('accepts a named mint scope — `keys create --device`', async () => {
+    const res = await POST(
+      deviceAuthRequest({ client_id: CLIENT_ID, scope: 'drive:drv1:member name:remote-key offline_access' }) as never,
+    );
+    expect(res.status).toBe(200);
+    expect(createDeviceAuthorization).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: expect.arrayContaining(['name:remote-key']) }),
+    );
+  });
+
+  it('rejects a mint scope with no name — an unnamed key would redeem to a generic placeholder the user cannot identify', async () => {
+    const res = await POST(
+      deviceAuthRequest({ client_id: CLIENT_ID, scope: 'drive:drv1:member offline_access' }) as never,
     );
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_scope' });
     expect(createDeviceAuthorization).not.toHaveBeenCalled();
   });
 
-  it('rejects an all_drives scope outright — pollDeviceToken has no isAllDrivesGrant branch and would mint a token that resolves to zero access', async () => {
+  it('still rejects an all_drives scope outright — a device-minted all_drives token lands in the ambiguous allowedDriveIds: [] shape', async () => {
     const res = await POST(deviceAuthRequest({ client_id: CLIENT_ID, scope: 'all_drives offline_access' }) as never);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_scope' });

--- a/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/__tests__/route.test.ts
@@ -30,6 +30,11 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
 
+const consumeStepUpGrant = vi.fn();
+vi.mock('@pagespace/lib/auth/step-up-service', () => ({
+  consumeStepUpGrant: (...args: unknown[]) => consumeStepUpGrant(...args),
+}));
+
 const getDriveAccess = vi.fn();
 vi.mock('@pagespace/lib/services/drive-service', () => ({
   getDriveAccess: (...args: unknown[]) => getDriveAccess(...args),
@@ -73,6 +78,7 @@ beforeEach(() => {
   // never need it, and recordDeviceApproval independently re-validates.
   verifyDeviceUserCode.mockResolvedValue({ outcome: 'not_found' });
   getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });
+  consumeStepUpGrant.mockResolvedValue({ ok: true });
   getMemberCustomRoleId.mockResolvedValue(null);
   customRoleBelongsToDrive.mockResolvedValue(true);
 });
@@ -230,6 +236,7 @@ describe('POST /api/oauth/device_authorization/decision — P1b: grant-authority
   it('allows approving a scope the user has authority to grant', async () => {
     verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes: ['drive:abc12345:member'] });
     getDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true, role: 'OWNER' });
+  consumeStepUpGrant.mockResolvedValue({ ok: true });
     recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
 
     const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
@@ -249,5 +256,95 @@ describe('POST /api/oauth/device_authorization/decision — P1b: grant-authority
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true, action: 'denied' });
     expect(recordDeviceApproval).toHaveBeenCalled();
+  });
+});
+
+
+/**
+ * The device flow can now redeem key-shaped grants, so the escalating subset
+ * must carry the same second factor the browser consent screen demands for
+ * every consent — otherwise `--device` would be a way to mint a key with
+ * strictly less proof of presence. Plain logins keep their no-step-up path so
+ * `login --device` is unchanged.
+ *
+ * `isCredentialEscalatingGrant` (packages/lib/.../scopes.ts) is the single
+ * predicate behind both this gate and the /activate screen's decision to RUN
+ * the ceremony; these cases pin this half of it.
+ */
+describe('POST /api/oauth/device_authorization/decision — step-up gate on credential-escalating grants', () => {
+  const ESCALATING: ReadonlyArray<readonly [string, string[]]> = [
+    ['a mint grant', ['drive:drv1:member', 'name:remote-key', 'offline_access']],
+    ['a re-scope grant', ['update_key:tok1', 'drive:drv1:member']],
+    ['an activation grant', ['activate_key:tok1']],
+  ];
+
+  for (const [label, scopes] of ESCALATING) {
+    it(`refuses ${label} approved without a step-up token`, async () => {
+      verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes });
+
+      const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+      expect(res.status).toBe(401);
+      expect(await res.json()).toEqual({ error: 'step_up_required' });
+      expect(recordDeviceApproval).not.toHaveBeenCalled();
+    });
+
+    it(`refuses ${label} when the step-up grant does not verify`, async () => {
+      verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes });
+      consumeStepUpGrant.mockResolvedValue({ ok: false, error: { code: 'STEP_UP_REQUIRED' } });
+
+      const res = await POST(
+        decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve', stepUpToken: 'stale-grant' }) as never,
+      );
+
+      expect(res.status).toBe(401);
+      expect(recordDeviceApproval).not.toHaveBeenCalled();
+    });
+
+    it(`binds the step-up grant to this exact code and scope for ${label}`, async () => {
+      verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes });
+      recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+      await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve', stepUpToken: 'grant' }) as never);
+
+      // Bound to the user code AND the scope string, so a grant obtained for
+      // one device approval cannot be replayed against another.
+      expect(consumeStepUpGrant).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user-1',
+          token: 'grant',
+          actionBinding: { userCode: 'ABCDEFGH', scope: scopes.join(' ') },
+        }),
+      );
+    });
+  }
+
+  it('does NOT require step-up for a plain login grant, leaving `login --device` unchanged', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['manage_keys', 'offline_access'],
+    });
+    recordDeviceApproval.mockResolvedValue({ outcome: 'approved' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'approve' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
+    expect(recordDeviceApproval).toHaveBeenCalled();
+  });
+
+  it('never requires step-up to DENY, however escalating the grant', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['drive:drv1:member', 'name:k', 'offline_access'],
+    });
+    recordDeviceApproval.mockResolvedValue({ outcome: 'denied' });
+
+    const res = await POST(decisionRequest({ userCode: 'ABCD-EFGH', action: 'deny' }) as never);
+
+    expect(res.status).toBe(200);
+    expect(consumeStepUpGrant).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
@@ -21,12 +21,35 @@ import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
 import { parseScopeList, checkGrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
 import { resolveGrantAuthority } from '@/lib/auth/oauth-grant-authority';
 import { recordDeviceApproval, verifyDeviceUserCode } from '@/lib/repositories/oauth-repository';
+import { requireStepUpGrant } from '@/app/api/auth/mcp-tokens/step-up-gate';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const bodySchema = z.object({
   userCode: z.string().min(1).max(32),
   action: z.enum(['approve', 'deny']),
+  /** Required only for key-shaped grants — see `requiresStepUp` below. */
+  stepUpToken: z.string().min(1).optional(),
 });
+
+/**
+ * Does approving this scope set escalate credentials rather than just log a
+ * device in? Minting a key (`name:`), re-scoping one (`update_key`), or
+ * making one a device's ambient default (`activate_key`) all do; a plain
+ * `manage_keys offline_access` login does not.
+ *
+ * The loopback consent screen requires a step-up grant for EVERY consent
+ * (`/api/oauth/authorize`). The device flow historically needed no step-up
+ * because it could only ever produce a login grant — the door rejected
+ * everything else. Now that it can produce key material, the escalating
+ * subset must carry the same second factor, or `--device` would be a way to
+ * mint a key with strictly less proof of presence than the browser flow
+ * demands. Logins keep their existing no-step-up path so `login --device` is
+ * unchanged.
+ */
+function requiresStepUp(scopes: ReturnType<typeof parseScopeList>): boolean {
+  if (!scopes.ok) return false;
+  return scopes.scopes.newKeyName !== null || scopes.scopes.updateKeyId !== null || scopes.scopes.activateKeyId !== null;
+}
 
 export async function POST(req: NextRequest) {
   const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: true });
@@ -77,6 +100,22 @@ export async function POST(req: NextRequest) {
           details: { oauthEvent: 'device_decision_scope_denied' },
         });
         return NextResponse.json({ error: 'invalid_scope' }, { status: 400 });
+      }
+
+      // Bound to this exact user code AND this exact scope string, so a grant
+      // obtained for one device approval can't be replayed against another —
+      // the device analogue of the loopback binding's
+      // clientId/redirectUri/scope/state tuple.
+      if (requiresStepUp(parsed)) {
+        const gate = await requireStepUpGrant({
+          req,
+          userId: auth.userId,
+          stepUpToken: body.stepUpToken,
+          actionBinding: { userCode: normalized, scope: lookup.scopes.join(' ') },
+          missingReason: 'device_decision_missing_step_up',
+          invalidReason: 'device_decision_step_up_invalid',
+        });
+        if (gate) return gate;
       }
     }
   }

--- a/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/decision/route.ts
@@ -18,7 +18,7 @@ import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
-import { parseScopeList, checkGrantAuthority } from '@pagespace/lib/auth/oauth/scopes';
+import { parseScopeList, checkGrantAuthority, isCredentialEscalatingGrant } from '@pagespace/lib/auth/oauth/scopes';
 import { resolveGrantAuthority } from '@/lib/auth/oauth-grant-authority';
 import { recordDeviceApproval, verifyDeviceUserCode } from '@/lib/repositories/oauth-repository';
 import { requireStepUpGrant } from '@/app/api/auth/mcp-tokens/step-up-gate';
@@ -27,29 +27,18 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 const bodySchema = z.object({
   userCode: z.string().min(1).max(32),
   action: z.enum(['approve', 'deny']),
-  /** Required only for key-shaped grants — see `requiresStepUp` below. */
+  /**
+   * Required only for credential-escalating grants (mint / re-scope /
+   * activate), per `isCredentialEscalatingGrant`. The loopback consent screen
+   * requires step-up for every consent; the device flow historically needed
+   * none because it could only produce a login grant. Now that it can produce
+   * key material, the escalating subset carries the same second factor — or
+   * `--device` would be a way to mint a key with strictly less proof of
+   * presence than the browser flow demands. Plain logins keep their existing
+   * no-step-up path, so `login --device` is unchanged.
+   */
   stepUpToken: z.string().min(1).optional(),
 });
-
-/**
- * Does approving this scope set escalate credentials rather than just log a
- * device in? Minting a key (`name:`), re-scoping one (`update_key`), or
- * making one a device's ambient default (`activate_key`) all do; a plain
- * `manage_keys offline_access` login does not.
- *
- * The loopback consent screen requires a step-up grant for EVERY consent
- * (`/api/oauth/authorize`). The device flow historically needed no step-up
- * because it could only ever produce a login grant — the door rejected
- * everything else. Now that it can produce key material, the escalating
- * subset must carry the same second factor, or `--device` would be a way to
- * mint a key with strictly less proof of presence than the browser flow
- * demands. Logins keep their existing no-step-up path so `login --device` is
- * unchanged.
- */
-function requiresStepUp(scopes: ReturnType<typeof parseScopeList>): boolean {
-  if (!scopes.ok) return false;
-  return scopes.scopes.newKeyName !== null || scopes.scopes.updateKeyId !== null || scopes.scopes.activateKeyId !== null;
-}
 
 export async function POST(req: NextRequest) {
   const auth = await authenticateRequestWithOptions(req, { allow: ['session'], requireCSRF: true });
@@ -106,7 +95,7 @@ export async function POST(req: NextRequest) {
       // obtained for one device approval can't be replayed against another —
       // the device analogue of the loopback binding's
       // clientId/redirectUri/scope/state tuple.
-      if (requiresStepUp(parsed)) {
+      if (parsed.ok && isCredentialEscalatingGrant(parsed.scopes)) {
         const gate = await requireStepUpGrant({
           req,
           userId: auth.userId,

--- a/apps/web/src/app/api/oauth/device_authorization/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/route.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
-import { parseScopeList, formatScopeSet, hasNewKeyName, isPureDriveGrant } from '@pagespace/lib/auth/oauth/scopes';
+import { parseScopeList, formatScopeSet, hasNewKeyName, isAllDrivesGrant, isPureDriveGrant } from '@pagespace/lib/auth/oauth/scopes';
 import { generateUserCode, normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
 import { generateToken, hashToken } from '@pagespace/lib/auth/token-utils';
 import { DEVICE_CODE_TTL_SECONDS, DEVICE_CODE_POLL_INTERVAL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
@@ -83,7 +83,7 @@ export async function POST(req: NextRequest) {
     // authority-checks them exactly as the loopback consent screen does. A
     // remote machine with no local browser could otherwise log in but never
     // mint, re-scope, or activate the scoped key that content access requires.
-    if (parsed.scopes.allDrives) {
+    if (isAllDrivesGrant(parsed.scopes)) {
       return noStoreJson({ error: 'invalid_scope' }, 400);
     }
 

--- a/apps/web/src/app/api/oauth/device_authorization/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/route.ts
@@ -10,7 +10,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { randomBytes } from 'crypto';
 import { getClientIP } from '@/lib/auth';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
-import { parseScopeList, formatScopeSet } from '@pagespace/lib/auth/oauth/scopes';
+import { parseScopeList, formatScopeSet, hasNewKeyName, isPureDriveGrant } from '@pagespace/lib/auth/oauth/scopes';
 import { generateUserCode, normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
 import { generateToken, hashToken } from '@pagespace/lib/auth/token-utils';
 import { DEVICE_CODE_TTL_SECONDS, DEVICE_CODE_POLL_INTERVAL_SECONDS } from '@pagespace/lib/auth/oauth/code-lifecycle';
@@ -56,16 +56,9 @@ export async function POST(req: NextRequest) {
     if (!parsed.ok) {
       return noStoreJson({ error: 'invalid_scope' }, 400);
     }
-    // update_key/activate_key are loopback-consent-only: their ownership/
-    // narration checks live on the consent screen + authorize POST, and
-    // pollDeviceToken has no ok_mcp_update/ok_mcp_activate branch — reject at
-    // the door rather than mint a device code that could only dead-end (fail
-    // closed).
-    //
-    // all_drives is rejected for the same reason: pollDeviceToken has no
-    // isAllDrivesGrant branch either — it mints a plain OAuth access/refresh
-    // pair via issueInitialTokenPair, persisting `all_drives` verbatim into
-    // `oauth_access_tokens.scopes`. `scopeSetToDriveScopes` returns zero rows
+    // `all_drives` is the one grant shape this door still refuses. Redeeming
+    // it over the device flow would have to persist `all_drives` verbatim into
+    // `oauth_access_tokens.scopes`; `scopeSetToDriveScopes` returns zero rows
     // for all_drives (by design — "all drives" has no drive list to
     // enumerate), so such a token would carry `allowedDriveIds: []` — a shape
     // this codebase's two authorization helper families disagree on: the
@@ -79,19 +72,27 @@ export async function POST(req: NextRequest) {
     // OAuth token and is out of scope to resolve here. all_drives only
     // resolves unambiguously when minted as a real, unscoped
     // (`isScoped: false`) `mcp_tokens` row, which only the authorization_code
-    // exchange's `isAllDrivesGrant` branch produces (`oauth-repository.ts`).
-    // Rejecting at the device door means a bearer token in this ambiguous
-    // shape can never be minted in the first place, sidestepping the
-    // ambiguity rather than resolving it.
-    // newKeyName is rejected for the identical reason: a name can never be
-    // honored on a flow with no mint branch, so it must fail closed rather
-    // than be silently ignored.
-    if (
-      parsed.scopes.updateKeyId !== null ||
-      parsed.scopes.activateKeyId !== null ||
-      parsed.scopes.allDrives ||
-      parsed.scopes.newKeyName !== null
-    ) {
+    // exchange produces. Rejecting at the device door means a bearer token in
+    // this ambiguous shape can never be minted in the first place, sidestepping
+    // the ambiguity rather than resolving it. `pollDeviceToken` re-checks at
+    // redemption as defense in depth.
+    //
+    // update_key/activate_key/newKeyName are NO LONGER rejected here: the
+    // device flow now redeems all three through the same `applyKeyGrant` the
+    // loopback exchange uses, and the /activate consent screen narrates and
+    // authority-checks them exactly as the loopback consent screen does. A
+    // remote machine with no local browser could otherwise log in but never
+    // mint, re-scope, or activate the scoped key that content access requires.
+    if (parsed.scopes.allDrives) {
+      return noStoreJson({ error: 'invalid_scope' }, 400);
+    }
+
+    // Mint-shaped grants must carry a name, matching the loopback flow's
+    // `validateAuthorizeRequest` (packages/lib/src/auth/oauth/authorize-request.ts).
+    // Enforced at the door so a nameless mint can never reach redemption,
+    // where `applyKeyGrant` would fall back to a generic placeholder name and
+    // silently produce an unidentifiable key in the user's key list.
+    if (isPureDriveGrant(parsed.scopes) && !hasNewKeyName(parsed.scopes)) {
       return noStoreJson({ error: 'invalid_scope' }, 400);
     }
     scopes = formatScopeSet(parsed.scopes).split(' ').filter(Boolean);

--- a/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/__tests__/route.test.ts
@@ -25,8 +25,12 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
   verifyDeviceUserCode: (...args: unknown[]) => verifyDeviceUserCode(...args),
 }));
 
+const findActiveMcpTokenByIdAndUser = vi.fn();
 vi.mock('@/lib/repositories/session-repository', () => ({
-  sessionRepository: { findDrivesByIds: vi.fn().mockResolvedValue([]) },
+  sessionRepository: {
+    findDrivesByIds: vi.fn().mockResolvedValue([]),
+    findActiveMcpTokenByIdAndUser: (...args: unknown[]) => findActiveMcpTokenByIdAndUser(...args),
+  },
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -160,5 +164,94 @@ describe('POST /api/oauth/device_authorization/verify — outcomes', () => {
     const res = await POST(verifyRequest({}) as never);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'invalid_request' });
+  });
+});
+
+
+/**
+ * The screen must advertise the step-up ceremony for exactly the grants the
+ * decision route will REQUIRE one for — both sides read the same
+ * `isCredentialEscalatingGrant` predicate, and these cases pin the
+ * advertising half. If they drift, the user either runs a ceremony the server
+ * ignores or clicks Allow and is rejected after the fact.
+ */
+describe('POST /api/oauth/device_authorization/verify — step-up advertisement', () => {
+  beforeEach(() => {
+    findActiveMcpTokenByIdAndUser.mockResolvedValue({ id: 'tok1', name: 'my-key' });
+  });
+
+  const ESCALATING: ReadonlyArray<readonly [string, string[]]> = [
+    ['a mint grant', ['drive:drv1:member', 'name:remote-key', 'offline_access']],
+    ['a re-scope grant', ['update_key:tok1', 'drive:drv1:member']],
+    ['an activation grant', ['activate_key:tok1']],
+  ];
+
+  for (const [label, scopes] of ESCALATING) {
+    it(`advertises step-up for ${label}, bound to this code and scope`, async () => {
+      verifyDeviceUserCode.mockResolvedValue({ outcome: 'ok', clientId: 'pagespace-cli', scopes });
+
+      const body = await (await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never)).json();
+
+      expect(body.requiresStepUp).toBe(true);
+      expect(body.stepUpActionBinding).toEqual({ userCode: 'ABCDEFGH', scope: scopes.join(' ') });
+    });
+  }
+
+  it('does not advertise step-up for a plain login grant', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['manage_keys', 'offline_access'],
+    });
+
+    const body = await (await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never)).json();
+
+    expect(body.requiresStepUp).toBe(false);
+    expect(body.stepUpActionBinding).toBeNull();
+  });
+
+  it('names the target key so the user sees WHICH key they are re-scoping', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['update_key:tok1', 'drive:drv1:member'],
+    });
+
+    const body = await (await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never)).json();
+
+    expect(findActiveMcpTokenByIdAndUser).toHaveBeenCalledWith('tok1', 'user-1');
+    expect(JSON.stringify(body.scopeDescriptions)).toContain('my-key');
+  });
+
+  // No oracle: a token id belonging to someone else, revoked, or nonexistent
+  // must be indistinguishable from a bad code — otherwise the screen becomes a
+  // probe for other users' key ids.
+  it('fails closed with invalid_code when the target key is not the verifying user\'s', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['activate_key:tok9'],
+    });
+    findActiveMcpTokenByIdAndUser.mockResolvedValue(null);
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
+  });
+
+  // Not merely a parse detail: rendering an empty capability list beneath an
+  // Allow button would ask a human to approve something unnarrated.
+  it('fails closed rather than rendering an empty consent list for an unparseable scope set', async () => {
+    verifyDeviceUserCode.mockResolvedValue({
+      outcome: 'ok',
+      clientId: 'pagespace-cli',
+      scopes: ['not a valid scope!'],
+    });
+
+    const res = await POST(verifyRequest({ userCode: 'ABCD-EFGH' }) as never);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_code' });
   });
 });

--- a/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
@@ -65,8 +65,58 @@ export async function POST(req: NextRequest) {
 
   const scopeDescriptions: string[] = [];
   const parsed = result.scopes.length > 0 ? parseScopeList(result.scopes.join(' ')) : null;
+  // Whether approving this code is a credential-escalation act (minting a new
+  // key, re-scoping an existing one, or making one a device's ambient
+  // default) rather than an ordinary login. The decision route requires a
+  // step-up grant for exactly these; surfaced here so the screen can run the
+  // ceremony before the user clicks Allow rather than failing them afterward.
+  let requiresStepUp = false;
 
   if (parsed?.ok) {
+    // An update_key grant re-scopes one of the VERIFYING user's existing keys
+    // in place; an activate_key grant approves making one of them a device's
+    // ambient default. Ownership (and un-revoked) is checked here so this
+    // screen can only ever narrate the user's own key — a foreign, revoked, or
+    // nonexistent token id all collapse to the same invalid_code response (no
+    // oracle), killing the "point a victim's approval at the attacker's token"
+    // direction. Mirrors the loopback consent screen (app/oauth/consent/page.tsx);
+    // the decision POST re-checks server-side, this is the human-facing half.
+    let updateKeyName: string | null = null;
+    let activateKeyName: string | null = null;
+    const targetKeyId = parsed.scopes.updateKeyId ?? parsed.scopes.activateKeyId;
+    if (targetKeyId !== null) {
+      const target = await sessionRepository.findActiveMcpTokenByIdAndUser(targetKeyId, auth.userId);
+      if (!target) {
+        return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
+      }
+      if (parsed.scopes.updateKeyId !== null) updateKeyName = target.name;
+      else activateKeyName = target.name;
+    }
+
+    // Named first so the user reads "this creates a key named X" before the
+    // capability list that follows — same ordering as the consent screen.
+    if (parsed.scopes.newKeyName !== null) {
+      requiresStepUp = true;
+      scopeDescriptions.push(describeScopeForConsent({ kind: 'name', name: parsed.scopes.newKeyName }, {}));
+    }
+    if (parsed.scopes.updateKeyId !== null) {
+      requiresStepUp = true;
+      scopeDescriptions.push(
+        describeScopeForConsent(
+          { kind: 'update_key', tokenId: parsed.scopes.updateKeyId },
+          { keyName: updateKeyName ?? undefined },
+        ),
+      );
+    }
+    if (parsed.scopes.activateKeyId !== null) {
+      requiresStepUp = true;
+      scopeDescriptions.push(
+        describeScopeForConsent(
+          { kind: 'activate_key', tokenId: parsed.scopes.activateKeyId },
+          { keyName: activateKeyName ?? undefined },
+        ),
+      );
+    }
     if (parsed.scopes.account) {
       scopeDescriptions.push(describeScopeForConsent({ kind: 'account' }, {}));
     }
@@ -108,5 +158,12 @@ export async function POST(req: NextRequest) {
     clientName: client.name,
     firstParty: client.firstParty,
     scopeDescriptions,
+    requiresStepUp,
+    // The exact binding the decision route will recompute from its own
+    // lookup, handed to the client so the grant it mints can't be bound to a
+    // different tuple by accident. Not a trust boundary: a client that lied
+    // here would mint a grant whose hash simply fails to match the server's
+    // recomputed one at decision time, and the approval is refused.
+    stepUpActionBinding: requiresStepUp ? { userCode: normalized, scope: result.scopes.join(' ') } : null,
   });
 }

--- a/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
@@ -64,7 +64,17 @@ export async function POST(req: NextRequest) {
   }
 
   const scopeDescriptions: string[] = [];
+  // An empty scope list is a legitimate device-authorization request (the
+  // device_authorization route leaves `scopes: []` when the initial POST omits
+  // `scope` entirely) — but a NON-empty list this parser rejects is not
+  // something a human can be asked to approve: the screen would render an
+  // empty capability list and still offer an Allow button. Fail closed with
+  // the same no-oracle response as a bad code, matching the decision route,
+  // which already refuses an unparseable scope set with invalid_scope.
   const parsed = result.scopes.length > 0 ? parseScopeList(result.scopes.join(' ')) : null;
+  if (parsed !== null && !parsed.ok) {
+    return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
+  }
   // Derived from the SAME predicate the decision route enforces with, so the
   // screen can never advertise a ceremony the server doesn't demand (or skip
   // one it does). Surfaced so the ceremony runs before the user clicks Allow

--- a/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
+++ b/apps/web/src/app/api/oauth/device_authorization/verify/route.ts
@@ -13,7 +13,7 @@ import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { normalizeUserCode } from '@pagespace/lib/auth/oauth/user-code';
 import { getRegisteredClient } from '@pagespace/lib/auth/oauth/clients';
-import { parseScopeList } from '@pagespace/lib/auth/oauth/scopes';
+import { isCredentialEscalatingGrant, parseScopeList } from '@pagespace/lib/auth/oauth/scopes';
 import { describeScopeForConsent } from '@pagespace/lib/auth/oauth/consent';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
@@ -65,12 +65,11 @@ export async function POST(req: NextRequest) {
 
   const scopeDescriptions: string[] = [];
   const parsed = result.scopes.length > 0 ? parseScopeList(result.scopes.join(' ')) : null;
-  // Whether approving this code is a credential-escalation act (minting a new
-  // key, re-scoping an existing one, or making one a device's ambient
-  // default) rather than an ordinary login. The decision route requires a
-  // step-up grant for exactly these; surfaced here so the screen can run the
-  // ceremony before the user clicks Allow rather than failing them afterward.
-  let requiresStepUp = false;
+  // Derived from the SAME predicate the decision route enforces with, so the
+  // screen can never advertise a ceremony the server doesn't demand (or skip
+  // one it does). Surfaced so the ceremony runs before the user clicks Allow
+  // rather than failing them afterward.
+  const requiresStepUp = parsed?.ok === true && isCredentialEscalatingGrant(parsed.scopes);
 
   if (parsed?.ok) {
     // An update_key grant re-scopes one of the VERIFYING user's existing keys
@@ -81,39 +80,34 @@ export async function POST(req: NextRequest) {
     // oracle), killing the "point a victim's approval at the attacker's token"
     // direction. Mirrors the loopback consent screen (app/oauth/consent/page.tsx);
     // the decision POST re-checks server-side, this is the human-facing half.
-    let updateKeyName: string | null = null;
-    let activateKeyName: string | null = null;
     const targetKeyId = parsed.scopes.updateKeyId ?? parsed.scopes.activateKeyId;
+    let targetKeyName: string | null = null;
     if (targetKeyId !== null) {
       const target = await sessionRepository.findActiveMcpTokenByIdAndUser(targetKeyId, auth.userId);
       if (!target) {
         return NextResponse.json({ error: 'invalid_code' }, { status: 400 });
       }
-      if (parsed.scopes.updateKeyId !== null) updateKeyName = target.name;
-      else activateKeyName = target.name;
+      targetKeyName = target.name;
     }
 
     // Named first so the user reads "this creates a key named X" before the
     // capability list that follows — same ordering as the consent screen.
     if (parsed.scopes.newKeyName !== null) {
-      requiresStepUp = true;
       scopeDescriptions.push(describeScopeForConsent({ kind: 'name', name: parsed.scopes.newKeyName }, {}));
     }
     if (parsed.scopes.updateKeyId !== null) {
-      requiresStepUp = true;
       scopeDescriptions.push(
         describeScopeForConsent(
           { kind: 'update_key', tokenId: parsed.scopes.updateKeyId },
-          { keyName: updateKeyName ?? undefined },
+          { keyName: targetKeyName ?? undefined },
         ),
       );
     }
     if (parsed.scopes.activateKeyId !== null) {
-      requiresStepUp = true;
       scopeDescriptions.push(
         describeScopeForConsent(
           { kind: 'activate_key', tokenId: parsed.scopes.activateKeyId },
-          { keyName: activateKeyName ?? undefined },
+          { keyName: targetKeyName ?? undefined },
         ),
       );
     }

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -198,6 +198,72 @@ async function resolveClient(form: URLSearchParams, clientId: string, grantType:
   return { client, clientDbId };
 }
 
+/**
+ * The three key-shaped success outcomes, rendered identically no matter which
+ * flow carried the grant. Both the loopback authorization-code exchange and
+ * the RFC 8628 device poll produce them (the repository applies them through
+ * one shared `applyKeyGrant`), and a client must not be able to tell the two
+ * doors apart from the response body — so the serialization, the audit event
+ * types, and the activity trail live here once rather than being mirrored per
+ * handler. Returns `null` when the outcome is not key-shaped, leaving the
+ * caller's own ok/error handling to run.
+ *
+ * `oauthEventPrefix` is the ONLY thing that differs between the two: the audit
+ * detail records which door was used.
+ */
+function keyGrantSuccessResponse(
+  req: NextRequest,
+  clientId: string,
+  result: { outcome: string; userId?: string; scopes?: string[]; mcpToken?: string; tokenId?: string },
+  oauthEventPrefix: 'code_exchange' | 'device_poll',
+): NextResponse | null {
+  if (result.outcome === 'ok_mcp_token') {
+    auditRequest(req, {
+      eventType: 'auth.token.created',
+      userId: result.userId,
+      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_token` },
+    });
+    return noStoreJson(mcpTokenSuccessBody(result.mcpToken!, result.scopes!), 200);
+  }
+
+  if (result.outcome === 'ok_mcp_update') {
+    // Mirror the web Settings PATCH's audit + activity trail
+    // (mcp-tokens/[tokenId]/route.ts) — same logical operation, different
+    // door. Fire-and-forget end to end: getActorInfo does a user lookup +
+    // PII decrypts, and it feeds only logTokenActivity (itself explicitly
+    // never awaited), so none of it belongs on the response path.
+    const userId = result.userId!;
+    const tokenId = result.tokenId!;
+    void getActorInfo(userId)
+      .then((actorInfo) => {
+        logTokenActivity(userId, 'token_update', { tokenId, tokenType: 'mcp' }, actorInfo);
+      })
+      .catch(() => {
+        // Activity logging is best-effort; the audit event below is the durable record.
+      });
+    auditRequest(req, {
+      eventType: 'auth.token.updated',
+      userId,
+      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_update` },
+    });
+    return noStoreJson(mcpUpdateSuccessBody(tokenId, result.scopes!), 200);
+  }
+
+  if (result.outcome === 'ok_mcp_activate') {
+    // Approval ceremony only — nothing was minted or changed, so this is an
+    // access-granted audit event (not token.created/updated), and there is
+    // no activity-trail write: the key row is untouched.
+    auditRequest(req, {
+      eventType: 'authz.access.granted',
+      userId: result.userId,
+      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_activate` },
+    });
+    return noStoreJson(mcpActivateSuccessBody(result.tokenId!, result.scopes!), 200);
+  }
+
+  return null;
+}
+
 async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
   const code = form.get('code');
   const redirectUri = form.get('redirect_uri');
@@ -223,48 +289,8 @@ async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchPar
     now: new Date(),
   });
 
-  if (result.outcome === 'ok_mcp_token') {
-    auditRequest(req, {
-      eventType: 'auth.token.created',
-      userId: result.userId,
-      details: { clientId: client.clientId, oauthEvent: 'code_exchange_mcp_token' },
-    });
-    return noStoreJson(mcpTokenSuccessBody(result.mcpToken, result.scopes), 200);
-  }
-
-  if (result.outcome === 'ok_mcp_update') {
-    // Mirror the web Settings PATCH's audit + activity trail
-    // (mcp-tokens/[tokenId]/route.ts) — same logical operation, different
-    // door. Fire-and-forget end to end: getActorInfo does a user lookup +
-    // PII decrypts, and it feeds only logTokenActivity (itself explicitly
-    // never awaited), so none of it belongs on the exchange response path.
-    const { userId, tokenId } = result;
-    void getActorInfo(userId)
-      .then((actorInfo) => {
-        logTokenActivity(userId, 'token_update', { tokenId, tokenType: 'mcp' }, actorInfo);
-      })
-      .catch(() => {
-        // Activity logging is best-effort; the audit event below is the durable record.
-      });
-    auditRequest(req, {
-      eventType: 'auth.token.updated',
-      userId: result.userId,
-      details: { clientId: client.clientId, oauthEvent: 'code_exchange_mcp_update' },
-    });
-    return noStoreJson(mcpUpdateSuccessBody(result.tokenId, result.scopes), 200);
-  }
-
-  if (result.outcome === 'ok_mcp_activate') {
-    // Approval ceremony only — nothing was minted or changed, so this is an
-    // access-granted audit event (not token.created/updated), and there is
-    // no activity-trail write: the key row is untouched.
-    auditRequest(req, {
-      eventType: 'authz.access.granted',
-      userId: result.userId,
-      details: { clientId: client.clientId, oauthEvent: 'code_exchange_mcp_activate' },
-    });
-    return noStoreJson(mcpActivateSuccessBody(result.tokenId, result.scopes), 200);
-  }
+  const keyGrantResponse = keyGrantSuccessResponse(req, client.clientId, result, 'code_exchange');
+  if (keyGrantResponse) return keyGrantResponse;
 
   if (result.outcome !== 'ok') {
     auditRequest(req, {
@@ -338,7 +364,11 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
  * unrecognized device_code (never issued) falls back to invalid_grant, same
  * treatment as an unknown authorization code or refresh token.
  */
-const DEVICE_POLL_ERROR_BODY: Record<Exclude<Awaited<ReturnType<typeof pollDeviceToken>>['outcome'], 'ok'>, Record<string, unknown>> = {
+type DevicePollOutcome = Awaited<ReturnType<typeof pollDeviceToken>>['outcome'];
+/** Every outcome that is a SUCCESS and therefore never appears in the error map below. */
+type DevicePollSuccessOutcome = 'ok' | 'ok_mcp_token' | 'ok_mcp_update' | 'ok_mcp_activate';
+
+const DEVICE_POLL_ERROR_BODY: Record<Exclude<DevicePollOutcome, DevicePollSuccessOutcome>, Record<string, unknown>> = {
   not_found: INVALID_GRANT,
   authorization_pending: { error: 'authorization_pending' },
   slow_down: { error: 'slow_down' },
@@ -346,6 +376,19 @@ const DEVICE_POLL_ERROR_BODY: Record<Exclude<Awaited<ReturnType<typeof pollDevic
   access_denied: { error: 'access_denied' },
   // Constant-shape with not_found/expired/etc — no oracle on account status.
   user_suspended: INVALID_GRANT,
+  // RFC 8628 §3.5: a redeemed device_code is dead. Constant-shape rather than
+  // a distinct code, so a stolen device_code can't be used to probe whether
+  // the legitimate client already completed the flow.
+  already_redeemed: INVALID_GRANT,
+  // The device door refuses all_drives up front; this is the redemption-time
+  // backstop (see pollDeviceToken). Constant-shape — the CLI already refuses
+  // `--device --all-drives` locally with an actionable message, so nothing
+  // legitimate ever reaches here to need a specific code.
+  all_drives_unsupported: INVALID_GRANT,
+  // Target key revoked between consent and redemption — same constant shape
+  // the authorization-code exchange gives these.
+  update_target_gone: INVALID_GRANT,
+  activate_target_gone: INVALID_GRANT,
 };
 
 async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
@@ -364,6 +407,17 @@ async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): P
   const { client, clientDbId } = resolved;
 
   const result = await pollDeviceToken({ deviceCode, clientDbId, now: new Date() });
+
+  const keyGrantResponse = keyGrantSuccessResponse(req, client.clientId, result, 'device_poll');
+  if (keyGrantResponse) return keyGrantResponse;
+
+  // `keyGrantSuccessResponse` returning null means the outcome was not one of
+  // the three key-shaped successes — but it is a runtime check the type system
+  // can't see through, so the remaining successes are excluded explicitly here
+  // to keep the error map exhaustively typed.
+  if (result.outcome === 'ok_mcp_token' || result.outcome === 'ok_mcp_update' || result.outcome === 'ok_mcp_activate') {
+    throw new Error('unreachable: key-grant outcomes are rendered by keyGrantSuccessResponse');
+  }
 
   if (result.outcome !== 'ok') {
     auditRequest(req, {

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -198,15 +198,35 @@ async function resolveClient(form: URLSearchParams, clientId: string, grantType:
   return { client, clientDbId };
 }
 
+/** The outcomes that mean a key was minted, re-scoped, or approved for activation. */
+const KEY_GRANT_OUTCOMES = ['ok_mcp_token', 'ok_mcp_update', 'ok_mcp_activate'] as const;
+
+type KeyGrantOutcome = (typeof KEY_GRANT_OUTCOMES)[number];
+
 /**
- * The three key-shaped success outcomes, rendered identically no matter which
+ * Narrows either flow's result union down to just its key-shaped successes, so
+ * `keyGrantSuccessResponse` can take a precisely-typed argument (no optional
+ * fields, no non-null assertions) and each caller's remaining `else` branch is
+ * narrowed to the outcomes its own error map must cover.
+ */
+function isKeyGrantSuccess<T extends { outcome: string }>(
+  result: T,
+): result is Extract<T, { outcome: KeyGrantOutcome }> {
+  return (KEY_GRANT_OUTCOMES as readonly string[]).includes(result.outcome);
+}
+
+type KeyGrantSuccess =
+  | Extract<Awaited<ReturnType<typeof exchangeAuthorizationCode>>, { outcome: KeyGrantOutcome }>
+  | Extract<Awaited<ReturnType<typeof pollDeviceToken>>, { outcome: KeyGrantOutcome }>;
+
+/**
+ * Renders the three key-shaped success outcomes identically no matter which
  * flow carried the grant. Both the loopback authorization-code exchange and
  * the RFC 8628 device poll produce them (the repository applies them through
  * one shared `applyKeyGrant`), and a client must not be able to tell the two
  * doors apart from the response body — so the serialization, the audit event
  * types, and the activity trail live here once rather than being mirrored per
- * handler. Returns `null` when the outcome is not key-shaped, leaving the
- * caller's own ok/error handling to run.
+ * handler.
  *
  * `oauthEventPrefix` is the ONLY thing that differs between the two: the audit
  * detail records which door was used.
@@ -214,16 +234,16 @@ async function resolveClient(form: URLSearchParams, clientId: string, grantType:
 function keyGrantSuccessResponse(
   req: NextRequest,
   clientId: string,
-  result: { outcome: string; userId?: string; scopes?: string[]; mcpToken?: string; tokenId?: string },
+  result: KeyGrantSuccess,
   oauthEventPrefix: 'code_exchange' | 'device_poll',
-): NextResponse | null {
+): NextResponse {
   if (result.outcome === 'ok_mcp_token') {
     auditRequest(req, {
       eventType: 'auth.token.created',
       userId: result.userId,
       details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_token` },
     });
-    return noStoreJson(mcpTokenSuccessBody(result.mcpToken!, result.scopes!), 200);
+    return noStoreJson(mcpTokenSuccessBody(result.mcpToken, result.scopes), 200);
   }
 
   if (result.outcome === 'ok_mcp_update') {
@@ -232,8 +252,7 @@ function keyGrantSuccessResponse(
     // door. Fire-and-forget end to end: getActorInfo does a user lookup +
     // PII decrypts, and it feeds only logTokenActivity (itself explicitly
     // never awaited), so none of it belongs on the response path.
-    const userId = result.userId!;
-    const tokenId = result.tokenId!;
+    const { userId, tokenId } = result;
     void getActorInfo(userId)
       .then((actorInfo) => {
         logTokenActivity(userId, 'token_update', { tokenId, tokenType: 'mcp' }, actorInfo);
@@ -246,22 +265,21 @@ function keyGrantSuccessResponse(
       userId,
       details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_update` },
     });
-    return noStoreJson(mcpUpdateSuccessBody(tokenId, result.scopes!), 200);
+    return noStoreJson(mcpUpdateSuccessBody(tokenId, result.scopes), 200);
   }
 
-  if (result.outcome === 'ok_mcp_activate') {
-    // Approval ceremony only — nothing was minted or changed, so this is an
-    // access-granted audit event (not token.created/updated), and there is
-    // no activity-trail write: the key row is untouched.
+  // The remaining outcome, by exhaustion over `KEY_GRANT_OUTCOMES`: an
+  // approval ceremony only — nothing was minted or changed, so this is an
+  // access-granted audit event (not token.created/updated), and there is no
+  // activity-trail write since the key row is untouched.
+  {
     auditRequest(req, {
       eventType: 'authz.access.granted',
       userId: result.userId,
       details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_activate` },
     });
-    return noStoreJson(mcpActivateSuccessBody(result.tokenId!, result.scopes!), 200);
+    return noStoreJson(mcpActivateSuccessBody(result.tokenId, result.scopes), 200);
   }
-
-  return null;
 }
 
 async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchParams): Promise<NextResponse> {
@@ -289,8 +307,9 @@ async function handleAuthorizationCodeGrant(req: NextRequest, form: URLSearchPar
     now: new Date(),
   });
 
-  const keyGrantResponse = keyGrantSuccessResponse(req, client.clientId, result, 'code_exchange');
-  if (keyGrantResponse) return keyGrantResponse;
+  if (isKeyGrantSuccess(result)) {
+    return keyGrantSuccessResponse(req, client.clientId, result, 'code_exchange');
+  }
 
   if (result.outcome !== 'ok') {
     auditRequest(req, {
@@ -408,15 +427,8 @@ async function handleDeviceCodeGrant(req: NextRequest, form: URLSearchParams): P
 
   const result = await pollDeviceToken({ deviceCode, clientDbId, now: new Date() });
 
-  const keyGrantResponse = keyGrantSuccessResponse(req, client.clientId, result, 'device_poll');
-  if (keyGrantResponse) return keyGrantResponse;
-
-  // `keyGrantSuccessResponse` returning null means the outcome was not one of
-  // the three key-shaped successes — but it is a runtime check the type system
-  // can't see through, so the remaining successes are excluded explicitly here
-  // to keep the error map exhaustively typed.
-  if (result.outcome === 'ok_mcp_token' || result.outcome === 'ok_mcp_update' || result.outcome === 'ok_mcp_activate') {
-    throw new Error('unreachable: key-grant outcomes are rendered by keyGrantSuccessResponse');
+  if (isKeyGrantSuccess(result)) {
+    return keyGrantSuccessResponse(req, client.clientId, result, 'device_poll');
   }
 
   if (result.outcome !== 'ok') {

--- a/apps/web/src/app/api/oauth/token/route.ts
+++ b/apps/web/src/app/api/oauth/token/route.ts
@@ -237,48 +237,50 @@ function keyGrantSuccessResponse(
   result: KeyGrantSuccess,
   oauthEventPrefix: 'code_exchange' | 'device_poll',
 ): NextResponse {
-  if (result.outcome === 'ok_mcp_token') {
-    auditRequest(req, {
-      eventType: 'auth.token.created',
-      userId: result.userId,
-      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_token` },
-    });
-    return noStoreJson(mcpTokenSuccessBody(result.mcpToken, result.scopes), 200);
-  }
-
-  if (result.outcome === 'ok_mcp_update') {
-    // Mirror the web Settings PATCH's audit + activity trail
-    // (mcp-tokens/[tokenId]/route.ts) — same logical operation, different
-    // door. Fire-and-forget end to end: getActorInfo does a user lookup +
-    // PII decrypts, and it feeds only logTokenActivity (itself explicitly
-    // never awaited), so none of it belongs on the response path.
-    const { userId, tokenId } = result;
-    void getActorInfo(userId)
-      .then((actorInfo) => {
-        logTokenActivity(userId, 'token_update', { tokenId, tokenType: 'mcp' }, actorInfo);
-      })
-      .catch(() => {
-        // Activity logging is best-effort; the audit event below is the durable record.
+  // A switch, not an if-chain ending in a bare block: totality over
+  // `KeyGrantOutcome` is then checked by the compiler rather than asserted in
+  // prose, so a fourth key-shaped outcome fails to build here.
+  switch (result.outcome) {
+    case 'ok_mcp_token':
+      auditRequest(req, {
+        eventType: 'auth.token.created',
+        userId: result.userId,
+        details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_token` },
       });
-    auditRequest(req, {
-      eventType: 'auth.token.updated',
-      userId,
-      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_update` },
-    });
-    return noStoreJson(mcpUpdateSuccessBody(tokenId, result.scopes), 200);
-  }
+      return noStoreJson(mcpTokenSuccessBody(result.mcpToken, result.scopes), 200);
 
-  // The remaining outcome, by exhaustion over `KEY_GRANT_OUTCOMES`: an
-  // approval ceremony only — nothing was minted or changed, so this is an
-  // access-granted audit event (not token.created/updated), and there is no
-  // activity-trail write since the key row is untouched.
-  {
-    auditRequest(req, {
-      eventType: 'authz.access.granted',
-      userId: result.userId,
-      details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_activate` },
-    });
-    return noStoreJson(mcpActivateSuccessBody(result.tokenId, result.scopes), 200);
+    case 'ok_mcp_update': {
+      // Mirror the web Settings PATCH's audit + activity trail
+      // (mcp-tokens/[tokenId]/route.ts) — same logical operation, different
+      // door. Fire-and-forget end to end: getActorInfo does a user lookup +
+      // PII decrypts, and it feeds only logTokenActivity (itself explicitly
+      // never awaited), so none of it belongs on the response path.
+      const { userId, tokenId } = result;
+      void getActorInfo(userId)
+        .then((actorInfo) => {
+          logTokenActivity(userId, 'token_update', { tokenId, tokenType: 'mcp' }, actorInfo);
+        })
+        .catch(() => {
+          // Activity logging is best-effort; the audit event below is the durable record.
+        });
+      auditRequest(req, {
+        eventType: 'auth.token.updated',
+        userId,
+        details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_update` },
+      });
+      return noStoreJson(mcpUpdateSuccessBody(tokenId, result.scopes), 200);
+    }
+
+    case 'ok_mcp_activate':
+      // Approval ceremony only — nothing was minted or changed, so this is an
+      // access-granted audit event (not token.created/updated), and there is
+      // no activity-trail write: the key row is untouched.
+      auditRequest(req, {
+        eventType: 'authz.access.granted',
+        userId: result.userId,
+        details: { clientId, oauthEvent: `${oauthEventPrefix}_mcp_activate` },
+      });
+      return noStoreJson(mcpActivateSuccessBody(result.tokenId, result.scopes), 200);
   }
 }
 
@@ -384,8 +386,12 @@ async function handleRefreshTokenGrant(req: NextRequest, form: URLSearchParams):
  * treatment as an unknown authorization code or refresh token.
  */
 type DevicePollOutcome = Awaited<ReturnType<typeof pollDeviceToken>>['outcome'];
-/** Every outcome that is a SUCCESS and therefore never appears in the error map below. */
-type DevicePollSuccessOutcome = 'ok' | 'ok_mcp_token' | 'ok_mcp_update' | 'ok_mcp_activate';
+/**
+ * Every outcome that is a SUCCESS and therefore never appears in the error map
+ * below. Derived from `KEY_GRANT_OUTCOMES` rather than re-listed, so adding a
+ * key-grant outcome can't leave the error map demanding an entry for it.
+ */
+type DevicePollSuccessOutcome = 'ok' | KeyGrantOutcome;
 
 const DEVICE_POLL_ERROR_BODY: Record<Exclude<DevicePollOutcome, DevicePollSuccessOutcome>, Record<string, unknown>> = {
   not_found: INVALID_GRANT,

--- a/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/oauth-repository.device.test.ts
@@ -23,6 +23,7 @@ const H = vi.hoisted(() => ({
     expiresAt: 'device_codes.expiresAt',
     approvedAt: 'device_codes.approvedAt',
     deniedAt: 'device_codes.deniedAt',
+    redeemedAt: 'device_codes.redeemedAt',
     lastPolledAt: 'device_codes.lastPolledAt',
     pollIntervalSeconds: 'device_codes.pollIntervalSeconds',
   } as Record<string, unknown>,
@@ -48,6 +49,19 @@ vi.mock('@pagespace/db/schema/oauth', () => ({
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: H.usersTable,
 }));
+// `applyKeyGrant` (shared with the authorization-code exchange) delegates the
+// actual mcp_tokens writes to sessionRepository, which has its own dedicated
+// coverage — mocked here rather than extending this harness to model those
+// tables too.
+vi.mock('../session-repository', () => ({
+  sessionRepository: {
+    createMcpTokenWithDriveScopes: vi.fn(),
+    updateMcpTokenDriveScopes: vi.fn(),
+    findActiveMcpTokenByIdAndUser: vi.fn(),
+    findUserMcpTokensWithDrives: vi.fn(),
+  },
+}));
+
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ _eq: [a, b] })),
   and: vi.fn((...args: unknown[]) => ({ _and: args })),
@@ -77,6 +91,7 @@ interface DeviceRow {
   expiresAt: Date;
   approvedAt: Date | null;
   deniedAt: Date | null;
+  redeemedAt: Date | null;
   lastPolledAt: Date | null;
   pollIntervalSeconds: number;
 }
@@ -185,6 +200,7 @@ import {
   verifyDeviceUserCode,
   recordDeviceApproval,
 } from '../oauth-repository';
+import { sessionRepository } from '../session-repository';
 
 const DEVICE_CODE = 'raw-device-code-value';
 const USER_CODE = 'ABCDEFGH';
@@ -202,6 +218,7 @@ function seedDeviceRow(overrides: Partial<DeviceRow> = {}): void {
     expiresAt: new Date(Date.now() + 1800_000),
     approvedAt: null,
     deniedAt: null,
+    redeemedAt: null,
     lastPolledAt: null,
     pollIntervalSeconds: 5,
     ...overrides,
@@ -341,6 +358,149 @@ describe('pollDeviceToken', () => {
     expect(result).toEqual({ outcome: 'user_suspended' });
     expect(refreshRows).toHaveLength(0);
     expect(accessRows).toHaveLength(0);
+  });
+
+  describe('single-use redemption (RFC 8628 §3.5)', () => {
+    it('marks the device code redeemed when it issues a token pair', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account', 'offline_access'] });
+      const now = new Date();
+
+      await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now });
+
+      expect(deviceRow?.redeemedAt).toEqual(now);
+    });
+
+    // Without this, an approved device code keeps issuing on every poll until
+    // it expires — and once the device flow can mint keys, every extra poll
+    // would mint another mcp_* key.
+    it('refuses a second poll of an already-redeemed code and issues nothing more', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['account', 'offline_access'] });
+
+      const first = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+      expect(first.outcome).toBe('ok');
+      expect(accessRows).toHaveLength(1);
+
+      const second = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+      expect(second).toEqual({ outcome: 'already_redeemed' });
+      expect(accessRows).toHaveLength(1);
+      expect(refreshRows).toHaveLength(1);
+    });
+
+    it('reports already_redeemed rather than expired_token once a redeemed code passes its TTL', async () => {
+      seedDeviceRow({
+        approvedAt: new Date(),
+        userId: USER_ID,
+        redeemedAt: new Date(Date.now() - 2000),
+        expiresAt: new Date(Date.now() - 1000),
+      });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+      expect(result).toEqual({ outcome: 'already_redeemed' });
+    });
+  });
+
+  describe('key-shaped grants (keys create/edit/use --device)', () => {
+    it('mints an mcp_* key for a named drive grant instead of an OAuth token pair', async () => {
+      seedDeviceRow({
+        approvedAt: new Date(),
+        userId: USER_ID,
+        scopes: ['drive:drv1:member', 'name:remote-key', 'offline_access'],
+      });
+      const now = new Date();
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now });
+
+      expect(result.outcome).toBe('ok_mcp_token');
+      if (result.outcome !== 'ok_mcp_token') throw new Error('unreachable');
+      expect(result.mcpToken).toMatch(/^mcp_/);
+      expect(result.userId).toBe(USER_ID);
+      // A key grant produces NO OAuth pair at all.
+      expect(accessRows).toHaveLength(0);
+      expect(refreshRows).toHaveLength(0);
+      expect(sessionRepository.createMcpTokenWithDriveScopes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: USER_ID,
+          name: 'remote-key',
+          isScoped: true,
+          drives: [expect.objectContaining({ id: 'drv1', role: 'MEMBER' })],
+        }),
+        expect.anything(),
+      );
+      expect(deviceRow?.redeemedAt).toEqual(now);
+    });
+
+    it('re-scopes an existing key in place for an update_key grant, minting nothing', async () => {
+      vi.mocked(sessionRepository.updateMcpTokenDriveScopes).mockResolvedValue({ id: 'tok123' } as never);
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['update_key:tok123', 'drive:drv1:member'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result.outcome).toBe('ok_mcp_update');
+      if (result.outcome !== 'ok_mcp_update') throw new Error('unreachable');
+      expect(result.tokenId).toBe('tok123');
+      expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+      expect(accessRows).toHaveLength(0);
+    });
+
+    it('approves an activate_key grant without minting or changing anything', async () => {
+      vi.mocked(sessionRepository.findActiveMcpTokenByIdAndUser).mockResolvedValue({
+        id: 'tok123',
+        name: 'work',
+      } as never);
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['activate_key:tok123'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result.outcome).toBe('ok_mcp_activate');
+      if (result.outcome !== 'ok_mcp_activate') throw new Error('unreachable');
+      expect(result.tokenId).toBe('tok123');
+      expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+      expect(sessionRepository.updateMcpTokenDriveScopes).not.toHaveBeenCalled();
+      expect(accessRows).toHaveLength(0);
+    });
+
+    it('burns the code when the update target was revoked between consent and redemption (fail closed)', async () => {
+      vi.mocked(sessionRepository.updateMcpTokenDriveScopes).mockResolvedValue(null as never);
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['update_key:tok123', 'drive:drv1:member'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result).toEqual({ outcome: 'update_target_gone' });
+      expect(deviceRow?.redeemedAt).not.toBeNull();
+    });
+
+    it('burns the code when the activate target was revoked between consent and redemption (fail closed)', async () => {
+      vi.mocked(sessionRepository.findActiveMcpTokenByIdAndUser).mockResolvedValue(null as never);
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['activate_key:tok123'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result).toEqual({ outcome: 'activate_target_gone' });
+      expect(deviceRow?.redeemedAt).not.toBeNull();
+    });
+
+    // The device_authorization door already refuses all_drives; this is the
+    // redemption-time backstop for a row that somehow carries it anyway.
+    it('refuses to redeem an all_drives grant even if one reaches redemption, and mints nothing', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['all_drives', 'offline_access'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result).toEqual({ outcome: 'all_drives_unsupported' });
+      expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+      expect(accessRows).toHaveLength(0);
+      expect(deviceRow?.redeemedAt).not.toBeNull();
+    });
+
+    it('still mints a plain OAuth pair for an ordinary manage_keys login grant', async () => {
+      seedDeviceRow({ approvedAt: new Date(), userId: USER_ID, scopes: ['manage_keys', 'offline_access'] });
+
+      const result = await pollDeviceToken({ deviceCode: DEVICE_CODE, clientDbId: CLIENT_DB_ID, now: new Date() });
+
+      expect(result.outcome).toBe('ok');
+      expect(sessionRepository.createMcpTokenWithDriveScopes).not.toHaveBeenCalled();
+      expect(accessRows).toHaveLength(1);
+    });
   });
 
   describe('F1 — refresh token gated on offline_access', () => {

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -126,6 +126,123 @@ function toSessionRepoDrives(scopes: Parameters<typeof scopeSetToDriveScopes>[0]
   }));
 }
 
+/**
+ * What a key-shaped grant DID, independent of which OAuth flow carried it.
+ * `not_a_key_grant` means the scope set is an ordinary login grant and the
+ * caller should fall through to minting an OAuth access/refresh pair.
+ */
+export type KeyGrantResult =
+  | { outcome: 'ok_mcp_token'; mcpToken: string }
+  | { outcome: 'ok_mcp_update'; tokenId: string }
+  | { outcome: 'ok_mcp_activate'; tokenId: string }
+  | { outcome: 'update_target_gone' }
+  | { outcome: 'activate_target_gone' }
+  | { outcome: 'not_a_key_grant' };
+
+/**
+ * Applies a consented, key-shaped grant — mint (`drive:*`/`all_drives`),
+ * re-scope in place (`update_key:<id>`), or approve activation
+ * (`activate_key:<id>`) — inside the caller's transaction.
+ *
+ * Extracted from `exchangeAuthorizationCode` so the RFC 8628 device flow
+ * (`pollDeviceToken`) applies grants through the SAME code rather than a
+ * parallel implementation: these branches decide what credential material a
+ * human's consent actually produces, and two copies would be two places for
+ * mint-vs-update semantics, ownership re-verification, or the `isScoped`
+ * flag to drift apart.
+ *
+ * What this function deliberately does NOT do is any per-flow bookkeeping:
+ * consuming the authorization code, persisting `lastPolledAt`, or checking
+ * user suspension all stay with the caller, which is the only party that
+ * knows what row it is holding. Callers MUST perform their own
+ * single-use bookkeeping for every outcome except `not_a_key_grant`,
+ * including the two `*_target_gone` failures — those fail closed by burning
+ * the grant, exactly as they did when this logic was inline.
+ *
+ * Ownership and un-revoked status of an update/activate target are
+ * re-verified here, inside the caller's transaction, so a key revoked
+ * between consent and redemption fails closed rather than being silently
+ * re-scoped or re-approved.
+ */
+async function applyKeyGrant(
+  tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
+  input: { userId: string; scopes: string[] },
+): Promise<KeyGrantResult> {
+  const parsed = parseScopeList(input.scopes.join(' '));
+  // Every branch below is gated on a successful parse; a scope array this
+  // parser rejects is not a key grant as far as this helper is concerned, and
+  // the caller's own fallthrough decides what to do with it.
+  if (!parsed.ok) return { outcome: 'not_a_key_grant' };
+  const scopes = parsed.scopes;
+
+  // An `update_key:<tokenId>` grant re-scopes the consenting user's EXISTING
+  // mcp token in place — nothing is minted and `tokenHash` is never read or
+  // written, so there is no secret to return. The target token id was bound
+  // into the consent (it rides inside `scope`, which the step-up grant's
+  // action binding covers) and the grant row binds `userId`; nothing the
+  // client presents at redemption can retarget either.
+  if (isKeyUpdateGrant(scopes)) {
+    const updated = await sessionRepository.updateMcpTokenDriveScopes(
+      scopes.updateKeyId,
+      input.userId,
+      toSessionRepoDrives(scopes),
+      tx,
+    );
+    if (updated === null) return { outcome: 'update_target_gone' };
+    return { outcome: 'ok_mcp_update', tokenId: scopes.updateKeyId };
+  }
+
+  // An `activate_key:<tokenId>` grant is a pure approval ceremony: the human
+  // confirmed in a browser that the requesting device may make this EXISTING
+  // key its ambient default (`pagespace keys use`). Nothing is minted,
+  // nothing is re-scoped, and no secret is read or returned — the verified
+  // success signal IS the product.
+  if (isKeyActivationGrant(scopes)) {
+    const target = await sessionRepository.findActiveMcpTokenByIdAndUser(scopes.activateKeyId, input.userId);
+    if (!target) return { outcome: 'activate_target_gone' };
+    return { outcome: 'ok_mcp_activate', tokenId: scopes.activateKeyId };
+  }
+
+  // A pure drive:* grant OR an `all_drives` grant both mint a real
+  // `mcp_tokens` row, not an OAuth refresh/access-token pair — the browser
+  // consent screen is still the human-approval gate for either. `all_drives`
+  // is the CLI/wizard equivalent of the web Settings > MCP "Clear selection
+  // (allow all drives)" key: unrestricted access to every drive the user
+  // owns, including ones created later, persisted `isScoped: false` with zero
+  // drive rows instead of a drive-scoped set. Deliberately NOT the `account`
+  // scope: `account` also grants full account control beyond drives (it
+  // resolves to a full personal OAuth session at the auth layer), which this
+  // feature must never silently produce.
+  if (isAllDrivesGrant(scopes) || isPureDriveGrant(scopes)) {
+    const allDrives = isAllDrivesGrant(scopes);
+    const { token: mcpToken, hash: tokenHash, tokenPrefix } = generateToken('mcp');
+    await sessionRepository.createMcpTokenWithDriveScopes(
+      {
+        userId: input.userId,
+        tokenHash,
+        tokenPrefix,
+        // Fallback is unreachable in practice: a mint-shaped grant with no
+        // name never gets this far — both entry points reject it before a
+        // redeemable grant is ever persisted (POST /api/oauth/authorize's
+        // validateAuthorizeRequest for the loopback flow; the
+        // device_authorization endpoint's own mint-name requirement for the
+        // device flow). NOT enforced by parseScopeList itself (that parser
+        // stays flow-agnostic — see its name_without_mint_grant rule and the
+        // doc comment on ScopeSet.newKeyName for why). Kept as defense in
+        // depth only, never meant to actually fire.
+        name: hasNewKeyName(scopes) ? scopes.newKeyName : 'pagespace CLI',
+        isScoped: !allDrives,
+        drives: allDrives ? [] : toSessionRepoDrives(scopes),
+      },
+      tx,
+    );
+
+    return { outcome: 'ok_mcp_token', mcpToken };
+  }
+
+  return { outcome: 'not_a_key_grant' };
+}
+
 async function revokeTokenFamily(
   tx: Pick<typeof db, 'update'>,
   familyId: string,
@@ -231,120 +348,40 @@ export async function exchangeAuthorizationCode(
     // `/api/oauth/authorize`) is the human-approval property this preserves;
     // only what gets PERSISTED on success changes. `manage_keys`/`account`
     // grants (`pagespace login`) are untouched — see `isPureDriveGrant`.
-    const parsedGrantedScope = parseScopeList(row.scopes.join(' '));
-
-    // An `update_key:<tokenId>` grant re-scopes the consenting user's
-    // EXISTING mcp token in place — nothing is minted and `tokenHash` is
-    // never read or written, so there is no secret to return. The target
-    // token id was bound into the consent (it rides inside `scope`, which
-    // the step-up grant's action binding covers) and the code row binds
-    // `userId`; nothing the client presents at exchange can retarget either.
-    // Ownership + un-revoked is re-verified inside this same FOR UPDATE
-    // transaction — a token revoked between consent and exchange fails
-    // closed as `update_target_gone` (route: constant-shape invalid_grant).
-    // Deliberately no `issuedFamilyId`: replaying the consumed code hits
-    // `already_consumed` above with nothing to revoke, which is correct —
-    // no credential family was ever issued for it.
-    if (parsedGrantedScope.ok && isKeyUpdateGrant(parsedGrantedScope.scopes)) {
+    //
+    // Shared verbatim with the device flow (`pollDeviceToken`) — see
+    // `applyKeyGrant`. Every non-`not_a_key_grant` outcome consumes the code,
+    // the two `*_target_gone` failures included: a burned code on a target
+    // that vanished between consent and exchange is the fail-closed result,
+    // and the route collapses both to the constant-shape invalid_grant.
+    // Deliberately no `issuedFamilyId` on any of them: replaying a consumed
+    // code then hits `already_consumed` above with nothing to revoke, which
+    // is correct — no credential family was ever issued for it.
+    const keyGrant = await applyKeyGrant(tx, { userId: row.userId, scopes: row.scopes });
+    if (keyGrant.outcome !== 'not_a_key_grant') {
       await tx
         .update(oauthAuthorizationCodes)
         .set({ consumedAt: input.now })
         .where(eq(oauthAuthorizationCodes.id, row.id));
 
-      const updated = await sessionRepository.updateMcpTokenDriveScopes(
-        parsedGrantedScope.scopes.updateKeyId,
-        row.userId,
-        toSessionRepoDrives(parsedGrantedScope.scopes),
-        tx,
-      );
-      if (updated === null) {
-        return { outcome: 'update_target_gone' };
+      switch (keyGrant.outcome) {
+        case 'ok_mcp_token':
+          return { outcome: 'ok_mcp_token', userId: row.userId, scopes: row.scopes, mcpToken: keyGrant.mcpToken };
+        case 'ok_mcp_update':
+          return { outcome: 'ok_mcp_update', userId: row.userId, scopes: row.scopes, tokenId: keyGrant.tokenId };
+        case 'ok_mcp_activate':
+          return { outcome: 'ok_mcp_activate', userId: row.userId, scopes: row.scopes, tokenId: keyGrant.tokenId };
+        case 'update_target_gone':
+          return { outcome: 'update_target_gone' };
+        case 'activate_target_gone':
+          return { outcome: 'activate_target_gone' };
       }
-
-      return {
-        outcome: 'ok_mcp_update',
-        userId: row.userId,
-        scopes: row.scopes,
-        tokenId: parsedGrantedScope.scopes.updateKeyId,
-      };
     }
 
-    // An `activate_key:<tokenId>` grant is a pure approval ceremony: the
-    // human confirmed in a browser that the requesting device may make this
-    // EXISTING key its ambient default (`pagespace keys use`). Nothing is
-    // minted, nothing is re-scoped, and no secret is read or returned — the
-    // PKCE-verified success signal IS the product. Ownership + un-revoked is
-    // re-verified here (same FOR UPDATE transaction as the code consume) so
-    // a key revoked between consent and exchange fails closed as
-    // `activate_target_gone` (route: constant-shape invalid_grant).
-    // Deliberately no `issuedFamilyId`, mirroring ok_mcp_update.
-    if (parsedGrantedScope.ok && isKeyActivationGrant(parsedGrantedScope.scopes)) {
-      await tx
-        .update(oauthAuthorizationCodes)
-        .set({ consumedAt: input.now })
-        .where(eq(oauthAuthorizationCodes.id, row.id));
-
-      const target = await sessionRepository.findActiveMcpTokenByIdAndUser(
-        parsedGrantedScope.scopes.activateKeyId,
-        row.userId,
-      );
-      if (!target) {
-        return { outcome: 'activate_target_gone' };
-      }
-
-      return {
-        outcome: 'ok_mcp_activate',
-        userId: row.userId,
-        scopes: row.scopes,
-        tokenId: parsedGrantedScope.scopes.activateKeyId,
-      };
-    }
-
-    // A pure drive:* grant OR an `all_drives` grant both mint a real
-    // `mcp_tokens` row, not an OAuth refresh/access-token pair — the browser
-    // consent screen is still the human-approval gate for either. `all_drives`
-    // is the CLI/wizard equivalent of the web Settings > MCP "Clear selection
-    // (allow all drives)" key: unrestricted access to every drive the user
-    // owns, including ones created later, persisted `isScoped: false` with
-    // zero drive rows instead of a drive-scoped set. Deliberately NOT the
-    // `account` branch below: `account` also grants full account control
-    // beyond drives (it resolves to a full personal OAuth session at the auth
-    // layer), which this feature must never silently produce.
-    if (parsedGrantedScope.ok && (isAllDrivesGrant(parsedGrantedScope.scopes) || isPureDriveGrant(parsedGrantedScope.scopes))) {
-      await tx
-        .update(oauthAuthorizationCodes)
-        .set({ consumedAt: input.now })
-        .where(eq(oauthAuthorizationCodes.id, row.id));
-
-      const allDrives = isAllDrivesGrant(parsedGrantedScope.scopes);
-      const { token: mcpToken, hash: tokenHash, tokenPrefix } = generateToken('mcp');
-      await sessionRepository.createMcpTokenWithDriveScopes(
-        {
-          userId: row.userId,
-          tokenHash,
-          tokenPrefix,
-          // Fallback is unreachable in practice: a mint-shaped grant with no
-          // name never gets this far — POST /api/oauth/authorize's
-          // validateAuthorizeRequest (packages/lib/src/auth/oauth/authorize-request.ts)
-          // rejects it before an authorization code is ever minted, and this
-          // function only runs against an already-consented, already-persisted
-          // code's scopes. NOT enforced by parseScopeList itself (that parser
-          // stays flow-agnostic — see its name_without_mint_grant rule and the
-          // doc comment on ScopeSet.newKeyName for why). Kept as defense in
-          // depth only, never meant to actually fire.
-          name: hasNewKeyName(parsedGrantedScope.scopes) ? parsedGrantedScope.scopes.newKeyName : 'pagespace CLI',
-          isScoped: !allDrives,
-          drives: allDrives ? [] : toSessionRepoDrives(parsedGrantedScope.scopes),
-        },
-        tx,
-      );
-
-      return { outcome: 'ok_mcp_token', userId: row.userId, scopes: row.scopes, mcpToken };
-    }
-
-    // NOTE: every mint/update/activate branch above is gated on
-    // `parsedGrantedScope.ok`. If parseScopeList ever rejects the persisted
-    // `row.scopes` for any reason (including some future unrelated bug), we
+    // NOTE: every mint/update/activate branch is gated on a successful
+    // `parseScopeList` inside `applyKeyGrant`. If that parser ever rejects
+    // the persisted `row.scopes` for any reason (including some future
+    // unrelated bug), it reports `not_a_key_grant` and we
     // fall through to here and mint a plain OAuth access/refresh pair
     // carrying the raw (rejected) scope array as its granted scopes — a
     // pre-existing fail-open risk, unrelated to and out of scope for this
@@ -612,6 +649,7 @@ interface DeviceCodeRow {
   expiresAt: Date;
   approvedAt: Date | null;
   deniedAt: Date | null;
+  redeemedAt: Date | null;
   lastPolledAt: Date | null;
   pollIntervalSeconds: number;
 }
@@ -626,6 +664,12 @@ function toDeviceCodeRecord(row: DeviceCodeRow): DeviceCodeRecord {
     pollIntervalSeconds: row.pollIntervalSeconds,
   };
 
+  // Checked before denied/approved: redemption is the strongest terminal
+  // state, and a redeemed code must never read back as freshly approved and
+  // issue credentials a second time (RFC 8628 §3.5).
+  if (row.redeemedAt !== null) {
+    return { status: 'redeemed', ...common };
+  }
   if (row.deniedAt !== null) {
     return { status: 'denied', ...common };
   }
@@ -674,8 +718,18 @@ export type PollDeviceTokenResult =
   | { outcome: 'slow_down' }
   | { outcome: 'expired_token' }
   | { outcome: 'access_denied' }
+  /** Already exchanged (RFC 8628 §3.5) — the route collapses this to invalid_grant. */
+  | { outcome: 'already_redeemed' }
   | { outcome: 'user_suspended' }
-  | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair };
+  /** An `all_drives` grant reached redemption despite the device door refusing it — see the check in `pollDeviceToken`. */
+  | { outcome: 'all_drives_unsupported' }
+  | { outcome: 'ok'; userId: string; scopes: string[]; tokens: IssuedTokenPair }
+  /** Key-shaped grants, shared verbatim with the authorization-code exchange via `applyKeyGrant`. */
+  | { outcome: 'ok_mcp_token'; userId: string; scopes: string[]; mcpToken: string }
+  | { outcome: 'ok_mcp_update'; userId: string; scopes: string[]; tokenId: string }
+  | { outcome: 'ok_mcp_activate'; userId: string; scopes: string[]; tokenId: string }
+  | { outcome: 'update_target_gone' }
+  | { outcome: 'activate_target_gone' };
 
 /**
  * Atomically poll a device code (RFC 8628 §3.4-3.5). `FOR UPDATE` locks the
@@ -707,6 +761,7 @@ export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<Poll
         expiresAt: oauthDeviceCodes.expiresAt,
         approvedAt: oauthDeviceCodes.approvedAt,
         deniedAt: oauthDeviceCodes.deniedAt,
+        redeemedAt: oauthDeviceCodes.redeemedAt,
         lastPolledAt: oauthDeviceCodes.lastPolledAt,
         pollIntervalSeconds: oauthDeviceCodes.pollIntervalSeconds,
       })
@@ -741,6 +796,64 @@ export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<Poll
     if (userRows[0]?.suspendedAt) {
       return { outcome: 'user_suspended' };
     }
+
+    // Defense in depth. `POST /api/oauth/device_authorization` refuses to mint
+    // a device code for an `all_drives` grant in the first place, for reasons
+    // documented there (a device-minted all_drives token would land in a shape
+    // the two authorization helper families read oppositely). This second
+    // check means even a device-code row that somehow carries the grant — a
+    // row predating that guard, or one written by a future code path — can
+    // never be redeemed into such a token. Fails closed; the route reports it
+    // as invalid_grant like any other unredeemable code.
+    const parsedGrant = parseScopeList(decision.grant.scopes.join(' '));
+    if (parsedGrant.ok && isAllDrivesGrant(parsedGrant.scopes)) {
+      await tx.update(oauthDeviceCodes).set({ redeemedAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
+      return { outcome: 'all_drives_unsupported' };
+    }
+
+    // Key-shaped grants (`keys create/edit/use --device`) apply through the
+    // same `applyKeyGrant` the loopback authorization-code exchange uses, and
+    // produce no OAuth token pair at all. Redemption is recorded for every
+    // outcome including the two `*_target_gone` failures — a target that
+    // vanished between consent and redemption burns the code rather than
+    // leaving it live for a retry.
+    const keyGrant = await applyKeyGrant(tx, { userId: decision.grant.userId, scopes: decision.grant.scopes });
+    if (keyGrant.outcome !== 'not_a_key_grant') {
+      await tx.update(oauthDeviceCodes).set({ redeemedAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
+
+      switch (keyGrant.outcome) {
+        case 'ok_mcp_token':
+          return {
+            outcome: 'ok_mcp_token',
+            userId: decision.grant.userId,
+            scopes: decision.grant.scopes,
+            mcpToken: keyGrant.mcpToken,
+          };
+        case 'ok_mcp_update':
+          return {
+            outcome: 'ok_mcp_update',
+            userId: decision.grant.userId,
+            scopes: decision.grant.scopes,
+            tokenId: keyGrant.tokenId,
+          };
+        case 'ok_mcp_activate':
+          return {
+            outcome: 'ok_mcp_activate',
+            userId: decision.grant.userId,
+            scopes: decision.grant.scopes,
+            tokenId: keyGrant.tokenId,
+          };
+        case 'update_target_gone':
+          return { outcome: 'update_target_gone' };
+        case 'activate_target_gone':
+          return { outcome: 'activate_target_gone' };
+      }
+    }
+
+    // RFC 8628 §3.5: the device_code is invalidated on redemption, in the same
+    // transaction that issues the credentials, so a concurrent second poll
+    // blocks on the FOR UPDATE lock above and then reads `redeemed`.
+    await tx.update(oauthDeviceCodes).set({ redeemedAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
 
     // F1 (ADR 0003, OIDC-standard): access-only unless offline_access was granted.
     const offlineAccess = decision.grant.scopes.includes('offline_access');
@@ -906,6 +1019,7 @@ export async function recordDeviceApproval(input: RecordDeviceApprovalInput): Pr
         expiresAt: oauthDeviceCodes.expiresAt,
         approvedAt: oauthDeviceCodes.approvedAt,
         deniedAt: oauthDeviceCodes.deniedAt,
+        redeemedAt: oauthDeviceCodes.redeemedAt,
         lastPolledAt: oauthDeviceCodes.lastPolledAt,
         pollIntervalSeconds: oauthDeviceCodes.pollIntervalSeconds,
       })

--- a/apps/web/src/lib/repositories/oauth-repository.ts
+++ b/apps/web/src/lib/repositories/oauth-repository.ts
@@ -164,6 +164,40 @@ export type KeyGrantResult =
  * between consent and redemption fails closed rather than being silently
  * re-scoped or re-approved.
  */
+/**
+ * Widens a `KeyGrantResult` into the shape both flows' result unions share,
+ * attaching the grant context the helper deliberately doesn't know about.
+ *
+ * Both callers previously re-implemented this as an identical five-case
+ * switch, so adding a sixth `KeyGrantResult` outcome meant the same edit in
+ * two places — the drift `applyKeyGrant` was extracted to prevent, reappearing
+ * one level up. Callers still own their own single-use bookkeeping, which is
+ * the part that genuinely differs (consuming an authorization code vs. setting
+ * `redeemedAt`).
+ */
+function withGrantContext(
+  keyGrant: Exclude<KeyGrantResult, { outcome: 'not_a_key_grant' }>,
+  userId: string,
+  scopes: string[],
+):
+  | { outcome: 'ok_mcp_token'; userId: string; scopes: string[]; mcpToken: string }
+  | { outcome: 'ok_mcp_update'; userId: string; scopes: string[]; tokenId: string }
+  | { outcome: 'ok_mcp_activate'; userId: string; scopes: string[]; tokenId: string }
+  | { outcome: 'update_target_gone' }
+  | { outcome: 'activate_target_gone' } {
+  switch (keyGrant.outcome) {
+    case 'ok_mcp_token':
+      return { outcome: 'ok_mcp_token', userId, scopes, mcpToken: keyGrant.mcpToken };
+    case 'ok_mcp_update':
+      return { outcome: 'ok_mcp_update', userId, scopes, tokenId: keyGrant.tokenId };
+    case 'ok_mcp_activate':
+      return { outcome: 'ok_mcp_activate', userId, scopes, tokenId: keyGrant.tokenId };
+    case 'update_target_gone':
+    case 'activate_target_gone':
+      return { outcome: keyGrant.outcome };
+  }
+}
+
 async function applyKeyGrant(
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
   input: { userId: string; scopes: string[] },
@@ -363,19 +397,7 @@ export async function exchangeAuthorizationCode(
         .update(oauthAuthorizationCodes)
         .set({ consumedAt: input.now })
         .where(eq(oauthAuthorizationCodes.id, row.id));
-
-      switch (keyGrant.outcome) {
-        case 'ok_mcp_token':
-          return { outcome: 'ok_mcp_token', userId: row.userId, scopes: row.scopes, mcpToken: keyGrant.mcpToken };
-        case 'ok_mcp_update':
-          return { outcome: 'ok_mcp_update', userId: row.userId, scopes: row.scopes, tokenId: keyGrant.tokenId };
-        case 'ok_mcp_activate':
-          return { outcome: 'ok_mcp_activate', userId: row.userId, scopes: row.scopes, tokenId: keyGrant.tokenId };
-        case 'update_target_gone':
-          return { outcome: 'update_target_gone' };
-        case 'activate_target_gone':
-          return { outcome: 'activate_target_gone' };
-      }
+      return withGrantContext(keyGrant, row.userId, row.scopes);
     }
 
     // NOTE: every mint/update/activate branch is gated on a successful
@@ -820,34 +842,7 @@ export async function pollDeviceToken(input: PollDeviceTokenInput): Promise<Poll
     const keyGrant = await applyKeyGrant(tx, { userId: decision.grant.userId, scopes: decision.grant.scopes });
     if (keyGrant.outcome !== 'not_a_key_grant') {
       await tx.update(oauthDeviceCodes).set({ redeemedAt: input.now }).where(eq(oauthDeviceCodes.id, row.id));
-
-      switch (keyGrant.outcome) {
-        case 'ok_mcp_token':
-          return {
-            outcome: 'ok_mcp_token',
-            userId: decision.grant.userId,
-            scopes: decision.grant.scopes,
-            mcpToken: keyGrant.mcpToken,
-          };
-        case 'ok_mcp_update':
-          return {
-            outcome: 'ok_mcp_update',
-            userId: decision.grant.userId,
-            scopes: decision.grant.scopes,
-            tokenId: keyGrant.tokenId,
-          };
-        case 'ok_mcp_activate':
-          return {
-            outcome: 'ok_mcp_activate',
-            userId: decision.grant.userId,
-            scopes: decision.grant.scopes,
-            tokenId: keyGrant.tokenId,
-          };
-        case 'update_target_gone':
-          return { outcome: 'update_target_gone' };
-        case 'activate_target_gone':
-          return { outcome: 'activate_target_gone' };
-      }
+      return withGrantContext(keyGrant, decision.grant.userId, decision.grant.scopes);
     }
 
     // RFC 8628 §3.5: the device_code is invalidated on redemption, in the same

--- a/packages/cli/src/auth/__tests__/device-flow.test.ts
+++ b/packages/cli/src/auth/__tests__/device-flow.test.ts
@@ -220,9 +220,13 @@ describe('runDeviceLogin — happy path', () => {
     expect(credentialSecret(store.get('https://pagespace.ai')!)).toBe(TOKENS.refreshToken);
   });
 
-  it('treats an mcp-kind token result as poll_failed rather than mis-persisting it as an oauth credential — device flow only ever requests manage_keys scope, so this is a defensive, not a real, path', async () => {
+  // The device flow legitimately mints keys now (`keys create --device`), but
+  // ONLY when this flow asked for one — a mint is always requested with a
+  // `name:` scope token.
+  it('treats a surprise mint as poll_failed when the requested scope never asked for one (login --device)', async () => {
     let setCalls = 0;
     const { deps } = baseDeps({
+      scope: 'manage_keys offline_access',
       pollDeviceToken: async () => ({ kind: 'success', tokens: { kind: 'mcp', token: 'mcp_unexpected', scope: 'drive:d1:member' } }),
       credentialStore: {
         set: async () => {
@@ -233,7 +237,114 @@ describe('runDeviceLogin — happy path', () => {
 
     const result = await runDeviceLogin(deps);
 
-    expect(result).toEqual({ outcome: 'poll_failed', message: 'Unexpected token type from device grant: mcp' });
+    expect(result.outcome).toBe('poll_failed');
+    expect(setCalls).toBe(0);
+  });
+
+  it('persists a minted mcp_* key as a static credential when the request DID ask for a mint (keys create --device)', async () => {
+    const { deps, store } = baseDeps({
+      scope: 'drive:d1:member name:remote-key offline_access',
+      profile: 'remote-key',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp', token: 'mcp_minted', scope: 'drive:d1:member name:remote-key offline_access' },
+      }),
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('success');
+    const stored = store.get('https://pagespace.ai');
+    expect(stored).toEqual({
+      kind: 'static',
+      token: 'mcp_minted',
+      scopes: ['drive:d1:member', 'name:remote-key', 'offline_access'],
+      createdAt: new Date(NOW).toISOString(),
+    });
+  });
+
+  it('surfaces a minted token through onMintedStaticToken for --show-token, and never for an oauth grant', async () => {
+    const surfaced: string[] = [];
+    const { deps } = baseDeps({
+      scope: 'drive:d1:member name:k offline_access',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp', token: 'mcp_minted', scope: 'drive:d1:member name:k' },
+      }),
+      onMintedStaticToken: (token) => surfaced.push(token),
+    });
+    await runDeviceLogin(deps);
+    expect(surfaced).toEqual(['mcp_minted']);
+
+    const oauth = baseDeps({ onMintedStaticToken: (token) => surfaced.push(token) });
+    await runDeviceLogin(oauth.deps);
+    expect(surfaced).toEqual(['mcp_minted']);
+  });
+
+  it('persists NOTHING and reports the re-scoped key id for an mcp_update redemption', async () => {
+    let setCalls = 0;
+    const { deps } = baseDeps({
+      scope: 'update_key:tok123 drive:d1:member',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp_update', tokenId: 'tok123', scope: 'update_key:tok123 drive:d1:member' },
+      }),
+      credentialStore: {
+        set: async () => {
+          setCalls += 1;
+        },
+      },
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('success');
+    if (result.outcome !== 'success') throw new Error('unreachable');
+    expect(result.updatedTokenId).toBe('tok123');
+    expect(setCalls).toBe(0);
+  });
+
+  it('persists NOTHING and reports the approved key id for an mcp_activate redemption', async () => {
+    let setCalls = 0;
+    const { deps } = baseDeps({
+      scope: 'activate_key:tok123',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp_activate', tokenId: 'tok123', scope: 'activate_key:tok123' },
+      }),
+      credentialStore: {
+        set: async () => {
+          setCalls += 1;
+        },
+      },
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('success');
+    if (result.outcome !== 'success') throw new Error('unreachable');
+    expect(result.activatedTokenId).toBe('tok123');
+    expect(setCalls).toBe(0);
+  });
+
+  it('fails closed when an update/activate request is answered with a real mint — nothing is stored', async () => {
+    let setCalls = 0;
+    const { deps } = baseDeps({
+      scope: 'activate_key:tok123',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp', token: 'mcp_surprise', scope: 'drive:d1:member name:sneaky' },
+      }),
+      credentialStore: {
+        set: async () => {
+          setCalls += 1;
+        },
+      },
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('poll_failed');
     expect(setCalls).toBe(0);
   });
 });

--- a/packages/cli/src/auth/__tests__/device-flow.test.ts
+++ b/packages/cli/src/auth/__tests__/device-flow.test.ts
@@ -281,6 +281,48 @@ describe('runDeviceLogin — happy path', () => {
     expect(surfaced).toEqual(['mcp_minted']);
   });
 
+  // `/api/auth/me` refuses `mcp_*` tokens by design, so asking on behalf of a
+  // freshly minted key could only 401 — a guaranteed-doomed round trip, billed
+  // at the confirm-identity timeout, on every `keys create --device`.
+  it('never asks /api/auth/me to identify a freshly minted mcp_* key', async () => {
+    let confirmCalls = 0;
+    const { deps } = baseDeps({
+      scope: 'drive:d1:member name:k offline_access',
+      pollDeviceToken: async () => ({
+        kind: 'success',
+        tokens: { kind: 'mcp', token: 'mcp_minted', scope: 'drive:d1:member name:k' },
+      }),
+      confirmIdentity: async () => {
+        confirmCalls += 1;
+        return IDENTITY;
+      },
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('success');
+    if (result.outcome !== 'success') throw new Error('unreachable');
+    expect(result.identity).toBeNull();
+    expect(confirmCalls).toBe(0);
+  });
+
+  it('still confirms identity for an oauth grant, which /api/auth/me does answer for', async () => {
+    let confirmCalls = 0;
+    const { deps } = baseDeps({
+      confirmIdentity: async () => {
+        confirmCalls += 1;
+        return IDENTITY;
+      },
+    });
+
+    const result = await runDeviceLogin(deps);
+
+    expect(result.outcome).toBe('success');
+    if (result.outcome !== 'success') throw new Error('unreachable');
+    expect(result.identity).toEqual(IDENTITY);
+    expect(confirmCalls).toBe(1);
+  });
+
   it('persists NOTHING and reports the re-scoped key id for an mcp_update redemption', async () => {
     let setCalls = 0;
     const { deps } = baseDeps({

--- a/packages/cli/src/auth/__tests__/resolve-credential-source.test.ts
+++ b/packages/cli/src/auth/__tests__/resolve-credential-source.test.ts
@@ -105,7 +105,7 @@ describe('resolveCredentialSource', () => {
 
     expect(resolved.keyName).toBe('work');
     expect(resolved.activeKeyName).toBeNull();
-    expect(resolved.credential).toEqual(KEY);
+    expect(resolved.source).toMatchObject({ kind: 'stored', credential: KEY });
     expect(resolved.explicit).toBe(true);
   });
 
@@ -117,7 +117,7 @@ describe('resolveCredentialSource', () => {
 
     expect(resolved.keyName).toBe('ALL');
     expect(resolved.activeKeyName).toBe('ALL');
-    expect(resolved.credential).toEqual(KEY);
+    expect(resolved.source).toMatchObject({ kind: 'stored', credential: KEY });
     expect(resolved.source.kind).toBe('stored');
     expect(resolved.explicit).toBe(false);
   });
@@ -131,7 +131,7 @@ describe('resolveCredentialSource', () => {
 
     expect(resolved.keyName).toBe('default');
     expect(resolved.activeKeyName).toBeNull();
-    expect(resolved.credential).toEqual(OAUTH);
+    expect(resolved.source).toMatchObject({ kind: 'stored', credential: OAUTH });
   });
 
   it('falls through to the default slot when the active key names a credential that is not stored', async () => {
@@ -142,7 +142,7 @@ describe('resolveCredentialSource', () => {
 
     expect(resolved.keyName).toBe('default');
     expect(resolved.activeKeyName).toBeNull();
-    expect(resolved.credential).toEqual(OAUTH);
+    expect(resolved.source).toMatchObject({ kind: 'stored', credential: OAUTH });
   });
 
   it('resolves to none when the active key is dangling and no default is stored', async () => {
@@ -152,7 +152,7 @@ describe('resolveCredentialSource', () => {
     });
 
     expect(resolved.source).toEqual({ kind: 'none', host: HOST });
-    expect(resolved.credential).toBeNull();
+    expect(resolved.source.kind).toBe('none');
   });
 
   it('an active key set for a DIFFERENT host is invisible', async () => {
@@ -175,7 +175,7 @@ describe('resolveCredentialSource', () => {
       activeKeyStore: activeKeys({ [HOST]: 'ALL' }),
     });
     expect(viaKey.keyName).toBe('work');
-    expect(viaKey.credential).toEqual(KEY);
+    expect(viaKey.source).toMatchObject({ kind: 'stored', credential: KEY });
   });
 });
 

--- a/packages/cli/src/auth/__tests__/resolve-credential-source.test.ts
+++ b/packages/cli/src/auth/__tests__/resolve-credential-source.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The full precedence chain, effects included. `resolve.ts`'s own tests cover
+ * the pure rules; these cover the two store reads layered on top — above all
+ * the active-key link, whose absence from `whoami`'s hand-rolled copy of this
+ * chain is what made a machine with a working activated key report
+ * "Not logged in".
+ */
+import { describe, expect, it } from 'vitest';
+import { resolveCredentialSource, describeCredentialSource } from '@pagespace/cli';
+import type { ActiveKeyStore, CredentialStore, HostCredential } from '@pagespace/cli';
+
+const HOST = 'https://pagespace.ai';
+
+const OAUTH: HostCredential = {
+  kind: 'oauth',
+  refreshToken: 'ps_rt_default',
+  clientId: 'pagespace-cli',
+  scopes: ['manage_keys', 'offline_access'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+const KEY: HostCredential = {
+  kind: 'static',
+  token: 'mcp_scoped',
+  scopes: ['drive:d1:member'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+};
+
+function store(entries: Record<string, Record<string, HostCredential>> = {}): CredentialStore {
+  return {
+    get: async (host, profile = 'default') => entries[host]?.[profile] ?? null,
+    set: async () => {},
+    delete: async () => {},
+    list: async () => [],
+  };
+}
+
+function activeKeys(map: Record<string, string> = {}): ActiveKeyStore {
+  return {
+    getActiveKey: async (host) => map[host] ?? null,
+    setActiveKey: async () => {},
+    clearActiveKey: async () => {},
+  };
+}
+
+function resolve(overrides: {
+  flags?: { token?: string; key?: string };
+  env?: Record<string, string | undefined>;
+  credentialStore?: CredentialStore;
+  activeKeyStore?: ActiveKeyStore;
+  allowActiveKey?: boolean;
+} = {}) {
+  return resolveCredentialSource({
+    flags: overrides.flags ?? {},
+    env: overrides.env ?? {},
+    host: HOST,
+    credentialStore: overrides.credentialStore ?? store(),
+    activeKeyStore: overrides.activeKeyStore ?? activeKeys(),
+    allowActiveKey: overrides.allowActiveKey ?? true,
+  });
+}
+
+describe('resolveCredentialSource', () => {
+  it('--token beats every other source, and reads no store at all', async () => {
+    let reads = 0;
+    const counting: CredentialStore = {
+      ...store({ [HOST]: { default: OAUTH, work: KEY } }),
+      get: async () => {
+        reads += 1;
+        return OAUTH;
+      },
+    };
+    const resolved = await resolve({
+      flags: { token: 'flag-token', key: 'work' },
+      env: { PAGESPACE_TOKEN: 'env-token' },
+      credentialStore: counting,
+      activeKeyStore: activeKeys({ [HOST]: 'work' }),
+    });
+
+    expect(resolved.source).toEqual({ kind: 'flag', token: 'flag-token' });
+    expect(resolved.explicit).toBe(true);
+    expect(resolved.activeKeyName).toBeNull();
+    // The store IS still consulted for the named key (harmless, no network),
+    // but the resolved source must not come from it.
+    expect(reads).toBeLessThanOrEqual(1);
+  });
+
+  it('PAGESPACE_TOKEN beats a stored key and the active key', async () => {
+    const resolved = await resolve({
+      env: { PAGESPACE_TOKEN: 'env-token' },
+      credentialStore: store({ [HOST]: { default: OAUTH, work: KEY } }),
+      activeKeyStore: activeKeys({ [HOST]: 'work' }),
+    });
+
+    expect(resolved.source).toEqual({ kind: 'env', token: 'env-token' });
+    expect(resolved.activeKeyName).toBeNull();
+  });
+
+  it('--key names the slot and suppresses the active key entirely', async () => {
+    const resolved = await resolve({
+      flags: { key: 'work' },
+      credentialStore: store({ [HOST]: { default: OAUTH, work: KEY, other: OAUTH } }),
+      activeKeyStore: activeKeys({ [HOST]: 'other' }),
+    });
+
+    expect(resolved.keyName).toBe('work');
+    expect(resolved.activeKeyName).toBeNull();
+    expect(resolved.credential).toEqual(KEY);
+    expect(resolved.explicit).toBe(true);
+  });
+
+  it('falls back to the active key when nothing explicit is given — the link whoami used to miss', async () => {
+    const resolved = await resolve({
+      credentialStore: store({ [HOST]: { ALL: KEY } }),
+      activeKeyStore: activeKeys({ [HOST]: 'ALL' }),
+    });
+
+    expect(resolved.keyName).toBe('ALL');
+    expect(resolved.activeKeyName).toBe('ALL');
+    expect(resolved.credential).toEqual(KEY);
+    expect(resolved.source.kind).toBe('stored');
+    expect(resolved.explicit).toBe(false);
+  });
+
+  it('ignores the active key when the caller forbids it, falling through to the default slot', async () => {
+    const resolved = await resolve({
+      allowActiveKey: false,
+      credentialStore: store({ [HOST]: { default: OAUTH, ALL: KEY } }),
+      activeKeyStore: activeKeys({ [HOST]: 'ALL' }),
+    });
+
+    expect(resolved.keyName).toBe('default');
+    expect(resolved.activeKeyName).toBeNull();
+    expect(resolved.credential).toEqual(OAUTH);
+  });
+
+  it('falls through to the default slot when the active key names a credential that is not stored', async () => {
+    const resolved = await resolve({
+      credentialStore: store({ [HOST]: { default: OAUTH } }),
+      activeKeyStore: activeKeys({ [HOST]: 'gone' }),
+    });
+
+    expect(resolved.keyName).toBe('default');
+    expect(resolved.activeKeyName).toBeNull();
+    expect(resolved.credential).toEqual(OAUTH);
+  });
+
+  it('resolves to none when the active key is dangling and no default is stored', async () => {
+    const resolved = await resolve({
+      credentialStore: store({}),
+      activeKeyStore: activeKeys({ [HOST]: 'gone' }),
+    });
+
+    expect(resolved.source).toEqual({ kind: 'none', host: HOST });
+    expect(resolved.credential).toBeNull();
+  });
+
+  it('an active key set for a DIFFERENT host is invisible', async () => {
+    const resolved = await resolve({
+      credentialStore: store({ [HOST]: { default: OAUTH } }),
+      activeKeyStore: activeKeys({ 'https://other.example': 'ALL' }),
+    });
+
+    expect(resolved.activeKeyName).toBeNull();
+    expect(resolved.keyName).toBe('default');
+  });
+
+  it('honors the deprecated PAGESPACE_AUTH_TOKEN / PAGESPACE_PROFILE aliases', async () => {
+    const viaToken = await resolve({ env: { PAGESPACE_AUTH_TOKEN: 'legacy-token' } });
+    expect(viaToken.source).toEqual({ kind: 'env', token: 'legacy-token' });
+
+    const viaKey = await resolve({
+      env: { PAGESPACE_PROFILE: 'work' },
+      credentialStore: store({ [HOST]: { default: OAUTH, work: KEY } }),
+      activeKeyStore: activeKeys({ [HOST]: 'ALL' }),
+    });
+    expect(viaKey.keyName).toBe('work');
+    expect(viaKey.credential).toEqual(KEY);
+  });
+});
+
+describe('describeCredentialSource', () => {
+  it('names each source in the copy whoami prints', async () => {
+    const label = (resolved: Parameters<typeof describeCredentialSource>[0]) =>
+      describeCredentialSource(resolved, 'PAGESPACE_TOKEN');
+
+    expect(label({ source: { kind: 'flag', token: 't' }, keyName: 'default', activeKeyName: null })).toBe('--token flag');
+    expect(label({ source: { kind: 'env', token: 't' }, keyName: 'default', activeKeyName: null })).toBe(
+      'PAGESPACE_TOKEN environment variable',
+    );
+    expect(
+      label({ source: { kind: 'stored', host: HOST, keyName: 'ALL', credential: KEY }, keyName: 'ALL', activeKeyName: 'ALL' }),
+    ).toBe('active key "ALL"');
+    expect(
+      label({ source: { kind: 'stored', host: HOST, keyName: 'work', credential: KEY }, keyName: 'work', activeKeyName: null }),
+    ).toBe('key "work"');
+    expect(
+      label({
+        source: { kind: 'stored', host: HOST, keyName: 'default', credential: OAUTH },
+        keyName: 'default',
+        activeKeyName: null,
+      }),
+    ).toBe('personal login');
+    expect(label({ source: { kind: 'none', host: HOST }, keyName: 'default', activeKeyName: null })).toBe('none');
+  });
+});

--- a/packages/cli/src/auth/__tests__/run-consent.test.ts
+++ b/packages/cli/src/auth/__tests__/run-consent.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `runConsent` is the transport switch every consent-driven command goes
+ * through, so the invariants worth pinning here are the ones a command author
+ * can't see from their own file: which effects each transport is allowed to
+ * touch, and — above all — which delay adapter the device branch gets.
+ */
+import { describe, expect, it } from 'vitest';
+import { runConsent } from '@pagespace/cli';
+import type { RunConsentParams } from '@pagespace/cli';
+
+const AUTHORIZATION = {
+  deviceCode: 'ps_dc_test',
+  userCode: 'ABCD-EFGH',
+  verificationUri: 'https://pagespace.ai/activate',
+  verificationUriComplete: 'https://pagespace.ai/activate?user_code=ABCD-EFGH',
+  expiresInSeconds: 900,
+  intervalSeconds: 5,
+};
+
+const OAUTH_TOKENS = {
+  kind: 'oauth' as const,
+  accessToken: 'ps_at_test',
+  refreshToken: 'ps_rt_test',
+  expiresIn: 900,
+  scope: 'manage_keys offline_access',
+};
+
+function params(overrides: Partial<RunConsentParams> = {}): RunConsentParams {
+  return {
+    device: false,
+    host: 'https://pagespace.ai',
+    clientId: 'pagespace-cli',
+    scope: 'manage_keys offline_access',
+    discoverMetadata: async () => ({
+      authorizationEndpoint: 'https://pagespace.ai/api/oauth/authorize',
+      tokenEndpoint: 'https://pagespace.ai/api/oauth/token',
+      deviceAuthorizationEndpoint: 'https://pagespace.ai/api/oauth/device_authorization',
+    }),
+    exchangeCode: async () => OAUTH_TOKENS,
+    confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+    credentialStore: { set: async () => {} },
+    waitMs: async () => {},
+    now: () => Date.parse('2026-07-23T00:00:00.000Z'),
+    timeoutMs: 60_000,
+    loopback: {
+      randomBytes: (n: number) => new Uint8Array(n).fill(7),
+      startServer: async () => {
+        throw new Error('loopback transport not expected in this test');
+      },
+      openBrowser: async () => true,
+      maxPortAttempts: 5,
+      onBrowserOpenFailed: () => {},
+    },
+    deviceDeps: {
+      requestDeviceAuthorization: async () => AUTHORIZATION,
+      pollDeviceToken: async () => ({ kind: 'success' as const, tokens: OAUTH_TOKENS }),
+      isInterrupted: () => false,
+      waitMs: async () => {},
+      onDeviceCode: () => {},
+    },
+    ...overrides,
+  };
+}
+
+describe('runConsent — transport selection', () => {
+  /**
+   * Regression guard. `keys create`/`keys use` wire `unrefWaitMs` for their
+   * loopback timeout race; handing that same adapter to the device poll loop
+   * lets Node exit right after printing the verification code, because between
+   * polls that timer is often the only live handle. The device branch must
+   * take its adapter from `deviceDeps`, never from the top-level `waitMs`.
+   */
+  it('polls with the device transport OWN waitMs, never the loopback one', async () => {
+    const used: string[] = [];
+
+    // One poll returns authorization_pending so the flow is forced to wait at
+    // least once — otherwise a success on the first poll would never touch a
+    // timer and the assertion would pass vacuously.
+    let polls = 0;
+    const result = await runConsent(
+      params({
+        device: true,
+        waitMs: async () => {
+          used.push('loopback');
+        },
+        deviceDeps: {
+          ...params().deviceDeps,
+          waitMs: async () => {
+            used.push('device');
+          },
+          pollDeviceToken: async () => {
+            polls += 1;
+            return polls === 1
+              ? { kind: 'authorization_pending' as const }
+              : { kind: 'success' as const, tokens: OAUTH_TOKENS };
+          },
+        },
+      }),
+      'pagespace login --device',
+    );
+
+    expect(result.outcome).toBe('success');
+    expect(polls).toBeGreaterThan(1);
+    expect(used).toContain('device');
+    expect(used).not.toContain('loopback');
+  });
+
+  it('never opens a browser or binds a loopback port in device mode', async () => {
+    let browserOpened = false;
+    let serverStarted = false;
+
+    const result = await runConsent(
+      params({
+        device: true,
+        loopback: {
+          ...params().loopback,
+          openBrowser: async () => {
+            browserOpened = true;
+            return true;
+          },
+          startServer: async () => {
+            serverStarted = true;
+            throw new Error('should not start');
+          },
+        },
+      }),
+      'pagespace login --device',
+    );
+
+    expect(result.outcome).toBe('success');
+    expect(browserOpened).toBe(false);
+    expect(serverStarted).toBe(false);
+  });
+
+  it('never requests a device authorization in loopback mode', async () => {
+    let deviceRequested = false;
+
+    await runConsent(
+      params({
+        device: false,
+        loopback: {
+          ...params().loopback,
+          startServer: async () => {
+            throw new Error('bind failed');
+          },
+        },
+        deviceDeps: {
+          ...params().deviceDeps,
+          requestDeviceAuthorization: async () => {
+            deviceRequested = true;
+            return AUTHORIZATION;
+          },
+        },
+      }),
+      'pagespace login',
+    );
+
+    expect(deviceRequested).toBe(false);
+  });
+
+  it('names the device fallback when a loopback port cannot be bound', async () => {
+    const result = await runConsent(
+      params({
+        loopback: {
+          ...params().loopback,
+          startServer: async () => {
+            throw new Error('EADDRINUSE');
+          },
+        },
+      }),
+      'pagespace keys create',
+    );
+
+    expect(result.outcome).toBe('failed');
+    if (result.outcome !== 'failed') throw new Error('unreachable');
+    expect(result.message).toContain('--device');
+  });
+
+  it('carries the retry command into the timeout message so the hint matches what was typed', async () => {
+    const result = await runConsent(
+      params({
+        device: true,
+        deviceDeps: {
+          ...params().deviceDeps,
+          pollDeviceToken: async () => ({ kind: 'expired_token' as const }),
+        },
+      }),
+      'pagespace keys create --device',
+    );
+
+    expect(result.outcome).toBe('failed');
+    if (result.outcome !== 'failed') throw new Error('unreachable');
+    expect(result.message).toContain('pagespace keys create --device');
+  });
+});

--- a/packages/cli/src/auth/__tests__/run-consent.test.ts
+++ b/packages/cli/src/auth/__tests__/run-consent.test.ts
@@ -39,7 +39,7 @@ function params(overrides: Partial<RunConsentParams> = {}): RunConsentParams {
     exchangeCode: async () => OAUTH_TOKENS,
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
     credentialStore: { set: async () => {} },
-    waitMs: async () => {},
+    loopbackWaitMs: async () => {},
     now: () => Date.parse('2026-07-23T00:00:00.000Z'),
     timeoutMs: 60_000,
     loopback: {
@@ -54,7 +54,7 @@ function params(overrides: Partial<RunConsentParams> = {}): RunConsentParams {
     deviceDeps: {
       requestDeviceAuthorization: async () => AUTHORIZATION,
       pollDeviceToken: async () => ({ kind: 'success' as const, tokens: OAUTH_TOKENS }),
-      isInterrupted: () => false,
+      createIsInterrupted: () => () => false,
       waitMs: async () => {},
       onDeviceCode: () => {},
     },
@@ -80,7 +80,7 @@ describe('runConsent — transport selection', () => {
     const result = await runConsent(
       params({
         device: true,
-        waitMs: async () => {
+        loopbackWaitMs: async () => {
           used.push('loopback');
         },
         deviceDeps: {

--- a/packages/cli/src/auth/device-flow.ts
+++ b/packages/cli/src/auth/device-flow.ts
@@ -280,14 +280,19 @@ export async function runDeviceLogin(deps: DeviceLoginDeps): Promise<DeviceLogin
           }
         }
 
-        let identity: Identity | null;
-        try {
-          identity = await deps.confirmIdentity({
-            host: deps.host,
-            accessToken: tokens.kind === 'oauth' ? tokens.accessToken : tokens.token,
-          });
-        } catch {
-          identity = null;
+        // Only an oauth grant has an identity to confirm. `/api/auth/me`
+        // deliberately refuses `mcp_*` tokens (a scoped key is its own
+        // principal — see `auth/probe-drives.ts`), so asking on behalf of a
+        // freshly minted key could only 401: a guaranteed-doomed round trip,
+        // billed at the confirm-identity timeout, on every `keys create
+        // --device`. `whoami` gates the same call the same way.
+        let identity: Identity | null = null;
+        if (tokens.kind === 'oauth') {
+          try {
+            identity = await deps.confirmIdentity({ host: deps.host, accessToken: tokens.accessToken });
+          } catch {
+            identity = null;
+          }
         }
 
         return { outcome: 'success', identity, scope: tokens.scope };

--- a/packages/cli/src/auth/device-flow.ts
+++ b/packages/cli/src/auth/device-flow.ts
@@ -131,10 +131,28 @@ export interface DeviceLoginDeps {
   readonly isInterrupted: () => boolean;
   /** Which named profile to store the credential under. Defaults to `"default"`, mirroring `loopback-flow.ts`. */
   readonly profile?: string;
+  /**
+   * Opt-in escape hatch for the "tokens never leave this function" rule,
+   * mirroring `loopback-flow.ts`'s hook of the same name: invoked
+   * synchronously with the raw `mcp_*` token immediately after persistence,
+   * ONLY when the redemption minted a static (`kind: 'mcp'`) token — never
+   * for the oauth pair, so `login --device` cannot surface a secret even if
+   * it wired this. Callers must capture-and-defer, never print inside the
+   * callback.
+   */
+  readonly onMintedStaticToken?: (token: string) => void;
 }
 
 export type DeviceLoginResult =
-  | { readonly outcome: 'success'; readonly identity: Identity | null; readonly scope: string }
+  | {
+      readonly outcome: 'success';
+      readonly identity: Identity | null;
+      readonly scope: string;
+      /** Set only for an `mcp_update` redemption — which existing key was re-scoped in place (no credential was stored). */
+      readonly updatedTokenId?: string;
+      /** Set only for an `mcp_activate` redemption — which existing key the human approved activating (nothing was stored). */
+      readonly activatedTokenId?: string;
+    }
   | { readonly outcome: 'access_denied' }
   | { readonly outcome: 'expired_token' }
   | { readonly outcome: 'timeout' }
@@ -202,31 +220,72 @@ export async function runDeviceLogin(deps: DeviceLoginDeps): Promise<DeviceLogin
     switch (decision.outcome.kind) {
       case 'success': {
         const { tokens } = decision.outcome;
-        // `login --device` only ever requests `manage_keys offline_access`
-        // (never a pure drive:* grant), so the token endpoint's
-        // `ok_mcp_token` branch (oauth-repository.ts) can't fire here — this
-        // is always the classic OAuth pair. Narrowed explicitly (not just
-        // asserted) so a future scope change to this flow fails loudly
-        // instead of silently mis-persisting an mcp token as an oauth grant.
-        if (tokens.kind !== 'oauth') {
-          return { outcome: 'poll_failed', message: `Unexpected token type from device grant: ${tokens.kind}` };
+
+        // An mcp_update redemption re-scoped an EXISTING key in place: the
+        // server returned no secret, the locally stored credential (if any) is
+        // unchanged, and there is no bearer in hand for confirmIdentity — so
+        // nothing is persisted and no identity call is made. Mirrors
+        // `runLoopbackLogin`.
+        if (tokens.kind === 'mcp_update') {
+          return { outcome: 'success', identity: null, scope: tokens.scope, updatedTokenId: tokens.tokenId };
         }
+
+        // An mcp_activate redemption approved a device activation ceremony:
+        // the server verified ownership and changed nothing. Same
+        // persist-nothing posture as mcp_update — the caller records the
+        // activation locally.
+        if (tokens.kind === 'mcp_activate') {
+          return { outcome: 'success', identity: null, scope: tokens.scope, activatedTokenId: tokens.tokenId };
+        }
+
+        // Flow-level invariant: only a request that actually ASKED for a mint
+        // may persist one. A mint-shaped grant always carries a `name:` token
+        // (the device authorization endpoint refuses a nameless mint outright),
+        // so its absence means this flow requested something else — an
+        // update/activate ceremony, or a plain `login --device`. A compromised
+        // or older server answering any of those with a real mint would
+        // otherwise leave a live secret in the keychain, stored under whatever
+        // profile the caller passed, that the user was never told exists —
+        // while the caller cheerfully reports the ceremony it asked for.
+        //
+        // Stricter than `runLoopbackLogin`'s equivalent guard, which only
+        // covers the update/activate case: this preserves the protection the
+        // device flow had when it rejected every non-oauth token outright,
+        // now that it legitimately accepts mints for `keys create --device`.
+        if (tokens.kind === 'mcp' && !deps.scope.split(' ').some((token) => token.startsWith('name:'))) {
+          return {
+            outcome: 'poll_failed',
+            message: 'The server minted a new credential for a request that did not ask for one; nothing was stored.',
+          };
+        }
+
+        const scopes = tokens.scope.split(' ').filter(Boolean);
+        const createdAt = new Date(deps.now()).toISOString();
 
         await deps.credentialStore.set(
           deps.host,
-          {
-            kind: 'oauth',
-            refreshToken: tokens.refreshToken,
-            clientId: deps.clientId,
-            scopes: tokens.scope.split(' ').filter(Boolean),
-            createdAt: new Date(deps.now()).toISOString(),
-          },
+          tokens.kind === 'oauth'
+            ? { kind: 'oauth', refreshToken: tokens.refreshToken, clientId: deps.clientId, scopes, createdAt }
+            : { kind: 'static', token: tokens.token, scopes, createdAt },
           deps.profile ?? DEFAULT_PROFILE_NAME,
         );
 
+        if (tokens.kind === 'mcp') {
+          try {
+            deps.onMintedStaticToken?.(tokens.token);
+          } catch {
+            // Best-effort surfacing hook (same fail-soft posture as
+            // confirmIdentity below): the credential is already persisted, so
+            // a buggy callback must not turn a successful mint into a failure.
+          }
+        }
+
         let identity: Identity | null;
         try {
-          identity = await deps.confirmIdentity({ host: deps.host, accessToken: tokens.accessToken });
+          identity = await deps.confirmIdentity({
+            host: deps.host,
+            accessToken: tokens.kind === 'oauth' ? tokens.accessToken : tokens.token,
+          });
         } catch {
           identity = null;
         }

--- a/packages/cli/src/auth/exchange-code.ts
+++ b/packages/cli/src/auth/exchange-code.ts
@@ -9,23 +9,12 @@
  * pre-authentication step no `AuthProvider` can exist for yet. The response
  * shape is still validated with zod rather than trusted blind.
  *
- * The response is one of three shapes, discriminated by `token_type`
- * (`oauth-repository.ts`'s `exchangeAuthorizationCode`): `'Bearer'` is the
- * classic OAuth refresh/access-token pair `pagespace login` uses, feeding
- * `PageSpaceClient`/`OAuthTokenProvider`. `'mcp'` is a pure drive:* grant
- * (`pagespace keys create`) — the server minted a real `mcp_*` token instead
- * of an OAuth grant (see that file's `ok_mcp_token` outcome), so there is no
- * `refresh_token`/`expires_in` to report: an `mcp_*` token doesn't expire
- * and has no refresh cycle. `'mcp_update'` is an `update_key:<id>` grant
- * (the wizard's Edit) — the server re-scoped an EXISTING `mcp_*` token in
- * place (`ok_mcp_update`) and deliberately returns no secret at all, only
- * the PKCE-verified success signal + granted scope + which token changed.
- * `loopback-flow.ts` persists the first two shapes differently (an
- * `OAuthHostCredential` vs a `StaticHostCredential`) and persists NOTHING
- * for the third (the stored credential's secret is unchanged).
+ * The four possible response shapes are discriminated by `parseTokenResponse`
+ * (`token-response.ts`), shared with the device-grant poller so both grants
+ * read the same wire contract.
  */
-import { z } from 'zod';
 import type { ExchangeCode, ExchangeCodeParams, ExchangedTokens } from './loopback-flow.js';
+import { parseTokenResponse } from './token-response.js';
 
 export class TokenExchangeError extends Error {
   constructor(public readonly code: string) {
@@ -33,32 +22,6 @@ export class TokenExchangeError extends Error {
     this.name = 'TokenExchangeError';
   }
 }
-
-const oauthTokenResponseSchema = z.object({
-  token_type: z.literal('Bearer'),
-  access_token: z.string(),
-  expires_in: z.number(),
-  refresh_token: z.string(),
-  scope: z.string(),
-});
-
-const mcpTokenResponseSchema = z.object({
-  token_type: z.literal('mcp'),
-  access_token: z.string(),
-  scope: z.string(),
-});
-
-const mcpUpdateResponseSchema = z.object({
-  token_type: z.literal('mcp_update'),
-  token_id: z.string(),
-  scope: z.string(),
-});
-
-const mcpActivateResponseSchema = z.object({
-  token_type: z.literal('mcp_activate'),
-  token_id: z.string(),
-  scope: z.string(),
-});
 
 function extractErrorCode(json: unknown, status: number): string {
   if (json !== null && typeof json === 'object' && 'error' in json && typeof (json as Record<string, unknown>).error === 'string') {
@@ -94,32 +57,10 @@ export function createExchangeCode(fetchImpl: typeof fetch = fetch): ExchangeCod
       throw new TokenExchangeError(extractErrorCode(json, response.status));
     }
 
-    const mcpParsed = mcpTokenResponseSchema.safeParse(json);
-    if (mcpParsed.success) {
-      return { kind: 'mcp', token: mcpParsed.data.access_token, scope: mcpParsed.data.scope };
-    }
-
-    const mcpUpdateParsed = mcpUpdateResponseSchema.safeParse(json);
-    if (mcpUpdateParsed.success) {
-      return { kind: 'mcp_update', tokenId: mcpUpdateParsed.data.token_id, scope: mcpUpdateParsed.data.scope };
-    }
-
-    const mcpActivateParsed = mcpActivateResponseSchema.safeParse(json);
-    if (mcpActivateParsed.success) {
-      return { kind: 'mcp_activate', tokenId: mcpActivateParsed.data.token_id, scope: mcpActivateParsed.data.scope };
-    }
-
-    const oauthParsed = oauthTokenResponseSchema.safeParse(json);
-    if (!oauthParsed.success) {
+    const tokens = parseTokenResponse(json);
+    if (tokens === null) {
       throw new TokenExchangeError('invalid_response');
     }
-
-    return {
-      kind: 'oauth',
-      accessToken: oauthParsed.data.access_token,
-      refreshToken: oauthParsed.data.refresh_token,
-      expiresIn: oauthParsed.data.expires_in,
-      scope: oauthParsed.data.scope,
-    };
+    return tokens;
   };
 }

--- a/packages/cli/src/auth/poll-device-token.ts
+++ b/packages/cli/src/auth/poll-device-token.ts
@@ -7,16 +7,8 @@
  * `DeviceTokenResult` variants rather than throwing, so `decideNextPoll`
  * never needs to parse an error string to decide what happened.
  */
-import { z } from 'zod';
 import type { DeviceTokenResult, PollDeviceToken } from './device-flow.js';
-
-const tokenResponseSchema = z.object({
-  access_token: z.string(),
-  token_type: z.string(),
-  expires_in: z.number(),
-  refresh_token: z.string(),
-  scope: z.string(),
-});
+import { parseTokenResponse } from './token-response.js';
 
 const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
 
@@ -64,24 +56,16 @@ export function createPollDeviceToken(fetchImpl: typeof fetch = fetch): PollDevi
       }
     }
 
-    const parsed = tokenResponseSchema.safeParse(json);
-    if (!parsed.success) {
+    // Discriminated through the SAME parser the authorization_code exchange
+    // uses (`token-response.ts`): the device grant now redeems key-shaped
+    // grants too, so any of the four shapes can arrive here. `runDeviceLogin`
+    // is what decides whether the shape it got is the one this particular
+    // flow asked for.
+    const tokens = parseTokenResponse(json);
+    if (tokens === null) {
       return { kind: 'request_failed', message: 'invalid_response' };
     }
 
-    return {
-      kind: 'success',
-      // `login --device` only ever requests `manage_keys offline_access`
-      // (never a pure drive:* grant), so the token endpoint's `ok_mcp_token`
-      // branch (oauth-repository.ts) never fires here — this is always the
-      // classic OAuth refresh/access-token pair, hence the literal 'oauth'.
-      tokens: {
-        kind: 'oauth',
-        accessToken: parsed.data.access_token,
-        refreshToken: parsed.data.refresh_token,
-        expiresIn: parsed.data.expires_in,
-        scope: parsed.data.scope,
-      },
-    };
+    return { kind: 'success', tokens };
   };
 }

--- a/packages/cli/src/auth/probe-drives.ts
+++ b/packages/cli/src/auth/probe-drives.ts
@@ -1,0 +1,37 @@
+/**
+ * Liveness probe for a credential that `GET /api/auth/me` cannot speak for.
+ *
+ * `mcp_*` keys are deliberately excluded from `/api/auth/me`
+ * (`apps/web/src/app/api/auth/me/route.ts`): a scoped key is its own
+ * drive-member principal, and resolving it to the personal owner behind it
+ * would hand that owner's name/email to whoever holds the key. So `whoami`
+ * cannot confirm a scoped key by asking "who am I?" — the honest question for
+ * a scoped key is "does this key still work, and what can it reach?", which
+ * `drives.list` answers with the smallest authenticated call the key is
+ * already entitled to make.
+ *
+ * A rejection here is the real "this key was revoked" signal; the caller maps
+ * it to the re-mint remediation, never to "run pagespace login" (a scoped key
+ * has no login session to refresh).
+ */
+import { PageSpaceClient, StaticTokenProvider } from '@pagespace/sdk';
+
+export type ProbeDriveCount = (params: { host: string; accessToken: string }) => Promise<number>;
+
+/**
+ * Same short, retry-free budget `confirmIdentity` uses (see
+ * `confirm-identity.ts`): this is a status readout, so a slow or unresponsive
+ * server must never stall CLI exit.
+ */
+export const PROBE_DRIVES_TIMEOUT_MS = 5_000;
+
+export const probeDriveCount: ProbeDriveCount = async ({ host, accessToken }) => {
+  const client = new PageSpaceClient({
+    baseUrl: host,
+    auth: new StaticTokenProvider(accessToken),
+    timeoutMs: PROBE_DRIVES_TIMEOUT_MS,
+    retryPolicy: { maxRetries: 0 },
+  });
+  const drives = await client.drives.list({});
+  return drives.length;
+};

--- a/packages/cli/src/auth/resolve-credential-source.ts
+++ b/packages/cli/src/auth/resolve-credential-source.ts
@@ -51,10 +51,8 @@ export interface ResolvedCredentialSource {
   readonly source: AuthSource;
   /** The key name the credential was (or would be) read from. */
   readonly keyName: string;
-  /** Non-null only when the active key is what supplied `credential`. */
+  /** Non-null only when the active key is what supplied the credential. */
   readonly activeKeyName: string | null;
-  /** The stored credential backing `source`, when `source.kind === 'stored'`. */
-  readonly credential: HostCredential | null;
   /** True when `--token`/`--key`/either env var named a credential explicitly. */
   readonly explicit: boolean;
 }
@@ -68,7 +66,24 @@ export async function resolveCredentialSource(
   const envKey = resolveEnvKeyName(env);
   const explicit = hasExplicitCredential({ token: flags.token, key: flags.key }, env);
 
-  let keyName = resolveKeyName({ key: flags.key }, { PAGESPACE_KEY: envKey.name });
+  const keyNameFromFlags = resolveKeyName({ key: flags.key }, { PAGESPACE_KEY: envKey.name });
+
+  // A bearer token given directly outranks anything on disk, so resolving it
+  // needs no store read at all. Worth short-circuiting rather than reading and
+  // discarding: on macOS a credential-store read is a native keychain call
+  // that can surface an access prompt, and this resolver now runs for every
+  // invocation of every command.
+  const directToken = flags.token?.trim() || envToken.token?.trim();
+  if (directToken) {
+    return {
+      source: resolveAuth({ token: flags.token }, { PAGESPACE_TOKEN: envToken.token }, {}, host, keyNameFromFlags),
+      keyName: keyNameFromFlags,
+      activeKeyName: null,
+      explicit,
+    };
+  }
+
+  let keyName = keyNameFromFlags;
   let credential: HostCredential | null = null;
   let activeKeyName: string | null = null;
 
@@ -95,7 +110,7 @@ export async function resolveCredentialSource(
     keyName,
   );
 
-  return { source, keyName, activeKeyName, credential, explicit };
+  return { source, keyName, activeKeyName, explicit };
 }
 
 /**

--- a/packages/cli/src/auth/resolve-credential-source.ts
+++ b/packages/cli/src/auth/resolve-credential-source.ts
@@ -1,0 +1,123 @@
+/**
+ * The ONE place that answers "which credential would this invocation actually
+ * use?" — the full precedence chain, effects included: `--token` flag >
+ * `PAGESPACE_TOKEN` env > the stored credential for the resolved `--key`/
+ * `PAGESPACE_KEY` name > this machine's active key (`pagespace keys use`) >
+ * the stored `"default"` login credential > none.
+ *
+ * The pure precedence rules still live in `resolve.ts` (`hasExplicitCredential`,
+ * `resolveKeyName`, `resolveAuth`) and `legacy-token-env.ts` (the deprecated
+ * env-name aliases); this module is the thin async shell that performs the two
+ * store reads those rules need (`activeKeyStore.getActiveKey`,
+ * `credentialStore.get`) and hands back a single resolved record.
+ *
+ * Extracted from `run.ts`, which previously inlined it — `whoami` reimplemented
+ * only the *last* link of the chain (the `"default"` slot) and so reported
+ * "Not logged in" on a machine whose every content command worked through an
+ * active key. A second implementation of this precedence is exactly the bug;
+ * both callers now share this one.
+ *
+ * Lives in `src/auth/` rather than in a command module deliberately: the
+ * `commands/__tests__/single-auth-path.test.ts` tripwire greps command sources
+ * for the raw `PAGESPACE_TOKEN`/`PAGESPACE_KEY` literals precisely so that no
+ * command grows its own env read.
+ */
+import type { ActiveKeyStore } from '../credentials/active-key.js';
+import { DEFAULT_PROFILE_NAME } from '../credentials/serialize.js';
+import type { HostCredential } from '../credentials/serialize.js';
+import type { CredentialStore } from '../credentials/store.js';
+import { resolveEnvKeyName, resolveEnvToken } from './legacy-token-env.js';
+import { hasExplicitCredential, resolveAuth, resolveKeyName, type AuthSource } from './resolve.js';
+
+export interface ResolveCredentialSourceInput {
+  readonly flags: { readonly token?: string; readonly key?: string };
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly host: string;
+  readonly credentialStore: Pick<CredentialStore, 'get'>;
+  readonly activeKeyStore: Pick<ActiveKeyStore, 'getActiveKey'>;
+  /**
+   * Whether this invocation may fall back to the machine's active key. `run.ts`
+   * passes `false` for auth-exempt handlers (the `keys` family needs the
+   * `manage_keys` scope a drive-scoped active key doesn't carry) and for
+   * `pagespace mcp` (invoked unattended; its config must name a credential
+   * itself). `whoami` passes `true` — its entire job is reporting what a
+   * content command on this machine would authenticate as.
+   */
+  readonly allowActiveKey: boolean;
+}
+
+export interface ResolvedCredentialSource {
+  /** The resolved source, ready for `buildAuthProvider`. */
+  readonly source: AuthSource;
+  /** The key name the credential was (or would be) read from. */
+  readonly keyName: string;
+  /** Non-null only when the active key is what supplied `credential`. */
+  readonly activeKeyName: string | null;
+  /** The stored credential backing `source`, when `source.kind === 'stored'`. */
+  readonly credential: HostCredential | null;
+  /** True when `--token`/`--key`/either env var named a credential explicitly. */
+  readonly explicit: boolean;
+}
+
+export async function resolveCredentialSource(
+  input: ResolveCredentialSourceInput,
+): Promise<ResolvedCredentialSource> {
+  const { flags, env, host, credentialStore, activeKeyStore, allowActiveKey } = input;
+
+  const envToken = resolveEnvToken(env);
+  const envKey = resolveEnvKeyName(env);
+  const explicit = hasExplicitCredential({ token: flags.token, key: flags.key }, env);
+
+  let keyName = resolveKeyName({ key: flags.key }, { PAGESPACE_KEY: envKey.name });
+  let credential: HostCredential | null = null;
+  let activeKeyName: string | null = null;
+
+  if (!explicit && allowActiveKey) {
+    const active = await activeKeyStore.getActiveKey(host);
+    if (active !== null) {
+      const activeCredential = await credentialStore.get(host, active);
+      if (activeCredential !== null) {
+        keyName = active;
+        credential = activeCredential;
+        activeKeyName = active;
+      }
+    }
+  }
+  if (activeKeyName === null) {
+    credential = await credentialStore.get(host, keyName);
+  }
+
+  const source = resolveAuth(
+    { token: flags.token },
+    { PAGESPACE_TOKEN: envToken.token },
+    credential ? { [host]: { [keyName]: credential } } : {},
+    host,
+    keyName,
+  );
+
+  return { source, keyName, activeKeyName, credential, explicit };
+}
+
+/**
+ * Human-readable one-liner naming where the resolved credential came from —
+ * display copy for `whoami`. Pure. Deliberately routed through
+ * `TOKEN_ENV_VAR_NAME`-free wording: the caller is a command module, and the
+ * `single-auth-path.test.ts` tripwire must stay sharp there.
+ */
+export function describeCredentialSource(
+  resolved: Pick<ResolvedCredentialSource, 'source' | 'keyName' | 'activeKeyName'>,
+  tokenEnvVarName: string,
+): string {
+  switch (resolved.source.kind) {
+    case 'flag':
+      return '--token flag';
+    case 'env':
+      return `${tokenEnvVarName} environment variable`;
+    case 'stored':
+      if (resolved.activeKeyName !== null) return `active key "${resolved.activeKeyName}"`;
+      if (resolved.keyName === DEFAULT_PROFILE_NAME) return 'personal login';
+      return `key "${resolved.keyName}"`;
+    case 'none':
+      return 'none';
+  }
+}

--- a/packages/cli/src/auth/run-consent.ts
+++ b/packages/cli/src/auth/run-consent.ts
@@ -1,0 +1,180 @@
+/**
+ * One entry point for "get a human to approve this scope", over either
+ * transport: the loopback+PKCE browser flow (`runLoopbackLogin`) or the RFC
+ * 8628 device flow (`runDeviceLogin`).
+ *
+ * Every consent-driven command — `login`, `keys create`, `keys use`, and the
+ * wizard's mint/edit/activate steps — needs the same `--device` choice, and
+ * each one previously hard-wired the loopback flow plus its own eight-case
+ * outcome switch. Adding a second transport per command would have meant four
+ * more copies of that switch, each free to drift on which failures are fatal
+ * or what remediation they name. Instead the transports are normalized here
+ * into one small result type, and the per-command copy is reduced to the retry
+ * hint each one wants to print.
+ *
+ * The two flows differ in what can go wrong (a browser flow can fail to bind a
+ * loopback port; a device flow can have its code expire before approval), so
+ * `describeConsentFailure` renders each transport's failure modes in its own
+ * words rather than flattening them to a generic "consent failed".
+ */
+import type { CredentialStore } from '../credentials/store.js';
+import { runDeviceLogin } from './device-flow.js';
+import type { DeviceAuthorization, PollDeviceToken, RequestDeviceAuthorization } from './device-flow.js';
+import { runLoopbackLogin } from './loopback-flow.js';
+import type {
+  ConfirmIdentity,
+  DiscoverMetadata,
+  ExchangeCode,
+  Identity,
+  OpenBrowser,
+  RandomBytes,
+  StartLoopbackServer,
+  WaitMs,
+} from './loopback-flow.js';
+
+/** Effects only the browser transport needs. */
+export interface LoopbackConsentDeps {
+  readonly randomBytes: RandomBytes;
+  readonly startServer: StartLoopbackServer;
+  readonly openBrowser: OpenBrowser;
+  readonly maxPortAttempts: number;
+  readonly onBrowserOpenFailed: (url: string) => void;
+}
+
+/** Effects only the device transport needs. */
+export interface DeviceConsentDeps {
+  readonly requestDeviceAuthorization: RequestDeviceAuthorization;
+  readonly pollDeviceToken: PollDeviceToken;
+  readonly isInterrupted: () => boolean;
+  readonly onDeviceCode: (authorization: DeviceAuthorization) => void;
+}
+
+export interface RunConsentParams {
+  /** True when `--device` was passed: no browser is opened, a code is printed instead. */
+  readonly device: boolean;
+  readonly host: string;
+  readonly clientId: string;
+  readonly scope: string;
+  readonly discoverMetadata: DiscoverMetadata;
+  readonly exchangeCode: ExchangeCode;
+  readonly confirmIdentity: ConfirmIdentity;
+  readonly credentialStore: Pick<CredentialStore, 'set'>;
+  readonly waitMs: WaitMs;
+  readonly now: () => number;
+  readonly timeoutMs: number;
+  readonly profile?: string;
+  readonly onMintedStaticToken?: (token: string) => void;
+  readonly loopback: LoopbackConsentDeps;
+  readonly deviceDeps: DeviceConsentDeps;
+}
+
+export type ConsentResult =
+  | {
+      readonly outcome: 'success';
+      readonly identity: Identity | null;
+      readonly scope: string;
+      readonly updatedTokenId?: string;
+      readonly activatedTokenId?: string;
+    }
+  | { readonly outcome: 'failed'; readonly message: string };
+
+/**
+ * Renders a transport-specific failure into one actionable line. `retryCommand`
+ * is the exact command the user should run again (e.g. `pagespace keys create
+ * --device`), so the remediation always matches what they actually typed.
+ */
+export function describeConsentFailure(
+  result: Awaited<ReturnType<typeof runLoopbackLogin>> | Awaited<ReturnType<typeof runDeviceLogin>>,
+  retryCommand: string,
+  host: string,
+): string {
+  switch (result.outcome) {
+    case 'success':
+      throw new Error('describeConsentFailure called on a successful consent');
+    // Shared by both transports.
+    case 'timeout':
+      return `Timed out waiting for approval. Run "${retryCommand}" again.`;
+    case 'access_denied':
+      return 'Access was denied.';
+    case 'discovery_failed':
+      return `Could not discover the OAuth server configuration for ${host}: ${result.message}`;
+    // Loopback only.
+    case 'state_mismatch':
+      return `The authorization response did not match this request. Run "${retryCommand}" again.`;
+    case 'authorize_error':
+      return `Consent failed: ${result.error}`;
+    case 'token_exchange_failed':
+      return `Consent failed while exchanging the authorization code: ${result.message}`;
+    case 'port_bind_failed':
+      return `Could not bind a local loopback port to receive the redirect. On a machine with no browser, run "${retryCommand} --device" instead.`;
+    // Device only.
+    case 'expired_token':
+      return `The device code expired before approval completed. Run "${retryCommand}" again.`;
+    case 'poll_failed':
+      return `Failed while polling for approval: ${result.message}`;
+    case 'interrupted':
+      return 'Cancelled.';
+    case 'device_authorization_failed':
+      return `Could not start device approval: ${result.message}`;
+    default: {
+      const unreachable: never = result;
+      throw new Error(`Unhandled consent outcome: ${JSON.stringify(unreachable)}`);
+    }
+  }
+}
+
+export async function runConsent(params: RunConsentParams, retryCommand: string): Promise<ConsentResult> {
+  const shared = {
+    host: params.host,
+    clientId: params.clientId,
+    scope: params.scope,
+    discoverMetadata: params.discoverMetadata,
+    confirmIdentity: params.confirmIdentity,
+    credentialStore: params.credentialStore,
+    waitMs: params.waitMs,
+    now: params.now,
+    timeoutMs: params.timeoutMs,
+    profile: params.profile,
+    onMintedStaticToken: params.onMintedStaticToken,
+  };
+
+  const result = params.device
+    ? await runDeviceLogin({
+        ...shared,
+        requestDeviceAuthorization: params.deviceDeps.requestDeviceAuthorization,
+        pollDeviceToken: params.deviceDeps.pollDeviceToken,
+        isInterrupted: params.deviceDeps.isInterrupted,
+        onDeviceCode: params.deviceDeps.onDeviceCode,
+      })
+    : await runLoopbackLogin({
+        ...shared,
+        exchangeCode: params.exchangeCode,
+        randomBytes: params.loopback.randomBytes,
+        startServer: params.loopback.startServer,
+        openBrowser: params.loopback.openBrowser,
+        maxPortAttempts: params.loopback.maxPortAttempts,
+        onBrowserOpenFailed: params.loopback.onBrowserOpenFailed,
+      });
+
+  if (result.outcome === 'success') {
+    return {
+      outcome: 'success',
+      identity: result.identity,
+      scope: result.scope,
+      updatedTokenId: result.updatedTokenId,
+      activatedTokenId: result.activatedTokenId,
+    };
+  }
+
+  return { outcome: 'failed', message: describeConsentFailure(result, retryCommand, params.host) };
+}
+
+/** The verification lines a device flow prints in place of opening a browser. */
+export function renderDeviceCodePrompt(authorization: DeviceAuthorization): string[] {
+  return [
+    'To approve this on any device with a browser, visit:',
+    `  ${authorization.verificationUri}`,
+    `And enter this code: ${authorization.userCode}`,
+    `Or open directly: ${authorization.verificationUriComplete}`,
+  ];
+}

--- a/packages/cli/src/auth/run-consent.ts
+++ b/packages/cli/src/auth/run-consent.ts
@@ -47,6 +47,24 @@ export interface DeviceConsentDeps {
   readonly pollDeviceToken: PollDeviceToken;
   readonly isInterrupted: () => boolean;
   readonly onDeviceCode: (authorization: DeviceAuthorization) => void;
+  /**
+   * The device transport's OWN delay adapter, deliberately separate from
+   * `RunConsentParams.waitMs`.
+   *
+   * The two transports need opposite timer semantics and must never share one
+   * adapter. Loopback consent races its 5-minute timeout against the callback
+   * and needs `unrefWaitMs`, or the losing timer pins the event loop and hangs
+   * the CLI at exit. Device polling is a sequential loop where the delay
+   * between polls is often the ONLY live handle, so it needs the REF'd
+   * `waitMs` — an unref'd one lets Node exit right after printing the
+   * verification code, before the user has any chance to approve. See
+   * `auth/wait.ts`.
+   *
+   * Keeping it here rather than at the top level means each transport carries
+   * the timer it actually needs, so a command wiring `unrefWaitMs` for its
+   * loopback path cannot silently impose it on the device path too.
+   */
+  readonly waitMs: WaitMs;
 }
 
 export interface RunConsentParams {
@@ -59,6 +77,7 @@ export interface RunConsentParams {
   readonly exchangeCode: ExchangeCode;
   readonly confirmIdentity: ConfirmIdentity;
   readonly credentialStore: Pick<CredentialStore, 'set'>;
+  /** The LOOPBACK transport's delay adapter; the device transport carries its own (`DeviceConsentDeps.waitMs`). */
   readonly waitMs: WaitMs;
   readonly now: () => number;
   readonly timeoutMs: number;
@@ -131,7 +150,6 @@ export async function runConsent(params: RunConsentParams, retryCommand: string)
     discoverMetadata: params.discoverMetadata,
     confirmIdentity: params.confirmIdentity,
     credentialStore: params.credentialStore,
-    waitMs: params.waitMs,
     now: params.now,
     timeoutMs: params.timeoutMs,
     profile: params.profile,
@@ -141,6 +159,8 @@ export async function runConsent(params: RunConsentParams, retryCommand: string)
   const result = params.device
     ? await runDeviceLogin({
         ...shared,
+        // The ref'd adapter — never `params.waitMs`. See DeviceConsentDeps.waitMs.
+        waitMs: params.deviceDeps.waitMs,
         requestDeviceAuthorization: params.deviceDeps.requestDeviceAuthorization,
         pollDeviceToken: params.deviceDeps.pollDeviceToken,
         isInterrupted: params.deviceDeps.isInterrupted,
@@ -148,6 +168,7 @@ export async function runConsent(params: RunConsentParams, retryCommand: string)
       })
     : await runLoopbackLogin({
         ...shared,
+        waitMs: params.waitMs,
         exchangeCode: params.exchangeCode,
         randomBytes: params.loopback.randomBytes,
         startServer: params.loopback.startServer,

--- a/packages/cli/src/auth/run-consent.ts
+++ b/packages/cli/src/auth/run-consent.ts
@@ -3,14 +3,21 @@
  * transport: the loopback+PKCE browser flow (`runLoopbackLogin`) or the RFC
  * 8628 device flow (`runDeviceLogin`).
  *
- * Every consent-driven command — `login`, `keys create`, `keys use`, and the
- * wizard's mint/edit/activate steps — needs the same `--device` choice, and
- * each one previously hard-wired the loopback flow plus its own eight-case
- * outcome switch. Adding a second transport per command would have meant four
- * more copies of that switch, each free to drift on which failures are fatal
- * or what remediation they name. Instead the transports are normalized here
- * into one small result type, and the per-command copy is reduced to the retry
- * hint each one wants to print.
+ * Every key ceremony — `keys create`, `keys use`, and the wizard's
+ * mint/edit/activate steps — needs the same `--device` choice, and each one
+ * previously hard-wired the loopback flow plus its own eight-case outcome
+ * switch. Adding a second transport per command would have meant three more
+ * copies of that switch, each free to drift on which failures are fatal or
+ * what remediation they name. Instead the transports are normalized here into
+ * one small result type, and the per-command copy is reduced to the retry hint
+ * each one wants to print.
+ *
+ * `login` / `login --device` deliberately do NOT route through here yet: they
+ * are two separate handlers selected by `run.ts`, predating this seam, and
+ * each still carries its own outcome switch. Folding them in means collapsing
+ * `login-device.ts` into `login.ts`, which is a bigger change than this PR's
+ * scope — but it is the obvious follow-up, and until it happens this module is
+ * the seam for the KEY ceremonies only.
  *
  * The two flows differ in what can go wrong (a browser flow can fail to bind a
  * loopback port; a device flow can have its code expire before approval), so
@@ -45,24 +52,22 @@ export interface LoopbackConsentDeps {
 export interface DeviceConsentDeps {
   readonly requestDeviceAuthorization: RequestDeviceAuthorization;
   readonly pollDeviceToken: PollDeviceToken;
-  readonly isInterrupted: () => boolean;
+  /**
+   * Creates the interrupt flag. A FACTORY, not a flag: it installs a
+   * `process.once('SIGINT')` listener, and registering one replaces Node's
+   * default terminate-on-Ctrl-C — so it must run only when a device flow is
+   * actually starting, never at a command module's top level where every
+   * `pagespace` invocation would pay for it. `runConsent` calls it inside the
+   * device branch alone.
+   */
+  readonly createIsInterrupted: () => () => boolean;
   readonly onDeviceCode: (authorization: DeviceAuthorization) => void;
   /**
-   * The device transport's OWN delay adapter, deliberately separate from
-   * `RunConsentParams.waitMs`.
-   *
-   * The two transports need opposite timer semantics and must never share one
-   * adapter. Loopback consent races its 5-minute timeout against the callback
-   * and needs `unrefWaitMs`, or the losing timer pins the event loop and hangs
-   * the CLI at exit. Device polling is a sequential loop where the delay
-   * between polls is often the ONLY live handle, so it needs the REF'd
-   * `waitMs` — an unref'd one lets Node exit right after printing the
-   * verification code, before the user has any chance to approve. See
-   * `auth/wait.ts`.
-   *
-   * Keeping it here rather than at the top level means each transport carries
-   * the timer it actually needs, so a command wiring `unrefWaitMs` for its
-   * loopback path cannot silently impose it on the device path too.
+   * The REF'd delay adapter. Device polling is a sequential loop where the
+   * delay between polls is often the only live handle, so an unref'd timer
+   * lets Node exit right after printing the verification code, before the user
+   * can approve. Named per-transport (vs `loopbackWaitMs`) so the two can
+   * never be handed the same adapter by omission. See `auth/wait.ts`.
    */
   readonly waitMs: WaitMs;
 }
@@ -77,8 +82,12 @@ export interface RunConsentParams {
   readonly exchangeCode: ExchangeCode;
   readonly confirmIdentity: ConfirmIdentity;
   readonly credentialStore: Pick<CredentialStore, 'set'>;
-  /** The LOOPBACK transport's delay adapter; the device transport carries its own (`DeviceConsentDeps.waitMs`). */
-  readonly waitMs: WaitMs;
+  /**
+   * The UNREF'd delay adapter, for the loopback flow's timeout race. Ref'ing it
+   * would pin the event loop after a successful login; the device transport
+   * needs the opposite and carries its own (`DeviceConsentDeps.waitMs`).
+   */
+  readonly loopbackWaitMs: WaitMs;
   readonly now: () => number;
   readonly timeoutMs: number;
   readonly profile?: string;
@@ -159,16 +168,17 @@ export async function runConsent(params: RunConsentParams, retryCommand: string)
   const result = params.device
     ? await runDeviceLogin({
         ...shared,
-        // The ref'd adapter — never `params.waitMs`. See DeviceConsentDeps.waitMs.
         waitMs: params.deviceDeps.waitMs,
         requestDeviceAuthorization: params.deviceDeps.requestDeviceAuthorization,
         pollDeviceToken: params.deviceDeps.pollDeviceToken,
-        isInterrupted: params.deviceDeps.isInterrupted,
+        // Installed here, and only here: the SIGINT listener must not exist
+        // for invocations that never reach a device flow.
+        isInterrupted: params.deviceDeps.createIsInterrupted(),
         onDeviceCode: params.deviceDeps.onDeviceCode,
       })
     : await runLoopbackLogin({
         ...shared,
-        waitMs: params.waitMs,
+        waitMs: params.loopbackWaitMs,
         exchangeCode: params.exchangeCode,
         randomBytes: params.loopback.randomBytes,
         startServer: params.loopback.startServer,

--- a/packages/cli/src/auth/sigint.ts
+++ b/packages/cli/src/auth/sigint.ts
@@ -1,0 +1,21 @@
+/**
+ * A one-shot "has the user hit Ctrl-C?" flag, as a plain function.
+ *
+ * The device flow polls this between waits so a cancelled `--device` command
+ * stops at the next poll boundary instead of hanging until the code expires.
+ * It is a function rather than an event emitter deliberately: `device-flow.ts`
+ * stays I/O-free and fully unit-testable, with the one `process.once` call
+ * confined here.
+ *
+ * Shared by every command that can run a device flow (`login --device`,
+ * `keys create --device`, `keys use --device`, and the wizard) — each used to
+ * need its own copy, and a copy that forgot the `once` semantics would leak a
+ * listener per invocation.
+ */
+export function createSigintFlag(): () => boolean {
+  let interrupted = false;
+  process.once('SIGINT', () => {
+    interrupted = true;
+  });
+  return () => interrupted;
+}

--- a/packages/cli/src/auth/sigint.ts
+++ b/packages/cli/src/auth/sigint.ts
@@ -11,6 +11,14 @@
  * `keys create --device`, `keys use --device`, and the wizard) — each used to
  * need its own copy, and a copy that forgot the `once` semantics would leak a
  * listener per invocation.
+ *
+ * MUST be called lazily, only once a device flow is actually starting — never
+ * at module scope. `router/routes.ts` imports every command module eagerly, so
+ * a top-level call installs the listener on EVERY `pagespace` invocation, and
+ * registering any SIGINT listener replaces Node's default terminate-on-Ctrl-C.
+ * That would make the first Ctrl-C a no-op for unrelated commands like
+ * `pagespace pages read`. `runConsent` calls this inside its device branch for
+ * exactly this reason.
  */
 export function createSigintFlag(): () => boolean {
   let interrupted = false;

--- a/packages/cli/src/auth/token-response.ts
+++ b/packages/cli/src/auth/token-response.ts
@@ -63,31 +63,38 @@ const mcpActivateResponseSchema = z.object({
  * thrown `TokenExchangeError` or a `request_failed` poll result). Pure.
  */
 export function parseTokenResponse(json: unknown): ExchangedTokens | null {
-  const mcp = mcpTokenResponseSchema.safeParse(json);
-  if (mcp.success) {
-    return { kind: 'mcp', token: mcp.data.access_token, scope: mcp.data.scope };
-  }
+  // Dispatch on the discriminant the server always sends, rather than trying
+  // each schema in turn — otherwise the overwhelmingly common `Bearer`
+  // response pays three failed parses first, and a validation failure on the
+  // RIGHT shape would be silently indistinguishable from the wrong shape.
+  const tokenType = (json as { token_type?: unknown } | null)?.token_type;
 
-  const mcpUpdate = mcpUpdateResponseSchema.safeParse(json);
-  if (mcpUpdate.success) {
-    return { kind: 'mcp_update', tokenId: mcpUpdate.data.token_id, scope: mcpUpdate.data.scope };
+  switch (tokenType) {
+    case 'mcp': {
+      const parsed = mcpTokenResponseSchema.safeParse(json);
+      return parsed.success ? { kind: 'mcp', token: parsed.data.access_token, scope: parsed.data.scope } : null;
+    }
+    case 'mcp_update': {
+      const parsed = mcpUpdateResponseSchema.safeParse(json);
+      return parsed.success ? { kind: 'mcp_update', tokenId: parsed.data.token_id, scope: parsed.data.scope } : null;
+    }
+    case 'mcp_activate': {
+      const parsed = mcpActivateResponseSchema.safeParse(json);
+      return parsed.success ? { kind: 'mcp_activate', tokenId: parsed.data.token_id, scope: parsed.data.scope } : null;
+    }
+    case 'Bearer': {
+      const parsed = oauthTokenResponseSchema.safeParse(json);
+      return parsed.success
+        ? {
+            kind: 'oauth',
+            accessToken: parsed.data.access_token,
+            refreshToken: parsed.data.refresh_token,
+            expiresIn: parsed.data.expires_in,
+            scope: parsed.data.scope,
+          }
+        : null;
+    }
+    default:
+      return null;
   }
-
-  const mcpActivate = mcpActivateResponseSchema.safeParse(json);
-  if (mcpActivate.success) {
-    return { kind: 'mcp_activate', tokenId: mcpActivate.data.token_id, scope: mcpActivate.data.scope };
-  }
-
-  const oauth = oauthTokenResponseSchema.safeParse(json);
-  if (oauth.success) {
-    return {
-      kind: 'oauth',
-      accessToken: oauth.data.access_token,
-      refreshToken: oauth.data.refresh_token,
-      expiresIn: oauth.data.expires_in,
-      scope: oauth.data.scope,
-    };
-  }
-
-  return null;
 }

--- a/packages/cli/src/auth/token-response.ts
+++ b/packages/cli/src/auth/token-response.ts
@@ -62,39 +62,37 @@ const mcpActivateResponseSchema = z.object({
  * `null` when it matches no known shape (the caller decides whether that is a
  * thrown `TokenExchangeError` or a `request_failed` poll result). Pure.
  */
-export function parseTokenResponse(json: unknown): ExchangedTokens | null {
-  // Dispatch on the discriminant the server always sends, rather than trying
-  // each schema in turn — otherwise the overwhelmingly common `Bearer`
-  // response pays three failed parses first, and a validation failure on the
-  // RIGHT shape would be silently indistinguishable from the wrong shape.
-  const tokenType = (json as { token_type?: unknown } | null)?.token_type;
+/**
+ * One schema, discriminated on the `token_type` the server always sends.
+ * Zod dispatches to the single matching member rather than trying each in
+ * turn, so a body of the RIGHT shape that fails validation can never be
+ * silently mistaken for a body of a different shape.
+ */
+const tokenResponseSchema = z.discriminatedUnion('token_type', [
+  oauthTokenResponseSchema,
+  mcpTokenResponseSchema,
+  mcpUpdateResponseSchema,
+  mcpActivateResponseSchema,
+]);
 
-  switch (tokenType) {
-    case 'mcp': {
-      const parsed = mcpTokenResponseSchema.safeParse(json);
-      return parsed.success ? { kind: 'mcp', token: parsed.data.access_token, scope: parsed.data.scope } : null;
-    }
-    case 'mcp_update': {
-      const parsed = mcpUpdateResponseSchema.safeParse(json);
-      return parsed.success ? { kind: 'mcp_update', tokenId: parsed.data.token_id, scope: parsed.data.scope } : null;
-    }
-    case 'mcp_activate': {
-      const parsed = mcpActivateResponseSchema.safeParse(json);
-      return parsed.success ? { kind: 'mcp_activate', tokenId: parsed.data.token_id, scope: parsed.data.scope } : null;
-    }
-    case 'Bearer': {
-      const parsed = oauthTokenResponseSchema.safeParse(json);
-      return parsed.success
-        ? {
-            kind: 'oauth',
-            accessToken: parsed.data.access_token,
-            refreshToken: parsed.data.refresh_token,
-            expiresIn: parsed.data.expires_in,
-            scope: parsed.data.scope,
-          }
-        : null;
-    }
-    default:
-      return null;
+export function parseTokenResponse(json: unknown): ExchangedTokens | null {
+  const parsed = tokenResponseSchema.safeParse(json);
+  if (!parsed.success) return null;
+
+  switch (parsed.data.token_type) {
+    case 'mcp':
+      return { kind: 'mcp', token: parsed.data.access_token, scope: parsed.data.scope };
+    case 'mcp_update':
+      return { kind: 'mcp_update', tokenId: parsed.data.token_id, scope: parsed.data.scope };
+    case 'mcp_activate':
+      return { kind: 'mcp_activate', tokenId: parsed.data.token_id, scope: parsed.data.scope };
+    case 'Bearer':
+      return {
+        kind: 'oauth',
+        accessToken: parsed.data.access_token,
+        refreshToken: parsed.data.refresh_token,
+        expiresIn: parsed.data.expires_in,
+        scope: parsed.data.scope,
+      };
   }
 }

--- a/packages/cli/src/auth/token-response.ts
+++ b/packages/cli/src/auth/token-response.ts
@@ -1,0 +1,93 @@
+/**
+ * The token endpoint's response contract, in one place.
+ *
+ * `apps/web/src/app/api/oauth/token/route.ts` renders the same four response
+ * shapes no matter which grant produced them — the authorization_code exchange
+ * and the RFC 8628 device poll both go through one `keyGrantSuccessResponse`
+ * helper server-side. This module is the client-side counterpart: both
+ * `exchange-code.ts` and `poll-device-token.ts` discriminate through it, so a
+ * change to the wire contract can't be applied to one grant and forgotten on
+ * the other.
+ *
+ * The four shapes, discriminated by `token_type`:
+ *
+ * - `'Bearer'` — the classic OAuth refresh/access-token pair `pagespace login`
+ *   uses, feeding `PageSpaceClient`/`OAuthTokenProvider`.
+ * - `'mcp'` — a pure drive:* grant (`pagespace keys create`): the server
+ *   minted a real `mcp_*` token instead of an OAuth grant, so there is no
+ *   `refresh_token`/`expires_in` to report — an `mcp_*` token doesn't expire
+ *   and has no refresh cycle.
+ * - `'mcp_update'` — an `update_key:<id>` grant (the wizard's Edit): the
+ *   server re-scoped an EXISTING `mcp_*` token in place and deliberately
+ *   returns no secret at all, only the verified success signal + granted
+ *   scope + which token changed.
+ * - `'mcp_activate'` — an `activate_key:<id>` approval (`pagespace keys
+ *   use`): nothing minted, nothing re-scoped, no secret returned.
+ *
+ * Callers persist these differently — an `OAuthHostCredential` vs a
+ * `StaticHostCredential` vs nothing at all — which is why the discrimination
+ * is worth doing once, precisely, rather than being re-derived per flow.
+ */
+import { z } from 'zod';
+import type { ExchangedTokens } from './loopback-flow.js';
+
+const oauthTokenResponseSchema = z.object({
+  token_type: z.literal('Bearer'),
+  access_token: z.string(),
+  expires_in: z.number(),
+  refresh_token: z.string(),
+  scope: z.string(),
+});
+
+const mcpTokenResponseSchema = z.object({
+  token_type: z.literal('mcp'),
+  access_token: z.string(),
+  scope: z.string(),
+});
+
+const mcpUpdateResponseSchema = z.object({
+  token_type: z.literal('mcp_update'),
+  token_id: z.string(),
+  scope: z.string(),
+});
+
+const mcpActivateResponseSchema = z.object({
+  token_type: z.literal('mcp_activate'),
+  token_id: z.string(),
+  scope: z.string(),
+});
+
+/**
+ * Discriminate a successful token-endpoint body into the typed union, or
+ * `null` when it matches no known shape (the caller decides whether that is a
+ * thrown `TokenExchangeError` or a `request_failed` poll result). Pure.
+ */
+export function parseTokenResponse(json: unknown): ExchangedTokens | null {
+  const mcp = mcpTokenResponseSchema.safeParse(json);
+  if (mcp.success) {
+    return { kind: 'mcp', token: mcp.data.access_token, scope: mcp.data.scope };
+  }
+
+  const mcpUpdate = mcpUpdateResponseSchema.safeParse(json);
+  if (mcpUpdate.success) {
+    return { kind: 'mcp_update', tokenId: mcpUpdate.data.token_id, scope: mcpUpdate.data.scope };
+  }
+
+  const mcpActivate = mcpActivateResponseSchema.safeParse(json);
+  if (mcpActivate.success) {
+    return { kind: 'mcp_activate', tokenId: mcpActivate.data.token_id, scope: mcpActivate.data.scope };
+  }
+
+  const oauth = oauthTokenResponseSchema.safeParse(json);
+  if (oauth.success) {
+    return {
+      kind: 'oauth',
+      accessToken: oauth.data.access_token,
+      refreshToken: oauth.data.refresh_token,
+      expiresIn: oauth.data.expires_in,
+      scope: oauth.data.scope,
+    };
+  }
+
+  return null;
+}

--- a/packages/cli/src/commands/__tests__/login-device.test.ts
+++ b/packages/cli/src/commands/__tests__/login-device.test.ts
@@ -57,7 +57,7 @@ function baseHandlerDeps(store: CredentialStore) {
     waitMs: async () => {},
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
     now: () => Date.parse('2026-07-03T00:00:00.000Z'),
-    isInterrupted: () => false,
+    createIsInterrupted: () => () => false,
   };
 }
 
@@ -195,7 +195,7 @@ describe('createLoginDeviceHandler', () => {
       ['access_denied', { pollDeviceToken: async () => ({ kind: 'access_denied' }) }, /denied/i],
       ['expired_token', { pollDeviceToken: async () => ({ kind: 'expired_token' }) }, /expired|again/i],
       ['poll_failed', { pollDeviceToken: async () => ({ kind: 'request_failed', message: 'boom' }) }, /boom/],
-      ['interrupted', { isInterrupted: () => true }, /cancel/i],
+      ['interrupted', { createIsInterrupted: () => () => true }, /cancel/i],
     ];
 
     for (const [, overrides, message] of cases) {

--- a/packages/cli/src/commands/__tests__/whoami.test.ts
+++ b/packages/cli/src/commands/__tests__/whoami.test.ts
@@ -49,6 +49,7 @@ function baseDeps(store: CredentialStore) {
     }),
     createRefreshAccessToken: () => async () => REFRESHED,
     confirmIdentity: async () => IDENTITY,
+    probeDriveCount: async () => 3,
     now: () => Date.parse('2026-07-03T00:00:00.000Z'),
   };
 }
@@ -86,10 +87,16 @@ describe('createWhoamiHandler', () => {
       email: 'ada@example.com',
       scopes: ['account', 'offline_access'],
       activeKey: null,
+      source: 'stored',
+      sourceLabel: 'personal login',
+      keyName: 'default',
+      tokenPrefix: null,
+      driveCount: null,
+      personalLogin: null,
     });
   });
 
-  it('shows the active key when one is set for the resolved host — human line and --json field', async () => {
+  it('reports the ACTIVE KEY as the source when one is set for the resolved host — human line and --json field', async () => {
     const store = fakeStore(new Map([['https://pagespace.ai', CREDENTIAL]]));
     const handler = createWhoamiHandler(baseDeps(store));
 
@@ -100,7 +107,7 @@ describe('createWhoamiHandler', () => {
       activeKeyStore: createFakeActiveKeyStore({ 'https://pagespace.ai': 'agent' }),
     });
     expect(await handler(humanCtx, commandIntent(['whoami']))).toBe(EXIT_SUCCESS);
-    expect(humanStdout.lines.join('')).toContain('Active key: agent');
+    expect(humanStdout.lines.join('')).toContain('Source: active key "agent"');
 
     const jsonStdout = createRecordingSink();
     const jsonCtx = createFakeContext({
@@ -112,7 +119,7 @@ describe('createWhoamiHandler', () => {
     expect(JSON.parse(jsonStdout.lines.join('')).activeKey).toBe('agent');
   });
 
-  it('never prints an Active key line when none is set (or it is set for a different host)', async () => {
+  it('never reports an active key when none is set (or it is set for a different host)', async () => {
     const store = fakeStore(new Map([['https://pagespace.ai', CREDENTIAL]]));
     const handler = createWhoamiHandler(baseDeps(store));
 
@@ -123,10 +130,60 @@ describe('createWhoamiHandler', () => {
       activeKeyStore: createFakeActiveKeyStore({ 'https://other.example': 'agent' }),
     });
     expect(await handler(ctx, commandIntent(['whoami']))).toBe(EXIT_SUCCESS);
-    expect(stdout.lines.join('')).not.toContain('Active key:');
+    expect(stdout.lines.join('')).not.toContain('active key');
   });
 
-  it('exits 1 with "not logged in" and does not prompt when no credential is stored', async () => {
+  // The exact machine state this command used to get wrong: a scoped key
+  // activated with `pagespace keys use`, no personal login at all. Every
+  // content command works; whoami said "Not logged in to ...".
+  it('reports a working active key even when the "default" login slot is empty, and exits 0', async () => {
+    const hosts = new Map<string, Map<string, HostCredential>>();
+    const activeCredential: HostCredential = {
+      kind: 'static',
+      token: 'mcp_activekey123',
+      scopes: ['all_drives', 'offline_access'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    hosts.set('https://pagespace.ai', new Map([['ALL', activeCredential]]));
+    const store: CredentialStore = {
+      get: async (host, profile = 'default') => hosts.get(host)?.get(profile) ?? null,
+      set: async () => {},
+      delete: async () => {},
+      list: async () => [],
+    };
+    const handler = createWhoamiHandler({ ...baseDeps(store), probeDriveCount: async () => 14 });
+
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({
+      stdout,
+      env: {},
+      activeKeyStore: createFakeActiveKeyStore({ 'https://pagespace.ai': 'ALL' }),
+    });
+    const code = await handler(ctx, commandIntent(['whoami']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    const output = stdout.lines.join('');
+    expect(output).toContain('Source: active key "ALL"');
+    expect(output).toContain('all_drives');
+    expect(output).toContain('Drives: 14 accessible');
+    expect(output).toContain('Personal login: none');
+    expect(output).not.toMatch(/not logged in/i);
+  });
+
+  it('reports a --token / PAGESPACE_TOKEN credential instead of ignoring it for the stored "default" slot', async () => {
+    const handler = createWhoamiHandler({ ...baseDeps(fakeStore()), probeDriveCount: async () => 2 });
+
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, env: {} });
+    const code = await handler(ctx, commandIntent(['whoami', '--token', 'mcp_flagtoken']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    const output = stdout.lines.join('');
+    expect(output).toContain('Source: --token flag');
+    expect(output).toContain('Drives: 2 accessible');
+  });
+
+  it('exits 1 with an actionable message and does not prompt when no credential resolves at all', async () => {
     const store = fakeStore();
     let refreshCalls = 0;
     const handler = createWhoamiHandler({
@@ -143,7 +200,8 @@ describe('createWhoamiHandler', () => {
 
     expect(code).toBe(EXIT_RUNTIME_ERROR);
     expect(refreshCalls).toBe(0);
-    expect(stderr.lines.join('')).toMatch(/not logged in/i);
+    expect(stderr.lines.join('')).toMatch(/no credential resolved/i);
+    expect(stderr.lines.join('')).toContain('pagespace login');
   });
 
   it('persists the rotated refresh token BEFORE using the new access token to confirm identity', async () => {
@@ -247,7 +305,7 @@ describe('createWhoamiHandler', () => {
     expect(credentialSecret((await store.get('https://pagespace.ai', 'work'))!)).toBe(REFRESHED.refreshToken);
   });
 
-  it('exits 1 "not logged in" when only a different key is stored for the host', async () => {
+  it('exits 1 when --key names a slot with nothing stored, even though another key IS stored for the host', async () => {
     const hosts = new Map<string, Map<string, HostCredential>>();
     hosts.set('https://pagespace.ai', new Map([['default', CREDENTIAL]]));
     const store: CredentialStore = {
@@ -263,7 +321,55 @@ describe('createWhoamiHandler', () => {
     const code = await handler(ctx, commandIntent(['whoami', '--key', 'work']));
 
     expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(stderr.lines.join('')).toMatch(/not logged in/i);
+    // Must name the key the user asked for, not the "default" one that happens
+    // to be stored.
+    expect(stderr.lines.join('')).toContain('under key "work"');
+  });
+
+  it('blames the requested --key, not a dangling active key that this invocation never consulted', async () => {
+    const handler = createWhoamiHandler(baseDeps(fakeStore()));
+
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({
+      stderr,
+      env: {},
+      activeKeyStore: createFakeActiveKeyStore({ 'https://pagespace.ai': 'ALL' }),
+    });
+    const code = await handler(ctx, commandIntent(['whoami', '--key', 'nope']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const err = stderr.lines.join('');
+    expect(err).toContain('under key "nope"');
+    expect(err).not.toContain('ALL');
+  });
+
+  it('strips the name:<...> mint plumbing token from the human Scopes line but keeps it in --json', async () => {
+    const named: HostCredential = {
+      kind: 'static',
+      token: 'mcp_named',
+      scopes: ['name:ALL', 'all_drives', 'offline_access'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+    };
+    const store = fakeStore(new Map([['https://pagespace.ai', named]]));
+    const handler = createWhoamiHandler({
+      ...baseDeps(store),
+      confirmIdentity: async () => {
+        throw new Error('must not be called for an mcp_* token');
+      },
+    });
+
+    const humanStdout = createRecordingSink();
+    expect(await handler(createFakeContext({ stdout: humanStdout, env: {} }), commandIntent(['whoami']))).toBe(
+      EXIT_SUCCESS,
+    );
+    expect(humanStdout.lines.join('')).toContain('Scopes: all_drives offline_access');
+    expect(humanStdout.lines.join('')).not.toContain('name:ALL');
+
+    const jsonStdout = createRecordingSink();
+    expect(
+      await handler(createFakeContext({ stdout: jsonStdout, env: {} }), commandIntent(['whoami', '--json'])),
+    ).toBe(EXIT_SUCCESS);
+    expect(JSON.parse(jsonStdout.lines.join('')).scopes).toEqual(['name:ALL', 'all_drives', 'offline_access']);
   });
 
   it('never writes the access or refresh token to stdout/stderr on success', async () => {
@@ -281,11 +387,15 @@ describe('createWhoamiHandler', () => {
     expect(allOutput).not.toContain(CREDENTIAL.refreshToken);
   });
 
-  it('a static (mcp) credential reports its own stored scopes directly and confirms identity with its token — no refresh grant, no discovery, no store write', async () => {
+  // `/api/auth/me` deliberately refuses `mcp_*` tokens (a scoped key is its
+  // own principal and must not surface the owner's email), so asking it for an
+  // identity could only ever 401 — which is exactly what whoami used to do,
+  // reporting a live key as "invalidated".
+  it('a static (mcp) credential reports its stored scopes and proves liveness with a drives probe — never an identity call, no refresh grant, no discovery, no store write', async () => {
     const staticCredential: HostCredential = { kind: 'static', token: 'mcp_abc123', scopes: ['drive:d1:member', 'offline_access'], createdAt: '2026-01-01T00:00:00.000Z' };
     const store = fakeStore(new Map([['https://pagespace.ai', staticCredential]]));
     let discoverCalls = 0;
-    let confirmIdentityAccessToken: string | undefined;
+    let probeAccessToken: string | undefined;
     const setCalls: unknown[] = [];
     const wrappedStore: CredentialStore = {
       ...store,
@@ -303,9 +413,12 @@ describe('createWhoamiHandler', () => {
       createRefreshAccessToken: () => {
         throw new Error('must not be called for a static credential — mcp_* tokens never refresh');
       },
-      confirmIdentity: async ({ accessToken }) => {
-        confirmIdentityAccessToken = accessToken;
-        return IDENTITY;
+      confirmIdentity: async () => {
+        throw new Error('must not be called for an mcp_* token — /api/auth/me refuses it by design');
+      },
+      probeDriveCount: async ({ accessToken }) => {
+        probeAccessToken = accessToken;
+        return 7;
       },
       now: () => Date.parse('2026-07-03T00:00:00.000Z'),
     });
@@ -317,8 +430,34 @@ describe('createWhoamiHandler', () => {
     expect(code).toBe(EXIT_SUCCESS);
     expect(discoverCalls).toBe(0);
     expect(setCalls).toEqual([]);
-    expect(confirmIdentityAccessToken).toBe('mcp_abc123');
+    expect(probeAccessToken).toBe('mcp_abc123');
     const parsed = JSON.parse(stdout.lines.join(''));
     expect(parsed.scopes).toEqual(['drive:d1:member', 'offline_access']);
+    expect(parsed.driveCount).toBe(7);
+    expect(parsed.name).toBeNull();
+  });
+
+  it('exits 1 pointing at re-minting (not re-login) when a static key is rejected by the probe', async () => {
+    const staticCredential: HostCredential = { kind: 'static', token: 'mcp_revoked', scopes: ['drive:d1:member'], createdAt: '2026-01-01T00:00:00.000Z' };
+    const store = fakeStore(new Map([['https://pagespace.ai', staticCredential]]));
+    const handler = createWhoamiHandler({
+      ...baseDeps(store),
+      confirmIdentity: async () => {
+        throw new Error('must not be called for an mcp_* token');
+      },
+      probeDriveCount: async () => {
+        throw new Error('401 Unauthorized');
+      },
+    });
+
+    const stderr = createRecordingSink();
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, stderr, env: {} });
+    const code = await handler(ctx, commandIntent(['whoami']));
+
+    expect(code).toBe(EXIT_RUNTIME_ERROR);
+    const err = stderr.lines.join('');
+    expect(err).toContain('keys create');
+    expect(err).not.toContain('mcp_revoked');
   });
 });

--- a/packages/cli/src/commands/help.ts
+++ b/packages/cli/src/commands/help.ts
@@ -20,6 +20,7 @@ const GLOBAL_FLAG_LINES = [
   '  --host <url>    Override the API host',
   '  --token <tok>   Override the credential',
   `  --key <name>    Use a stored key by name (env: ${KEY_ENV_VAR_NAME})`,
+  '  --device        Approve on another device via a code, without a local browser',
   '  --yes           Assume yes to confirmation prompts',
   '  --all           Apply to every stored credential (logout)',
   '  --force         Proceed despite a non-fatal failure (logout)',

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -397,7 +397,7 @@ function baseHandlerDeps(store: CredentialStore) {
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
     requestDeviceAuthorization: async () => DEVICE_AUTHORIZATION,
     pollDeviceToken: async () => ({ kind: 'success' as const, tokens: FIXED_MCP_TOKENS }),
-    isInterrupted: () => false,
+    createIsInterrupted: () => () => false,
     deviceWaitMs: async () => {},
     now: () => Date.parse('2026-07-03T00:00:00.000Z'),
   };

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -398,6 +398,7 @@ function baseHandlerDeps(store: CredentialStore) {
     requestDeviceAuthorization: async () => DEVICE_AUTHORIZATION,
     pollDeviceToken: async () => ({ kind: 'success' as const, tokens: FIXED_MCP_TOKENS }),
     isInterrupted: () => false,
+    deviceWaitMs: async () => {},
     now: () => Date.parse('2026-07-03T00:00:00.000Z'),
   };
 }

--- a/packages/cli/src/commands/keys/__tests__/create.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/create.test.ts
@@ -388,15 +388,34 @@ function baseHandlerDeps(store: CredentialStore) {
     discoverMetadata: async () => ({
       authorizationEndpoint: 'https://pagespace.ai/api/oauth/authorize',
       tokenEndpoint: 'https://pagespace.ai/api/oauth/token',
+      deviceAuthorizationEndpoint: 'https://pagespace.ai/api/oauth/device_authorization',
     }),
     startServer: async () => fakeServer().server,
     openBrowser: async () => true,
     waitMs: () => new Promise<void>(() => {}),
     exchangeCode: async () => FIXED_TOKENS,
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+    requestDeviceAuthorization: async () => DEVICE_AUTHORIZATION,
+    pollDeviceToken: async () => ({ kind: 'success' as const, tokens: FIXED_MCP_TOKENS }),
+    isInterrupted: () => false,
     now: () => Date.parse('2026-07-03T00:00:00.000Z'),
   };
 }
+
+const DEVICE_AUTHORIZATION = {
+  deviceCode: 'ps_dc_test',
+  userCode: 'ABCD-EFGH',
+  verificationUri: 'https://pagespace.ai/activate',
+  verificationUriComplete: 'https://pagespace.ai/activate?user_code=ABCD-EFGH',
+  expiresInSeconds: 900,
+  intervalSeconds: 5,
+};
+
+const FIXED_MCP_TOKENS = {
+  kind: 'mcp' as const,
+  token: 'mcp_device_minted',
+  scope: 'drive:drv1:member name:remote-key offline_access',
+};
 
 function autoApprove(fake: ReturnType<typeof fakeServer>) {
   return async (url: string) => {
@@ -710,7 +729,7 @@ describe('createTokensCreateHandler', () => {
     const code = await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']));
 
     expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(stderr.lines.join('')).toMatch(/consent was denied/i);
+    expect(stderr.lines.join('')).toMatch(/access was denied/i);
     expect(await store.get('https://pagespace.ai', 'drv1')).toBeNull();
     const allOutput = [...stdout.lines, ...stderr.lines].join('');
     expect(allOutput).not.toContain(FIXED_TOKENS.accessToken);
@@ -732,7 +751,7 @@ describe('createTokensCreateHandler', () => {
     const code = await handler(ctx, commandIntent(['keys', 'create', '--drive', 'drv1', '--role', 'member']));
 
     expect(code).toBe(EXIT_RUNTIME_ERROR);
-    expect(stderr.lines.join('')).toMatch(/consent timed out/i);
+    expect(stderr.lines.join('')).toMatch(/timed out waiting for approval/i);
     expect(await store.get('https://pagespace.ai', 'drv1')).toBeNull();
   });
 
@@ -974,5 +993,98 @@ describe('createTokensCreateHandler', () => {
     expect(code).toBe(EXIT_RUNTIME_ERROR);
     expect(stderr.lines.join('')).toMatch(/could not bind a local loopback port/i);
     expect(await store.get('https://pagespace.ai', 'drv1')).toBeNull();
+  });
+});
+
+// The shared fixture's `waitMs` never resolves — the loopback tests use it to
+// hold the flow open at the redirect wait. The device flow genuinely sleeps
+// between polls, so these tests need a real (instant) one.
+function deviceHandlerDeps(store: CredentialStore) {
+  return { ...baseHandlerDeps(store), waitMs: async () => {} };
+}
+
+describe('createTokensCreateHandler — --device', () => {
+  it('mints through the device flow without opening a browser, printing the verification code', async () => {
+    const store = fakeStore();
+    let browserOpened = false;
+    let deviceScope: string | undefined;
+    const handler = createTokensCreateHandler({
+      ...deviceHandlerDeps(store),
+      openBrowser: async () => {
+        browserOpened = true;
+        return true;
+      },
+      requestDeviceAuthorization: async ({ scope }) => {
+        deviceScope = scope;
+        return DEVICE_AUTHORIZATION;
+      },
+    });
+    const stdout = createRecordingSink();
+    const ctx = createFakeContext({ stdout, env: {} });
+
+    const code = await handler(
+      ctx,
+      commandIntent(['keys', 'create', '--device', '--drive', 'drv1', '--role', 'member', '--name', 'remote-key']),
+    );
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(browserOpened).toBe(false);
+    const output = stdout.lines.join('');
+    expect(output).toContain('ABCD-EFGH');
+    expect(output).toContain('https://pagespace.ai/activate');
+    expect(output).not.toContain('Opening your browser');
+    // The mint request must carry the name the server now requires.
+    expect(deviceScope).toContain('name:remote-key');
+    // Persisted under the key's own name, as a static credential.
+    const stored = await store.get('https://pagespace.ai', 'remote-key');
+    expect(stored?.kind).toBe('static');
+    expect(credentialSecret(stored!)).toBe('mcp_device_minted');
+  });
+
+  it('rejects --device with --all-drives as a usage error, naming the browser workaround', async () => {
+    const store = fakeStore();
+    let deviceRequested = false;
+    const handler = createTokensCreateHandler({
+      ...deviceHandlerDeps(store),
+      requestDeviceAuthorization: async () => {
+        deviceRequested = true;
+        return DEVICE_AUTHORIZATION;
+      },
+    });
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stderr, env: {} });
+
+    const code = await handler(
+      ctx,
+      commandIntent(['keys', 'create', '--device', '--all-drives', '--name', 'everything', '--yes']),
+    );
+
+    expect(code).toBe(EXIT_USAGE_ERROR);
+    expect(deviceRequested).toBe(false);
+    const err = stderr.lines.join('');
+    expect(err).toContain('--all-drives cannot be combined with --device');
+    expect(err).toContain('browser');
+  });
+
+  it('keeps the --show-token stdout contract (exactly one line) in device mode', async () => {
+    const store = fakeStore();
+    const handler = createTokensCreateHandler(deviceHandlerDeps(store));
+    const stdout = createRecordingSink();
+    const stderr = createRecordingSink();
+    const ctx = createFakeContext({ stdout, stderr, env: {} });
+
+    const code = await handler(
+      ctx,
+      commandIntent([
+        'keys', 'create', '--device', '--drive', 'drv1', '--role', 'member', '--name', 'remote-key', '--show-token',
+      ]),
+    );
+
+    expect(code).toBe(EXIT_SUCCESS);
+    // The verification code goes to stderr in --show-token mode, keeping
+    // stdout to the single machine-readable assignment.
+    expect(stdout.lines.join('').trim().split('\n')).toHaveLength(1);
+    expect(stdout.lines.join('')).toContain('mcp_device_minted');
+    expect(stderr.lines.join('')).toContain('ABCD-EFGH');
   });
 });

--- a/packages/cli/src/commands/keys/__tests__/use.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/use.test.ts
@@ -133,7 +133,7 @@ function baseDeps(store: CredentialStore, fake = fakeLoopbackServer()) {
       pollDeviceToken: async () => {
         throw new Error('device flow not exercised by this test — loopback transport expected');
       },
-      isInterrupted: () => false,
+      createIsInterrupted: () => () => false,
       deviceWaitMs: async () => {},
       now: () => Date.parse('2026-07-07T00:00:00.000Z'),
     },

--- a/packages/cli/src/commands/keys/__tests__/use.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/use.test.ts
@@ -134,6 +134,7 @@ function baseDeps(store: CredentialStore, fake = fakeLoopbackServer()) {
         throw new Error('device flow not exercised by this test — loopback transport expected');
       },
       isInterrupted: () => false,
+      deviceWaitMs: async () => {},
       now: () => Date.parse('2026-07-07T00:00:00.000Z'),
     },
   };

--- a/packages/cli/src/commands/keys/__tests__/use.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/use.test.ts
@@ -127,6 +127,13 @@ function baseDeps(store: CredentialStore, fake = fakeLoopbackServer()) {
       waitMs: () => new Promise<void>(() => {}),
       exchangeCode: async () => ({ kind: 'mcp_activate' as const, tokenId: 'tok1', scope: 'activate_key:tok1' }),
       confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+      requestDeviceAuthorization: async () => {
+        throw new Error('device flow not exercised by this test — loopback transport expected');
+      },
+      pollDeviceToken: async () => {
+        throw new Error('device flow not exercised by this test — loopback transport expected');
+      },
+      isInterrupted: () => false,
       now: () => Date.parse('2026-07-07T00:00:00.000Z'),
     },
   };

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -119,7 +119,7 @@ function baseMintDeps(store: CredentialStore) {
     pollDeviceToken: async () => {
       throw new Error('device flow not exercised by this test — loopback transport expected');
     },
-    isInterrupted: () => false,
+    createIsInterrupted: () => () => false,
     deviceWaitMs: async () => {},
     now: () => Date.parse('2026-07-06T00:00:00.000Z'),
   };
@@ -805,7 +805,7 @@ describe('createKeysHandler — --device', () => {
         };
       },
       pollDeviceToken: async () => pollResult,
-      isInterrupted: () => false,
+      createIsInterrupted: () => () => false,
       deviceWaitMs: async () => {},
       discoverMetadata: async () => ({
         authorizationEndpoint: 'https://pagespace.ai/api/oauth/authorize',

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { PageSpaceClient } from '@pagespace/sdk';
-import type { CredentialStore, HostCredential, LoopbackCallback, LoopbackServer } from '@pagespace/cli';
+import type { CredentialStore, DeviceTokenResult, HostCredential, LoopbackCallback, LoopbackServer } from '@pagespace/cli';
 import { parseArgv } from '../../../argv/parse.js';
 import type { CommandIntent } from '../../../argv/parse.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS, EXIT_USAGE_ERROR } from '../../../exit-codes.js';
@@ -120,6 +120,7 @@ function baseMintDeps(store: CredentialStore) {
       throw new Error('device flow not exercised by this test — loopback transport expected');
     },
     isInterrupted: () => false,
+    deviceWaitMs: async () => {},
     now: () => Date.parse('2026-07-06T00:00:00.000Z'),
   };
 }
@@ -766,5 +767,143 @@ describe('createKeysHandler — Revoke flow', () => {
 
     expect(code).toBe(EXIT_SUCCESS);
     expect(tokensRevoke).toHaveBeenCalledWith({ tokenId: 'tok1' });
+  });
+});
+
+/**
+ * Regression guard: the wizard used to wire the device adapters into its deps
+ * but never read `intent.flags.device`, so `pagespace keys --device` still
+ * opened a local browser for every ceremony — and Edit, which exists ONLY in
+ * the wizard, had no headless path at all.
+ */
+describe('createKeysHandler — --device', () => {
+  const DRIVE_ROW = { id: 'drv1', name: 'Engineering', slug: 'eng', ownerId: 'u1', kind: 'STANDARD', isTrashed: false, trashedAt: null, drivePrompt: null, createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', isOwned: true, role: 'OWNER', lastAccessedAt: null, homePageId: null };
+  const MCP_TOKENS = { kind: 'mcp' as const, token: 'mcp_device_tok', scope: 'drive:drv1:member name:my-key offline_access' };
+
+  function deviceSetup(pollResult: DeviceTokenResult) {
+    const store = fakeStore();
+    let browserOpened = false;
+    let deviceScope: string | undefined;
+    const deps = {
+      ...baseMintDeps(store),
+      openBrowser: async () => {
+        browserOpened = true;
+        return true;
+      },
+      startServer: async () => {
+        throw new Error('loopback server must not start in device mode');
+      },
+      requestDeviceAuthorization: async ({ scope }: { scope: string }) => {
+        deviceScope = scope;
+        return {
+          deviceCode: 'ps_dc_test',
+          userCode: 'ABCD-EFGH',
+          verificationUri: 'https://pagespace.ai/activate',
+          verificationUriComplete: 'https://pagespace.ai/activate?user_code=ABCD-EFGH',
+          expiresInSeconds: 900,
+          intervalSeconds: 5,
+        };
+      },
+      pollDeviceToken: async () => pollResult,
+      isInterrupted: () => false,
+      deviceWaitMs: async () => {},
+      discoverMetadata: async () => ({
+        authorizationEndpoint: 'https://pagespace.ai/api/oauth/authorize',
+        tokenEndpoint: 'https://pagespace.ai/api/oauth/token',
+        deviceAuthorizationEndpoint: 'https://pagespace.ai/api/oauth/device_authorization',
+      }),
+    };
+    return { deps, store, browserOpened: () => browserOpened, deviceScope: () => deviceScope };
+  }
+
+  it('Create mints over the device transport and never opens a browser', async () => {
+    selectMock
+      .mockReset()
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('specific')
+      .mockResolvedValueOnce({ kind: 'member' })
+      .mockResolvedValueOnce('exit');
+    multiselectMock.mockReset().mockResolvedValueOnce(['drv1']);
+    textMock.mockReset().mockResolvedValueOnce('my-key');
+    confirmMock.mockReset().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    spinnerHandle.message.mockReset();
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const setup = deviceSetup({ kind: 'success', tokens: MCP_TOKENS });
+    const sdk = fakeSdk({ drivesList: vi.fn(async () => [DRIVE_ROW]), tokensList: vi.fn(async () => []) });
+    const handler = createKeysHandler(setup.deps);
+
+    const code = await handler(createFakeContext({ sdk, isTTY: true, env: {} }), commandIntent(['keys', '--device']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(setup.browserOpened()).toBe(false);
+    expect(setup.deviceScope()).toContain('name:my-key');
+    // The verification code reaches the user through the spinner, since clack
+    // owns the terminal while a ceremony is pending.
+    const messages = spinnerHandle.message.mock.calls.map((call) => String(call[0]));
+    expect(messages.some((m) => m.includes('ABCD-EFGH'))).toBe(true);
+    expect(credentialSecret((await setup.store.get('https://pagespace.ai', 'my-key'))!)).toBe('mcp_device_tok');
+  });
+
+  it('Edit — the wizard-only ceremony — re-scopes over the device transport', async () => {
+    const KEY = { id: 'tok1', name: 'my-key', tokenPrefix: 'mcp_abc', driveScopes: [{ id: 'drv1', name: 'Engineering' }], createdAt: '2026-01-01T00:00:00.000Z', lastUsed: null, isScoped: true };
+    selectMock
+      .mockReset()
+      .mockResolvedValueOnce('edit')
+      .mockResolvedValueOnce('tok1')
+      .mockResolvedValueOnce({ kind: 'member' })
+      .mockResolvedValueOnce('exit');
+    multiselectMock.mockReset().mockResolvedValueOnce(['drv1']);
+    confirmMock.mockReset().mockResolvedValue(true);
+    spinnerHandle.message.mockReset();
+    spinnerHandle.error.mockReset();
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const setup = deviceSetup({
+      kind: 'success',
+      tokens: { kind: 'mcp_update', tokenId: 'tok1', scope: 'update_key:tok1 drive:drv1:member' },
+    });
+    const sdk = fakeSdk({ drivesList: vi.fn(async () => [DRIVE_ROW]), tokensList: vi.fn(async () => [KEY]) });
+    const handler = createKeysHandler(setup.deps);
+
+    const code = await handler(createFakeContext({ sdk, isTTY: true, env: {} }), commandIntent(['keys', '--device']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(setup.browserOpened()).toBe(false);
+    expect(setup.deviceScope()).toContain('update_key:tok1');
+    expect(spinnerHandle.error).not.toHaveBeenCalled();
+  });
+
+  it('without --device the wizard still uses the browser transport', async () => {
+    selectMock
+      .mockReset()
+      .mockResolvedValueOnce('create')
+      .mockResolvedValueOnce('specific')
+      .mockResolvedValueOnce({ kind: 'member' })
+      .mockResolvedValueOnce('exit');
+    multiselectMock.mockReset().mockResolvedValueOnce(['drv1']);
+    textMock.mockReset().mockResolvedValueOnce('my-key');
+    confirmMock.mockReset().mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const { createKeysHandler } = await import('../wizard.js');
+    const store = fakeStore();
+    const fake = fakeLoopbackServer();
+    let deviceRequested = false;
+    const deps = {
+      ...baseMintDeps(store),
+      startServer: async () => fake.server,
+      openBrowser: autoApprove(fake),
+      exchangeCode: async () => MCP_TOKENS,
+      requestDeviceAuthorization: async () => {
+        deviceRequested = true;
+        throw new Error('device transport must not be used without --device');
+      },
+    };
+    const sdk = fakeSdk({ drivesList: vi.fn(async () => [DRIVE_ROW]), tokensList: vi.fn(async () => []) });
+
+    const code = await createKeysHandler(deps)(createFakeContext({ sdk, isTTY: true, env: {} }), commandIntent(['keys']));
+
+    expect(code).toBe(EXIT_SUCCESS);
+    expect(deviceRequested).toBe(false);
   });
 });

--- a/packages/cli/src/commands/keys/__tests__/wizard.test.ts
+++ b/packages/cli/src/commands/keys/__tests__/wizard.test.ts
@@ -113,6 +113,13 @@ function baseMintDeps(store: CredentialStore) {
     waitMs: () => new Promise<void>(() => {}),
     exchangeCode: async () => FIXED_TOKENS,
     confirmIdentity: async () => ({ name: 'Ada Lovelace', email: 'ada@example.com' }),
+    requestDeviceAuthorization: async () => {
+      throw new Error('device flow not exercised by this test — loopback transport expected');
+    },
+    pollDeviceToken: async () => {
+      throw new Error('device flow not exercised by this test — loopback transport expected');
+    },
+    isInterrupted: () => false,
     now: () => Date.parse('2026-07-06T00:00:00.000Z'),
   };
 }

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -35,7 +35,11 @@ import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
 import { unrefWaitMs } from '../../auth/wait.js';
-import { runLoopbackLogin } from '../../auth/loopback-flow.js';
+import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
+import { createPollDeviceToken } from '../../auth/poll-device-token.js';
+import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
+import { createSigintFlag } from '../../auth/sigint.js';
+import type { PollDeviceToken, RequestDeviceAuthorization } from '../../auth/device-flow.js';
 import { DEFAULT_LOGIN_TIMEOUT_MS, DEFAULT_MAX_PORT_ATTEMPTS } from '../login.js';
 import type {
   ConfirmIdentity,
@@ -246,6 +250,9 @@ export interface TokensCreateHandlerDeps {
   readonly waitMs: WaitMs;
   readonly exchangeCode: ExchangeCode;
   readonly confirmIdentity: ConfirmIdentity;
+  readonly requestDeviceAuthorization: RequestDeviceAuthorization;
+  readonly pollDeviceToken: PollDeviceToken;
+  readonly isInterrupted: () => boolean;
   readonly now: () => number;
   readonly timeoutMs?: number;
   readonly maxPortAttempts?: number;
@@ -269,6 +276,20 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
     const structuralCheck = buildTokenScope(parsedArgs.args.drives, { allDrives: parsedArgs.args.allDrives });
     if (!structuralCheck.ok) {
       ctx.stderr.write(`${structuralCheck.message}\n`);
+      return EXIT_USAGE_ERROR;
+    }
+
+    // The server refuses an all_drives grant at the device door — such a key
+    // can only be minted unambiguously through the authorization-code
+    // exchange (see apps/web/src/app/api/oauth/device_authorization/route.ts).
+    // Caught locally so the user gets the reason and the workaround up front,
+    // instead of an opaque invalid_scope after typing a code into a browser.
+    if (parsedArgs.args.allDrives && intent.flags.device) {
+      ctx.stderr.write(
+        '--all-drives cannot be combined with --device: an all-drives key must be approved through the browser flow. ' +
+          'Run "pagespace keys create --all-drives --name <name>" on a machine with a browser, or scope the key to ' +
+          'specific drives with --drive to use --device.\n',
+      );
       return EXIT_USAGE_ERROR;
     }
 
@@ -326,79 +347,71 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
     // ordinary informational role.
     const info: OutputSink = parsedArgs.args.showToken ? ctx.stderr : ctx.stdout;
 
-    info.write(`Opening your browser to approve access for key "${keyName}" on ${host}...\n`);
+    if (!intent.flags.device) {
+      info.write(`Opening your browser to approve access for key "${keyName}" on ${host}...\n`);
+    }
 
     // Captured, never printed inline: the callback fires mid-flow, and the
     // token must only ever surface behind the explicit --show-token opt-in.
     let mintedToken: string | null = null;
 
-    const result = await runLoopbackLogin({
-      host,
-      clientId: PAGESPACE_CLI_CLIENT_ID,
-      scope: scopeResult.scope,
-      randomBytes: deps.randomBytes,
-      discoverMetadata: deps.discoverMetadata,
-      startServer: deps.startServer,
-      maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
-      openBrowser: deps.openBrowser,
-      onBrowserOpenFailed: (url) => {
-        ctx.stderr.write(`Could not open a browser automatically. Open this URL to continue:\n${url}\n`);
+    const result = await runConsent(
+      {
+        device: intent.flags.device,
+        host,
+        clientId: PAGESPACE_CLI_CLIENT_ID,
+        scope: scopeResult.scope,
+        discoverMetadata: deps.discoverMetadata,
+        exchangeCode: deps.exchangeCode,
+        confirmIdentity: deps.confirmIdentity,
+        credentialStore: store,
+        waitMs: deps.waitMs,
+        now: deps.now,
+        timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
+        profile: keyName,
+        onMintedStaticToken: (token) => {
+          mintedToken = token;
+        },
+        loopback: {
+          randomBytes: deps.randomBytes,
+          startServer: deps.startServer,
+          openBrowser: deps.openBrowser,
+          maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
+          onBrowserOpenFailed: (url) => {
+            ctx.stderr.write(`Could not open a browser automatically. Open this URL to continue:\n${url}\n`);
+          },
+        },
+        deviceDeps: {
+          requestDeviceAuthorization: deps.requestDeviceAuthorization,
+          pollDeviceToken: deps.pollDeviceToken,
+          isInterrupted: deps.isInterrupted,
+          onDeviceCode: (authorization) => {
+            // Routed through `info` so --show-token's one-line stdout contract
+            // holds for the device flow too.
+            info.write(`${renderDeviceCodePrompt(authorization).join('\n')}\n`);
+          },
+        },
       },
-      waitMs: deps.waitMs,
-      timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
-      exchangeCode: deps.exchangeCode,
-      confirmIdentity: deps.confirmIdentity,
-      credentialStore: store,
-      now: deps.now,
-      profile: keyName,
-      onMintedStaticToken: (token) => {
-        mintedToken = token;
-      },
-    });
+      `pagespace keys create${intent.flags.device ? ' --device' : ''}`,
+    );
 
-    switch (result.outcome) {
-      case 'success': {
-        info.write(`Created key "${keyName}" on ${host}, scoped to: ${scopeResult.driveScope}.\n`);
-        if (parsedArgs.args.showToken) {
-          if (mintedToken !== null) {
-            // The ONLY stdout line in --show-token mode (see `info` above).
-            ctx.stdout.write(`${TOKEN_ENV_VAR_NAME}=${mintedToken}\n`);
-            ctx.stderr.write("This token is shown once and never again. Anyone holding it gets this key's access.\n");
-          } else {
-            ctx.stderr.write('--show-token: no raw token to show — the server returned a refresh credential instead of a static token.\n');
-          }
-        }
-        info.write(`${renderAgentWiringGuidance({ keyName, host }).join('\n')}\n`);
-        return EXIT_SUCCESS;
-      }
-      case 'timeout':
-        ctx.stderr.write('Consent timed out waiting for the browser redirect. Run "pagespace keys create" again.\n');
-        return EXIT_RUNTIME_ERROR;
-      case 'state_mismatch':
-        ctx.stderr.write(
-          'Consent failed: the authorization response did not match this request. Run "pagespace keys create" again.\n',
-        );
-        return EXIT_RUNTIME_ERROR;
-      case 'access_denied':
-        ctx.stderr.write('Consent was denied.\n');
-        return EXIT_RUNTIME_ERROR;
-      case 'authorize_error':
-        ctx.stderr.write(`Consent failed: ${result.error}\n`);
-        return EXIT_RUNTIME_ERROR;
-      case 'token_exchange_failed':
-        ctx.stderr.write(`Consent failed while exchanging the authorization code: ${result.message}\n`);
-        return EXIT_RUNTIME_ERROR;
-      case 'port_bind_failed':
-        ctx.stderr.write('Could not bind a local loopback port to receive the consent redirect.\n');
-        return EXIT_RUNTIME_ERROR;
-      case 'discovery_failed':
-        ctx.stderr.write(`Could not discover the OAuth server configuration for ${host}: ${result.message}\n`);
-        return EXIT_RUNTIME_ERROR;
-      default: {
-        const unreachable: never = result;
-        throw new Error(`Unhandled consent outcome: ${JSON.stringify(unreachable)}`);
+    if (result.outcome === 'failed') {
+      ctx.stderr.write(`${result.message}\n`);
+      return EXIT_RUNTIME_ERROR;
+    }
+
+    info.write(`Created key "${keyName}" on ${host}, scoped to: ${scopeResult.driveScope}.\n`);
+    if (parsedArgs.args.showToken) {
+      if (mintedToken !== null) {
+        // The ONLY stdout line in --show-token mode (see `info` above).
+        ctx.stdout.write(`${TOKEN_ENV_VAR_NAME}=${mintedToken}\n`);
+        ctx.stderr.write("This token is shown once and never again. Anyone holding it gets this key's access.\n");
+      } else {
+        ctx.stderr.write('--show-token: no raw token to show — the server returned a refresh credential instead of a static token.\n');
       }
     }
+    info.write(`${renderAgentWiringGuidance({ keyName, host }).join('\n')}\n`);
+    return EXIT_SUCCESS;
   };
 }
 
@@ -415,5 +428,8 @@ export const tokensCreateHandler: CommandHandler = createTokensCreateHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  requestDeviceAuthorization: createRequestDeviceAuthorization(),
+  pollDeviceToken: createPollDeviceToken(),
+  isInterrupted: createSigintFlag(),
   now: Date.now,
 });

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -34,7 +34,7 @@ import { createDiscoverMetadata } from '../../auth/discover.js';
 import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
-import { unrefWaitMs } from '../../auth/wait.js';
+import { unrefWaitMs, waitMs } from '../../auth/wait.js';
 import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
 import { createPollDeviceToken } from '../../auth/poll-device-token.js';
 import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
@@ -253,6 +253,13 @@ export interface TokensCreateHandlerDeps {
   readonly requestDeviceAuthorization: RequestDeviceAuthorization;
   readonly pollDeviceToken: PollDeviceToken;
   readonly isInterrupted: () => boolean;
+  /**
+   * The device transport's delay adapter. Deliberately NOT `waitMs` above:
+   * that one is `unrefWaitMs` for the loopback timeout race, which would let
+   * Node exit right after printing the verification code, before the user
+   * could approve. See `auth/run-consent.ts`'s `DeviceConsentDeps.waitMs`.
+   */
+  readonly deviceWaitMs: WaitMs;
   readonly now: () => number;
   readonly timeoutMs?: number;
   readonly maxPortAttempts?: number;
@@ -385,6 +392,7 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
           requestDeviceAuthorization: deps.requestDeviceAuthorization,
           pollDeviceToken: deps.pollDeviceToken,
           isInterrupted: deps.isInterrupted,
+          waitMs: deps.deviceWaitMs,
           onDeviceCode: (authorization) => {
             // Routed through `info` so --show-token's one-line stdout contract
             // holds for the device flow too.
@@ -431,5 +439,7 @@ export const tokensCreateHandler: CommandHandler = createTokensCreateHandler({
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   isInterrupted: createSigintFlag(),
+  // The REF'D adapter for device polling — see `deviceWaitMs` above.
+  deviceWaitMs: waitMs,
   now: Date.now,
 });

--- a/packages/cli/src/commands/keys/create.ts
+++ b/packages/cli/src/commands/keys/create.ts
@@ -252,12 +252,17 @@ export interface TokensCreateHandlerDeps {
   readonly confirmIdentity: ConfirmIdentity;
   readonly requestDeviceAuthorization: RequestDeviceAuthorization;
   readonly pollDeviceToken: PollDeviceToken;
-  readonly isInterrupted: () => boolean;
   /**
-   * The device transport's delay adapter. Deliberately NOT `waitMs` above:
-   * that one is `unrefWaitMs` for the loopback timeout race, which would let
-   * Node exit right after printing the verification code, before the user
-   * could approve. See `auth/run-consent.ts`'s `DeviceConsentDeps.waitMs`.
+   * Creates the interrupt flag. A factory, not a flag: calling it installs a
+   * SIGINT listener, which must not happen for commands that never start a
+   * device flow. `runConsent` invokes it inside its device branch only.
+   */
+  readonly createIsInterrupted: () => () => boolean;
+  /**
+   * The device transport's REF'd delay adapter. Deliberately NOT `waitMs`
+   * above: that one is `unrefWaitMs` for the loopback timeout race, which
+   * would let Node exit right after printing the verification code, before the
+   * user could approve. See `auth/run-consent.ts`.
    */
   readonly deviceWaitMs: WaitMs;
   readonly now: () => number;
@@ -372,7 +377,7 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
         exchangeCode: deps.exchangeCode,
         confirmIdentity: deps.confirmIdentity,
         credentialStore: store,
-        waitMs: deps.waitMs,
+        loopbackWaitMs: deps.waitMs,
         now: deps.now,
         timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
         profile: keyName,
@@ -391,7 +396,7 @@ export function createTokensCreateHandler(deps: TokensCreateHandlerDeps): Comman
         deviceDeps: {
           requestDeviceAuthorization: deps.requestDeviceAuthorization,
           pollDeviceToken: deps.pollDeviceToken,
-          isInterrupted: deps.isInterrupted,
+          createIsInterrupted: deps.createIsInterrupted,
           waitMs: deps.deviceWaitMs,
           onDeviceCode: (authorization) => {
             // Routed through `info` so --show-token's one-line stdout contract
@@ -438,7 +443,10 @@ export const tokensCreateHandler: CommandHandler = createTokensCreateHandler({
   confirmIdentity,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
-  isInterrupted: createSigintFlag(),
+  // Passed UNCALLED — `runConsent` installs the SIGINT listener only if a
+  // device flow actually starts. Calling it here would install one on every
+  // `pagespace` invocation, since routes.ts imports every command module.
+  createIsInterrupted: createSigintFlag,
   // The REF'D adapter for device polling — see `deviceWaitMs` above.
   deviceWaitMs: waitMs,
   now: Date.now,

--- a/packages/cli/src/commands/keys/use.ts
+++ b/packages/cli/src/commands/keys/use.ts
@@ -25,7 +25,10 @@ import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
 import { unrefWaitMs } from '../../auth/wait.js';
-import { runLoopbackLogin } from '../../auth/loopback-flow.js';
+import { createPollDeviceToken } from '../../auth/poll-device-token.js';
+import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
+import { createSigintFlag } from '../../auth/sigint.js';
+import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
 import type { LoopbackLoginResult } from '../../auth/loopback-flow.js';
 import { resolveConfig } from '../../config/resolve.js';
 import { createCredentialStore } from '../../credentials/store.js';
@@ -122,6 +125,10 @@ export interface ActivateCeremonyParams {
    */
   readonly store: CredentialStore;
   readonly onBrowserOpenFailed: (url: string) => void;
+  /** True when `--device` was passed: print a verification code instead of opening a browser. */
+  readonly device?: boolean;
+  /** Where to print the device verification lines (the wizard routes these around its spinner). */
+  readonly onDeviceCode?: (lines: string[]) => void;
 }
 
 export type ActivateCeremonyResult = { readonly ok: true } | { readonly ok: false; readonly message: string };
@@ -143,30 +150,45 @@ export async function runActivateCeremony(
     return { ok: false, message: scopeResult.message };
   }
 
-  const result = await runLoopbackLogin({
-    host: params.host,
-    clientId: PAGESPACE_CLI_CLIENT_ID,
-    scope: scopeResult.scope,
-    randomBytes: deps.randomBytes,
-    discoverMetadata: deps.discoverMetadata,
-    startServer: deps.startServer,
-    maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
-    openBrowser: deps.openBrowser,
-    onBrowserOpenFailed: params.onBrowserOpenFailed,
-    waitMs: deps.waitMs,
-    timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
-    exchangeCode: deps.exchangeCode,
-    confirmIdentity: deps.confirmIdentity,
-    credentialStore: params.store,
-    now: deps.now,
-    // Defense-in-depth sentinel only: the flow persists nothing for an
-    // activate_key grant and fails closed on a surprise mint, so this name
-    // is never written — but if it ever were, it must not be a real slot.
-    profile: `activate-${params.tokenId}`,
-  });
+  const device = params.device ?? false;
+  const result = await runConsent(
+    {
+      device,
+      host: params.host,
+      clientId: PAGESPACE_CLI_CLIENT_ID,
+      scope: scopeResult.scope,
+      discoverMetadata: deps.discoverMetadata,
+      exchangeCode: deps.exchangeCode,
+      confirmIdentity: deps.confirmIdentity,
+      credentialStore: params.store,
+      waitMs: deps.waitMs,
+      now: deps.now,
+      timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
+      // Defense-in-depth sentinel only: both flows persist nothing for an
+      // activate_key grant and fail closed on a surprise mint, so this name is
+      // never written — but if it ever were, it must not be a real slot.
+      profile: `activate-${params.tokenId}`,
+      loopback: {
+        randomBytes: deps.randomBytes,
+        startServer: deps.startServer,
+        openBrowser: deps.openBrowser,
+        maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
+        onBrowserOpenFailed: params.onBrowserOpenFailed,
+      },
+      deviceDeps: {
+        requestDeviceAuthorization: deps.requestDeviceAuthorization,
+        pollDeviceToken: deps.pollDeviceToken,
+        isInterrupted: deps.isInterrupted,
+        onDeviceCode: (authorization) => {
+          params.onDeviceCode?.(renderDeviceCodePrompt(authorization));
+        },
+      },
+    },
+    `pagespace keys use${device ? ' --device' : ''}`,
+  );
 
-  if (result.outcome !== 'success') {
-    return { ok: false, message: describeActivateFailure(result) };
+  if (result.outcome === 'failed') {
+    return { ok: false, message: result.message };
   }
 
   // Fail closed unless the server approved EXACTLY the key this ceremony
@@ -249,7 +271,9 @@ export function createKeysUseHandler(deps: TokensCreateHandlerDeps): CommandHand
       return EXIT_RUNTIME_ERROR;
     }
 
-    ctx.stdout.write(`Opening your browser to approve activating "${name}" on ${host}...\n`);
+    if (!intent.flags.device) {
+      ctx.stdout.write(`Opening your browser to approve activating "${name}" on ${host}...\n`);
+    }
 
     const result = await runActivateCeremony(ctx, deps, {
       host,
@@ -258,6 +282,10 @@ export function createKeysUseHandler(deps: TokensCreateHandlerDeps): CommandHand
       store,
       onBrowserOpenFailed: (url) => {
         ctx.stderr.write(`Could not open a browser automatically. Open this URL to continue:\n${url}\n`);
+      },
+      device: intent.flags.device,
+      onDeviceCode: (lines) => {
+        ctx.stdout.write(`${lines.join('\n')}\n`);
       },
     });
 
@@ -284,5 +312,8 @@ export const keysUseHandler: CommandHandler = createKeysUseHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  requestDeviceAuthorization: createRequestDeviceAuthorization(),
+  pollDeviceToken: createPollDeviceToken(),
+  isInterrupted: createSigintFlag(),
   now: Date.now,
 });

--- a/packages/cli/src/commands/keys/use.ts
+++ b/packages/cli/src/commands/keys/use.ts
@@ -29,7 +29,6 @@ import { createPollDeviceToken } from '../../auth/poll-device-token.js';
 import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
 import { createSigintFlag } from '../../auth/sigint.js';
 import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
-import type { LoopbackLoginResult } from '../../auth/loopback-flow.js';
 import { resolveConfig } from '../../config/resolve.js';
 import { createCredentialStore } from '../../credentials/store.js';
 import type { CredentialStore } from '../../credentials/store.js';
@@ -88,30 +87,6 @@ export function findServerTokenId(keys: readonly ServerKeyRef[], credential: Hos
   return match?.id ?? null;
 }
 
-/** Mirrors `keys create`'s outcome-to-message mapping as plain strings — the ceremony's callers render them. */
-export function describeActivateFailure(result: Exclude<LoopbackLoginResult, { outcome: 'success' }>): string {
-  switch (result.outcome) {
-    case 'timeout':
-      return 'Approval timed out waiting for the browser redirect. Run "pagespace keys use" again.';
-    case 'state_mismatch':
-      return 'Approval failed: the authorization response did not match this request. Run "pagespace keys use" again.';
-    case 'access_denied':
-      return 'Approval was denied.';
-    case 'authorize_error':
-      return `Approval failed: ${result.error}`;
-    case 'token_exchange_failed':
-      return `Approval failed while exchanging the authorization code: ${result.message}`;
-    case 'port_bind_failed':
-      return 'Could not bind a local loopback port to receive the approval redirect.';
-    case 'discovery_failed':
-      return `Could not discover the OAuth server configuration: ${result.message}`;
-    default: {
-      const unreachable: never = result;
-      throw new Error(`Unhandled approval outcome: ${JSON.stringify(unreachable)}`);
-    }
-  }
-}
-
 export interface ActivateCeremonyParams {
   readonly host: string;
   /** The LOCAL credential name to record as active on success. */
@@ -161,7 +136,7 @@ export async function runActivateCeremony(
       exchangeCode: deps.exchangeCode,
       confirmIdentity: deps.confirmIdentity,
       credentialStore: params.store,
-      waitMs: deps.waitMs,
+      loopbackWaitMs: deps.waitMs,
       now: deps.now,
       timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
       // Defense-in-depth sentinel only: both flows persist nothing for an
@@ -178,7 +153,7 @@ export async function runActivateCeremony(
       deviceDeps: {
         requestDeviceAuthorization: deps.requestDeviceAuthorization,
         pollDeviceToken: deps.pollDeviceToken,
-        isInterrupted: deps.isInterrupted,
+        createIsInterrupted: deps.createIsInterrupted,
         waitMs: deps.deviceWaitMs,
         onDeviceCode: (authorization) => {
           params.onDeviceCode?.(renderDeviceCodePrompt(authorization));
@@ -315,7 +290,8 @@ export const keysUseHandler: CommandHandler = createKeysUseHandler({
   confirmIdentity,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
-  isInterrupted: createSigintFlag(),
+  // Passed UNCALLED — see create.ts.
+  createIsInterrupted: createSigintFlag,
   // The REF'D adapter for device polling — see `deviceWaitMs` in create.ts.
   deviceWaitMs: waitMs,
   now: Date.now,

--- a/packages/cli/src/commands/keys/use.ts
+++ b/packages/cli/src/commands/keys/use.ts
@@ -24,7 +24,7 @@ import { createDiscoverMetadata } from '../../auth/discover.js';
 import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
-import { unrefWaitMs } from '../../auth/wait.js';
+import { unrefWaitMs, waitMs } from '../../auth/wait.js';
 import { createPollDeviceToken } from '../../auth/poll-device-token.js';
 import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
 import { createSigintFlag } from '../../auth/sigint.js';
@@ -179,6 +179,7 @@ export async function runActivateCeremony(
         requestDeviceAuthorization: deps.requestDeviceAuthorization,
         pollDeviceToken: deps.pollDeviceToken,
         isInterrupted: deps.isInterrupted,
+        waitMs: deps.deviceWaitMs,
         onDeviceCode: (authorization) => {
           params.onDeviceCode?.(renderDeviceCodePrompt(authorization));
         },
@@ -315,5 +316,7 @@ export const keysUseHandler: CommandHandler = createKeysUseHandler({
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   isInterrupted: createSigintFlag(),
+  // The REF'D adapter for device polling — see `deviceWaitMs` in create.ts.
+  deviceWaitMs: waitMs,
   now: Date.now,
 });

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -200,7 +200,7 @@ function consentFlowDeps(deps: TokensCreateHandlerDeps, s: ReturnType<typeof cla
     discoverMetadata: deps.discoverMetadata,
     exchangeCode: deps.exchangeCode,
     confirmIdentity: deps.confirmIdentity,
-    waitMs: deps.waitMs,
+    loopbackWaitMs: deps.waitMs,
     timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
     now: deps.now,
     loopback: {
@@ -215,7 +215,7 @@ function consentFlowDeps(deps: TokensCreateHandlerDeps, s: ReturnType<typeof cla
     deviceDeps: {
       requestDeviceAuthorization: deps.requestDeviceAuthorization,
       pollDeviceToken: deps.pollDeviceToken,
-      isInterrupted: deps.isInterrupted,
+      createIsInterrupted: deps.createIsInterrupted,
       waitMs: deps.deviceWaitMs,
       onDeviceCode: (authorization: DeviceAuthorization) => {
         // Through the spinner, not stdout: clack owns the terminal here, and a
@@ -224,11 +224,6 @@ function consentFlowDeps(deps: TokensCreateHandlerDeps, s: ReturnType<typeof cla
       },
     },
   };
-}
-
-/** The line a spinner shows while a consent is pending, per transport. */
-function consentPendingMessage(device: boolean, browserAction: string, deviceAction: string): string {
-  return device ? deviceAction : browserAction;
 }
 
 async function mintScopedKey(
@@ -243,13 +238,7 @@ async function mintScopedKey(
   },
 ): Promise<ConsentResult> {
   const s = clack.spinner();
-  s.start(
-    consentPendingMessage(
-      params.device,
-      `Opening your browser to approve access for key "${params.keyName}" on ${params.host}...`,
-      `Waiting for approval of key "${params.keyName}" on ${params.host}...`,
-    ),
-  );
+  s.start(params.device ? `Waiting for approval of key "${params.keyName}" on ${params.host}...` : `Opening your browser to approve access for key "${params.keyName}" on ${params.host}...`);
 
   // Captured, never printed while the spinner is live — only surfaced behind
   // the explicit show-once confirm below.
@@ -470,13 +459,7 @@ async function runEdit(
   if (clack.isCancel(proceed) || !proceed) return abortSubflow();
 
   const s = clack.spinner();
-  s.start(
-    consentPendingMessage(
-      device,
-      `Opening your browser to approve the new scopes for "${key.name}" on ${host}...`,
-      `Waiting for approval of the new scopes for "${key.name}" on ${host}...`,
-    ),
-  );
+  s.start(device ? `Waiting for approval of the new scopes for "${key.name}" on ${host}...` : `Opening your browser to approve the new scopes for "${key.name}" on ${host}...`);
 
   const result = await runConsent(
     {
@@ -608,13 +591,7 @@ async function runUse(
   }
 
   const s = clack.spinner();
-  s.start(
-    consentPendingMessage(
-      device,
-      `Opening your browser to approve activating "${key.name}" on ${host}...`,
-      `Waiting for approval to activate "${key.name}" on ${host}...`,
-    ),
-  );
+  s.start(device ? `Waiting for approval to activate "${key.name}" on ${host}...` : `Opening your browser to approve activating "${key.name}" on ${host}...`);
 
   const result = await runActivateCeremony(ctx, deps, {
     host,
@@ -718,7 +695,8 @@ export const keysHandler: CommandHandler = createKeysHandler({
   confirmIdentity,
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
-  isInterrupted: createSigintFlag(),
+  // Passed UNCALLED — see create.ts.
+  createIsInterrupted: createSigintFlag,
   // The REF'D adapter for device polling — see `deviceWaitMs` in create.ts.
   deviceWaitMs: waitMs,
   now: Date.now,

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -33,12 +33,13 @@ import { createDiscoverMetadata } from '../../auth/discover.js';
 import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
-import { unrefWaitMs } from '../../auth/wait.js';
+import { unrefWaitMs, waitMs } from '../../auth/wait.js';
 import { createPollDeviceToken } from '../../auth/poll-device-token.js';
 import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
 import { createSigintFlag } from '../../auth/sigint.js';
-import { runLoopbackLogin } from '../../auth/loopback-flow.js';
-import type { LoopbackLoginResult } from '../../auth/loopback-flow.js';
+import { renderDeviceCodePrompt, runConsent } from '../../auth/run-consent.js';
+import type { ConsentResult } from '../../auth/run-consent.js';
+import type { DeviceAuthorization } from '../../auth/device-flow.js';
 import { resolveConfig } from '../../config/resolve.js';
 import { credentialSecret } from '../../credentials/serialize.js';
 import type { HostCredential } from '../../credentials/serialize.js';
@@ -105,30 +106,6 @@ async function fetchKeys(ctx: HandlerContext): Promise<readonly KeySummary[] | n
   } catch (error) {
     clack.log.error(`Failed to load your keys: ${error instanceof Error ? error.message : String(error)}`);
     return null;
-  }
-}
-
-/** Mirrors `keys create`'s outcome-to-message mapping (`commands/keys/create.ts`) as plain strings for a spinner. */
-function describeMintFailure(result: Exclude<LoopbackLoginResult, { outcome: 'success' }>): string {
-  switch (result.outcome) {
-    case 'timeout':
-      return 'Consent timed out waiting for the browser redirect.';
-    case 'state_mismatch':
-      return 'Consent failed: the authorization response did not match this request.';
-    case 'access_denied':
-      return 'Consent was denied.';
-    case 'authorize_error':
-      return `Consent failed: ${result.error}`;
-    case 'token_exchange_failed':
-      return `Consent failed while exchanging the authorization code: ${result.message}`;
-    case 'port_bind_failed':
-      return 'Could not bind a local loopback port to receive the consent redirect.';
-    case 'discovery_failed':
-      return `Could not discover the OAuth server configuration: ${result.message}`;
-    default: {
-      const unreachable: never = result;
-      throw new Error(`Unhandled consent outcome: ${JSON.stringify(unreachable)}`);
-    }
   }
 }
 
@@ -207,51 +184,90 @@ async function isKeyWriteConfirmed(store: CredentialStore, host: string, keyName
 }
 
 /**
- * The runLoopbackLogin dep wiring shared by every wizard consent flow
- * (Create's mint, Edit's in-place update) — one place to thread a new
- * effect or default through, so the two flows can't silently diverge.
+ * The consent wiring shared by every wizard flow (Create's mint, Edit's
+ * in-place update) — one place to thread a new effect or default through, so
+ * the flows can't silently diverge.
+ *
+ * `device` selects the transport for THIS invocation: with `pagespace keys
+ * --device` the wizard prints a verification code instead of opening a
+ * browser, which is the only way Edit — a wizard-only operation — can be
+ * driven from a machine with no local browser at all.
  */
-function consentFlowDeps(deps: TokensCreateHandlerDeps, s: ReturnType<typeof clack.spinner>) {
+function consentFlowDeps(deps: TokensCreateHandlerDeps, s: ReturnType<typeof clack.spinner>, device: boolean) {
   return {
+    device,
     clientId: PAGESPACE_CLI_CLIENT_ID,
-    randomBytes: deps.randomBytes,
     discoverMetadata: deps.discoverMetadata,
-    startServer: deps.startServer,
-    maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
-    openBrowser: deps.openBrowser,
-    onBrowserOpenFailed: (url: string) => {
-      s.message(`Could not open a browser automatically. Open this URL to continue: ${url}`);
-    },
-    waitMs: deps.waitMs,
-    timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
     exchangeCode: deps.exchangeCode,
     confirmIdentity: deps.confirmIdentity,
+    waitMs: deps.waitMs,
+    timeoutMs: deps.timeoutMs ?? DEFAULT_LOGIN_TIMEOUT_MS,
     now: deps.now,
+    loopback: {
+      randomBytes: deps.randomBytes,
+      startServer: deps.startServer,
+      maxPortAttempts: deps.maxPortAttempts ?? DEFAULT_MAX_PORT_ATTEMPTS,
+      openBrowser: deps.openBrowser,
+      onBrowserOpenFailed: (url: string) => {
+        s.message(`Could not open a browser automatically. Open this URL to continue: ${url}`);
+      },
+    },
+    deviceDeps: {
+      requestDeviceAuthorization: deps.requestDeviceAuthorization,
+      pollDeviceToken: deps.pollDeviceToken,
+      isInterrupted: deps.isInterrupted,
+      waitMs: deps.deviceWaitMs,
+      onDeviceCode: (authorization: DeviceAuthorization) => {
+        // Through the spinner, not stdout: clack owns the terminal here, and a
+        // raw write would be overwritten by the next spinner frame.
+        s.message(renderDeviceCodePrompt(authorization).join(' '));
+      },
+    },
   };
+}
+
+/** The line a spinner shows while a consent is pending, per transport. */
+function consentPendingMessage(device: boolean, browserAction: string, deviceAction: string): string {
+  return device ? deviceAction : browserAction;
 }
 
 async function mintScopedKey(
   deps: TokensCreateHandlerDeps,
   store: CredentialStore,
-  params: { readonly host: string; readonly scope: string; readonly keyName: string; readonly displayScope?: string },
-): Promise<LoopbackLoginResult> {
+  params: {
+    readonly host: string;
+    readonly scope: string;
+    readonly keyName: string;
+    readonly displayScope?: string;
+    readonly device: boolean;
+  },
+): Promise<ConsentResult> {
   const s = clack.spinner();
-  s.start(`Opening your browser to approve access for key "${params.keyName}" on ${params.host}...`);
+  s.start(
+    consentPendingMessage(
+      params.device,
+      `Opening your browser to approve access for key "${params.keyName}" on ${params.host}...`,
+      `Waiting for approval of key "${params.keyName}" on ${params.host}...`,
+    ),
+  );
 
   // Captured, never printed while the spinner is live — only surfaced behind
   // the explicit show-once confirm below.
   let mintedToken: string | null = null;
 
-  const result = await runLoopbackLogin({
-    ...consentFlowDeps(deps, s),
-    host: params.host,
-    scope: params.scope,
-    credentialStore: store,
-    profile: params.keyName,
-    onMintedStaticToken: (token) => {
-      mintedToken = token;
+  const result = await runConsent(
+    {
+      ...consentFlowDeps(deps, s, params.device),
+      host: params.host,
+      scope: params.scope,
+      credentialStore: store,
+      profile: params.keyName,
+      onMintedStaticToken: (token) => {
+        mintedToken = token;
+      },
     },
-  });
+    `pagespace keys${params.device ? ' --device' : ''}`,
+  );
 
   if (result.outcome === 'success') {
     s.stop(`Created key "${params.keyName}" on ${params.host}, scoped to: ${params.displayScope ?? params.scope}.`);
@@ -263,7 +279,7 @@ async function mintScopedKey(
     }
     clack.note(renderAgentWiringGuidance({ keyName: params.keyName, host: params.host }).join('\n'), 'Wire up an agent');
   } else {
-    s.error(describeMintFailure(result));
+    s.error(result.message);
   }
   return result;
 }
@@ -301,7 +317,8 @@ async function selectScopeAndMint(
   drives: readonly DriveOption[],
   initialDriveIds: readonly string[],
   messages: ScopeAndMintMessages,
-): Promise<LoopbackLoginResult | null> {
+  device: boolean,
+): Promise<ConsentResult | null> {
   const target = await selectDriveTarget();
   if (target === null) {
     abortSubflow();
@@ -354,10 +371,16 @@ async function selectScopeAndMint(
     scope: scopeResult.scope,
     keyName,
     displayScope: scopeResult.driveScope,
+    device,
   });
 }
 
-async function runCreate(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: string): Promise<FlowOutcome> {
+async function runCreate(
+  ctx: HandlerContext,
+  deps: TokensCreateHandlerDeps,
+  host: string,
+  device: boolean,
+): Promise<FlowOutcome> {
   const drives = await fetchDrives(ctx);
   if (drives === null) return null;
   if (drives.length === 0) {
@@ -365,10 +388,18 @@ async function runCreate(ctx: HandlerContext, deps: TokensCreateHandlerDeps, hos
     return null;
   }
 
-  await selectScopeAndMint(ctx, deps, host, drives, [], {
-    selectDrives: 'Select drives to grant access to',
-    keyName: 'Name this key (agents on this machine reference it by this name)',
-  });
+  await selectScopeAndMint(
+    ctx,
+    deps,
+    host,
+    drives,
+    [],
+    {
+      selectDrives: 'Select drives to grant access to',
+      keyName: 'Name this key (agents on this machine reference it by this name)',
+    },
+    device,
+  );
   return null;
 }
 
@@ -384,7 +415,13 @@ async function runCreate(ctx: HandlerContext, deps: TokensCreateHandlerDeps, hos
  * non-"default" sentinel `profile` passed below is defense-in-depth only and
  * is never written on any reachable path.
  */
-async function runEdit(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: string, keys: readonly KeySummary[]): Promise<FlowOutcome> {
+async function runEdit(
+  ctx: HandlerContext,
+  deps: TokensCreateHandlerDeps,
+  host: string,
+  keys: readonly KeySummary[],
+  device: boolean,
+): Promise<FlowOutcome> {
   const keyId = await clack.select({ message: 'Which key would you like to edit?', options: [...keySelectOptions(keys)] });
   if (clack.isCancel(keyId)) return abortSubflow();
   const key = keys.find((candidate) => candidate.id === keyId);
@@ -433,18 +470,27 @@ async function runEdit(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host:
   if (clack.isCancel(proceed) || !proceed) return abortSubflow();
 
   const s = clack.spinner();
-  s.start(`Opening your browser to approve the new scopes for "${key.name}" on ${host}...`);
+  s.start(
+    consentPendingMessage(
+      device,
+      `Opening your browser to approve the new scopes for "${key.name}" on ${host}...`,
+      `Waiting for approval of the new scopes for "${key.name}" on ${host}...`,
+    ),
+  );
 
-  const result = await runLoopbackLogin({
-    ...consentFlowDeps(deps, s),
-    host,
-    scope: updateScope.scope,
-    credentialStore: deps.createCredentialStore(),
-    profile: `edit-${key.id}`,
-  });
+  const result = await runConsent(
+    {
+      ...consentFlowDeps(deps, s, device),
+      host,
+      scope: updateScope.scope,
+      credentialStore: deps.createCredentialStore(),
+      profile: `edit-${key.id}`,
+    },
+    `pagespace keys${device ? ' --device' : ''}`,
+  );
 
-  if (result.outcome !== 'success') {
-    s.error(describeMintFailure(result));
+  if (result.outcome === 'failed') {
+    s.error(result.message);
     return null;
   }
 
@@ -502,7 +548,13 @@ function matchesServerKey(credential: HostCredential, key: KeySummary): boolean 
  * token it prefixes; a key with no local credential on this machine cannot
  * be activated here.
  */
-async function runUse(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: string, keys: readonly KeySummary[]): Promise<FlowOutcome> {
+async function runUse(
+  ctx: HandlerContext,
+  deps: TokensCreateHandlerDeps,
+  host: string,
+  keys: readonly KeySummary[],
+  device: boolean,
+): Promise<FlowOutcome> {
   const store = deps.createCredentialStore();
 
   const activeName = await ctx.activeKeyStore.getActiveKey(host);
@@ -556,7 +608,13 @@ async function runUse(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: 
   }
 
   const s = clack.spinner();
-  s.start(`Opening your browser to approve activating "${key.name}" on ${host}...`);
+  s.start(
+    consentPendingMessage(
+      device,
+      `Opening your browser to approve activating "${key.name}" on ${host}...`,
+      `Waiting for approval to activate "${key.name}" on ${host}...`,
+    ),
+  );
 
   const result = await runActivateCeremony(ctx, deps, {
     host,
@@ -565,6 +623,10 @@ async function runUse(ctx: HandlerContext, deps: TokensCreateHandlerDeps, host: 
     store,
     onBrowserOpenFailed: (url) => {
       s.message(`Could not open a browser automatically. Open this URL to continue: ${url}`);
+    },
+    device,
+    onDeviceCode: (lines) => {
+      s.message(lines.join(' '));
     },
   });
 
@@ -627,13 +689,13 @@ export function createKeysHandler(deps: TokensCreateHandlerDeps): CommandHandler
 
       const outcome =
         choice === 'create'
-          ? await runCreate(ctx, deps, host)
+          ? await runCreate(ctx, deps, host, intent.flags.device)
           : choice === 'list'
             ? await runList(keys)
             : choice === 'edit'
-              ? await runEdit(ctx, deps, host, keys)
+              ? await runEdit(ctx, deps, host, keys, intent.flags.device)
               : choice === 'use'
-                ? await runUse(ctx, deps, host, keys)
+                ? await runUse(ctx, deps, host, keys, intent.flags.device)
                 : await runRevoke(ctx, keys);
 
       if (outcome !== null) return outcome;
@@ -657,5 +719,7 @@ export const keysHandler: CommandHandler = createKeysHandler({
   requestDeviceAuthorization: createRequestDeviceAuthorization(),
   pollDeviceToken: createPollDeviceToken(),
   isInterrupted: createSigintFlag(),
+  // The REF'D adapter for device polling — see `deviceWaitMs` in create.ts.
+  deviceWaitMs: waitMs,
   now: Date.now,
 });

--- a/packages/cli/src/commands/keys/wizard.ts
+++ b/packages/cli/src/commands/keys/wizard.ts
@@ -34,6 +34,9 @@ import { createExchangeCode } from '../../auth/exchange-code.js';
 import { createLoopbackServer } from '../../auth/create-loopback-server.js';
 import { openBrowser } from '../../auth/open-browser.js';
 import { unrefWaitMs } from '../../auth/wait.js';
+import { createPollDeviceToken } from '../../auth/poll-device-token.js';
+import { createRequestDeviceAuthorization } from '../../auth/request-device-authorization.js';
+import { createSigintFlag } from '../../auth/sigint.js';
 import { runLoopbackLogin } from '../../auth/loopback-flow.js';
 import type { LoopbackLoginResult } from '../../auth/loopback-flow.js';
 import { resolveConfig } from '../../config/resolve.js';
@@ -651,5 +654,8 @@ export const keysHandler: CommandHandler = createKeysHandler({
   waitMs: unrefWaitMs,
   exchangeCode: createExchangeCode(),
   confirmIdentity,
+  requestDeviceAuthorization: createRequestDeviceAuthorization(),
+  pollDeviceToken: createPollDeviceToken(),
+  isInterrupted: createSigintFlag(),
   now: Date.now,
 });

--- a/packages/cli/src/commands/login-device.ts
+++ b/packages/cli/src/commands/login-device.ts
@@ -23,6 +23,7 @@ import { createPollDeviceToken } from '../auth/poll-device-token.js';
 import { createRequestDeviceAuthorization } from '../auth/request-device-authorization.js';
 import { resolveEnvKeyName } from '../auth/legacy-token-env.js';
 import { resolveKeyName } from '../auth/resolve.js';
+import { createSigintFlag } from '../auth/sigint.js';
 import { waitMs } from '../auth/wait.js';
 import { runDeviceLogin } from '../auth/device-flow.js';
 import type { DeviceAuthorization, PollDeviceToken, RequestDeviceAuthorization } from '../auth/device-flow.js';
@@ -37,7 +38,14 @@ export interface LoginDeviceHandlerDeps {
   readonly waitMs: WaitMs;
   readonly confirmIdentity: ConfirmIdentity;
   readonly now: () => number;
-  readonly isInterrupted: () => boolean;
+  /**
+   * Creates the interrupt flag. A factory, not a flag: calling it installs a
+   * `process.once('SIGINT')` listener, which replaces Node's default
+   * terminate-on-Ctrl-C. `run.ts` imports this module for every invocation, so
+   * calling it at module scope would impose that on unrelated commands. The
+   * handler calls it only once a device login is actually starting.
+   */
+  readonly createIsInterrupted: () => () => boolean;
   readonly timeoutMs?: number;
 }
 
@@ -74,7 +82,7 @@ export function createLoginDeviceHandler(deps: LoginDeviceHandlerDeps): CommandH
       pollDeviceToken: deps.pollDeviceToken,
       waitMs: deps.waitMs,
       now: deps.now,
-      isInterrupted: deps.isInterrupted,
+      isInterrupted: deps.createIsInterrupted(),
       timeoutMs: deps.timeoutMs,
       credentialStore: store,
       confirmIdentity: deps.confirmIdentity,
@@ -126,14 +134,6 @@ export function createLoginDeviceHandler(deps: LoginDeviceHandlerDeps): CommandH
   };
 }
 
-function createSigintFlag(): () => boolean {
-  let interrupted = false;
-  process.once('SIGINT', () => {
-    interrupted = true;
-  });
-  return () => interrupted;
-}
-
 export const loginDeviceHandler: CommandHandler = createLoginDeviceHandler({
   createCredentialStore,
   discoverMetadata: createDiscoverMetadata(),
@@ -145,5 +145,5 @@ export const loginDeviceHandler: CommandHandler = createLoginDeviceHandler({
   waitMs,
   confirmIdentity,
   now: Date.now,
-  isInterrupted: createSigintFlag(),
+  createIsInterrupted: createSigintFlag,
 });

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -212,24 +212,31 @@ export function createWhoamiHandler(deps: WhoamiHandlerDeps): CommandHandler {
 
       // Concurrent, not sequential: neither call feeds the other, and this is
       // an interactive status command — serializing them would double its
-      // latency for no gain.
-      const [identityResult, probeResult] = await Promise.allSettled([
+      // latency for no gain. Each carries its own failure, so neither can fail
+      // the other.
+      const [resolvedIdentity, probe] = await Promise.all([
+        // Nothing to ask for an `mcp_*` key — `/api/auth/me` refuses it by
+        // design (see `auth/probe-drives.ts`). Any other token is tried, and a
+        // server that won't speak for it simply yields null.
         isScopedKeyToken(secret)
-          ? Promise.reject(new Error('mcp_* tokens are not identity-bearing'))
-          : deps.confirmIdentity({ host, accessToken: secret }),
-        deps.probeDriveCount({ host, accessToken: secret }),
+          ? Promise.resolve(null)
+          : deps.confirmIdentity({ host, accessToken: secret }).catch(() => null),
+        deps
+          .probeDriveCount({ host, accessToken: secret })
+          .then((count) => ({ ok: true as const, count }))
+          .catch((error: unknown) => ({ ok: false as const, error })),
       ]);
 
-      identity = identityResult.status === 'fulfilled' ? identityResult.value : null;
+      identity = resolvedIdentity;
 
-      if (probeResult.status === 'fulfilled') {
-        driveCount = probeResult.value;
+      if (probe.ok) {
+        driveCount = probe.count;
       } else if (identity === null) {
         // A rejected probe is only fatal when nothing else vouched for the
         // credential: an OAuth access token that `/api/auth/me` already
         // answered for is live regardless of whether its scope reaches drives.
         ctx.stderr.write(
-          `The credential resolved for ${host} (${sourceLabel}) was rejected: ${messageOf(probeResult.reason)}\n` +
+          `The credential resolved for ${host} (${sourceLabel}) was rejected: ${messageOf(probe.error)}\n` +
             'Re-mint it with "pagespace keys create" (or "pagespace keys" for the guided wizard).\n',
         );
         return EXIT_RUNTIME_ERROR;

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -37,7 +37,7 @@
 import { resolveConfig } from '../config/resolve.js';
 import { createCredentialStore } from '../credentials/store.js';
 import type { CredentialStore } from '../credentials/store.js';
-import { DEFAULT_PROFILE_NAME, tokenPrefix } from '../credentials/serialize.js';
+import { credentialSecret, DEFAULT_PROFILE_NAME, tokenPrefix } from '../credentials/serialize.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS } from '../exit-codes.js';
 import type { CommandHandler } from '../router/router.js';
 import { confirmIdentity } from '../auth/confirm-identity.js';
@@ -197,40 +197,42 @@ export function createWhoamiHandler(deps: WhoamiHandlerDeps): CommandHandler {
       // only 401); anything else is tried as an OAuth access token first and
       // falls through to the drives probe when the server won't speak for it.
       if (source.kind === 'stored') {
-        // Narrowed by the `if` above: the only stored kind left here is
-        // `static`. Asserted structurally rather than cast so a future third
-        // credential kind fails to compile instead of silently landing here.
-        const credential = source.credential;
-        if (credential.kind === 'oauth') throw new Error('unreachable: oauth handled above');
-        secret = credential.token;
-        scopes = credential.scopes;
+        // `credentialSecret` reads whichever field carries the bearer for this
+        // credential kind, so a future third kind is its problem to handle
+        // rather than a new branch to remember here. Stored scopes are only
+        // meaningful for a static key — an oauth credential took the branch
+        // above.
+        secret = credentialSecret(source.credential);
+        scopes = source.credential.kind === 'static' ? source.credential.scopes : null;
       } else {
         secret = source.token;
         scopes = null;
       }
       shownTokenPrefix = tokenPrefix(secret);
 
-      if (!isScopedKeyToken(secret)) {
-        try {
-          identity = await deps.confirmIdentity({ host, accessToken: secret });
-        } catch {
-          identity = null;
-        }
-      }
+      // Concurrent, not sequential: neither call feeds the other, and this is
+      // an interactive status command — serializing them would double its
+      // latency for no gain.
+      const [identityResult, probeResult] = await Promise.allSettled([
+        isScopedKeyToken(secret)
+          ? Promise.reject(new Error('mcp_* tokens are not identity-bearing'))
+          : deps.confirmIdentity({ host, accessToken: secret }),
+        deps.probeDriveCount({ host, accessToken: secret }),
+      ]);
 
-      try {
-        driveCount = await deps.probeDriveCount({ host, accessToken: secret });
-      } catch (error) {
+      identity = identityResult.status === 'fulfilled' ? identityResult.value : null;
+
+      if (probeResult.status === 'fulfilled') {
+        driveCount = probeResult.value;
+      } else if (identity === null) {
         // A rejected probe is only fatal when nothing else vouched for the
         // credential: an OAuth access token that `/api/auth/me` already
         // answered for is live regardless of whether its scope reaches drives.
-        if (identity === null) {
-          ctx.stderr.write(
-            `The credential resolved for ${host} (${sourceLabel}) was rejected: ${messageOf(error)}\n` +
-              'Re-mint it with "pagespace keys create" (or "pagespace keys" for the guided wizard).\n',
-          );
-          return EXIT_RUNTIME_ERROR;
-        }
+        ctx.stderr.write(
+          `The credential resolved for ${host} (${sourceLabel}) was rejected: ${messageOf(probeResult.reason)}\n` +
+            'Re-mint it with "pagespace keys create" (or "pagespace keys" for the guided wizard).\n',
+        );
+        return EXIT_RUNTIME_ERROR;
       }
     }
 

--- a/packages/cli/src/commands/whoami.ts
+++ b/packages/cli/src/commands/whoami.ts
@@ -1,31 +1,51 @@
 /**
- * `pagespace whoami [--host <url>] [--json]` (Phase 4 task 5). For an
- * `oauth`-kind (OAuth refresh/access-token) credential, no access token is
- * cached between CLI invocations (`pagespace login` discards it once its own
- * `confirmIdentity` call has run), so every `whoami` call performs one
- * refresh_token grant to mint a fresh access token, reusing the same
- * discovery + `confirmIdentity` effects `pagespace login` uses.
- * Persist-before-use (ADR 0003 §3.5): the rotated refresh token is written
- * to the credential store BEFORE the new access token is used to call the
- * identity endpoint, so a crash between refresh and identity confirmation
- * never strands a rotated-away token. A `static`-kind credential (`pagespace
- * keys create`'s `mcp_*` token) has no refresh cycle at all — its stored
- * scopes ARE the current grant, and the token itself confirms identity
- * directly, no discovery/refresh effects needed.
+ * `pagespace whoami [--host <url>] [--key <name>] [--token <token>] [--json]`.
  *
- * Non-interactive: a missing credential exits 1 immediately, never
- * prompting — safe in CI/non-TTY.
+ * Reports the credential THIS INVOCATION WOULD ACTUALLY USE, resolved through
+ * the one shared precedence resolver (`auth/resolve-credential-source.ts`,
+ * where the chain — token flag, then token env var, then the named key, then
+ * this machine's active key from `pagespace keys use`, then the stored
+ * `"default"` login credential — is spelled out). It previously looked only at
+ * that LAST link, so a machine whose every content command worked through an
+ * active key was told "Not logged in" — the credential it reported on was not
+ * the credential it would have used.
+ *
+ * The env-var NAMES are deliberately not written out anywhere in this file:
+ * `commands/__tests__/single-auth-path.test.ts` greps every command module for
+ * those literals so no command can grow its own env read, and display copy
+ * naming them would blunt that tripwire. `TOKEN_ENV_VAR_NAME` is interpolated
+ * instead (see `auth/resolve.ts`).
+ *
+ * Two kinds of credential, two honest questions:
+ *
+ * - An `oauth`-kind (personal login) credential caches no access token between
+ *   invocations, so `whoami` performs one refresh_token grant to mint a fresh
+ *   one, then asks `/api/auth/me` who it belongs to. Persist-before-use (ADR
+ *   0003 §3.5): the rotated refresh token is written to the credential store
+ *   BEFORE the new access token is used, so a crash between refresh and
+ *   identity confirmation never strands a rotated-away token.
+ * - A `static`-kind (`mcp_*`) key has no refresh cycle and no "current user":
+ *   `/api/auth/me` deliberately refuses it (see `auth/probe-drives.ts`).
+ *   Asking it for an identity could only ever fail — which is exactly what it
+ *   used to do, reporting a live key as invalidated. Its stored scopes ARE the
+ *   current grant, so `whoami` reports those and proves the key still works
+ *   with a `drives.list` probe instead.
+ *
+ * Non-interactive: a missing credential exits 1 immediately, never prompting —
+ * safe in CI/non-TTY.
  */
 import { resolveConfig } from '../config/resolve.js';
 import { createCredentialStore } from '../credentials/store.js';
 import type { CredentialStore } from '../credentials/store.js';
+import { DEFAULT_PROFILE_NAME, tokenPrefix } from '../credentials/serialize.js';
 import { EXIT_RUNTIME_ERROR, EXIT_SUCCESS } from '../exit-codes.js';
 import type { CommandHandler } from '../router/router.js';
 import { confirmIdentity } from '../auth/confirm-identity.js';
 import { createDiscoverMetadata } from '../auth/discover.js';
-import type { ConfirmIdentity, DiscoverMetadata } from '../auth/loopback-flow.js';
-import { resolveEnvKeyName } from '../auth/legacy-token-env.js';
-import { resolveKeyName } from '../auth/resolve.js';
+import type { ConfirmIdentity, DiscoverMetadata, Identity } from '../auth/loopback-flow.js';
+import { probeDriveCount, type ProbeDriveCount } from '../auth/probe-drives.js';
+import { describeCredentialSource, resolveCredentialSource } from '../auth/resolve-credential-source.js';
+import { TOKEN_ENV_VAR_NAME } from '../auth/resolve.js';
 import { createRefreshAccessToken } from '../auth/silent-refresh.js';
 import type { RefreshAccessToken } from '@pagespace/sdk';
 
@@ -34,7 +54,29 @@ export interface WhoamiHandlerDeps {
   readonly discoverMetadata: DiscoverMetadata;
   readonly createRefreshAccessToken: (tokenEndpoint: string, clientId: string) => RefreshAccessToken;
   readonly confirmIdentity: ConfirmIdentity;
+  readonly probeDriveCount: ProbeDriveCount;
   readonly now: () => number;
+}
+
+/** `mcp_*` tokens are scoped keys, not OAuth access tokens — see `auth/probe-drives.ts`. */
+function isScopedKeyToken(token: string): boolean {
+  return token.startsWith('mcp_');
+}
+
+/**
+ * Display-only: drop the `name:<percent-encoded>` wire token from a scope
+ * list. It is a mint-request parameter that rides along in the granted scope
+ * (see `commands/keys/create.ts`'s `buildTokenScope`), not an access grant —
+ * printing it in a line headed "Scopes:" reads as though the key can do
+ * something called "name:ALL". `--json` keeps the stored scope array verbatim:
+ * a machine reader wants what was actually persisted, not a prettied subset.
+ */
+function displayScopes(scopes: readonly string[]): string[] {
+  return scopes.filter((scope) => !scope.startsWith('name:'));
+}
+
+function messageOf(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function createWhoamiHandler(deps: WhoamiHandlerDeps): CommandHandler {
@@ -44,36 +86,73 @@ export function createWhoamiHandler(deps: WhoamiHandlerDeps): CommandHandler {
       env: { PAGESPACE_API_URL: ctx.env.PAGESPACE_API_URL },
       credential: null,
     });
-    const keyName = resolveKeyName(
-      { key: intent.flags.key },
-      // The deprecated PAGESPACE_PROFILE alias folds in here (run.ts already
-      // printed its one-line notice before dispatch).
-      { PAGESPACE_KEY: resolveEnvKeyName(ctx.env).name },
-    );
 
     const store = deps.createCredentialStore();
-    const credential = await store.get(host, keyName);
-    if (!credential) {
-      ctx.stderr.write(`Not logged in to ${host}. Run "pagespace login".\n`);
+    const resolved = await resolveCredentialSource({
+      flags: { token: intent.flags.token, key: intent.flags.key },
+      env: ctx.env,
+      host,
+      credentialStore: store,
+      // Unlike every other auth-exempt handler, whoami's whole job is
+      // reporting what a content command on this machine would authenticate
+      // as — so it must see the active key that `run.ts` withholds from the
+      // `keys` family (which needs a `manage_keys` scope no drive-scoped
+      // active key carries).
+      activeKeyStore: ctx.activeKeyStore,
+      allowActiveKey: true,
+    });
+    const { source } = resolved;
+
+    if (source.kind === 'none') {
+      // Name the source the user actually reached for. An explicit `--key`
+      // suppresses the active key entirely, so blaming a dangling active key
+      // there would send them to fix something this invocation never consulted.
+      if (resolved.explicit) {
+        ctx.stderr.write(
+          `No credential stored for ${host} under key "${resolved.keyName}". List what is stored with "pagespace keys list", or mint it with "pagespace keys create".\n`,
+        );
+        return EXIT_RUNTIME_ERROR;
+      }
+      const active = await ctx.activeKeyStore.getActiveKey(host);
+      ctx.stderr.write(
+        active === null
+          ? `No credential resolved for ${host}: no stored login, and no active key set on this machine. Run "pagespace login", then "pagespace keys create" and "pagespace keys use <name>".\n`
+          : `No credential resolved for ${host}: the active key "${active}" has no stored credential on this machine. Re-mint it with "pagespace keys create", or pick another with "pagespace keys use <name>".\n`,
+      );
       return EXIT_RUNTIME_ERROR;
     }
 
-    // A static (mcp) credential has no refresh cycle — mcp_* tokens don't
-    // expire — so there is no live refresh response to reconcile scope
-    // against; the credential's own stored scopes ARE the current grant, and
-    // the token itself is used directly to confirm identity.
-    let accessToken: string;
-    let scopes: readonly string[];
+    // Rendered on every report except the one where it IS the subject: knowing
+    // whether a personal login exists separately from the key in use is what
+    // makes the "content commands work but `keys list` says no credentials"
+    // state legible.
+    const personalLogin =
+      source.kind === 'stored' && resolved.keyName === DEFAULT_PROFILE_NAME
+        ? null
+        : (await store.get(host, DEFAULT_PROFILE_NAME)) !== null;
 
-    if (credential.kind === 'static') {
-      accessToken = credential.token;
-      scopes = credential.scopes;
-    } else {
+    const sourceLabel = describeCredentialSource(resolved, TOKEN_ENV_VAR_NAME);
+    let identity: Identity | null = null;
+    let scopes: readonly string[] | null = null;
+    let driveCount: number | null = null;
+    let secret: string;
+    /**
+     * Shown only for a long-lived bearer key, where a prefix is the key's
+     * stable identifier and matches what `pagespace keys list` prints. The
+     * oauth path deliberately leaves this null: its `secret` is an access
+     * token minted seconds ago by this very command, so a prefix of it
+     * identifies nothing a reader could act on and is one more place for a
+     * live token fragment to land in a terminal scrollback or CI log.
+     */
+    let shownTokenPrefix: string | null = null;
+
+    if (source.kind === 'stored' && source.credential.kind === 'oauth') {
+      const credential = source.credential;
       let tokenEndpoint: string;
       try {
         tokenEndpoint = (await deps.discoverMetadata(host)).tokenEndpoint;
       } catch (error) {
-        ctx.stderr.write(`Could not confirm identity on ${host}: ${error instanceof Error ? error.message : String(error)}\n`);
+        ctx.stderr.write(`Could not confirm identity on ${host}: ${messageOf(error)}\n`);
         return EXIT_RUNTIME_ERROR;
       }
 
@@ -101,32 +180,93 @@ export function createWhoamiHandler(deps: WhoamiHandlerDeps): CommandHandler {
           scopes,
           createdAt: new Date(deps.now()).toISOString(),
         },
-        keyName,
+        resolved.keyName,
       );
-      accessToken = tokens.accessToken;
-    }
+      secret = tokens.accessToken;
 
-    let identity;
-    try {
-      identity = await deps.confirmIdentity({ host, accessToken });
-    } catch (error) {
-      ctx.stderr.write(`Could not confirm identity on ${host}: ${error instanceof Error ? error.message : String(error)}\n`);
-      return EXIT_RUNTIME_ERROR;
-    }
+      try {
+        identity = await deps.confirmIdentity({ host, accessToken: secret });
+      } catch (error) {
+        ctx.stderr.write(`Could not confirm identity on ${host}: ${messageOf(error)}\n`);
+        return EXIT_RUNTIME_ERROR;
+      }
+    } else {
+      // Everything else is a bearer secret used exactly as given: a stored
+      // `static` key, or a `--token`/env token whose kind isn't knowable from
+      // disk. An `mcp_*` prefix skips the identity call outright (it could
+      // only 401); anything else is tried as an OAuth access token first and
+      // falls through to the drives probe when the server won't speak for it.
+      if (source.kind === 'stored') {
+        // Narrowed by the `if` above: the only stored kind left here is
+        // `static`. Asserted structurally rather than cast so a future third
+        // credential kind fails to compile instead of silently landing here.
+        const credential = source.credential;
+        if (credential.kind === 'oauth') throw new Error('unreachable: oauth handled above');
+        secret = credential.token;
+        scopes = credential.scopes;
+      } else {
+        secret = source.token;
+        scopes = null;
+      }
+      shownTokenPrefix = tokenPrefix(secret);
 
-    // The machine's active key for this host (`pagespace keys use`) — shown
-    // whenever one is set, because it changes what a bare content command on
-    // this machine will authenticate as.
-    const activeKey = await ctx.activeKeyStore.getActiveKey(host);
+      if (!isScopedKeyToken(secret)) {
+        try {
+          identity = await deps.confirmIdentity({ host, accessToken: secret });
+        } catch {
+          identity = null;
+        }
+      }
+
+      try {
+        driveCount = await deps.probeDriveCount({ host, accessToken: secret });
+      } catch (error) {
+        // A rejected probe is only fatal when nothing else vouched for the
+        // credential: an OAuth access token that `/api/auth/me` already
+        // answered for is live regardless of whether its scope reaches drives.
+        if (identity === null) {
+          ctx.stderr.write(
+            `The credential resolved for ${host} (${sourceLabel}) was rejected: ${messageOf(error)}\n` +
+              'Re-mint it with "pagespace keys create" (or "pagespace keys" for the guided wizard).\n',
+          );
+          return EXIT_RUNTIME_ERROR;
+        }
+      }
+    }
 
     if (intent.flags.json) {
-      ctx.stdout.write(`${JSON.stringify({ host, name: identity.name, email: identity.email, scopes, activeKey })}\n`);
-    } else {
-      ctx.stdout.write(`Logged in as ${identity.name ?? identity.email} <${identity.email}> on ${host}.\n`);
-      ctx.stdout.write(`Scopes: ${scopes.length > 0 ? scopes.join(' ') : '(none)'}\n`);
-      if (activeKey !== null) {
-        ctx.stdout.write(`Active key: ${activeKey}\n`);
-      }
+      ctx.stdout.write(
+        `${JSON.stringify({
+          host,
+          name: identity?.name ?? null,
+          email: identity?.email ?? null,
+          scopes: scopes ?? [],
+          activeKey: resolved.activeKeyName,
+          source: source.kind,
+          sourceLabel,
+          keyName: source.kind === 'stored' ? resolved.keyName : null,
+          tokenPrefix: shownTokenPrefix,
+          driveCount,
+          personalLogin,
+        })}\n`,
+      );
+      return EXIT_SUCCESS;
+    }
+
+    ctx.stdout.write(`Host:   ${host}\n`);
+    ctx.stdout.write(`Source: ${sourceLabel}${shownTokenPrefix === null ? '' : ` (${shownTokenPrefix}…)`}\n`);
+    if (identity !== null) {
+      ctx.stdout.write(`User:   ${identity.name ?? identity.email} <${identity.email}>\n`);
+    }
+    const shownScopes = scopes === null ? null : displayScopes(scopes);
+    ctx.stdout.write(
+      `Scopes: ${shownScopes === null ? '(not stored locally)' : shownScopes.length > 0 ? shownScopes.join(' ') : '(none)'}\n`,
+    );
+    if (driveCount !== null) {
+      ctx.stdout.write(`Drives: ${driveCount} accessible\n`);
+    }
+    if (personalLogin !== null) {
+      ctx.stdout.write(personalLogin ? 'Personal login: present\n' : 'Personal login: none (run "pagespace login")\n');
     }
 
     return EXIT_SUCCESS;
@@ -138,5 +278,6 @@ export const whoamiHandler: CommandHandler = createWhoamiHandler({
   discoverMetadata: createDiscoverMetadata(),
   createRefreshAccessToken,
   confirmIdentity,
+  probeDriveCount,
   now: Date.now,
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,6 +267,19 @@ export type {
   ResolveKeyNameFlags,
 } from './auth/resolve.js';
 export { createRefreshAccessToken } from './auth/silent-refresh.js';
+
+// The async shell around that pure resolver: the single implementation of the
+// full precedence chain INCLUDING its two store reads (the machine's active
+// key, then the credential itself). `run.ts` and `pagespace whoami` both go
+// through it — a second implementation of this chain is precisely what made
+// `whoami` report "Not logged in" on a machine driven by an active key.
+export { describeCredentialSource, resolveCredentialSource } from './auth/resolve-credential-source.js';
+export type { ResolveCredentialSourceInput, ResolvedCredentialSource } from './auth/resolve-credential-source.js';
+
+// Liveness probe for `mcp_*` keys, which `/api/auth/me` deliberately refuses.
+export { PROBE_DRIVES_TIMEOUT_MS, probeDriveCount } from './auth/probe-drives.js';
+export type { ProbeDriveCount } from './auth/probe-drives.js';
+
 export { buildAuthProvider, enforceAuth, FailingAuthProvider } from './auth/auth-context.js';
 export type { BuildAuthProviderDeps, DiscoverTokenEndpoint, EnforceAuthDeps } from './auth/auth-context.js';
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -322,7 +322,6 @@ export {
   activationSuccessMessage,
   createKeysUseHandler,
   deactivationMessage,
-  describeActivateFailure,
   findServerTokenId,
   keysUseHandler,
   loginCredentialNotActivatableMessage,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -280,6 +280,14 @@ export type { ResolveCredentialSourceInput, ResolvedCredentialSource } from './a
 export { PROBE_DRIVES_TIMEOUT_MS, probeDriveCount } from './auth/probe-drives.js';
 export type { ProbeDriveCount } from './auth/probe-drives.js';
 
+// The transport switch every consent-driven command goes through — loopback
+// browser flow or RFC 8628 device flow — with each transport carrying its own
+// delay adapter (they need opposite ref/unref semantics; see wait.ts).
+export { describeConsentFailure, renderDeviceCodePrompt, runConsent } from './auth/run-consent.js';
+export type { ConsentResult, DeviceConsentDeps, LoopbackConsentDeps, RunConsentParams } from './auth/run-consent.js';
+export { createSigintFlag } from './auth/sigint.js';
+export { parseTokenResponse } from './auth/token-response.js';
+
 export { buildAuthProvider, enforceAuth, FailingAuthProvider } from './auth/auth-context.js';
 export type { BuildAuthProviderDeps, DiscoverTokenEndpoint, EnforceAuthDeps } from './auth/auth-context.js';
 

--- a/packages/cli/src/router/routes.ts
+++ b/packages/cli/src/router/routes.ts
@@ -82,7 +82,7 @@ export interface RouteEntry extends Route {
 }
 
 const OTHER_ROUTES: readonly RouteEntry[] = [
-  { path: ['login'], handler: loginHandler, summary: 'Log in via the browser (loopback + PKCE)' },
+  { path: ['login'], handler: loginHandler, summary: 'Log in via the browser, or --device for a headless machine' },
   { path: ['logout'], handler: logoutHandler, summary: 'Revoke and remove a stored credential' },
   { path: ['whoami'], handler: whoamiHandler, summary: 'Show the currently authenticated identity' },
   // `keys` (Phase 9 task 5, consolidated Phase 9 follow-up) is the sole
@@ -94,10 +94,10 @@ const OTHER_ROUTES: readonly RouteEntry[] = [
   // `keys edit`/`update` flag subcommand — per this phase's plan,
   // scope-editing is wizard-only.
   { path: ['keys'], handler: keysHandler, summary: 'Guided wizard to create/list/edit/revoke access keys' },
-  { path: ['keys', 'create'], handler: tokensCreateHandler, summary: 'Mint a new access key' },
+  { path: ['keys', 'create'], handler: tokensCreateHandler, summary: 'Mint a new access key (--device for a headless machine)' },
   { path: ['keys', 'list'], handler: tokensListHandler, summary: 'List access keys' },
   { path: ['keys', 'revoke'], handler: tokensRevokeHandler, summary: 'Revoke an access key' },
-  { path: ['keys', 'use'], handler: keysUseHandler, summary: "Set this machine's active key (browser approval)" },
+  { path: ['keys', 'use'], handler: keysUseHandler, summary: "Set this machine's active key (--device for a headless machine)" },
   { path: ['mcp'], handler: mcpHandler, longRunning: true, summary: 'Serve the full operation registry as an MCP stdio server' },
   { path: ['drives', 'list'], handler: drivesListHandler, summary: 'List drives' },
   { path: ['drives', 'create'], handler: drivesCreateHandler, summary: 'Create a drive' },

--- a/packages/cli/src/run.ts
+++ b/packages/cli/src/run.ts
@@ -10,13 +10,8 @@ import { buildAuthProvider, enforceAuth } from './auth/auth-context.js';
 import { createDiscoverMetadata } from './auth/discover.js';
 import { resolveEnvKeyName, resolveEnvToken } from './auth/legacy-token-env.js';
 import { createRefreshAccessToken } from './auth/silent-refresh.js';
-import {
-  hasExplicitCredential,
-  mcpNoExplicitCredentialMessage,
-  noExplicitCredentialMessage,
-  resolveAuth,
-  resolveKeyName,
-} from './auth/resolve.js';
+import { mcpNoExplicitCredentialMessage, noExplicitCredentialMessage } from './auth/resolve.js';
+import { resolveCredentialSource } from './auth/resolve-credential-source.js';
 import { loginHandler } from './commands/login.js';
 import { loginDeviceHandler } from './commands/login-device.js';
 import { logoutHandler } from './commands/logout.js';
@@ -31,7 +26,6 @@ import { whoamiHandler } from './commands/whoami.js';
 import { resolveConfig } from './config/resolve.js';
 import { createNullActiveKeyStore, type ActiveKeyStore } from './credentials/active-key.js';
 import type { CredentialStore } from './credentials/store.js';
-import type { HostCredential } from './credentials/serialize.js';
 import { EXIT_RUNTIME_ERROR, EXIT_USAGE_ERROR, type ExitCode } from './exit-codes.js';
 import type { HandlerContext, OutputSink } from './handler-context.js';
 import { resolveRoute } from './router/router.js';
@@ -156,42 +150,24 @@ export async function run(deps: RunDependencies): Promise<ExitCode> {
   const resolution = resolveRoute(ROUTES, parsed.args);
   const routedHandler = resolution.kind === 'match' ? resolution.route.handler : null;
   const isAuthExempt = routedHandler !== null && AUTH_EXEMPT_HANDLERS.has(routedHandler);
-  const explicit = hasExplicitCredential({ token: parsed.flags.token, key: parsed.flags.key }, deps.env);
 
   // The active key (`pagespace keys use`) is the lowest-priority source, and
   // only for gated CONTENT commands: explicit --token/--key/env always wins
-  // (`explicit` above), auth-exempt handlers keep their ambient login
+  // (`explicit` below), auth-exempt handlers keep their ambient login
   // credential (the keys family needs its `manage_keys` scope, which a
   // drive-scoped active key doesn't carry), and `pagespace mcp` — invoked
   // unattended by an MCP client — deliberately never rides a human's
   // per-machine activation (its config must name a credential itself).
   const activeKeyEligible = routedHandler !== null && !isAuthExempt && routedHandler !== mcpHandler;
 
-  let keyName = resolveKeyName({ key: parsed.flags.key }, { PAGESPACE_KEY: envKey.name });
-  let credential: HostCredential | null = null;
-  let activeKeyName: string | null = null;
-  if (!explicit && activeKeyEligible) {
-    const active = await activeKeyStore.getActiveKey(host);
-    if (active !== null) {
-      const activeCredential = await deps.credentialStore.get(host, active);
-      if (activeCredential !== null) {
-        keyName = active;
-        credential = activeCredential;
-        activeKeyName = active;
-      }
-    }
-  }
-  if (activeKeyName === null) {
-    credential = await deps.credentialStore.get(host, keyName);
-  }
-
-  const source = resolveAuth(
-    { token: parsed.flags.token },
-    { PAGESPACE_TOKEN: envToken.token },
-    credential ? { [host]: { [keyName]: credential } } : {},
+  const { source, activeKeyName, explicit } = await resolveCredentialSource({
+    flags: { token: parsed.flags.token, key: parsed.flags.key },
+    env: deps.env,
     host,
-    keyName,
-  );
+    credentialStore: deps.credentialStore,
+    activeKeyStore,
+    allowActiveKey: activeKeyEligible,
+  });
 
   const auth = buildAuthProvider(source, {
     discoverMetadata: createDiscoverMetadata(),

--- a/packages/db/drizzle/0220_stiff_selene.sql
+++ b/packages/db/drizzle/0220_stiff_selene.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "oauth_device_codes" ADD COLUMN "redeemedAt" timestamp;

--- a/packages/db/drizzle/meta/0220_snapshot.json
+++ b/packages/db/drizzle/meta/0220_snapshot.json
@@ -1,0 +1,20887 @@
+{
+  "id": "67b2f17d-4e82-47e3-b335-ecfd6c2c3403",
+  "prevId": "6b135b1d-0d3c-4b6b-b054-b4b80bd0c6ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      }
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailBidx": {
+          "name": "emailBidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'openai/gpt-5.3-chat'"
+        },
+        "imageGenerationModel": {
+          "name": "imageGenerationModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_email_bidx_idx": {
+          "name": "users_email_bidx_idx",
+          "columns": [
+            {
+              "expression": "emailBidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      }
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        }
+      },
+      "indexes": {
+        "chat_messages_page_id_idx": {
+          "name": "chat_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_user_id_idx": {
+          "name": "chat_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_conversation_id_idx": {
+          "name": "chat_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_conversation_id_idx": {
+          "name": "chat_messages_page_id_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_is_active_created_at_idx": {
+          "name": "chat_messages_page_id_is_active_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_pageId_pages_id_fk": {
+          "name": "chat_messages_pageId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_userId_users_id_fk": {
+          "name": "chat_messages_userId_users_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_sourceAgentId_pages_id_fk": {
+          "name": "chat_messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "DriveKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'STANDARD'"
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishSubdomain": {
+          "name": "publishSubdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "homePageId": {
+          "name": "homePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_default_og_image_url": {
+          "name": "publish_default_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "not_found_page_id": {
+          "name": "not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_favicon_url": {
+          "name": "publish_favicon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_home_unique": {
+          "name": "drives_owner_home_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"drives\".\"kind\" = 'HOME'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drives_homePageId_pages_id_fk": {
+          "name": "drives_homePageId_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "homePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drives_not_found_page_id_pages_id_fk": {
+          "name": "drives_not_found_page_id_pages_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drives_publishSubdomain_unique": {
+          "name": "drives_publishSubdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "publishSubdomain"
+          ]
+        }
+      }
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_tags": {
+      "name": "page_tags",
+      "schema": "",
+      "columns": {
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_tags_pageId_pages_id_fk": {
+          "name": "page_tags_pageId_pages_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_tags_tagId_tags_id_fk": {
+          "name": "page_tags_tagId_tags_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_tags_pageId_tagId_pk": {
+          "name": "page_tags_pageId_tagId_pk",
+          "columns": [
+            "pageId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "toolExposureMode": {
+          "name": "toolExposureMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'upfront'"
+        },
+        "userScopedAccess": {
+          "name": "userScopedAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "terminalAccess": {
+          "name": "terminalAccess",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "machines": {
+          "name": "machines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowPageAgents": {
+          "name": "allowPageAgents",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "PermissionAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "SubjectType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectId": {
+          "name": "subjectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_page_id_idx": {
+          "name": "permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_subject_id_subject_type_idx": {
+          "name": "permissions_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_page_id_subject_id_subject_type_idx": {
+          "name": "permissions_page_id_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_pageId_pages_id_fk": {
+          "name": "permissions_pageId_pages_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_agent_members": {
+      "name": "drive_agent_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeContext": {
+          "name": "includeContext",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedAt": {
+          "name": "addedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_agent_members_drive_id_idx": {
+          "name": "drive_agent_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_agent_members_agent_page_id_idx": {
+          "name": "drive_agent_members_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_agent_members_driveId_drives_id_fk": {
+          "name": "drive_agent_members_driveId_drives_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_agentPageId_pages_id_fk": {
+          "name": "drive_agent_members_agentPageId_pages_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_agent_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_agent_members_addedBy_users_id_fk": {
+          "name": "drive_agent_members_addedBy_users_id_fk",
+          "tableFrom": "drive_agent_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_agent_members_drive_agent_key": {
+          "name": "drive_agent_members_drive_agent_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "agentPageId"
+          ]
+        }
+      }
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      }
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_parent_created_idx": {
+          "name": "channel_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_quoted_id_idx": {
+          "name": "channel_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_parentId_channel_messages_id_fk": {
+          "name": "channel_messages_parentId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_mirroredFromId_channel_messages_id_fk": {
+          "name": "channel_messages_mirroredFromId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "channel_messages_quotedMessageId_channel_messages_id_fk": {
+          "name": "channel_messages_quotedMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.channel_thread_followers": {
+      "name": "channel_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_thread_followers_user_id_idx": {
+          "name": "channel_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_thread_followers_rootMessageId_channel_messages_id_fk": {
+          "name": "channel_thread_followers_rootMessageId_channel_messages_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_thread_followers_userId_users_id_fk": {
+          "name": "channel_thread_followers_userId_users_id_fk",
+          "tableFrom": "channel_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_thread_followers_rootMessageId_userId_pk": {
+          "name": "channel_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isShared": {
+          "name": "isShared",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'complete'"
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_toast_notification_preferences": {
+      "name": "user_toast_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "toast_notification_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_toast_notification_preferences_user_idx": {
+          "name": "user_toast_notification_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_toast_notification_preferences_userId_users_id_fk": {
+          "name": "user_toast_notification_preferences_userId_users_id_fk",
+          "tableFrom": "user_toast_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dataCategory": {
+          "name": "dataCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legalBasis": {
+          "name": "legalBasis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retentionPolicy": {
+          "name": "retentionPolicy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipients": {
+          "name": "recipients",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_status": {
+          "name": "reconcile_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcile_attempts": {
+          "name": "reconcile_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_source": {
+          "name": "idx_ai_usage_user_source",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_reconcile": {
+          "name": "idx_ai_usage_reconcile",
+          "columns": [
+            {
+              "expression": "reconcile_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "reconcile_status = 'pending'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_resolutions": {
+      "name": "error_resolutions",
+      "schema": "",
+      "columns": {
+        "error_id": {
+          "name": "error_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_wide_permissions": {
+          "name": "drive_wide_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "NULL"
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_schedules": {
+      "name": "drive_backup_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "drive_backup_schedule_frequency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "drive_backup_schedules_enabled_next_run_idx": {
+          "name": "drive_backup_schedules_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_schedules_driveId_drives_id_fk": {
+          "name": "drive_backup_schedules_driveId_drives_id_fk",
+          "tableFrom": "drive_backup_schedules",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_backup_schedules_driveId_unique": {
+          "name": "drive_backup_schedules_driveId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId"
+          ]
+        }
+      }
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      }
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replyCount": {
+          "name": "replyCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastReplyAt": {
+          "name": "lastReplyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirroredFromId": {
+          "name": "mirroredFromId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quotedMessageId": {
+          "name": "quotedMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_active_created_idx": {
+          "name": "direct_messages_conversation_active_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_inactive_deleted_at_idx": {
+          "name": "direct_messages_inactive_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_parent_created_idx": {
+          "name": "direct_messages_parent_created_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_quoted_id_idx": {
+          "name": "direct_messages_quoted_id_idx",
+          "columns": [
+            {
+              "expression": "quotedMessageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_parentId_direct_messages_id_fk": {
+          "name": "direct_messages_parentId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "parentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_mirroredFromId_direct_messages_id_fk": {
+          "name": "direct_messages_mirroredFromId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "mirroredFromId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "direct_messages_quotedMessageId_direct_messages_id_fk": {
+          "name": "direct_messages_quotedMessageId_direct_messages_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "quotedMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      }
+    },
+    "public.dm_message_reactions": {
+      "name": "dm_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_unique_reaction_idx": {
+          "name": "dm_unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_reaction_message_idx": {
+          "name": "dm_reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_message_reactions_messageId_direct_messages_id_fk": {
+          "name": "dm_message_reactions_messageId_direct_messages_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_message_reactions_userId_users_id_fk": {
+          "name": "dm_message_reactions_userId_users_id_fk",
+          "tableFrom": "dm_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dm_thread_followers": {
+      "name": "dm_thread_followers",
+      "schema": "",
+      "columns": {
+        "rootMessageId": {
+          "name": "rootMessageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dm_thread_followers_user_id_idx": {
+          "name": "dm_thread_followers_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_thread_followers_rootMessageId_direct_messages_id_fk": {
+          "name": "dm_thread_followers_rootMessageId_direct_messages_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "direct_messages",
+          "columnsFrom": [
+            "rootMessageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_thread_followers_userId_users_id_fk": {
+          "name": "dm_thread_followers_userId_users_id_fk",
+          "tableFrom": "dm_thread_followers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "dm_thread_followers_rootMessageId_userId_pk": {
+          "name": "dm_thread_followers_rootMessageId_userId_pk",
+          "columns": [
+            "rootMessageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "gifted": {
+          "name": "gifted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      }
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      }
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_items_pageId_unique": {
+          "name": "task_items_pageId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId"
+          ]
+        }
+      }
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_bidx": {
+          "name": "ip_bidx",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip_bidx": {
+          "name": "idx_security_audit_ip_bidx",
+          "columns": [
+            {
+              "expression": "ip_bidx",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "terminal_access": {
+          "name": "terminal_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "machines": {
+          "name": "machines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "own_machine_page_id": {
+          "name": "own_machine_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "global_assistant_config_own_machine_page_id_pages_id_fk": {
+          "name": "global_assistant_config_own_machine_page_id_pages_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "own_machine_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      }
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      }
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_automation_preferences": {
+      "name": "user_automation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pulseEnabled": {
+          "name": "pulseEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_automation_preferences_user_idx": {
+          "name": "user_automation_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_automation_preferences_userId_users_id_fk": {
+          "name": "user_automation_preferences_userId_users_id_fk",
+          "tableFrom": "user_automation_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.calendar_event_drives": {
+      "name": "calendar_event_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sharedBy": {
+          "name": "sharedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharedAt": {
+          "name": "sharedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "calendar_event_drives_event_id_idx": {
+          "name": "calendar_event_drives_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_event_drives_drive_id_idx": {
+          "name": "calendar_event_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_event_drives_eventId_calendar_events_id_fk": {
+          "name": "calendar_event_drives_eventId_calendar_events_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_driveId_drives_id_fk": {
+          "name": "calendar_event_drives_driveId_drives_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_event_drives_sharedBy_users_id_fk": {
+          "name": "calendar_event_drives_sharedBy_users_id_fk",
+          "tableFrom": "calendar_event_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "sharedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_event_drives_event_drive_key": {
+          "name": "calendar_event_drives_event_drive_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "driveId"
+          ]
+        }
+      }
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      }
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_trigger_at_idx": {
+          "name": "calendar_triggers_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      }
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.workflow_runs": {
+      "name": "workflow_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceTable": {
+          "name": "sourceTable",
+          "type": "WorkflowRunSourceTable",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "workflow_runs_workflow_started_at_idx": {
+          "name": "workflow_runs_workflow_started_at_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_source_lookup_idx": {
+          "name": "workflow_runs_source_lookup_idx",
+          "columns": [
+            {
+              "expression": "sourceTable",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_stuck_run_idx": {
+          "name": "workflow_runs_stuck_run_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflow_runs_running_claim_idx": {
+          "name": "workflow_runs_running_claim_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"workflow_runs\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflow_runs_workflowId_workflows_id_fk": {
+          "name": "workflow_runs_workflowId_workflows_id_fk",
+          "tableFrom": "workflow_runs",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      }
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pending_invites": {
+      "name": "pending_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_invites_drive_id_idx": {
+          "name": "pending_invites_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_email_idx": {
+          "name": "pending_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_expires_at_idx": {
+          "name": "pending_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_custom_role_id_idx": {
+          "name": "pending_invites_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_invites_active_drive_email_idx": {
+          "name": "pending_invites_active_drive_email_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_invites_drive_id_drives_id_fk": {
+          "name": "pending_invites_drive_id_drives_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_invites_custom_role_id_drive_roles_id_fk": {
+          "name": "pending_invites_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pending_invites_invited_by_users_id_fk": {
+          "name": "pending_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_invites_token_hash_unique": {
+          "name": "pending_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.pending_page_invites": {
+      "name": "pending_page_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_page_invites_page_id_idx": {
+          "name": "pending_page_invites_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_email_idx": {
+          "name": "pending_page_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_expires_at_idx": {
+          "name": "pending_page_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_page_invites_active_page_email_idx": {
+          "name": "pending_page_invites_active_page_email_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_page_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_page_invites_invited_by_users_id_fk": {
+          "name": "pending_page_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_page_invites_page_id_pages_id_fk": {
+          "name": "pending_page_invites_page_id_pages_id_fk",
+          "tableFrom": "pending_page_invites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_page_invites_token_hash_unique": {
+          "name": "pending_page_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.pending_connection_invites": {
+      "name": "pending_connection_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_message": {
+          "name": "request_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pending_connection_invites_invited_by_idx": {
+          "name": "pending_connection_invites_invited_by_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_email_idx": {
+          "name": "pending_connection_invites_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_expires_at_idx": {
+          "name": "pending_connection_invites_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_connection_invites_active_inviter_email_idx": {
+          "name": "pending_connection_invites_active_inviter_email_idx",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pending_connection_invites\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_connection_invites_invited_by_users_id_fk": {
+          "name": "pending_connection_invites_invited_by_users_id_fk",
+          "tableFrom": "pending_connection_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_connection_invites_token_hash_unique": {
+          "name": "pending_connection_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.ai_pending_abort_intents": {
+      "name": "ai_pending_abort_intents",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ai_pending_abort_intents_conversation_id_user_id_pk": {
+          "name": "ai_pending_abort_intents_conversation_id_user_id_pk",
+          "columns": [
+            "conversation_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "parts": {
+          "name": "parts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "raw_parts_count": {
+          "name": "raw_parts_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stream_id": {
+          "name": "stream_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abort_requested_at": {
+          "name": "abort_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_conversation_status_idx": {
+          "name": "ai_stream_sessions_conversation_status_idx",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_user_status_idx": {
+          "name": "ai_stream_sessions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ai_stream_sessions_stream_id_idx": {
+          "name": "ai_stream_sessions_stream_id_idx",
+          "columns": [
+            {
+              "expression": "stream_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_share_links": {
+      "name": "drive_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "custom_role_id": {
+          "name": "custom_role_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "drive_share_links_drive_id_idx": {
+          "name": "drive_share_links_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_expires_at_idx": {
+          "name": "drive_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_is_active_idx": {
+          "name": "drive_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_share_links_custom_role_id_idx": {
+          "name": "drive_share_links_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "custom_role_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_share_links_drive_id_drives_id_fk": {
+          "name": "drive_share_links_drive_id_drives_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_custom_role_id_drive_roles_id_fk": {
+          "name": "drive_share_links_custom_role_id_drive_roles_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "custom_role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_share_links_created_by_users_id_fk": {
+          "name": "drive_share_links_created_by_users_id_fk",
+          "tableFrom": "drive_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_share_links_token_unique": {
+          "name": "drive_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.page_share_links": {
+      "name": "page_share_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "page_share_links_page_id_idx": {
+          "name": "page_share_links_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_expires_at_idx": {
+          "name": "page_share_links_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_share_links_is_active_idx": {
+          "name": "page_share_links_is_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_share_links_page_id_pages_id_fk": {
+          "name": "page_share_links_page_id_pages_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_share_links_created_by_users_id_fk": {
+          "name": "page_share_links_created_by_users_id_fk",
+          "tableFrom": "page_share_links",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_share_links_token_unique": {
+          "name": "page_share_links_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "public.zoom_connections": {
+      "name": "zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "zoomUserId": {
+          "name": "zoomUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomAccountId": {
+          "name": "zoomAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoomEmail": {
+          "name": "zoomEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ZoomConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetFolderId": {
+          "name": "targetFolderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopeVersion": {
+          "name": "scopeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeAiSummary": {
+          "name": "includeAiSummary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeActionItems": {
+          "name": "includeActionItems",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includeTranscript": {
+          "name": "includeTranscript",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "zoom_connections_user_id_idx": {
+          "name": "zoom_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_status_idx": {
+          "name": "zoom_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_account_id_idx": {
+          "name": "zoom_connections_account_id_idx",
+          "columns": [
+            {
+              "expression": "zoomAccountId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "zoom_connections_target_drive_id_idx": {
+          "name": "zoom_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "zoom_connections_userId_users_id_fk": {
+          "name": "zoom_connections_userId_users_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "zoom_connections_targetDriveId_drives_id_fk": {
+          "name": "zoom_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "zoom_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "zoom_connections_userId_unique": {
+          "name": "zoom_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.webhook_triggers": {
+      "name": "webhook_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connectionId": {
+          "name": "connectionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageWebhookId": {
+          "name": "pageWebhookId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "webhook_triggers_workflow_id_idx": {
+          "name": "webhook_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_provider_event_idx": {
+          "name": "webhook_triggers_provider_event_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_connection_id_idx": {
+          "name": "webhook_triggers_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connectionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_id_idx": {
+          "name": "webhook_triggers_page_webhook_id_idx",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_triggers_page_webhook_workflow_unique": {
+          "name": "webhook_triggers_page_webhook_workflow_unique",
+          "columns": [
+            {
+              "expression": "pageWebhookId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"webhook_triggers\".\"pageWebhookId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_triggers_workflowId_workflows_id_fk": {
+          "name": "webhook_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_connectionId_zoom_connections_id_fk": {
+          "name": "webhook_triggers_connectionId_zoom_connections_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "zoom_connections",
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhook_triggers_pageWebhookId_page_webhooks_id_fk": {
+          "name": "webhook_triggers_pageWebhookId_page_webhooks_id_fk",
+          "tableFrom": "webhook_triggers",
+          "tableTo": "page_webhooks",
+          "columnsFrom": [
+            "pageWebhookId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "webhook_triggers_connection_workflow_event_unique": {
+          "name": "webhook_triggers_connection_workflow_event_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connectionId",
+            "workflowId",
+            "eventType"
+          ]
+        }
+      }
+    },
+    "public.message_drafts": {
+      "name": "message_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextKey": {
+          "name": "contextKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_drafts_user_context_key": {
+          "name": "message_drafts_user_context_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contextKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_drafts_expires_at_idx": {
+          "name": "message_drafts_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_drafts_userId_users_id_fk": {
+          "name": "message_drafts_userId_users_id_fk",
+          "tableFrom": "message_drafts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_sessions": {
+      "name": "machine_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "egressPolicyToken": {
+          "name": "egressPolicyToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_sessions_page_id_idx": {
+          "name": "machine_sessions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_sessions_last_active_at_idx": {
+          "name": "machine_sessions_last_active_at_idx",
+          "columns": [
+            {
+              "expression": "lastActiveAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_sessions_pageId_pages_id_fk": {
+          "name": "machine_sessions_pageId_pages_id_fk",
+          "tableFrom": "machine_sessions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_sessions_userId_users_id_fk": {
+          "name": "machine_sessions_userId_users_id_fk",
+          "tableFrom": "machine_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_sessions_sessionKey_unique": {
+          "name": "machine_sessions_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
+    },
+    "public.published_pages": {
+      "name": "published_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "publish_title": {
+          "name": "publish_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_description": {
+          "name": "publish_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_og_image_url": {
+          "name": "publish_og_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "noindex": {
+          "name": "noindex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "published_pages_drive_id_idx": {
+          "name": "published_pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "published_pages_page_id_idx": {
+          "name": "published_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "published_pages_drive_id_drives_id_fk": {
+          "name": "published_pages_drive_id_drives_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_page_id_pages_id_fk": {
+          "name": "published_pages_page_id_pages_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "published_pages_published_by_users_id_fk": {
+          "name": "published_pages_published_by_users_id_fk",
+          "tableFrom": "published_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "published_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "published_pages_page_id_key": {
+          "name": "published_pages_page_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "page_id"
+          ]
+        },
+        "published_pages_drive_id_path_key": {
+          "name": "published_pages_drive_id_path_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "path"
+          ]
+        }
+      }
+    },
+    "public.credit_balances": {
+      "name": "credit_balances",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "monthlyRemainingCents": {
+          "name": "monthlyRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyAllowanceCents": {
+          "name": "monthlyAllowanceCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "topupRemainingCents": {
+          "name": "topupRemainingCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "debtCents": {
+          "name": "debtCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pendingMillicents": {
+          "name": "pendingMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "monthlyPeriodStart": {
+          "name": "monthlyPeriodStart",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monthlyPeriodEnd": {
+          "name": "monthlyPeriodEnd",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credit_balances_userId_users_id_fk": {
+          "name": "credit_balances_userId_users_id_fk",
+          "tableFrom": "credit_balances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.credit_holds": {
+      "name": "credit_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "estCents": {
+          "name": "estCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "credit_holds_user_idx": {
+          "name": "credit_holds_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_holds_expires_idx": {
+          "name": "credit_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_holds_userId_users_id_fk": {
+          "name": "credit_holds_userId_users_id_fk",
+          "tableFrom": "credit_holds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.credit_ledger": {
+      "name": "credit_ledger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryType": {
+          "name": "entryType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountCents": {
+          "name": "amountCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "appliedCents": {
+          "name": "appliedCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chargeMillicents": {
+          "name": "chargeMillicents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiUsageLogId": {
+          "name": "aiUsageLogId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realCostCents": {
+          "name": "realCostCents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "markupBps": {
+          "name": "markupBps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15000
+        },
+        "stripeRef": {
+          "name": "stripeRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumeStatus": {
+          "name": "consumeStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "consumeError": {
+          "name": "consumeError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconcileGenerationKey": {
+          "name": "reconcileGenerationKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credit_ledger_user_idx": {
+          "name": "credit_ledger_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_usage_log_unique": {
+          "name": "credit_ledger_usage_log_unique",
+          "columns": [
+            {
+              "expression": "aiUsageLogId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"aiUsageLogId\" IS NOT NULL AND \"credit_ledger\".\"entryType\" = 'usage'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_stripe_ref_unique": {
+          "name": "credit_ledger_stripe_ref_unique",
+          "columns": [
+            {
+              "expression": "stripeRef",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"stripeRef\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_reconcile_key_unique": {
+          "name": "credit_ledger_reconcile_key_unique",
+          "columns": [
+            {
+              "expression": "reconcileGenerationKey",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"credit_ledger\".\"reconcileGenerationKey\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "credit_ledger_consume_status_idx": {
+          "name": "credit_ledger_consume_status_idx",
+          "columns": [
+            {
+              "expression": "consumeStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credit_ledger_userId_users_id_fk": {
+          "name": "credit_ledger_userId_users_id_fk",
+          "tableFrom": "credit_ledger",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.commands": {
+      "name": "commands",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_page_id": {
+          "name": "entry_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'document'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "commands_user_id_idx": {
+          "name": "commands_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_drive_id_idx": {
+          "name": "commands_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "commands_entry_page_id_idx": {
+          "name": "commands_entry_page_id_idx",
+          "columns": [
+            {
+              "expression": "entry_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "commands_user_id_users_id_fk": {
+          "name": "commands_user_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_drive_id_drives_id_fk": {
+          "name": "commands_drive_id_drives_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "commands_created_by_id_users_id_fk": {
+          "name": "commands_created_by_id_users_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "commands_entry_page_id_pages_id_fk": {
+          "name": "commands_entry_page_id_pages_id_fk",
+          "tableFrom": "commands",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "entry_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "commands_user_trigger": {
+          "name": "commands_user_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trigger"
+          ]
+        },
+        "commands_drive_trigger": {
+          "name": "commands_drive_trigger",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "trigger"
+          ]
+        }
+      }
+    },
+    "public.conversation_compactions": {
+      "name": "conversation_compactions",
+      "schema": "",
+      "columns": {
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "summary_tokens": {
+          "name": "summary_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "compacted_up_to_message_id": {
+          "name": "compacted_up_to_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "compacted_up_to_created_at": {
+          "name": "compacted_up_to_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_version": {
+          "name": "summary_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "summarizer_model": {
+          "name": "summarizer_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_compacted_at": {
+          "name": "last_compacted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "conversation_compactions_page_id_idx": {
+          "name": "conversation_compactions_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "conversation_compactions_conversation_id_source_pk": {
+          "name": "conversation_compactions_conversation_id_source_pk",
+          "columns": [
+            "conversation_id",
+            "source"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.custom_domains": {
+      "name": "custom_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "custom_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform_owned": {
+          "name": "platform_owned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "publish_landing_page_id": {
+          "name": "publish_landing_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publish_not_found_page_id": {
+          "name": "publish_not_found_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "custom_domains_hostname_key": {
+          "name": "custom_domains_hostname_key",
+          "columns": [
+            {
+              "expression": "hostname",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_drive_id_idx": {
+          "name": "custom_domains_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "custom_domains_primary_per_drive": {
+          "name": "custom_domains_primary_per_drive",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"custom_domains\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "custom_domains_drive_id_drives_id_fk": {
+          "name": "custom_domains_drive_id_drives_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_landing_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_landing_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_landing_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "custom_domains_publish_not_found_page_id_pages_id_fk": {
+          "name": "custom_domains_publish_not_found_page_id_pages_id_fk",
+          "tableFrom": "custom_domains",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "publish_not_found_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.incidents": {
+      "name": "incidents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detectedAt": {
+          "name": "detectedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reportedBy": {
+          "name": "reportedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedUserCount": {
+          "name": "affectedUserCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affectedScope": {
+          "name": "affectedScope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "riskLevel": {
+          "name": "riskLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresAuthorityNotification": {
+          "name": "requiresAuthorityNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotificationDeadline": {
+          "name": "authorityNotificationDeadline",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorityNotifiedAt": {
+          "name": "authorityNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresSubjectNotification": {
+          "name": "requiresSubjectNotification",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subjectsNotifiedAt": {
+          "name": "subjectsNotifiedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_incidents_status": {
+          "name": "idx_incidents_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_detected_at": {
+          "name": "idx_incidents_detected_at",
+          "columns": [
+            {
+              "expression": "detectedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_authority_deadline": {
+          "name": "idx_incidents_authority_deadline",
+          "columns": [
+            {
+              "expression": "authorityNotificationDeadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incidents_reportedBy_users_id_fk": {
+          "name": "incidents_reportedBy_users_id_fk",
+          "tableFrom": "incidents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reportedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.data_subject_requests": {
+      "name": "data_subject_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_email": {
+          "name": "subject_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_type": {
+          "name": "request_type",
+          "type": "data_subject_request_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'erasure'"
+        },
+        "status": {
+          "name": "status",
+          "type": "data_subject_request_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "force_delete": {
+          "name": "force_delete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_by_type": {
+          "name": "requested_by_type",
+          "type": "data_subject_requester_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'self'"
+        },
+        "legal_basis": {
+          "name": "legal_basis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sla_deadline": {
+          "name": "sla_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_subject_requests_status_idx": {
+          "name": "data_subject_requests_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_sla_deadline_idx": {
+          "name": "data_subject_requests_sla_deadline_idx",
+          "columns": [
+            {
+              "expression": "sla_deadline",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "data_subject_requests_user_id_idx": {
+          "name": "data_subject_requests_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_subject_requests_user_id_users_id_fk": {
+          "name": "data_subject_requests_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "data_subject_requests_requested_by_user_id_users_id_fk": {
+          "name": "data_subject_requests_requested_by_user_id_users_id_fk",
+          "tableFrom": "data_subject_requests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requested_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_access_tokens_family_id_idx": {
+          "name": "oauth_access_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_user_id_idx": {
+          "name": "oauth_access_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_client_id_idx": {
+          "name": "oauth_access_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_token_hash_idx": {
+          "name": "oauth_access_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_tokens_expires_at_idx": {
+          "name": "oauth_access_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_access_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_userId_users_id_fk": {
+          "name": "oauth_access_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_tokenHash_unique": {
+          "name": "oauth_access_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_authorization_codes": {
+      "name": "oauth_authorization_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "codeHash": {
+          "name": "codeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codePrefix": {
+          "name": "codePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUri": {
+          "name": "redirectUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallenge": {
+          "name": "codeChallenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeChallengeMethod": {
+          "name": "codeChallengeMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumedAt": {
+          "name": "consumedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issuedFamilyId": {
+          "name": "issuedFamilyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_authorization_codes_client_id_idx": {
+          "name": "oauth_authorization_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_user_id_idx": {
+          "name": "oauth_authorization_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_code_hash_idx": {
+          "name": "oauth_authorization_codes_code_hash_idx",
+          "columns": [
+            {
+              "expression": "codeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_codes_expires_at_idx": {
+          "name": "oauth_authorization_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_authorization_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_codes_userId_users_id_fk": {
+          "name": "oauth_authorization_codes_userId_users_id_fk",
+          "tableFrom": "oauth_authorization_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_authorization_codes_codeHash_unique": {
+          "name": "oauth_authorization_codes_codeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "codeHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientType": {
+          "name": "clientType",
+          "type": "OAuthClientType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirectUris": {
+          "name": "redirectUris",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isFirstParty": {
+          "name": "isFirstParty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "disabledAt": {
+          "name": "disabledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_clients_client_id_idx": {
+          "name": "oauth_clients_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_clientId_unique": {
+          "name": "oauth_clients_clientId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clientId"
+          ]
+        }
+      }
+    },
+    "public.oauth_device_codes": {
+      "name": "oauth_device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deviceCodeHash": {
+          "name": "deviceCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceCodePrefix": {
+          "name": "deviceCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodeHash": {
+          "name": "userCodeHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userCodePrefix": {
+          "name": "userCodePrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvedAt": {
+          "name": "approvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deniedAt": {
+          "name": "deniedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemedAt": {
+          "name": "redeemedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastPolledAt": {
+          "name": "lastPolledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pollIntervalSeconds": {
+          "name": "pollIntervalSeconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_device_codes_client_id_idx": {
+          "name": "oauth_device_codes_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_id_idx": {
+          "name": "oauth_device_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_device_code_hash_idx": {
+          "name": "oauth_device_codes_device_code_hash_idx",
+          "columns": [
+            {
+              "expression": "deviceCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_user_code_hash_idx": {
+          "name": "oauth_device_codes_user_code_hash_idx",
+          "columns": [
+            {
+              "expression": "userCodeHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_device_codes_expires_at_idx": {
+          "name": "oauth_device_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_device_codes_clientId_oauth_clients_id_fk": {
+          "name": "oauth_device_codes_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_device_codes_userId_users_id_fk": {
+          "name": "oauth_device_codes_userId_users_id_fk",
+          "tableFrom": "oauth_device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_device_codes_deviceCodeHash_unique": {
+          "name": "oauth_device_codes_deviceCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "deviceCodeHash"
+          ]
+        },
+        "oauth_device_codes_userCodeHash_unique": {
+          "name": "oauth_device_codes_userCodeHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userCodeHash"
+          ]
+        }
+      }
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyId": {
+          "name": "familyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clientId": {
+          "name": "clientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "familyExpiresAt": {
+          "name": "familyExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_refresh_tokens_family_id_idx": {
+          "name": "oauth_refresh_tokens_family_id_idx",
+          "columns": [
+            {
+              "expression": "familyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_user_id_idx": {
+          "name": "oauth_refresh_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_client_id_idx": {
+          "name": "oauth_refresh_tokens_client_id_idx",
+          "columns": [
+            {
+              "expression": "clientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_token_hash_idx": {
+          "name": "oauth_refresh_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_tokens_expires_at_idx": {
+          "name": "oauth_refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_tokens_clientId_oauth_clients_id_fk": {
+          "name": "oauth_refresh_tokens_clientId_oauth_clients_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": [
+            "clientId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_userId_users_id_fk": {
+          "name": "oauth_refresh_tokens_userId_users_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_tokenHash_unique": {
+          "name": "oauth_refresh_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.form_targets": {
+      "name": "form_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'sheet:append'"
+        },
+        "canvas_page_id": {
+          "name": "canvas_page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "header_row": {
+          "name": "header_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "next_row": {
+          "name": "next_row",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_count": {
+          "name": "submission_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "form_targets_page_id_idx": {
+          "name": "form_targets_page_id_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_drive_id_idx": {
+          "name": "form_targets_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_status_idx": {
+          "name": "form_targets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_canvas_page_id_idx": {
+          "name": "form_targets_canvas_page_id_idx",
+          "columns": [
+            {
+              "expression": "canvas_page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "form_targets_one_active_per_page_idx": {
+          "name": "form_targets_one_active_per_page_idx",
+          "columns": [
+            {
+              "expression": "page_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"form_targets\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "form_targets_drive_id_drives_id_fk": {
+          "name": "form_targets_drive_id_drives_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_page_id_pages_id_fk": {
+          "name": "form_targets_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "form_targets_canvas_page_id_pages_id_fk": {
+          "name": "form_targets_canvas_page_id_pages_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "canvas_page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "form_targets_created_by_users_id_fk": {
+          "name": "form_targets_created_by_users_id_fk",
+          "tableFrom": "form_targets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "form_targets_token_hash_unique": {
+          "name": "form_targets_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.machine_projects": {
+      "name": "machine_projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repoUrl": {
+          "name": "repoUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_projects_machine_id_idx": {
+          "name": "machine_projects_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_projects_machine_id_name_idx": {
+          "name": "machine_projects_machine_id_name_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_projects_ownerId_users_id_fk": {
+          "name": "machine_projects_ownerId_users_id_fk",
+          "tableFrom": "machine_projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_projects_machineId_pages_id_fk": {
+          "name": "machine_projects_machineId_pages_id_fk",
+          "tableFrom": "machine_projects",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_projects_sessionKey_unique": {
+          "name": "machine_projects_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
+    },
+    "public.machine_branches": {
+      "name": "machine_branches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionKey": {
+          "name": "sessionKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "teardownRequestedAt": {
+          "name": "teardownRequestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spriteTornDownAt": {
+          "name": "spriteTornDownAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageLastBilledAt": {
+          "name": "storageLastBilledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "storageMeasuredBytes": {
+          "name": "storageMeasuredBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storageMeasuredAt": {
+          "name": "storageMeasuredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_branches_machine_id_idx": {
+          "name": "machine_branches_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_branches_machine_project_branch_idx": {
+          "name": "machine_branches_machine_project_branch_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "projectName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "branchName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_branches_ownerId_users_id_fk": {
+          "name": "machine_branches_ownerId_users_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_branches_machineId_pages_id_fk": {
+          "name": "machine_branches_machineId_pages_id_fk",
+          "tableFrom": "machine_branches",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "machine_branches_sessionKey_unique": {
+          "name": "machine_branches_sessionKey_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "sessionKey"
+          ]
+        }
+      }
+    },
+    "public.machine_sprite_reclaims": {
+      "name": "machine_sprite_reclaims",
+      "schema": "",
+      "columns": {
+        "sandboxId": {
+          "name": "sandboxId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "spriteInstanceId": {
+          "name": "spriteInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recordedAt": {
+          "name": "recordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastAttemptAt": {
+          "name": "lastAttemptAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "machine_sprite_reclaims_recorded_at_idx": {
+          "name": "machine_sprite_reclaims_recorded_at_idx",
+          "columns": [
+            {
+              "expression": "recordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_agent_terminals": {
+      "name": "machine_agent_terminals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "machineBranchId": {
+          "name": "machineBranchId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentType": {
+          "name": "agentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSessionId": {
+          "name": "streamSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_agent_terminals_machine_id_idx": {
+          "name": "machine_agent_terminals_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_agent_terminals_branch_id_idx": {
+          "name": "machine_agent_terminals_branch_id_idx",
+          "columns": [
+            {
+              "expression": "machineBranchId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "machine_agent_terminals_scope_name_idx": {
+          "name": "machine_agent_terminals_scope_name_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"projectName\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"machineBranchId\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_agent_terminals_ownerId_users_id_fk": {
+          "name": "machine_agent_terminals_ownerId_users_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_agent_terminals_machineId_pages_id_fk": {
+          "name": "machine_agent_terminals_machineId_pages_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_agent_terminals_machineBranchId_machine_branches_id_fk": {
+          "name": "machine_agent_terminals_machineBranchId_machine_branches_id_fk",
+          "tableFrom": "machine_agent_terminals",
+          "tableTo": "machine_branches",
+          "columnsFrom": [
+            "machineBranchId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.machine_workspaces": {
+      "name": "machine_workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectName": {
+          "name": "projectName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branchName": {
+          "name": "branchName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "layout": {
+          "name": "layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "machine_workspaces_machine_id_idx": {
+          "name": "machine_workspaces_machine_id_idx",
+          "columns": [
+            {
+              "expression": "machineId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "machine_workspaces_ownerId_users_id_fk": {
+          "name": "machine_workspaces_ownerId_users_id_fk",
+          "tableFrom": "machine_workspaces",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_workspaces_machineId_pages_id_fk": {
+          "name": "machine_workspaces_machineId_pages_id_fk",
+          "tableFrom": "machine_workspaces",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "machine_workspaces_machineId_id_pk": {
+          "name": "machine_workspaces_machineId_id_pk",
+          "columns": [
+            "machineId",
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.machine_workspace_bootstraps": {
+      "name": "machine_workspace_bootstraps",
+      "schema": "",
+      "columns": {
+        "machineId": {
+          "name": "machineId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bootstrappedByUserId": {
+          "name": "bootstrappedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bootstrappedAt": {
+          "name": "bootstrappedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "machine_workspace_bootstraps_machineId_pages_id_fk": {
+          "name": "machine_workspace_bootstraps_machineId_pages_id_fk",
+          "tableFrom": "machine_workspace_bootstraps",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "machineId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk": {
+          "name": "machine_workspace_bootstraps_bootstrappedByUserId_users_id_fk",
+          "tableFrom": "machine_workspace_bootstraps",
+          "tableTo": "users",
+          "columnsFrom": [
+            "bootstrappedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.broadcast_recipients": {
+      "name": "broadcast_recipients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_email": {
+          "name": "recipient_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_recipient_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "skip_reason": {
+          "name": "skip_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_unique": {
+          "name": "broadcast_recipients_broadcast_user_unique",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "broadcast_recipients_broadcast_status_idx": {
+          "name": "broadcast_recipients_broadcast_status_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_recipients_broadcast_id_email_broadcasts_id_fk": {
+          "name": "broadcast_recipients_broadcast_id_email_broadcasts_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "email_broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcast_recipients_user_id_users_id_fk": {
+          "name": "broadcast_recipients_user_id_users_id_fk",
+          "tableFrom": "broadcast_recipients",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.broadcast_templates": {
+      "name": "broadcast_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcast_templates_active_idx": {
+          "name": "broadcast_templates_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcast_templates_created_by_user_id_users_id_fk": {
+          "name": "broadcast_templates_created_by_user_id_users_id_fk",
+          "tableFrom": "broadcast_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_broadcasts": {
+      "name": "email_broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "email_broadcast_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'transactional'"
+        },
+        "content_mode": {
+          "name": "content_mode",
+          "type": "email_broadcast_content_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'compose'"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_markdown": {
+          "name": "body_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PRODUCT_UPDATE'"
+        },
+        "audience_definition": {
+          "name": "audience_definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "email_broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "dry_run": {
+          "name": "dry_run",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "send_limit": {
+          "name": "send_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delay_ms": {
+          "name": "delay_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 120
+        },
+        "total_targeted": {
+          "name": "total_targeted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent_count": {
+          "name": "sent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "step_results": {
+          "name": "step_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_broadcasts_status_idx": {
+          "name": "email_broadcasts_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_at_idx": {
+          "name": "email_broadcasts_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_broadcasts_created_by_idx": {
+          "name": "email_broadcasts_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_broadcasts_template_id_broadcast_templates_id_fk": {
+          "name": "email_broadcasts_template_id_broadcast_templates_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "broadcast_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "email_broadcasts_created_by_user_id_users_id_fk": {
+          "name": "email_broadcasts_created_by_user_id_users_id_fk",
+          "tableFrom": "email_broadcasts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_webhooks": {
+      "name": "page_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookToken": {
+          "name": "webhookToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookSecretEncrypted": {
+          "name": "webhookSecretEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_webhooks_page_id_idx": {
+          "name": "page_webhooks_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_webhooks_token_idx": {
+          "name": "page_webhooks_token_idx",
+          "columns": [
+            {
+              "expression": "webhookToken",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_webhooks_pageId_pages_id_fk": {
+          "name": "page_webhooks_pageId_pages_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_webhooks_createdBy_users_id_fk": {
+          "name": "page_webhooks_createdBy_users_id_fk",
+          "tableFrom": "page_webhooks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_webhooks_webhookToken_unique": {
+          "name": "page_webhooks_webhookToken_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "webhookToken"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.DriveKind": {
+      "name": "DriveKind",
+      "schema": "public",
+      "values": [
+        "STANDARD",
+        "HOME"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "MACHINE"
+      ]
+    },
+    "public.PermissionAction": {
+      "name": "PermissionAction",
+      "schema": "public",
+      "values": [
+        "VIEW",
+        "EDIT",
+        "SHARE",
+        "DELETE"
+      ]
+    },
+    "public.SubjectType": {
+      "name": "SubjectType",
+      "schema": "public",
+      "values": [
+        "USER"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED",
+        "PRODUCT_UPDATE"
+      ]
+    },
+    "public.toast_notification_level": {
+      "name": "toast_notification_level",
+      "schema": "public",
+      "values": [
+        "all",
+        "mentions",
+        "off"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_schedule_frequency": {
+      "name": "drive_backup_schedule_frequency",
+      "schema": "public",
+      "values": [
+        "daily",
+        "weekly",
+        "monthly"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.WorkflowRunSourceTable": {
+      "name": "WorkflowRunSourceTable",
+      "schema": "public",
+      "values": [
+        "taskTriggers",
+        "calendarTriggers",
+        "webhookTriggers",
+        "cron",
+        "manual"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "running",
+        "success",
+        "error",
+        "cancelled"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    },
+    "public.ZoomConnectionStatus": {
+      "name": "ZoomConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.custom_domain_status": {
+      "name": "custom_domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "failed",
+        "provisioning",
+        "active",
+        "dns_failed",
+        "cert_failed"
+      ]
+    },
+    "public.data_subject_request_status": {
+      "name": "data_subject_request_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "queued",
+        "in_progress",
+        "blocked",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.data_subject_request_type": {
+      "name": "data_subject_request_type",
+      "schema": "public",
+      "values": [
+        "erasure",
+        "export",
+        "access",
+        "rectification",
+        "restriction",
+        "portability",
+        "objection"
+      ]
+    },
+    "public.data_subject_requester_type": {
+      "name": "data_subject_requester_type",
+      "schema": "public",
+      "values": [
+        "self",
+        "admin"
+      ]
+    },
+    "public.OAuthClientType": {
+      "name": "OAuthClientType",
+      "schema": "public",
+      "values": [
+        "public",
+        "confidential"
+      ]
+    },
+    "public.broadcast_recipient_status": {
+      "name": "broadcast_recipient_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.email_broadcast_content_mode": {
+      "name": "email_broadcast_content_mode",
+      "schema": "public",
+      "values": [
+        "compose",
+        "template"
+      ]
+    },
+    "public.email_broadcast_engine": {
+      "name": "email_broadcast_engine",
+      "schema": "public",
+      "values": [
+        "transactional",
+        "resend_broadcast"
+      ]
+    },
+    "public.email_broadcast_status": {
+      "name": "email_broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "pending",
+        "queued",
+        "in_progress",
+        "paused",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1541,6 +1541,13 @@
       "when": 1784751730586,
       "tag": "0219_project_sprite_reclaim_trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 220,
+      "version": "7",
+      "when": 1784779520759,
+      "tag": "0220_stiff_selene",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/oauth.ts
+++ b/packages/db/src/schema/oauth.ts
@@ -64,6 +64,13 @@ export const oauthDeviceCodes = pgTable('oauth_device_codes', {
   expiresAt: timestamp('expiresAt', { mode: 'date' }).notNull(),
   approvedAt: timestamp('approvedAt', { mode: 'date' }),
   deniedAt: timestamp('deniedAt', { mode: 'date' }),
+  // RFC 8628 §3.5: the device_code MUST be invalidated once redeemed. Set in
+  // the same transaction that issues credentials for it, so a second poll of
+  // an approved code sees it already set and is refused (invalid_grant)
+  // instead of issuing again. Load-bearing for mint-shaped grants — without
+  // it, every extra poll of an approved `keys create --device` code would
+  // mint another `mcp_*` key.
+  redeemedAt: timestamp('redeemedAt', { mode: 'date' }),
   lastPolledAt: timestamp('lastPolledAt', { mode: 'date' }),
   pollIntervalSeconds: integer('pollIntervalSeconds').default(5).notNull(),
   createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),

--- a/packages/lib/src/auth/oauth/code-lifecycle.ts
+++ b/packages/lib/src/auth/oauth/code-lifecycle.ts
@@ -117,7 +117,9 @@ interface DeviceCodeCommon {
 export type DeviceCodeRecord =
   | ({ status: 'pending' } & DeviceCodeCommon)
   | ({ status: 'approved'; approvedUserId: string } & DeviceCodeCommon)
-  | ({ status: 'denied' } & DeviceCodeCommon);
+  | ({ status: 'denied' } & DeviceCodeCommon)
+  /** Already exchanged for credentials — RFC 8628 §3.5 requires it be invalidated. */
+  | ({ status: 'redeemed' } & DeviceCodeCommon);
 
 export interface DeviceGrant {
   clientId: string;
@@ -130,21 +132,33 @@ export type DevicePollDecision =
   | { status: 'slow_down' }
   | { status: 'expired_token' }
   | { status: 'access_denied' }
+  /** The device_code was already exchanged; the route collapses this to invalid_grant. */
+  | { status: 'already_redeemed' }
   | { status: 'ok'; grant: DeviceGrant };
 
 /**
  * Decide the response to a device-code poll (RFC 8628 §3.5).
  *
  * Precedence:
- *  1. expired_token — absolute boundary, checked before anything else,
- *     including an already-approved-but-unexchanged code.
- *  2. A settled record (approved/denied) reports its outcome immediately —
+ *  1. already_redeemed — a code that has been exchanged is dead for good, and
+ *     stays dead regardless of the clock; reported before expiry so the answer
+ *     doesn't change to `expired_token` once the TTL passes. RFC 8628 §3.5.
+ *     Without this, an approved code keeps issuing credentials on every poll
+ *     until it expires — harmless-looking for a login grant, but a mint-shaped
+ *     grant (`keys create --device`) would mint a fresh key each time.
+ *  2. expired_token — absolute boundary, checked before anything else
+ *     remaining, including an already-approved-but-unexchanged code.
+ *  3. A settled record (approved/denied) reports its outcome immediately —
  *     the poll-interval throttle only governs *continued waiting*, not
  *     delivery of an already-decided result.
- *  3. pending — throttle repeated polling faster than pollIntervalSeconds;
+ *  4. pending — throttle repeated polling faster than pollIntervalSeconds;
  *     exactly-at-interval is allowed (only strictly-less-than throttles).
  */
 export function decideDevicePoll(record: DeviceCodeRecord, now: Date): DevicePollDecision {
+  if (record.status === 'redeemed') {
+    return { status: 'already_redeemed' };
+  }
+
   if (now.getTime() >= record.expiresAt.getTime()) {
     return { status: 'expired_token' };
   }
@@ -179,16 +193,17 @@ export type DeviceApprovalAction = 'approve' | 'deny';
 export type DeviceApprovalDecision =
   | { status: 'approved'; grant: DeviceGrant }
   | { status: 'denied' }
-  | { status: 'already_settled'; existingStatus: 'approved' | 'denied' }
+  | { status: 'already_settled'; existingStatus: 'approved' | 'denied' | 'redeemed' }
   | { status: 'expired' };
 
 /**
  * Decide the outcome of a user's approve/deny action at the /activate screen.
  *
- * A settled record (already approved or denied) always rejects further
- * decisions — that check runs before expiry, since a terminal outcome stays
- * terminal regardless of whether the code has since expired. A still-pending
- * record fails closed exactly at (and after) its expiry boundary.
+ * A settled record (already approved, denied, or redeemed) always rejects
+ * further decisions — that check runs before expiry, since a terminal outcome
+ * stays terminal regardless of whether the code has since expired. A
+ * still-pending record fails closed exactly at (and after) its expiry
+ * boundary.
  */
 export function decideDeviceApproval(
   record: DeviceCodeRecord,

--- a/packages/lib/src/auth/oauth/scopes.ts
+++ b/packages/lib/src/auth/oauth/scopes.ts
@@ -474,6 +474,27 @@ export function hasNewKeyName(scopes: ScopeSet): scopes is ScopeSet & { newKeyNa
   return scopes.newKeyName !== null;
 }
 
+/**
+ * True iff approving this grant escalates the approver's credentials — it
+ * mints a key (`name:`), re-scopes one (`update_key:`), or makes one a
+ * device's ambient default (`activate_key:`) — as opposed to merely
+ * establishing a login session.
+ *
+ * Exists so the two halves of the device-flow step-up gate cannot drift: the
+ * `/activate` verify route uses it to decide whether to advertise (and run)
+ * the second-factor ceremony, and the decision route uses it to decide whether
+ * to REQUIRE one. Two independent expressions of that rule would mean a fourth
+ * key-shaped scope could be added where the screen never runs the ceremony and
+ * the server then rejects a legitimate approval — or, worse, where the server
+ * stops demanding one.
+ *
+ * The loopback consent screen does not need this: `/api/oauth/authorize`
+ * requires step-up for EVERY consent, escalating or not.
+ */
+export function isCredentialEscalatingGrant(scopes: ScopeSet): boolean {
+  return hasNewKeyName(scopes) || isKeyUpdateGrant(scopes) || isKeyActivationGrant(scopes);
+}
+
 /** Bridge to the capability model: rows in mcp_token_drives shape (Decision 2). */
 export function scopeSetToDriveScopes(scopes: ScopeSet): DriveScopeRow[] {
   const sortedDriveIds = [...scopes.drives.keys()].sort();


### PR DESCRIPTION
## Why

Two reported breakages in `pagespace` (`packages/cli`).

**1. `whoami` said "Not logged in" on a machine where everything worked.** It read only the `default` (personal login) slot, ignoring the rest of the precedence chain `run.ts` actually resolves. A machine driven by an active key (`pagespace keys use`) has no personal login at all — so the credential `whoami` reported on was never the credential it would have used:

```
$ pagespace drives list
… 54 drives …
$ pagespace whoami
Not logged in to https://pagespace.ai. Run "pagespace login."   # exit 1
```

The duplicate precedence implementation *was* the bug, so both callers now share one resolver (`auth/resolve-credential-source.ts`).

A second, independent defect: `whoami --key <staticKey>` could never succeed. `/api/auth/me` deliberately refuses `mcp_*` tokens (a scoped key is its own principal and must not surface the owner's email), so asking it for an identity could only 401 — reporting live keys as invalidated.

**2. No headless path to a scoped key.** `login --device` worked (undocumented), but `keys create` / `keys use` / the wizard were browser-loopback-only, and the server rejected their scopes at the device door. A remote/SSH machine could log in but never obtain the scoped key that content access actually requires.

## What changed

**whoami** — resolves the same chain `run.ts` does (`--token` > `PAGESPACE_TOKEN` > `--key` > active key > default login). Scoped keys skip the identity call entirely and prove liveness with a `drives.list` probe:

```
Host:   https://pagespace.ai
Source: active key "ALL" (mcp_j5zeddyf…)
Scopes: all_drives offline_access
Drives: 54 accessible
Personal login: none (run "pagespace login")
```

**`--device`** — the device grant now redeems mint, re-scope, and activate grants through the *same* `applyKeyGrant` the authorization-code exchange uses (extracted, not duplicated); `/activate` narrates and authority-checks them; `--device` is wired through `keys create`, `keys use`, and the wizard, and documented in `--help`.

## Three changes beyond the original scope — all load-bearing

- **`oauth_device_codes.redeemedAt` + migration.** Device codes had no single-use marker: an approved code re-issued credentials on *every* poll until expiry. Tolerable for logins; once the flow can mint keys, each extra poll mints another `mcp_*` key. Now enforced for all grants, per RFC 8628 §3.5.
- **Step-up parity on `/activate`.** The browser consent requires a second factor for every consent; the device decision route required none. Key-shaped grants now require one too — otherwise `--device` would mint keys with strictly *less* proof of presence than the browser flow demands. Logins unchanged.
- **SIGINT is no longer hooked at import.** `createSigintFlag()` was being *called* at module scope; `routes.ts` imports every command eagerly, and registering any SIGINT listener replaces Node's default terminate-on-Ctrl-C — so the first Ctrl-C became a no-op for unrelated commands like `pages read`. Now installed lazily inside the device branch. Importing the route table leaves **0** listeners, down from 1 on master, so this also fixes a pre-existing instance.

`all_drives` stays rejected over the device grant (it lands in the `allowedDriveIds: []` shape the two authorization helper families read oppositely). The CLI refuses `--device --all-drives` locally with the workaround, and `pollDeviceToken` re-checks at redemption.

## ⚠️ Requires `bun run db:migrate` before deploy

`packages/db/drizzle/0220_stiff_selene.sql` — one nullable column.

## Review round

Two P1s from Codex, both real, both fixed:

| Finding | Fix |
|---|---|
| Device polling used the loopback's **unref'd** timer, so Node could exit right after printing the verification code | The timer moved into `DeviceConsentDeps`, so each transport carries the adapter it needs and a command can't impose `unrefWaitMs` on the device path by omission. Regression test verified to fail against the old code. |
| The `keys` wizard **ignored `--device`** — and Edit, which exists only in the wizard, had no headless path at all | `intent.flags.device` is now read once and threaded through Create, Edit and Use. |

CodeRabbit independently flagged the same wizard gap.

A four-angle quality pass (reuse / simplification / efficiency / altitude) then cleared the leftovers — dead `describeActivateFailure`, a duplicate `createSigintFlag`, a redundant `ResolvedCredentialSource.credential`, a wasted keychain read when `--token` already decides, serialized whoami probes, and `parseTokenResponse` trying four schemas in order. Most consequentially it found **one security-relevant condition expressed twice**: `/activate`'s verify route decided whether to *advertise* the step-up ceremony while the decision route decided whether to *require* one, from two independent predicates. Both now call `isCredentialEscalatingGrant` from `scopes.ts`, and 16 tests pin both halves over the same three escalating shapes plus a plain-login control.

Writing those tests surfaced one more gap of my own making: when `parseScopeList` rejected a stored scope set, the verify route returned 200 with an **empty** `scopeDescriptions` list — a consent screen asking a human to approve something entirely unnarrated, under an Allow button. It now fails closed with the same no-oracle `invalid_code` the decision route already used. The legitimate empty-scope case (no `scope` sent at device-authorization time) is unaffected.

### Second follow-up pass

Continued the same quality pass after the P1s above landed:

- `runDeviceLogin` called `confirmIdentity` unconditionally and swallowed the resulting 401 into `identity = null` for `mcp` grants — masking a doomed round trip (billed at the confirm-identity timeout) on every `keys create --device`. Now gated on `tokens.kind === 'oauth'`, matching the gate `whoami` already uses. Two tests pin it: zero identity calls for a freshly minted `mcp` grant, still-confirms for `oauth`.
- `parseTokenResponse`'s per-branch switch collapsed into one `z.discriminatedUnion('token_type', […])` — same dispatch, one call site instead of four.
- `ActivateFlow` now drops a rejected step-up token on failure. Keeping it meant the `!token` guard skipped the ceremony on every retry and resubmitted the same dead token forever — a silent dead end, most easily hit by following an expired magic link. `ActivateFlow.test.tsx` (new, 4 tests) covers this plus the existing step-up/plain-login/deny paths.

### Known follow-ups (deliberately not in this PR)

- `login` / `login --device` remain two separate handlers outside the new `runConsent` seam, each with its own outcome switch. Folding them in means collapsing `login-device.ts` into `login.ts` — a bigger change than this PR's scope. The seam's docblock now says so rather than claiming otherwise.
- `ActivateFlow.tsx` is the third copy of the step-up-from-email-hash component protocol (after `ConsentActions.tsx` and `ConnectedAppsList.tsx`). Extracting a `useStepUpCeremony()` hook would touch two working security screens outside this diff.

## Verification

- CLI: **1115 tests pass** (2 more from the second follow-up pass). Web/lib oauth + repositories: **675 pass**, plus 4 new `ActivateFlow` tests. `tsc` clean across all 16 packages; `bun run lint` 14/14.
- Live-verified: whoami across all source kinds, the `--device --all-drives` guard, and 0 SIGINT listeners after importing the full route table.
- **Not verified end-to-end: a real headless key mint.** Production still runs the old server, so `keys create --device` there returns `Could not start device approval: … invalid_scope` — which confirms the CLI reaches the door, but the full flow can't be exercised until this server change is deployed. The device redemption paths are covered by unit tests, not a live run.

Two pre-existing test failures in `api/oauth/authorize/__tests__` (`x-forwarded-host` / issue #1908) are unrelated to this branch and fail identically on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMP1HVieaa4PLE2KSkK3LR

