### PR TITLE
fix(types): derive every PageType list from the canonical enum

### DIFF
--- a/apps/marketing/src/app/docs/features/cli/page.tsx
+++ b/apps/marketing/src/app/docs/features/cli/page.tsx
@@ -95,7 +95,7 @@ pagespace pages export <pageId> --format md --out -
 pagespace pages trash <pageId> --yes
 \`\`\`
 
-Page types are \`FOLDER\`, \`DOCUMENT\`, \`CHANNEL\`, \`AI_CHAT\`, \`CANVAS\`, \`FILE\`, \`SHEET\`, \`TASK_LIST\`, and \`CODE\`.
+Page types are \`FOLDER\`, \`DOCUMENT\`, \`CHANNEL\`, \`AI_CHAT\`, \`CANVAS\`, \`FILE\`, \`SHEET\`, \`TASK_LIST\`, \`CODE\`, and \`MACHINE\`.
 
 **Search**
 

--- a/apps/web/src/app/api/drives/[driveId]/search/glob/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/glob/__tests__/route.test.ts
@@ -45,6 +45,7 @@ vi.mock('@pagespace/lib/permissions/app-permissions', () => ({
 
 import { checkDriveAccessForSearch, globSearchPages } from '@pagespace/lib/services/drive-search-service';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { PAGE_TYPE_VALUES } from '@pagespace/lib/utils/enums';
 
 // ============================================================================
 // Test Fixtures
@@ -278,6 +279,74 @@ describe('GET /api/drives/[driveId]/search/glob', () => {
       const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
       // Must be a real, non-empty filter — NOT undefined (which would mean "return everything").
       expect(options?.includeTypes).toEqual(['TASK_LIST']);
+    });
+
+    // Regression tests for #2150: the route hand-declared VALID_PAGE_TYPES with
+    // only 8 of the enum's 10 members, so FILE and MACHINE were stripped from
+    // the filter. Asking for FILE alone left an empty array, which
+    // globSearchPages treats as "no filter" — the caller silently got EVERY
+    // page instead of only files.
+    it('should include FILE and MACHINE as valid includeTypes values (#2150)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=FILE,MACHINE`);
+      await GET(request, createContext(mockDriveId));
+
+      expect(globSearchPages).toHaveBeenCalledWith(
+        mockDriveId,
+        mockUserId,
+        '*',
+        'test-drive',
+        { includeTypes: ['FILE', 'MACHINE'], maxResults: 100 }
+      );
+    });
+
+    it('should not silently widen the search when FILE is the only requested type (#2150)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=FILE`);
+      await GET(request, createContext(mockDriveId));
+
+      const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
+      // Must be a real, non-empty filter — an empty array would mean "return everything".
+      expect(options?.includeTypes).toEqual(['FILE']);
+    });
+
+    it('should accept every page type in the canonical enum (#2150)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(
+        `https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=${PAGE_TYPE_VALUES.join(',')}`
+      );
+      await GET(request, createContext(mockDriveId));
+
+      const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
+      expect(options?.includeTypes).toEqual([...PAGE_TYPE_VALUES]);
+    });
+
+    it('should trim whitespace around includeTypes values (#2150)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=FOLDER,%20FILE`);
+      await GET(request, createContext(mockDriveId));
+
+      const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
+      expect(options?.includeTypes).toEqual(['FOLDER', 'FILE']);
+    });
+
+    it('should dedupe repeated includeTypes values (#2150)', async () => {
+      vi.mocked(checkDriveAccessForSearch).mockResolvedValue(createDriveSearchInfo());
+      vi.mocked(globSearchPages).mockResolvedValue(createGlobSearchResponse());
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/search/glob?pattern=*&includeTypes=FILE,FOLDER,FILE`);
+      await GET(request, createContext(mockDriveId));
+
+      const [, , , , options] = vi.mocked(globSearchPages).mock.calls[0];
+      expect(options?.includeTypes).toEqual(['FILE', 'FOLDER']);
     });
 
     it('should cap maxResults at 200', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
@@ -8,11 +8,9 @@ import { eq } from '@pagespace/db/operators';
 import { drives } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { parsePageTypesParam } from '@pagespace/lib/utils/enums';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
-
-const VALID_PAGE_TYPES = ['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'] as const;
-type PageType = (typeof VALID_PAGE_TYPES)[number];
 
 /**
  * GET /api/drives/[driveId]/search/glob
@@ -49,12 +47,10 @@ export async function GET(
       );
     }
 
-    // Parse includeTypes
-    const includeTypes = includeTypesParam
-      ? (includeTypesParam
-          .split(',')
-          .filter((t): t is PageType => VALID_PAGE_TYPES.includes(t as PageType)))
-      : undefined;
+    // Parse includeTypes. Derived from the canonical PageType enum — a
+    // hand-written list here had drifted and silently dropped FILE and
+    // MACHINE (#2150).
+    const includeTypes = parsePageTypesParam(includeTypesParam);
 
     // Check drive access. A scoped MCP token is its own drive member — gate on
     // the TOKEN's membership, not the owning user's.

--- a/apps/web/src/hooks/useBreadcrumbs.ts
+++ b/apps/web/src/hooks/useBreadcrumbs.ts
@@ -1,11 +1,12 @@
 import { useRef, useEffect } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { PageTypeValue } from '@pagespace/lib/utils/enums';
 
 interface BreadcrumbItem {
   id: string;
   title: string;
-  type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'FILE' | 'SHEET' | 'TASK_LIST' | 'CODE';
+  type: PageTypeValue;
   parentId: string | null;
   driveId: string;
   drive: { id: string; slug: string; name: string } | null;

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -52,6 +52,9 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
     getDefaultContent: vi.fn(() => ''),
     getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
+    // create_page's description interpolates each type's gloss from this config
+    // so the prose can't drift from the schema (#2150).
+    getPageTypeConfig: vi.fn((type: string) => ({ description: `${type} pages` })),
     isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
     isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
     isCodePage: vi.fn((type) => type === 'CODE'),

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -380,6 +380,17 @@ describe('page-write-tools', () => {
       expect(pageWriteTools.create_page.description).toContain('Create');
     });
 
+    // Regression test for #2150: the description used to hardcode 8 page
+    // type names and glosses, so it could (and did) drift from the schema
+    // built from getCreatablePageTypes(). It now interpolates each creatable
+    // type's own gloss from page-types.config, so the two can't diverge.
+    it('interpolates every creatable type and its gloss from page-types.config', () => {
+      const description = pageWriteTools.create_page.description;
+      for (const type of ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']) {
+        expect(description).toContain(`${type} (${type} pages)`);
+      }
+    });
+
     it('requires user authentication', async () => {
       const context = { toolCallId: '1', messages: [], experimental_context: {} };
 

--- a/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
+import { PAGE_TYPE_VALUES } from '@pagespace/lib/utils/enums';
 
 const {
   mockSelect, mockSelectWhere,
@@ -143,6 +144,64 @@ describe('search-tools', () => {
         should: 'validate successfully against the input schema',
         actual: result.success,
         expected: true,
+      });
+    });
+
+    // Regression test for #2150: the tool's z.enum listed only 8 of the
+    // enum's 10 members, so an agent asking for FILE or MACHINE pages was
+    // rejected by zod before execute() ever ran. The schema is now derived
+    // from the canonical PageType enum.
+    it('accepts every canonical page type in its includeTypes schema', () => {
+      const schema = searchTools.glob_search.inputSchema as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        driveId: 'drive-1',
+        pattern: '*',
+        includeTypes: [...PAGE_TYPE_VALUES],
+      });
+
+      assert({
+        given: 'glob_search includeTypes containing all ten PageType values',
+        should: 'validate successfully against the input schema',
+        actual: result.success,
+        expected: true,
+      });
+    });
+
+    it('accepts FILE and MACHINE as includeTypes values', () => {
+      const schema = searchTools.glob_search.inputSchema as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        driveId: 'drive-1',
+        pattern: '*',
+        includeTypes: ['FILE', 'MACHINE'],
+      });
+
+      assert({
+        given: 'glob_search includeTypes containing FILE and MACHINE',
+        should: 'validate successfully against the input schema',
+        actual: result.success,
+        expected: true,
+      });
+    });
+
+    it('still rejects an includeTypes value outside the enum', () => {
+      const schema = searchTools.glob_search.inputSchema as {
+        safeParse: (v: unknown) => { success: boolean };
+      };
+      const result = schema.safeParse({
+        driveId: 'drive-1',
+        pattern: '*',
+        includeTypes: ['BOGUS'],
+      });
+
+      assert({
+        given: 'glob_search includeTypes containing an unknown page type',
+        should: 'fail schema validation',
+        actual: result.success,
+        expected: false,
       });
     });
   });

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { canActorEditPage, canActorDeletePage, canActorManageDrive, driveDeniedByAppToken } from './actor-permissions';
 import { isHomeDrive, homeDriveActionError } from '@pagespace/lib/services/drive-guards';
 import { PageType } from '@pagespace/lib/utils/enums';
-import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
+import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes, getPageTypeConfig } from '@pagespace/lib/content/page-types.config';
 import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger';
@@ -546,7 +546,12 @@ export const pageWriteTools = {
    * Create new documents, folders, or other content
    */
   create_page: tool({
-    description: 'Create new pages in the workspace. Supports all page types: FOLDER (hierarchical organization), DOCUMENT (text content), AI_CHAT (AI conversation spaces), CHANNEL (team discussions), CANVAS (custom HTML/CSS pages), SHEET (spreadsheets with formulas), TASK_LIST (table-based task management), CODE (code editor with syntax highlighting). Any page type can contain any other page type as children with infinite nesting. For AI_CHAT pages, use update_agent_config after creation to configure agent behavior.',
+    // Both the type list and its glosses come from the same config the schema
+    // below is built from, so the prose can never drift from what the tool
+    // actually accepts — the hardcoded list here had gone stale (#2150).
+    description: `Create new pages in the workspace. Supported page types: ${getCreatablePageTypes()
+      .map((type) => `${type} (${getPageTypeConfig(type).description})`)
+      .join(', ')}. Any page type can contain any other page type as children with infinite nesting. For AI_CHAT pages, use update_agent_config after creation to configure agent behavior.`,
     inputSchema: z.object({
       driveId: z.string().describe('The unique ID of the drive to create the page in'),
       parentId: z.string().optional().describe('The unique ID of the parent page from list_pages - REQUIRED when creating inside any page (folder, document, channel, etc). Only omit for root-level pages in the drive.'),

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -5,6 +5,7 @@ import { eq, and, ne, sql, inArray, asc } from '@pagespace/db/operators'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
 import { getActorAccessiblePagesInDrive, canActorAccessDrive } from './actor-permissions';
 import type { ToolExecutionContext } from '../core/types';
+import { PageType } from '@pagespace/lib/utils/enums';
 
 export const searchTools = {
   /**
@@ -355,7 +356,10 @@ export const searchTools = {
     inputSchema: z.object({
       driveId: z.string().describe('The unique ID of the drive to search in'),
       pattern: z.string().describe('Glob pattern to match page titles/paths (e.g., "**/README*", "docs/**/*.md", "meeting-*")'),
-      includeTypes: z.array(z.enum(['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'])).optional().describe('Filter by page types'),
+      // Derived from the canonical PageType enum: a hand-written list here
+      // omitted FILE and MACHINE, so agents filtering for those page types
+      // were rejected by zod before execute() ever ran (#2150).
+      includeTypes: z.array(z.enum(PageType)).optional().describe('Filter by page types'),
       maxResults: z.number().optional().default(100).describe('Maximum number of results to return'),
     }),
     execute: async ({ driveId, pattern, includeTypes, maxResults = 100 }, { experimental_context: context }) => {

--- a/apps/web/src/lib/pages/get-page-breadcrumb-trail.ts
+++ b/apps/web/src/lib/pages/get-page-breadcrumb-trail.ts
@@ -1,11 +1,12 @@
 import { db } from '@pagespace/db/db';
 import { sql } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
+import type { PageTypeValue } from '@pagespace/lib/utils/enums';
 
 export interface BreadcrumbPage {
   id: string;
   title: string;
-  type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'FILE' | 'SHEET' | 'TASK_LIST' | 'CODE';
+  type: PageTypeValue;
   parentId: string | null;
   driveId: string;
   drive: { id: string; slug: string; name: string } | null;
@@ -14,7 +15,7 @@ export interface BreadcrumbPage {
 type QueryResultRow = {
   id: string;
   title: string;
-  type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'FILE' | 'SHEET' | 'TASK_LIST' | 'CODE';
+  type: PageTypeValue;
   driveId: string;
   parentId: string | null;
   drive_id: string | null;

--- a/apps/web/src/services/api/__tests__/page-type-drift-guard.test.ts
+++ b/apps/web/src/services/api/__tests__/page-type-drift-guard.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Drift guard for the `PageType` alias exported by
+ * `apps/web/src/services/api/page-service.ts`. It used to be a hand-written
+ * string union that omitted FILE, so FILE pages did not fit the type used for
+ * API page data (#2150). It is now derived from the canonical enum in
+ * `packages/lib/src/utils/enums.ts`.
+ *
+ * The `AssertExact` line is a compile-time-only check: if the two shapes ever
+ * drift, `tsc` (`bun run typecheck`) fails right here with "Type 'false' is
+ * not assignable to type 'true'" — before any test runs. Same pattern as
+ * `packages/sdk/src/operations/__tests__/roles-pageperm-drift-guard.test.ts`.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PageTypeValue } from '@pagespace/lib/utils/enums';
+import type { PageType as ServicePageType } from '../page-service';
+
+type AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const structurallyIdentical: AssertExact<ServicePageType, PageTypeValue> = true;
+
+describe('page-service PageType — drift guard vs the canonical PageType enum', () => {
+  it('is structurally identical to the lib enum values (enforced at compile time above)', () => {
+    expect(structurallyIdentical).toBe(true);
+  });
+
+  it('admits FILE, the member the hand-written union dropped (#2150)', () => {
+    const fileType: ServicePageType = 'FILE';
+    expect(fileType).toBe('FILE');
+  });
+
+  it('admits MACHINE', () => {
+    const machineType: ServicePageType = 'MACHINE';
+    expect(machineType).toBe('MACHINE');
+  });
+});

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -8,6 +8,7 @@ import { canUserViewPage, canUserEditPage, canUserDeletePage } from '@pagespace/
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format'
 import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils'
+import type { PageTypeValue } from '@pagespace/lib/utils/enums'
 import { computePageStateHash, createPageVersion, type PageVersionSource } from '@pagespace/lib/services/page-version-service';
 import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard';
 import { validatePageCreation, validateAIChatTools } from '@pagespace/lib/content/page-type-validators'
@@ -108,9 +109,12 @@ function sanitizeEmptyContent(content: string): string {
 }
 
 /**
- * Page types
+ * Page types. Derived from the canonical enum — the hand-written union this
+ * replaced had drifted and omitted FILE, so FILE pages did not fit the type
+ * used for API page data (#2150). Guarded by
+ * `__tests__/page-type-drift-guard.test.ts`.
  */
-export type PageType = 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET' | 'TASK_LIST' | 'CODE' | 'MACHINE';
+export type PageType = PageTypeValue;
 
 /**
  * Message with user info for page details

--- a/packages/lib/src/utils/__tests__/enums.test.ts
+++ b/packages/lib/src/utils/__tests__/enums.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the canonical `PageType` list and the `includeTypes` query-param
+ * parser (issue #2150). Three hand re-declarations of the page-type list had
+ * drifted from this enum, silently dropping FILE and MACHINE from glob search
+ * and the AI `glob_search` tool; every consumer now derives from here.
+ *
+ * The `AssertExact` line below is a compile-time-only drift guard against the
+ * DB `pgEnum` (`packages/db/src/schema/core.ts`): if the two ever diverge,
+ * `tsc` fails right here with "Type 'false' is not assignable to type 'true'"
+ * before any test runs. Same pattern as
+ * `packages/sdk/src/operations/__tests__/roles-pageperm-drift-guard.test.ts`.
+ */
+import { describe, it, expect } from 'vitest';
+import type { PageTypeEnum } from '@pagespace/db/schema/core';
+import {
+  PageType,
+  PAGE_TYPE_VALUES,
+  isPageTypeValue,
+  parsePageTypesParam,
+  type PageTypeValue,
+} from '../enums';
+
+type AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const matchesDbEnum: AssertExact<PageTypeValue, PageTypeEnum> = true;
+
+describe('PAGE_TYPE_VALUES', () => {
+  it('is exactly the members of the PageType enum', () => {
+    expect(PAGE_TYPE_VALUES).toEqual(Object.values(PageType));
+  });
+
+  it('contains all ten page types, including FILE and MACHINE (#2150)', () => {
+    expect([...PAGE_TYPE_VALUES].sort()).toEqual(
+      [
+        'AI_CHAT',
+        'CANVAS',
+        'CHANNEL',
+        'CODE',
+        'DOCUMENT',
+        'FILE',
+        'FOLDER',
+        'MACHINE',
+        'SHEET',
+        'TASK_LIST',
+      ].sort()
+    );
+  });
+
+  it('does not drift from the DB pgEnum (enforced at compile time above)', () => {
+    expect(matchesDbEnum).toBe(true);
+  });
+});
+
+describe('isPageTypeValue', () => {
+  it('accepts a known page type', () => {
+    expect(isPageTypeValue('FOLDER')).toBe(true);
+  });
+
+  it('accepts FILE and MACHINE', () => {
+    expect(isPageTypeValue('FILE')).toBe(true);
+    expect(isPageTypeValue('MACHINE')).toBe(true);
+  });
+
+  it('rejects an unknown value', () => {
+    expect(isPageTypeValue('BOGUS')).toBe(false);
+  });
+
+  it('rejects a differently-cased value', () => {
+    expect(isPageTypeValue('folder')).toBe(false);
+  });
+
+  it('rejects the empty string', () => {
+    expect(isPageTypeValue('')).toBe(false);
+  });
+});
+
+describe('parsePageTypesParam', () => {
+  it('returns undefined for a null param (no filter)', () => {
+    expect(parsePageTypesParam(null)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty string (no filter)', () => {
+    expect(parsePageTypesParam('')).toBeUndefined();
+  });
+
+  it('parses a single valid type', () => {
+    expect(parsePageTypesParam('FOLDER')).toEqual(['FOLDER']);
+  });
+
+  it('parses FILE and MACHINE, the two types that used to be dropped (#2150)', () => {
+    expect(parsePageTypesParam('FILE,MACHINE')).toEqual(['FILE', 'MACHINE']);
+  });
+
+  it('parses every page type', () => {
+    expect(parsePageTypesParam(PAGE_TYPE_VALUES.join(','))).toEqual([...PAGE_TYPE_VALUES]);
+  });
+
+  it('silently drops unknown values but keeps the valid ones', () => {
+    expect(parsePageTypesParam('FOLDER,BOGUS,FILE')).toEqual(['FOLDER', 'FILE']);
+  });
+
+  it('returns an empty array when every value is unknown', () => {
+    expect(parsePageTypesParam('BOGUS')).toEqual([]);
+  });
+
+  it('trims surrounding whitespace on each segment', () => {
+    expect(parsePageTypesParam(' FOLDER , FILE ')).toEqual(['FOLDER', 'FILE']);
+  });
+
+  it('drops empty segments', () => {
+    expect(parsePageTypesParam('FOLDER,,DOCUMENT')).toEqual(['FOLDER', 'DOCUMENT']);
+  });
+
+  it('drops whitespace-only segments', () => {
+    expect(parsePageTypesParam('FOLDER,   ,DOCUMENT')).toEqual(['FOLDER', 'DOCUMENT']);
+  });
+
+  it('dedupes repeated types, preserving first-seen order', () => {
+    expect(parsePageTypesParam('FILE,FOLDER,FILE')).toEqual(['FILE', 'FOLDER']);
+  });
+
+  it('returns an empty array for a param of only separators', () => {
+    expect(parsePageTypesParam(',,')).toEqual([]);
+  });
+});

--- a/packages/lib/src/utils/enums.ts
+++ b/packages/lib/src/utils/enums.ts
@@ -11,6 +11,47 @@ export enum PageType {
   MACHINE = 'MACHINE',
 }
 
+/**
+ * The string-literal union form of `PageType`. Prefer this over hand-written
+ * unions like `'FOLDER' | 'DOCUMENT' | ...`: it is derived, so it cannot
+ * drift, and unlike the enum type itself it is mutually assignable with the
+ * DB's `PageTypeEnum` (`@pagespace/db/schema/core`).
+ */
+export type PageTypeValue = `${PageType}`;
+
+/**
+ * Every page type, as runtime values. Prefer this over hand-written arrays —
+ * see #2150, where three separate re-declarations had drifted and silently
+ * dropped FILE and MACHINE.
+ */
+export const PAGE_TYPE_VALUES: readonly PageTypeValue[] = Object.values(PageType);
+
+export function isPageTypeValue(value: string): value is PageTypeValue {
+  return (PAGE_TYPE_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * Parses a comma-separated `includeTypes` query param into page types.
+ *
+ * Segments are trimmed; empty and unknown segments are dropped silently (the
+ * route's long-standing behaviour — an unknown type is not a request error),
+ * and duplicates are removed with first-seen order preserved. A missing or
+ * empty param returns `undefined`, meaning "no type filter".
+ *
+ * Note that an all-unknown param yields `[]`, which downstream callers such
+ * as `globSearchPages` also treat as "no filter".
+ */
+export function parsePageTypesParam(param: string | null): PageTypeValue[] | undefined {
+  if (!param) return undefined;
+
+  const seen = new Set<PageTypeValue>();
+  for (const segment of param.split(',')) {
+    const candidate = segment.trim();
+    if (isPageTypeValue(candidate)) seen.add(candidate);
+  }
+  return [...seen];
+}
+
 export enum PermissionAction {
   VIEW = 'VIEW',
   EDIT = 'EDIT',

--- a/packages/sdk/src/operations/__tests__/glob-page-types-drift-guard.test.ts
+++ b/packages/sdk/src/operations/__tests__/glob-page-types-drift-guard.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Drift guard for `GLOB_SEARCH_PAGE_TYPES`, inlined in `operations/search.ts`
+ * so the published SDK never runtime- or type-imports `@pagespace/lib` (a
+ * published `.d.ts` referencing an unpublished internal package would break a
+ * consumer's `tsc`). This test-only import from `@pagespace/lib` (a
+ * devDependency, never in the published `dist`) asserts the inlined list is
+ * exactly the canonical `PageType` enum in
+ * `packages/lib/src/utils/enums.ts` — the same pattern
+ * `./roles-pageperm-drift-guard.test.ts` uses for `PagePerm`.
+ *
+ * Filed as #2150: the inlined list had drifted to 8 of 10 members, so SDK and
+ * CLI callers could not filter glob search for FILE or MACHINE pages.
+ *
+ * The `AssertExact` line is a compile-time-only check: if the two lists ever
+ * diverge, `tsc` (this package's `typecheck`/`pretest` script) fails right
+ * here with "Type 'false' is not assignable to type 'true'" — before any test
+ * even runs.
+ */
+import { describe, expect, it } from 'vitest';
+import { PageType, PAGE_TYPE_VALUES } from '@pagespace/lib/utils/enums';
+import { GLOB_SEARCH_PAGE_TYPES } from '../search.js';
+
+type AssertExact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const structurallyIdentical: AssertExact<
+  (typeof GLOB_SEARCH_PAGE_TYPES)[number],
+  `${PageType}`
+> = true;
+
+describe('operations/search.ts GLOB_SEARCH_PAGE_TYPES — drift guard vs the canonical PageType enum', () => {
+  it('is type-identical to the lib enum values (enforced at compile time above)', () => {
+    expect(structurallyIdentical).toBe(true);
+  });
+
+  it('has the same members as the lib enum at runtime', () => {
+    expect([...GLOB_SEARCH_PAGE_TYPES].sort()).toEqual([...PAGE_TYPE_VALUES].sort());
+  });
+
+  it('includes FILE and MACHINE, the two members it had drifted away from (#2150)', () => {
+    expect(GLOB_SEARCH_PAGE_TYPES).toContain('FILE');
+    expect(GLOB_SEARCH_PAGE_TYPES).toContain('MACHINE');
+  });
+});

--- a/packages/sdk/src/operations/__tests__/search.test.ts
+++ b/packages/sdk/src/operations/__tests__/search.test.ts
@@ -76,8 +76,13 @@ describe('search.glob — input validation', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts includeTypes drawn from the route\'s current type set — FOLDER, DOCUMENT, AI_CHAT, CHANNEL, CANVAS, SHEET, CODE, TASK_LIST (route.ts:14, post #1773/74 fix)', () => {
+  it('accepts includeTypes drawn from the route\'s type set — the full canonical PageType enum (#2150; the route now derives its filter from the enum)', () => {
     const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', includeTypes: 'CODE,TASK_LIST' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts FILE and MACHINE, which the inlined list used to omit (#2150)', () => {
+    const result = globSearch.inputSchema.safeParse({ driveId: 'd1abc', pattern: '*', includeTypes: 'FILE,MACHINE' });
     expect(result.success).toBe(true);
   });
 

--- a/packages/sdk/src/operations/search.ts
+++ b/packages/sdk/src/operations/search.ts
@@ -24,12 +24,28 @@ import { defineOperation } from '../registry/define.js';
 // ---------------------------------------------------------------------------
 
 /**
- * The route's current type filter (`search/glob/route.ts:14`, VALID_PAGE_TYPES,
- * post #1773/74 fix): CODE and TASK_LIST are both accepted today — the
- * operations-inventory D8 discrepancy (TASK_LIST silently dropped) is
- * resolved at the route, so the SDK enum matches the route enum exactly.
+ * The route's type filter (`search/glob/route.ts`), which since #2150 derives
+ * from the canonical `PageType` enum in `packages/lib/src/utils/enums.ts`
+ * rather than a hand-written list — so this must be all ten members.
+ *
+ * It stays inlined rather than imported because the published SDK must never
+ * runtime- or type-import `@pagespace/lib`: a published `.d.ts` referencing an
+ * unpublished internal package would break a consumer's `tsc`. Equality with
+ * the canonical enum is instead enforced at compile time by
+ * `__tests__/glob-page-types-drift-guard.test.ts`.
  */
-const GLOB_SEARCH_PAGE_TYPES = ['FOLDER', 'DOCUMENT', 'AI_CHAT', 'CHANNEL', 'CANVAS', 'SHEET', 'CODE', 'TASK_LIST'] as const;
+export const GLOB_SEARCH_PAGE_TYPES = [
+  'FOLDER',
+  'DOCUMENT',
+  'CHANNEL',
+  'AI_CHAT',
+  'CANVAS',
+  'FILE',
+  'SHEET',
+  'TASK_LIST',
+  'CODE',
+  'MACHINE',
+] as const;
 const globSearchPageTypeSchema = z.enum(GLOB_SEARCH_PAGE_TYPES);
 
 /**


### PR DESCRIPTION
## Summary

`PageType` (`packages/lib/src/utils/enums.ts`) has 10 members. Five separate hand-written re-declarations of that list had drifted, silently dropping `FILE` and/or `MACHINE`:

- `apps/web/.../search/glob/route.ts` `VALID_PAGE_TYPES` (8/10) — an `includeTypes=FILE` request degraded to an empty filter, and `globSearchPages` treats an empty filter as "no filter", so the caller silently got **every page** instead of just files.
- The AI `glob_search` tool's `z.enum([...])` (8/10) — agents requesting FILE/MACHINE were rejected by zod before `execute()` ever ran.
- `page-service.ts`'s `PageType` union (9/10, missing FILE).
- `packages/sdk`'s `GLOB_SEARCH_PAGE_TYPES` (8/10) — same bug for SDK/CLI callers.
- `useBreadcrumbs.ts` / `get-page-breadcrumb-trail.ts` unions (9/10, missing MACHINE — type-only drift, no runtime symptom).

Also fixed two stale prose lists: the `create_page` tool description (now interpolates from `getCreatablePageTypes()`/`getPageTypeConfig()` so it can't drift from its own schema again) and the marketing CLI docs page (was missing MACHINE).

## Changes

- New in `packages/lib/src/utils/enums.ts`: `PageTypeValue`, `PAGE_TYPE_VALUES`, `isPageTypeValue`, and `parsePageTypesParam` (the `includeTypes` query-param parser — now trims, drops empty segments, and dedupes; unknown values are still silently dropped, preserving prior behavior).
- Every site above now derives from the enum instead of hand-listing members.
- The SDK keeps an inlined literal list (a published SDK `.d.ts` can't reference the unpublished `@pagespace/lib` package), but is pinned to the canonical list by a compile-time `AssertExact` drift-guard test, same pattern as the existing `roles-pageperm-drift-guard.test.ts`.
- New drift-guard tests: `packages/lib/src/utils/__tests__/enums.test.ts` (also pins lib against the DB `pgEnum`), `apps/web/src/services/api/__tests__/page-type-drift-guard.test.ts`, `packages/sdk/src/operations/__tests__/glob-page-types-drift-guard.test.ts`.

## Test plan

- [x] `bun --cwd packages/lib test src/utils/__tests__/enums.test.ts` — 20 tests pass, including 100%-branch coverage of the parser and the DB-pgEnum drift guard.
- [x] `bun --cwd packages/sdk test src/operations/__tests__` — 522 tests pass, including the new SDK drift guard.
- [x] `bun --cwd apps/web test src/app/api/drives src/lib/ai/tools src/services/api` — 2725 tests pass (1 unrelated pre-existing failure in `activity-tools.test.ts` from a local DB-role env issue, untouched by this change).
- [x] `bun run typecheck` — clean (drift guards would fail `tsc` here if lib/db/sdk/page-service lists ever diverge again).
- [x] `bun run lint` — clean (14/14 tasks, including `next build`).
- [ ] `bun run changelog:generate` — fails in this worktree with `ERR_MODULE_NOT_FOUND` on `scripts/changelog/index.ts`; this is the known pre-existing staleness tracked in #1044, not something this PR introduces.

Closes #2150

https://claude.ai/code/session_01GC414LHWsWNYAh4qHsNVhF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for all page types, including `FILE` and `MACHINE`, in glob search filters.
  * Improved parsing of page-type filters, including whitespace handling and duplicate removal.
  * Updated SDK validation to recognize the complete set of supported page types.
  * Enhanced AI page-creation guidance to reflect supported page types accurately.

* **Documentation**
  * Updated CLI documentation to list `MACHINE` as a supported page type.

* **Bug Fixes**
  * Fixed page-type inconsistencies across search, breadcrumbs, and API services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->